### PR TITLE
Fixed Lucene.NET exception serialization

### DIFF
--- a/src/core/Index/CorruptIndexException.cs
+++ b/src/core/Index/CorruptIndexException.cs
@@ -16,6 +16,8 @@
  */
 
 using System;
+using System.IO;
+using System.Runtime.Serialization;
 
 namespace Lucene.Net.Index
 {
@@ -24,13 +26,22 @@ namespace Lucene.Net.Index
 	/// an inconsistency in the index.
 	/// </summary>
 	[Serializable]
-	public class CorruptIndexException:System.IO.IOException
+	public class CorruptIndexException : IOException
 	{
-		public CorruptIndexException(String message):base(message)
+	    public CorruptIndexException()
+	    {
+	    }
+
+		public CorruptIndexException(String message) : base(message)
 		{
 		}
-		public CorruptIndexException(String message, Exception exp):base(message, exp)
+
+		public CorruptIndexException(String message, Exception exp) : base(message, exp)
 		{
 		}
+
+        public CorruptIndexException(SerializationInfo info, StreamingContext context) : base(info, context)
+	    {
+	    }
 	}
 }

--- a/src/core/Index/FieldReaderException.cs
+++ b/src/core/Index/FieldReaderException.cs
@@ -16,6 +16,7 @@
  */
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Lucene.Net.Index
 {
@@ -51,7 +52,7 @@ namespace Lucene.Net.Index
 		/// </param>
 		/// <since> 1.4
 		/// </since>
-		public FieldReaderException(System.Exception cause):base((cause == null)?null:cause.Message, cause)
+		public FieldReaderException(Exception cause) : base((cause == null) ? null : cause.Message, cause)
 		{
 		}
 		
@@ -63,7 +64,7 @@ namespace Lucene.Net.Index
 		/// <param name="message">the detail message. The detail message is saved for
         /// later retrieval by the <see cref="Exception.Message" /> method.
 		/// </param>
-		public FieldReaderException(System.String message):base(message)
+		public FieldReaderException(String message) : base(message)
 		{
 		}
 		
@@ -83,8 +84,12 @@ namespace Lucene.Net.Index
 		/// </param>
 		/// <since> 1.4
 		/// </since>
-		public FieldReaderException(System.String message, System.Exception cause):base(message, cause)
+		public FieldReaderException(String message, Exception cause) : base(message, cause)
 		{
 		}
+
+	    public FieldReaderException(SerializationInfo info, StreamingContext context) : base(info, context)
+	    {
+	    }
 	}
 }

--- a/src/core/Index/MergePolicy.cs
+++ b/src/core/Index/MergePolicy.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Directory = Lucene.Net.Store.Directory;
 
 namespace Lucene.Net.Index
@@ -206,24 +207,40 @@ namespace Lucene.Net.Index
 		[Serializable]
 		public class MergeException:System.SystemException
 		{
-			private readonly Directory dir;
+			private readonly Directory _dir;
 
-			public MergeException(System.String message, Directory dir):base(message)
+			public MergeException(System.String message, Directory dir) : base(message)
 			{
-				this.dir = dir;
+				this._dir = dir;
 			}
 
-			public MergeException(System.Exception exc, Directory dir):base(null, exc)
+			public MergeException(System.Exception exc, Directory dir) : base(null, exc)
 			{
-				this.dir = dir;
+				this._dir = dir;
 			}
+
+		    public MergeException()
+		    {
+		    }
+
+		    public MergeException(string message) : base(message)
+		    {
+		    }
+
+		    public MergeException(string message, Exception inner) : base(message, inner)
+		    {
+		    }
+
+            public MergeException(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+            }
 
 		    /// <summary>Returns the <see cref="Directory" /> of the index that hit
 		    /// the exception. 
 		    /// </summary>
 		    public virtual Directory Directory
 		    {
-		        get { return dir; }
+		        get { return _dir; }
 		    }
 		}
 		
@@ -236,6 +253,14 @@ namespace Lucene.Net.Index
 			public MergeAbortedException(System.String message):base(message)
 			{
 			}
+
+		    public MergeAbortedException(string message, Exception inner) : base(message, inner)
+		    {
+		    }
+
+            public MergeAbortedException(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+            }
 		}
 		
 		protected internal IndexWriter writer;

--- a/src/core/Index/StaleReaderException.cs
+++ b/src/core/Index/StaleReaderException.cs
@@ -16,6 +16,8 @@
  */
 
 using System;
+using System.IO;
+using System.Runtime.Serialization;
 
 namespace Lucene.Net.Index
 {
@@ -30,10 +32,22 @@ namespace Lucene.Net.Index
 	/// the changes.
 	/// </summary>
 	[Serializable]
-	public class StaleReaderException:System.IO.IOException
+	public class StaleReaderException : IOException
 	{
-		public StaleReaderException(System.String message):base(message)
+	    public StaleReaderException()
+	    {
+	    }
+
+		public StaleReaderException(String message) : base(message)
 		{
 		}
+
+	    public StaleReaderException(string message, Exception inner) : base(message, inner)
+	    {
+	    }
+
+	    public StaleReaderException(SerializationInfo info, StreamingContext context) : base(info, context)
+	    {
+	    }
 	}
 }

--- a/src/core/QueryParser/ParseException.cs
+++ b/src/core/QueryParser/ParseException.cs
@@ -19,6 +19,7 @@
 /* JavaCCOptions:KEEP_LINE_COL=null */
 
 using System;
+using System.Runtime.Serialization;
 using Lucene.Net.Support;
 
 namespace Lucene.Net.QueryParsers
@@ -33,7 +34,7 @@ namespace Lucene.Net.QueryParsers
 	/// mechanisms so long as you retain the public fields.
 	/// </summary>
 	[Serializable]
-	public class ParseException:System.Exception
+	public class ParseException : Exception
 	{
 		/// <summary> This method has the standard behavior when this object has been
 		/// created using the standard constructors.  Otherwise, it uses
@@ -147,6 +148,11 @@ namespace Lucene.Net.QueryParsers
         {
 	        specialConstructor = false;
         }
+
+	    public ParseException(SerializationInfo info, StreamingContext context) : base(info, context)
+	    {
+	        specialConstructor = false;
+	    }
 		
 		/// <summary> This variable determines which constructor was used to create
 		/// this object and thereby affects the semantics of the

--- a/src/core/QueryParser/QueryParser.cs
+++ b/src/core/QueryParser/QueryParser.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.Serialization;
 using System.Text;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Tokenattributes;
@@ -1862,8 +1863,23 @@ namespace Lucene.Net.QueryParsers
         }
 
         [Serializable]
-        private sealed class LookaheadSuccess : System.Exception
+        private sealed class LookaheadSuccess : Exception
         {
+            public LookaheadSuccess()
+            {
+            }
+
+            public LookaheadSuccess(string message) : base(message)
+            {
+            }
+
+            public LookaheadSuccess(string message, Exception inner) : base(message, inner)
+            {
+            }
+
+            public LookaheadSuccess(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+            }
         }
 
         private LookaheadSuccess jj_ls = new LookaheadSuccess();

--- a/src/core/QueryParser/TokenMgrError.cs
+++ b/src/core/QueryParser/TokenMgrError.cs
@@ -19,13 +19,14 @@
 /* JavaCCOptions: */
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Lucene.Net.QueryParsers
 {
 	
 	/// <summary>Token Manager Error. </summary>
 	[Serializable]
-	public class TokenMgrError:System.ApplicationException
+	public class TokenMgrError : ApplicationException
 	{
 		/// <summary> You can also modify the body of this method to customize your error messages.
 		/// For example, cases like LOOP_DETECTED and INVALID_LEXICAL_STATE are not
@@ -164,6 +165,10 @@ namespace Lucene.Net.QueryParsers
 		public TokenMgrError(bool EOFSeen, int lexState, int errorLine, int errorColumn, System.String errorAfter, char curChar, int reason):this(LexicalError(EOFSeen, lexState, errorLine, errorColumn, errorAfter, curChar), reason)
 		{
 		}
+
+	    public TokenMgrError(SerializationInfo info, StreamingContext context) : base(info, context)
+	    {
+	    }
 	}
     /* JavaCC - OriginalChecksum=1c94e13236c7e0121e49427992341ee3 (do not edit this line) */
 }

--- a/src/core/Search/BooleanQuery.cs
+++ b/src/core/Search/BooleanQuery.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections;
+using System.Runtime.Serialization;
 using Lucene.Net.Index;
 using Lucene.Net.Support;
 using IndexReader = Lucene.Net.Index.IndexReader;
@@ -67,16 +68,23 @@ namespace Lucene.Net.Search
 		/// is expanded to many terms during search. 
 		/// </summary>
 		[Serializable]
-		public class TooManyClauses:System.SystemException
+		public class TooManyClauses : Exception
 		{
-			public override System.String Message
-			{
-				get
-				{
-					return "maxClauseCount is set to " + Lucene.Net.Search.BooleanQuery._maxClauses;
-				}
-				
-			}
+		    public TooManyClauses() : base("maxClauseCount is set to " + _maxClauses)
+		    {
+		    }
+
+            public TooManyClauses(string message) : base(message)
+            {
+            }
+
+            public TooManyClauses(string message, Exception inner) : base(message, inner)
+            {
+            }
+
+            public TooManyClauses(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+            }
 		}
 
 	    /// <summary>Gets or sets the maximum number of clauses permitted, 1024 by default.

--- a/src/core/Search/FieldCacheImpl.cs
+++ b/src/core/Search/FieldCacheImpl.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using Lucene.Net.Support;
 using NumericField = Lucene.Net.Documents.NumericField;
 using IndexReader = Lucene.Net.Index.IndexReader;
@@ -171,8 +172,23 @@ namespace Lucene.Net.Search
         /// array.
         /// </summary>
         [Serializable]
-        internal sealed class StopFillCacheException:System.SystemException
+        internal sealed class StopFillCacheException : Exception
         {
+            public StopFillCacheException()
+            {
+            }
+
+            public StopFillCacheException(string message) : base(message)
+            {
+            }
+
+            public StopFillCacheException(string message, Exception inner) : base(message, inner)
+            {
+            }
+
+            public StopFillCacheException(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+            }
         }
         
         /// <summary>Expert: Internal cache. </summary>

--- a/src/core/Search/TimeLimitingCollector.cs
+++ b/src/core/Search/TimeLimitingCollector.cs
@@ -16,6 +16,7 @@
  */
 
 using System;
+using System.Runtime.Serialization;
 using Lucene.Net.Support;
 using IndexReader = Lucene.Net.Index.IndexReader;
 
@@ -93,17 +94,33 @@ namespace Lucene.Net.Search
 		
 		/// <summary>Thrown when elapsed search time exceeds allowed search time. </summary>
 		[Serializable]
-		public class TimeExceededException:System.SystemException
+		public class TimeExceededException : Exception
 		{
-			private long timeAllowed;
-			private long timeElapsed;
-			private int lastDocCollected;
+			private readonly long timeAllowed;
+			private readonly long timeElapsed;
+			private readonly int lastDocCollected;
 			internal TimeExceededException(long timeAllowed, long timeElapsed, int lastDocCollected):base("Elapsed time: " + timeElapsed + "Exceeded allowed search time: " + timeAllowed + " ms.")
 			{
 				this.timeAllowed = timeAllowed;
 				this.timeElapsed = timeElapsed;
 				this.lastDocCollected = lastDocCollected;
 			}
+
+		    public TimeExceededException()
+		    {   
+		    }
+
+            public TimeExceededException(string message) : base(message)
+            {
+            }
+
+            public TimeExceededException(string message, Exception inner) : base(message, inner)
+            {
+            }
+
+            public TimeExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+            }
 
 		    /// <summary>Returns allowed time (milliseconds). </summary>
 		    public virtual long TimeAllowed

--- a/src/core/Store/LockObtainFailedException.cs
+++ b/src/core/Store/LockObtainFailedException.cs
@@ -16,6 +16,8 @@
  */
 
 using System;
+using System.IO;
+using System.Runtime.Serialization;
 
 namespace Lucene.Net.Store
 {
@@ -28,14 +30,22 @@ namespace Lucene.Net.Store
 	/// <seealso cref="Lock.Obtain(long)">
 	/// </seealso>
 	[Serializable]
-	public class LockObtainFailedException:System.IO.IOException
+	public class LockObtainFailedException : IOException
 	{
-		public LockObtainFailedException(System.String message):base(message)
+	    public LockObtainFailedException()
+	    {
+	    }
+
+		public LockObtainFailedException(string message) : base(message)
 		{
 		}
 
-        public LockObtainFailedException(System.String message, System.Exception ex) : base(message, ex)
+        public LockObtainFailedException(string message, Exception inner) : base(message, inner)
         {
         }
+
+	    public LockObtainFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
+	    {
+	    }
     }
 }

--- a/src/core/Store/LockReleaseFailedException.cs
+++ b/src/core/Store/LockReleaseFailedException.cs
@@ -16,6 +16,8 @@
  */
 
 using System;
+using System.IO;
+using System.Runtime.Serialization;
 
 namespace Lucene.Net.Store
 {
@@ -26,10 +28,22 @@ namespace Lucene.Net.Store
 	/// <seealso cref="Lock.Release()">
 	/// </seealso>
 	[Serializable]
-	public class LockReleaseFailedException:System.IO.IOException
+	public class LockReleaseFailedException : IOException
 	{
-		public LockReleaseFailedException(System.String message):base(message)
+	    public LockReleaseFailedException()
+	    {
+	    }
+
+		public LockReleaseFailedException(string message) : base(message)
 		{
 		}
+
+		public LockReleaseFailedException(string message, Exception inner) : base(message, inner)
+		{
+		}
+
+	    public LockReleaseFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
+	    {
+	    }
 	}
 }

--- a/src/core/Store/NoSuchDirectoryException.cs
+++ b/src/core/Store/NoSuchDirectoryException.cs
@@ -16,6 +16,7 @@
  */
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Lucene.Net.Store
 {
@@ -25,10 +26,22 @@ namespace Lucene.Net.Store
 	/// </summary>
 	
 	[Serializable]
-	public class NoSuchDirectoryException:System.IO.FileNotFoundException
+	public class NoSuchDirectoryException : System.IO.FileNotFoundException
 	{
-		public NoSuchDirectoryException(System.String message):base(message)
+	    public NoSuchDirectoryException()
+	    {
+	    }
+
+		public NoSuchDirectoryException(String message) : base(message)
 		{
 		}
+
+	    public NoSuchDirectoryException(String message, Exception innerException) : base(message, innerException)
+	    {   
+	    }
+
+	    public NoSuchDirectoryException(SerializationInfo info, StreamingContext context) : base(info, context)
+	    {
+	    }
 	}
 }

--- a/test/core/Lucene.Net.Test.csproj
+++ b/test/core/Lucene.Net.Test.csproj
@@ -506,6 +506,7 @@
     <Compile Include="SupportClassException.cs" />
     <Compile Include="Support\BigObject.cs" />
     <Compile Include="Support\CollisionTester.cs" />
+    <Compile Include="Support\TestExceptionSerialization.cs" />
     <Compile Include="Support\TestWeakDictionaryBehavior.cs" />
     <Compile Include="Support\TestWeakDictionary.cs" />
     <Compile Include="Support\SmallObject.cs" />

--- a/test/core/Support/TestExceptionSerialization.cs
+++ b/test/core/Support/TestExceptionSerialization.cs
@@ -1,0 +1,99 @@
+﻿/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using Lucene.Net.Store;
+using NUnit.Framework;
+
+namespace Lucene.Net.Support
+{
+    [TestFixture]
+    public class TestExceptionSerialization
+    {
+        [Test]
+        public void NoSuchDirectoryExceptionCanBeDeserialized()
+        {
+            var exception = new NoSuchDirectoryException("Message text");
+            Assert.That(TypeCanSerialize(exception));
+        }
+
+        [Test]
+        public void AllExceptionsInLuceneNamespaceCanSerialize()
+        {
+            var luceneExceptions = typeof (NoSuchDirectoryException).Assembly.GetTypes()
+                                                                  .Where(t => typeof(Exception).IsAssignableFrom(t));
+
+            foreach (var luceneException in luceneExceptions)
+            {
+                var instance = TryInstantiate(luceneException);
+                Assert.That(TypeCanSerialize(instance), string.Format("Unable to serialize {0}", luceneException.FullName));
+            }
+        }
+
+        private static bool TypeCanSerialize<T>(T exception)
+        {
+            T clone;
+
+            try
+            {
+                var binaryFormatter = new BinaryFormatter();
+                using (var serializationStream = new MemoryStream())
+                {
+                    binaryFormatter.Serialize(serializationStream, exception);
+                    serializationStream.Seek(0, SeekOrigin.Begin);
+                    clone = (T)binaryFormatter.Deserialize(serializationStream);
+                }
+            }
+            catch (SerializationException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static object TryInstantiate(Type type)
+        {
+            object instance = null;
+            try
+            {
+                instance = Activator.CreateInstance(type, new object[] { "A message" });
+            }
+            catch (MissingMethodException)
+            {
+                try
+                {
+                    instance = Activator.CreateInstance(type);
+                }
+                catch (MissingMethodException)
+                {
+                    Assert.Fail("Can't instantiate type {0}, it's missing the necessary constructors.", type.FullName);
+                }
+            }
+            return instance;
+        }
+    }
+}


### PR DESCRIPTION
The fact that Lucene.NET exceptions aren't serializable is causing havoc with error logging amongst other problems.

I've added two tests to demonstrate the issue and fixed all of the exceptions.

All exceptions are now capable of serialization and comply with the Microsoft guide to custom exception design at: http://msdn.microsoft.com/en-gb/library/vstudio/ms229064(v=vs.100).aspx

This is my first contrib to this project so I appreciate any feedback and apologise in advance if I've violated any guidelines.
