### PR TITLE
Added an upper bounds check for a List<int>

### DIFF
--- a/src/core/Index/FieldInfos.cs
+++ b/src/core/Index/FieldInfos.cs
@@ -375,7 +375,7 @@ namespace Lucene.Net.Index
 		/// </returns>
 		public FieldInfo FieldInfo(int fieldNumber)
 		{
-		    return (fieldNumber >= 0) ? byNumber[fieldNumber] : null;
+			return (fieldNumber >= 0 && fieldNumber < byNumber.Count)?(FieldInfo) byNumber[fieldNumber]:null;
 		}
 		
 		public int Size()

--- a/test/core/Index/TestFieldInfos.cs
+++ b/test/core/Index/TestFieldInfos.cs
@@ -99,5 +99,16 @@ namespace Lucene.Net.Index
 				Assert.IsTrue(false);
 			}
 		}
+
+		[Test]
+		public void TestFieldInfoShouldNotThrowIndexOutOfRangeException()
+		{
+			FieldInfos fieldInfos = new FieldInfos();
+		    fieldInfos.Add("foo", true);
+			Assert.AreEqual(1, fieldInfos.Size(), "Should have added a single field info");
+
+		    Assert.IsNotNull(fieldInfos.FieldInfo(0), "In-bounds index should still return a field info");
+		    Assert.IsNull(fieldInfos.FieldInfo(1), "Out-of-bounds index should return null");
+		}
 	}
 }


### PR DESCRIPTION
The `DIFFs FROM 2.9.4.txt` file indicates that the Java collections return
null when the index is out of bounds. I imagine that this bug was simply copied
from generally correct Java code and now is just simply not correct anymore.
Please stop me if this is actually an indication of a deeper problem, like
corruption of the index.

In the problem that I was observing, fieldNumber = 110 and byNumber.Count = 10,
Since the list index was 11x the size of the list, it feels like it indicates
data corruption in the index. I'm using MongoDB.Lucene's MongoFSDirectory, so
I'm concerned that could be at fault.

fixes LUCENENET-520
