### PR TITLE
Minor fix in SesarchFiles.

### DIFF
--- a/src/demo/SearchFiles/SearchFiles.cs
+++ b/src/demo/SearchFiles/SearchFiles.cs
@@ -348,16 +348,25 @@ namespace Lucene.Net.Demo
 						}
 						else
 						{
-							int page = Int32.Parse(line);
-							if ((page - 1) * hitsPerPage < numTotalHits)
-							{
-								start = (page - 1) * hitsPerPage;
-								break;
-							}
-							else
-							{
-								Console.Out.WriteLine("No such page");
-							}
+						    int page;
+                            if(Int32.TryParse(line, out page))
+						    {
+						        if ((page - 1)*hitsPerPage < numTotalHits)
+						        {
+						            start = (page - 1)*hitsPerPage;
+						            break;
+						        }
+						        else
+						        {
+						            Console.Out.WriteLine("No such page");
+						        }
+						    }
+						    else
+						    {
+						        Console.Out.WriteLine("Unrecognized page number. Quitting.");
+						        quit = true;
+                                break;
+						    }
 						}
 					}
 					if (quit)


### PR DESCRIPTION
When entering incorrect page number after search results are displayed exception is raised.
Replaced with TryParse and proceeded to quit.
