### PR TITLE
change implementation so that Read overrides behave as expected

### DIFF
--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -939,7 +939,7 @@ namespace Lucene.Net.Analysis
                         }
                         // Throw an errant exception from the Reader:
 
-                        MockReaderWrapper evilReader = new MockReaderWrapper(random, new StringReader(text));
+                        MockReaderWrapper evilReader = new MockReaderWrapper(random, text);
                         evilReader.ThrowExcAfterChar(random.Next(text.Length));
                         reader = evilReader;
 
@@ -1046,7 +1046,7 @@ namespace Lucene.Net.Analysis
                     Console.WriteLine(Thread.CurrentThread.Name + ": NOTE: baseTokenStreamTestCase: using spoon-feed reader");
                 }
 
-                reader = new MockReaderWrapper(random, reader);
+                reader = new MockReaderWrapper(random, text);
             }
 
             ts = a.TokenStream("dummy", useCharFilter ? (TextReader)new MockCharFilter(reader, remainder) : reader);
@@ -1092,7 +1092,7 @@ namespace Lucene.Net.Analysis
                         Console.WriteLine(Thread.CurrentThread.Name + ": NOTE: baseTokenStreamTestCase: indexing using spoon-feed reader");
                     }
 
-                    reader = new MockReaderWrapper(random, reader);
+                    reader = new MockReaderWrapper(random, text);
                 }
 
                 field.ReaderValue = useCharFilter ? (TextReader)new MockCharFilter(reader, remainder) : reader;


### PR DESCRIPTION
Discovered this issue while running Lucene.Net.Analysis\TestGraphTokenizers tests. From time to time an assert would fail at this location:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs#L964

The idea here is to randomly simulate an exception being thrown when token stream is being iterated. Instead of "evil exception" being thrown, the following assert would fail:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.TestFramework/Analysis/MockReaderWrapper.cs#L92

The underlying problem is the implementation of MockReaderWrapper in C#. It was not exactly a 1-to-1 map to the Java version due to framework differences and bug was introduced in MockReaderWrapper constructor:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.TestFramework/Analysis/MockReaderWrapper.cs#L43

StringReader's ReadToEnd() gets called advancing the iterator to the end. When the actual token stream iteration tries to read the stream, 0 is returned as the underlying text stream has been already iterated by the "ReadToEnd" call in the constructor. Furthermore, MockReaderWrapper should override Read() method as to make sure that all the possible ways that the reader is being used are covered (see https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs#L242 how it can call Read with no params).

Also changed the way MockReader is initialized, instead of new StringReader, text string is passed to it directly. That seemed to make the most sense as there does not appear to be the need to create new stream reader on the same text just to extract that text again.

TestGraphTokenizers still occassionally fail but that appears to be due to another bug that gets invoked radomly and is yet to be determined what is the cause of it. Taking care of this "evil exception" branch gets us moving forward in that investigation.
