### PR TITLE
return -1 if reader returns 0 or less

### DIFF
--- a/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
@@ -248,14 +248,14 @@ namespace Lucene.Net.Analysis
                         // read(char[])
                         char[] c = new char[1];
                         int ret = input.Read(c, 0, c.Length);
-                        return ret == 0 ? -1 : c[0];
+                        return ret <= 0 ? -1 : c[0];
                     }
                 case 1:
                     {
                         // read(char[], int, int)
                         char[] c = new char[2];
                         int ret = input.Read(c, 1, 1);
-                        return ret == 0 ? -1 : c[1];
+                        return ret <= 0 ? -1 : c[1];
                     }
                 /* LUCENE TO-DO not sure if needed, CharBuffer not supported
                   case 2:


### PR DESCRIPTION
This fixes failures that can be observed in Lucene.Net.Analysis tests and possible other locations with test failure messages like these:

Expected string length 9 but was 13. Strings differ at index 1.
  Expected: "npffoeijg"
  But was:  "n\0pf\0\0\0foeijg"

Expected string length 2 but was 1. Strings differ at index 1.
  Expected: "[\0"
  But was:  "["

Expected string length 6 but was 8. Strings differ at index 6.
  Expected: "432794"
  But was:  "432794\0\0"

MockTokenizer implementation uses equals comparison to 0 to check for an end of stream and rewrites it to -1 as Java would return and the calling classes expect. However some of the implementations (e.g. MockCharFilter) return -1 already and MockTokenizer should handle that. Without that check it ends up using values in the byte array which in "end of stream" cases contains \0 chars.

I tried checking other locations for cases of the same bug and could not find any. Although it does not mean it does not exist. It is so subtle and hard to find, took me forever just to figure out what was going on. Hopefully we don't have this situation anywhere else, and if we do, tests will lead us to such locations.
