### PR TITLE
throw a more informative exception to track down TeamCity test failures

### DIFF
--- a/src/Lucene.Net.TestFramework/Util/Paths.cs
+++ b/src/Lucene.Net.TestFramework/Util/Paths.cs
@@ -139,10 +139,23 @@ namespace Lucene.Net.Util
                     // where [Section] is either core, demo, or contrib, and [Build] is either Debug or Release.
                     string assemblyLocation = AssemblyDirectory;
                     int index = -1;
+
+                    var buildPathPart = Path.DirectorySeparatorChar + "build" + Path.DirectorySeparatorChar;
+                    var binPathPart = Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar;
+
                     if (assemblyLocation.IndexOf("build", StringComparison.InvariantCultureIgnoreCase) > -1)
-                        index = assemblyLocation.IndexOf(Path.DirectorySeparatorChar + "build" + Path.DirectorySeparatorChar, StringComparison.InvariantCultureIgnoreCase);
+                    {
+                        index = assemblyLocation.IndexOf(buildPathPart, StringComparison.InvariantCultureIgnoreCase);
+                    }
                     else
-                        index = assemblyLocation.IndexOf(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar, StringComparison.InvariantCultureIgnoreCase);
+                    {
+                        index = assemblyLocation.IndexOf(binPathPart, StringComparison.InvariantCultureIgnoreCase);
+                    }
+
+                    if (index < 0)
+                    {
+                        throw new ArgumentOutOfRangeException("Could not locate project root directory in " + assemblyLocation + ", checked " + buildPathPart + " and " + binPathPart);
+                    }
 
                     int difference = assemblyLocation.Substring(index).Count(o => o == Path.DirectorySeparatorChar);
 


### PR DESCRIPTION
TeamCity CI tests show a lot of tests failing locating test artifacts:

Test(s) failed. System.ArgumentOutOfRangeException : StartIndex cannot be less than zero.
Parameter name: startIndex
   at System.String.Substring(Int32 startIndex, Int32 length)
   at Lucene.Net.Util.Paths.get_ProjectRootDirectory() in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.TestFramework\Util\Paths.cs:line 145
   at Lucene.Net.Util.Paths.ResolveTestArtifactPath(String fileName) in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.TestFramework\Util\Paths.cs:line 115
   at Lucene.Net.Util.LineFileDocs..ctor(Random random, String path, Boolean useDocValues) in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.TestFramework\Util\LineFileDocs.cs:line 248

Link: http://teamcity.codebetter.com/viewLog.html?buildId=176935&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId-5403764739034623459

Hard to say what the issue is as running locally from NUnit or R# in VS does not cause this issue to appear even though the same code path is triggered.

Added a better exception that will report what value is returned for assembly location that might be something that is not expected.
