### PR TITLE
fix ProjectRootDirectory lookup

### DIFF
--- a/src/Lucene.Net.TestFramework/Util/Paths.cs
+++ b/src/Lucene.Net.TestFramework/Util/Paths.cs
@@ -137,32 +137,27 @@ namespace Lucene.Net.Util
                 {
                     // we currently assume that the assembly's directory is root/bin/[Section]/[Build]
                     // where [Section] is either core, demo, or contrib, and [Build] is either Debug or Release.
-                    string assemblyLocation = AssemblyDirectory;
-                    int index = -1;
+                    var assemblyLocation = AssemblyDirectory;
 
-                    var buildPathPart = Path.DirectorySeparatorChar + "build" + Path.DirectorySeparatorChar;
-                    var binPathPart = Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar;
-
-                    if (assemblyLocation.IndexOf("build", StringComparison.InvariantCultureIgnoreCase) > -1)
+                    var index = assemblyLocation.IndexOf(Path.DirectorySeparatorChar + "build" + Path.DirectorySeparatorChar, StringComparison.InvariantCultureIgnoreCase);
+                    if (index == -1)
                     {
-                        index = assemblyLocation.IndexOf(buildPathPart, StringComparison.InvariantCultureIgnoreCase);
-                    }
-                    else
-                    {
-                        index = assemblyLocation.IndexOf(binPathPart, StringComparison.InvariantCultureIgnoreCase);
+                        index = assemblyLocation.IndexOf(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar, StringComparison.InvariantCultureIgnoreCase);
                     }
 
                     if (index < 0)
                     {
-                        throw new ArgumentOutOfRangeException("Could not locate project root directory in " + assemblyLocation + ", checked " + buildPathPart + " and " + binPathPart);
+                        throw new ArgumentOutOfRangeException("Could not locate project root directory in " + assemblyLocation);
                     }
 
-                    int difference = assemblyLocation.Substring(index).Count(o => o == Path.DirectorySeparatorChar);
+                    var difference = assemblyLocation.Substring(index).Count(o => o == Path.DirectorySeparatorChar);
 
                     var list = new List<string>();
 
                     for (int i = 0; i < difference; i++)
+                    {
                         list.Add("..");
+                    }
 
                     var parameters = list.ToArray();
 


### PR DESCRIPTION
When the tests are run in TeamCity, the assembly location is this:

Z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Tests\bin\Release

the "\Builds\" part was tripping up path look up logic as it would test for presence for "build" (case invariant) and then expect that to be "\build\". Rewrote it so that it checks first for "\build\" (instead of "build") and then for "\bin\" as a fallback.
