### PR TITLE
fixes for handling surrogate chars properly

### DIFF
--- a/src/Lucene.Net.Core/Support/Character.cs
+++ b/src/Lucene.Net.Core/Support/Character.cs
@@ -80,15 +80,16 @@ namespace Lucene.Net.Support
 
         public static int ToChars(int codePoint, char[] dst, int dstIndex)
         {
-            // .NET Port: we don't have to do anything funky with surrogates here. chars are always UTF-16.
-            dst[dstIndex] = (char)codePoint;
-            return 1; // always 1 char written in .NET
+            var converted = UnicodeUtil.ToCharArray(new[] {codePoint}, 0, 1);
+
+            Array.Copy(converted, 0, dst, dstIndex, converted.Length);
+
+            return converted.Length;
         }
 
         public static char[] ToChars(int codePoint)
         {
-            // .NET Port: we don't have to do anything funky with surrogates here. chars are always UTF-16.
-            return new[] { (char)codePoint };
+            return UnicodeUtil.ToCharArray(new[] {codePoint}, 0, 1);
         }
 
         public static int ToCodePoint(char high, char low)
@@ -104,8 +105,11 @@ namespace Lucene.Net.Support
 
         public static int ToLowerCase(int codePoint)
         {
-            // .NET Port: chars are always UTF-16 in .NET
-            return (int)char.ToLower((char)codePoint);
+            var str = UnicodeUtil.NewString(new[] {codePoint}, 0, 1);
+
+            str = str.ToLower();
+
+            return CodePointAt(str, 0);
         }
 
         public static int CharCount(int codePoint)

--- a/src/Lucene.Net.Core/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net.Core/Util/UnicodeUtil.cs
@@ -538,6 +538,19 @@ namespace Lucene.Net.Util
         /// <exception cref="IndexOutOfBoundsException"> If the offset or count are out of bounds. </exception>
         public static string NewString(int[] codePoints, int offset, int count)
         {
+            var chars = ToCharArray(codePoints, offset, count);
+            return new string(chars);
+        }
+
+        /// <summary>
+        /// Generates char array that represents the provided input code points
+        /// </summary>
+        /// <param name="codePoints"> The code array </param>
+        /// <param name="offset"> The start of the text in the code point array </param>
+        /// <param name="count"> The number of code points </param>
+        /// <returns> a char array representing the code points between offset and count </returns>
+        public static char[] ToCharArray(int[] codePoints, int offset, int count)
+        {
             if (count < 0)
             {
                 throw new System.ArgumentException();
@@ -577,7 +590,10 @@ namespace Lucene.Net.Util
                     }
                 }
             }
-            return new string(chars, 0, w);
+
+            var result = new char[w];
+            Array.Copy(chars, result, w);
+            return result;
         }
 
         // for debugging


### PR DESCRIPTION
TestUTF32ToUTF8.TestRandomRanges were failing because of the issue with how the surrogate pairs were handled in Character class. Changed the implementation to call UnicodeUtils to provide correct ToChars implementation. Now the test passes.

Added method to UnicodeUtil to provide public API for converting code points to strings and chars so that we don't have to do repeating conversion (char[] -> string -> char[]).
