### PR TITLE
comment out incorrect default codec setting, fixes for read

### DIFF
--- a/src/Lucene.Net.Tests/core/Analysis/TestGraphTokenizers.cs
+++ b/src/Lucene.Net.Tests/core/Analysis/TestGraphTokenizers.cs
@@ -123,7 +123,9 @@ namespace Lucene.Net.Analysis
                     int count = input.Read(buffer, 0, buffer.Length);
 
                     //.NET TextReader.Read(buff, int, int) returns 0, not -1 on no chars
-                    if (count == 0)
+                    // but in some cases, such as MockCharFilter, it overloads read and returns -1
+                    // so we should handle both 0 and -1 values
+                    if (count <= 0)
                     {
                         break;
                     }

--- a/src/Lucene.Net.Tests/core/Index/TestRollingUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestRollingUpdates.cs
@@ -48,10 +48,12 @@ namespace Lucene.Net.Index
             LineFileDocs docs = new LineFileDocs(random, DefaultCodecSupportsDocValues());
 
             //provider.register(new MemoryCodec());
-            if ((!"Lucene3x".Equals(Codec.Default.Name)) && Random().NextBoolean())
-            {
-                Codec.Default = TestUtil.AlwaysPostingsFormat(new Codecs.Lucene3x.Lucene3xPostingsFormat(/*Random().NextBoolean(), random.NextDouble()*/));
-            }
+            // LUCENE TODO: uncomment this out once MemoryPostingsFormat is brought over
+            //if ((!"Lucene3x".Equals(Codec.Default.Name)) && Random().NextBoolean())
+            //{
+            //    Codec.Default =
+            //        TestUtil.AlwaysPostingsFormat(new MemoryPostingsFormat(random().nextBoolean(), random.NextFloat()));
+            //}
 
             MockAnalyzer analyzer = new MockAnalyzer(Random());
             analyzer.MaxTokenLength = TestUtil.NextInt(Random(), 1, IndexWriter.MAX_TERM_LENGTH);


### PR DESCRIPTION
TestRollingUpdates can leave Default Codec in unusable state, comment that part out until the appropriate codecs are ported over.

TestGraphTokenizer does not handle TextReader subclasses that return -1 instead of 0 when end of stream is reached.
