### PR TITLE
open and access memory mapped file in read mode

### DIFF
--- a/src/Lucene.Net.Core/Store/MMapDirectory.cs
+++ b/src/Lucene.Net.Core/Store/MMapDirectory.cs
@@ -352,14 +352,16 @@ namespace Lucene.Net.Store
              */
 
             if (input.memoryMappedFile == null)
-                input.memoryMappedFile = MemoryMappedFile.CreateFromFile(fc, null, length == 0 ? 100 : length, MemoryMappedFileAccess.ReadWrite, null, HandleInheritability.Inheritable, false);
+            {
+                input.memoryMappedFile = MemoryMappedFile.CreateFromFile(fc, null, length == 0 ? 100 : length, MemoryMappedFileAccess.Read, null, HandleInheritability.Inheritable, false);
+            }
 
             long bufferStart = 0L;
             for (int bufNr = 0; bufNr < nrBuffers; bufNr++)
             {
                 int bufSize = (int)((length > (bufferStart + chunkSize)) ? chunkSize : (length - bufferStart));
                 //LUCENE TO-DO
-                buffers[bufNr] = new MemoryMappedFileByteBuffer(input.memoryMappedFile.CreateViewAccessor(offset + bufferStart, bufSize), -1, 0, bufSize, bufSize);
+                buffers[bufNr] = new MemoryMappedFileByteBuffer(input.memoryMappedFile.CreateViewAccessor(offset + bufferStart, bufSize, MemoryMappedFileAccess.Read), -1, 0, bufSize, bufSize);
                 //buffers[bufNr] = fc.Map(FileStream.MapMode.READ_ONLY, offset + bufferStart, bufSize);
                 bufferStart += bufSize;
             }


### PR DESCRIPTION
~80 tests failed with UnauthorizedAccessException : Access to the path is denied. that point to MMapDirectory.Map call and how it accesses the MemoryMappedFile. Looks like we need to be explicit with "Read" flag when we open it and read from memory mapped files.

(Java version also accesses the file in MMapDirectory in Read Only mode: https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java)

I don't expect this commit to fix all of those tests as once the code gets passed the access denied it runs into other errors (e.g. timeout), but it gets us moving forward.
