### PR TITLE
Fix test lucene40 doc values format

### DIFF
--- a/src/Lucene.Net.TestFramework/Support/RandomizedTest.cs
+++ b/src/Lucene.Net.TestFramework/Support/RandomizedTest.cs
@@ -35,14 +35,14 @@ namespace Lucene.Net.TestFramework.Support
             return defaultValue;
         }
 
-        public void AssumeTrue(string msg, bool value)
+        public static void AssumeTrue(string msg, bool value)
         {
-            Assume.That(value);
+            Assume.That(value, msg);
         }
 
-        public void AssumeFalse(string msg, bool value)
+        public static void AssumeFalse(string msg, bool value)
         {
-            Assume.That(!value);
+            Assume.That(!value, msg);
         }
     }
 }

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -340,7 +340,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public static bool VERBOSE = RandomizedTest.SystemPropertyAsBoolean("tests.verbose",
 #if DEBUG
-            true
+            false
 #else
             false
 #endif
@@ -822,12 +822,12 @@ namespace Lucene.Net.Util
 
         public static void AssumeTrue(string msg, bool condition)
         {
-            //RandomizedTest.AssumeTrue(msg, condition);
+            RandomizedTest.AssumeTrue(msg, condition);
         }
 
         public static void AssumeFalse(string msg, bool condition)
         {
-            //RandomizedTest.AssumeFalse(msg, condition);
+            RandomizedTest.AssumeFalse(msg, condition);
         }
 
         public static void AssumeNoException(string msg, Exception e)

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -340,7 +340,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public static bool VERBOSE = RandomizedTest.SystemPropertyAsBoolean("tests.verbose",
 #if DEBUG
-            false
+            true
 #else
             false
 #endif


### PR DESCRIPTION
20 tests were failing in TestLucene40DocValuesFormat with "Lucene 4.0 does not support SortedSet docvalues". Lucene40 codec does not support sorted set but the tests ran anyway. What is happening is that the base class, BaseDocValuesFormatTestCase, uses the following test to see if it should run the test:

AssumeTrue("Codec does not support SORTED_SET", DefaultCodecSupportsSortedSet());

It looks like AssumeTrue internally had commented out RandomizedTests call that was supposed to mark the test as "inconclusive" with NUnit's Assume.That.

Uncommented the call, now the tests are not marked as failures.