### PR TITLE
Use Set equality check

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -490,7 +490,7 @@ namespace Lucene.Net.Index
             {
                 fields2.Add(field);
             }
-            Assert.AreEqual(fields1, fields2);
+            Assert.IsTrue(fields1.SetEquals(fields2));
 
             for (int i = 0; i < doc.FieldNames.Length; ++i)
             {


### PR DESCRIPTION
There are ~20 tests failing with this type of message:

Expected and actual are both &lt;System.Collections.Generic.HashSet`1[System.String]&gt;
  Values differ at index [0]
  Expected string length 16 but was 12. Strings differ at index 0.
  Expected: "fjdcqoqrmvtmfupr"
  But was:  "dsncorcvbzne"

After debugging through, it looked like assertion was comparing two sets that actually contained the same values but they were in different order. In Java Set implementations appear to override Equals so that AreEqual assertion passes there. In .NET we have to use SetEquals method to compare two sets if the intention is to make sure sets are of the same size and have the same elements.

Took forever to track down and seconds to fix, sigh...


