### PR TITLE
remove unnecessary byte buffer

### DIFF
--- a/src/Lucene.Net.Core/Support/Inflater.cs
+++ b/src/Lucene.Net.Core/Support/Inflater.cs
@@ -102,9 +102,7 @@ namespace Lucene.Net.Support
 
         public int Inflate(byte[] buffer, int offset, int count)
         {
-            //LUCENE TODO: brute-force converting for now to eliminate TypeMismatchError
-            byte[] byteBuffer = buffer.Select(b => (byte)b).ToArray();
-            return inflate3Method(byteBuffer, offset, count);
+            return inflate3Method(buffer, offset, count);
         }
 
         public void Reset()


### PR DESCRIPTION
Fixes null reference exception that can be observed at times in some of the TestCompressingStoredFieldsFormat and TestCompressingTermVectorsFormat tests. The issue is that those tests set Codec to CompressingCodec using CompressingCodec.RandomInstance which can result in HighCompressionCompressingCodec being used. HighCompressionCompressingCodec in turn uses decompressor that has a bug. The fix removes instantiation of a separate byte buffer in the Inflater and instead uses the buffer that was provided in the call. Instantiating a new buffer essentially wrote bits to an array that no upstream code used. So the callers were getting empty bytes buffer back always. There might be more test that were affected by this.

