### PR TITLE
fix ReverseByteReader Position setter

### DIFF
--- a/src/Lucene.Net.Core/Util/Fst/BytesStore.cs
+++ b/src/Lucene.Net.Core/Util/Fst/BytesStore.cs
@@ -482,12 +482,8 @@ namespace Lucene.Net.Util.Fst
                 }
                 set
                 {
-                    // NOTE: a little weird because if you
-                    // setPosition(0), the next byte you read is
-                    // bytes[0] ... but I would expect bytes[-1] (ie,
-                    // EOF)...?
                     int bufferIndex = (int)(value >> OuterInstance.blockBits);
-                    nextBuffer = bufferIndex - 1;
+                    nextBuffer = bufferIndex + 1;
                     OuterInstance.Current = OuterInstance.Blocks[bufferIndex];
                     nextRead = (int)(value & OuterInstance.BlockMask);
                     Debug.Assert(OuterInstance.Position == value, "pos=" + value + " getPos()=" + OuterInstance.Position);
@@ -564,12 +560,15 @@ namespace Lucene.Net.Util.Fst
                 }
                 set
                 {
+                    // NOTE: a little weird because if you
+                    // setPosition(0), the next byte you read is
+                    // bytes[0] ... but I would expect bytes[-1] (ie,
+                    // EOF)...?
                     int bufferIndex = (int)(value >> OuterInstance.blockBits);
-                    nextBuffer = bufferIndex + 1;
+                    nextBuffer = bufferIndex - 1;
                     OuterInstance.Current = OuterInstance.Blocks[bufferIndex];
                     nextRead = (int)(value & OuterInstance.BlockMask);
-                    //LUCENE TODO: Put this back
-                    //Debug.Assert(OuterInstance.Position == value);
+                    Debug.Assert(OuterInstance.Position == value, "value=" + value + " this.Position=" + this.Position);
                 }
             }
 


### PR DESCRIPTION
Part of the code that belonged in Forward reader had ended up in Reverse reader during port. Reviewed bot iterators to make sure they match what exists https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/util/fst/BytesStore.java 

This also now passes a bunch of failures in Lucene42Codec tests.