### PR TITLE
Lucene42 codec fixes

### DIFF
--- a/src/Lucene.Net.Core/Codecs/Lucene42/Lucene42DocValuesProducer.cs
+++ b/src/Lucene.Net.Core/Codecs/Lucene42/Lucene42DocValuesProducer.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Codecs.Lucene42
         private readonly IDictionary<int, NumericDocValues> NumericInstances = new Dictionary<int, NumericDocValues>();
 
         private readonly IDictionary<int, BinaryDocValues> BinaryInstances = new Dictionary<int, BinaryDocValues>();
-        private readonly IDictionary<int, FST<long>> FstInstances = new Dictionary<int, FST<long>>();
+        private readonly IDictionary<int, FST<long?>> FstInstances = new Dictionary<int, FST<long?>>();
 
         private readonly int MaxDoc;
         private readonly AtomicLong RamBytesUsed_Renamed;
@@ -430,26 +430,26 @@ namespace Lucene.Net.Codecs.Lucene42
         public override SortedDocValues GetSorted(FieldInfo field)
         {
             FSTEntry entry = Fsts[field.Number];
-            FST<long> instance;
+            FST<long?> instance;
             lock (this)
             {
                 if (!FstInstances.TryGetValue(field.Number, out instance))
                 {
                     Data.Seek(entry.Offset);
-                    instance = new FST<long>(Data, PositiveIntOutputs.Singleton);
+                    instance = new FST<long?>(Data, PositiveIntOutputs.Singleton);
                     RamBytesUsed_Renamed.AddAndGet(instance.SizeInBytes());
                     FstInstances[field.Number] = instance;
                 }
             }
             NumericDocValues docToOrd = GetNumeric(field);
-            FST<long> fst = instance;
+            FST<long?> fst = instance;
 
             // per-thread resources
-            FST<long>.BytesReader @in = fst.BytesReader;
-            FST<long>.Arc<long> firstArc = new FST<long>.Arc<long>();
-            FST<long>.Arc<long> scratchArc = new FST<long>.Arc<long>();
+            FST<long?>.BytesReader @in = fst.BytesReader;
+            FST<long?>.Arc<long?> firstArc = new FST<long?>.Arc<long?>();
+            FST<long?>.Arc<long?> scratchArc = new FST<long?>.Arc<long?>();
             IntsRef scratchInts = new IntsRef();
-            BytesRefFSTEnum<long> fstEnum = new BytesRefFSTEnum<long>(fst);
+            BytesRefFSTEnum<long?> fstEnum = new BytesRefFSTEnum<long?>(fst);
 
             return new SortedDocValuesAnonymousInnerClassHelper(this, entry, docToOrd, fst, @in, firstArc, scratchArc, scratchInts, fstEnum);
         }
@@ -460,14 +460,14 @@ namespace Lucene.Net.Codecs.Lucene42
 
             private FSTEntry Entry;
             private NumericDocValues DocToOrd;
-            private FST<long> Fst;
-            private FST<long>.BytesReader @in;
-            private FST<long>.Arc<long> FirstArc;
-            private FST<long>.Arc<long> ScratchArc;
+            private FST<long?> Fst;
+            private FST<long?>.BytesReader @in;
+            private FST<long?>.Arc<long?> FirstArc;
+            private FST<long?>.Arc<long?> ScratchArc;
             private IntsRef ScratchInts;
-            private BytesRefFSTEnum<long> FstEnum;
+            private BytesRefFSTEnum<long?> FstEnum;
 
-            public SortedDocValuesAnonymousInnerClassHelper(Lucene42DocValuesProducer outerInstance, FSTEntry entry, NumericDocValues docToOrd, FST<long> fst, FST<long>.BytesReader @in, FST<long>.Arc<long> firstArc, FST<long>.Arc<long> scratchArc, IntsRef scratchInts, BytesRefFSTEnum<long> fstEnum)
+            public SortedDocValuesAnonymousInnerClassHelper(Lucene42DocValuesProducer outerInstance, FSTEntry entry, NumericDocValues docToOrd, FST<long?> fst, FST<long?>.BytesReader @in, FST<long?>.Arc<long?> firstArc, FST<long?>.Arc<long?> scratchArc, IntsRef scratchInts, BytesRefFSTEnum<long?> fstEnum)
             {
                 this.OuterInstance = outerInstance;
                 this.Entry = entry;
@@ -507,7 +507,7 @@ namespace Lucene.Net.Codecs.Lucene42
             {
                 try
                 {
-                    BytesRefFSTEnum<long>.InputOutput<long> o = FstEnum.SeekCeil(key);
+                    BytesRefFSTEnum<long?>.InputOutput<long?> o = FstEnum.SeekCeil(key);
                     if (o == null)
                     {
                         return -ValueCount - 1;
@@ -548,26 +548,26 @@ namespace Lucene.Net.Codecs.Lucene42
             {
                 return DocValues.EMPTY_SORTED_SET; // empty FST!
             }
-            FST<long> instance;
+            FST<long?> instance;
             lock (this)
             {
                 if (!FstInstances.TryGetValue(field.Number, out instance))
                 {
                     Data.Seek(entry.Offset);
-                    instance = new FST<long>((DataInput)Data, Lucene.Net.Util.Fst.PositiveIntOutputs.Singleton);
+                    instance = new FST<long?>((DataInput)Data, Lucene.Net.Util.Fst.PositiveIntOutputs.Singleton);
                     RamBytesUsed_Renamed.AddAndGet(instance.SizeInBytes());
                     FstInstances[field.Number] = instance;
                 }
             }
             BinaryDocValues docToOrds = GetBinary(field);
-            FST<long> fst = instance;
+            FST<long?> fst = instance;
 
             // per-thread resources
-            FST<long>.BytesReader @in = fst.BytesReader;
-            FST<long>.Arc<long> firstArc = new FST<long>.Arc<long>();
-            FST<long>.Arc<long> scratchArc = new FST<long>.Arc<long>();
+            FST<long?>.BytesReader @in = fst.BytesReader;
+            FST<long?>.Arc<long?> firstArc = new FST<long?>.Arc<long?>();
+            FST<long?>.Arc<long?> scratchArc = new FST<long?>.Arc<long?>();
             IntsRef scratchInts = new IntsRef();
-            BytesRefFSTEnum<long> fstEnum = new BytesRefFSTEnum<long>(fst);
+            BytesRefFSTEnum<long?> fstEnum = new BytesRefFSTEnum<long?>(fst);
             BytesRef @ref = new BytesRef();
             ByteArrayDataInput input = new ByteArrayDataInput();
             return new SortedSetDocValuesAnonymousInnerClassHelper(this, entry, docToOrds, fst, @in, firstArc, scratchArc, scratchInts, fstEnum, @ref, input);
@@ -579,16 +579,16 @@ namespace Lucene.Net.Codecs.Lucene42
 
             private FSTEntry Entry;
             private BinaryDocValues DocToOrds;
-            private FST<long> Fst;
-            private FST<long>.BytesReader @in;
-            private FST<long>.Arc<long> FirstArc;
-            private FST<long>.Arc<long> ScratchArc;
+            private FST<long?> Fst;
+            private FST<long?>.BytesReader @in;
+            private FST<long?>.Arc<long?> FirstArc;
+            private FST<long?>.Arc<long?> ScratchArc;
             private IntsRef ScratchInts;
-            private BytesRefFSTEnum<long> FstEnum;
+            private BytesRefFSTEnum<long?> FstEnum;
             private BytesRef @ref;
             private ByteArrayDataInput Input;
 
-            public SortedSetDocValuesAnonymousInnerClassHelper(Lucene42DocValuesProducer outerInstance, FSTEntry entry, BinaryDocValues docToOrds, FST<long> fst, FST<long>.BytesReader @in, FST<long>.Arc<long> firstArc, FST<long>.Arc<long> scratchArc, IntsRef scratchInts, BytesRefFSTEnum<long> fstEnum, BytesRef @ref, ByteArrayDataInput input)
+            public SortedSetDocValuesAnonymousInnerClassHelper(Lucene42DocValuesProducer outerInstance, FSTEntry entry, BinaryDocValues docToOrds, FST<long?> fst, FST<long?>.BytesReader @in, FST<long?>.Arc<long?> firstArc, FST<long?>.Arc<long?> scratchArc, IntsRef scratchInts, BytesRefFSTEnum<long?> fstEnum, BytesRef @ref, ByteArrayDataInput input)
             {
                 this.OuterInstance = outerInstance;
                 this.Entry = entry;
@@ -650,18 +650,18 @@ namespace Lucene.Net.Codecs.Lucene42
             {
                 try
                 {
-                    Lucene.Net.Util.Fst.BytesRefFSTEnum<long>.InputOutput<long> o = FstEnum.SeekCeil(key);
+                    Lucene.Net.Util.Fst.BytesRefFSTEnum<long?>.InputOutput<long?> o = FstEnum.SeekCeil(key);
                     if (o == null)
                     {
                         return -ValueCount - 1;
                     }
                     else if (o.Input.Equals(key))
                     {
-                        return (int)o.Output;
+                        return (int)o.Output.Value;
                     }
                     else
                     {
-                        return -o.Output - 1;
+                        return -o.Output.Value - 1;
                     }
                 }
                 catch (System.IO.IOException bogus)
@@ -730,28 +730,28 @@ namespace Lucene.Net.Codecs.Lucene42
         // exposes FSTEnum directly as a TermsEnum: avoids binary-search next()
         internal class FSTTermsEnum : TermsEnum
         {
-            internal readonly BytesRefFSTEnum<long> @in;
+            internal readonly BytesRefFSTEnum<long?> @in;
 
             // this is all for the complicated seek(ord)...
             // maybe we should add a FSTEnum that supports this operation?
-            internal readonly FST<long> Fst;
+            internal readonly FST<long?> Fst;
 
-            internal readonly FST<long>.BytesReader BytesReader;
-            internal readonly FST<long>.Arc<long> FirstArc = new FST<long>.Arc<long>();
-            internal readonly FST<long>.Arc<long> ScratchArc = new FST<long>.Arc<long>();
+            internal readonly FST<long?>.BytesReader BytesReader;
+            internal readonly FST<long?>.Arc<long?> FirstArc = new FST<long?>.Arc<long?>();
+            internal readonly FST<long?>.Arc<long?> ScratchArc = new FST<long?>.Arc<long?>();
             internal readonly IntsRef ScratchInts = new IntsRef();
             internal readonly BytesRef ScratchBytes = new BytesRef();
 
-            internal FSTTermsEnum(FST<long> fst)
+            internal FSTTermsEnum(FST<long?> fst)
             {
                 this.Fst = fst;
-                @in = new BytesRefFSTEnum<long>(fst);
+                @in = new BytesRefFSTEnum<long?>(fst);
                 BytesReader = fst.BytesReader;
             }
 
             public override BytesRef Next()
             {
-                Lucene.Net.Util.Fst.BytesRefFSTEnum<long>.InputOutput<long> io = @in.Next();
+                Lucene.Net.Util.Fst.BytesRefFSTEnum<long?>.InputOutput<long?> io = @in.Next();
                 if (io == null)
                 {
                     return null;
@@ -822,7 +822,7 @@ namespace Lucene.Net.Codecs.Lucene42
 
             public override long Ord()
             {
-                return @in.Current().Output;
+                return @in.Current().Output.Value;
             }
 
             public override int DocFreq()

--- a/src/Lucene.Net.Core/Util/Fst/Builder.cs
+++ b/src/Lucene.Net.Core/Util/Fst/Builder.cs
@@ -464,7 +464,7 @@ namespace Lucene.Net.Util.Fst
                 T commonOutputPrefix;
                 T wordSuffix;
 
-                if ((object)lastOutput != (object)NO_OUTPUT)
+                if (!lastOutput.Equals(NO_OUTPUT))
                 {
                     commonOutputPrefix = Fst.Outputs.Common(output, lastOutput);
                     Debug.Assert(ValidOutput(commonOutputPrefix));
@@ -503,7 +503,7 @@ namespace Lucene.Net.Util.Fst
 
         private bool ValidOutput(T output)
         {
-            return (object)output == (object)NO_OUTPUT || !output.Equals(NO_OUTPUT);
+            return output.Equals(NO_OUTPUT) || !output.Equals(NO_OUTPUT);
         }
 
         /// <summary>

--- a/src/Lucene.Net.Core/Util/Fst/BytesStore.cs
+++ b/src/Lucene.Net.Core/Util/Fst/BytesStore.cs
@@ -486,7 +486,7 @@ namespace Lucene.Net.Util.Fst
                     nextBuffer = bufferIndex + 1;
                     OuterInstance.Current = OuterInstance.Blocks[bufferIndex];
                     nextRead = (int)(value & OuterInstance.BlockMask);
-                    Debug.Assert(OuterInstance.Position == value, "pos=" + value + " getPos()=" + OuterInstance.Position);
+                    Debug.Assert(this.Position == value, "pos=" + value + " getPos()=" + this.Position);
                 }
             }
 
@@ -568,7 +568,7 @@ namespace Lucene.Net.Util.Fst
                     nextBuffer = bufferIndex - 1;
                     OuterInstance.Current = OuterInstance.Blocks[bufferIndex];
                     nextRead = (int)(value & OuterInstance.BlockMask);
-                    Debug.Assert(OuterInstance.Position == value, "value=" + value + " this.Position=" + this.Position);
+                    Debug.Assert(this.Position == value, "value=" + value + " this.Position=" + this.Position);
                 }
             }
 

--- a/src/Lucene.Net.Core/Util/Fst/FST.cs
+++ b/src/Lucene.Net.Core/Util/Fst/FST.cs
@@ -715,14 +715,14 @@ namespace Lucene.Net.Util.Fst
                 if (arc.IsFinal)
                 {
                     flags += BIT_FINAL_ARC;
-                    if ((object)arc.NextFinalOutput != (object)NO_OUTPUT)
+                    if (!arc.NextFinalOutput.Equals(NO_OUTPUT))
                     {
                         flags += BIT_ARC_HAS_FINAL_OUTPUT;
                     }
                 }
                 else
                 {
-                    Debug.Assert((object)arc.NextFinalOutput == (object)NO_OUTPUT);
+                    Debug.Assert(arc.NextFinalOutput.Equals(NO_OUTPUT));
                 }
 
                 bool targetHasArcs = target.Node > 0;
@@ -736,7 +736,7 @@ namespace Lucene.Net.Util.Fst
                     InCounts.Set((int)target.Node, InCounts.Get((int)target.Node) + 1);
                 }
 
-                if ((object)arc.Output != (object)NO_OUTPUT)
+                if (!arc.Output.Equals(NO_OUTPUT))
                 {
                     flags += BIT_ARC_HAS_OUTPUT;
                 }
@@ -746,14 +746,14 @@ namespace Lucene.Net.Util.Fst
 
                 // System.out.println("  write arc: label=" + (char) arc.Label + " flags=" + flags + " target=" + target.Node + " pos=" + bytes.getPosition() + " output=" + outputs.outputToString(arc.Output));
 
-                if ((object)arc.Output != (object)NO_OUTPUT)
+                if (!arc.Output.Equals(NO_OUTPUT))
                 {
                     Outputs.Write(arc.Output, Bytes);
                     //System.out.println("    write output");
                     arcWithOutputCount++;
                 }
 
-                if ((object)arc.NextFinalOutput != (object)NO_OUTPUT)
+                if (!arc.NextFinalOutput.Equals(NO_OUTPUT))
                 {
                     //System.out.println("    write final output");
                     Outputs.WriteFinalOutput(arc.NextFinalOutput, Bytes);
@@ -888,7 +888,7 @@ namespace Lucene.Net.Util.Fst
             {
                 arc.Flags = (sbyte)(BIT_FINAL_ARC | BIT_LAST_ARC);
                 arc.NextFinalOutput = emptyOutput;
-                if ((object)emptyOutput != (object)NO_OUTPUT)
+                if (!emptyOutput.Equals(NO_OUTPUT))
                 {
                     arc.Flags |= (sbyte)BIT_ARC_HAS_FINAL_OUTPUT;
                 }
@@ -1878,21 +1878,21 @@ namespace Lucene.Net.Util.Fst
                             if (arc.Final)
                             {
                                 flags += (sbyte)BIT_FINAL_ARC;
-                                if ((object)arc.NextFinalOutput != (object)NO_OUTPUT)
+                                if (!arc.NextFinalOutput.Equals(NO_OUTPUT))
                                 {
                                     flags += (sbyte)BIT_ARC_HAS_FINAL_OUTPUT;
                                 }
                             }
                             else
                             {
-                                Debug.Assert((object)arc.NextFinalOutput == (object)NO_OUTPUT);
+                                Debug.Assert(arc.NextFinalOutput.Equals(NO_OUTPUT));
                             }
                             if (!TargetHasArcs(arc))
                             {
                                 flags += (sbyte)BIT_STOP_NODE;
                             }
 
-                            if ((object)arc.Output != (object)NO_OUTPUT)
+                            if (!arc.Output.Equals(NO_OUTPUT))
                             {
                                 flags += (sbyte)BIT_ARC_HAS_OUTPUT;
                             }
@@ -1934,7 +1934,7 @@ namespace Lucene.Net.Util.Fst
 
                             fst.WriteLabel(writer, arc.Label);
 
-                            if ((object)arc.Output != (object)NO_OUTPUT)
+                            if (!arc.Output.Equals(NO_OUTPUT))
                             {
                                 Outputs.Write(arc.Output, writer);
                                 if (!retry)
@@ -1942,7 +1942,7 @@ namespace Lucene.Net.Util.Fst
                                     fst.arcWithOutputCount++;
                                 }
                             }
-                            if ((object)arc.NextFinalOutput != (object)NO_OUTPUT)
+                            if (!arc.NextFinalOutput.Equals(NO_OUTPUT))
                             {
                                 Outputs.WriteFinalOutput(arc.NextFinalOutput, writer);
                             }

--- a/src/Lucene.Net.Core/Util/Fst/PairOutputs.cs
+++ b/src/Lucene.Net.Core/Util/Fst/PairOutputs.cs
@@ -91,7 +91,7 @@ namespace Lucene.Net.Util.Fst
                 b = Outputs2.NoOutput;
             }
 
-            if ((object)a == (object)Outputs1.NoOutput && (object)b == (object)Outputs2.NoOutput)
+            if (a.Equals(Outputs1.NoOutput) && b.Equals(Outputs2.NoOutput))
             {
                 return NO_OUTPUT;
             }
@@ -109,19 +109,19 @@ namespace Lucene.Net.Util.Fst
             bool noOutput1 = pair.Output1.Equals(Outputs1.NoOutput);
             bool noOutput2 = pair.Output2.Equals(Outputs2.NoOutput);
 
-            if (noOutput1 && (object)pair.Output1 != (object)Outputs1.NoOutput)
+            if (noOutput1 && !pair.Output1.Equals(Outputs1.NoOutput))
             {
                 return false;
             }
 
-            if (noOutput2 && (object)pair.Output2 != (object)Outputs2.NoOutput)
+            if (noOutput2 && !pair.Output2.Equals(Outputs2.NoOutput))
             {
                 return false;
             }
 
             if (noOutput1 && noOutput2)
             {
-                if (pair != NO_OUTPUT)
+                if (!pair.Equals(NO_OUTPUT))
                 {
                     return false;
                 }

--- a/src/Lucene.Net.Core/Util/Fst/PositiveIntOutputs.cs
+++ b/src/Lucene.Net.Core/Util/Fst/PositiveIntOutputs.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Util.Fst
     ///
     /// @lucene.experimental
     /// </summary>
-    public sealed class PositiveIntOutputs : Outputs<long>
+    public sealed class PositiveIntOutputs : Outputs<long?>
     {
         private static readonly long NO_OUTPUT = new long();
 
@@ -47,7 +47,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        public override long Common(long output1, long output2)
+        public override long? Common(long? output1, long? output2)
         {
             Debug.Assert(Valid(output1));
             Debug.Assert(Valid(output2));
@@ -59,11 +59,11 @@ namespace Lucene.Net.Util.Fst
             {
                 Debug.Assert(output1 > 0);
                 Debug.Assert(output2 > 0);
-                return Math.Min(output1, output2);
+                return Math.Min(output1.Value, output2.Value);
             }
         }
 
-        public override long Subtract(long output, long inc)
+        public override long? Subtract(long? output, long? inc)
         {
             Debug.Assert(Valid(output));
             Debug.Assert(Valid(inc));
@@ -83,7 +83,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        public override long Add(long prefix, long output)
+        public override long? Add(long? prefix, long? output)
         {
             Debug.Assert(Valid(prefix));
             Debug.Assert(Valid(output));
@@ -101,13 +101,13 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        public override void Write(long output, DataOutput @out)
+        public override void Write(long? output, DataOutput @out)
         {
             Debug.Assert(Valid(output));
-            @out.WriteVLong(output);
+            @out.WriteVLong(output.Value);
         }
 
-        public override long Read(DataInput @in)
+        public override long? Read(DataInput @in)
         {
             long v = @in.ReadVLong();
             if (v == 0)
@@ -120,14 +120,14 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private bool Valid(long o)
+        private bool Valid(long? o)
         {
-            Debug.Assert(o != null);
+            Debug.Assert(o != null, "PositiveIntOutput precondition fail");
             Debug.Assert(o == NO_OUTPUT || o > 0, "o=" + o);
             return true;
         }
 
-        public override long NoOutput
+        public override long? NoOutput
         {
             get
             {
@@ -135,7 +135,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        public override string OutputToString(long output)
+        public override string OutputToString(long? output)
         {
             return output.ToString();
         }

--- a/src/Lucene.Net.Core/Util/Fst/Util.cs
+++ b/src/Lucene.Net.Core/Util/Fst/Util.cs
@@ -122,14 +122,14 @@ namespace Lucene.Net.Util.Fst
         ///  2, ...), or file offets (when appending to a file)
         ///  fit this.
         /// </summary>
-        public static IntsRef GetByOutput(FST<long> fst, long targetOutput)
+        public static IntsRef GetByOutput(FST<long?> fst, long targetOutput)
         {
             var @in = fst.BytesReader;
 
             // TODO: would be nice not to alloc this on every lookup
-            FST<long>.Arc<long> arc = fst.GetFirstArc(new FST<long>.Arc<long>());
+            FST<long?>.Arc<long?> arc = fst.GetFirstArc(new FST<long?>.Arc<long?>());
 
-            FST<long>.Arc<long> scratchArc = new FST<long>.Arc<long>();
+            FST<long?>.Arc<long?> scratchArc = new FST<long?>.Arc<long?>();
 
             IntsRef result = new IntsRef();
 
@@ -140,9 +140,9 @@ namespace Lucene.Net.Util.Fst
         /// Expert: like <seealso cref="Util#getByOutput(FST, long)"/> except reusing
         /// BytesReader, initial and scratch Arc, and result.
         /// </summary>
-        public static IntsRef GetByOutput(FST<long> fst, long targetOutput, FST<long>.BytesReader @in, FST<long>.Arc<long> arc, FST<long>.Arc<long> scratchArc, IntsRef result)
+        public static IntsRef GetByOutput(FST<long?> fst, long targetOutput, FST<long?>.BytesReader @in, FST<long?>.Arc<long?> arc, FST<long?>.Arc<long?> scratchArc, IntsRef result)
         {
-            long output = arc.Output;
+            long output = arc.Output.Value;
             int upto = 0;
 
             //System.out.println("reverseLookup output=" + targetOutput);
@@ -152,7 +152,7 @@ namespace Lucene.Net.Util.Fst
                 //System.out.println("loop: output=" + output + " upto=" + upto + " arc=" + arc);
                 if (arc.Final)
                 {
-                    long finalOutput = output + arc.NextFinalOutput;
+                    long finalOutput = output + arc.NextFinalOutput.Value;
                     //System.out.println("  isFinal finalOutput=" + finalOutput);
                     if (finalOutput == targetOutput)
                     {
@@ -167,7 +167,7 @@ namespace Lucene.Net.Util.Fst
                     }
                 }
 
-                if (FST<long>.TargetHasArcs(arc))
+                if (FST<long?>.TargetHasArcs(arc))
                 {
                     //System.out.println("  targetHasArcs");
                     if (result.Ints.Length == upto)
@@ -194,7 +194,7 @@ namespace Lucene.Net.Util.Fst
                             long minArcOutput;
                             if ((flags & FST<long>.BIT_ARC_HAS_OUTPUT) != 0)
                             {
-                                long arcOutput = fst.Outputs.Read(@in);
+                                long arcOutput = fst.Outputs.Read(@in).Value;
                                 minArcOutput = output + arcOutput;
                             }
                             else
@@ -231,11 +231,11 @@ namespace Lucene.Net.Util.Fst
 
                         fst.ReadNextRealArc(arc, @in);
                         result.Ints[upto++] = arc.Label;
-                        output += arc.Output;
+                        output += arc.Output.Value;
                     }
                     else
                     {
-                        FST<long>.Arc<long> prevArc = null;
+                        FST<long?>.Arc<long?> prevArc = null;
 
                         while (true)
                         {
@@ -243,7 +243,7 @@ namespace Lucene.Net.Util.Fst
 
                             // this is the min output we'd hit if we follow
                             // this arc:
-                            long minArcOutput = output + arc.Output;
+                            long minArcOutput = output + arc.Output.Value;
 
                             if (minArcOutput == targetOutput)
                             {
@@ -265,7 +265,7 @@ namespace Lucene.Net.Util.Fst
                                     // Recurse on previous arc:
                                     arc.CopyFrom(prevArc);
                                     result.Ints[upto++] = arc.Label;
-                                    output += arc.Output;
+                                    output += arc.Output.Value;
                                     //System.out.println("    recurse prev label=" + (char) arc.label + " output=" + output);
                                     break;
                                 }

--- a/src/Lucene.Net.Core/Util/Fst/Util.cs
+++ b/src/Lucene.Net.Core/Util/Fst/Util.cs
@@ -780,7 +780,7 @@ namespace Lucene.Net.Util.Fst
                 if (startArc.Final)
                 {
                     isFinal = true;
-                    finalOutput = (object)startArc.NextFinalOutput == (object)NO_OUTPUT ? default(T) : startArc.NextFinalOutput;
+                    finalOutput = startArc.NextFinalOutput.Equals(NO_OUTPUT) ? default(T) : startArc.NextFinalOutput;
                 }
                 else
                 {
@@ -848,7 +848,7 @@ namespace Lucene.Net.Util.Fst
                                 }
 
                                 string finalOutput;
-                                if (arc.NextFinalOutput != null && (object)arc.NextFinalOutput != (object)NO_OUTPUT)
+                                if (arc.NextFinalOutput != null && !arc.NextFinalOutput.Equals(NO_OUTPUT))
                                 {
                                     finalOutput = fst.Outputs.OutputToString(arc.NextFinalOutput);
                                 }
@@ -866,7 +866,7 @@ namespace Lucene.Net.Util.Fst
                             }
 
                             string outs;
-                            if ((object)arc.Output != (object)NO_OUTPUT)
+                            if (!arc.Output.Equals(NO_OUTPUT))
                             {
                                 outs = "/" + fst.Outputs.OutputToString(arc.Output);
                             }
@@ -875,7 +875,7 @@ namespace Lucene.Net.Util.Fst
                                 outs = "";
                             }
 
-                            if (!FST<T>.TargetHasArcs(arc) && arc.Final && (object)arc.NextFinalOutput != (object)NO_OUTPUT)
+                            if (!FST<T>.TargetHasArcs(arc) && arc.Final && !arc.NextFinalOutput.Equals(NO_OUTPUT))
                             {
                                 // Tricky special case: sometimes, due to
                                 // pruning, the builder can [sillily] produce

--- a/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42DocValuesConsumer.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42DocValuesConsumer.cs
@@ -288,7 +288,7 @@ namespace Lucene.Net.Codecs.Lucene42
             Meta.WriteByte((byte)Lucene42DocValuesProducer.FST);
             Meta.WriteLong(Data.FilePointer);
             PositiveIntOutputs outputs = PositiveIntOutputs.Singleton;
-            Builder<long> builder = new Builder<long>(INPUT_TYPE.BYTE1, outputs);
+            Builder<long?> builder = new Builder<long?>(INPUT_TYPE.BYTE1, outputs);
             IntsRef scratch = new IntsRef();
             long ord = 0;
             foreach (BytesRef v in values)
@@ -296,7 +296,7 @@ namespace Lucene.Net.Codecs.Lucene42
                 builder.Add(Util.ToIntsRef(v, scratch), ord);
                 ord++;
             }
-            Lucene.Net.Util.Fst.FST<long> fst = builder.Finish();
+            Lucene.Net.Util.Fst.FST<long?> fst = builder.Finish();
             if (fst != null)
             {
                 fst.Save(Data);

--- a/src/Lucene.Net.TestFramework/Util/fst/FSTTester.cs
+++ b/src/Lucene.Net.TestFramework/Util/fst/FSTTester.cs
@@ -401,16 +401,16 @@ namespace Lucene.Net.Util.Fst
         // FST is complete
         private void VerifyUnPruned(int inputMode, FST<T> fst)
         {
-            FST<long> fstLong;
-            ISet<long> validOutputs;
+            FST<long?> fstLong;
+            ISet<long?> validOutputs;
             long minLong = long.MaxValue;
             long maxLong = long.MinValue;
 
             if (DoReverseLookup)
             {
-                FST<long> fstLong0 = fst as FST<long>;
+                FST<long?> fstLong0 = fst as FST<long?>;
                 fstLong = fstLong0;
-                validOutputs = new HashSet<long>();
+                validOutputs = new HashSet<long?>();
                 foreach (InputOutput<T> pair in Pairs)
                 {
                     long? output = pair.Output as long?;

--- a/src/Lucene.Net.Tests/core/Util/Fst/Test2BFST.cs
+++ b/src/Lucene.Net.Tests/core/Util/Fst/Test2BFST.cs
@@ -234,8 +234,8 @@ namespace Lucene.Net.Util.Fst
                 // size = 3GB
                 {
                     Console.WriteLine("\nTEST: 3 GB size; doPack=" + doPack + " outputs=long");
-                    Outputs<long> outputs = PositiveIntOutputs.Singleton;
-                    Builder<long> b = new Builder<long>(FST.INPUT_TYPE.BYTE1, 0, 0, true, true, int.MaxValue, outputs, null, doPack, PackedInts.COMPACT, true, 15);
+                    Outputs<long?> outputs = PositiveIntOutputs.Singleton;
+                    Builder<long?> b = new Builder<long?>(FST.INPUT_TYPE.BYTE1, 0, 0, true, true, int.MaxValue, outputs, null, doPack, PackedInts.COMPACT, true, 15);
 
                     long output = 1;
 
@@ -259,7 +259,7 @@ namespace Lucene.Net.Util.Fst
                         NextInput(r, ints);
                     }
 
-                    FST<long> fst = b.Finish();
+                    FST<long?> fst = b.Finish();
 
                     for (int verify = 0; verify < 2; verify++)
                     {
@@ -285,7 +285,7 @@ namespace Lucene.Net.Util.Fst
                         }
 
                         Console.WriteLine("\nTEST: enum all input/outputs");
-                        IntsRefFSTEnum<long> fstEnum = new IntsRefFSTEnum<long>(fst);
+                        IntsRefFSTEnum<long?> fstEnum = new IntsRefFSTEnum<long?>(fst);
 
                         Arrays.Fill(ints, 0);
                         r = new Random(seed);
@@ -293,13 +293,13 @@ namespace Lucene.Net.Util.Fst
                         output = 1;
                         while (true)
                         {
-                            IntsRefFSTEnum<long>.InputOutput<long> pair = fstEnum.Next();
+                            IntsRefFSTEnum<long?>.InputOutput<long?> pair = fstEnum.Next();
                             if (pair == null)
                             {
                                 break;
                             }
                             Assert.AreEqual(input, pair.Input);
-                            Assert.AreEqual(output, (long)pair.Output);
+                            Assert.AreEqual(output, pair.Output.Value);
                             output += 1 + r.Next(10);
                             upto++;
                             NextInput(r, ints);
@@ -313,7 +313,7 @@ namespace Lucene.Net.Util.Fst
                             fst.Save(@out);
                             @out.Dispose();
                             IndexInput @in = dir.OpenInput("fst", IOContext.DEFAULT);
-                            fst = new FST<long>(@in, outputs);
+                            fst = new FST<long?>(@in, outputs);
                             @in.Dispose();
                         }
                         else


### PR DESCRIPTION
This PR contains fixes for numerous bugs in Lucene42 codec port, especially around FST functionality. 

First commit is all about changing from long to long? for FST instances to make sure that code branches such as this one https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.Core/Util/Fst/FST.cs#L465 evaluate properly. With long, Outputs.Merge gets called when it should not have and then an exception "Specified method is not supported." is thrown. (here is one example in TC: http://teamcity.codebetter.com/viewLog.html?buildId=178533&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId8117509285720903580)

Then once the fix allowed further code execution, noticed that FST and some other classes related to it use cast to object when comparing generic type values. Equals should be used as that will work for reference and value types properly. Next commits take care of that.

This also gets a bunch of TestLucene42DocValuesFormat tests to pass.