### PR TITLE
Codec Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ obj
 *.VisualState.xml
 *.userprefs
 *.pidb
+*.ide
 test-results
 build/artifacts
 build/bin

--- a/src/Lucene.Net.Codecs.Tests/Lucene.Net.Codecs.Tests.csproj
+++ b/src/Lucene.Net.Codecs.Tests/Lucene.Net.Codecs.Tests.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{351B75B1-BBD5-4E32-8036-7BED4E0135A6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Lucene.Net.Codecs.Tests</RootNamespace>
+    <AssemblyName>Lucene.Net.Codecs.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="diskdv\TestDiskDocValuesFormat.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Lucene.Net.Codecs\Lucene.Net.Codecs.csproj">
+      <Project>{3f79b6d4-4359-4f83-b64f-07f4f6262425}</Project>
+      <Name>Lucene.Net.Codecs</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Lucene.Net.Core\Lucene.Net.csproj">
+      <Project>{5d4ad9be-1ffb-41ab-9943-25737971bf57}</Project>
+      <Name>Lucene.Net</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Lucene.Net.Tests\Lucene.Net.Tests.csproj">
+      <Project>{de63db10-975f-460d-af85-572c17a91284}</Project>
+      <Name>Lucene.Net.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Lucene.Net.Codecs.Tests/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Codecs.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Lucene.Net.Codecs.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Lucene.Net.Codecs.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("39e5e0c8-c1d3-4583-b9f7-8fbd695e5601")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Lucene.Net.Codecs.Tests/blockterms/TestFixedGapPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/blockterms/TestFixedGapPostingsFormat.cs
@@ -1,0 +1,43 @@
+﻿namespace org.apache.lucene.codecs.blockterms
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using Lucene41WithOrds = org.apache.lucene.codecs.lucene41ords.Lucene41WithOrds;
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Basic tests of a PF using FixedGap terms dictionary
+	/// </summary>
+	// TODO: we should add an instantiation for VarGap too to TestFramework, and a test in this package
+	// TODO: ensure both of these are also in rotation in RandomCodec
+	public class TestFixedGapPostingsFormat : BasePostingsFormatTestCase
+	{
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new Lucene41WithOrds());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/bloom/TestBloomPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/bloom/TestBloomPostingsFormat.cs
@@ -1,0 +1,40 @@
+﻿namespace org.apache.lucene.codecs.bloom
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Basic tests for BloomPostingsFormat
+	/// </summary>
+	public class TestBloomPostingsFormat : BasePostingsFormatTestCase
+	{
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new TestBloomFilteredLucene41Postings());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/diskdv/TestDiskDocValuesFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/diskdv/TestDiskDocValuesFormat.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Codecs.DiskDV;
+
+namespace Lucene.Net.Codecs.DiskDV
+{
+
+	using BaseCompressingDocValuesFormatTestCase = Lucene.Net.Index.BaseCompressingDocValuesFormatTestCase;
+	using TestUtil = Lucene.Net.Util.TestUtil;
+
+	/// <summary>
+	/// Tests DiskDocValuesFormat
+	/// </summary>
+	public class TestDiskDocValuesFormat : BaseCompressingDocValuesFormatTestCase
+	{
+	  private readonly Codec codec = TestUtil.alwaysDocValuesFormat(new DiskDocValuesFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/intblock/TestFixedIntBlockPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/intblock/TestFixedIntBlockPostingsFormat.cs
@@ -1,0 +1,42 @@
+﻿namespace org.apache.lucene.codecs.intblock
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using MockFixedIntBlockPostingsFormat = org.apache.lucene.codecs.mockintblock.MockFixedIntBlockPostingsFormat;
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Basic tests for FixedIntBlock
+	/// </summary>
+	public class TestFixedIntBlockPostingsFormat : BasePostingsFormatTestCase
+	{
+	  // TODO: randomize blocksize
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new MockFixedIntBlockPostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/intblock/TestIntBlockCodec.cs
+++ b/src/Lucene.Net.Codecs.Tests/intblock/TestIntBlockCodec.cs
@@ -1,0 +1,76 @@
+﻿namespace org.apache.lucene.codecs.intblock
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using LuceneTestCase = org.apache.lucene.util.LuceneTestCase;
+	using org.apache.lucene.store;
+	using org.apache.lucene.codecs.mockintblock;
+	using org.apache.lucene.codecs.sep;
+
+	public class TestIntBlockCodec : LuceneTestCase
+	{
+
+//JAVA TO C# CONVERTER WARNING: Method 'throws' clauses are not available in .NET:
+//ORIGINAL LINE: public void testSimpleIntBlocks() throws Exception
+	  public virtual void testSimpleIntBlocks()
+	  {
+		Directory dir = newDirectory();
+
+		IntStreamFactory f = (new MockFixedIntBlockPostingsFormat(128)).IntFactory;
+
+		IntIndexOutput @out = f.createOutput(dir, "test", newIOContext(random()));
+		for (int i = 0;i < 11777;i++)
+		{
+		  @out.write(i);
+		}
+		@out.close();
+
+		IntIndexInput @in = f.openInput(dir, "test", newIOContext(random()));
+		IntIndexInput.Reader r = @in.reader();
+
+		for (int i = 0;i < 11777;i++)
+		{
+		  assertEquals(i, r.next());
+		}
+		@in.close();
+
+		dir.close();
+	  }
+
+//JAVA TO C# CONVERTER WARNING: Method 'throws' clauses are not available in .NET:
+//ORIGINAL LINE: public void testEmptySimpleIntBlocks() throws Exception
+	  public virtual void testEmptySimpleIntBlocks()
+	  {
+		Directory dir = newDirectory();
+
+		IntStreamFactory f = (new MockFixedIntBlockPostingsFormat(128)).IntFactory;
+		IntIndexOutput @out = f.createOutput(dir, "test", newIOContext(random()));
+
+		// write no ints
+		@out.close();
+
+		IntIndexInput @in = f.openInput(dir, "test", newIOContext(random()));
+		@in.reader();
+		// read no ints
+		@in.close();
+		dir.close();
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/intblock/TestVariableIntBlockPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/intblock/TestVariableIntBlockPostingsFormat.cs
@@ -1,0 +1,43 @@
+﻿namespace org.apache.lucene.codecs.intblock
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using MockVariableIntBlockPostingsFormat = org.apache.lucene.codecs.mockintblock.MockVariableIntBlockPostingsFormat;
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Basic tests for VariableIntBlock
+	/// </summary>
+	public class TestVariableIntBlockPostingsFormat : BasePostingsFormatTestCase
+	{
+	  // TODO: randomize blocksize
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new MockVariableIntBlockPostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/memory/TestDirectDocValuesFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/memory/TestDirectDocValuesFormat.cs
@@ -1,0 +1,40 @@
+﻿namespace org.apache.lucene.codecs.memory
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BaseDocValuesFormatTestCase = org.apache.lucene.index.BaseDocValuesFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests DirectDocValuesFormat
+	/// </summary>
+	public class TestDirectDocValuesFormat : BaseDocValuesFormatTestCase
+	{
+	  private readonly Codec codec = TestUtil.alwaysDocValuesFormat(new DirectDocValuesFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/memory/TestDirectPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/memory/TestDirectPostingsFormat.cs
@@ -1,0 +1,42 @@
+﻿namespace org.apache.lucene.codecs.memory
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests DirectPostingsFormat
+	/// </summary>
+	public class TestDirectPostingsFormat : BasePostingsFormatTestCase
+	{
+	  // TODO: randomize parameters
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new DirectPostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/memory/TestFSTOrdPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/memory/TestFSTOrdPostingsFormat.cs
@@ -1,0 +1,40 @@
+﻿namespace org.apache.lucene.codecs.memory
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests FSTOrdPostingsFormat 
+	/// </summary>
+	public class TestFSTOrdPostingsFormat : BasePostingsFormatTestCase
+	{
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new FSTOrdPostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/memory/TestFSTOrdPulsing41PostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/memory/TestFSTOrdPulsing41PostingsFormat.cs
@@ -1,0 +1,40 @@
+﻿namespace org.apache.lucene.codecs.memory
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests FSTOrdPulsing41PostingsFormat 
+	/// </summary>
+	public class TestFSTOrdPulsing41PostingsFormat : BasePostingsFormatTestCase
+	{
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new FSTOrdPulsing41PostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/memory/TestFSTPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/memory/TestFSTPostingsFormat.cs
@@ -1,0 +1,40 @@
+﻿namespace org.apache.lucene.codecs.memory
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests FSTPostingsFormat 
+	/// </summary>
+	public class TestFSTPostingsFormat : BasePostingsFormatTestCase
+	{
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new FSTPostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/memory/TestFSTPulsing41PostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/memory/TestFSTPulsing41PostingsFormat.cs
@@ -1,0 +1,40 @@
+﻿namespace org.apache.lucene.codecs.memory
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests FSTPulsing41PostingsFormat 
+	/// </summary>
+	public class TestFSTPulsing41PostingsFormat : BasePostingsFormatTestCase
+	{
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new FSTPulsing41PostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/memory/TestMemoryDocValuesFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/memory/TestMemoryDocValuesFormat.cs
@@ -1,0 +1,45 @@
+﻿namespace org.apache.lucene.codecs.memory
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BaseCompressingDocValuesFormatTestCase = org.apache.lucene.index.BaseCompressingDocValuesFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests MemoryDocValuesFormat
+	/// </summary>
+	public class TestMemoryDocValuesFormat : BaseCompressingDocValuesFormatTestCase
+	{
+	  private readonly Codec codec = TestUtil.alwaysDocValuesFormat(new MemoryDocValuesFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+
+	  protected internal override bool codecAcceptsHugeBinaryValues(string field)
+	  {
+		return false;
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/memory/TestMemoryPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/memory/TestMemoryPostingsFormat.cs
@@ -1,0 +1,42 @@
+﻿namespace org.apache.lucene.codecs.memory
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests MemoryPostingsFormat
+	/// </summary>
+	public class TestMemoryPostingsFormat : BasePostingsFormatTestCase
+	{
+	  // TODO: randomize doPack
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new MemoryPostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/pulsing/Test10KPulsings.cs
+++ b/src/Lucene.Net.Codecs.Tests/pulsing/Test10KPulsings.cs
@@ -1,0 +1,183 @@
+﻿using System.Text;
+
+namespace org.apache.lucene.codecs.pulsing
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+
+	using MockAnalyzer = org.apache.lucene.analysis.MockAnalyzer;
+	using Document = org.apache.lucene.document.Document;
+	using Field = org.apache.lucene.document.Field;
+	using FieldType = org.apache.lucene.document.FieldType;
+	using TextField = org.apache.lucene.document.TextField;
+	using DocsEnum = org.apache.lucene.index.DocsEnum;
+	using IndexOptions = org.apache.lucene.index.FieldInfo.IndexOptions;
+	using IndexReader = org.apache.lucene.index.IndexReader;
+	using MultiFields = org.apache.lucene.index.MultiFields;
+	using RandomIndexWriter = org.apache.lucene.index.RandomIndexWriter;
+	using TermsEnum = org.apache.lucene.index.TermsEnum;
+	using DocIdSetIterator = org.apache.lucene.search.DocIdSetIterator;
+	using BaseDirectoryWrapper = org.apache.lucene.store.BaseDirectoryWrapper;
+	using LuceneTestCase = org.apache.lucene.util.LuceneTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Pulses 10k terms/docs, 
+	/// originally designed to find JRE bugs (https://issues.apache.org/jira/browse/LUCENE-3335)
+	/// 
+	/// @lucene.experimental
+	/// </summary>
+//JAVA TO C# CONVERTER TODO TASK: Most Java annotations will not have direct .NET equivalent attributes:
+//ORIGINAL LINE: @LuceneTestCase.Nightly public class Test10KPulsings extends org.apache.lucene.util.LuceneTestCase
+	public class Test10KPulsings : LuceneTestCase
+	{
+//JAVA TO C# CONVERTER WARNING: Method 'throws' clauses are not available in .NET:
+//ORIGINAL LINE: public void test10kPulsed() throws Exception
+	  public virtual void test10kPulsed()
+	  {
+		// we always run this test with pulsing codec.
+		Codec cp = TestUtil.alwaysPostingsFormat(new Pulsing41PostingsFormat(1));
+
+		File f = createTempDir("10kpulsed");
+		BaseDirectoryWrapper dir = newFSDirectory(f);
+		dir.CheckIndexOnClose = false; // we do this ourselves explicitly
+		RandomIndexWriter iw = new RandomIndexWriter(random(), dir, newIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random())).setCodec(cp));
+
+		Document document = new Document();
+		FieldType ft = new FieldType(TextField.TYPE_STORED);
+
+		switch (TestUtil.Next(random(), 0, 2))
+		{
+		  case 0:
+			  ft.IndexOptions = IndexOptions.DOCS_ONLY;
+			  break;
+		  case 1:
+			  ft.IndexOptions = IndexOptions.DOCS_AND_FREQS;
+			  break;
+		  default:
+			  ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS;
+			  break;
+		}
+
+		Field field = newField("field", "", ft);
+		document.add(field);
+
+		NumberFormat df = new DecimalFormat("00000", new DecimalFormatSymbols(Locale.ROOT));
+
+		for (int i = 0; i < 10050; i++)
+		{
+		  field.StringValue = df.format(i);
+		  iw.addDocument(document);
+		}
+
+		IndexReader ir = iw.Reader;
+		iw.close();
+
+		TermsEnum te = MultiFields.getTerms(ir, "field").iterator(null);
+		DocsEnum de = null;
+
+		for (int i = 0; i < 10050; i++)
+		{
+		  string expected = df.format(i);
+		  assertEquals(expected, te.next().utf8ToString());
+		  de = TestUtil.docs(random(), te, null, de, DocsEnum.FLAG_NONE);
+		  assertTrue(de.nextDoc() != DocIdSetIterator.NO_MORE_DOCS);
+		  assertEquals(DocIdSetIterator.NO_MORE_DOCS, de.nextDoc());
+		}
+		ir.close();
+
+		TestUtil.checkIndex(dir);
+		dir.close();
+	  }
+
+	  /// <summary>
+	  /// a variant, that uses pulsing, but uses a high TF to force pass thru to the underlying codec
+	  /// </summary>
+//JAVA TO C# CONVERTER WARNING: Method 'throws' clauses are not available in .NET:
+//ORIGINAL LINE: public void test10kNotPulsed() throws Exception
+	  public virtual void test10kNotPulsed()
+	  {
+		// we always run this test with pulsing codec.
+		int freqCutoff = TestUtil.Next(random(), 1, 10);
+		Codec cp = TestUtil.alwaysPostingsFormat(new Pulsing41PostingsFormat(freqCutoff));
+
+		File f = createTempDir("10knotpulsed");
+		BaseDirectoryWrapper dir = newFSDirectory(f);
+		dir.CheckIndexOnClose = false; // we do this ourselves explicitly
+		RandomIndexWriter iw = new RandomIndexWriter(random(), dir, newIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random())).setCodec(cp));
+
+		Document document = new Document();
+		FieldType ft = new FieldType(TextField.TYPE_STORED);
+
+		switch (TestUtil.Next(random(), 0, 2))
+		{
+		  case 0:
+			  ft.IndexOptions = IndexOptions.DOCS_ONLY;
+			  break;
+		  case 1:
+			  ft.IndexOptions = IndexOptions.DOCS_AND_FREQS;
+			  break;
+		  default:
+			  ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS;
+			  break;
+		}
+
+		Field field = newField("field", "", ft);
+		document.add(field);
+
+		NumberFormat df = new DecimalFormat("00000", new DecimalFormatSymbols(Locale.ROOT));
+
+//JAVA TO C# CONVERTER WARNING: The original Java variable was marked 'final':
+//ORIGINAL LINE: final int freq = freqCutoff + 1;
+		int freq = freqCutoff + 1;
+
+		for (int i = 0; i < 10050; i++)
+		{
+		  StringBuilder sb = new StringBuilder();
+		  for (int j = 0; j < freq; j++)
+		  {
+			sb.Append(df.format(i));
+			sb.Append(' '); // whitespace
+		  }
+		  field.StringValue = sb.ToString();
+		  iw.addDocument(document);
+		}
+
+		IndexReader ir = iw.Reader;
+		iw.close();
+
+		TermsEnum te = MultiFields.getTerms(ir, "field").iterator(null);
+		DocsEnum de = null;
+
+		for (int i = 0; i < 10050; i++)
+		{
+		  string expected = df.format(i);
+		  assertEquals(expected, te.next().utf8ToString());
+		  de = TestUtil.docs(random(), te, null, de, DocsEnum.FLAG_NONE);
+		  assertTrue(de.nextDoc() != DocIdSetIterator.NO_MORE_DOCS);
+		  assertEquals(DocIdSetIterator.NO_MORE_DOCS, de.nextDoc());
+		}
+		ir.close();
+
+		TestUtil.checkIndex(dir);
+		dir.close();
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/pulsing/TestPulsingPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/pulsing/TestPulsingPostingsFormat.cs
@@ -1,0 +1,42 @@
+﻿namespace org.apache.lucene.codecs.pulsing
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests PulsingPostingsFormat
+	/// </summary>
+	public class TestPulsingPostingsFormat : BasePostingsFormatTestCase
+	{
+	  // TODO: randomize cutoff
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new Pulsing41PostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/pulsing/TestPulsingReuse.cs
+++ b/src/Lucene.Net.Codecs.Tests/pulsing/TestPulsingReuse.cs
@@ -1,0 +1,134 @@
+﻿using System.Collections.Generic;
+
+namespace org.apache.lucene.codecs.pulsing
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+
+	using MockAnalyzer = org.apache.lucene.analysis.MockAnalyzer;
+	using NestedPulsingPostingsFormat = org.apache.lucene.codecs.nestedpulsing.NestedPulsingPostingsFormat;
+	using Document = org.apache.lucene.document.Document;
+	using Field = org.apache.lucene.document.Field;
+	using TextField = org.apache.lucene.document.TextField;
+	using AtomicReader = org.apache.lucene.index.AtomicReader;
+	using DirectoryReader = org.apache.lucene.index.DirectoryReader;
+	using DocsAndPositionsEnum = org.apache.lucene.index.DocsAndPositionsEnum;
+	using DocsEnum = org.apache.lucene.index.DocsEnum;
+	using RandomIndexWriter = org.apache.lucene.index.RandomIndexWriter;
+	using TermsEnum = org.apache.lucene.index.TermsEnum;
+	using BaseDirectoryWrapper = org.apache.lucene.store.BaseDirectoryWrapper;
+	using Directory = org.apache.lucene.store.Directory;
+	using LuceneTestCase = org.apache.lucene.util.LuceneTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests that pulsing codec reuses its enums and wrapped enums
+	/// </summary>
+	public class TestPulsingReuse : LuceneTestCase
+	{
+	  // TODO: this is a basic test. this thing is complicated, add more
+//JAVA TO C# CONVERTER WARNING: Method 'throws' clauses are not available in .NET:
+//ORIGINAL LINE: public void testSophisticatedReuse() throws Exception
+	  public virtual void testSophisticatedReuse()
+	  {
+		// we always run this test with pulsing codec.
+		Codec cp = TestUtil.alwaysPostingsFormat(new Pulsing41PostingsFormat(1));
+		Directory dir = newDirectory();
+		RandomIndexWriter iw = new RandomIndexWriter(random(), dir, newIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random())).setCodec(cp));
+		Document doc = new Document();
+		doc.add(new TextField("foo", "a b b c c c d e f g g h i i j j k", Field.Store.NO));
+		iw.addDocument(doc);
+		DirectoryReader ir = iw.Reader;
+		iw.close();
+
+		AtomicReader segment = getOnlySegmentReader(ir);
+		DocsEnum reuse = null;
+		IDictionary<DocsEnum, bool?> allEnums = new IdentityHashMap<DocsEnum, bool?>();
+		TermsEnum te = segment.terms("foo").iterator(null);
+		while (te.next() != null)
+		{
+		  reuse = te.docs(null, reuse, DocsEnum.FLAG_NONE);
+		  allEnums[reuse] = true;
+		}
+
+		assertEquals(2, allEnums.Count);
+
+		allEnums.Clear();
+		DocsAndPositionsEnum posReuse = null;
+		te = segment.terms("foo").iterator(null);
+		while (te.next() != null)
+		{
+		  posReuse = te.docsAndPositions(null, posReuse);
+		  allEnums[posReuse] = true;
+		}
+
+		assertEquals(2, allEnums.Count);
+
+		ir.close();
+		dir.close();
+	  }
+
+	  /// <summary>
+	  /// tests reuse with Pulsing1(Pulsing2(Standard)) </summary>
+//JAVA TO C# CONVERTER WARNING: Method 'throws' clauses are not available in .NET:
+//ORIGINAL LINE: public void testNestedPulsing() throws Exception
+	  public virtual void testNestedPulsing()
+	  {
+		// we always run this test with pulsing codec.
+		Codec cp = TestUtil.alwaysPostingsFormat(new NestedPulsingPostingsFormat());
+		BaseDirectoryWrapper dir = newDirectory();
+		RandomIndexWriter iw = new RandomIndexWriter(random(), dir, newIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random())).setCodec(cp));
+		Document doc = new Document();
+		doc.add(new TextField("foo", "a b b c c c d e f g g g h i i j j k l l m m m", Field.Store.NO));
+		// note: the reuse is imperfect, here we would have 4 enums (lost reuse when we get an enum for 'm')
+		// this is because we only track the 'last' enum we reused (not all).
+		// but this seems 'good enough' for now.
+		iw.addDocument(doc);
+		DirectoryReader ir = iw.Reader;
+		iw.close();
+
+		AtomicReader segment = getOnlySegmentReader(ir);
+		DocsEnum reuse = null;
+		IDictionary<DocsEnum, bool?> allEnums = new IdentityHashMap<DocsEnum, bool?>();
+		TermsEnum te = segment.terms("foo").iterator(null);
+		while (te.next() != null)
+		{
+		  reuse = te.docs(null, reuse, DocsEnum.FLAG_NONE);
+		  allEnums[reuse] = true;
+		}
+
+		assertEquals(4, allEnums.Count);
+
+		allEnums.Clear();
+		DocsAndPositionsEnum posReuse = null;
+		te = segment.terms("foo").iterator(null);
+		while (te.next() != null)
+		{
+		  posReuse = te.docsAndPositions(null, posReuse);
+		  allEnums[posReuse] = true;
+		}
+
+		assertEquals(4, allEnums.Count);
+
+		ir.close();
+		dir.close();
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/sep/TestSepPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/sep/TestSepPostingsFormat.cs
@@ -1,0 +1,42 @@
+﻿namespace org.apache.lucene.codecs.sep
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using MockSepPostingsFormat = org.apache.lucene.codecs.mocksep.MockSepPostingsFormat;
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using TestUtil = org.apache.lucene.util.TestUtil;
+
+	/// <summary>
+	/// Tests sep layout
+	/// </summary>
+	public class TestSepPostingsFormat : BasePostingsFormatTestCase
+	{
+	  // TODO: randomize cutoff
+	  private readonly Codec codec = TestUtil.alwaysPostingsFormat(new MockSepPostingsFormat());
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/simpletext/TestSimpleTextDocValuesFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/simpletext/TestSimpleTextDocValuesFormat.cs
@@ -1,0 +1,39 @@
+﻿namespace org.apache.lucene.codecs.simpletext
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BaseDocValuesFormatTestCase = org.apache.lucene.index.BaseDocValuesFormatTestCase;
+
+	/// <summary>
+	/// Tests SimpleTextDocValuesFormat
+	/// </summary>
+	public class TestSimpleTextDocValuesFormat : BaseDocValuesFormatTestCase
+	{
+	  private readonly Codec codec = new SimpleTextCodec();
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/simpletext/TestSimpleTextPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/simpletext/TestSimpleTextPostingsFormat.cs
@@ -1,0 +1,42 @@
+﻿namespace org.apache.lucene.codecs.simpletext
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BasePostingsFormatTestCase = org.apache.lucene.index.BasePostingsFormatTestCase;
+	using Nightly = org.apache.lucene.util.LuceneTestCase.Nightly;
+
+	/// <summary>
+	/// Tests SimpleText's postings
+	/// </summary>
+//JAVA TO C# CONVERTER TODO TASK: Most Java annotations will not have direct .NET equivalent attributes:
+//ORIGINAL LINE: @Nightly public class TestSimpleTextPostingsFormat extends org.apache.lucene.index.BasePostingsFormatTestCase
+	public class TestSimpleTextPostingsFormat : BasePostingsFormatTestCase // please figure out why I am so horrendously slow!
+	{
+	  private readonly Codec codec = new SimpleTextCodec();
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return codec;
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/simpletext/TestSimpleTextStoredFieldsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/simpletext/TestSimpleTextStoredFieldsFormat.cs
@@ -1,0 +1,35 @@
+﻿namespace org.apache.lucene.codecs.simpletext
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BaseStoredFieldsFormatTestCase = org.apache.lucene.index.BaseStoredFieldsFormatTestCase;
+
+	public class TestSimpleTextStoredFieldsFormat : BaseStoredFieldsFormatTestCase
+	{
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return new SimpleTextCodec();
+		  }
+	  }
+	}
+
+}

--- a/src/Lucene.Net.Codecs.Tests/simpletext/TestSimpleTextTermVectorsFormat.cs
+++ b/src/Lucene.Net.Codecs.Tests/simpletext/TestSimpleTextTermVectorsFormat.cs
@@ -1,0 +1,36 @@
+﻿namespace org.apache.lucene.codecs.simpletext
+{
+
+	/*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+	using BaseTermVectorsFormatTestCase = org.apache.lucene.index.BaseTermVectorsFormatTestCase;
+
+	public class TestSimpleTextTermVectorsFormat : BaseTermVectorsFormatTestCase
+	{
+
+	  protected internal override Codec Codec
+	  {
+		  get
+		  {
+			return new SimpleTextCodec();
+		  }
+	  }
+
+	}
+
+}

--- a/src/Lucene.Net.Codecs/Lucene.Net.Codecs.csproj
+++ b/src/Lucene.Net.Codecs/Lucene.Net.Codecs.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Lucene.Net.Codecs</RootNamespace>
     <AssemblyName>Lucene.Net.Codecs</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -124,7 +124,6 @@
     <Compile Include="SimpleText\SimpleTextUtil.cs" />
     <Compile Include="StringHelperClass.cs" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net.Core\Lucene.Net.csproj">
       <Project>{5d4ad9be-1ffb-41ab-9943-25737971bf57}</Project>

--- a/src/Lucene.Net.Codecs/Memory/DirectDocValuesConsumer.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectDocValuesConsumer.cs
@@ -20,13 +20,15 @@ namespace Lucene.Net.Codecs.Memory
     using System;
     using System.Diagnostics;
     using System.Collections.Generic;
-   
+
     using FieldInfo = Index.FieldInfo;
     using IndexFileNames = Index.IndexFileNames;
     using SegmentWriteState = Index.SegmentWriteState;
     using IndexOutput = Store.IndexOutput;
     using BytesRef = Util.BytesRef;
     using IOUtils = Util.IOUtils;
+    using System.Collections;
+
 
     /// <summary>
     /// Writer for <seealso cref="DirectDocValuesFormat"/>
@@ -62,14 +64,14 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        public override void AddNumericField(FieldInfo field, IEnumerable<long> values)
+        public override void AddNumericField(FieldInfo field, IEnumerable<long?> values)
         {
             meta.WriteVInt(field.Number);
             meta.WriteByte(MemoryDocValuesProducer.NUMBER);
             AddNumericFieldValues(field, values);
         }
 
-        private void AddNumericFieldValues(FieldInfo field, IEnumerable<long> values)
+        private void AddNumericFieldValues(FieldInfo field, IEnumerable<long?> values)
         {
             meta.WriteLong(data.FilePointer);
             long minValue = long.MaxValue;
@@ -81,7 +83,7 @@ namespace Lucene.Net.Codecs.Memory
             {
                 if (nv != null)
                 {
-                    var v = nv;
+                    var v = nv.Value;
                     minValue = Math.Min(minValue, v);
                     maxValue = Math.Max(maxValue, v);
                 }
@@ -278,10 +280,10 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        public override void AddSortedField(FieldInfo field, IEnumerable<BytesRef> values, IEnumerable<long> docToOrd)
+        public override void AddSortedField(FieldInfo field, IEnumerable<BytesRef> values, IEnumerable<long?> docToOrd)
         {
             meta.WriteVInt(field.Number);
-            meta.WriteByte(SORTED);
+            meta.WriteByte((byte)DirectDocValuesProducer.SORTED);
 
             // write the ordinals as numerics
             AddNumericFieldValues(field, docToOrd);
@@ -292,10 +294,10 @@ namespace Lucene.Net.Codecs.Memory
 
         // note: this might not be the most efficient... but its fairly simple
         public override void AddSortedSetField(FieldInfo field, IEnumerable<BytesRef> values,
-            IEnumerable<long> docToOrdCount, IEnumerable<long> ords)
+            IEnumerable<long?> docToOrdCount, IEnumerable<long?> ords)
         {
             meta.WriteVInt(field.Number);
-            meta.WriteByte(SORTED_SET);
+            meta.WriteByte((byte)DirectDocValuesProducer.SORTED_SET);
 
             // First write docToOrdCounts, except we "aggregate" the
             // counts so they turn into addresses, and add a final
@@ -310,13 +312,13 @@ namespace Lucene.Net.Codecs.Memory
             AddBinaryFieldValues(field, values);
         }
 
-        private class IterableAnonymousInnerClassHelper : IEnumerable<long>
+        private class IterableAnonymousInnerClassHelper : IEnumerable<long?>
         {
             private readonly DirectDocValuesConsumer _outerInstance;
-            private readonly IEnumerable<long> _docToOrdCount;
+            private readonly IEnumerable<long?> _docToOrdCount;
 
             public IterableAnonymousInnerClassHelper(DirectDocValuesConsumer outerInstance,
-                IEnumerable<long> docToOrdCount)
+                IEnumerable<long?> docToOrdCount)
             {
                 _outerInstance = outerInstance;
                 _docToOrdCount = docToOrdCount;
@@ -325,18 +327,23 @@ namespace Lucene.Net.Codecs.Memory
             // Just aggregates the count values so they become
             // "addresses", and adds one more value in the end
             // (the final sum):
-            public virtual IEnumerator<long> GetEnumerator()
+            public virtual IEnumerator<long?> GetEnumerator()
             {
                 var iter = _docToOrdCount.GetEnumerator();
                 return new IteratorAnonymousInnerClassHelper(this, iter);
             }
 
-            private class IteratorAnonymousInnerClassHelper : IEnumerator<long>
+            IEnumerator IEnumerable.GetEnumerator()
             {
-                private readonly IEnumerator<long> _iter;
+                return GetEnumerator();
+            }
+
+            private class IteratorAnonymousInnerClassHelper : IEnumerator<long?>
+            {
+                private readonly IEnumerator<long?> _iter;
 
                 public IteratorAnonymousInnerClassHelper(IterableAnonymousInnerClassHelper outerInstance,
-                    IEnumerator<long> iter)
+                    IEnumerator<long?> iter)
                 {
                     _iter = iter;
                 }
@@ -345,38 +352,88 @@ namespace Lucene.Net.Codecs.Memory
                 private long sum;
                 private bool ended;
 
-                public virtual bool HasNext()
+                public long? Current
                 {
-                    return _iter.HasNext() || !ended;
+                    get
+                    {
+                        return _iter.Current;
+                    }
                 }
 
-                public virtual long Next()
+                object IEnumerator.Current
                 {
-                    long toReturn = sum;
-                    if (_iter.hasNext())
+                    get
                     {
-                        long n = _iter.Next();
-                        if (n != null)
-                        {
-                            sum += n;
-                        }
+                        return Current;
                     }
-                    else if (!ended)
-                    {
-                        ended = true;
-                    }
-                    else
-                    {
-                        Debug.Assert(false);
-                    }
-
-                    return toReturn;
                 }
 
                 public virtual void Remove()
                 {
                     throw new NotSupportedException();
                 }
+
+                public bool MoveNext()
+                {
+                    long toReturn = sum;
+                    if (_iter.MoveNext())
+                    {
+                        long? n = _iter.Current;
+                        if (n.HasValue)
+                        {
+                            sum += n.Value;
+                        }
+
+                        return true;
+                    }
+                    else 
+                    {
+                        ended = true;
+                        return false;
+                    }
+
+                    //return toReturn;
+                }
+
+                public void Reset()
+                {
+                    throw new NotImplementedException();
+                }
+
+                #region IDisposable Support
+                private bool disposedValue = false; // To detect redundant calls
+
+                protected virtual void Dispose(bool disposing)
+                {
+                    if (!disposedValue)
+                    {
+                        if (disposing)
+                        {
+                            // TODO: dispose managed state (managed objects).          
+                        }
+
+                        // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                        // TODO: set large fields to null.
+
+                        disposedValue = true;
+                    }
+                }
+
+                // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources. 
+                // ~IteratorAnonymousInnerClassHelper() {
+                //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+                //   Dispose(false);
+                // }
+
+                // This code added to correctly implement the disposable pattern.
+                public void Dispose()
+                {
+                    // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+                    Dispose(true);
+                    // TODO: uncomment the following line if the finalizer is overridden above.
+                    // GC.SuppressFinalize(this);
+                }
+                #endregion
             }
         }
     }

--- a/src/Lucene.Net.Codecs/Memory/DirectDocValuesProducer.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectDocValuesProducer.cs
@@ -8,7 +8,7 @@ using Lucene.Net.Util;
 namespace Lucene.Net.Codecs.Memory
 {
 
-	/*
+    /*
 	 * Licensed to the Apache Software Foundation (ASF) under one or more
 	 * contributor license agreements.  See the NOTICE file distributed with
 	 * this work for additional information regarding copyright ownership.
@@ -25,635 +25,635 @@ namespace Lucene.Net.Codecs.Memory
 	 * limitations under the License.
 	 */
 
-	/// <summary>
-	/// Reader for <seealso cref="DirectDocValuesFormat"/>
-	/// </summary>
-
-	internal class DirectDocValuesProducer : DocValuesProducer
-	{
-	  // metadata maps (just file pointers and minimal stuff)
-	  private readonly IDictionary<int?, NumericEntry> numerics = new Dictionary<int?, NumericEntry>();
-	  private readonly IDictionary<int?, BinaryEntry> binaries = new Dictionary<int?, BinaryEntry>();
-	  private readonly IDictionary<int?, SortedEntry> sorteds = new Dictionary<int?, SortedEntry>();
-	  private readonly IDictionary<int?, SortedSetEntry> sortedSets = new Dictionary<int?, SortedSetEntry>();
-	  private readonly IndexInput data;
-
-	  // ram instances we have already loaded
-	  private readonly IDictionary<int?, NumericDocValues> numericInstances = new Dictionary<int?, NumericDocValues>();
-	  private readonly IDictionary<int?, BinaryDocValues> binaryInstances = new Dictionary<int?, BinaryDocValues>();
-	  private readonly IDictionary<int?, SortedDocValues> sortedInstances = new Dictionary<int?, SortedDocValues>();
-	  private readonly IDictionary<int?, SortedSetRawValues> sortedSetInstances = new Dictionary<int?, SortedSetRawValues>();
-	  private readonly IDictionary<int?, Bits> docsWithFieldInstances = new Dictionary<int?, Bits>();
-
-	  private readonly int maxDoc;
-	  private readonly AtomicLong ramBytesUsed;
-	  private readonly int version;
-
-	  internal const sbyte NUMBER = 0;
-	  internal const sbyte BYTES = 1;
-	  internal const sbyte SORTED = 2;
-	  internal const sbyte SORTED_SET = 3;
-
-	  internal const int VERSION_START = 0;
-	  internal const int VERSION_CHECKSUM = 1;
-	  internal const int VERSION_CURRENT = VERSION_CHECKSUM;
-
-	  internal DirectDocValuesProducer(SegmentReadState state, string dataCodec, string dataExtension, string metaCodec, string metaExtension)
-	  {
-		maxDoc = state.SegmentInfo.DocCount;
-		string metaName = IndexFileNames.SegmentFileName(state.SegmentInfo.Name, state.SegmentSuffix, metaExtension);
-		// read in the entries from the metadata file.
-		ChecksumIndexInput @in = state.Directory.OpenChecksumInput(metaName, state.Context);
-		ramBytesUsed = new AtomicLong(RamUsageEstimator.ShallowSizeOfInstance(this.GetType()));
-		bool success = false;
-		try
-		{
-		  version = CodecUtil.CheckHeader(@in, metaCodec, VERSION_START, VERSION_CURRENT);
-		  ReadFields(@in);
-
-		  if (version >= VERSION_CHECKSUM)
-		  {
-			CodecUtil.CheckFooter(@in);
-		  }
-		  else
-		  {
-			CodecUtil.CheckEOF(@in);
-		  }
-		  success = true;
-		}
-		finally
-		{
-		  if (success)
-		  {
-			IOUtils.Close(@in);
-		  }
-		  else
-		  {
-			IOUtils.CloseWhileHandlingException(@in);
-		  }
-		}
-
-		success = false;
-		try
-		{
-		  string dataName = IndexFileNames.SegmentFileName(state.SegmentInfo.Name, state.SegmentSuffix, dataExtension);
-		  data = state.Directory.OpenInput(dataName, state.Context);
-		  int version2 = CodecUtil.CheckHeader(data, dataCodec, VERSION_START, VERSION_CURRENT);
-		  if (version != version2)
-		  {
-			throw new CorruptIndexException("Format versions mismatch");
-		  }
-
-		  success = true;
-		}
-		finally
-		{
-		  if (!success)
-		  {
-			IOUtils.CloseWhileHandlingException(this.data);
-		  }
-		}
-	  }
-
-	  private static NumericEntry ReadNumericEntry(IndexInput meta)
-	  {
-		var entry = new NumericEntry {offset = meta.ReadLong(), count = meta.ReadInt(), missingOffset = meta.ReadLong()};
-	      if (entry.missingOffset != -1)
-		{
-		  entry.missingBytes = meta.ReadLong();
-		}
-		else
-		{
-		  entry.missingBytes = 0;
-		}
-		entry.byteWidth = meta.ReadByte();
-
-		return entry;
-	  }
-
-	  private BinaryEntry readBinaryEntry(IndexInput meta)
-	  {
-		var entry = new BinaryEntry();
-		entry.offset = meta.ReadLong();
-		entry.numBytes = meta.ReadInt();
-		entry.count = meta.ReadInt();
-		entry.missingOffset = meta.ReadLong();
-		if (entry.missingOffset != -1)
-		{
-		  entry.missingBytes = meta.ReadLong();
-		}
-		else
-		{
-		  entry.missingBytes = 0;
-		}
-
-		return entry;
-	  }
-
-	  private SortedEntry ReadSortedEntry(IndexInput meta)
-	  {
-		var entry = new SortedEntry();
-		entry.docToOrd = ReadNumericEntry(meta);
-		entry.values = ReadBinaryEntry(meta);
-		return entry;
-	  }
-
-	  private SortedSetEntry ReadSortedSetEntry(IndexInput meta)
-	  {
-		var entry = new SortedSetEntry();
-		entry.docToOrdAddress = ReadNumericEntry(meta);
-		entry.ords = ReadNumericEntry(meta);
-		entry.values = readBinaryEntry(meta);
-		return entry;
-	  }
-
-	  private void ReadFields(IndexInput meta)
-	  {
-		int fieldNumber = meta.ReadVInt();
-		while (fieldNumber != -1)
-		{
-		  int fieldType = meta.ReadByte();
-		  if (fieldType == NUMBER)
-		  {
-			numerics[fieldNumber] = ReadNumericEntry(meta);
-		  }
-		  else if (fieldType == BYTES)
-		  {
-			binaries[fieldNumber] = readBinaryEntry(meta);
-		  }
-		  else if (fieldType == SORTED)
-		  {
-			sorteds[fieldNumber] = ReadSortedEntry(meta);
-		  }
-		  else if (fieldType == SORTED_SET)
-		  {
-			sortedSets[fieldNumber] = ReadSortedSetEntry(meta);
-		  }
-		  else
-		  {
-			throw new CorruptIndexException("invalid entry type: " + fieldType + ", input=" + meta);
-		  }
-		  fieldNumber = meta.ReadVInt();
-		}
-	  }
-
-	  public override long RamBytesUsed()
-	  {
-		return ramBytesUsed.Get();
-	  }
-
-	  public override void CheckIntegrity()
-	  {
-		if (version >= VERSION_CHECKSUM)
-		{
-		  CodecUtil.ChecksumEntireFile(data);
-		}
-	  }
-
-	  public override NumericDocValues GetNumeric(FieldInfo field)
-	  {
-		  lock (this)
-		  {
-			var instance = numericInstances[field.Number];
-			if (instance == null)
-			{
-			  // Lazy load
-			  instance = LoadNumeric(numerics[field.Number]);
-			  numericInstances[field.Number] = instance;
-			}
-			return instance;
-		  }
-	  }
-
-	  private NumericDocValues LoadNumeric(NumericEntry entry)
-	  {
-		data.Seek(entry.offset + entry.missingBytes);
-		switch (entry.byteWidth)
-		{
-		case 1:
-		{
-			var values = new byte[entry.count];
-			data.ReadBytes(values, 0, entry.count);
-			ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(values));
-			return new NumericDocValuesAnonymousInnerClassHelper(values);
-		}
-
-		case 2:
-		{
-			var values = new short[entry.count];
-			for (int i = 0;i < entry.count;i++)
-			{
-			  values[i] = data.ReadShort();
-			}
-			ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(values));
-			return new NumericDocValuesAnonymousInnerClassHelper2(this, values);
-		}
-
-		case 4:
-		{
-			var values = new int[entry.count];
-			for (var i = 0;i < entry.count;i++)
-			{
-			  values[i] = data.ReadInt();
-			}
-			ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(values));
-			return new NumericDocValuesAnonymousInnerClassHelper3(values);
-		}
-
-		case 8:
-		{
-			var values = new long[entry.count];
-			for (int i = 0;i < entry.count;i++)
-			{
-			  values[i] = data.ReadLong();
-			}
-			ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(values));
-			return new NumericDocValuesAnonymousInnerClassHelper4(values);
-		}
-
-		default:
-		  throw new AssertionError();
-		}
-	  }
-
-	  private class NumericDocValuesAnonymousInnerClassHelper : NumericDocValues
-	  {
-	      private readonly byte[] values;
-
-		  public NumericDocValuesAnonymousInnerClassHelper(byte[] values)
-		  {
-		      this.values = values;
-		  }
-
-		  public override long Get(int idx)
-		  {
-			return values[idx];
-		  }
-	  }
-
-	  private class NumericDocValuesAnonymousInnerClassHelper2 : NumericDocValues
-	  {
-	      private readonly short[] values;
-
-		  public NumericDocValuesAnonymousInnerClassHelper2(DirectDocValuesProducer outerInstance, short[] values)
-		  {
-		      this.values = values;
-		  }
-
-		  public override long Get(int idx)
-		  {
-			return values[idx];
-		  }
-	  }
-
-	  private class NumericDocValuesAnonymousInnerClassHelper3 : NumericDocValues
-	  {
-	      private readonly int[] values;
-
-		  public NumericDocValuesAnonymousInnerClassHelper3(int[] values)
-		  {
-		      this.values = values;
-		  }
-
-		  public override long Get(int idx)
-		  {
-			return values[idx];
-		  }
-	  }
-
-	  private class NumericDocValuesAnonymousInnerClassHelper4 : NumericDocValues
-	  {
-	      private readonly long[] values;
-
-		  public NumericDocValuesAnonymousInnerClassHelper4(long[] values)
-		  {
-		      this.values = values;
-		  }
-
-		  public override long Get(int idx)
-		  {
-			return values[idx];
-		  }
-	  }
-
-	  public override BinaryDocValues GetBinary(FieldInfo field)
-	  {
-		  lock (this)
-		  {
-			var instance = binaryInstances[field.Number];
-			if (instance == null)
-			{
-			  // Lazy load
-			  instance = LoadBinary(binaries[field.Number]);
-			  binaryInstances[field.Number] = instance;
-			}
-			return instance;
-		  }
-	  }
-
-	  private BinaryDocValues LoadBinary(BinaryEntry entry)
-	  {
-		data.Seek(entry.offset);
-		var bytes = new byte[entry.numBytes];
-		data.ReadBytes(bytes, 0, entry.numBytes);
-		data.Seek(entry.offset + entry.numBytes + entry.missingBytes);
-
-		var address = new int[entry.count + 1];
-		for (int i = 0;i < entry.count;i++)
-		{
-		  address[i] = data.ReadInt();
-		}
-		address[entry.count] = data.ReadInt();
-
-		ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(bytes) + RamUsageEstimator.SizeOf(address));
-
-		return new BinaryDocValuesAnonymousInnerClassHelper(bytes, address);
-	  }
-
-	  private class BinaryDocValuesAnonymousInnerClassHelper : BinaryDocValues
-	  {
-	      private readonly byte[] bytes;
-		  private readonly int[] address;
-
-		  public BinaryDocValuesAnonymousInnerClassHelper(byte[] bytes, int[] address)
-		  {
-		      this.bytes = bytes;
-			  this.address = address;
-		  }
-
-		  public override void Get(int docID, BytesRef result)
-		  {
-			result.Bytes = bytes;
-			result.Offset = address[docID];
-			result.Length = address[docID + 1] - result.Offset;
-		  }
-	  }
-
-	  public override SortedDocValues GetSorted(FieldInfo field)
-	  {
-		  lock (this)
-		  {
-			var instance = sortedInstances[field.Number];
-			if (instance == null)
-			{
-			  // Lazy load
-			  instance = LoadSorted(field);
-			  sortedInstances[field.Number] = instance;
-			}
-			return instance;
-		  }
-	  }
-
-	  private SortedDocValues LoadSorted(FieldInfo field)
-	  {
-		SortedEntry entry = sorteds[field.Number];
-		NumericDocValues docToOrd = LoadNumeric(entry.docToOrd);
-		BinaryDocValues values = LoadBinary(entry.values);
-
-		return new SortedDocValuesAnonymousInnerClassHelper(this, entry, docToOrd, values);
-	  }
-
-	  private class SortedDocValuesAnonymousInnerClassHelper : SortedDocValues
-	  {
-		  private readonly DirectDocValuesProducer outerInstance;
-
-		  private readonly SortedEntry entry;
-		  private readonly NumericDocValues docToOrd;
-		  private readonly BinaryDocValues values;
-
-		  public SortedDocValuesAnonymousInnerClassHelper(DirectDocValuesProducer outerInstance, SortedEntry entry, NumericDocValues docToOrd, BinaryDocValues values)
-		  {
-			  this.outerInstance = outerInstance;
-			  this.entry = entry;
-			  this.docToOrd = docToOrd;
-			  this.values = values;
-		  }
-
-
-		  public override int GetOrd(int docID)
-		  {
-			return (int) docToOrd.Get(docID);
-		  }
-
-		  public override void LookupOrd(int ord, BytesRef result)
-		  {
-			values.Get(ord, result);
-		  }
-
-		  public override int ValueCount
-		  {
-			  get
-			  {
-				return entry.values.count;
-			  }
-		  }
-
-		  // Leave lookupTerm to super's binary search
-
-		  // Leave termsEnum to super
-	  }
-
-	  public override SortedSetDocValues GetSortedSet(FieldInfo field)
-	  {
-		  lock (this)
-		  {
-			var instance = sortedSetInstances[field.Number];
-			var entry = sortedSets[field.Number];
-			if (instance == null)
-			{
-			  // Lazy load
-			  instance = LoadSortedSet(entry);
-			  sortedSetInstances[field.Number] = instance;
-			}
-        
-			var docToOrdAddress = instance.docToOrdAddress;
-			var ords = instance.ords;
-			var values = instance.values;
-        
-			// Must make a new instance since the iterator has state:
-			return new RandomAccessOrdsAnonymousInnerClassHelper(this, entry, docToOrdAddress, ords, values);
-		  }
-	  }
-
-	  private class RandomAccessOrdsAnonymousInnerClassHelper : RandomAccessOrds
-	  {
-	      private readonly SortedSetEntry entry;
-		  private readonly NumericDocValues docToOrdAddress;
-		  private readonly NumericDocValues ords;
-		  private readonly BinaryDocValues values;
-
-		  public RandomAccessOrdsAnonymousInnerClassHelper(DirectDocValuesProducer outerInstance, SortedSetEntry entry, NumericDocValues docToOrdAddress, NumericDocValues ords, BinaryDocValues values)
-		  {
-		      this.entry = entry;
-			  this.docToOrdAddress = docToOrdAddress;
-			  this.ords = ords;
-			  this.values = values;
-		  }
-
-	      private int ordStart;
-	      private int ordUpto;
-	      private int ordLimit;
-
-		  public override long NextOrd()
-		  {
-			if (ordUpto == ordLimit)
-			{
-			  return NO_MORE_ORDS;
-			}
-			else
-			{
-			  return ords.Get(ordUpto++);
-			}
-		  }
-
-		  public override int Document
-		  {
-			  set
-			  {
-				ordStart = ordUpto = (int) docToOrdAddress.Get(value);
-				ordLimit = (int) docToOrdAddress.Get(value+1);
-			  }
-		  }
-
-		  public override void LookupOrd(long ord, BytesRef result)
-		  {
-			values.Get((int) ord, result);
-		  }
-
-		  public override long ValueCount
-		  {
-			  get
-			  {
-				return entry.values.count;
-			  }
-		  }
-
-		  public override long OrdAt(int index)
-		  {
-			return ords.Get(ordStart + index);
-		  }
-
-		  public override int Cardinality()
-		  {
-			return ordLimit - ordStart;
-		  }
-
-		  // Leave lookupTerm to super's binary search
-
-		  // Leave termsEnum to super
-	  }
-
-	  private SortedSetRawValues LoadSortedSet(SortedSetEntry entry)
-	  {
-		var instance = new SortedSetRawValues();
-		instance.docToOrdAddress = LoadNumeric(entry.docToOrdAddress);
-		instance.ords = LoadNumeric(entry.ords);
-		instance.values = LoadBinary(entry.values);
-		return instance;
-	  }
-
-	  private Bits GetMissingBits(int fieldNumber, long offset, long length)
-	  {
-		if (offset == -1)
-		{
-		  return new Bits_MatchAllBits(maxDoc);
-		}
-		else
-		{
-		  Bits instance;
-		  lock (this)
-		  {
-			instance = docsWithFieldInstances[fieldNumber];
-			if (instance == null)
-			{
-			  var data = (IndexInput)this.data.Clone();
-			  data.Seek(offset);
-			  Debug.Assert(length % 8 == 0);
-			  var bits = new long[(int) length >> 3];
-			  for (var i = 0; i < bits.Length; i++)
-			  {
-				bits[i] = data.ReadLong();
-			  }
-			  instance = new FixedBitSet(bits, maxDoc);
-			  docsWithFieldInstances[fieldNumber] = instance;
-			}
-		  }
-		  return instance;
-		}
-	  }
-
-	  public override Bits GetDocsWithField(FieldInfo field)
-	  {
-		switch (field.DocValuesType)
-		{
-		  case SORTED_SET:
-			return DocValues.DocsWithValue(GetSortedSet(field), maxDoc);
-		  case SORTED:
-			return DocValues.DocsWithValue(GetSorted(field), maxDoc);
-		  case BINARY:
-			BinaryEntry be = binaries[field.Number];
-			return GetMissingBits(field.Number, be.missingOffset, be.missingBytes);
-		  case NUMERIC:
-			NumericEntry ne = numerics[field.Number];
-			return GetMissingBits(field.Number, ne.missingOffset, ne.missingBytes);
-		  default:
-			throw new AssertionError();
-		}
-	  }
-
-	    protected override void Dispose(bool disposing)
-	    {
-	        if (disposing)
-	            data.Dispose();
-	    }
-
-	    internal class SortedSetRawValues
-	  {
-		internal NumericDocValues docToOrdAddress;
-		internal NumericDocValues ords;
-		internal BinaryDocValues values;
-	  }
-
-	  internal class NumericEntry
-	  {
-		internal long offset;
-		internal int count;
-		internal long missingOffset;
-		internal long missingBytes;
-		internal byte byteWidth;
-		internal int packedIntsVersion;
-	  }
-
-	  internal class BinaryEntry
-	  {
-		internal long offset;
-		internal long missingOffset;
-		internal long missingBytes;
-		internal int count;
-		internal int numBytes;
-		internal int minLength;
-		internal int maxLength;
-		internal int packedIntsVersion;
-		internal int blockSize;
-	  }
-
-	  internal class SortedEntry
-	  {
-		internal NumericEntry docToOrd;
-		internal BinaryEntry values;
-	  }
-
-	  internal class SortedSetEntry
-	  {
-		internal NumericEntry docToOrdAddress;
-		internal NumericEntry ords;
-		internal BinaryEntry values;
-	  }
-
-	  internal class FSTEntry
-	  {
-		internal long offset;
-		internal long numOrds;
-	  }
-	}
+    /// <summary>
+    /// Reader for <seealso cref="DirectDocValuesFormat"/>
+    /// </summary>
+
+    internal class DirectDocValuesProducer : DocValuesProducer
+    {
+        // metadata maps (just file pointers and minimal stuff)
+        private readonly IDictionary<int?, NumericEntry> numerics = new Dictionary<int?, NumericEntry>();
+        private readonly IDictionary<int?, BinaryEntry> binaries = new Dictionary<int?, BinaryEntry>();
+        private readonly IDictionary<int?, SortedEntry> sorteds = new Dictionary<int?, SortedEntry>();
+        private readonly IDictionary<int?, SortedSetEntry> sortedSets = new Dictionary<int?, SortedSetEntry>();
+        private readonly IndexInput data;
+
+        // ram instances we have already loaded
+        private readonly IDictionary<int?, NumericDocValues> numericInstances = new Dictionary<int?, NumericDocValues>();
+        private readonly IDictionary<int?, BinaryDocValues> binaryInstances = new Dictionary<int?, BinaryDocValues>();
+        private readonly IDictionary<int?, SortedDocValues> sortedInstances = new Dictionary<int?, SortedDocValues>();
+        private readonly IDictionary<int?, SortedSetRawValues> sortedSetInstances = new Dictionary<int?, SortedSetRawValues>();
+        private readonly IDictionary<int?, Bits> docsWithFieldInstances = new Dictionary<int?, Bits>();
+
+        private readonly int maxDoc;
+        private readonly AtomicLong ramBytesUsed;
+        private readonly int version;
+
+        internal const sbyte NUMBER = 0;
+        internal const sbyte BYTES = 1;
+        internal const sbyte SORTED = 2;
+        internal const sbyte SORTED_SET = 3;
+
+        internal const int VERSION_START = 0;
+        internal const int VERSION_CHECKSUM = 1;
+        internal const int VERSION_CURRENT = VERSION_CHECKSUM;
+
+        internal DirectDocValuesProducer(SegmentReadState state, string dataCodec, string dataExtension, string metaCodec, string metaExtension)
+        {
+            maxDoc = state.SegmentInfo.DocCount;
+            string metaName = IndexFileNames.SegmentFileName(state.SegmentInfo.Name, state.SegmentSuffix, metaExtension);
+            // read in the entries from the metadata file.
+            ChecksumIndexInput @in = state.Directory.OpenChecksumInput(metaName, state.Context);
+            ramBytesUsed = new AtomicLong(RamUsageEstimator.ShallowSizeOfInstance(this.GetType()));
+            bool success = false;
+            try
+            {
+                version = CodecUtil.CheckHeader(@in, metaCodec, VERSION_START, VERSION_CURRENT);
+                ReadFields(@in);
+
+                if (version >= VERSION_CHECKSUM)
+                {
+                    CodecUtil.CheckFooter(@in);
+                }
+                else
+                {
+                    CodecUtil.CheckEOF(@in);
+                }
+                success = true;
+            }
+            finally
+            {
+                if (success)
+                {
+                    IOUtils.Close(@in);
+                }
+                else
+                {
+                    IOUtils.CloseWhileHandlingException(@in);
+                }
+            }
+
+            success = false;
+            try
+            {
+                string dataName = IndexFileNames.SegmentFileName(state.SegmentInfo.Name, state.SegmentSuffix, dataExtension);
+                data = state.Directory.OpenInput(dataName, state.Context);
+                int version2 = CodecUtil.CheckHeader(data, dataCodec, VERSION_START, VERSION_CURRENT);
+                if (version != version2)
+                {
+                    throw new CorruptIndexException("Format versions mismatch");
+                }
+
+                success = true;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    IOUtils.CloseWhileHandlingException(this.data);
+                }
+            }
+        }
+
+        private static NumericEntry ReadNumericEntry(IndexInput meta)
+        {
+            var entry = new NumericEntry { offset = meta.ReadLong(), count = meta.ReadInt(), missingOffset = meta.ReadLong() };
+            if (entry.missingOffset != -1)
+            {
+                entry.missingBytes = meta.ReadLong();
+            }
+            else
+            {
+                entry.missingBytes = 0;
+            }
+            entry.byteWidth = meta.ReadByte();
+
+            return entry;
+        }
+
+        private BinaryEntry ReadBinaryEntry(IndexInput meta)
+        {
+            var entry = new BinaryEntry();
+            entry.offset = meta.ReadLong();
+            entry.numBytes = meta.ReadInt();
+            entry.count = meta.ReadInt();
+            entry.missingOffset = meta.ReadLong();
+            if (entry.missingOffset != -1)
+            {
+                entry.missingBytes = meta.ReadLong();
+            }
+            else
+            {
+                entry.missingBytes = 0;
+            }
+
+            return entry;
+        }
+
+        private SortedEntry ReadSortedEntry(IndexInput meta)
+        {
+            var entry = new SortedEntry();
+            entry.docToOrd = ReadNumericEntry(meta);
+            entry.values = ReadBinaryEntry(meta);
+            return entry;
+        }
+
+        private SortedSetEntry ReadSortedSetEntry(IndexInput meta)
+        {
+            var entry = new SortedSetEntry();
+            entry.docToOrdAddress = ReadNumericEntry(meta);
+            entry.ords = ReadNumericEntry(meta);
+            entry.values = ReadBinaryEntry(meta);
+            return entry;
+        }
+
+        private void ReadFields(IndexInput meta)
+        {
+            int fieldNumber = meta.ReadVInt();
+            while (fieldNumber != -1)
+            {
+                int fieldType = meta.ReadByte();
+                if (fieldType == NUMBER)
+                {
+                    numerics[fieldNumber] = ReadNumericEntry(meta);
+                }
+                else if (fieldType == BYTES)
+                {
+                    binaries[fieldNumber] = ReadBinaryEntry(meta);
+                }
+                else if (fieldType == SORTED)
+                {
+                    sorteds[fieldNumber] = ReadSortedEntry(meta);
+                }
+                else if (fieldType == SORTED_SET)
+                {
+                    sortedSets[fieldNumber] = ReadSortedSetEntry(meta);
+                }
+                else
+                {
+                    throw new CorruptIndexException("invalid entry type: " + fieldType + ", input=" + meta);
+                }
+                fieldNumber = meta.ReadVInt();
+            }
+        }
+
+        public override long RamBytesUsed()
+        {
+            return ramBytesUsed.Get();
+        }
+
+        public override void CheckIntegrity()
+        {
+            if (version >= VERSION_CHECKSUM)
+            {
+                CodecUtil.ChecksumEntireFile(data);
+            }
+        }
+
+        public override NumericDocValues GetNumeric(FieldInfo field)
+        {
+            lock (this)
+            {
+                var instance = numericInstances[field.Number];
+                if (instance == null)
+                {
+                    // Lazy load
+                    instance = LoadNumeric(numerics[field.Number]);
+                    numericInstances[field.Number] = instance;
+                }
+                return instance;
+            }
+        }
+
+        private NumericDocValues LoadNumeric(NumericEntry entry)
+        {
+            data.Seek(entry.offset + entry.missingBytes);
+            switch (entry.byteWidth)
+            {
+                case 1:
+                    {
+                        var values = new byte[entry.count];
+                        data.ReadBytes(values, 0, entry.count);
+                        ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(values));
+                        return new NumericDocValuesAnonymousInnerClassHelper(values);
+                    }
+
+                case 2:
+                    {
+                        var values = new short[entry.count];
+                        for (int i = 0; i < entry.count; i++)
+                        {
+                            values[i] = data.ReadShort();
+                        }
+                        ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(values));
+                        return new NumericDocValuesAnonymousInnerClassHelper2(this, values);
+                    }
+
+                case 4:
+                    {
+                        var values = new int[entry.count];
+                        for (var i = 0; i < entry.count; i++)
+                        {
+                            values[i] = data.ReadInt();
+                        }
+                        ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(values));
+                        return new NumericDocValuesAnonymousInnerClassHelper3(values);
+                    }
+
+                case 8:
+                    {
+                        var values = new long[entry.count];
+                        for (int i = 0; i < entry.count; i++)
+                        {
+                            values[i] = data.ReadLong();
+                        }
+                        ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(values));
+                        return new NumericDocValuesAnonymousInnerClassHelper4(values);
+                    }
+
+                default:
+                    throw new System.InvalidOperationException();
+            }
+        }
+
+        private class NumericDocValuesAnonymousInnerClassHelper : NumericDocValues
+        {
+            private readonly byte[] values;
+
+            public NumericDocValuesAnonymousInnerClassHelper(byte[] values)
+            {
+                this.values = values;
+            }
+
+            public override long Get(int idx)
+            {
+                return values[idx];
+            }
+        }
+
+        private class NumericDocValuesAnonymousInnerClassHelper2 : NumericDocValues
+        {
+            private readonly short[] values;
+
+            public NumericDocValuesAnonymousInnerClassHelper2(DirectDocValuesProducer outerInstance, short[] values)
+            {
+                this.values = values;
+            }
+
+            public override long Get(int idx)
+            {
+                return values[idx];
+            }
+        }
+
+        private class NumericDocValuesAnonymousInnerClassHelper3 : NumericDocValues
+        {
+            private readonly int[] values;
+
+            public NumericDocValuesAnonymousInnerClassHelper3(int[] values)
+            {
+                this.values = values;
+            }
+
+            public override long Get(int idx)
+            {
+                return values[idx];
+            }
+        }
+
+        private class NumericDocValuesAnonymousInnerClassHelper4 : NumericDocValues
+        {
+            private readonly long[] values;
+
+            public NumericDocValuesAnonymousInnerClassHelper4(long[] values)
+            {
+                this.values = values;
+            }
+
+            public override long Get(int idx)
+            {
+                return values[idx];
+            }
+        }
+
+        public override BinaryDocValues GetBinary(FieldInfo field)
+        {
+            lock (this)
+            {
+                var instance = binaryInstances[field.Number];
+                if (instance == null)
+                {
+                    // Lazy load
+                    instance = LoadBinary(binaries[field.Number]);
+                    binaryInstances[field.Number] = instance;
+                }
+                return instance;
+            }
+        }
+
+        private BinaryDocValues LoadBinary(BinaryEntry entry)
+        {
+            data.Seek(entry.offset);
+            var bytes = new byte[entry.numBytes];
+            data.ReadBytes(bytes, 0, entry.numBytes);
+            data.Seek(entry.offset + entry.numBytes + entry.missingBytes);
+
+            var address = new int[entry.count + 1];
+            for (int i = 0; i < entry.count; i++)
+            {
+                address[i] = data.ReadInt();
+            }
+            address[entry.count] = data.ReadInt();
+
+            ramBytesUsed.AddAndGet(RamUsageEstimator.SizeOf(bytes) + RamUsageEstimator.SizeOf(address));
+
+            return new BinaryDocValuesAnonymousInnerClassHelper(bytes, address);
+        }
+
+        private class BinaryDocValuesAnonymousInnerClassHelper : BinaryDocValues
+        {
+            private readonly byte[] bytes;
+            private readonly int[] address;
+
+            public BinaryDocValuesAnonymousInnerClassHelper(byte[] bytes, int[] address)
+            {
+                this.bytes = bytes;
+                this.address = address;
+            }
+
+            public override void Get(int docID, BytesRef result)
+            {
+                result.Bytes = bytes;
+                result.Offset = address[docID];
+                result.Length = address[docID + 1] - result.Offset;
+            }
+        }
+
+        public override SortedDocValues GetSorted(FieldInfo field)
+        {
+            lock (this)
+            {
+                var instance = sortedInstances[field.Number];
+                if (instance == null)
+                {
+                    // Lazy load
+                    instance = LoadSorted(field);
+                    sortedInstances[field.Number] = instance;
+                }
+                return instance;
+            }
+        }
+
+        private SortedDocValues LoadSorted(FieldInfo field)
+        {
+            SortedEntry entry = sorteds[field.Number];
+            NumericDocValues docToOrd = LoadNumeric(entry.docToOrd);
+            BinaryDocValues values = LoadBinary(entry.values);
+
+            return new SortedDocValuesAnonymousInnerClassHelper(this, entry, docToOrd, values);
+        }
+
+        private class SortedDocValuesAnonymousInnerClassHelper : SortedDocValues
+        {
+            private readonly DirectDocValuesProducer outerInstance;
+
+            private readonly SortedEntry entry;
+            private readonly NumericDocValues docToOrd;
+            private readonly BinaryDocValues values;
+
+            public SortedDocValuesAnonymousInnerClassHelper(DirectDocValuesProducer outerInstance, SortedEntry entry, NumericDocValues docToOrd, BinaryDocValues values)
+            {
+                this.outerInstance = outerInstance;
+                this.entry = entry;
+                this.docToOrd = docToOrd;
+                this.values = values;
+            }
+
+
+            public override int GetOrd(int docID)
+            {
+                return (int)docToOrd.Get(docID);
+            }
+
+            public override void LookupOrd(int ord, BytesRef result)
+            {
+                values.Get(ord, result);
+            }
+
+            public override int ValueCount
+            {
+                get
+                {
+                    return entry.values.count;
+                }
+            }
+
+            // Leave lookupTerm to super's binary search
+
+            // Leave termsEnum to super
+        }
+
+        public override SortedSetDocValues GetSortedSet(FieldInfo field)
+        {
+            lock (this)
+            {
+                var instance = sortedSetInstances[field.Number];
+                var entry = sortedSets[field.Number];
+                if (instance == null)
+                {
+                    // Lazy load
+                    instance = LoadSortedSet(entry);
+                    sortedSetInstances[field.Number] = instance;
+                }
+
+                var docToOrdAddress = instance.docToOrdAddress;
+                var ords = instance.ords;
+                var values = instance.values;
+
+                // Must make a new instance since the iterator has state:
+                return new RandomAccessOrdsAnonymousInnerClassHelper(this, entry, docToOrdAddress, ords, values);
+            }
+        }
+
+        private class RandomAccessOrdsAnonymousInnerClassHelper : RandomAccessOrds
+        {
+            private readonly SortedSetEntry entry;
+            private readonly NumericDocValues docToOrdAddress;
+            private readonly NumericDocValues ords;
+            private readonly BinaryDocValues values;
+
+            public RandomAccessOrdsAnonymousInnerClassHelper(DirectDocValuesProducer outerInstance, SortedSetEntry entry, NumericDocValues docToOrdAddress, NumericDocValues ords, BinaryDocValues values)
+            {
+                this.entry = entry;
+                this.docToOrdAddress = docToOrdAddress;
+                this.ords = ords;
+                this.values = values;
+            }
+
+            private int ordStart;
+            private int ordUpto;
+            private int ordLimit;
+
+            public override long NextOrd()
+            {
+                if (ordUpto == ordLimit)
+                {
+                    return NO_MORE_ORDS;
+                }
+                else
+                {
+                    return ords.Get(ordUpto++);
+                }
+            }
+
+            public override int Document
+            {
+                set
+                {
+                    ordStart = ordUpto = (int)docToOrdAddress.Get(value);
+                    ordLimit = (int)docToOrdAddress.Get(value + 1);
+                }
+            }
+
+            public override void LookupOrd(long ord, BytesRef result)
+            {
+                values.Get((int)ord, result);
+            }
+
+            public override long ValueCount
+            {
+                get
+                {
+                    return entry.values.count;
+                }
+            }
+
+            public override long OrdAt(int index)
+            {
+                return ords.Get(ordStart + index);
+            }
+
+            public override int Cardinality()
+            {
+                return ordLimit - ordStart;
+            }
+
+            // Leave lookupTerm to super's binary search
+
+            // Leave termsEnum to super
+        }
+
+        private SortedSetRawValues LoadSortedSet(SortedSetEntry entry)
+        {
+            var instance = new SortedSetRawValues();
+            instance.docToOrdAddress = LoadNumeric(entry.docToOrdAddress);
+            instance.ords = LoadNumeric(entry.ords);
+            instance.values = LoadBinary(entry.values);
+            return instance;
+        }
+
+        private Bits GetMissingBits(int fieldNumber, long offset, long length)
+        {
+            if (offset == -1)
+            {
+                return new Bits_MatchAllBits(maxDoc);
+            }
+            else
+            {
+                Bits instance;
+                lock (this)
+                {
+                    instance = docsWithFieldInstances[fieldNumber];
+                    if (instance == null)
+                    {
+                        var data = (IndexInput)this.data.Clone();
+                        data.Seek(offset);
+                        Debug.Assert(length % 8 == 0);
+                        var bits = new long[(int)length >> 3];
+                        for (var i = 0; i < bits.Length; i++)
+                        {
+                            bits[i] = data.ReadLong();
+                        }
+                        instance = new FixedBitSet(bits, maxDoc);
+                        docsWithFieldInstances[fieldNumber] = instance;
+                    }
+                }
+                return instance;
+            }
+        }
+
+        public override Bits GetDocsWithField(FieldInfo field)
+        {
+            switch (field.DocValuesType)
+            {
+                case FieldInfo.DocValuesType_e.SORTED_SET:
+                    return DocValues.DocsWithValue(GetSortedSet(field), maxDoc);
+                case FieldInfo.DocValuesType_e.SORTED:
+                    return DocValues.DocsWithValue(GetSorted(field), maxDoc);
+                case FieldInfo.DocValuesType_e.BINARY:
+                    BinaryEntry be = binaries[field.Number];
+                    return GetMissingBits(field.Number, be.missingOffset, be.missingBytes);
+                case FieldInfo.DocValuesType_e.NUMERIC:
+                    NumericEntry ne = numerics[field.Number];
+                    return GetMissingBits(field.Number, ne.missingOffset, ne.missingBytes);
+                default:
+                    throw new System.ArgumentOutOfRangeException();
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                data.Dispose();
+        }
+
+        internal class SortedSetRawValues
+        {
+            internal NumericDocValues docToOrdAddress;
+            internal NumericDocValues ords;
+            internal BinaryDocValues values;
+        }
+
+        internal class NumericEntry
+        {
+            internal long offset;
+            internal int count;
+            internal long missingOffset;
+            internal long missingBytes;
+            internal byte byteWidth;
+            internal int packedIntsVersion;
+        }
+
+        internal class BinaryEntry
+        {
+            internal long offset;
+            internal long missingOffset;
+            internal long missingBytes;
+            internal int count;
+            internal int numBytes;
+            internal int minLength;
+            internal int maxLength;
+            internal int packedIntsVersion;
+            internal int blockSize;
+        }
+
+        internal class SortedEntry
+        {
+            internal NumericEntry docToOrd;
+            internal BinaryEntry values;
+        }
+
+        internal class SortedSetEntry
+        {
+            internal NumericEntry docToOrdAddress;
+            internal NumericEntry ords;
+            internal BinaryEntry values;
+        }
+
+        internal class FSTEntry
+        {
+            internal long offset;
+            internal long numOrds;
+        }
+    }
 }

--- a/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
@@ -546,7 +546,7 @@ namespace Lucene.Net.Codecs.Memory
                             {
 //JAVA TO C# CONVERTER WARNING: The original Java variable was marked 'final':
 //ORIGINAL LINE: final int freq = docsEnum2.freq();
-                                int freq = docsEnum2.freq();
+                                int freq = docsEnum2.Freq();
                                 freqs[upto] = freq;
                                 if (hasPos)
                                 {
@@ -569,23 +569,23 @@ namespace Lucene.Net.Codecs.Memory
                                     int posUpto = 0;
                                     for (int pos = 0; pos < freq; pos++)
                                     {
-                                        positions[upto][posUpto] = docsAndPositionsEnum.nextPosition();
+                                        positions[upto][posUpto] = docsAndPositionsEnum.NextPosition();
                                         if (hasPayloads_Renamed)
                                         {
                                             BytesRef payload = docsAndPositionsEnum.Payload;
                                             if (payload != null)
                                             {
-                                                sbyte[] payloadBytes = new sbyte[payload.length];
-                                                Array.Copy(payload.bytes, payload.offset, payloadBytes, 0,
-                                                    payload.length);
+                                                sbyte[] payloadBytes = new sbyte[payload.Length];
+                                                Array.Copy(payload.Bytes, payload.Offset, payloadBytes, 0,
+                                                    payload.Length);
                                                 payloads[upto][pos] = payloadBytes;
                                             }
                                         }
                                         posUpto++;
                                         if (hasOffsets_Renamed)
                                         {
-                                            positions[upto][posUpto++] = docsAndPositionsEnum.startOffset();
-                                            positions[upto][posUpto++] = docsAndPositionsEnum.endOffset();
+                                            positions[upto][posUpto++] = docsAndPositionsEnum.StartOffset();
+                                            positions[upto][posUpto++] = docsAndPositionsEnum.EndOffset();
                                         }
                                     }
                                 }
@@ -605,7 +605,7 @@ namespace Lucene.Net.Codecs.Memory
                 // End sentinel:
                 termOffsets[count] = termOffset;
 
-                finishSkips();
+                FinishSkips();
 
                 //System.out.println(skipCount + " skips: " + field);
 
@@ -694,17 +694,14 @@ namespace Lucene.Net.Codecs.Memory
 
                 if (sameCounts.Length < termLength)
                 {
-                    sameCounts = ArrayUtil.grow(sameCounts, termLength);
+                    sameCounts = ArrayUtil.Grow(sameCounts, termLength);
                 }
 
                 // Update skip pointers:
                 if (termOrd > 0)
                 {
-//JAVA TO C# CONVERTER WARNING: The original Java variable was marked 'final':
-//ORIGINAL LINE: final int lastTermLength = termOffsets[termOrd] - termOffsets[termOrd-1];
+
                     int lastTermLength = termOffsets[termOrd] - termOffsets[termOrd - 1];
-//JAVA TO C# CONVERTER WARNING: The original Java variable was marked 'final':
-//ORIGINAL LINE: final int limit = Math.min(termLength, lastTermLength);
                     int limit = Math.Min(termLength, lastTermLength);
 
                     int lastTermOffset = termOffsets[termOrd - 1];
@@ -724,7 +721,7 @@ namespace Lucene.Net.Codecs.Memory
                                 if (sameCounts[i] >= minSkipCount)
                                 {
                                     // Go back and add a skip pointer:
-                                    saveSkip(termOrd, sameCounts[i]);
+                                    SaveSkip(termOrd, sameCounts[i]);
                                 }
                                 sameCounts[i] = 1;
                             }
@@ -737,7 +734,7 @@ namespace Lucene.Net.Codecs.Memory
                         if (sameCounts[i] >= minSkipCount)
                         {
                             // Go back and add a skip pointer:
-                            saveSkip(termOrd, sameCounts[i]);
+                            SaveSkip(termOrd, sameCounts[i]);
                         }
                         sameCounts[i] = 0;
                     }
@@ -755,7 +752,7 @@ namespace Lucene.Net.Codecs.Memory
                 }
             }
 
-            internal void finishSkips()
+            internal void FinishSkips()
             {
                 Debug.Assert(count == terms.Length);
                 int lastTermOffset = termOffsets[count - 1];
@@ -766,7 +763,7 @@ namespace Lucene.Net.Codecs.Memory
                     if (sameCounts[i] >= minSkipCount)
                     {
                         // Go back and add a skip pointer:
-                        saveSkip(count, sameCounts[i]);
+                        SaveSkip(count, sameCounts[i]);
                     }
                 }
 
@@ -778,12 +775,8 @@ namespace Lucene.Net.Codecs.Memory
                     {
                         for (int pos = 0; pos < term.skips.Length/2; pos++)
                         {
-//JAVA TO C# CONVERTER WARNING: The original Java variable was marked 'final':
-//ORIGINAL LINE: final int otherPos = term.skips.length-pos-1;
                             int otherPos = term.skips.Length - pos - 1;
 
-//JAVA TO C# CONVERTER WARNING: The original Java variable was marked 'final':
-//ORIGINAL LINE: final int temp = term.skips[pos];
                             int temp = term.skips[pos];
                             term.skips[pos] = term.skips[otherPos];
                             term.skips[otherPos] = temp;
@@ -792,10 +785,8 @@ namespace Lucene.Net.Codecs.Memory
                 }
             }
 
-            internal void saveSkip(int ord, int backCount)
+            internal void SaveSkip(int ord, int backCount)
             {
-//JAVA TO C# CONVERTER WARNING: The original Java variable was marked 'final':
-//ORIGINAL LINE: final TermAndSkip term = terms[ord - backCount];
                 TermAndSkip term = terms[ord - backCount];
                 skipCount++;
                 if (term.skips == null)

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesWriter.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesWriter.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Codecs.SimpleText
             numDocs = state.SegmentInfo.DocCount;
         }
 
-        public override void AddNumericField(FieldInfo field, IEnumerable<long> values)
+        public override void AddNumericField(FieldInfo field, IEnumerable<long?> values)
         {
             Debug.Assert(FieldSeen(field.Name));
             Debug.Assert(field.DocValuesType == FieldInfo.DocValuesType_e.NUMERIC ||
@@ -74,8 +74,8 @@ namespace Lucene.Net.Codecs.SimpleText
             foreach (var n in values)
             {
                 var v = n;
-                minValue = Math.Min(minValue, v);
-                maxValue = Math.Max(maxValue, v);
+                minValue = Math.Min(minValue, v.Value); // Added .Value to account for long?
+                maxValue = Math.Max(maxValue, v.Value); // Added .Value to account for long?
             }
 
             // write our minimum value to the .dat, all entries are deltas from that
@@ -103,8 +103,10 @@ namespace Lucene.Net.Codecs.SimpleText
             int numDocsWritten = 0;
 
             // second pass to write the values
-            foreach (var value in values)
+            foreach (var n in values)
             {
+                long value = n == null ? 0 : n.Value;
+
                 Debug.Assert(value >= minValue);
 
                 var delta = value - minValue;
@@ -180,7 +182,7 @@ namespace Lucene.Net.Codecs.SimpleText
             Debug.Assert(numDocs == numDocsWritten);
         }
 
-        public override void AddSortedField(FieldInfo field, IEnumerable<BytesRef> values, IEnumerable<long> docToOrd)
+        public override void AddSortedField(FieldInfo field, IEnumerable<BytesRef> values, IEnumerable<long?> docToOrd)
         {
             Debug.Assert(FieldSeen(field.Name));
             Debug.Assert(field.DocValuesType == FieldInfo.DocValuesType_e.SORTED);
@@ -260,13 +262,13 @@ namespace Lucene.Net.Codecs.SimpleText
 
             foreach (var ord in docToOrd)
             {
-                SimpleTextUtil.Write(data, (ord + 1).ToString(ordEncoderFormat), scratch);
+                SimpleTextUtil.Write(data, (ord + 1).Value.ToString(ordEncoderFormat), scratch);
                 SimpleTextUtil.WriteNewline(data);
             }
         }
 
         public override void AddSortedSetField(FieldInfo field, IEnumerable<BytesRef> values,
-            IEnumerable<long> docToOrdCount, IEnumerable<long> ords)
+            IEnumerable<long?> docToOrdCount, IEnumerable<long?> ords)
         {
             Debug.Assert(FieldSeen(field.Name));
             Debug.Assert(field.DocValuesType == FieldInfo.DocValuesType_e.SORTED_SET);


### PR DESCRIPTION
- Added Tests (they are completely broken, this is a stub)
- Updated SimpleText to fit with recent changes to Core
- Upgraded to 4.5.1

At this point I believe Memory is the only Codec still in the process of porting over. Then I will review all the code with the java version and start porting over tests more thoroughly

For anyone looking at porting issues, the java reference base is located here: http://svn.apache.org/repos/asf/lucene/dev/branches/lucene_solr_4_8/lucene/codecs/src/java/org/apache/lucene/codecs/


