### PR TITLE
fix enumerator port to use appropriate logic

### DIFF
--- a/src/Lucene.Net.TestFramework/Codecs/MissingOrdRemapper.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MissingOrdRemapper.cs
@@ -71,22 +71,20 @@ namespace Lucene.Net.Codecs
 
                 public bool MoveNext()
                 {
-                    if (seenEmpty || !@in.MoveNext())
-                    {
-                        return false;
-                    }
-
                     if (!seenEmpty)
                     {
                         seenEmpty = true;
                         current = new BytesRef();
-                    }
-                    else
-                    {
-                        current = @in.Current;
+                        return true;
                     }
 
-                    return true;
+                    if (@in.MoveNext())
+                    {
+                        current = @in.Current;
+                        return true;
+                    }
+
+                    return false;
                 }
 
                 public BytesRef Current


### PR DESCRIPTION
This makes several tests in Lucene45/Lucene40 namespace pass. The issue was with how the logic in "insertEmptyValue" iterator was rewritten in .NET. Here is Lucene source:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/test-framework/src/java/org/apache/lucene/codecs/MissingOrdRemapper.java#L40

The goal of this iterator was to first add empty byte array to the enumeration followed by the actual elements returned by  "@in.MoveNext()". The port instead returned empty byte array and then stopped: if seenEmpty OR @in.MoveNext() needs to be, if not seen empty, move next and return empty, otherwise defer to wrapped iterator.