### PR TITLE
fixing the Facet tests so that they use the right assembly name and default namespace.

### DIFF
--- a/src/Lucene.Net.Tests.Facet/Lucene.Net.Tests.Facet.csproj
+++ b/src/Lucene.Net.Tests.Facet/Lucene.Net.Tests.Facet.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{4D77E491-F50F-4A0C-9BD9-F9AB655720AD}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Lucene.Net.Tests.Classification</RootNamespace>
-    <AssemblyName>Lucene.Net.Tests.Classification</AssemblyName>
+    <RootNamespace>Lucene.Net.Tests.Facet</RootNamespace>
+    <AssemblyName>Lucene.Net.Tests.Facet</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>


### PR DESCRIPTION
Fixing a little error that was prevent CI for the Lucene.Net.Tests.Facet project.