### PR TITLE
Fix overflow resulting in negative values

### DIFF
--- a/src/Lucene.Net.Core/Index/LogByteSizeMergePolicy.cs
+++ b/src/Lucene.Net.Core/Index/LogByteSizeMergePolicy.cs
@@ -44,7 +44,14 @@ namespace Lucene.Net.Index
         {
             MinMergeSize = (long)(DEFAULT_MIN_MERGE_MB * 1024 * 1024);
             MaxMergeSize = (long)(DEFAULT_MAX_MERGE_MB * 1024 * 1024);
-            MaxMergeSizeForForcedMerge = (long)(DEFAULT_MAX_MERGE_MB_FOR_FORCED_MERGE * 1024 * 1024);
+            
+            // .Net port, original line is inappropriate, overflows in .NET 
+            // and the property gets set to a negative value.
+            // In Java however such statements results in long.MaxValue
+
+            //MaxMergeSizeForForcedMerge = (long)(DEFAULT_MAX_MERGE_MB_FOR_FORCED_MERGE * 1024 * 1024);
+            MaxMergeSizeForForcedMerge = long.MaxValue;
+            
         }
 
         protected internal override long Size(SegmentCommitInfo info)
@@ -70,6 +77,10 @@ namespace Lucene.Net.Index
             set
             {
                 MaxMergeSize = (long)(value * 1024 * 1024);
+                if (MaxMergeSize < 0)
+                {
+                    MaxMergeSize = long.MaxValue;
+                }
             }
             get
             {
@@ -89,6 +100,10 @@ namespace Lucene.Net.Index
             set
             {
                 MaxMergeSizeForForcedMerge = (long)(value * 1024 * 1024);
+                if (MaxMergeSizeForForcedMerge < 0)
+                {
+                    MaxMergeSizeForForcedMerge = long.MaxValue;
+                }
             }
             get
             {
@@ -112,6 +127,10 @@ namespace Lucene.Net.Index
             set
             {
                 MinMergeSize = (long)(value * 1024 * 1024);
+                if (MinMergeSize < 0)
+                {
+                    MinMergeSize = long.MaxValue;
+                }
             }
             get
             {


### PR DESCRIPTION
Noticed while debugging failing Lucene42/45 codec tests that sometimes when a test ran ForceMerge(1) on an index writer, the merge of segments did not occur and the directory contained whatever the number of segments existed before the merge. The tests then proceeded to fail as they expected only one segment to be in the index.

The issue is LogByteSizeMergePolicy. It does not occur all the time in the tests as its selection is random (https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs#L977). LogByteSizeMergePolicy policy in constructor sets the max size of the segment for forced merges. The value always ends up being too large for the long type and gets overflown, ie set to a negative value. This then caused LogMergePolicy to inappropriately mark small segments as too large at this logic branch:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.Core/Index/LogMergePolicy.cs#L433

I double checked that Java does indeed behave by not setting the value to a negative number and instead setting it to long.MaxValue. Looks like the previous port developers dealt with this before as well :) https://issues.apache.org/jira/browse/LUCENENET-282 

Note that this does not fix all of the tests that use ForceMerges, most of them continue to fail due to another bug, but the fix for that is coming up in a separate PR.