### PR TITLE
fix LogMergePolicy IsMerged logic

### DIFF
--- a/src/Lucene.Net.Core/Index/LogMergePolicy.cs
+++ b/src/Lucene.Net.Core/Index/LogMergePolicy.cs
@@ -224,7 +224,7 @@ namespace Lucene.Net.Index
             int numSegments = infos.Size();
             int numToMerge = 0;
             SegmentCommitInfo mergeInfo = null;
-            bool? segmentIsOriginal = false;
+            bool segmentIsOriginal = false;
             for (int i = 0; i < numSegments && numToMerge <= maxNumSegments; i++)
             {
                 SegmentCommitInfo info = infos.Info(i);
@@ -232,13 +232,13 @@ namespace Lucene.Net.Index
                 segmentsToMerge.TryGetValue(info, out isOriginal);
                 if (isOriginal != null)
                 {
-                    segmentIsOriginal = isOriginal;
+                    segmentIsOriginal = isOriginal.Value;
                     numToMerge++;
                     mergeInfo = info;
                 }
             }
 
-            return numToMerge <= maxNumSegments && (numToMerge != 1 || segmentIsOriginal != false || IsMerged(infos, mergeInfo));
+            return numToMerge <= maxNumSegments && (numToMerge != 1 || !segmentIsOriginal || IsMerged(infos, mergeInfo));
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -974,9 +974,8 @@ namespace Lucene.Net.Util
 
         public static LogMergePolicy NewLogMergePolicy(Random r)
         {
-            // LUCENENET TODO: don't use LogByteSizeMergePolicy until it is fixed
-            //LogMergePolicy logmp = r.NextBoolean() ? (LogMergePolicy)new LogDocMergePolicy() : new LogByteSizeMergePolicy();
-            LogMergePolicy logmp = new LogDocMergePolicy();
+            LogMergePolicy logmp = r.NextBoolean() ? (LogMergePolicy)new LogDocMergePolicy() : new LogByteSizeMergePolicy();
+            
             logmp.CalibrateSizeByDeletes = r.NextBoolean();
             if (Rarely(r))
             {


### PR DESCRIPTION
This fixes the issue where if LogByteSizeMergePolicy is used, the merges run "forever". At the end of the day the issue was not with the byte size policy, but with the LogMergePolicy "IsMerged" logic. segmentIsOriginal check was inverted, forcing the evaluation to continue and check IsMerged on already merged index and for LogByteSizeMergePolicy that returned false when in reality that check should have never happened. Changed the code to match Lucene:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/index/LogMergePolicy.java#L181