### PR TITLE
fix enumerators to use appropriate logic

### DIFF
--- a/src/Lucene.Net.Core/Codecs/DocValuesConsumer.cs
+++ b/src/Lucene.Net.Core/Codecs/DocValuesConsumer.cs
@@ -324,7 +324,7 @@ namespace Lucene.Net.Codecs
                 {
                     int segOrd = dvs[readerUpTo].GetOrd(docIDUpTo);
                     docIDUpTo++;
-                    yield return map.GetGlobalOrd(readerUpTo, segOrd);
+                    yield return segOrd == -1 ? -1 : map.GetGlobalOrd(readerUpTo, segOrd);
                     continue;
                 }
 
@@ -618,8 +618,9 @@ namespace Lucene.Net.Codecs
 
                 if (ordUpto < ordLength)
                 {
+                    var value = ords[ordUpto];
                     ordUpto++;
-                    yield return ords[ordUpto];
+                    yield return value;
                     continue;
                 }
 


### PR DESCRIPTION
When merging segments with sorted or sortedset values, incorrect data was written to the index:

- GetMergeSortValuesEnumerable was ignoring ordinal value of -1. Here is Lucene code for the same iterator: https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java#L390

- GetMergeSortedSetValuesEnumerable was skipping one value. Here is the relevant part in Lucene: https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java#L583

Lucene45, Lucene41, and Perfield codecs are now all green with a few runs that I did locally.