### PR TITLE
Support negative numbers in Lucene40 codec

### DIFF
--- a/src/Lucene.Net.Core/Codecs/Lucene40/Lucene40DocValuesReader.cs
+++ b/src/Lucene.Net.Core/Codecs/Lucene40/Lucene40DocValuesReader.cs
@@ -241,7 +241,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
             public override long Get(int docID)
             {
-                return Values[docID];
+                return (sbyte)Values[docID];
             }
         }
 


### PR DESCRIPTION
Lucene40 codec picks different methods of storing numeric values based on what data type is large enough to represent them. The issue was with the numbers that can fit in sbyte, they were being returned as byte due to our migration. Negative numbers -128 or greater were being returned as positive numbers.

This passes all remaining failing Lucene40 codec tests. Here is one example:

http://teamcity.codebetter.com/viewLog.html?buildId=180212&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId-8934306368705483624

Test expects to get back -10 but is getting back 246 instead.