### PR TITLE
replace dictionary with hashmap to support null keys

### DIFF
--- a/src/Lucene.Net.Core/Index/IndexWriter.cs
+++ b/src/Lucene.Net.Core/Index/IndexWriter.cs
@@ -247,7 +247,7 @@ namespace Lucene.Net.Index
         internal readonly IndexFileDeleter Deleter;
 
         // used by forceMerge to note those needing merging
-        private IDictionary<SegmentCommitInfo, bool?> SegmentsToMerge = new Dictionary<SegmentCommitInfo, bool?>();
+        private HashMap <SegmentCommitInfo, bool?> SegmentsToMerge = new HashMap<SegmentCommitInfo, bool?>();
 
         private int MergeMaxNumSegments;
 


### PR DESCRIPTION
Replace Dictionary with HashMap for tracking SegmentsToMerge in the IndexWriter. Lucene is using HashMap, and I can confirm by running Lucene 4.8 tests that sometimes there are cases when IndexWriter will insert null value as key. It is happening here:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L1788

When instance of OneMerge is created and passed around there is no guarantee that segment info will be set.

This now passes TestAddIndexesWithThreads and TestAddIndexesWithRollback in Lucene.Net.Index.TestAddIndexes.