### PR TITLE
Set lock factory directly and not through setter

### DIFF
--- a/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
@@ -117,7 +117,7 @@ namespace Lucene.Net.Index
             public FaultyFSDirectory(DirectoryInfo dir)
             {
                 FsDir = NewFSDirectory(dir);
-                LockFactory = FsDir.LockFactory;
+                _lockFactory = FsDir.LockFactory;
             }
 
             public override IndexInput OpenInput(string name, IOContext context)


### PR DESCRIPTION
FaultyFSDirectory was using a setter to set lock factory when it should have assigned directly to a class variable. Using a setter executes logic that should have never been run. 

Lucene is not using setLockFactory there:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/test/org/apache/lucene/index/TestFieldsReader.java#L113

This fixes failure in TestFieldsReader.TestExceptions