### PR TITLE
Marking Long Running Tests

### DIFF
--- a/src/Lucene.Net.Tests/core/Analysis/TestLookaheadTokenFilter.cs
+++ b/src/Lucene.Net.Tests/core/Analysis/TestLookaheadTokenFilter.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Attributes;
 using Lucene.Net.Randomized.Generators;
 using NUnit.Framework;
 using System;
@@ -25,7 +26,7 @@ namespace Lucene.Net.Analysis
     [TestFixture]
     public class TestLookaheadTokenFilter : BaseTokenStreamTestCase
     {
-        [Test]
+        [Test, LongRunningTest, Timeout(int.MaxValue)]
         public virtual void TestRandomStrings()
         {
             Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
@@ -68,7 +69,7 @@ namespace Lucene.Net.Analysis
             }
         }
 
-        [Test]
+        [Test, LongRunningTest, Timeout(int.MaxValue)]
         public virtual void TestNeverCallingPeek()
         {
             Analyzer a = new NCPAnalyzerAnonymousInnerClassHelper(this);

--- a/src/Lucene.Net.Tests/core/Analysis/TestMockAnalyzer.cs
+++ b/src/Lucene.Net.Tests/core/Analysis/TestMockAnalyzer.cs
@@ -1,4 +1,5 @@
 using System;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 
@@ -228,7 +229,7 @@ namespace Lucene.Net.Analysis
 
         /// <summary>
         /// blast some random strings through differently configured tokenizers </summary>
-        [Test]
+        [Test, LongRunningTest, Timeout(int.MaxValue)]
         public virtual void TestRandomRegexps()
         {
             int iters = AtLeast(30);

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterUnicode.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterUnicode.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Support;
 using System;
@@ -185,7 +186,7 @@ namespace Lucene.Net.Index
         }
 
         // LUCENE-510
-        [Test]
+        [Test, LongRunningTest]
         public virtual void TestRandomUnicodeStrings()
         {
             char[] buffer = new char[20];

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 
 namespace Lucene.Net.Index
@@ -200,6 +201,7 @@ namespace Lucene.Net.Index
         */
 
         [Test]
+        [LongRunningTest]
         public virtual void TestStressIndexAndSearching()
         {
             Directory directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Index/TestTermsEnum.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTermsEnum.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Search;
 
@@ -225,7 +226,7 @@ namespace Lucene.Net.Index
         }
 
         // Tests Terms.intersect
-        [Test]
+        [Test, LongRunningTest, Timeout(int.MaxValue)]
         public virtual void TestIntersectRandom()
         {
             Directory dir = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Util/TestPagedBytes.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestPagedBytes.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Util
         // Writes random byte/s to "normal" file in dir, then
         // copies into PagedBytes and verifies with
         // PagedBytes.Reader:
-        [Test]
+        [Test, LongRunningTest]
         public virtual void TestDataInputOutput()
         {
             Random random = Random();
@@ -114,7 +114,7 @@ namespace Lucene.Net.Util
         // Writes random byte/s into PagedBytes via
         // .getDataOutput(), then verifies with
         // PagedBytes.getDataInput():
-        [Test]
+        [Test, LongRunningTest]
         public virtual void TestDataInputOutput2()
         {
             Random random = Random();


### PR DESCRIPTION
Marking a few tests that always take 20 seconds long running, expanding timeouts on a few for good measure.