### PR TITLE
use set equality check

### DIFF
--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterUnicode.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterUnicode.cs
@@ -173,7 +173,7 @@ namespace Lucene.Net.Index
 
             if (isTop)
             {
-                Assert.IsTrue(allTerms.Equals(seenTerms));
+                Assert.IsTrue(allTerms.SetEquals(seenTerms));
             }
 
             // Test seeking:


### PR DESCRIPTION
Fixes failure in TestIndexWriterUnicode that was using reference comparison to compare sets. Should be using set comparison.