### PR TITLE
Initialize random once to ensure different random values

### DIFF
--- a/src/Lucene.Net.Tests/core/Index/TestLongPostings.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestLongPostings.cs
@@ -366,9 +366,10 @@ namespace Lucene.Net.Index
             }
 
             FixedBitSet isS1 = new FixedBitSet(NUM_DOCS);
+            var rnd = Random();
             for (int idx = 0; idx < NUM_DOCS; idx++)
             {
-                if (Random().NextBoolean())
+                if (rnd.NextBoolean())
                 {
                     isS1.Set(idx);
                 }

--- a/src/Lucene.Net.Tests/core/Index/TestLongPostings.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestLongPostings.cs
@@ -128,9 +128,10 @@ namespace Lucene.Net.Index
             }
 
             FixedBitSet isS1 = new FixedBitSet(NUM_DOCS);
+            var rnd = new Random();
             for (int idx = 0; idx < NUM_DOCS; idx++)
             {
-                if (Random().NextBoolean())
+                if (rnd.NextBoolean())
                 {
                     isS1.Set(idx);
                 }


### PR DESCRIPTION
This fixes intermittent failures in TestLongPostings that error out with a message stating that files are being used by other process: http://teamcity.codebetter.com/viewLog.html?buildId=180872&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId4501500834530776105

The issue is actually that sometimes NUM_DOCS is low enough where all Random() execute with the same seed and result in NextBoolean() returning the same value. As a result, test documents are not initialized as expected, resulting in some test asserts failing afterwards which then results in not all objects being disposed properly and holding open files which test tear down tries to clean up.