### PR TITLE
Initialize doc before each test run

### DIFF
--- a/src/Lucene.Net.Tests/core/Index/TestSegmentTermDocs.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSegmentTermDocs.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Index
     [TestFixture]
     public class TestSegmentTermDocs : LuceneTestCase
     {
-        private Document TestDoc = new Document();
+        private Document TestDoc;
         private Directory Dir;
         private SegmentCommitInfo Info;
 
@@ -41,6 +41,7 @@ namespace Lucene.Net.Index
         public override void SetUp()
         {
             base.SetUp();
+            TestDoc = new Document();
             Dir = NewDirectory();
             DocHelper.SetupDoc(TestDoc);
             Info = DocHelper.WriteDoc(Random(), Dir, TestDoc);


### PR DESCRIPTION
In Java each test run initializes a new TestDoc instance, while in .NET version that is initialized once and all the other per test inits are done in SetUp. Moved the doc init into SetUp as well. This fixes failures in Lucene.Net.Index.TestSegmentTermDocs