### PR TITLE
Index fixes

### DIFF
--- a/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
@@ -138,7 +138,7 @@ namespace Lucene.Net.Analysis
         {
         }
 
-        public override bool IncrementToken()
+        public sealed override bool IncrementToken()
         {
             //Debug.Assert(!EnableChecks_Renamed || (StreamState == State.RESET || StreamState == State.INCREMENT), "IncrementToken() called while in wrong state: " + StreamState);
             ClearAttributes();

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -1025,7 +1025,7 @@ namespace Lucene.Net.Index
             internal readonly IEnumerator<string> terms;
             internal bool first;
 
-            public override bool IncrementToken()
+            public sealed override bool IncrementToken()
             {
                 if (!terms.MoveNext())
                 {


### PR DESCRIPTION
This PR marks several IncrementToken methods as sealed that allow some tests to pass. Also contains fixes for TestIndexWriterReader where "ShouldFail" flag was totally ignored and exception were simulated at the times when tests did not expect it. The same with TestIndexWriterExceptions. 

TestIndexWriterExceptions has an additional fix where tests handled generic exception as an "unexpected" exception and treated "CorruptIndexException" as the expected type That does not match the Lucene version:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java#L185

Fixed that and used a more explicit exception type to make sure that we are handling only the expected exception and nothing else.
