### PR TITLE
Use CompareOrdinal to compare field_renamed because unit tests can creat...

### DIFF
--- a/src/Lucene.Net.Core/Index/Term.cs
+++ b/src/Lucene.Net.Core/Index/Term.cs
@@ -149,13 +149,14 @@ namespace Lucene.Net.Index
         /// </summary>
         public int CompareTo(Term other)
         {
-            if (Field_Renamed.Equals(other.Field_Renamed))
+            int comp = string.Compare(Field_Renamed, other.Field_Renamed, StringComparison.Ordinal);
+            if (comp == 0)
             {
                 return Bytes_Renamed.CompareTo(other.Bytes_Renamed);
             }
             else
             {
-                return Field_Renamed.CompareTo(other.Field_Renamed);
+                return comp;
             }
         }
 


### PR DESCRIPTION
...e a string with a trailing \0 char which is ignored in the default culture.