### PR TITLE
Fix for TestIndexableField.TestArbitraryFields - In java, the byte class...

### DIFF
--- a/src/Lucene.Net.Core/Index/DocumentsWriterDeleteQueue.cs
+++ b/src/Lucene.Net.Core/Index/DocumentsWriterDeleteQueue.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Store;
 using Lucene.Net.Support;
 using System;
 using System.Threading;
@@ -294,6 +295,7 @@ namespace Lucene.Net.Index
             internal DeleteSlice(Node currentTail)
             {
                 Debug.Assert(currentTail != null);
+                Debug.Assert(currentTail.Next == null);
                 /*
                  * Initially this is a 0 length slice pointing to the 'current' tail of
                  * the queue. Once we update the slice we only need to assign the tail and
@@ -391,10 +393,8 @@ namespace Lucene.Net.Index
             {
                 // .NET port: Interlocked.CompareExchange(location, value, comparand) is backwards from
                 // AtomicReferenceFieldUpdater.compareAndSet(obj, expect, update), so swapping val and cmp.
-                // Also, it doesn't return bool if it was updated, so we need to compare to see if
-                // original == comparand to determine whether to return true or false here.
-                Node original = Next;
-                return ReferenceEquals(Interlocked.CompareExchange(ref Next, val, cmp), original);
+                // Return true if the result of the CompareExchange is the same as the comparison.
+                return ReferenceEquals(Interlocked.CompareExchange(ref Next, val, cmp), cmp);
             }
         }
 

--- a/src/Lucene.Net.Core/Support/AtomicInteger.cs
+++ b/src/Lucene.Net.Core/Support/AtomicInteger.cs
@@ -33,9 +33,7 @@ namespace Lucene.Net.Support
 
         public int GetAndDecrement()
         {
-            int ret = value;
-            Interlocked.Decrement(ref value);
-            return ret;
+            return Interlocked.Decrement(ref value) + 1;
         }
 
         public void Set(int value_)
@@ -45,8 +43,7 @@ namespace Lucene.Net.Support
 
         public int AddAndGet(int value_)
         {
-            Interlocked.Add(ref value, value_);
-            return value;
+            return Interlocked.Add(ref value, value_);
         }
 
         public int Get()

--- a/src/Lucene.Net.Core/Support/AtomicInteger.cs
+++ b/src/Lucene.Net.Core/Support/AtomicInteger.cs
@@ -23,9 +23,7 @@ namespace Lucene.Net.Support
 
         public int GetAndIncrement()
         {
-            int ret = value;
-            Interlocked.Increment(ref value);
-            return ret;
+            return Interlocked.Increment(ref value) - 1;
         }
 
         public int DecrementAndGet()

--- a/src/Lucene.Net.Core/Support/AtomicLong.cs
+++ b/src/Lucene.Net.Core/Support/AtomicLong.cs
@@ -33,8 +33,7 @@ namespace Lucene.Net.Support
 
         public long AddAndGet(long value_)
         {
-            Interlocked.Add(ref value, value_);
-            return value;
+            return Interlocked.Add(ref value, value_);
         }
 
         public long Get()

--- a/src/Lucene.Net.Tests/core/Index/TestCustomNorms.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestCustomNorms.cs
@@ -60,7 +60,8 @@ namespace Lucene.Net.Index
             {
                 Document doc = docs.NextDoc();
                 float nextFloat = (float)Random().NextDouble();
-                Field f = new TextField(FloatTestField, "" + nextFloat, Field.Store.YES);
+                // Cast to a double to get more precision output to the string.
+                Field f = new TextField(FloatTestField, "" + (double)nextFloat, Field.Store.YES);
                 f.Boost = nextFloat;
 
                 doc.Add(f);

--- a/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
@@ -307,7 +307,7 @@ namespace Lucene.Net.Index
                             Assert.AreEqual(10, b.Length);
                             for (int idx = 0; idx < 10; idx++)
                             {
-                                Assert.AreEqual((sbyte)(idx + counter), b.Bytes[b.Offset + idx]);
+                                Assert.AreEqual((byte)(idx + counter), b.Bytes[b.Offset + idx]);
                             }
                         }
                         else

--- a/src/Lucene.Net.Tests/core/Index/TestParallelCompositeReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestParallelCompositeReader.cs
@@ -473,7 +473,7 @@ namespace Lucene.Net.Index
             ParallelCompositeReader pr = new ParallelCompositeReader(new CompositeReader[] { new MultiReader(ir1) });
 
             string s = pr.ToString();
-            Assert.IsTrue(s.StartsWith("ParallelCompositeReader(ParallelCompositeReader(ParallelAtomicReader("), "toString incorrect: " + s);
+            Assert.IsTrue(s.StartsWith("ParallelCompositeReader(ParallelCompositeReaderAnonymousInnerClassHelper(ParallelAtomicReader("), "toString incorrect: " + s);
 
             pr.Dispose();
             dir1.Dispose();


### PR DESCRIPTION
... is signed and in C# it is unsigned. Changed the unit test to cast to a (byte) insetad of an (sbyte).

An alternate much deeper fix would be to change the Lucene.Net.Util.BytesRef class to use sbyte insetad of byte. Not sure if this class was intentionally setup this way or if it is a conversion error. Comments please.