### PR TITLE
Moving to a separate branch for independent PR.

### DIFF
--- a/src/Lucene.Net.Tests/core/Index/TestParallelCompositeReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestParallelCompositeReader.cs
@@ -473,7 +473,8 @@ namespace Lucene.Net.Index
             ParallelCompositeReader pr = new ParallelCompositeReader(new CompositeReader[] { new MultiReader(ir1) });
 
             string s = pr.ToString();
-            Assert.IsTrue(s.StartsWith("ParallelCompositeReader(ParallelCompositeReader(ParallelAtomicReader("), "toString incorrect: " + s);
+
+            Assert.IsTrue(s.StartsWith("ParallelCompositeReader(ParallelCompositeReaderAnonymousInnerClassHelper(ParallelAtomicReader("), "toString incorrect: " + s);
 
             pr.Dispose();
             dir1.Dispose();


### PR DESCRIPTION
The ParallelCompositComposit reader now has a ParallelCompositReaderAnonymousInnerClassHelper for the inner instance instead of ParallelCompositReader. Looking back at the history, it has been this way for a long time but this test does not exist in the java version. Is this test in place to show there is something that needs to be fixed in ParallelCompositComposit reader?