### PR TITLE
Port from Support's to Util's PQ.

### DIFF
--- a/src/Lucene.Net.Core/Util/PriorityQueue.cs
+++ b/src/Lucene.Net.Core/Util/PriorityQueue.cs
@@ -282,6 +282,13 @@ namespace Lucene.Net.Util
             QueueSize = 0;
         }
 
+        public T[] ToArray()
+        {
+            T[] copy = new T[QueueSize];
+            Array.Copy(Heap, 1, copy, 0, QueueSize);
+            return copy;
+        }
+
         private void Resize()
         {
             int newSize = Math.Min(ArrayUtil.MAX_ARRAY_LENGTH - 1, 2*MaxSize);

--- a/src/Lucene.Net.Core/Util/PriorityQueue.cs
+++ b/src/Lucene.Net.Core/Util/PriorityQueue.cs
@@ -39,10 +39,12 @@ namespace Lucene.Net.Util
         private int QueueSize = 0;
         private int MaxSize;
         private T[] Heap;
+        private bool resizable;
 
         public PriorityQueue()
-            : this(0, false)
+            : this(8, false)
         {
+            resizable = true;
         } 
 
         public PriorityQueue(int maxSize)
@@ -52,7 +54,8 @@ namespace Lucene.Net.Util
  
         public PriorityQueue(int maxSize, bool prepopulate)
         {
-            int heapSize;
+            resizable = false;
+
             if (maxSize < 0)
             {
                 throw new System.ArgumentException("maxSize must be >= 0; got: " + maxSize);
@@ -84,7 +87,7 @@ namespace Lucene.Net.Util
 
             // NOTE: we add +1 because all access to heap is
             // 1-based not 0-based.  heap[0] is unused.
-            heapSize = maxSize + 1;
+            int heapSize = maxSize + 1;
             
             // T is unbounded type, so this unchecked cast works always:
             T[] h = new T[heapSize];
@@ -169,7 +172,7 @@ namespace Lucene.Net.Util
         public T Add(T element)
         {
             QueueSize++;
-            if (QueueSize > MaxSize)
+            if (resizable && QueueSize > MaxSize)
             {
                 Resize();
             }

--- a/src/Lucene.Net.Tests/core/Util/TestPriorityQueue.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestPriorityQueue.cs
@@ -373,6 +373,35 @@ namespace Lucene.Net.Util
         }
 
         [Test]
+        public static void TestIntegrityAfterResize()
+        {
+            // Tests that after a resize, the queue keeps working fine
+            PriorityQueue<int?> pq = new IntegerQueue(4);
+            pq.Add(3);
+            pq.Add(-2);
+            pq.Add(1);
+            pq.Add(-10);
+            pq.Add(-100);  // Resize
+            Assert.AreEqual(pq.Top(), -100);
+
+            pq.Add(-1000);
+            Assert.AreEqual(pq.Top(), -1000);
+
+            pq.Pop();
+            Assert.AreEqual(pq.Top(), -100);
+
+            pq.Add(0);
+            Assert.AreEqual(pq.Top(), -100);
+
+            for(int i = 0; i < 100; i++)
+            {
+                pq.Add(5);  // Lots of resizes
+            }
+            
+            Assert.AreEqual(pq.Top(), -100);
+        }
+
+        [Test]
         public virtual void TestClear()
         {
             PriorityQueue<int?> pq = new IntegerQueue(3);

--- a/src/Lucene.Net.Tests/core/Util/TestPriorityQueue.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestPriorityQueue.cs
@@ -30,6 +30,11 @@ namespace Lucene.Net.Util
 
         private class IntegerQueue : PriorityQueue<int?>
         {
+            public IntegerQueue()
+                : base()   
+            {
+            }
+
             public IntegerQueue(int count)
                 : base(count)
             {
@@ -302,8 +307,6 @@ namespace Lucene.Net.Util
             Assert.AreEqual(pq.Top().Field, 1);
         }
 
-        /*
-         * With the resizing feature, this test has no longer sense.
         [Test]
         public static void TestOverflow()
         {
@@ -340,65 +343,74 @@ namespace Lucene.Net.Util
             {
             }
         }
-         */
 
         [Test]
         public static void TestResize()
         {
-            // Initialize a queue with maximum size 4
-            PriorityQueue<int?> pq = new IntegerQueue(4);
+            // Initialize a resizable queue
+            PriorityQueue<int?> pq = new IntegerQueue();
             pq.Add(3);
             pq.Add(-2);
             pq.Add(1);
             pq.Add(-10);
-               
             Assert.AreEqual(pq.Size(), 4);
 
-            // Should resize the queue
             pq.Add(7);
-
-            Assert.AreEqual(pq.Size(), 5);
+            pq.Add(5);
+            pq.Add(10);
+            pq.Add(1);
+            Assert.AreEqual(pq.Size(), 8);
 
             pq.Add(10);
             pq.Add(1);
             pq.Add(5);
+            Assert.AreEqual(pq.Size(), 11);
 
-            Assert.AreEqual(pq.Size(), 8);
-
-            // Should resize again
-            pq.Add(100);
+            pq.Add(12);
+            pq.Add(13);
+            pq.Add(14);
+            pq.Add(15);
             pq.Add(16);
+            Assert.AreEqual(pq.Size(), 16);
 
-            Assert.AreEqual(pq.Size(), 10);
+            pq.Add(-17);
+            pq.Add(-18);
+            Assert.AreEqual(pq.Size(), 18);
         }
 
         [Test]
         public static void TestIntegrityAfterResize()
         {
             // Tests that after a resize, the queue keeps working fine
-            PriorityQueue<int?> pq = new IntegerQueue(4);
+            PriorityQueue<int?> pq = new IntegerQueue();
             pq.Add(3);
             pq.Add(-2);
             pq.Add(1);
+            pq.Add(7);
+            pq.Add(5);
+            pq.Add(10);
+            pq.Add(1);
             pq.Add(-10);
-            pq.Add(-100);  // Resize
+            pq.Add(-100);
             Assert.AreEqual(pq.Top(), -100);
 
             pq.Add(-1000);
             Assert.AreEqual(pq.Top(), -1000);
 
             pq.Pop();
-            Assert.AreEqual(pq.Top(), -100);
+            pq.Pop();
+            pq.Pop();
+            Assert.AreEqual(pq.Top(), -2);
 
             pq.Add(0);
-            Assert.AreEqual(pq.Top(), -100);
+            Assert.AreEqual(pq.Top(), -2);
 
             for(int i = 0; i < 100; i++)
             {
-                pq.Add(5);  // Lots of resizes
+                pq.Add(5);
             }
             
-            Assert.AreEqual(pq.Top(), -100);
+            Assert.AreEqual(pq.Top(), -2);
         }
 
         [Test]
@@ -607,8 +619,7 @@ namespace Lucene.Net.Util
         {
             if (!VERBOSE)
             {
-                // You won't see the results
-                return;
+                Assert.Fail("Turn VERBOSE on or otherwise you won't see the results.");
             }
                
             int maxSize = AtLeast(100000);

--- a/src/Lucene.Net.Tests/core/Util/TestPriorityQueue.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestPriorityQueue.cs
@@ -302,6 +302,8 @@ namespace Lucene.Net.Util
             Assert.AreEqual(pq.Top().Field, 1);
         }
 
+        /*
+         * With the resizing feature, this test has no longer sense.
         [Test]
         public static void TestOverflow()
         {
@@ -337,6 +339,37 @@ namespace Lucene.Net.Util
             catch (IndexOutOfRangeException)
             {
             }
+        }
+         */
+
+        [Test]
+        public static void TestResize()
+        {
+            // Initialize a queue with maximum size 4
+            PriorityQueue<int?> pq = new IntegerQueue(4);
+            pq.Add(3);
+            pq.Add(-2);
+            pq.Add(1);
+            pq.Add(-10);
+               
+            Assert.AreEqual(pq.Size(), 4);
+
+            // Should resize the queue
+            pq.Add(7);
+
+            Assert.AreEqual(pq.Size(), 5);
+
+            pq.Add(10);
+            pq.Add(1);
+            pq.Add(5);
+
+            Assert.AreEqual(pq.Size(), 8);
+
+            // Should resize again
+            pq.Add(100);
+            pq.Add(16);
+
+            Assert.AreEqual(pq.Size(), 10);
         }
 
         [Test]
@@ -494,9 +527,8 @@ namespace Lucene.Net.Util
         [Test, Timeout(0)]
         public static void TestStress()
         {
-            int atLeast = 10000000;
+            int atLeast = 1000000;
             int maxSize = AtLeast(atLeast);
-            int size;
             PriorityQueue<int?> pq = new IntegerQueue(maxSize);
 
             // Add a lot of elements
@@ -532,7 +564,7 @@ namespace Lucene.Net.Util
             Assert.AreEqual(pq.Size(), 0);
 
             // One last time
-            for (int i = 0; i < 2 * maxSize; i++)
+            for (int i = 0; 2 * i < maxSize; i++)
             {
                 pq.Add(Random().Next());
             }


### PR DESCRIPTION
Added a resizing functionality. Now the PQ resizes when it runs out of space. Since the former version was more restrictive (the size was fixed from the beginning) it should be backwards compatible. Nevertheless, it should be checked that no previous usage was expecting an IndexOutOfRangeException when adding elements to the queue.

Added a ToArray method.

Added tests.

With this change, TestsFuzzyQuery/TestFuzziness and TestFuzzyQuery/TestTieBreaker, from the Search package, now succeed.