### PR TITLE
more sealed increment token

### DIFF
--- a/src/Lucene.Net.Tests/core/Analysis/TestCachingTokenFilter.cs
+++ b/src/Lucene.Net.Tests/core/Analysis/TestCachingTokenFilter.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Analysis
             private ICharTermAttribute termAtt;
             private IOffsetAttribute offsetAtt;
 
-            public override bool IncrementToken()
+            public sealed override bool IncrementToken()
             {
                 if (index == OuterInstance.Tokens.Length)
                 {

--- a/src/Lucene.Net.Tests/core/Analysis/TestGraphTokenizers.cs
+++ b/src/Lucene.Net.Tests/core/Analysis/TestGraphTokenizers.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Analysis
                 Upto = 0;
             }
 
-            public override bool IncrementToken()
+            public sealed override bool IncrementToken()
             {
                 if (Tokens == null)
                 {

--- a/src/Lucene.Net.Tests/core/Analysis/TestLookaheadTokenFilter.cs
+++ b/src/Lucene.Net.Tests/core/Analysis/TestLookaheadTokenFilter.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Analysis
                 return new LookaheadTokenFilter.Position();
             }
 
-            public override bool IncrementToken()
+            public sealed override bool IncrementToken()
             {
                 return NextToken();
             }

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
@@ -79,7 +79,7 @@ namespace Lucene.Net.Search.Payloads
                 PayloadAtt = AddAttribute<IPayloadAttribute>();
             }
 
-            public override bool IncrementToken()
+            public sealed override bool IncrementToken()
             {
                 bool hasNext = input.IncrementToken();
                 if (hasNext)

--- a/src/Lucene.Net.Tests/core/Util/TestQueryBuilder.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestQueryBuilder.cs
@@ -158,7 +158,7 @@ namespace Lucene.Net.Util
                 PosIncAtt = AddAttribute<IPositionIncrementAttribute>();
             }
 
-            public override bool IncrementToken()
+            public sealed override bool IncrementToken()
             {
                 if (AddSynonym) // inject our synonym
                 {
@@ -218,7 +218,7 @@ namespace Lucene.Net.Util
                 TermAtt = AddAttribute<ICharTermAttribute>();
             }
 
-            public override bool IncrementToken()
+            public sealed override bool IncrementToken()
             {
                 int ch = input.Read();
                 if (ch < 0)


### PR DESCRIPTION
Different unit tests failing as the test related classes do not have IncrementToken marked as sealed.