### PR TITLE
make sure base is not appended as char

### DIFF
--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -2169,7 +2169,7 @@ namespace Lucene.Net.Index
                 for (int i = 0; i < numDocs; i++)
                 {
                     Document doc = new Document();
-                    doc.Add(new StringField("id", "" + docBase + i, Field.Store.NO));
+                    doc.Add(new StringField("id", (docBase + i).ToString(), Field.Store.NO));
                     if (DefaultCodecSupportsDocValues())
                     {
                         doc.Add(new NumericDocValuesField("f", 1L));


### PR DESCRIPTION
TestIndexWriterExceptions was failing because deletes were not reflected when the index was opened with the reader. The reason for that was that the documents were being sent with leading 0 in the id (e.g. "id:01" instead of "id:1") but deletes were executed against id without leading zero. Simple oversight of .NET port, Lucene adds the base and i first before converting to string.