### PR TITLE
don't convert to sbyte

### DIFF
--- a/src/Lucene.Net.Tests/core/Codecs/Compressing/AbstractTestLZ4CompressionMode.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Compressing/AbstractTestLZ4CompressionMode.cs
@@ -26,8 +26,6 @@ namespace Lucene.Net.Codecs.Compressing
     [TestFixture]
     public abstract class AbstractTestLZ4CompressionMode : AbstractTestCompressionMode
     {
-        private LZ4 lz4;
-
         public override byte[] Test(byte[] decompressed)
         {
             var compressed = base.Test(decompressed);
@@ -39,7 +37,7 @@ namespace Lucene.Net.Codecs.Compressing
                 int literalLen = (int)((uint)token >> 4);
                 if (literalLen == 0x0F)
                 {
-                    while (compressed[off] == unchecked((sbyte)0xFF))
+                    while (compressed[off] == 0xFF)
                     {
                         literalLen += 0xFF;
                         ++off;


### PR DESCRIPTION
This fixes TestLongLiterals for Codec.Compressing.TestFastCompressionMode and TestFastDecompressionMode tests. sbyte cast changed comparison logic where compressed[off] evaluated to 255.

Example failure on TC: http://teamcity.codebetter.com/viewLog.html?buildId=182801&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId-5764249506196176847 