### PR TITLE
Fix for TestDirectoryReaderReopen.TestThreadSafety

### DIFF
--- a/src/Lucene.Net.Core/Util/VirtualMethod.cs
+++ b/src/Lucene.Net.Core/Util/VirtualMethod.cs
@@ -64,7 +64,7 @@ namespace Lucene.Net.Util
         private readonly Type BaseClass;
         private readonly string Method;
         private readonly Type[] Parameters;
-        private readonly WeakIdentityMap<Type, int> Cache = WeakIdentityMap<Type, int>.NewHashMap(false);
+        private readonly WeakIdentityMap<Type, int> Cache = WeakIdentityMap<Type, int>.NewConcurrentHashMap(false);
 
         /// <summary>
         /// Creates a new instance for the given {@code baseClass} and method declaration. </summary>


### PR DESCRIPTION
The java version uses a concurrent hash map so I updated VirtualMethod to use that.
After that change, we no longer needed the lock on the Reap() function.
Next the Get() needed to use a tryGet() and return the default if there was nothing in the collection.