### PR TITLE
Fix for TestIndexReaderClose.TestCloseUnderException

### DIFF
--- a/src/Lucene.Net.Core/Index/IndexReader.cs
+++ b/src/Lucene.Net.Core/Index/IndexReader.cs
@@ -148,22 +148,23 @@ namespace Lucene.Net.Index
             {
                 foreach (ReaderClosedListener listener in ReaderClosedListeners)
                 {
-                    // LUCENENET TODO
-                    /*try
-                    {*/
-                    listener.OnClose(this);
-                    /*}
+                    try
+                    {
+                        listener.OnClose(this);
+                    }
                     catch (Exception t)
                     {
-                      if (th == null)
-                      {
-                        th = t;
-                      }
-                      else
-                      {
-                        th.AddSuppressed(t);
-                      }
-                    }*/
+                        if (th == null)
+                        {
+                            th = t;
+                        }
+                        else
+                        {
+                            //th.AddSuppressed(t);
+                            // Drop the exception instead of wrapping in AggregateException.
+                            // Wrapping will change the exception type and change flow control.
+                        }
+                    }
                 }
                 IOUtils.ReThrowUnchecked(th);
             }


### PR DESCRIPTION
The IndexReader.NotifyReaderClosedListeners() did not properly suppress the exceptions thrown from the call to listener.OnClose(). Unfortunately there is no place to track the suppressed exception so it is just dropped.
Changing to return AggregateException will change the type and cause problems later for flow control.