### PR TITLE
match Lucene logic of not creating the directory

### DIFF
--- a/src/Lucene.Net.Core/Store/FSDirectory.cs
+++ b/src/Lucene.Net.Core/Store/FSDirectory.cs
@@ -118,18 +118,14 @@ namespace Lucene.Net.Store
         protected internal readonly ISet<string> StaleFiles = new HashSet<string>(); // Files written, but not yet sync'ed
         private int ChunkSize = DEFAULT_READ_CHUNK_SIZE;
 
+        // LUCENENET TODO: Lucene uses "GetCanonicalPath" call
+        // and there is a possibility we don't need it in .NET version.
+        // Please refer to the discussions here for more info:
+        // https://github.com/apache/lucenenet/pull/70
+        //
         // returns the canonical version of the directory, creating it if it doesn't exist.
         private static DirectoryInfo GetCanonicalPath(DirectoryInfo file)
         {
-            try
-            {
-                file.Create();
-            }
-            catch (IOException)
-            {
-                //File already exists
-            }
-
             return file;
         }
 


### PR DESCRIPTION
There is still discussion going on about what to do with FSDirectory's GetCanonicalPath: https://github.com/apache/lucenenet/pull/70 @synhershko  has assigned this to himself to investigate. While he is doing that, this PR removes the offending code so that we match Lucene's behavior in that we don't create the directory if it does not exist. The failing tests related to this, TestIndexWriter.TestNoDocs and TestMultiPhraseQuery now pass.