### PR TITLE
Index fixes

### DIFF
--- a/src/Lucene.Net.Tests/core/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestAddIndexes.cs
@@ -1207,8 +1207,8 @@ namespace Lucene.Net.Index
         /*
          * simple test that ensures we getting expected exceptions
          */
-
         [Test]
+        [Ignore("We don't have all the codecs in place to run this.")]
         public virtual void TestAddIndexMissingCodec()
         {
             BaseDirectoryWrapper toAdd = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Index/TestAtomicUpdate.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestAtomicUpdate.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 
 namespace Lucene.Net.Index
@@ -194,7 +195,7 @@ namespace Lucene.Net.Index
           FSDirectory.
         */
 
-        [Test]
+        [Test, LongRunningTest]
         public virtual void TestAtomicUpdates()
         {
             Directory directory;

--- a/src/Lucene.Net.Tests/core/Index/TestSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSnapshotDeletionPolicy.cs
@@ -110,6 +110,7 @@ namespace Lucene.Net.Index
 
         protected internal IList<IndexCommit> Snapshots;
 
+        [SetUp]
         public override void SetUp()
         {
             base.SetUp();

--- a/src/Lucene.Net.Tests/core/Index/TestSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSnapshotDeletionPolicy.cs
@@ -71,8 +71,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        protected internal IList<IndexCommit> Snapshots = new List<IndexCommit>();
-
         protected internal virtual void PrepareIndexAndSnapshots(SnapshotDeletionPolicy sdp, IndexWriter writer, int numSnapshots)
         {
             for (int i = 0; i < numSnapshots; i++)
@@ -108,6 +106,15 @@ namespace Lucene.Net.Index
                     Assert.AreEqual(snapshot.Generation, sdp.GetIndexCommit(snapshot.Generation).Generation);
                 }
             }
+        }
+
+        protected internal IList<IndexCommit> Snapshots;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            this.Snapshots = new List<IndexCommit>();
         }
 
         [Ignore]


### PR DESCRIPTION
TestSnapshotDeletionPolicy and TestPersistentSnapshotDeletionPolicy were failing because Snapshots list was not initialized on each test run. Results from previous test run would interfere and the test would fail. To reproduce, run the whole fixture as running a test by itself passes.

Marking TestAddIndexes.TestAddIndexMissingCodec with ignore because we are missing some codecs for that test to match what Lucene is doing.

Marking TestAtomicUpdate.TestAtomicUpdates with LongRunning attribute so that it runs on nightly only.

