### PR TITLE
initialize docs on each test run

### DIFF
--- a/src/Lucene.Net.Tests/core/Index/TestSegmentMerger.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSegmentMerger.cs
@@ -43,19 +43,21 @@ namespace Lucene.Net.Index
         //First segment to be merged
         private Directory Merge1Dir;
 
-        private Document Doc1 = new Document();
-        private SegmentReader Reader1 = null;
+        private Document Doc1;
+        private SegmentReader Reader1;
 
         //Second Segment to be merged
         private Directory Merge2Dir;
 
-        private Document Doc2 = new Document();
-        private SegmentReader Reader2 = null;
+        private Document Doc2;
+        private SegmentReader Reader2;
 
         [SetUp]
         public override void SetUp()
         {
             base.SetUp();
+            this.Doc1 = new Document();
+            this.Doc2 = new Document();
             MergedDir = NewDirectory();
             Merge1Dir = NewDirectory();
             Merge2Dir = NewDirectory();


### PR DESCRIPTION
Doc1/doc2 need to be initialized on each test run otherwise there is state left over from previous test runs and TestSegmentMerger tests fail.