### PR TITLE
Regexp fixes

### DIFF
--- a/src/Lucene.Net.Core/Util/Automaton/RegExp.cs
+++ b/src/Lucene.Net.Core/Util/Automaton/RegExp.cs
@@ -691,11 +691,11 @@ namespace Lucene.Net.Util.Automaton
                     break;
 
                 case Kind.REGEXP_CHAR:
-                    b.Append("\\").Append(c);
+                    b.Append("\\").Append(Character.ToChars(c));
                     break;
 
                 case Kind.REGEXP_CHAR_RANGE:
-                    b.Append("[\\").Append(From).Append("-\\").Append(To).Append("]");
+                    b.Append("[\\").Append(Character.ToChars(From)).Append("-\\").Append(Character.ToChars(To)).Append("]");
                     break;
 
                 case Kind.REGEXP_ANYCHAR:
@@ -828,7 +828,7 @@ namespace Lucene.Net.Util.Automaton
             }
             else
             {
-                b.Append(exp1.c);
+                b.Append(Character.ToChars(exp1.c));
             }
             if (exp2.kind == Kind.REGEXP_STRING)
             {
@@ -836,7 +836,7 @@ namespace Lucene.Net.Util.Automaton
             }
             else
             {
-                b.Append(exp2.c);
+                b.Append(Character.ToChars(exp2.c));
             }
             return MakeString(b.ToString());
         }

--- a/src/Lucene.Net.Tests/core/Search/TestRegexpRandom.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestRegexpRandom.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text;
 using Lucene.Net.Documents;
 
@@ -60,13 +59,9 @@ namespace Lucene.Net.Search
             Field field = NewField("field", "", customType);
             doc.Add(field);
 
-            NumberFormatInfo df = new NumberFormatInfo();
-            df.NumberDecimalDigits = 0;
-
-            //NumberFormat df = new DecimalFormat("000", new DecimalFormatSymbols(Locale.ROOT));
             for (int i = 0; i < 1000; i++)
             {
-                field.StringValue = i.ToString(df);
+                field.StringValue = i.ToString("D3");
                 writer.AddDocument(doc);
             }
 

--- a/src/Lucene.Net.Tests/core/Search/TestWildcardRandom.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestWildcardRandom.cs
@@ -58,13 +58,9 @@ namespace Lucene.Net.Search
             Field field = NewStringField("field", "", Field.Store.NO);
             doc.Add(field);
 
-            NumberFormatInfo df = new NumberFormatInfo();
-            df.NumberDecimalDigits = 0;
-
-            //NumberFormat df = new DecimalFormat("000", new DecimalFormatSymbols(Locale.ROOT));
             for (int i = 0; i < 1000; i++)
             {
-                field.StringValue = i.ToString(df);
+                field.StringValue = i.ToString("D3");
                 writer.AddDocument(doc);
             }
 


### PR DESCRIPTION
Searches that use RegExp queries were failing because RegExp implementation had a bug in how it dealt with simple character regular expressions. Lucene version makes sure to append characters based on the codepoint value, while .NET version was simply appending code point value that would get translated into string. (if code point value was set to 48 which is 0, resulting expression was "48" and not "0").

Here is Lucene code for reference https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java, note the places it uses appendCodePoint.

This fixes failures in the tests that use RegExp, e.g. http://teamcity.codebetter.com/viewLog.html?buildId=185033&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId3978078468772906159

In addition TestWildcardRandom and TestRegexpRandom were failing as they initialized data using incorrect value format for the decimal string. Changed to match what Lucene is doing (which Lucene.NET had commented out).

