### PR TITLE
LineFileDocs fix

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
@@ -736,7 +736,7 @@ namespace Lucene.Net.Index
                     TopDocs hits = s.Search(new TermQuery(new Term("docid", stringID)), 1);
                     if (hits.TotalHits != 1)
                     {
-                        Console.WriteLine("doc id=" + stringID + " is not supposed to be deleted, but got hitCount=" + hits.TotalHits + "; delIDs=" + delIDs);
+                        Console.WriteLine("doc id=" + stringID + " is not supposed to be deleted, but got hitCount=" + hits.TotalHits + "; delIDs=" + string.Join(",",  delIDs.ToArray()));
                         doFail = true;
                     }
                 }

--- a/src/Lucene.Net.TestFramework/Util/LineFileDocs.cs
+++ b/src/Lucene.Net.TestFramework/Util/LineFileDocs.cs
@@ -295,7 +295,7 @@ namespace Lucene.Net.Util
             }
             docState.TitleTokenized.StringValue = title;
             docState.Date.StringValue = line.Substring(1 + spot, spot2 - (1 + spot));
-            docState.Id.StringValue = Convert.ToString(Id.IncrementAndGet());
+            docState.Id.StringValue = Convert.ToString(Id.GetAndIncrement());
             return docState.Doc;
         }
     }


### PR DESCRIPTION
Test helper class LineFileDocs generates test documents with the smallest id set to 1 instead of 0. Tests that expected docId:0 to be in the index failed as a result. Changed the implementation to get the value of id first and then increment, which matches what Lucene is doing:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/test-framework/src/java/org/apache/lucene/util/LineFileDocs.java#L237

With the fix TestNRTThreads.TestNRTThreads_Mem and TestSearcherManager.TestSearcherManager_Mem now pass. Here are the failures in TC:

http://teamcity.codebetter.com/viewLog.html?buildId=185350&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId5653300530033422727

http://teamcity.codebetter.com/viewLog.html?buildId=185350&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId1102378654731360526
