### PR TITLE
Query fixes

### DIFF
--- a/src/Lucene.Net.Tests/core/Search/TestMultiPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiPhraseQuery.cs
@@ -175,6 +175,7 @@ namespace Lucene.Net.Search
 
         //ORIGINAL LINE: @Ignore public void testMultiSloppyWithRepeats() throws java.io.IOException
         [Test]
+        [Ignore("This appears to be a known issue")]
         public virtual void TestMultiSloppyWithRepeats() //LUCENE-3821 fixes sloppy phrase scoring, except for this known problem
         {
             Directory indexStore = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestMultiValuedNumericRangeQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiValuedNumericRangeQuery.cs
@@ -46,11 +46,7 @@ namespace Lucene.Net.Search
         {
             Directory directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(TestUtil.NextInt(Random(), 50, 1000)));
-
-            //DecimalFormat format = new DecimalFormat("00000000000", new DecimalFormatSymbols(Locale.ROOT));
-            NumberFormatInfo f = new NumberFormatInfo();
-            f.NumberDecimalSeparator = ".";
-            f.NumberDecimalDigits = 0;
+            const string format = "D11";
 
             int num = AtLeast(500);
             for (int l = 0; l < num; l++)
@@ -59,7 +55,7 @@ namespace Lucene.Net.Search
                 for (int m = 0, c = Random().Next(10); m <= c; m++)
                 {
                     int value = Random().Next(int.MaxValue);
-                    doc.Add(NewStringField("asc", value.ToString(f), Field.Store.NO));
+                    doc.Add(NewStringField("asc", value.ToString(format), Field.Store.NO));
                     doc.Add(new IntField("trie", value, Field.Store.NO));
                 }
                 writer.AddDocument(doc);
@@ -79,7 +75,7 @@ namespace Lucene.Net.Search
                     lower = upper;
                     upper = a;
                 }
-                TermRangeQuery cq = TermRangeQuery.NewStringRange("asc", lower.ToString(f), upper.ToString(f), true, true);
+                TermRangeQuery cq = TermRangeQuery.NewStringRange("asc", lower.ToString(format), upper.ToString(format), true, true);
                 NumericRangeQuery<int> tq = NumericRangeQuery.NewIntRange("trie", lower, upper, true, true);
                 TopDocs trTopDocs = searcher.Search(cq, 1);
                 TopDocs nrTopDocs = searcher.Search(tq, 1);


### PR DESCRIPTION
TestMultiPhraseQuery.TestMultiSloppyWithRepeats appears to be ignored in Lucene and I can confirm it fails there as well. https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/test/org/apache/lucene/search/TestMultiPhraseQuery.java#L162

TestMultiValuedNumericRangeQuery.TestMultiValuedNRQ was using incorrect digit format, corrected to match what Lucene is doing.