### PR TITLE
fix Bits2words logic

### DIFF
--- a/src/Lucene.Net.Core/Util/OpenBitSet.cs
+++ b/src/Lucene.Net.Core/Util/OpenBitSet.cs
@@ -1060,7 +1060,7 @@ namespace Lucene.Net.Util
         /// returns the number of 64 bit words it would take to hold numBits </summary>
         public static int Bits2words(long numBits)
         {
-            return (int)(((int)((uint)(numBits - 1) >> 6)) + 1);
+            return (int)(((numBits - 1) >> 6) + 1);
         }
 
         /// <summary>


### PR DESCRIPTION
TestOpenBitSet.TestSmall test was failing with out of memory exception which you can see here: http://teamcity.codebetter.com/viewLog.html?buildId=185366&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId-1093084322476268678). Trying to run it locally with timeout restriction removed resulted in the test process using 4 or more GB of RAM within seconds. After looking into it more, narrowed down what was triggering the condition: bug in Bits2words logic which would get triggered when numBits parameter was set to 0.

To reproduce and observe the results, run TestOpenBitSet.TestSmall test and put a breakpoint here https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.Tests/core/Util/TestOpenBitSet.cs#L174 with condition of sz == 0 so that it triggers when random int generation returns 0. You will see then that OpenBitSet constructor instead of initializing bits array of 0 length will initialize it to 67108864 and then it is all downhill from there.

Verified the fix by running Lucene Java tests and made sure the math came out the same for 0 input, where the result is 0 instead of 67108864.

Here is Java version: 

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/util/OpenBitSet.java#L854