### PR TITLE
init bytesref on each iteration

### DIFF
--- a/src/Lucene.Net.Core/Index/BinaryDocValuesWriter.cs
+++ b/src/Lucene.Net.Core/Index/BinaryDocValuesWriter.cs
@@ -128,27 +128,7 @@ namespace Lucene.Net.Index
             int maxDoc = state.SegmentInfo.DocCount;
             Bytes.Freeze(false);
             dvConsumer.AddBinaryField(FieldInfo, GetBytesIterator(maxDoc));
-            //dvConsumer.AddBinaryField(FieldInfo, new IterableAnonymousInnerClassHelper(this, maxDoc));
         }
-
-        /*
-	  private class IterableAnonymousInnerClassHelper : IEnumerable<BytesRef>
-	  {
-		  private readonly BinaryDocValuesWriter OuterInstance;
-
-		  private int MaxDoc;
-
-		  public IterableAnonymousInnerClassHelper(BinaryDocValuesWriter outerInstance, int maxDoc)
-		  {
-			  this.OuterInstance = outerInstance;
-			  this.MaxDoc = maxDoc;
-		  }
-
-		  public virtual IEnumerator<BytesRef> GetEnumerator()
-		  {
-			 return new BytesIterator(OuterInstance, MaxDoc);
-		  }
-	  }*/
 
         internal override void Abort()
         {
@@ -158,7 +138,6 @@ namespace Lucene.Net.Index
         {
             // Use yield return instead of ucsom IEnumerable
 
-            BytesRef value = new BytesRef();
             AppendingDeltaPackedLongBuffer.Iterator lengthsIterator = Lengths.GetIterator();
             int size = (int)Lengths.Size();
             DataInput bytesIterator = Bytes.DataInput;
@@ -167,10 +146,11 @@ namespace Lucene.Net.Index
 
             while (upto < maxDoc)
             {
-                BytesRef v;
+                BytesRef v = null;
                 if (upto < size)
                 {
                     int length = (int)lengthsIterator.Next();
+                    var value = new BytesRef();
                     value.Grow(length);
                     value.Length = length;
                     bytesIterator.ReadBytes(value.Bytes, value.Offset, value.Length);
@@ -179,102 +159,11 @@ namespace Lucene.Net.Index
                     {
                         v = value;
                     }
-                    else
-                    {
-                        v = null;
-                    }
-                }
-                else
-                {
-                    v = null;
                 }
 
                 upto++;
                 yield return v;
             }
         }
-
-        /*
-	  // iterates over the values we have in ram
-	  private class BytesIterator : IEnumerator<BytesRef>
-	  {
-		  internal bool InstanceFieldsInitialized = false;
-
-		  internal virtual void InitializeInstanceFields()
-		  {
-			  LengthsIterator = OuterInstance.Lengths.Iterator();
-              BytesIterator_Renamed = OuterInstance.Bytes.DataInput;
-              Size = (int)OuterInstance.Lengths.Size();
-		  }
-
-		  private readonly BinaryDocValuesWriter OuterInstance;
-
-		internal readonly BytesRef Value = new BytesRef();
-		internal AppendingDeltaPackedLongBuffer.Iterator LengthsIterator;
-		internal DataInput BytesIterator_Renamed;
-		internal int Size;
-		internal readonly int MaxDoc;
-		internal int Upto;
-
-		internal BytesIterator(BinaryDocValuesWriter outerInstance, int maxDoc)
-		{
-			this.OuterInstance = outerInstance;
-
-			if (!InstanceFieldsInitialized)
-			{
-				InitializeInstanceFields();
-				InstanceFieldsInitialized = true;
-			}
-		  this.MaxDoc = maxDoc;
-		}
-
-		public override bool HasNext()
-		{
-		  return Upto < MaxDoc;
-		}
-
-		public override BytesRef Next()
-		{
-		  if (!HasNext())
-		  {
-			throw new NoSuchElementException();
-		  }
-		  BytesRef v;
-		  if (Upto < Size)
-		  {
-			int length = (int) LengthsIterator.Next();
-			Value.Grow(length);
-			Value.Length = length;
-			try
-			{
-			  BytesIterator_Renamed.ReadBytes(Value.Bytes, Value.Offset, Value.Length);
-			}
-			catch (System.IO.IOException ioe)
-			{
-			  // Should never happen!
-			  throw new Exception(ioe.ToString(), ioe);
-			}
-            if (OuterInstance.DocsWithField.Get(Upto))
-			{
-			  v = Value;
-			}
-			else
-			{
-			  v = null;
-			}
-		  }
-		  else
-		  {
-			v = null;
-		  }
-		  Upto++;
-		  return v;
-		}
-
-		public override void Remove()
-		{
-		  throw new System.NotSupportedException();
-		}
-	  }*/
     }
 }


### PR DESCRIPTION
Fixes a bug where bytes were written to the index incorrectly if Lucene40Codec was used. The issue can be observed by following the data flow starting here:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40DocValuesWriter.cs#L176

values.ToArray() enumeration instead of returning an array of different values, it returns an array with all members pointing to the same bytesref instance. This broke logic to detect min / max Lengths down the stream and as a result incorrect bytes were written to an index.

This bug did not show up until the Lucene40DocValuesWriter was rewritten to call ToArray(). Here is a gist illustrating the difference between the two usages with bug in place: https://gist.github.com/laimis/d49291d2f02a7f4830bf

The fix removes  BytesRef value = new BytesRef(); initialization and instead initializes new bytes ref instance anytime one should be returned.

There might be more places in code base that suffer from this, will need to review the iterators that use similar approach.

With the fix in place all Lucene40Codec tests pass.