### PR TITLE
Enumerable fixes and ReverseByteReader fix

### DIFF
--- a/src/Lucene.Net.Core/Codecs/DocValuesConsumer.cs
+++ b/src/Lucene.Net.Core/Codecs/DocValuesConsumer.cs
@@ -281,11 +281,11 @@ namespace Lucene.Net.Codecs
 
         private IEnumerable<BytesRef> GetMergeSortValuesEnumerable(OrdinalMap map, SortedDocValues[] dvs)
         {
-            var scratch = new BytesRef();
             int currentOrd = 0;
 
             while (currentOrd < map.ValueCount)
             {
+                var scratch = new BytesRef();
                 int segmentNumber = map.GetFirstSegmentNumber(currentOrd);
                 var segmentOrd = (int)map.GetFirstSegmentOrd(currentOrd);
                 dvs[segmentNumber].LookupOrd(segmentOrd, scratch);
@@ -542,13 +542,13 @@ namespace Lucene.Net.Codecs
 
         private IEnumerable<BytesRef> GetMergeSortedSetValuesEnumerable(OrdinalMap map, SortedSetDocValues[] dvs)
         {
-            var scratch = new BytesRef();
             long currentOrd = 0;
 
             while (currentOrd < map.ValueCount)
             {
                 int segmentNumber = map.GetFirstSegmentNumber(currentOrd);
                 long segmentOrd = map.GetFirstSegmentOrd(currentOrd);
+                var scratch = new BytesRef();
                 dvs[segmentNumber].LookupOrd(segmentOrd, scratch);
                 currentOrd++;
                 yield return scratch;

--- a/src/Lucene.Net.Core/Index/ReadersAndUpdates.cs
+++ b/src/Lucene.Net.Core/Index/ReadersAndUpdates.cs
@@ -707,7 +707,6 @@ namespace Lucene.Net.Index
             Bits DocsWithField = reader.GetDocsWithField(field);
             int maxDoc = reader.MaxDoc;
             var iter = (BinaryDocValuesFieldUpdates.Iterator)fieldUpdates.GetIterator();
-            BytesRef scratch = new BytesRef();
             int updateDoc = iter.NextDoc();
 
             for (int curDoc = 0; curDoc < maxDoc; ++curDoc)
@@ -722,6 +721,7 @@ namespace Lucene.Net.Index
                 {   // no update for this document
                     if (currentValues != null && DocsWithField.Get(curDoc))
                     {
+                        var scratch = new BytesRef();
                         // only read the current value if the document had a value before
                         currentValues.Get(curDoc, scratch);
                         yield return scratch;

--- a/src/Lucene.Net.Core/Index/SortedDocValuesWriter.cs
+++ b/src/Lucene.Net.Core/Index/SortedDocValuesWriter.cs
@@ -133,10 +133,9 @@ namespace Lucene.Net.Index
 
         private IEnumerable<BytesRef> GetBytesRefEnumberable(int valueCount, int[] sortedValues)
         {
-            BytesRef scratch = new BytesRef();
-
             for (int i = 0; i < valueCount; ++i)
             {
+                var scratch = new BytesRef();
                 yield return Hash.Get(sortedValues[i], scratch);
             }
         }

--- a/src/Lucene.Net.Core/Index/SortedSetDocValuesWriter.cs
+++ b/src/Lucene.Net.Core/Index/SortedSetDocValuesWriter.cs
@@ -189,9 +189,9 @@ namespace Lucene.Net.Index
 
         private IEnumerable<BytesRef> GetBytesRefEnumberable(int valueCount, int[] sortedValues)
         {
-            BytesRef scratch = new BytesRef();
             for (int i = 0; i < valueCount; ++i)
             {
+                var scratch = new BytesRef();
                 yield return Hash.Get(sortedValues[i], scratch);
             }
         }

--- a/src/Lucene.Net.Core/Util/Fst/BytesStore.cs
+++ b/src/Lucene.Net.Core/Util/Fst/BytesStore.cs
@@ -520,12 +520,12 @@ namespace Lucene.Net.Util.Fst
             public ReverseBytesReaderAnonymousInner(BytesStore outerInstance)
             {
                 this.OuterInstance = outerInstance;
-                outerInstance.Current = outerInstance.Blocks.Count == 0 ? null : outerInstance.Blocks[0];
+                Current = outerInstance.Blocks.Count == 0 ? null : outerInstance.Blocks[0];
                 nextBuffer = -1;
                 nextRead = 0;
             }
 
-            private sbyte[] Current;
+            private byte[] Current;
             private int nextBuffer;
             private int nextRead;
 
@@ -533,10 +533,10 @@ namespace Lucene.Net.Util.Fst
             {
                 if (nextRead == -1)
                 {
-                    OuterInstance.Current = OuterInstance.Blocks[nextBuffer--];
+                    Current = OuterInstance.Blocks[nextBuffer--];
                     nextRead = OuterInstance.BlockSize - 1;
                 }
-                return OuterInstance.Current[nextRead--];
+                return Current[nextRead--];
             }
 
             public override void SkipBytes(int count)
@@ -566,7 +566,7 @@ namespace Lucene.Net.Util.Fst
                     // EOF)...?
                     int bufferIndex = (int)(value >> OuterInstance.blockBits);
                     nextBuffer = bufferIndex - 1;
-                    OuterInstance.Current = OuterInstance.Blocks[bufferIndex];
+                    Current = OuterInstance.Blocks[bufferIndex];
                     nextRead = (int)(value & OuterInstance.BlockMask);
                     Debug.Assert(this.Position == value, "value=" + value + " this.Position=" + this.Position);
                 }

--- a/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42DocValuesConsumer.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42DocValuesConsumer.cs
@@ -296,7 +296,8 @@ namespace Lucene.Net.Codecs.Lucene42
                 builder.Add(Util.ToIntsRef(v, scratch), ord);
                 ord++;
             }
-            Lucene.Net.Util.Fst.FST<long?> fst = builder.Finish();
+
+            var fst = builder.Finish();
             if (fst != null)
             {
                 fst.Save(Data);

--- a/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
@@ -992,7 +992,7 @@ namespace Lucene.Net.Index
             Document doc = new Document();
             var bytes = new byte[32766];
             BytesRef b = new BytesRef(bytes);
-            Random().NextBytes((byte[])(Array)bytes);
+            Random().NextBytes(bytes);
             doc.Add(new BinaryDocValuesField("dv", b));
             iwriter.AddDocument(doc);
             iwriter.Dispose();


### PR DESCRIPTION
Two fixes in this commit as the both are needed to fix the bug discovered in the failing BaseDocValuesFormatTestCase.TestVeryLargeButLegalSortedBytes when run with Lucene42DocValuesFormat.

First commit replaces all the enumerables that reused the same instance variable to return enumeration values.

Second commit fixes a bug with reverse byte reader anonymous class to match Lucene's version:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/util/fst/BytesStore.java#L419

Note how a private byte[] current pointer is used to keep track of the current byte block that the iterator is traveling through. In Lucene.Net port the private array was left unused and instead the higher level "current" was modified which is used and modified by other iterators at the same time.

It only affected Lucene42 because it uses FST to store the sorted doc values. Also it affected only the large bytes test because it needs a value large enough where multiple byte blocks come into play and that's where "current block" mistakenly was pointed to a wrong one.

The assert console output has gone away and the TestVeryLargeButLegalSortedBytes test passes. I am seeing those assert "frozenHash vs h" messages in other Lucene42 tests, investigating right now.