### PR TITLE
detect NaN and return appropriate value

### DIFF
--- a/src/Lucene.Net.Core/Support/Number.cs
+++ b/src/Lucene.Net.Core/Support/Number.cs
@@ -424,6 +424,11 @@ namespace Lucene.Net.Support
 
         public static int FloatToIntBits(float value)
         {
+            if (float.IsNaN(value))
+            {
+                return 0x7fc00000;
+            }
+
             // TODO it is claimed that this could be faster
             return BitConverter.ToInt32(BitConverter.GetBytes(value), 0);
         }
@@ -435,6 +440,16 @@ namespace Lucene.Net.Support
 
         public static long DoubleToRawLongBits(double value)
         {
+            return BitConverter.DoubleToInt64Bits(value);
+        }
+
+        public static long DoubleToLongBits(double value)
+        {
+            if (double.IsNaN(value))
+            {
+                return 0x7ff8000000000000L;
+            }
+
             return BitConverter.DoubleToInt64Bits(value);
         }
 

--- a/src/Lucene.Net.Core/Util/NumericUtils.cs
+++ b/src/Lucene.Net.Core/Util/NumericUtils.cs
@@ -278,7 +278,7 @@ namespace Lucene.Net.Util
         /// <seealso cref= #sortableLongToDouble </seealso>
         public static long DoubleToSortableLong(double val)
         {
-            long f = BitConverter.DoubleToInt64Bits(val);
+            long f = Number.DoubleToLongBits(val);
             if (f < 0)
             {
                 f ^= 0x7fffffffffffffffL;

--- a/src/Lucene.Net.Tests/core/Util/TestNumericUtils.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestNumericUtils.cs
@@ -165,7 +165,7 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestDoubles()
         {
-            double[] vals = new double[] { double.NaN, double.NegativeInfinity, -2.3E25, -1.0E15, -1.0, -1.0E-1, -1.0E-2, -0.0, +0.0, 1.0E-2, 1.0E-1, 1.0, 1.0E15, 2.3E25, double.PositiveInfinity };
+            double[] vals = new double[] { double.NegativeInfinity, -2.3E25, -1.0E15, -1.0, -1.0E-1, -1.0E-2, -0.0, +0.0, 1.0E-2, 1.0E-1, 1.0, 1.0E15, 2.3E25, double.PositiveInfinity, double.NaN };
             long[] longVals = new long[vals.Length];
 
             // check forward and back conversion
@@ -199,7 +199,7 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestFloats()
         {
-            float[] vals = new float[] { float.NaN, float.NegativeInfinity, -2.3E25f, -1.0E15f, -1.0f, -1.0E-1f, -1.0E-2f, -0.0f, +0.0f, 1.0E-2f, 1.0E-1f, 1.0f, 1.0E15f, 2.3E25f, float.PositiveInfinity };
+            float[] vals = new float[] { float.NegativeInfinity, -2.3E25f, -1.0E15f, -1.0f, -1.0E-1f, -1.0E-2f, -0.0f, +0.0f, 1.0E-2f, 1.0E-1f, 1.0f, 1.0E15f, 2.3E25f, float.PositiveInfinity, float.NaN };
             int[] intVals = new int[vals.Length];
 
             // check forward and back conversion


### PR DESCRIPTION
Lucene.Net versions of FloatToIntBits and DoubleToLongBits are returning incorrect values if the input is NaN. It seems like it returns correct values in all other cases but in NaN returns negative of what it should. Added code to detect if the input is NaN and return the value that matches Lucene version and what is specified in Java docs: 

https://docs.oracle.com/javase/7/docs/api/java/lang/Float.html#floatToIntBits(float)
https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#doubleToLongBits(double)

This passes TestNumericRangeQuery32/64 failing tests.