### PR TITLE
change how TopTermsRewrite instance of is checked

### DIFF
--- a/src/Lucene.Net.Core/Lucene.Net.csproj
+++ b/src/Lucene.Net.Core/Lucene.Net.csproj
@@ -438,6 +438,7 @@
     <Compile Include="Search\FuzzyTermsEnum.cs" />
     <Compile Include="Search\HitQueue.cs" />
     <Compile Include="Search\IndexSearcher.cs" />
+    <Compile Include="Search\ITopTermsRewrite.cs" />
     <Compile Include="Search\LiveFieldValues.cs" />
     <Compile Include="Search\MatchAllDocsQuery.cs" />
     <Compile Include="Search\IMaxNonCompetitiveBoostAttribute.cs" />

--- a/src/Lucene.Net.Core/Search/ITopTermsRewrite.cs
+++ b/src/Lucene.Net.Core/Search/ITopTermsRewrite.cs
@@ -1,0 +1,7 @@
+namespace Lucene.Net.Search
+{
+    public interface ITopTermsRewrite
+    {
+        int Size { get; }
+    }
+}

--- a/src/Lucene.Net.Core/Search/ITopTermsRewrite.cs
+++ b/src/Lucene.Net.Core/Search/ITopTermsRewrite.cs
@@ -1,6 +1,6 @@
 namespace Lucene.Net.Search
 {
-    public interface ITopTermsRewrite
+    internal interface ITopTermsRewrite
     {
         int Size { get; }
     }

--- a/src/Lucene.Net.Core/Search/Spans/SpanMultiTermQueryWrapper.cs
+++ b/src/Lucene.Net.Core/Search/Spans/SpanMultiTermQueryWrapper.cs
@@ -64,9 +64,9 @@ namespace Lucene.Net.Search.Spans
             this.query = query_;
 
             MultiTermQuery.RewriteMethod method = query.GetRewriteMethod();
-            if (method is TopTermsRewrite<Q>)
+            if (method is ITopTermsRewrite)
             {
-                int pqsize = ((TopTermsRewrite<Q>)method).Size;
+                int pqsize = ((ITopTermsRewrite)method).Size;
                 RewriteMethod = new TopTermsSpanBooleanQueryRewrite(pqsize);
             }
             else

--- a/src/Lucene.Net.Core/Search/TopTermsRewrite.cs
+++ b/src/Lucene.Net.Core/Search/TopTermsRewrite.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Search
     /// via a priority queue.
     /// @lucene.internal Only public to be accessible by spans package.
     /// </summary>
-    public abstract class TopTermsRewrite<Q> : TermCollectingRewrite<Q>
+    public abstract class TopTermsRewrite<Q> : TermCollectingRewrite<Q>, ITopTermsRewrite
         where Q : Query
     {
         private readonly int size;


### PR DESCRIPTION
Changing the logic that checks if rewrite method is an instance of some sort of TopTermsRewrite to match Lucene. Key change is here:

https://github.com/apache/lucenenet/compare/master...laimis:fuzzyquery_fix?expand=1#diff-605c6558db33049a7e4d93482e5432aeL67

Instead of checking for TopTermsRewrite< Q >, it seems like Lucene cares only if it is TopTermsRewrite based class but does not care what parameter type is used and it does not need to match SpanMultiTermQueryWrapper parameter type:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/search/spans/SpanMultiTermQueryWrapper.java#L68

At least that's how interpreted it. The tests seem to pass and this also fixes failing test in TestSpanMultiTermQueryWrapper. TestFuzzy2