### PR TITLE
Patch for QueryParser to avoid throwing lots of exceptions that slows down the debugger

### DIFF
--- a/src/core/QueryParser/CharStream.cs
+++ b/src/core/QueryParser/CharStream.cs
@@ -44,6 +44,7 @@ namespace Lucene.Net.QueryParsers
 		/// implementing this interface.  Can throw any java.io.IOException.
 		/// </summary>
 		char ReadChar();
+		char ReadChar(ref bool? systemIoException);
 
 	    /// <summary> Returns the column position of the character last read.</summary>
 	    /// <deprecated>
@@ -82,17 +83,18 @@ namespace Lucene.Net.QueryParsers
 	    int BeginLine { get; }
 
 	    /// <summary> Backs up the input stream by amount steps. Lexer calls this method if it
-		/// had already read some characters, but could not use them to match a
-		/// (longer) token. So, they will be used again as the prefix of the next
-		/// token and it is the implemetation's responsibility to do this right.
-		/// </summary>
-		void  Backup(int amount);
+	    /// had already read some characters, but could not use them to match a
+	    /// (longer) token. So, they will be used again as the prefix of the next
+	    /// token and it is the implemetation's responsibility to do this right.
+	    /// </summary>
+	    void  Backup(int amount);
 		
-		/// <summary> Returns the next character that marks the beginning of the next token.
-		/// All characters must remain in the buffer between two successive calls
-		/// to this method to implement backup correctly.
-		/// </summary>
-		char BeginToken();
+	    /// <summary> Returns the next character that marks the beginning of the next token.
+	    /// All characters must remain in the buffer between two successive calls
+	    /// to this method to implement backup correctly.
+	    /// </summary>
+	    char BeginToken();
+	    char BeginToken(ref bool? systemIoException);
 
 	    /// <summary> Returns a string made up of characters from the marked token beginning
 	    /// to the current buffer position. Implementations have the choice of returning
@@ -102,23 +104,23 @@ namespace Lucene.Net.QueryParsers
 	    string Image { get; }
 
 	    /// <summary> Returns an array of characters that make up the suffix of length 'len' for
-		/// the currently matched token. This is used to build up the matched string
-		/// for use in actions in the case of MORE. A simple and inefficient
-		/// implementation of this is as follows :
-		/// 
-		/// {
-		/// String t = GetImage();
-		/// return t.substring(t.length() - len, t.length()).toCharArray();
-		/// }
-		/// </summary>
-		char[] GetSuffix(int len);
-		
-		/// <summary> The lexer calls this function to indicate that it is done with the stream
-		/// and hence implementations can free any resources held by this class.
-		/// Again, the body of this function can be just empty and it will not
-		/// affect the lexer's operation.
-		/// </summary>
-		void  Done();
+	    /// the currently matched token. This is used to build up the matched string
+	    /// for use in actions in the case of MORE. A simple and inefficient
+	    /// implementation of this is as follows :
+	    /// 
+	    /// {
+	    /// String t = GetImage();
+	    /// return t.substring(t.length() - len, t.length()).toCharArray();
+	    /// }
+	    /// </summary>
+	    char[] GetSuffix(int len);
+	    
+	    /// <summary> The lexer calls this function to indicate that it is done with the stream
+	    /// and hence implementations can free any resources held by this class.
+	    /// Again, the body of this function can be just empty and it will not
+	    /// affect the lexer's operation.
+	    /// </summary>
+	    void  Done();
 	}
     /* JavaCC - OriginalChecksum=32a89423891f765dde472f7ef0e3ef7b (do not edit this line) */
 }

--- a/src/core/QueryParser/QueryParser.cs
+++ b/src/core/QueryParser/QueryParser.cs
@@ -1709,15 +1709,12 @@ namespace Lucene.Net.QueryParsers
 
         private bool Jj_2_1(int xla)
         {
+            bool lookaheadSuccess = false;
             jj_la = xla;
             jj_lastpos = jj_scanpos = token;
             try
             {
-                return !Jj_3_1();
-            }
-            catch (LookaheadSuccess)
-            {
-                return true;
+                return !Jj_3_1(out lookaheadSuccess);
             }
             finally
             {
@@ -1725,29 +1722,31 @@ namespace Lucene.Net.QueryParsers
             }
         }
 
-        private bool Jj_3R_2()
+        private bool Jj_3R_2(out bool lookaheadSuccess)
         {
-            if (jj_scan_token(TermToken)) return true;
-            if (jj_scan_token(ColonToken)) return true;
+            if (jj_scan_token(TermToken, out lookaheadSuccess)) return true;
+            if (lookaheadSuccess) return false;
+            if (jj_scan_token(ColonToken, out lookaheadSuccess)) return true;
             return false;
         }
 
-        private bool Jj_3_1()
+        private bool Jj_3_1(out bool lookaheadSuccess)
         {
             Token xsp;
             xsp = jj_scanpos;
-            if (Jj_3R_2())
+            if (Jj_3R_2(out lookaheadSuccess))
             {
                 jj_scanpos = xsp;
-                if (Jj_3R_3()) return true;
+                if (Jj_3R_3(out lookaheadSuccess)) return true;
             }
             return false;
         }
 
-        private bool Jj_3R_3()
+        private bool Jj_3R_3(out bool lookaheadSuccess)
         {
-            if (jj_scan_token(StarToken)) return true;
-            if (jj_scan_token(ColonToken)) return true;
+            if (jj_scan_token(StarToken, out lookaheadSuccess)) return true;
+            if (lookaheadSuccess) return false;
+            if (jj_scan_token(ColonToken, out lookaheadSuccess)) return true;
             return false;
         }
 
@@ -1861,14 +1860,9 @@ namespace Lucene.Net.QueryParsers
             throw GenerateParseException();
         }
 
-        [Serializable]
-        private sealed class LookaheadSuccess : System.Exception
+        private bool jj_scan_token(int kind, out bool lookaheadSuccess)
         {
-        }
-
-        private LookaheadSuccess jj_ls = new LookaheadSuccess();
-        private bool jj_scan_token(int kind)
-        {
+            lookaheadSuccess = false;
             if (jj_scanpos == jj_lastpos)
             {
                 jj_la--;
@@ -1897,7 +1891,7 @@ namespace Lucene.Net.QueryParsers
                 if (tok != null) Jj_add_error_token(kind, i);
             }
             if (jj_scanpos.kind != kind) return true;
-            if (jj_la == 0 && jj_scanpos == jj_lastpos) throw jj_ls;
+            if (jj_la == 0 && jj_scanpos == jj_lastpos) lookaheadSuccess = true;
             return false;
         }
 
@@ -2030,31 +2024,33 @@ namespace Lucene.Net.QueryParsers
 
         private void Jj_rescan_token()
         {
+            bool lookaheadSuccess = false;
             jj_rescan = true;
             for (int i = 0; i < 1; i++)
             {
-                try
+                JJCalls p = jj_2_rtns[i];
+                do
                 {
-                    JJCalls p = jj_2_rtns[i];
-                    do
+                    if (p.gen > jj_gen)
                     {
-                        if (p.gen > jj_gen)
+                        jj_la = p.arg;
+                        jj_lastpos = jj_scanpos = p.first;
+                        switch (i)
                         {
-                            jj_la = p.arg;
-                            jj_lastpos = jj_scanpos = p.first;
-                            switch (i)
-                            {
-                                case 0:
-                                    Jj_3_1();
-                                    break;
-                            }
+                            case 0:
+                                Jj_3_1(out lookaheadSuccess);
+                                if (lookaheadSuccess)
+                                {
+                                    goto Jj_rescan_token_after_while_label;
+                                }
+                                break;
                         }
-                        p = p.next;
-                    } while (p != null);
-                }
-                catch (LookaheadSuccess)
-                {
-                }
+                    }
+                    p = p.next;
+                } while (p != null);
+
+            Jj_rescan_token_after_while_label:
+                lookaheadSuccess = false;
             }
             jj_rescan = false;
         }

--- a/src/core/QueryParser/QueryParserTokenManager.cs
+++ b/src/core/QueryParser/QueryParserTokenManager.cs
@@ -1341,9 +1341,16 @@ namespace Lucene.Net.QueryParsers
 			
 			for (; ; )
 			{
+				bool? systemIoException = false;
 				try
 				{
-					curChar = input_stream.BeginToken();
+					curChar = input_stream.BeginToken(ref systemIoException);
+					if (systemIoException != null && systemIoException.HasValue && systemIoException.Value == true)
+					{
+						jjmatchedKind = 0;
+						matchedToken = JjFillToken();
+						return matchedToken;
+					}
 				}
 				catch (System.IO.IOException)
 				{


### PR DESCRIPTION
Patch for QueryParser to avoid throwing lots of exceptions as part of main control flow.
When called very often, it slowed down a lot the
execution time when the visual studio debugger was attached.
This patch enhance the performance of the QueryParser under a debugger.
