### PR TITLE
make sure to invoke appropriate CompareValues via FieldComparator

### DIFF
--- a/src/Lucene.Net.Core/Search/FieldComparator.cs
+++ b/src/Lucene.Net.Core/Search/FieldComparator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Lucene.Net.Search
@@ -199,8 +200,13 @@ namespace Lucene.Net.Search
             }
             else
             {
-                return ((IComparable<T>)first).CompareTo(second);
+                return Comparer<T>.Default.Compare(first, second);
             }
+        }
+
+        public override int CompareValues(object first, object second)
+        {
+            return CompareValues((T)first, (T)second);
         }
     }
 
@@ -208,6 +214,8 @@ namespace Lucene.Net.Search
     // type parameter to access these nested types. Also moving non-generic methods here for casting without generics.
     public abstract class FieldComparator
     {
+        public abstract int CompareValues(object first, object second);
+
         //Set up abstract methods
         /// <summary>
         /// Compare hit at slot1 with hit at slot2.
@@ -312,11 +320,6 @@ namespace Lucene.Net.Search
         /// <param name="slot"> the value </param>
         /// <returns> value in this slot </returns>
         public abstract IComparable Value(int slot);
-
-        public int CompareValues(IComparable first, IComparable second)
-        {
-            return (first).CompareTo(second);
-        }
 
         /// <summary>
         /// Base FieldComparator class for numeric types

--- a/src/Lucene.Net.Core/Search/FieldDoc.cs
+++ b/src/Lucene.Net.Core/Search/FieldDoc.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Search
         /// FieldComparator used to sort this field. </summary>
         /// <seealso cref= Sort </seealso>
         /// <seealso cref= IndexSearcher#search(Query,Filter,int,Sort) </seealso>
-        public IComparable[] Fields;
+        public Object[] Fields;
 
         /// <summary>
         /// Expert: Creates one of these objects with empty sort information. </summary>
@@ -60,7 +60,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Expert: Creates one of these objects with the given sort information. </summary>
-        public FieldDoc(int doc, float score, IComparable[] fields)
+        public FieldDoc(int doc, float score, Object[] fields)
             : base(doc, score)
         {
             this.Fields = fields;
@@ -68,7 +68,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Expert: Creates one of these objects with the given sort information. </summary>
-        public FieldDoc(int doc, float score, IComparable[] fields, int shardIndex)
+        public FieldDoc(int doc, float score, Object[] fields, int shardIndex)
             : base(doc, score, shardIndex)
         {
             this.Fields = fields;

--- a/src/Lucene.Net.Tests/core/Search/TestElevationComparator.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestElevationComparator.cs
@@ -170,6 +170,11 @@ namespace Lucene.Net.Search
             private readonly BytesRef tempBR;
             internal int bottomVal;
 
+            public override int CompareValues(object first, object second)
+            {
+                return ((IComparable) first).CompareTo(second);
+            }
+
             public override int Compare(int slot1, int slot2)
             {
                 return values[slot2] - values[slot1]; // values will be small enough that there is no overflow concern


### PR DESCRIPTION
.NET port introduced FieldComparator that generic FieldComparator<T> inherits from. The issue is that the CompareValues it introduced does not properly propagate CompareValues calls to subclasses of FieldComparator<T>.

To see the bug in action, look at the failing tests in TestTopDocsMerge.TestSort_1 or TestTopDocsMerge. TestSort_2 (does not fail always, but can be repro with a few runs). Here is the link on TC: http://teamcity.codebetter.com/viewLog.html?buildId=189195&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId-8365680837810961892

The call invoked here:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.Core/Search/TopDocs.cs#L207

Results in execution of:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.Core/Search/FieldComparator.cs#L318

Instead of let's say specific FieldComparator implementation such as this:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.Core/Search/FieldComparator.cs#L1002


FieldDoc.Fields array was put back to contain object types to match what Lucene has since IComparable interface becomes not used with the changes.