### PR TITLE
Fix SkipBytes in the reverse reader

### DIFF
--- a/src/Lucene.Net.Core/Index/SortedSetDocValuesWriter.cs
+++ b/src/Lucene.Net.Core/Index/SortedSetDocValuesWriter.cs
@@ -200,7 +200,7 @@ namespace Lucene.Net.Index
         {
             AppendingDeltaPackedLongBuffer.Iterator iter = PendingCounts.GetIterator();
 
-            Debug.Assert(maxDoc == Pending.Size(), "MaxDoc: " + maxDoc + ", pending.Size(): " + Pending.Size());
+            Debug.Assert(maxDoc == PendingCounts.Size(), "MaxDoc: " + maxDoc + ", pending.Size(): " + Pending.Size());
 
             for (int i = 0; i < maxDoc; ++i)
             {

--- a/src/Lucene.Net.Core/Util/Fst/BytesStore.cs
+++ b/src/Lucene.Net.Core/Util/Fst/BytesStore.cs
@@ -541,7 +541,7 @@ namespace Lucene.Net.Util.Fst
 
             public override void SkipBytes(int count)
             {
-                Position = OuterInstance.Position - count;
+                Position = Position - count;
             }
 
             public override void ReadBytes(byte[] b, int offset, int len)


### PR DESCRIPTION
Lucene42 tests were passing but still showing assert failures occasionally with Fail: frozenHash=xxxxx vs h=xxxx" messages. SkipBytes had a bug where Position value was being read from BytesStore (outer instance) and not using reverse reader logic. Here is the method in Lucene:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/util/fst/BytesStore.java#L434 

The other commit was to eliminate assert messages showing up that were actually not valid failures. There was a bug where Pending.Size() was used instead of PendingCounts.Size() call, as Lucene is doing:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValuesWriter.java#L284