### PR TITLE
Fix "The process cannot access the file '...' because it is being used by another process." issues

### DIFF
--- a/src/Lucene.Net.Core/Store/FSDirectory.cs
+++ b/src/Lucene.Net.Core/Store/FSDirectory.cs
@@ -477,7 +477,7 @@ namespace Lucene.Net.Store
             {
                 this.Parent = parent;
                 this.Name = name;
-                File = new FileStream(Path.Combine(parent.directory.FullName, name), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+                File = new FileStream(Path.Combine(parent.directory.FullName, name), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
                 IsOpen = true;
             }
 

--- a/src/Lucene.Net.Core/Store/MMapDirectory.cs
+++ b/src/Lucene.Net.Core/Store/MMapDirectory.cs
@@ -198,23 +198,17 @@ namespace Lucene.Net.Store
         public override IndexInput OpenInput(string name, IOContext context)
         {
             EnsureOpen();
-            FileInfo file = new FileInfo(Path.Combine(Directory.FullName, name));
+            var file = new FileInfo(Path.Combine(Directory.FullName, name));
 
-            FileStream c = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var c = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
 
-            return new MMapIndexInput(this, "MMapIndexInput(path=\"" + file.ToString() + "\")", c);
+            return new MMapIndexInput(this, "MMapIndexInput(path=\"" + file + "\")", c);
         }
 
         public override IndexInputSlicer CreateSlicer(string name, IOContext context)
         {
-            EnsureOpen();
-            FileInfo file = new FileInfo(Path.Combine(Directory.FullName, name));
+            var full = (MMapIndexInput)OpenInput(name, context);
 
-            FileStream c = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
-
-            var full = new MMapIndexInput(this, "MMapIndexInputSlicer(path=\"" + file.ToString() + "\")", c);
-
-            //MMapIndexInput full = (MMapIndexInput)OpenInput(name, context);
             return new IndexInputSlicerAnonymousInnerClassHelper(this, full);
         }
 
@@ -222,9 +216,9 @@ namespace Lucene.Net.Store
         {
             private readonly MMapDirectory OuterInstance;
 
-            private Lucene.Net.Store.MMapDirectory.MMapIndexInput Full;
+            private MMapIndexInput Full;
 
-            public IndexInputSlicerAnonymousInnerClassHelper(MMapDirectory outerInstance, Lucene.Net.Store.MMapDirectory.MMapIndexInput full)
+            public IndexInputSlicerAnonymousInnerClassHelper(MMapDirectory outerInstance, MMapIndexInput full)
                 : base(outerInstance)
             {
                 this.OuterInstance = outerInstance;

--- a/src/Lucene.Net.Core/Store/NIOFSDirectory.cs
+++ b/src/Lucene.Net.Core/Store/NIOFSDirectory.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Store
             //File path = new File(Directory, name);
             FileInfo path = new FileInfo(Path.Combine(Directory.FullName, name));
             //path.Create();
-            FileStream fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);//FileChannel.open(path.toPath(), StandardOpenOption.READ);
+            FileStream fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);//FileChannel.open(path.toPath(), StandardOpenOption.READ);
             return new NIOFSIndexInput("NIOFSIndexInput(path=\"" + path + "\")", fc, context);
             //return new NIOFSIndexInput(new FileInfo(Path.Combine(Directory.FullName, name)), context, ReadChunkSize);
         }
@@ -91,7 +91,7 @@ namespace Lucene.Net.Store
             //File path = new File(Directory, name);
             //FileStream descriptor = FileChannel.open(path.toPath(), StandardOpenOption.READ);
             FileInfo path = new FileInfo(Path.Combine(Directory.FullName, name));
-            FileStream fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            FileStream fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new IndexInputSlicerAnonymousInnerClassHelper(this, context, path, fc);
         }
 

--- a/src/Lucene.Net.Core/Store/SimpleFSDirectory.cs
+++ b/src/Lucene.Net.Core/Store/SimpleFSDirectory.cs
@@ -59,7 +59,7 @@ namespace Lucene.Net.Store
         {
             EnsureOpen();
             var path = new FileInfo(Path.Combine(Directory.FullName, name));
-            var raf = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var raf = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return new SimpleFSIndexInput("SimpleFSIndexInput(path=\"" + path.FullName + "\")", raf, context);
         }
 
@@ -67,7 +67,7 @@ namespace Lucene.Net.Store
         {
             EnsureOpen();
             var file = new FileInfo(Path.Combine(Directory.FullName, name));
-            var descriptor = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var descriptor = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return new IndexInputSlicerAnonymousInnerClassHelper(this, context, file, descriptor);
         }
 

--- a/src/Lucene.Net.Tests/core/Store/TestBufferedIndexInput.cs
+++ b/src/Lucene.Net.Tests/core/Store/TestBufferedIndexInput.cs
@@ -269,55 +269,61 @@ namespace Lucene.Net.Store
         public virtual void TestSetBufferSize()
         {
             var indexDir = CreateTempDir("testSetBufferSize");
-            using (var dir = new MockFSDirectory(indexDir, Random()))
+            var dir = new MockFSDirectory(indexDir, Random());
+            try
             {
-                using (var writer = new IndexWriter(dir,
-                    (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))).SetOpenMode(
-                        IndexWriterConfig.OpenMode_e.CREATE).SetMergePolicy(NewLogMergePolicy(false))))
+                var writer = new IndexWriter(
+                    dir,
+                    new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                        .SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE)
+                        .SetMergePolicy(NewLogMergePolicy(false)));
+                    
+                for (int i = 0; i < 37; i++)
                 {
-                    for (int i = 0; i < 37; i++)
-                    {
-                        var doc = new Document();
-                        doc.Add(NewTextField("content", "aaa bbb ccc ddd" + i, Field.Store.YES));
-                        doc.Add(NewTextField("id", "" + i, Field.Store.YES));
-                        writer.AddDocument(doc);
-                    }
-
-                    dir.AllIndexInputs.Clear();
-                    dir.TweakBufferSizes();
-                    writer.DeleteDocuments(new Term("id", "0"));
-
-                    var aaa = new Term("content", "aaa");
-                    var bbb = new Term("content", "bbb");
-
-                    IndexSearcher searcher;
-                    ScoreDoc[] hits;
-                    using (var reader = DirectoryReader.Open(writer, true))
-                    {
-                        searcher = NewSearcher(reader);
-                        hits = searcher.Search(new TermQuery(bbb), null, 1000).ScoreDocs;
-                        dir.TweakBufferSizes();
-                        Assert.AreEqual(36, hits.Length);
-                    }
-
-                    dir.TweakBufferSizes();
-                    writer.DeleteDocuments(new Term("id", "4"));
-                    using (var reader = DirectoryReader.Open(writer, true))
-                    {
-                        searcher = NewSearcher(reader);
-
-                        hits = searcher.Search(new TermQuery(bbb), null, 1000).ScoreDocs;
-                        dir.TweakBufferSizes();
-                        Assert.AreEqual(35, hits.Length);
-                        dir.TweakBufferSizes();
-                        hits = searcher.Search(new TermQuery(new Term("id", "33")), null, 1000).ScoreDocs;
-                        dir.TweakBufferSizes();
-                        Assert.AreEqual(1, hits.Length);
-                        hits = searcher.Search(new TermQuery(aaa), null, 1000).ScoreDocs;
-                        dir.TweakBufferSizes();
-                        Assert.AreEqual(35, hits.Length);
-                    }
+                    var doc = new Document();
+                    doc.Add(NewTextField("content", "aaa bbb ccc ddd" + i, Field.Store.YES));
+                    doc.Add(NewTextField("id", "" + i, Field.Store.YES));
+                    writer.AddDocument(doc);
                 }
+
+                dir.AllIndexInputs.Clear();
+
+                IndexReader reader = DirectoryReader.Open(writer, true);
+                var aaa = new Term("content", "aaa");
+                var bbb = new Term("content", "bbb");
+                reader.Dispose();
+
+                dir.TweakBufferSizes();
+                writer.DeleteDocuments(new Term("id", "0"));
+                reader = DirectoryReader.Open(writer, true);
+                var searcher = NewSearcher(reader);
+                var hits = searcher.Search(new TermQuery(bbb), null, 1000).ScoreDocs;
+                dir.TweakBufferSizes();
+                Assert.AreEqual(36, hits.Length);
+
+                reader.Dispose();
+
+                dir.TweakBufferSizes();
+                writer.DeleteDocuments(new Term("id", "4"));
+                reader = DirectoryReader.Open(writer, true);
+                searcher = NewSearcher(reader);
+
+                hits = searcher.Search(new TermQuery(bbb), null, 1000).ScoreDocs;
+                dir.TweakBufferSizes();
+                Assert.AreEqual(35, hits.Length);
+                dir.TweakBufferSizes();
+                hits = searcher.Search(new TermQuery(new Term("id", "33")), null, 1000).ScoreDocs;
+                dir.TweakBufferSizes();
+                Assert.AreEqual(1, hits.Length);
+                hits = searcher.Search(new TermQuery(aaa), null, 1000).ScoreDocs;
+                dir.TweakBufferSizes();
+                Assert.AreEqual(35, hits.Length);
+                writer.Dispose();
+                reader.Dispose();
+            }
+            finally
+            {
+                indexDir.Delete(true);
             }
         }
 


### PR DESCRIPTION
A good number of tests fail with the error message stating that certain file cannot be accessed. Side by side comparison with what Lucene is doing while using Filemon showed that Lucene.Net version was opening the filestreams with correct FileAccess flag but incorrect FileShare flag. Instead of read it should have been ReadWrite.

The failure would occur when writer was disposed and it called IOUtils fsync. Fsync opens the stream again in FileAccess ReadWrite mode while at the same time there were readers that have the file opened with FileShare set to Read only.

Here is the screenshot of the file handle opened when Lucene is running:

![javaversion](https://cloud.githubusercontent.com/assets/911757/7439229/af717934-f041-11e4-84a6-42dd073eab08.PNG)

And here is the Lucene.Net:

![dotnetversion](https://cloud.githubusercontent.com/assets/911757/7439236/c787fca0-f041-11e4-8453-040200d2ca0f.PNG)

(hopefully these images come through).

Also was using the TestBufferedIndexInput to confirm the fix and noticed that it was rewritten to use using(..)s but during the rewrite some code was omitted so I rewrote it back to match exactly what Lucene is doing so it is easier to compare.