### PR TITLE
use GetSafe instead of Get to match java behavior

### DIFF
--- a/src/Lucene.Net.Core/Util/DocIdBitSet.cs
+++ b/src/Lucene.Net.Core/Util/DocIdBitSet.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Util
 
         public bool Get(int index)
         {
-            return bitSet.Get(index);
+            return bitSet.SafeGet(index);
         }
 
         public int Length()


### PR DESCRIPTION
Discovered this issue while diagnosing why TestFilteredQuery.TestFilteredQuery_Mem was failing randomly. It came down to a specific filter that needs to be selected with random at this point:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.TestFramework/Util/TestUtil.cs#L1303

that gets selected together with "MatchAllDocs" query, called from here:

https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.Tests/core/Search/TestFilteredQuery.cs#L170

The test fails with:

Test(s) failed. System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
   at System.Collections.BitArray.Get(Int32 index)
at Lucene.Net.Util.DocIdBitSet.Get(Int32 index) in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Core\Util\DocIdBitSet.cs:line 71

Lucene.Net data / logic flow matches what Lucene is doing and in this case Lucene returns False as bitset returns false in case the index is greater than the bitset length. While BitArray returns exception in that case.

There are more places in the code base that use BitArray.Get, not sure if it is worth adjusting all of those to use SafeGet or instead fix those as they are discovered to lead into issues. Open to the suggestions.   


