### PR TITLE
Use SafeGet and SafeSet for BitArray to match Lucene behavior

### DIFF
--- a/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
@@ -967,9 +967,9 @@ namespace Lucene.Net.Codecs.Memory
 
                 long node = arc.Target;
                 //System.out.println(arc);
-                if (FST<T>.TargetHasArcs(arc) && !seen.Get((int)node))
+                if (FST<T>.TargetHasArcs(arc) && !seen.SafeGet((int)node))
                 {
-                    seen.Set((int)node, true);
+                    seen.SafeSet((int)node, true);
                     fst.ReadFirstRealTargetArc(node, arc, reader);
                     while (true)
                     {

--- a/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+using Lucene.Net.Support;
+
 namespace Lucene.Net.Codecs.Memory
 {
     using System;
@@ -873,9 +875,9 @@ namespace Lucene.Net.Codecs.Memory
 
                 long node = arc.Target;
                 //System.out.println(arc);
-                if (FST<T>.TargetHasArcs(arc) && !seen.Get((int)node))
+                if (FST<T>.TargetHasArcs(arc) && !seen.SafeGet((int)node))
                 {
-                    seen.Set((int)node, true);
+                    seen.SafeSet((int)node, true);
                     fst.ReadFirstRealTargetArc(node, arc, reader);
                     while (true)
                     {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextLiveDocsFormat.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextLiveDocsFormat.cs
@@ -91,7 +91,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 {
                     Debug.Assert(StringHelper.StartsWith(scratch, DOC));
                     var docid = ParseIntAt(scratch, DOC.Length, scratchUtf16);
-                    bits.Set(docid, true);
+                    bits.SafeSet(docid, true);
                     SimpleTextUtil.ReadLine(input, scratch);
                 }
 
@@ -183,7 +183,7 @@ namespace Lucene.Net.Codecs.SimpleText
 
             public bool Get(int index)
             {
-                return BITS.Get(index);
+                return BITS.SafeGet(index);
             }
 
             public int Length()
@@ -207,7 +207,7 @@ namespace Lucene.Net.Codecs.SimpleText
 
             public void Clear(int bit)
             {
-                BITS.Set(bit, false);
+                BITS.SafeSet(bit, false);
             }
         }
     }

--- a/src/Lucene.Net.Core/Support/BitSetSupport.cs
+++ b/src/Lucene.Net.Core/Support/BitSetSupport.cs
@@ -165,7 +165,7 @@ namespace Lucene.Net.Support
         /// <param name="index">The position to set to true.</param>
         public static void Set(this BitArray bits, int index)
         {
-            bits.Set(index, true);
+            bits.SafeSet(index, true);
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Lucene.Net.Support
         {
             for (int i = fromIndex; i < toIndex; ++i)
             {
-                bits.Set(i, value);
+                bits.SafeSet(i, value);
             }
         }
 
@@ -190,7 +190,7 @@ namespace Lucene.Net.Support
         /// <param name="index">The position to set to false.</param>
         public static void Clear(this BitArray bits, int index)
         {
-            bits.Set(index, false);
+            bits.SafeSet(index, false);
         }
 
         /// <summary>
@@ -289,7 +289,7 @@ namespace Lucene.Net.Support
 
             for (int i = 0; i < bitArrayCardinality; i++)
             {
-                if (a.Get(i) != b.Get(i))
+                if (a.SafeGet(i) != b.Get(i))
                     return false;
             }
 

--- a/src/Lucene.Net.Core/Util/Automaton/Automaton.cs
+++ b/src/Lucene.Net.Core/Util/Automaton/Automaton.cs
@@ -560,7 +560,7 @@ namespace Lucene.Net.Util.Automaton
             BitArray liveSet = new BitArray(states.Length);
             foreach (State s in live)
             {
-                liveSet.Set(s.number, true);
+                liveSet.SafeSet(s.number, true);
             }
 
             foreach (State s in states)
@@ -570,7 +570,7 @@ namespace Lucene.Net.Util.Automaton
                 for (int i = 0; i < s.numTransitions; i++)
                 {
                     Transition t = s.TransitionsArray[i];
-                    if (liveSet.Get(t.To.Number))
+                    if (liveSet.SafeGet(t.To.Number))
                     {
                         s.TransitionsArray[upto++] = s.TransitionsArray[i];
                     }

--- a/src/Lucene.Net.Core/Util/Automaton/BasicOperations.cs
+++ b/src/Lucene.Net.Core/Util/Automaton/BasicOperations.cs
@@ -1097,9 +1097,9 @@ namespace Lucene.Net.Util.Automaton
                             {
                                 accept = true;
                             }
-                            if (!bb_other.Get(q.number))
+                            if (!bb_other.SafeGet(q.number))
                             {
-                                bb_other.Set(q.number, true);
+                                bb_other.SafeSet(q.number, true);
                                 pp_other.AddLast(q);
                             }
                         }

--- a/src/Lucene.Net.Core/Util/Automaton/MinimizationOperations.cs
+++ b/src/Lucene.Net.Core/Util/Automaton/MinimizationOperations.cs
@@ -135,7 +135,7 @@ namespace Lucene.Net.Util.Automaton
             {
                 int j = (active[0, x].Size <= active[1, x].Size) ? 0 : 1;
                 pending.AddLast(new IntPair(j, x));
-                pending2.Set(x * statesLen + j, true);
+                pending2.SafeSet(x * statesLen + j, true);
             }
             // process pending until fixed point
             int k = 2;
@@ -145,7 +145,7 @@ namespace Lucene.Net.Util.Automaton
                 pending.RemoveFirst();
                 int p = ip.N1;
                 int x = ip.N2;
-                pending2.Set(x * statesLen + p, false);
+                pending2.SafeSet(x * statesLen + p, false);
                 // find states that need to be split off their blocks
                 for (StateListNode m = active[p, x].First; m != null; m = m.Next)
                 {
@@ -155,15 +155,15 @@ namespace Lucene.Net.Util.Automaton
                         foreach (State s in r)
                         {
                             int i = s.number;
-                            if (!split.Get(i))
+                            if (!split.SafeGet(i))
                             {
-                                split.Set(i, true);
+                                split.SafeSet(i, true);
                                 int j = block[i];
                                 splitblock[j].Add(s);
-                                if (!refine2.Get(j))
+                                if (!refine2.SafeGet(j))
                                 {
-                                    refine2.Set(j, true);
-                                    refine.Set(j, true);
+                                    refine2.SafeSet(j, true);
+                                    refine.SafeSet(j, true);
                                 }
                             }
                         }
@@ -196,23 +196,23 @@ namespace Lucene.Net.Util.Automaton
                         for (int c = 0; c < sigmaLen; c++)
                         {
                             int aj = active[j, c].Size, ak = active[k, c].Size, ofs = c * statesLen;
-                            if (!pending2.Get(ofs + j) && 0 < aj && aj <= ak)
+                            if (!pending2.SafeGet(ofs + j) && 0 < aj && aj <= ak)
                             {
-                                pending2.Set(ofs + j, true);
+                                pending2.SafeSet(ofs + j, true);
                                 pending.AddLast(new IntPair(j, c));
                             }
                             else
                             {
-                                pending2.Set(ofs + k, true);
+                                pending2.SafeSet(ofs + k, true);
                                 pending.AddLast(new IntPair(k, c));
                             }
                         }
                         k++;
                     }
-                    refine2.Set(j, false);
+                    refine2.SafeSet(j, false);
                     foreach (State s in sb)
                     {
-                        split.Set(s.number, false);
+                        split.SafeSet(s.number, false);
                     }
                     sb.Clear();
                 }

--- a/src/Lucene.Net.Core/Util/Automaton/SpecialOperations.cs
+++ b/src/Lucene.Net.Core/Util/Automaton/SpecialOperations.cs
@@ -96,16 +96,16 @@ namespace Lucene.Net.Util.Automaton
         // large automata could exceed java's stack
         private static bool IsFinite(State s, BitArray path, BitArray visited)
         {
-            path.Set(s.number, true);
+            path.SafeSet(s.number, true);
             foreach (Transition t in s.Transitions)
             {
-                if (path.Get(t.To.number) || (!visited.Get(t.To.number) && !IsFinite(t.To, path, visited)))
+                if (path.SafeGet(t.To.number) || (!visited.SafeGet(t.To.number) && !IsFinite(t.To, path, visited)))
                 {
                     return false;
                 }
             }
-            path.Set(s.number, false);
-            visited.Set(s.number, true);
+            path.SafeSet(s.number, false);
+            visited.SafeSet(s.number, true);
             return true;
         }
 

--- a/src/Lucene.Net.Core/Util/Fst/Util.cs
+++ b/src/Lucene.Net.Core/Util/Fst/Util.cs
@@ -742,7 +742,7 @@ namespace Lucene.Net.Util.Fst
 
             // A bitset of already seen states (target offset).
             BitArray seen = new BitArray(32);
-            seen.Set((int)startArc.Target, true);
+            seen.SafeSet((int)startArc.Target, true);
 
             // Shape for states.
             const string stateShape = "circle";
@@ -824,7 +824,7 @@ namespace Lucene.Net.Util.Fst
                         {
                             //System.out.println("  cycle arc=" + arc);
                             // Emit the unseen state and add it to the queue for the next level.
-                            if (arc.Target >= 0 && !seen.Get((int)arc.Target))
+                            if (arc.Target >= 0 && !seen.SafeGet((int)arc.Target))
                             {
                                 /*
                                 boolean isFinal = false;
@@ -860,7 +860,7 @@ namespace Lucene.Net.Util.Fst
                                 EmitDotState(@out, Convert.ToString(arc.Target), stateShape, stateColor, finalOutput);
                                 // To see the node address, use this instead:
                                 //emitDotState(out, Integer.toString(arc.target), stateShape, stateColor, String.valueOf(arc.target));
-                                seen.Set((int)arc.Target, true);
+                                seen.SafeSet((int)arc.Target, true);
                                 nextLevelQueue.Add((new FST<T>.Arc<T>()).CopyFrom(arc));
                                 sameLevelStates.Add((int)arc.Target);
                             }

--- a/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
@@ -214,7 +214,7 @@ namespace Lucene.Net.Search
             // check in the subset, that every bit was set by the super
             for (int i = 0; i < td1.ScoreDocs.Length; i++)
             {
-                Assert.IsTrue(bitset.Get(td1.ScoreDocs[i].Doc));
+                Assert.IsTrue(bitset.SafeGet(td1.ScoreDocs[i].Doc));
             }
         }
     }

--- a/src/Lucene.Net.TestFramework/Util/BaseDocIdSetTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/BaseDocIdSetTestCase.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Util
             Random random = Random();
             if (numBitsSet == numBits)
             {
-                set.Set(0, numBits != 0); //convert int to boolean
+                set.SafeSet(0, numBits != 0); //convert int to boolean
             }
             else
             {
@@ -56,9 +56,9 @@ namespace Lucene.Net.Util
                     while (true)
                     {
                         int o = random.Next(numBits);
-                        if (!set.Get(o))
+                        if (!set.SafeGet(o))
                         {
-                            set.Set(o, true);
+                            set.SafeSet(o, true);
                             break;
                         }
                     }
@@ -94,7 +94,7 @@ namespace Lucene.Net.Util
             BitArray bs = new BitArray(1);
             if (Random().NextBoolean())
             {
-                bs.Set(0, true);
+                bs.SafeSet(0, true);
             }
             T copy = CopyOf(bs, 1);
             AssertEquals(1, bs, copy);
@@ -109,11 +109,11 @@ namespace Lucene.Net.Util
             BitArray bs = new BitArray(2);
             if (Random().NextBoolean())
             {
-                bs.Set(0, true);
+                bs.SafeSet(0, true);
             }
             if (Random().NextBoolean())
             {
-                bs.Set(1, true);
+                bs.SafeSet(1, true);
             }
             T copy = CopyOf(bs, 2);
             AssertEquals(2, bs, copy);
@@ -136,11 +136,11 @@ namespace Lucene.Net.Util
             }
             // test one doc
             BitArray set_ = new BitArray(numBits);
-            set_.Set(0, true); // 0 first
+            set_.SafeSet(0, true); // 0 first
             T copy_ = CopyOf(set_, numBits);
             AssertEquals(numBits, set_, copy_);
-            set_.Set(0, false);
-            set_.Set(Random().Next(numBits), true);
+            set_.SafeSet(0, false);
+            set_.SafeSet(Random().Next(numBits), true);
             copy_ = CopyOf(set_, numBits); // then random index
             AssertEquals(numBits, set_, copy_);
             // test regular increments
@@ -149,7 +149,7 @@ namespace Lucene.Net.Util
                 set_ = new BitArray(numBits);
                 for (int d = Random().Next(10); d < numBits; d += inc)
                 {
-                    set_.Set(d, true);
+                    set_.SafeSet(d, true);
                 }
                 copy_ = CopyOf(set_, numBits);
                 AssertEquals(numBits, set_, copy_);

--- a/src/Lucene.Net.Tests/core/Index/TestTransactionRollback.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTransactionRollback.cs
@@ -107,8 +107,8 @@ namespace Lucene.Net.Index
                     if (sval != null)
                     {
                         int val = Convert.ToInt32(sval);
-                        Assert.IsTrue(expecteds.Get(val), "Did not expect document #" + val);
-                        expecteds.Set(val, false);
+                        Assert.IsTrue(expecteds.SafeGet(val), "Did not expect document #" + val);
+                        expecteds.SafeSet(val, false);
                     }
                 }
             }

--- a/src/Lucene.Net.Tests/core/Search/TestFilteredQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestFilteredQuery.cs
@@ -123,11 +123,11 @@ namespace Lucene.Net.Search
                 BitArray bitset = new BitArray(5);
                 if (acceptDocs.Get(1))
                 {
-                    bitset.Set(1, true);
+                    bitset.SafeSet(1, true);
                 }
                 if (acceptDocs.Get(3))
                 {
-                    bitset.Set(3, true);
+                    bitset.SafeSet(3, true);
                 }
                 return new DocIdBitSet(bitset);
             }
@@ -568,8 +568,8 @@ namespace Lucene.Net.Search
 
                     public bool Get(int index)
                     {
-                        Assert.IsTrue(OuterInstance.BitSet.Get(index), "filter was called for a non-matching doc");
-                        return OuterInstance.BitSet.Get(index);
+                        Assert.IsTrue(OuterInstance.BitSet.SafeGet(index), "filter was called for a non-matching doc");
+                        return OuterInstance.BitSet.SafeGet(index);
                     }
 
                     public int Length()

--- a/src/Lucene.Net.Tests/core/Search/TestScorerPerf.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestScorerPerf.cs
@@ -95,7 +95,7 @@ namespace Lucene.Net.Search
             BitArray set = new BitArray(sz);
             for (int i = 0; i < numBitsToSet; i++)
             {
-                set.Set(Random().Next(sz), true);
+                set.SafeSet(Random().Next(sz), true);
             }
             return set;
         }
@@ -301,7 +301,7 @@ namespace Lucene.Net.Search
                     int tnum;
                     // don't pick same clause twice
                     tnum = Random().Next(termsInIndex);
-                    if (termflag.Get(tnum))
+                    if (termflag.SafeGet(tnum))
                     {
                         tnum = termflag.NextClearBit(tnum);
                     }
@@ -309,7 +309,7 @@ namespace Lucene.Net.Search
                     {
                         tnum = termflag.NextClearBit(0);
                     }
-                    termflag.Set(tnum, true);
+                    termflag.SafeSet(tnum, true);
                     Query tq = new TermQuery(Terms[tnum]);
                     bq.Add(tq, BooleanClause.Occur.MUST);
                 }
@@ -345,7 +345,7 @@ namespace Lucene.Net.Search
                         int tnum;
                         // don't pick same clause twice
                         tnum = Random().Next(termsInIndex);
-                        if (termflag.Get(tnum))
+                        if (termflag.SafeGet(tnum))
                         {
                             tnum = termflag.NextClearBit(tnum);
                         }
@@ -353,7 +353,7 @@ namespace Lucene.Net.Search
                         {
                             tnum = termflag.NextClearBit(0);
                         }
-                        termflag.Set(tnum, true);
+                        termflag.SafeSet(tnum, true);
                         Query tq = new TermQuery(Terms[tnum]);
                         bq.Add(tq, BooleanClause.Occur.MUST);
                     } // inner

--- a/src/Lucene.Net.Tests/core/Util/TestBytesRefHash.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestBytesRefHash.cs
@@ -164,12 +164,12 @@ namespace Lucene.Net.Util
                     int key = Hash.Add(@ref);
                     if (key < 0)
                     {
-                        Assert.IsTrue(bits.Get((-key) - 1));
+                        Assert.IsTrue(bits.SafeGet((-key) - 1));
                     }
                     else
                     {
-                        Assert.IsFalse(bits.Get(key));
-                        bits.Set(key, true);
+                        Assert.IsFalse(bits.SafeGet(key));
+                        bits.SafeSet(key, true);
                         numEntries++;
                     }
                 }
@@ -180,7 +180,7 @@ namespace Lucene.Net.Util
                 Assert.IsTrue(numEntries < compact.Length);
                 for (int i = 0; i < numEntries; i++)
                 {
-                    bits.Set(compact[i], false);
+                    bits.SafeSet(compact[i], false);
                 }
                 Assert.AreEqual(0, bits.Cardinality());
                 Hash.Clear();

--- a/src/Lucene.Net.Tests/core/Util/TestFixedBitSet.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestFixedBitSet.cs
@@ -45,9 +45,9 @@ namespace Lucene.Net.Util
             int max = b.Length();
             for (int i = 0; i < max; i++)
             {
-                if (a.Get(i) != b.Get(i))
+                if (a.SafeGet(i) != b.Get(i))
                 {
-                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.Get(i));
+                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.SafeGet(i));
                 }
             }
         }
@@ -71,7 +71,7 @@ namespace Lucene.Net.Util
             {
                 // aa = a.PrevSetBit(aa-1);
                 aa--;
-                while ((aa >= 0) && (aa >= a.Length || !a.Get(aa)))
+                while ((aa >= 0) && (aa >= a.Length || !a.SafeGet(aa)))
                 {
                     aa--;
                 }
@@ -152,19 +152,19 @@ namespace Lucene.Net.Util
                         int idx;
 
                         idx = Random().Next(sz);
-                        a.Set(idx, true);
+                        a.SafeSet(idx, true);
                         b.Set(idx);
 
                         idx = Random().Next(sz);
-                        a.Set(idx, false);
+                        a.SafeSet(idx, false);
                         b.Clear(idx);
 
                         idx = Random().Next(sz);
-                        a.Set(idx, !a.Get(idx));
+                        a.SafeSet(idx, !a.SafeGet(idx));
                         b.Flip(idx, idx + 1);
 
                         idx = Random().Next(sz);
-                        a.Set(idx, !a.Get(idx));
+                        a.SafeSet(idx, !a.SafeGet(idx));
                         b.Flip(idx, idx + 1);
 
                         bool val2 = b.Get(idx);
@@ -442,7 +442,7 @@ namespace Lucene.Net.Util
                     bs.CopyTo(copy, bs.Length - 1);
                     bs = MakeBitSet(copy);
                 }*/
-                bs.Set(e, true);
+                bs.SafeSet(e, true);
             }
             return bs;
         }

--- a/src/Lucene.Net.Tests/core/Util/TestLongBitSet.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestLongBitSet.cs
@@ -31,9 +31,9 @@ namespace Lucene.Net.Util
             long max = b.Length();
             for (int i = 0; i < max; i++)
             {
-                if (a.Get(i) != b.Get(i))
+                if (a.SafeGet(i) != b.Get(i))
                 {
-                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.Get(i));
+                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.SafeGet(i));
                 }
             }
         }
@@ -110,7 +110,7 @@ namespace Lucene.Net.Util
                         b.Clear(idx);
 
                         idx = Random().Next(sz);
-                        a.SafeSet(idx, !a.Get(idx));
+                        a.SafeSet(idx, !a.SafeGet(idx));
                         b.Flip(idx, idx + 1);
 
                         idx = Random().Next(sz);

--- a/src/Lucene.Net.Tests/core/Util/TestOpenBitSet.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestOpenBitSet.cs
@@ -44,13 +44,13 @@ namespace Lucene.Net.Util
             int max = a.Count;
             for (int i = 0; i < max; i++)
             {
-                if (a.Get(i) != b.Get(i))
+                if (a.SafeGet(i) != b.Get(i))
                 {
-                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.Get(i));
+                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.SafeGet(i));
                 }
-                if (a.Get(i) != b.Get((long)i))
+                if (a.SafeGet(i) != b.Get((long)i))
                 {
-                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.Get(i));
+                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.SafeGet(i));
                 }
             }
         }
@@ -59,13 +59,13 @@ namespace Lucene.Net.Util
         {
             for (int i = 0; i < max; i++)
             {
-                if (a.Get(i) != b.FastGet(i))
+                if (a.SafeGet(i) != b.FastGet(i))
                 {
-                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.Get(i));
+                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.SafeGet(i));
                 }
-                if (a.Get(i) != b.FastGet((long)i))
+                if (a.SafeGet(i) != b.FastGet((long)i))
                 {
-                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.Get(i));
+                    Assert.Fail("mismatch: BitSet=[" + i + "]=" + a.SafeGet(i));
                 }
             }
         }

--- a/src/Lucene.Net.Tests/core/Util/TestWAH8DocIdSet.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestWAH8DocIdSet.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Util
             {
                 for (int doc = set.NextSetBit(0); doc != -1; doc = set.NextSetBit(doc + 1))
                 {
-                    expected.Set(doc, true);
+                    expected.SafeSet(doc, true);
                 }
             }
             AssertEquals(numBits, expected, union);


### PR DESCRIPTION
Lucene.Net port uses BitArray as a replacement for BitSet that Lucene uses. However BitArray behaves differently from BitSet when the bit index is greater than the length of the bit set in Get and Set methods. Adjust all the places where Get/Set is used and use extension methods SafeGet/SafeSet.