### PR TITLE
Make sure offsetGap is nullable int

### DIFF
--- a/src/Lucene.Net.TestFramework/Analysis/MockAnalyzer.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockAnalyzer.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Analysis
         private readonly bool LowerCase;
         private readonly CharacterRunAutomaton Filter;
         private int PositionIncrementGap_Renamed;
-        private int OffsetGap_Renamed;
+        private int? OffsetGap_Renamed;
         private readonly Random Random;
         private IDictionary<string, int?> PreviousMappings = new Dictionary<string, int?>();
         private bool EnableChecks_Renamed = true;
@@ -181,7 +181,7 @@ namespace Lucene.Net.Analysis
         /// <param name="fieldName"> Currently not used, the same offset gap is returned for each field. </param>
         public override int GetOffsetGap(string fieldName)
         {
-            return OffsetGap_Renamed == null ? base.GetOffsetGap(fieldName) : OffsetGap_Renamed;
+            return OffsetGap_Renamed == null ? base.GetOffsetGap(fieldName) : OffsetGap_Renamed.Value;
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests/core/Index/TestTermVectorsWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTermVectorsWriter.cs
@@ -136,8 +136,8 @@ namespace Lucene.Net.Index
             Assert.AreEqual(4, dpEnum.EndOffset());
 
             dpEnum.NextPosition();
-            Assert.AreEqual(4, dpEnum.StartOffset());
-            Assert.AreEqual(8, dpEnum.EndOffset());
+            Assert.AreEqual(5, dpEnum.StartOffset());
+            Assert.AreEqual(9, dpEnum.EndOffset());
             Assert.AreEqual(DocIdSetIterator.NO_MORE_DOCS, dpEnum.NextDoc());
 
             r.Dispose();
@@ -155,7 +155,7 @@ namespace Lucene.Net.Index
             customType.StoreTermVectors = true;
             customType.StoreTermVectorPositions = true;
             customType.StoreTermVectorOffsets = true;
-            Field f = NewField("field", "abcd    ", customType);
+            Field f = NewField("field", "abcd   ", customType);
             doc.Add(f);
             doc.Add(f);
             w.AddDocument(doc);
@@ -190,7 +190,7 @@ namespace Lucene.Net.Index
             IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer));
             Document doc = new Document();
             IOException priorException = null;
-            TokenStream stream = analyzer.TokenStream("field", new StringReader("abcd    "));
+            TokenStream stream = analyzer.TokenStream("field", new StringReader("abcd   "));
             try
             {
                 stream.Reset(); // TODO: weird to reset before wrapping with CachingTokenFilter... correct?
@@ -245,7 +245,7 @@ namespace Lucene.Net.Index
             customType.StoreTermVectors = true;
             customType.StoreTermVectorPositions = true;
             customType.StoreTermVectorOffsets = true;
-            Field f = NewField("field", "abcd the ", customType);
+            Field f = NewField("field", "abcd the", customType);
             doc.Add(f);
             doc.Add(f);
             w.AddDocument(doc);
@@ -282,7 +282,7 @@ namespace Lucene.Net.Index
             customType.StoreTermVectors = true;
             customType.StoreTermVectorPositions = true;
             customType.StoreTermVectorOffsets = true;
-            Field f = NewField("field", "abcd the   ", customType);
+            Field f = NewField("field", "abcd the  ", customType);
             Field f2 = NewField("field", "crunch man", customType);
             doc.Add(f);
             doc.Add(f2);
@@ -328,7 +328,7 @@ namespace Lucene.Net.Index
             customType.StoreTermVectors = true;
             customType.StoreTermVectorPositions = true;
             customType.StoreTermVectorOffsets = true;
-            Field f = NewField("field", " ", customType);
+            Field f = NewField("field", "", customType);
             Field f2 = NewField("field", "crunch man", customType);
             doc.Add(f);
             doc.Add(f2);
@@ -371,7 +371,7 @@ namespace Lucene.Net.Index
 
             Field f = NewField("field", "abcd", customType);
             doc.Add(f);
-            doc.Add(NewField("field", "  ", customType));
+            doc.Add(NewField("field", "", customType));
 
             Field f2 = NewField("field", "crunch", customType);
             doc.Add(f2);


### PR DESCRIPTION
When MockAnalyzer is used, in certain cases the index could have incorrect values written to it. GetOffsetGap does a comparison of OffsetGap_Renamed to null which is always false if OffsetGap_Renamed is not nullable int. Corrected the logic.

To see the bug in action, refer to the following failing test:

http://teamcity.codebetter.com/viewLog.html?buildId=190073&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId778192460553334183
