### PR TITLE
check for the appropriate exception

### DIFF
--- a/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
@@ -743,7 +743,7 @@ namespace Lucene.Net.Index
                 DirectoryReader.Open(dir);
                 Assert.Fail("did not hit expected exception");
             }
-            catch (IndexNotFoundException nsde)
+            catch (NoSuchDirectoryException nsde)
             {
                 // expected
             }


### PR DESCRIPTION
TestDirectoryReader.TestNoDir was failing because catch was catching a wrong exception type. Changed it to match Lucene: https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReader.java#L724