### PR TITLE
IOUtils fix

### DIFF
--- a/src/Lucene.Net.Core/Util/IOUtils.cs
+++ b/src/Lucene.Net.Core/Util/IOUtils.cs
@@ -428,11 +428,7 @@ namespace Lucene.Net.Util
         {
             if (th != null)
             {
-                if (th is IOException || th is InvalidOperationException)
-                {
-                    throw th;
-                }
-                throw new Exception(th.ToString(), th);
+                throw th;
             }
         }
 

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -81,6 +81,7 @@ namespace Lucene.Net.Index
     {
         private static readonly FieldType StoredTextType = new FieldType(TextField.TYPE_NOT_STORED);
 
+        [Test]
         public virtual void TestDocCount()
         {
             Directory dir = NewDirectory();


### PR DESCRIPTION
ReThrowUnchecked in IOUtils is wrapping exceptions when it should not. Doing that causes issues with upstream code that handles a specific type of exception but "Exception" is thrown instead. Looking at the Lucene code, the fixed version matches what Lucene is trying to do:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/java/org/apache/lucene/util/IOUtils.java#L360

- if null, don't throw
- otherwise throw exception itself
- unless it is not of RuntimeException type or Error type in which case wrap it - but this does not apply in .NET world.

At the very least the following test was failing because of this that now passes (unless there is another "rand" situation that I had not encountered):

http://teamcity.codebetter.com/viewLog.html?buildId=190499&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId-8985981477427802206