### PR TITLE
Debug.Assert with side effects fix

### DIFF
--- a/src/Lucene.Net.Core/Analysis/TokenStream.cs
+++ b/src/Lucene.Net.Core/Analysis/TokenStream.cs
@@ -91,7 +91,7 @@ namespace Lucene.Net.Analysis
         /// </summary>
         protected TokenStream()
         {
-            Debug.Assert(AssertFinal());
+            AssertFinal();
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Lucene.Net.Analysis
         protected TokenStream(AttributeSource input)
             : base(input)
         {
-            Debug.Assert(AssertFinal());
+            AssertFinal();
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Lucene.Net.Analysis
         protected TokenStream(AttributeFactory factory)
             : base(factory)
         {
-            Debug.Assert(AssertFinal());
+            AssertFinal();
         }
 
         private bool AssertFinal()

--- a/src/Lucene.Net.Core/Index/DocumentsWriterStallControl.cs
+++ b/src/Lucene.Net.Core/Index/DocumentsWriterStallControl.cs
@@ -81,9 +81,13 @@ namespace Lucene.Net.Index
                         // don't loop here, higher level logic will re-stall!
                         try
                         {
-                            Debug.Assert(IncWaiters());
+                            // make sure not to run IncWaiters / DecrWaiters id Debug.Assert as that gets 
+                            // removed at compile time if built in Release mode
+                            var result = IncWaiters();
+                            Debug.Assert(result);
                             Monitor.Wait(this);
-                            Debug.Assert(DecrWaiters());
+                            result = DecrWaiters();
+                            Debug.Assert(result);
                         }
                         catch (ThreadInterruptedException e)
                         {

--- a/src/Lucene.Net.Core/Index/DocumentsWriterStallControl.cs
+++ b/src/Lucene.Net.Core/Index/DocumentsWriterStallControl.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Index
                         // don't loop here, higher level logic will re-stall!
                         try
                         {
-                            // make sure not to run IncWaiters / DecrWaiters id Debug.Assert as that gets 
+                            // make sure not to run IncWaiters / DecrWaiters in Debug.Assert as that gets 
                             // removed at compile time if built in Release mode
                             var result = IncWaiters();
                             Debug.Assert(result);

--- a/src/Lucene.Net.Core/Index/IndexWriter.cs
+++ b/src/Lucene.Net.Core/Index/IndexWriter.cs
@@ -2576,7 +2576,8 @@ namespace Lucene.Net.Index
                         infoStream.Message("IW", "rollback: infos=" + SegString(segmentInfos.Segments));
                     }
 
-                    Debug.Assert(TestPoint("rollback before checkpoint"));
+                    var result = TestPoint("rollback before checkpoint");
+                    Debug.Assert(result);
 
                     // Ask deleter to locate unreferenced files & remove
                     // them:

--- a/src/Lucene.Net.Core/Index/IndexWriter.cs
+++ b/src/Lucene.Net.Core/Index/IndexWriter.cs
@@ -2576,8 +2576,8 @@ namespace Lucene.Net.Index
                         infoStream.Message("IW", "rollback: infos=" + SegString(segmentInfos.Segments));
                     }
 
-                    var result = TestPoint("rollback before checkpoint");
-                    Debug.Assert(result);
+                    var tpResult = TestPoint("rollback before checkpoint");
+                    Debug.Assert(tpResult);
 
                     // Ask deleter to locate unreferenced files & remove
                     // them:
@@ -3557,7 +3557,8 @@ namespace Lucene.Net.Index
                 }
 
                 DoBeforeFlush();
-                Debug.Assert(TestPoint("startDoFlush"));
+                var tpResult = TestPoint("startDoFlush");
+                Debug.Assert(tpResult);
                 SegmentInfos toCommit = null;
                 bool anySegmentsFlushed = false;
 
@@ -3863,7 +3864,8 @@ namespace Lucene.Net.Index
             }
 
             DoBeforeFlush();
-            Debug.Assert(TestPoint("startDoFlush"));
+            var tpResult = TestPoint("startDoFlush");
+            Debug.Assert(tpResult);
             bool success = false;
             try
             {
@@ -4103,7 +4105,8 @@ namespace Lucene.Net.Index
         {
             lock (this)
             {
-                Debug.Assert(TestPoint("startCommitMergeDeletes"));
+                var tpResult = TestPoint("startCommitMergeDeletes");
+                Debug.Assert(tpResult);
 
                 IList<SegmentCommitInfo> sourceSegments = merge.Segments;
 
@@ -4339,7 +4342,8 @@ namespace Lucene.Net.Index
         {
             lock (this)
             {
-                Debug.Assert(TestPoint("startCommitMerge"));
+                var tpResult = TestPoint("startCommitMerge");
+                Debug.Assert(tpResult);
 
                 if (HitOOM)
                 {
@@ -4758,7 +4762,8 @@ namespace Lucene.Net.Index
         {
             lock (this)
             {
-                Debug.Assert(TestPoint("startMergeInit"));
+                var testPointResult = TestPoint("startMergeInit");
+                Debug.Assert(testPointResult);
 
                 Debug.Assert(merge.RegisterDone);
                 Debug.Assert(merge.MaxNumSegments == -1 || merge.MaxNumSegments > 0);
@@ -5440,7 +5445,8 @@ namespace Lucene.Net.Index
         /// </summary>
         private void StartCommit(SegmentInfos toSync)
         {
-            Debug.Assert(TestPoint("startStartCommit"));
+            var tpResult = TestPoint("startStartCommit");
+            Debug.Assert(tpResult);
             Debug.Assert(PendingCommit == null);
 
             if (HitOOM)
@@ -5478,13 +5484,15 @@ namespace Lucene.Net.Index
                     Debug.Assert(FilesExist(toSync));
                 }
 
-                Debug.Assert(TestPoint("midStartCommit"));
+                tpResult = TestPoint("midStartCommit");
+                Debug.Assert(tpResult);
 
                 bool pendingCommitSet = false;
 
                 try
                 {
-                    Debug.Assert(TestPoint("midStartCommit2"));
+                    tpResult = TestPoint("midStartCommit2");
+                    Debug.Assert(tpResult);
 
                     lock (this)
                     {
@@ -5527,7 +5535,8 @@ namespace Lucene.Net.Index
                         infoStream.Message("IW", "done all syncs: " + filesToSync);
                     }
 
-                    Debug.Assert(TestPoint("midStartCommitSuccess"));
+                    tpResult = TestPoint("midStartCommitSuccess");
+                    Debug.Assert(tpResult);
                 }
                 finally
                 {
@@ -5557,7 +5566,8 @@ namespace Lucene.Net.Index
             {
                 HandleOOM(oom, "startCommit");
             }
-            Debug.Assert(TestPoint("finishStartCommit"));
+            tpResult = TestPoint("finishStartCommit");
+            Debug.Assert(tpResult);
         }
 
         /// <summary>


### PR DESCRIPTION
TestDocumentsWriterStallControl fails in Release mode but not in Debug builds. Looks like Lucene is performing logic when calling assert, which translated to Debug.Assert in Lucene.Net. Debug.Assert is removed at the compile time if compiled in release mode.

Took out the logic from the Debug.Assert.

Here is the failing test that this fixes:
http://teamcity.codebetter.com/viewLog.html?buildId=190748&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId-5834889155160949386

There are more places in the code base that suffer from this, I believe. Looking for them.