### PR TITLE
use setup/teardown instead of fixture setup/teardown

### DIFF
--- a/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestBlockPostingsFormat2.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestBlockPostingsFormat2.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Codecs.Lucene41
         internal RandomIndexWriter Iw;
         internal IndexWriterConfig Iwc;
 
-        [TestFixtureSetUp]
+        [SetUp]
         public override void SetUp()
         {
             base.SetUp();
@@ -58,7 +58,7 @@ namespace Lucene.Net.Codecs.Lucene41
             Iw.RandomForceMerge = false; // we will ourselves
         }
 
-        [TestFixtureTearDown]
+        [TearDown]
         public override void TearDown()
         {
             Iw.Dispose();


### PR DESCRIPTION
Lucene41.TestBlockPostingsFormat2 teardown is failing because the cleanup is not run after each test. Instead it is run after all test cases finish. Use setup / teardown after each test instead.