### PR TITLE
Incrementtoken fixes

### DIFF
--- a/src/Lucene.Net.Core/Lucene.Net.csproj
+++ b/src/Lucene.Net.Core/Lucene.Net.csproj
@@ -30,7 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -624,7 +624,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                 returned = false;
             }
 
-            public override bool IncrementToken()
+            public sealed override bool IncrementToken()
             {
                 if (returned)
                 {

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
@@ -54,11 +54,6 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
         private class TaxonomyWriterCacheAnonymousInnerClassHelper : TaxonomyWriterCache
         {
-            public TaxonomyWriterCacheAnonymousInnerClassHelper()
-            {
-            }
-
-
             public virtual void Close()
             {
             }

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -1893,7 +1893,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            public override bool IncrementToken()
+            public sealed override bool IncrementToken()
             {
                 ClearAttributes();
                 if (Upto < Tokens.Length)

--- a/src/Lucene.Net.Tests/core/Index/TestTermdocPerf.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTermdocPerf.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Index
             this.TermAtt = AddAttribute<ICharTermAttribute>();
         }
 
-        public override bool IncrementToken()
+        public sealed override bool IncrementToken()
         {
             Num--;
             if (Num >= 0)


### PR DESCRIPTION
Couple more places where incrementtoken was not sealed. 

Also match target platform for release builds to what is set in debug builds. This was preventing tests to run on 64 bit machines when compiled in release mode.