### PR TITLE
use nullable int to matche Lucene, proper string format usage

### DIFF
--- a/src/Lucene.Net.Core/Search/LiveFieldValues.cs
+++ b/src/Lucene.Net.Core/Search/LiveFieldValues.cs
@@ -36,7 +36,6 @@ namespace Lucene.Net.Search
 
     public abstract class LiveFieldValues<S, T> : ReferenceManager.RefreshListener, IDisposable
         where S : class
-        where T : struct
     {
         private volatile IDictionary<string, T> Current = new ConcurrentDictionary<string, T>();
         private volatile IDictionary<string, T> Old = new ConcurrentDictionary<string, T>();
@@ -113,26 +112,26 @@ namespace Lucene.Net.Search
             // First try to get the "live" value:
             T value;
             Current.TryGetValue(id, out value);
-            if ((object)value == (object)MissingValue)
+            if (EqualityComparer<T>.Default.Equals(value, MissingValue))
             {
                 // Deleted but the deletion is not yet reflected in
                 // the reader:
                 return default(T);
             }
-            else if ((object)value != (object)default(T))
+            else if (!EqualityComparer<T>.Default.Equals(value, default(T)))
             {
                 return value;
             }
             else
             {
                 Old.TryGetValue(id, out value);
-                if ((object)value == (object)MissingValue)
+                if (EqualityComparer<T>.Default.Equals(value, MissingValue))
                 {
                     // Deleted but the deletion is not yet reflected in
                     // the reader:
                     return default(T);
                 }
-                else if ((object)value != (object)default(T))
+                else if (!EqualityComparer<T>.Default.Equals(value, default(T)))
                 {
                     return value;
                 }


### PR DESCRIPTION
TestLiveFieldValues test is not failing but console contains several failures in that test that are getting ignored.

First match the test to use nullable integer like Lucene does:

https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/test/org/apache/lucene/search/TestLiveFieldValues.java) 

And then correct string format usage:

https://github.com/apache/lucenenet/compare/master...laimis:livefieldvalues_fixes?expand=1#diff-db6d92460fa820ed96ad430d1c338012R180

