### PR TITLE
synchronize access to underlying file stream for NIOFSDirectory

### DIFF
--- a/src/Lucene.Net.Core/Store/NIOFSDirectory.cs
+++ b/src/Lucene.Net.Core/Store/NIOFSDirectory.cs
@@ -77,36 +77,28 @@ namespace Lucene.Net.Store
         public override IndexInput OpenInput(string name, IOContext context)
         {
             EnsureOpen();
-            //File path = new File(Directory, name);
-            FileInfo path = new FileInfo(Path.Combine(Directory.FullName, name));
-            //path.Create();
-            FileStream fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);//FileChannel.open(path.toPath(), StandardOpenOption.READ);
+            var path = new FileInfo(Path.Combine(Directory.FullName, name));
+            var fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new NIOFSIndexInput("NIOFSIndexInput(path=\"" + path + "\")", fc, context);
-            //return new NIOFSIndexInput(new FileInfo(Path.Combine(Directory.FullName, name)), context, ReadChunkSize);
         }
 
         public override IndexInputSlicer CreateSlicer(string name, IOContext context)
         {
             EnsureOpen();
-            //File path = new File(Directory, name);
-            //FileStream descriptor = FileChannel.open(path.toPath(), StandardOpenOption.READ);
-            FileInfo path = new FileInfo(Path.Combine(Directory.FullName, name));
-            FileStream fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var path = new FileInfo(Path.Combine(Directory.FullName, name));
+            var fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new IndexInputSlicerAnonymousInnerClassHelper(this, context, path, fc);
         }
 
-        private class IndexInputSlicerAnonymousInnerClassHelper : Directory.IndexInputSlicer
+        private class IndexInputSlicerAnonymousInnerClassHelper : IndexInputSlicer
         {
-            private readonly NIOFSDirectory OuterInstance;
-
             private readonly IOContext Context;
             private readonly FileInfo Path;
             private readonly FileStream Descriptor;
 
-            public IndexInputSlicerAnonymousInnerClassHelper(NIOFSDirectory outerInstance, Lucene.Net.Store.IOContext context, FileInfo path, FileStream descriptor)
+            public IndexInputSlicerAnonymousInnerClassHelper(NIOFSDirectory outerInstance, IOContext context, FileInfo path, FileStream descriptor)
                 : base(outerInstance)
             {
-                this.OuterInstance = outerInstance;
                 this.Context = context;
                 this.Path = path;
                 this.Descriptor = descriptor;
@@ -131,7 +123,7 @@ namespace Lucene.Net.Store
                 {
                     return OpenSlice("full-slice", 0, Descriptor.Length);
                 }
-                catch (System.IO.IOException ex)
+                catch (IOException ex)
                 {
                     throw new Exception(ex.Message, ex);
                 }

--- a/src/Lucene.Net.Core/Support/FileStreamExtensions.cs
+++ b/src/Lucene.Net.Core/Support/FileStreamExtensions.cs
@@ -4,31 +4,36 @@ namespace Lucene.Net.Support
 {
     public static class FileStreamExtensions
     {
+        private static object _fsReadLock = new object();
+
         //Reads bytes from the Filestream into the bytebuffer
         public static int Read(this FileStream file, ByteBuffer dst, long position)
         {
-            // TODO: check this logic, could probably optimize
-            if (position >= file.Length)
-                return 0;
-
-            var original = file.Position;
-
-            file.Seek(position, SeekOrigin.Begin);
-
-            int count = 0;
-
-            for (int i = dst.Position; i < dst.Limit; i++)
+            lock (_fsReadLock)
             {
-                int v = file.ReadByte();
-                if (v == -1)
-                    break;
-                dst.Put((byte)v);
-                count++;
+                // TODO: check this logic, could probably optimize
+                if (position >= file.Length)
+                    return 0;
+
+                var original = file.Position;
+
+                file.Seek(position, SeekOrigin.Begin);
+
+                int count = 0;
+
+                for (int i = dst.Position; i < dst.Limit; i++)
+                {
+                    int v = file.ReadByte();
+                    if (v == -1)
+                        break;
+                    dst.Put((byte) v);
+                    count++;
+                }
+
+                file.Seek(original, SeekOrigin.Begin);
+
+                return count;
             }
-
-            file.Seek(original, SeekOrigin.Begin);
-
-            return count;
         }
     }
 }


### PR DESCRIPTION
It seems like Lucene.Net NIOFSDirectory port has an issue when used in multiple threads for reading. Any test that is based on BasePostingsFormatTestCase, which runs multiple threads that read from directory, has a lot of errors in the logs when NIOFSDirectory is used as an implementation type of FSDirectory.

You can see the failures from the TC build logs, here are some of the highlights:

System.Exception: Index was outside the bounds of the array. ---> System.IndexOutOfRangeException: Index was outside the bounds of the array.
at System.IO.FileStream.ReadByte()
at Lucene.Net.Support.FileStreamExtensions.Read(FileStream file, ByteBuffer dst, Int64 position) in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Core\Support\FileStreamExtensions.cs:line 22
at Lucene.Net.Store.NIOFSDirectory.NIOFSIndexInput.ReadInternal(Byte[] b, Int32 offset, Int32 len) in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Core\Store\NIOFSDirectory.cs:line 252
at Lucene.Net.Store.BufferedIndexInput.Refill() in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Core\Store\BufferedIndexInput.cs:line 368
at Lucene.Net.Store.BufferedIndexInput.ReadByte() in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Core\Store\BufferedIndexIn

System.Exception: read past EOF: NIOFSIndexInput(path="Z:\Builds\temp\buildTmp\LuceneTemp\testPostingsFormat-1\_0.tis") off: 0 len: 543 pos: 24 chunkLen: 543 end: 567 ---> System.Exception: read past EOF: NIOFSIndexInput(path="Z:\Builds\temp\buildTmp\LuceneTemp\testPostingsFormat-1\_0.tis") off: 0 len: 543 pos: 24 chunkLen: 543 end: 567
at Lucene.Net.Store.NIOFSDirectory.NIOFSIndexInput.ReadInternal(Byte[] b, Int32 offset, Int32 len) in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Core\Store\NIOFSDirectory.cs:line 256
at Lucene.Net.Store.BufferedIndexInput.Refill() in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Core\Store\BufferedIndexInput.cs:line 368
at Lucene.Net.Store.BufferedIndexInput.ReadByte() in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Core\Store\BufferedIndexInput.cs:line 55
at Lucene.Net.Store.DataInput.ReadVInt() in z:\Builds\work\bcdbe6b8cc677a49\src\Lucene.Net.Core\Store\DataInput.cs:line 117

docID is wrong
Expected: 208378
But was:  208410

The tests don't fail because the pieces that are being tested pass, but I think this is causing failures in other tests when NIOFSDirectory is picked at random. After digging more into this, it seems like Lucene implementation relied on JRE specific FileChannel construct that is not available in .NET. The replacement in FileStreamExtensions is not thread safe because of the filestream seek calls it makes. Synchronizing that operation made all the tests clean. I reran the whole test suite for core with NIOFSDirectory as the Directory implementation and things seem to pass fine.

Not sure what performance implications this has since it looks like the purpose of NIOFSDirectory was to provide an optimized version of SimpleFSDirectory that worked fast when reading from concurrent threads. As it stands, existing implementation is not safe to be used from multiple threads so perhaps adding the synchronization is the only option for us.