### PR TITLE
calculate max boost once

### DIFF
--- a/src/Lucene.Net.Core/Search/FuzzyTermsEnum.cs
+++ b/src/Lucene.Net.Core/Search/FuzzyTermsEnum.cs
@@ -238,11 +238,14 @@ namespace Lucene.Net.Search
             // true if the last term encountered is lexicographically equal or after the bottom term in the PQ
             bool termAfter = BottomTerm == null || (lastTerm != null && TermComparator.Compare(lastTerm, BottomTerm) >= 0);
 
+            var maxBoost = CalculateMaxBoost(MaxEdits);
+
             // as long as the max non-competitive boost is >= the max boost
             // for some edit distance, keep dropping the max edit distance.
-            while (MaxEdits > 0 && (termAfter ? Bottom >= CalculateMaxBoost(MaxEdits) : Bottom > CalculateMaxBoost(MaxEdits)))
+            while (MaxEdits > 0 && (termAfter ? Bottom >= maxBoost : Bottom > maxBoost))
             {
                 MaxEdits--;
+                maxBoost = CalculateMaxBoost(MaxEdits);
             }
 
             if (oldMaxEdits != MaxEdits || init) // the maximum n has changed


### PR DESCRIPTION
This is a bit long, but the issue is a bit messy so putting as much info as possible. Troubleshooting the failing tests shown here:

http://teamcity.codebetter.com/viewLog.html?buildId=191414&tab=buildResultsDiv&buildTypeId=LuceneNet_Core#testNameId-6371662534320583798

There is something odd going on with float number comparison that is triggered by the environment that the code is running. No matter how many times this is run on my machine in release or debug builds it never fails, but fails all the time on TC. A separate branch was created with more logging to see what the difference is between passing and failing cases and I arrived at the change that is in this PR.

What the diagnostic output is showing is that Bottom > CalculateMaxBoost(MaxEdits) is evaluating to true in the failing cases when it really should be false.

Here is the link to verbose branch so you can see what output means what:

https://github.com/apache/lucenenet/blob/61c2d06814fa942331ce229e26553d6148a292fe/src/Lucene.Net.Core/Search/FuzzyTermsEnum.cs#L236

Here is diagnostics info when the failure occurs:

FuzzyTermsEnum bottom changed, lastTerm=, init=True, MaxEdits=1
    termAfter=False, Bottom=0.857142866
    subtract.  <----- this should never happen
    oldMaxEdits=1, maxEdits=0
    Max distance changed

Here is the passing output:

FuzzyTermsEnum bottom changed, lastTerm=, init=True, MaxEdits=1
    termAfter=False, Bottom=0.857142866
    oldMaxEdits=1, maxEdits=1  <-- note maxEdits=1 and not 0
    Max distance changed

That maxEdits value change prevents 3 docs from being scored. That changes total hits from 5 to 2 and you can see that in the assert failure in the unit test.

I suspect TestTopDocsMerge failures is the same issue. I am still trying to pin point which floating comparison is changing the results there but got myself into a situation where adding verbose output now makes it not fail in TC anymore. So I will continue to dig there.