### PR TITLE
Use DateTime.UtcNow.Ticks instead of Environment.TickCount

### DIFF
--- a/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Search
             Directory indexStore = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
 
-            long now = Environment.TickCount / TimeSpan.TicksPerMillisecond;
+            long now = DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
 
             Document doc = new Document();
             // add time that is in the past

--- a/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
@@ -111,7 +111,7 @@ namespace Lucene.Net.Search
             Directory indexStore = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
 
-            long now = Environment.TickCount;
+            long now = DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
 
             Document doc = new Document();
             // add time that is in the future


### PR DESCRIPTION
Use DateTime.UtcNow.Ticks instead of Environment.TickCount, otherwise test can fail with low Environment.TickCount value resulting in negative value passed to DateTools.TimeToString method. UtcNow.Ticks match closer what Lucene is doing by calling System.currentTimeMillis();

Lucene: https://github.com/apache/lucene-solr/blob/lucene_solr_4_8_0/lucene/core/src/test/org/apache/lucene/search/TestDateFilter.java#L46

Failing test:
http://teamcity.codebetter.com/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=192345#_focus=5607