### PR TITLE
use reduced precision float base class

### DIFF
--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -419,6 +419,7 @@
     <Compile Include="Store\TestHelper.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Support\FloatUtils.cs" />
     <Compile Include="Support\RandomizedTest.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -452,6 +453,7 @@
     <Compile Include="Util\Paths.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Util\LuceneTestCaseWithReducedFloatPrecision.cs" />
     <Compile Include="Util\TestRuleSetupAndRestoreClassEnv.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/Lucene.Net.TestFramework/Support/FloatUtils.cs
+++ b/src/Lucene.Net.TestFramework/Support/FloatUtils.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support
+{
+    public static class FloatUtils
+    {
+        [DllImport("msvcrt", CharSet = CharSet.Auto)]
+        public static extern IntPtr _controlfp_s(IntPtr currentControl, int newControl, int mask);
+
+        public static void SetPrecision()
+        {
+            //if (!IsLinux())
+            {
+                // precision control
+                const int _MCW_PC = 0x00030000;
+                const int _PC_24 = 0x00020000;
+
+                _controlfp_s(IntPtr.Zero, _PC_24, _MCW_PC);
+            }
+            //else
+            {
+                // LUCENENET TODO: implement setting float precision
+                // on *nix systems.
+            }
+        }
+    }
+}

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCaseWithReducedFloatPrecision.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCaseWithReducedFloatPrecision.cs
@@ -1,0 +1,15 @@
+﻿using Lucene.Net.Support;
+
+namespace Lucene.Net.Util
+{
+    public class LuceneTestCaseWithReducedFloatPrecision :  LuceneTestCase
+    {
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            // set precision
+            FloatUtils.SetPrecision();
+        }
+    }
+}

--- a/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Documents;
+using Lucene.Net.Util;
 using NUnit.Framework;
 
 namespace Lucene.Net.Search
@@ -48,7 +49,7 @@ namespace Lucene.Net.Search
     /// </summary>
     /// <seealso cref= "Subclasses for actual tests" </seealso>
     [TestFixture]
-    public class TestExplanations : LuceneTestCase
+    public class TestExplanations : LuceneTestCaseWithReducedFloatPrecision
     {
         protected internal static IndexSearcher Searcher;
         protected internal static IndexReader Reader;

--- a/src/Lucene.Net.Tests/core/Search/TestFuzzyQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestFuzzyQuery.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Lucene.Net.Documents;
+using Lucene.Net.Util;
 
 namespace Lucene.Net.Search
 {
@@ -39,7 +40,7 @@ namespace Lucene.Net.Search
     ///
     /// </summary>
     [TestFixture]
-    public class TestFuzzyQuery : LuceneTestCase
+    public class TestFuzzyQuery : LuceneTestCaseWithReducedFloatPrecision
     {
         [Test]
         public virtual void TestFuzziness()

--- a/src/Lucene.Net.Tests/core/Search/TestQueryRescorer.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestQueryRescorer.cs
@@ -246,7 +246,7 @@ namespace Lucene.Net.Search
             Assert.IsTrue(s.Contains("no second pass score"));
             Assert.IsFalse(s.Contains("= second pass score"));
             Assert.IsTrue(s.Contains("NON-MATCH"));
-            Assert.AreEqual(hits2.ScoreDocs[1].Score, explain.Value, 0.0f);
+            Assert.IsTrue(Math.Abs(hits2.ScoreDocs[1].Score - explain.Value) < 0.0000001f);
 
             r.Dispose();
             dir.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestSearchAfter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSearchAfter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
+using Lucene.Net.Util;
 
 namespace Lucene.Net.Search
 {
@@ -51,7 +52,7 @@ namespace Lucene.Net.Search
     /// Tests IndexSearcher's searchAfter() method
     /// </summary>
     [TestFixture]
-    public class TestSearchAfter : LuceneTestCase
+    public class TestSearchAfter : LuceneTestCaseWithReducedFloatPrecision
     {
         private Directory Dir;
         private IndexReader Reader;

--- a/src/Lucene.Net.Tests/core/Search/TestTopDocsMerge.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTopDocsMerge.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Lucene.Net.Documents;
+using Lucene.Net.Util;
 
 namespace Lucene.Net.Search
 {
@@ -41,7 +42,7 @@ namespace Lucene.Net.Search
     using TestUtil = Lucene.Net.Util.TestUtil;
 
     [TestFixture]
-    public class TestTopDocsMerge : LuceneTestCase
+    public class TestTopDocsMerge : LuceneTestCaseWithReducedFloatPrecision
     {
         private class ShardSearcher : IndexSearcher
         {


### PR DESCRIPTION
We noticed that running tests in 32 bit CPUs was introducing floating point rounding issues and tests were failing as the same calculation could produce different result if executed multiple times in a single test. After some discussions on the mailing list it was determined that on 32 bit machines different instructions are used from 64 bit machines to process floating point numbers. Intermediate results when transferred with higher precision to the next operations eventually lead to rounding errors once a final calculation is returned as float.

From all the reading and trying several approaches so far, the only way I was able to consistently to get floating point conversion issues to go away is to pinvoke _controlfp_s to set floating point precision to 24 bits.

I got the idea from https://randomascii.wordpress.com/2013/07/16/floating-point-determinism/, see section "Floating-point settings (runtime)", last paragraph. controlfp seems to come up in other suggestions around this issue as well. 

Here is the information on _controlfp_s: https://msdn.microsoft.com/en-us/library/c9676k6h.aspx. And it seems like there is an equivalent function in *nix environments although I haven't tried them or researched them in more depth yet.

For tests that rely on floating point calculations to be consistent, a variant of LuceneTestCase is used that sets the precision mask to 24 bits before each test run. I put this in the test as I don't think this code belongs to the core itself.