### PR TITLE
Fix OpenBitSet.Union and .Xor methods.

### DIFF
--- a/src/Lucene.Net.Core/Util/OpenBitSet.cs
+++ b/src/Lucene.Net.Core/Util/OpenBitSet.cs
@@ -932,21 +932,22 @@ namespace Lucene.Net.Util
         public virtual void Union(OpenBitSet other)
         {
             int newLen = Math.Max(Wlen, other.Wlen);
+            int oldLen = Wlen;
+
             EnsureCapacityWords(newLen);
             Debug.Assert((NumBits = Math.Max(other.NumBits, NumBits)) >= 0);
 
             long[] thisArr = this.bits;
             long[] otherArr = other.bits;
-            int pos = Math.Min(Wlen, other.Wlen);
+            int pos = Math.Min(oldLen, other.Wlen);
             while (--pos >= 0)
             {
                 thisArr[pos] |= otherArr[pos];
             }
-            if (this.Wlen < newLen)
+            if (oldLen < newLen)
             {
-                Array.Copy(otherArr, this.Wlen, thisArr, this.Wlen, newLen - this.Wlen);
+                Array.Copy(otherArr, oldLen, thisArr, oldLen, newLen - oldLen);
             }
-            this.Wlen = newLen;
         }
 
         /// <summary>
@@ -967,21 +968,21 @@ namespace Lucene.Net.Util
         public virtual void Xor(OpenBitSet other)
         {
             int newLen = Math.Max(Wlen, other.Wlen);
+            int oldLen = Wlen;
             EnsureCapacityWords(newLen);
             Debug.Assert((NumBits = Math.Max(other.NumBits, NumBits)) >= 0);
 
             long[] thisArr = this.bits;
             long[] otherArr = other.bits;
-            int pos = Math.Min(Wlen, other.Wlen);
+            int pos = Math.Min(oldLen, other.Wlen);
             while (--pos >= 0)
             {
                 thisArr[pos] ^= otherArr[pos];
             }
-            if (this.Wlen < newLen)
+            if (oldLen < newLen)
             {
-                Array.Copy(otherArr, this.Wlen, thisArr, this.Wlen, newLen - this.Wlen);
+                Array.Copy(otherArr, oldLen, thisArr, oldLen, newLen - oldLen);
             }
-            this.Wlen = newLen;
         }
 
         // some BitSet compatability methods

--- a/src/Lucene.Net.Tests/core/Util/TestOpenBitSet.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestOpenBitSet.cs
@@ -514,5 +514,24 @@ namespace Lucene.Net.Util
             bits.FastSet(bit - 1);
             Assert.IsTrue(bits.FastGet(bit - 1));
         }
+
+        [Test]
+        public virtual void TestXorWithDifferentCapacity()
+        {
+            OpenBitSet smaller = new OpenBitSet(2);
+            OpenBitSet larger = new OpenBitSet(64 * 10000);
+
+            larger.Set(64 * 10000 - 1);
+            larger.Set(65);
+            larger.Set(3);
+            smaller.Set(3);
+            smaller.Set(66);
+
+            smaller.Xor(larger);
+            Assert.IsTrue(smaller.Get(64 * 10000 - 1));
+            Assert.IsTrue(smaller.Get(65));
+            Assert.IsFalse(smaller.Get(3));
+            Assert.IsTrue(smaller.Get(66));
+        }
     }
 }


### PR DESCRIPTION
EnsureCapacityWords method changes this.Wlen to newLen,
so we have to save this.Wlen value before calling it.

Bugged version never copied the tail of the bigger array.
It worked correctly, but inefficiently.
