### PR TITLE
Fixed exception messages in NamedSPILoader and Codec classes

### DIFF
--- a/src/Lucene.Net.Core/Codecs/Codec.cs
+++ b/src/Lucene.Net.Core/Codecs/Codec.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Codecs
         {
             if (Loader == null)
             {
-                throw new InvalidOperationException("You called Codec.forName() before all Codecs could be initialized. " + "this likely happens if you call it from a Codec's ctor.");
+                throw new InvalidOperationException("You called Codec.ForName() before all Codecs could be initialized. This likely happens if you call it from a Codec's ctor.");
             }
             return Loader.Lookup(name);
         }
@@ -119,7 +119,7 @@ namespace Lucene.Net.Codecs
         {
             if (Loader == null)
             {
-                throw new InvalidOperationException("You called Codec.availableCodecs() before all Codecs could be initialized. " + "this likely happens if you call it from a Codec's ctor.");
+                throw new InvalidOperationException("You called Codec.AvailableCodecs() before all Codecs could be initialized. This likely happens if you call it from a Codec's ctor.");
             }
             return Loader.AvailableServices();
         }

--- a/src/Lucene.Net.Core/Util/NamedSPILoader.cs
+++ b/src/Lucene.Net.Core/Util/NamedSPILoader.cs
@@ -1,5 +1,6 @@
 using Lucene.Net.Support;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace Lucene.Net.Util
@@ -115,7 +116,10 @@ namespace Lucene.Net.Util
             {
                 return service;
             }
-            throw new System.ArgumentException("A SPI class of type " + Clazz.Name + " with name '" + name + "' does not exist. " + "You need to add the corresponding JAR file supporting this SPI to your classpath." + "The current classpath supports the following names: " + AvailableServices());
+            var availableServices = string.Join(", ", AvailableServices());
+            throw new ArgumentException("An SPI class of type " + Clazz.Name + " with name '" + name + "' does not exist. "
+                + "You need to reference the corresponding assembly that contains the class. "
+                + "The current NamedSPILoader supports the following names: " + availableServices);
         }
 
         public ISet<string> AvailableServices()

--- a/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
+++ b/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
@@ -154,6 +154,7 @@
     <Compile Include="core\Codecs\Perfield\TestPerFieldDocValuesFormat.cs" />
     <Compile Include="core\Codecs\Perfield\TestPerFieldPostingsFormat.cs" />
     <Compile Include="core\Codecs\Perfield\TestPerFieldPostingsFormat2.cs" />
+    <Compile Include="core\Codecs\TestCodec.cs" />
     <Compile Include="core\Document\TestBinaryDocument.cs" />
     <Compile Include="core\Document\TestDateTools.cs" />
     <Compile Include="core\Document\TestDocument.cs" />

--- a/src/Lucene.Net.Tests/core/Codecs/TestCodec.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/TestCodec.cs
@@ -1,0 +1,48 @@
+using System;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Lucene.Net.Codecs
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    [TestFixture]
+    public class TestCodec
+    {
+        [Test]
+        public void TestLookup()
+        {
+            Codec codec = Codec.ForName("Lucene46");
+            Assert.AreEqual("Lucene46", codec.Name);
+        }
+
+        // we want an exception if its not found.
+        [Test]
+        public void TestBogusLookup()
+        {
+            Assert.Throws<ArgumentException>(() => Codec.ForName("dskfdskfsdfksdfdsf"));
+        }
+
+        [Test]
+        public void TestAvailableServices()
+        {
+            ISet<string> codecs = Codec.AvailableCodecs();
+            Assert.IsTrue(codecs.Contains("Lucene46"));
+        }
+    }
+}


### PR DESCRIPTION
NamedSPILoader and Codec classes used original Java based texts in exception messages that referenced JAR files and Java method names. This commit rewords these messages to be more .NET friendly.

It also fixes bug in the exception message in NamedSPILoader.Lookup() method that did not list the names of available services properly.

I refactored unit tests for the NamedSPILoader class to be more reliable. Original tests were moved to TestCodec class.