### PR TITLE
replace InstanceNotFoundException to allow building on Mono

### DIFF
--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Management.Instrumentation;
+
 
 namespace Lucene.Net.Facet.Taxonomy.WriterCache
 {
@@ -261,7 +261,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 Entry e = this.next_Renamed;
                 if (e == null)
                 {
-                    throw new InstanceNotFoundException();
+					throw new Exception("InstanceNotFoundException");
                 }
 
                 Entry n = e.next;

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
@@ -261,7 +261,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 Entry e = this.next_Renamed;
                 if (e == null)
                 {
-					throw new Exception("InstanceNotFoundException");
+					throw new InvalidOperationException(this.GetType() + " cannot get next entry");;
                 }
 
                 Entry n = e.next;

--- a/src/Lucene.Net.Tests.Codecs/Lucene.Net.Codecs.Tests.csproj
+++ b/src/Lucene.Net.Tests.Codecs/Lucene.Net.Codecs.Tests.csproj
@@ -42,7 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="diskdv\TestDiskDocValuesFormat.cs" />
+    <Compile Include="DiskDv\TestDiskDocValuesFormat.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
It will be great to keep LuceneNet cross platform and compatible with Mono.
This is just a simple fix to make the build pass on Mono\Linux.