### PR TITLE
Removing Apache.NMS dependency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ obj/
 doc/
 src/demo/
 packages/
+TestResults/

--- a/src/Lucene.Net.Core/Lucene.Net.csproj
+++ b/src/Lucene.Net.Core/Lucene.Net.csproj
@@ -606,6 +606,7 @@
     <Compile Include="Support\AtomicBoolean.cs" />
     <Compile Include="Support\AtomicInteger.cs" />
     <Compile Include="Support\AtomicLong.cs" />
+    <Compile Include="Support\AtomicObject.cs" />
     <Compile Include="Support\Buffer.cs" />
     <Compile Include="Support\AttributeImplItem.cs" />
     <Compile Include="Support\BitSetSupport.cs" />

--- a/src/Lucene.Net.Core/Support/AtomicObject.cs
+++ b/src/Lucene.Net.Core/Support/AtomicObject.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading;
+
+namespace Lucene.Net.Support
+{
+    public class AtomicObject<T> where T : class
+    {
+        private T _value;
+        private ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
+
+        public AtomicObject() : this(default(T))
+        { }
+
+        public AtomicObject(T initial)
+        {
+            _value = initial;
+        }
+
+        public T Value
+        {
+            get
+            {
+                try
+                {
+                    _lock.EnterReadLock();
+                    return _value;
+                }
+                finally
+                {
+                    _lock.ExitReadLock();
+                }
+            }
+            set
+            {
+                Interlocked.Exchange(ref _value, value);
+            }
+        }
+    }
+}

--- a/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
@@ -1,9 +1,9 @@
-using Apache.NMS.Util;
 using Lucene.Net.Documents;
 using Lucene.Net.Randomized.Generators;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using Lucene.Net.Search;
 
 namespace Lucene.Net.Index
@@ -3209,14 +3209,14 @@ namespace Lucene.Net.Index
             DirectoryReader ir = DirectoryReader.Open(dir);
             int numThreads = TestUtil.NextInt(Random(), 2, 7);
             ThreadClass[] threads = new ThreadClass[numThreads];
-            CountDownLatch startingGun = new CountDownLatch(1);
+            CountdownEvent startingGun = new CountdownEvent(1);
 
             for (int i = 0; i < threads.Length; i++)
             {
                 threads[i] = new ThreadAnonymousInnerClassHelper(this, ir, startingGun);
                 threads[i].Start();
             }
-            startingGun.countDown();
+            startingGun.Signal();
             foreach (ThreadClass t in threads)
             {
                 t.Join();
@@ -3230,9 +3230,9 @@ namespace Lucene.Net.Index
             private readonly BaseDocValuesFormatTestCase OuterInstance;
 
             private DirectoryReader Ir;
-            private CountDownLatch StartingGun;
+            private CountdownEvent StartingGun;
 
-            public ThreadAnonymousInnerClassHelper(BaseDocValuesFormatTestCase outerInstance, DirectoryReader ir, CountDownLatch startingGun)
+            public ThreadAnonymousInnerClassHelper(BaseDocValuesFormatTestCase outerInstance, DirectoryReader ir, CountdownEvent startingGun)
             {
                 this.OuterInstance = outerInstance;
                 this.Ir = ir;
@@ -3243,7 +3243,7 @@ namespace Lucene.Net.Index
             {
                 try
                 {
-                    StartingGun.@await();
+                    StartingGun.Wait();
                     foreach (AtomicReaderContext context in Ir.Leaves)
                     {
                         AtomicReader r = context.AtomicReader;
@@ -3347,14 +3347,14 @@ namespace Lucene.Net.Index
             DirectoryReader ir = DirectoryReader.Open(dir);
             int numThreads = TestUtil.NextInt(Random(), 2, 7);
             ThreadClass[] threads = new ThreadClass[numThreads];
-            CountDownLatch startingGun = new CountDownLatch(1);
+            CountdownEvent startingGun = new CountdownEvent(1);
 
             for (int i = 0; i < threads.Length; i++)
             {
                 threads[i] = new ThreadAnonymousInnerClassHelper2(this, ir, startingGun);
                 threads[i].Start();
             }
-            startingGun.countDown();
+            startingGun.Signal();
             foreach (ThreadClass t in threads)
             {
                 t.Join();
@@ -3368,9 +3368,9 @@ namespace Lucene.Net.Index
             private readonly BaseDocValuesFormatTestCase OuterInstance;
 
             private DirectoryReader Ir;
-            private CountDownLatch StartingGun;
+            private CountdownEvent StartingGun;
 
-            public ThreadAnonymousInnerClassHelper2(BaseDocValuesFormatTestCase outerInstance, DirectoryReader ir, CountDownLatch startingGun)
+            public ThreadAnonymousInnerClassHelper2(BaseDocValuesFormatTestCase outerInstance, DirectoryReader ir, CountdownEvent startingGun)
             {
                 this.OuterInstance = outerInstance;
                 this.Ir = ir;
@@ -3381,7 +3381,7 @@ namespace Lucene.Net.Index
             {
                 try
                 {
-                    StartingGun.@await();
+                    StartingGun.Wait();
                     foreach (AtomicReaderContext context in Ir.Leaves)
                     {
                         AtomicReader r = context.AtomicReader;

--- a/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
@@ -1,4 +1,3 @@
-using Apache.NMS.Util;
 using Lucene.Net.Attributes;
 using Lucene.Net.Codecs;
 using Lucene.Net.Documents;
@@ -10,6 +9,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Lucene.Net.Index
 {
@@ -472,7 +472,7 @@ namespace Lucene.Net.Index
             int concurrentReads = AtLeast(5);
             int readsPerThread = AtLeast(50);
             IList<ThreadClass> readThreads = new List<ThreadClass>();
-            AtomicReference<Exception> ex = new AtomicReference<Exception>();
+            AtomicObject<Exception> ex = new AtomicObject<Exception>();
             for (int i = 0; i < concurrentReads; ++i)
             {
                 readThreads.Add(new ThreadAnonymousInnerClassHelper(numDocs, rd, searcher, readsPerThread, ex, i));
@@ -501,11 +501,11 @@ namespace Lucene.Net.Index
             private readonly DirectoryReader Rd;
             private readonly IndexSearcher Searcher;
             private int ReadsPerThread;
-            private AtomicReference<Exception> Ex;
+            private AtomicObject<Exception> Ex;
             private int i;
             private readonly int[] queries;
 
-            public ThreadAnonymousInnerClassHelper(int numDocs, DirectoryReader rd, IndexSearcher searcher, int readsPerThread, AtomicReference<Exception> ex, int i)
+            public ThreadAnonymousInnerClassHelper(int numDocs, DirectoryReader rd, IndexSearcher searcher, int readsPerThread, AtomicObject<Exception> ex, int i)
             {
                 this.NumDocs = numDocs;
                 this.Rd = rd;
@@ -546,8 +546,7 @@ namespace Lucene.Net.Index
                     }
                     catch (Exception e)
                     {
-                        Ex.GetAndSet(e);
-                        //Ex.compareAndSet(null, e);
+                        Ex.Value = e;
                     }
                 }
             }

--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -1,4 +1,3 @@
-using Apache.NMS.Util;
 using Lucene.Net.Analysis.Tokenattributes;
 using System;
 using System.Collections.Generic;
@@ -890,7 +889,7 @@ namespace Lucene.Net.Index
                     AssertEquals(docs[i], reader.GetTermVectors(docID));
                 }
 
-                AtomicReference<Exception> exception = new AtomicReference<Exception>();
+                AtomicObject<Exception> exception = new AtomicObject<Exception>();
                 ThreadClass[] threads = new ThreadClass[2];
                 for (int i = 0; i < threads.Length; ++i)
                 {
@@ -918,10 +917,10 @@ namespace Lucene.Net.Index
             private int NumDocs;
             private Lucene.Net.Index.BaseTermVectorsFormatTestCase.RandomDocument[] Docs;
             private IndexReader Reader;
-            private AtomicReference<Exception> ARException;
+            private AtomicObject<Exception> ARException;
             private int i;
 
-            public ThreadAnonymousInnerClassHelper(BaseTermVectorsFormatTestCase outerInstance, int numDocs, Lucene.Net.Index.BaseTermVectorsFormatTestCase.RandomDocument[] docs, IndexReader reader, AtomicReference<Exception> exception, int i)
+            public ThreadAnonymousInnerClassHelper(BaseTermVectorsFormatTestCase outerInstance, int numDocs, Lucene.Net.Index.BaseTermVectorsFormatTestCase.RandomDocument[] docs, IndexReader reader, AtomicObject<Exception> exception, int i)
             {
                 this.OuterInstance = outerInstance;
                 this.NumDocs = numDocs;
@@ -944,7 +943,7 @@ namespace Lucene.Net.Index
                 }
                 catch (Exception t)
                 {
-                    ARException.Value = t;
+                    this.ARException.Value = t;
                 }
             }
         }

--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -43,12 +43,6 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.NMS">
-      <HintPath>..\..\packages\Apache.NMS.1.6.0.3083\lib\net40\Apache.NMS.dll</HintPath>
-    </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/src/Lucene.Net.TestFramework/packages.config
+++ b/src/Lucene.Net.TestFramework/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Apache.NMS" version="1.6.0.3083" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>

--- a/src/Lucene.Net.Tests.Facet/AssertingSubDocsAtOnceCollector.cs
+++ b/src/Lucene.Net.Tests.Facet/AssertingSubDocsAtOnceCollector.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Apache.NMS;
 
 namespace Lucene.Net.Facet
 {
@@ -26,7 +25,7 @@ namespace Lucene.Net.Facet
     using Collector = Lucene.Net.Search.Collector;
     using ChildScorer = Lucene.Net.Search.Scorer.ChildScorer;
     using Scorer = Lucene.Net.Search.Scorer;
-
+    using System;
     /// <summary>
     /// Verifies in collect() that all child subScorers are on
     ///  the collected doc. 
@@ -63,7 +62,7 @@ namespace Lucene.Net.Facet
             {
                 if (docID != s.DocID())
                 {
-                    throw new IllegalStateException("subScorer=" + s + " has docID=" + s.DocID() + " != collected docID=" + docID);
+                    throw new InvalidOperationException("subScorer=" + s + " has docID=" + s.DocID() + " != collected docID=" + docID);
                 }
             }
         }

--- a/src/Lucene.Net.Tests.Facet/Lucene.Net.Tests.Facet.csproj
+++ b/src/Lucene.Net.Tests.Facet/Lucene.Net.Tests.Facet.csproj
@@ -30,9 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.NMS">
-      <HintPath>..\..\packages\Apache.NMS.1.6.0.3083\lib\net40\Apache.NMS.dll</HintPath>
-    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using Apache.NMS;
 using Lucene.Net.Support;
 using NUnit.Framework;
 
@@ -339,7 +338,7 @@ namespace Lucene.Net.Facet.Taxonomy
                 mgr.MaybeRefresh();
                 Fail("should have hit exception");
             }
-            catch (IllegalStateException)
+            catch (InvalidOperationException)
             {
                 // expected
             }

--- a/src/Lucene.Net.Tests.Facet/packages.config
+++ b/src/Lucene.Net.Tests.Facet/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Apache.NMS" version="1.6.0.3083" targetFramework="net451" />
   <package id="NUnit" version="2.6.3" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Join/Lucene.Net.Tests.Join.csproj
+++ b/src/Lucene.Net.Tests.Join/Lucene.Net.Tests.Join.csproj
@@ -30,10 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.NMS, Version=1.6.0.3083, Culture=neutral, PublicKeyToken=82756feee3957618, processorArchitecture=MSIL">
-      <HintPath>..\packages\Apache.NMS.1.6.0.3083\lib\net40\Apache.NMS.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/src/Lucene.Net.Tests.Join/TestBlockJoinValidation.cs
+++ b/src/Lucene.Net.Tests.Join/TestBlockJoinValidation.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Apache.NMS;
 using Lucene.Net.Analysis;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;

--- a/src/Lucene.Net.Tests.Join/packages.config
+++ b/src/Lucene.Net.Tests.Join/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Apache.NMS" version="1.6.0.3083" targetFramework="net451" />
   <package id="NUnit" version="2.6.3" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
+++ b/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
@@ -38,13 +38,6 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.NMS">
-      <HintPath>..\..\packages\Apache.NMS.1.6.0.3083\lib\net40\Apache.NMS.dll</HintPath>
-    </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>

--- a/src/Lucene.Net.Tests/core/Index/TestBagOfPostings.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBagOfPostings.cs
@@ -1,8 +1,8 @@
-using Apache.NMS.Util;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using Lucene.Net.Documents;
 
 namespace Lucene.Net.Index
@@ -89,14 +89,14 @@ namespace Lucene.Net.Index
             }
 
             ThreadClass[] threads = new ThreadClass[threadCount];
-            CountDownLatch startingGun = new CountDownLatch(1);
+            CountdownEvent startingGun = new CountdownEvent(1);
 
             for (int threadID = 0; threadID < threadCount; threadID++)
             {
                 threads[threadID] = new ThreadAnonymousInnerClassHelper(this, maxTermsPerDoc, postings, iw, startingGun);
                 threads[threadID].Start();
             }
-            startingGun.countDown();
+            startingGun.Signal();
             foreach (ThreadClass t in threads)
             {
                 t.Join();
@@ -135,9 +135,9 @@ namespace Lucene.Net.Index
             private int MaxTermsPerDoc;
             private ConcurrentQueue<string> Postings;
             private RandomIndexWriter Iw;
-            private CountDownLatch StartingGun;
+            private CountdownEvent StartingGun;
 
-            public ThreadAnonymousInnerClassHelper(TestBagOfPostings outerInstance, int maxTermsPerDoc, ConcurrentQueue<string> postings, RandomIndexWriter iw, CountDownLatch startingGun)
+            public ThreadAnonymousInnerClassHelper(TestBagOfPostings outerInstance, int maxTermsPerDoc, ConcurrentQueue<string> postings, RandomIndexWriter iw, CountdownEvent startingGun)
             {
                 this.OuterInstance = outerInstance;
                 this.MaxTermsPerDoc = maxTermsPerDoc;
@@ -153,7 +153,7 @@ namespace Lucene.Net.Index
                     Document document = new Document();
                     Field field = NewTextField("field", "", Field.Store.NO);
                     document.Add(field);
-                    StartingGun.@await();
+                    StartingGun.Wait();
                     while (!(Postings.Count == 0))
                     {
                         StringBuilder text = new StringBuilder();

--- a/src/Lucene.Net.Tests/core/Index/TestBinaryDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBinaryDocValuesUpdates.cs
@@ -1,6 +1,6 @@
-using Apache.NMS.Util;
 using System;
 using System.Collections.Generic;
+    using System.Threading;
 using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 
@@ -1187,7 +1187,7 @@ namespace Lucene.Net.Index
                 writer.AddDocument(doc);
             }
 
-            CountDownLatch done = new CountDownLatch(numThreads);
+            CountdownEvent done = new CountdownEvent(numThreads);
             AtomicInteger numUpdates = new AtomicInteger(AtLeast(100));
 
             // same thread updates a field as well as reopens
@@ -1203,7 +1203,7 @@ namespace Lucene.Net.Index
             {
                 t.Start();
             }
-            done.@await();
+            done.Wait();
             writer.Dispose();
 
             DirectoryReader reader = DirectoryReader.Open(dir);
@@ -1242,12 +1242,12 @@ namespace Lucene.Net.Index
 
             private IndexWriter Writer;
             private int NumDocs;
-            private CountDownLatch Done;
+            private CountdownEvent Done;
             private AtomicInteger NumUpdates;
             private string f;
             private string Cf;
 
-            public ThreadAnonymousInnerClassHelper(TestBinaryDocValuesUpdates outerInstance, string str, IndexWriter writer, int numDocs, CountDownLatch done, AtomicInteger numUpdates, string f, string cf)
+            public ThreadAnonymousInnerClassHelper(TestBinaryDocValuesUpdates outerInstance, string str, IndexWriter writer, int numDocs, CountdownEvent done, AtomicInteger numUpdates, string f, string cf)
                 : base(str)
             {
                 this.OuterInstance = outerInstance;
@@ -1355,7 +1355,7 @@ namespace Lucene.Net.Index
                             }
                         }
                     }
-                    Done.countDown();
+                    Done.Signal();
                 }
             }
         }

--- a/src/Lucene.Net.Tests/core/Index/TestDocValuesIndexing.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocValuesIndexing.cs
@@ -1,5 +1,5 @@
-using Apache.NMS.Util;
 using System;
+using System.Threading;
 using Lucene.Net.Documents;
 using Lucene.Net.Search;
 
@@ -510,7 +510,7 @@ namespace Lucene.Net.Index
             Directory dir = NewDirectory();
             IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())));
 
-            CountDownLatch startingGun = new CountDownLatch(1);
+            CountdownEvent startingGun = new CountdownEvent(1);
             AtomicBoolean hitExc = new AtomicBoolean();
             ThreadClass[] threads = new ThreadClass[3];
             for (int i = 0; i < 3; i++)
@@ -535,7 +535,7 @@ namespace Lucene.Net.Index
                 threads[i].Start();
             }
 
-            startingGun.countDown();
+            startingGun.Signal();
 
             foreach (ThreadClass t in threads)
             {
@@ -551,11 +551,11 @@ namespace Lucene.Net.Index
             private readonly TestDocValuesIndexing OuterInstance;
 
             private IndexWriter w;
-            private CountDownLatch StartingGun;
+            private CountdownEvent StartingGun;
             private AtomicBoolean HitExc;
             private Document Doc;
 
-            public ThreadAnonymousInnerClassHelper(TestDocValuesIndexing outerInstance, IndexWriter w, CountDownLatch startingGun, AtomicBoolean hitExc, Document doc)
+            public ThreadAnonymousInnerClassHelper(TestDocValuesIndexing outerInstance, IndexWriter w, CountdownEvent startingGun, AtomicBoolean hitExc, Document doc)
             {
                 this.OuterInstance = outerInstance;
                 this.w = w;
@@ -568,7 +568,7 @@ namespace Lucene.Net.Index
             {
                 try
                 {
-                    StartingGun.@await();
+                    StartingGun.Wait();
                     w.AddDocument(Doc);
                 }
                 catch (System.ArgumentException iae)

--- a/src/Lucene.Net.Tests/core/Index/TestDocValuesWithThreads.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocValuesWithThreads.cs
@@ -1,6 +1,6 @@
-using Apache.NMS.Util;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Lucene.Net.Documents;
 using Lucene.Net.Search;
 
@@ -75,7 +75,7 @@ namespace Lucene.Net.Index
 
             int numThreads = TestUtil.NextInt(Random(), 2, 5);
             IList<ThreadClass> threads = new List<ThreadClass>();
-            CountDownLatch startingGun = new CountDownLatch(1);
+            CountdownEvent startingGun = new CountdownEvent(1);
             for (int t = 0; t < numThreads; t++)
             {
                 Random threadRandom = new Random(Random().Next());
@@ -84,7 +84,7 @@ namespace Lucene.Net.Index
                 threads.Add(thread);
             }
 
-            startingGun.countDown();
+            startingGun.Signal();
 
             foreach (ThreadClass thread in threads)
             {
@@ -104,10 +104,10 @@ namespace Lucene.Net.Index
             private IList<BytesRef> Sorted;
             private int NumDocs;
             private AtomicReader Ar;
-            private CountDownLatch StartingGun;
+            private CountdownEvent StartingGun;
             private Random ThreadRandom;
 
-            public ThreadAnonymousInnerClassHelper(TestDocValuesWithThreads outerInstance, IList<long?> numbers, IList<BytesRef> binary, IList<BytesRef> sorted, int numDocs, AtomicReader ar, CountDownLatch startingGun, Random threadRandom)
+            public ThreadAnonymousInnerClassHelper(TestDocValuesWithThreads outerInstance, IList<long?> numbers, IList<BytesRef> binary, IList<BytesRef> sorted, int numDocs, AtomicReader ar, CountdownEvent startingGun, Random threadRandom)
             {
                 this.OuterInstance = outerInstance;
                 this.Numbers = numbers;
@@ -128,7 +128,7 @@ namespace Lucene.Net.Index
                     //BinaryDocValues bdv = ar.GetBinaryDocValues("bytes");
                     BinaryDocValues bdv = FieldCache.DEFAULT.GetTerms(Ar, "bytes", false);
                     SortedDocValues sdv = FieldCache.DEFAULT.GetTermsIndex(Ar, "sorted");
-                    StartingGun.@await();
+                    StartingGun.Wait();
                     int iters = AtLeast(1000);
                     BytesRef scratch = new BytesRef();
                     BytesRef scratch2 = new BytesRef();

--- a/src/Lucene.Net.Tests/core/Index/TestDocumentsWriterDeleteQueue.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocumentsWriterDeleteQueue.cs
@@ -1,5 +1,4 @@
 using System.Threading;
-using Apache.NMS.Util;
 using Lucene.Net.Search;
 using System;
 using System.Collections;
@@ -219,7 +218,7 @@ namespace Lucene.Net.Index
                 ids[i] = Random().Next();
                 uniqueValues.Add(new Term("id", ids[i].ToString()));
             }
-            CountDownLatch latch = new CountDownLatch(1);
+            CountdownEvent latch = new CountdownEvent(1);
             AtomicInteger index = new AtomicInteger(0);
             int numThreads = 2 + Random().Next(5);
             UpdateThread[] threads = new UpdateThread[numThreads];
@@ -228,7 +227,7 @@ namespace Lucene.Net.Index
                 threads[i] = new UpdateThread(queue, index, ids, latch);
                 threads[i].Start();
             }
-            latch.countDown();
+            latch.Signal();
             for (int i = 0; i < threads.Length; i++)
             {
                 threads[i].Join();
@@ -262,9 +261,9 @@ namespace Lucene.Net.Index
             internal readonly int?[] Ids;
             internal readonly DeleteSlice Slice;
             internal readonly BufferedUpdates Deletes;
-            internal readonly CountDownLatch Latch;
+            internal readonly CountdownEvent Latch;
 
-            protected internal UpdateThread(DocumentsWriterDeleteQueue queue, AtomicInteger index, int?[] ids, CountDownLatch latch)
+            protected internal UpdateThread(DocumentsWriterDeleteQueue queue, AtomicInteger index, int?[] ids, CountdownEvent latch)
             {
                 this.Queue = queue;
                 this.Index = index;
@@ -278,7 +277,7 @@ namespace Lucene.Net.Index
             {
                 try
                 {
-                    Latch.@await();
+                    Latch.Wait();
                 }
                 catch (ThreadInterruptedException e)
                 {

--- a/src/Lucene.Net.Tests/core/Index/TestMixedDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestMixedDocValuesUpdates.cs
@@ -1,5 +1,5 @@
-using Apache.NMS.Util;
 using System;
+using System.Threading;
 using System.Collections.Generic;
 using Lucene.Net.Documents;
 
@@ -263,7 +263,7 @@ namespace Lucene.Net.Index
                 writer.AddDocument(doc);
             }
 
-            CountDownLatch done = new CountDownLatch(numThreads);
+            CountdownEvent done = new CountdownEvent(numThreads);
             AtomicInteger numUpdates = new AtomicInteger(AtLeast(100));
 
             // same thread updates a field as well as reopens
@@ -279,7 +279,7 @@ namespace Lucene.Net.Index
             {
                 t.Start();
             }
-            done.@await();
+            done.Wait();
             writer.Dispose();
 
             DirectoryReader reader = DirectoryReader.Open(dir);
@@ -323,12 +323,12 @@ namespace Lucene.Net.Index
 
             private IndexWriter Writer;
             private int NumDocs;
-            private CountDownLatch Done;
+            private CountdownEvent Done;
             private AtomicInteger NumUpdates;
             private string f;
             private string Cf;
 
-            public ThreadAnonymousInnerClassHelper(TestMixedDocValuesUpdates outerInstance, string str, IndexWriter writer, int numDocs, CountDownLatch done, AtomicInteger numUpdates, string f, string cf)
+            public ThreadAnonymousInnerClassHelper(TestMixedDocValuesUpdates outerInstance, string str, IndexWriter writer, int numDocs, CountdownEvent done, AtomicInteger numUpdates, string f, string cf)
                 : base(str)
             {
                 this.OuterInstance = outerInstance;
@@ -438,7 +438,7 @@ namespace Lucene.Net.Index
                             }
                         }
                     }
-                    Done.countDown();
+                    Done.Signal();
                 }
             }
         }

--- a/src/Lucene.Net.Tests/core/Index/TestNumericDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestNumericDocValuesUpdates.cs
@@ -1,6 +1,6 @@
-using Apache.NMS.Util;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Lucene.Net.Documents;
 
 namespace Lucene.Net.Index
@@ -1140,7 +1140,7 @@ namespace Lucene.Net.Index
                 writer.AddDocument(doc);
             }
 
-            CountDownLatch done = new CountDownLatch(numThreads);
+            CountdownEvent done = new CountdownEvent(numThreads);
             AtomicInteger numUpdates = new AtomicInteger(AtLeast(100));
 
             // same thread updates a field as well as reopens
@@ -1156,7 +1156,7 @@ namespace Lucene.Net.Index
             {
                 t.Start();
             }
-            done.@await();
+            done.Wait();
             writer.Dispose();
 
             DirectoryReader reader = DirectoryReader.Open(dir);
@@ -1194,12 +1194,12 @@ namespace Lucene.Net.Index
 
             private IndexWriter Writer;
             private int NumDocs;
-            private CountDownLatch Done;
+            private CountdownEvent Done;
             private AtomicInteger NumUpdates;
             private string f;
             private string Cf;
 
-            public ThreadAnonymousInnerClassHelper(TestNumericDocValuesUpdates outerInstance, string str, IndexWriter writer, int numDocs, CountDownLatch done, AtomicInteger numUpdates, string f, string cf)
+            public ThreadAnonymousInnerClassHelper(TestNumericDocValuesUpdates outerInstance, string str, IndexWriter writer, int numDocs, CountdownEvent done, AtomicInteger numUpdates, string f, string cf)
                 : base(str)
             {
                 this.OuterInstance = outerInstance;
@@ -1307,7 +1307,7 @@ namespace Lucene.Net.Index
                             }
                         }
                     }
-                    Done.countDown();
+                    Done.Signal();
                 }
             }
         }

--- a/src/Lucene.Net.Tests/core/Search/TestAutomatonQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestAutomatonQuery.cs
@@ -1,7 +1,7 @@
-using Apache.NMS.Util;
 using Lucene.Net.Documents;
 using Lucene.Net.Support;
 using System;
+using System.Threading;
 
 namespace Lucene.Net.Search
 {
@@ -230,7 +230,7 @@ namespace Lucene.Net.Search
             {
                 queries[i] = new AutomatonQuery(new Term("bogus", "bogus"), AutomatonTestUtil.RandomAutomaton(Random()));
             }
-            CountDownLatch startingGun = new CountDownLatch(1);
+            CountdownEvent startingGun = new CountdownEvent(1);
             int numThreads = TestUtil.NextInt(Random(), 2, 5);
             ThreadClass[] threads = new ThreadClass[numThreads];
             for (int threadID = 0; threadID < numThreads; threadID++)
@@ -239,7 +239,7 @@ namespace Lucene.Net.Search
                 threads[threadID] = thread;
                 thread.Start();
             }
-            startingGun.countDown();
+            startingGun.Signal();
             foreach (ThreadClass thread in threads)
             {
                 thread.Join();
@@ -251,9 +251,9 @@ namespace Lucene.Net.Search
             private readonly TestAutomatonQuery OuterInstance;
 
             private AutomatonQuery[] Queries;
-            private CountDownLatch StartingGun;
+            private CountdownEvent StartingGun;
 
-            public ThreadAnonymousInnerClassHelper(TestAutomatonQuery outerInstance, AutomatonQuery[] queries, CountDownLatch startingGun)
+            public ThreadAnonymousInnerClassHelper(TestAutomatonQuery outerInstance, AutomatonQuery[] queries, CountdownEvent startingGun)
             {
                 this.OuterInstance = outerInstance;
                 this.Queries = queries;
@@ -262,7 +262,7 @@ namespace Lucene.Net.Search
 
             public override void Run()
             {
-                StartingGun.@await();
+                StartingGun.Wait();
                 for (int i = 0; i < Queries.Length; i++)
                 {
                     Queries[i].GetHashCode();

--- a/src/Lucene.Net.Tests/core/Search/TestLiveFieldValues.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestLiveFieldValues.cs
@@ -1,9 +1,9 @@
-using Apache.NMS.Util;
 using Lucene.Net.Documents;
 using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 
 namespace Lucene.Net.Search
 {
@@ -62,7 +62,7 @@ namespace Lucene.Net.Search
                 Console.WriteLine(numThreads + " threads");
             }
 
-            CountDownLatch startingGun = new CountDownLatch(1);
+            CountdownEvent startingGun = new CountdownEvent(1);
             IList<ThreadClass> threads = new List<ThreadClass>();
 
             int iters = AtLeast(1000);
@@ -81,7 +81,7 @@ namespace Lucene.Net.Search
                 thread.Start();
             }
 
-            startingGun.countDown();
+            startingGun.Signal();
 
             foreach (ThreadClass thread in threads)
             {
@@ -134,7 +134,7 @@ namespace Lucene.Net.Search
             private SearcherManager Mgr;
             private int? Missing;
             private LiveFieldValues<IndexSearcher, int?> Rt;
-            private CountDownLatch StartingGun;
+            private CountdownEvent StartingGun;
             private int Iters;
             private int IdCount;
             private double ReopenChance;
@@ -144,7 +144,7 @@ namespace Lucene.Net.Search
             private int ThreadID;
             private Random ThreadRandom;
 
-            public ThreadAnonymousInnerClassHelper(IndexWriter w, SearcherManager mgr, int? missing, LiveFieldValues<IndexSearcher, int?> rt, CountDownLatch startingGun, int iters, int idCount, double reopenChance, double deleteChance, double addChance, int t, int threadID, Random threadRandom)
+            public ThreadAnonymousInnerClassHelper(IndexWriter w, SearcherManager mgr, int? missing, LiveFieldValues<IndexSearcher, int?> rt, CountdownEvent startingGun, int iters, int idCount, double reopenChance, double deleteChance, double addChance, int t, int threadID, Random threadRandom)
             {
                 this.w = w;
                 this.Mgr = mgr;
@@ -168,7 +168,7 @@ namespace Lucene.Net.Search
                     IDictionary<string, int?> values = new Dictionary<string, int?>();
                     IList<string> allIDs = new SynchronizedCollection<string>();
 
-                    StartingGun.@await();
+                    StartingGun.Wait();
                     for (int iter = 0; iter < Iters; iter++)
                     {
                         // Add/update a document

--- a/src/Lucene.Net.Tests/core/Search/TestSameScoresWithThreads.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSameScoresWithThreads.cs
@@ -1,6 +1,6 @@
-using Apache.NMS.Util;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Lucene.Net.Search
 {
@@ -89,7 +89,7 @@ namespace Lucene.Net.Search
 
             if (answers.Count > 0)
             {
-                CountDownLatch startingGun = new CountDownLatch(1);
+                CountdownEvent startingGun = new CountdownEvent(1);
                 int numThreads = TestUtil.NextInt(Random(), 2, 5);
                 ThreadClass[] threads = new ThreadClass[numThreads];
                 for (int threadID = 0; threadID < numThreads; threadID++)
@@ -98,7 +98,7 @@ namespace Lucene.Net.Search
                     threads[threadID] = thread;
                     thread.Start();
                 }
-                startingGun.countDown();
+                startingGun.Signal();
                 foreach (ThreadClass thread in threads)
                 {
                     thread.Join();
@@ -114,9 +114,9 @@ namespace Lucene.Net.Search
 
             private IndexSearcher s;
             private IDictionary<BytesRef, TopDocs> Answers;
-            private CountDownLatch StartingGun;
+            private CountdownEvent StartingGun;
 
-            public ThreadAnonymousInnerClassHelper(TestSameScoresWithThreads outerInstance, IndexSearcher s, IDictionary<BytesRef, TopDocs> answers, CountDownLatch startingGun)
+            public ThreadAnonymousInnerClassHelper(TestSameScoresWithThreads outerInstance, IndexSearcher s, IDictionary<BytesRef, TopDocs> answers, CountdownEvent startingGun)
             {
                 this.OuterInstance = outerInstance;
                 this.s = s;
@@ -128,7 +128,7 @@ namespace Lucene.Net.Search
             {
                 try
                 {
-                    StartingGun.@await();
+                    StartingGun.Wait();
                     for (int i = 0; i < 20; i++)
                     {
                         IList<KeyValuePair<BytesRef, TopDocs>> shuffled = new List<KeyValuePair<BytesRef, TopDocs>>(Answers.EntrySet());

--- a/src/Lucene.Net.Tests/packages.config
+++ b/src/Lucene.Net.Tests/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Apache.NMS" version="1.6.0.3083" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Removing dependency on Apache.NMS.  This is needed to build Lucene.Net on .NET Core.
-Replaced AtomicReference with use of Interlocked.Exchange.
-Replaced CountDownLatch with CountdownEvent.