### PR TITLE
Fixes the Nuget Nunit reference for Lucene.Net.Tests.Expressions

### DIFF
--- a/src/Lucene.Net.Tests.Expressions/Lucene.Net.Tests.Expressions.csproj
+++ b/src/Lucene.Net.Tests.Expressions/Lucene.Net.Tests.Expressions.csproj
@@ -30,8 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -71,6 +72,9 @@
       <Project>{B2C0D749-CE34-4F62-A15E-00CB2FF5DDB3}</Project>
       <Name>Lucene.Net.TestFramework</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Lucene.Net.Tests.Expressions/packages.config
+++ b/src/Lucene.Net.Tests.Expressions/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+</packages>


### PR DESCRIPTION
Super simple PR just to fix the nuget package reference for  Lucene.Net.Tests.Expressions for Nunit since it wasn't using a real Nuget reference.