### PR TITLE
Adding a MergeScheduler that uses Tasks

### DIFF
--- a/src/Lucene.Net.Core/Index/ConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/ConcurrentMergeScheduler.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Index
     ///  incoming threads by pausing until one more more merges
     ///  complete.</p>
     /// </summary>
-    public class ConcurrentMergeScheduler : MergeScheduler
+    public class ConcurrentMergeScheduler : MergeScheduler, IConcurrentMergeScheduler
     {
         private int MergeThreadPriority_Renamed = -1;
 
@@ -743,7 +743,7 @@ namespace Lucene.Net.Index
             return sb.ToString();
         }
 
-        public override object Clone()
+        public override IMergeScheduler Clone()
         {
             ConcurrentMergeScheduler clone = (ConcurrentMergeScheduler)base.Clone();
             clone.Writer = null;

--- a/src/Lucene.Net.Core/Index/IConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/IConcurrentMergeScheduler.cs
@@ -1,0 +1,15 @@
+﻿namespace Lucene.Net.Index
+{
+    public interface IConcurrentMergeScheduler : IMergeScheduler
+    {
+        int MaxThreadCount { get; }
+        int MaxMergeCount { get; }
+        int MergeThreadPriority { get; set; }
+
+        void Sync();
+        void SetMaxMergesAndThreads(int maxMergeCount, int maxThreadCount);
+
+        void SetSuppressExceptions();
+        void ClearSuppressExceptions();
+    }
+}

--- a/src/Lucene.Net.Core/Index/IConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/IConcurrentMergeScheduler.cs
@@ -1,5 +1,6 @@
 ﻿namespace Lucene.Net.Index
 {
+    // LUCENENET specific
     public interface IConcurrentMergeScheduler : IMergeScheduler
     {
         int MaxThreadCount { get; }

--- a/src/Lucene.Net.Core/Index/IMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/IMergeScheduler.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Lucene.Net.Index
+{
+    public interface IMergeScheduler : IDisposable
+    {
+        void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound);
+
+        IMergeScheduler Clone();
+    }
+}

--- a/src/Lucene.Net.Core/Index/IMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/IMergeScheduler.cs
@@ -2,6 +2,7 @@
 
 namespace Lucene.Net.Index
 {
+    // LUCENENET specific
     public interface IMergeScheduler : IDisposable
     {
         void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound);

--- a/src/Lucene.Net.Core/Index/IndexWriter.cs
+++ b/src/Lucene.Net.Core/Index/IndexWriter.cs
@@ -260,7 +260,7 @@ namespace Lucene.Net.Index
         private readonly HashSet<SegmentCommitInfo> mergingSegments = new HashSet<SegmentCommitInfo>();
 
         private readonly MergePolicy mergePolicy;
-        private readonly MergeScheduler mergeScheduler;
+        private readonly IMergeScheduler mergeScheduler;
         private readonly LinkedList<MergePolicy.OneMerge> PendingMerges = new LinkedList<MergePolicy.OneMerge>();
         private readonly HashSet<MergePolicy.OneMerge> RunningMerges = new HashSet<MergePolicy.OneMerge>();
         private IList<MergePolicy.OneMerge> MergeExceptions = new List<MergePolicy.OneMerge>();

--- a/src/Lucene.Net.Core/Index/IndexWriterConfig.cs
+++ b/src/Lucene.Net.Core/Index/IndexWriterConfig.cs
@@ -201,7 +201,7 @@ namespace Lucene.Net.Index
                 // such as line numbers, message throughput, ...
                 clone.infoStream = (InfoStream)infoStream.Clone();
                 clone.mergePolicy = (MergePolicy)mergePolicy.Clone();
-                clone.mergeScheduler = (MergeScheduler)mergeScheduler.Clone();
+                clone.mergeScheduler = mergeScheduler.Clone();
 
                 return clone;
             }
@@ -322,7 +322,7 @@ namespace Lucene.Net.Index
         ///
         /// <p>Only takes effect when IndexWriter is first created.
         /// </summary>
-        public IndexWriterConfig SetMergeScheduler(MergeScheduler mergeScheduler)
+        public IndexWriterConfig SetMergeScheduler(IMergeScheduler mergeScheduler)
         {
             if (mergeScheduler == null)
             {
@@ -332,7 +332,7 @@ namespace Lucene.Net.Index
             return this;
         }
 
-        public override MergeScheduler MergeScheduler
+        public override IMergeScheduler MergeScheduler
         {
             get
             {

--- a/src/Lucene.Net.Core/Index/LiveIndexWriterConfig.cs
+++ b/src/Lucene.Net.Core/Index/LiveIndexWriterConfig.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// <seealso cref="MergeScheduler"/> to use for running merges. </summary>
-        protected internal volatile MergeScheduler mergeScheduler;
+        protected internal volatile IMergeScheduler mergeScheduler;
 
         /// <summary>
         /// Timeout when trying to obtain the write lock on init. </summary>
@@ -149,7 +149,9 @@ namespace Lucene.Net.Index
             useCompoundFile = IndexWriterConfig.DEFAULT_USE_COMPOUND_FILE_SYSTEM;
             openMode = OpenMode_e.CREATE_OR_APPEND;
             similarity = IndexSearcher.DefaultSimilarity;
+
             mergeScheduler = new ConcurrentMergeScheduler();
+
             writeLockTimeout = IndexWriterConfig.WRITE_LOCK_TIMEOUT;
             indexingChain = DocumentsWriterPerThread.defaultIndexingChain;
             codec = Codec.Default;
@@ -547,7 +549,7 @@ namespace Lucene.Net.Index
         /// Returns the <seealso cref="MergeScheduler"/> that was set by
         /// <seealso cref="IndexWriterConfig#setMergeScheduler(MergeScheduler)"/>.
         /// </summary>
-        public virtual MergeScheduler MergeScheduler
+        public virtual IMergeScheduler MergeScheduler
         {
             get
             {

--- a/src/Lucene.Net.Core/Index/LiveIndexWriterConfig.cs
+++ b/src/Lucene.Net.Core/Index/LiveIndexWriterConfig.cs
@@ -149,9 +149,11 @@ namespace Lucene.Net.Index
             useCompoundFile = IndexWriterConfig.DEFAULT_USE_COMPOUND_FILE_SYSTEM;
             openMode = OpenMode_e.CREATE_OR_APPEND;
             similarity = IndexSearcher.DefaultSimilarity;
-
+#if FEATURE_TASKMERGESCHEDULER
+            mergeScheduler = new TaskMergeScheduler();
+#else
             mergeScheduler = new ConcurrentMergeScheduler();
-
+#endif
             writeLockTimeout = IndexWriterConfig.WRITE_LOCK_TIMEOUT;
             indexingChain = DocumentsWriterPerThread.defaultIndexingChain;
             codec = Codec.Default;

--- a/src/Lucene.Net.Core/Index/LiveIndexWriterConfig.cs
+++ b/src/Lucene.Net.Core/Index/LiveIndexWriterConfig.cs
@@ -149,11 +149,7 @@ namespace Lucene.Net.Index
             useCompoundFile = IndexWriterConfig.DEFAULT_USE_COMPOUND_FILE_SYSTEM;
             openMode = OpenMode_e.CREATE_OR_APPEND;
             similarity = IndexSearcher.DefaultSimilarity;
-#if FEATURE_TASKMERGESCHEDULER
-            mergeScheduler = new TaskMergeScheduler();
-#else
             mergeScheduler = new ConcurrentMergeScheduler();
-#endif
             writeLockTimeout = IndexWriterConfig.WRITE_LOCK_TIMEOUT;
             indexingChain = DocumentsWriterPerThread.defaultIndexingChain;
             codec = Codec.Default;

--- a/src/Lucene.Net.Core/Index/MergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/MergeScheduler.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Index
     ///  instance.</p>
     /// @lucene.experimental
     /// </summary>
-    public abstract class MergeScheduler : IDisposable, ICloneable
+    public abstract class MergeScheduler : IDisposable, IMergeScheduler
     {
         /// <summary>
         /// Sole constructor. (For invocation by subclass
@@ -51,7 +51,7 @@ namespace Lucene.Net.Index
         /// Close this MergeScheduler. </summary>
         public abstract void Dispose();
 
-        public virtual object Clone()
+        public virtual IMergeScheduler Clone()
         {
             return (MergeScheduler)base.MemberwiseClone();
         }

--- a/src/Lucene.Net.Core/Index/NoMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/NoMergeScheduler.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Index
         {
         }
 
-        public override object Clone()
+        public override IMergeScheduler Clone()
         {
             return this;
         }

--- a/src/Lucene.Net.Core/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/TaskMergeScheduler.cs
@@ -1,0 +1,665 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Lucene.Net.Index
+{
+    using Lucene.Net.Support;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Util;
+
+    /*
+         * Licensed to the Apache Software Foundation (ASF) under one or more
+         * contributor license agreements.  See the NOTICE file distributed with
+         * this work for additional information regarding copyright ownership.
+         * The ASF licenses this file to You under the Apache License, Version 2.0
+         * (the "License"); you may not use this file except in compliance with
+         * the License.  You may obtain a copy of the License at
+         *
+         *     http://www.apache.org/licenses/LICENSE-2.0
+         *
+         * Unless required by applicable law or agreed to in writing, software
+         * distributed under the License is distributed on an "AS IS" BASIS,
+         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+         * See the License for the specific language governing permissions and
+         * limitations under the License.
+         */
+
+    using Directory = Lucene.Net.Store.Directory;
+
+    /// <summary>
+    ///  A <seealso cref="MergeScheduler"/> that runs each merge using
+    ///  Tasks on the default TaskScheduler.
+    /// 
+    ///  <p>If more than <seealso cref="#GetMaxMergeCount"/> merges are
+    ///  requested then this class will forcefully throttle the
+    ///  incoming threads by pausing until one more more merges
+    ///  complete.</p>
+    /// </summary>
+    public class TaskMergeScheduler : MergeScheduler, IConcurrentMergeScheduler
+    {
+        public const string COMPONENT_NAME = "CMS";
+
+        private readonly TaskScheduler _taskScheduler = TaskScheduler.Default;
+        private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
+        private readonly ManualResetEventSlim _manualResetEvent = new ManualResetEventSlim();
+        /// <summary>
+        /// List of currently active <seealso cref="MergeThread"/>s.</summary>
+        private readonly IList<MergeThread> _mergeThreads = new List<MergeThread>();
+
+        /// <summary>
+        /// How many <seealso cref="MergeThread"/>s have kicked off (this is use
+        ///  to name them).
+        /// </summary>
+        private int _mergeThreadCount;
+
+        /// <summary>
+        /// <seealso cref="Directory"/> that holds the index. </summary>
+        private Directory _directory;
+
+        /// <summary>
+        /// <seealso cref="IndexWriter"/> that owns this instance.
+        /// </summary>
+        private IndexWriter _writer;
+
+        /// <summary>
+        /// Sole constructor, with all settings set to default
+        ///  values.
+        /// </summary>
+        public TaskMergeScheduler() : base()
+        {
+            MaxThreadCount = _taskScheduler.MaximumConcurrencyLevel;
+            MaxMergeCount = _taskScheduler.MaximumConcurrencyLevel;
+        }
+
+        /// <summary>
+        /// Sets the maximum number of merge threads and simultaneous merges allowed.
+        /// </summary>
+        /// <param name="maxMergeCount"> the max # simultaneous merges that are allowed.
+        ///       If a merge is necessary yet we already have this many
+        ///       threads running, the incoming thread (that is calling
+        ///       add/updateDocument) will block until a merge thread
+        ///       has completed.  Note that we will only run the
+        ///       smallest <code>maxThreadCount</code> merges at a time. </param>
+        /// <param name="maxThreadCount"> the max # simultaneous merge threads that should
+        ///       be running at once.  this must be &lt;= <code>maxMergeCount</code> </param>
+        public void SetMaxMergesAndThreads(int maxMergeCount, int maxThreadCount)
+        {
+            // This is handled by TaskScheduler.Default.MaximumConcurrencyLevel
+        }
+
+        /// <summary>
+        /// Max number of merge threads allowed to be running at
+        /// once.  When there are more merges then this, we
+        /// forcefully pause the larger ones, letting the smaller
+        /// ones run, up until maxMergeCount merges at which point
+        /// we forcefully pause incoming threads (that presumably
+        /// are the ones causing so much merging).
+        /// </summary>
+        /// <seealso cref= #setMaxMergesAndThreads(int, int)  </seealso>
+        public int MaxThreadCount { get; private set; }
+
+        /// <summary>
+        /// Max number of merges we accept before forcefully
+        /// throttling the incoming threads
+        /// </summary>
+        public int MaxMergeCount { get; private set; }
+
+        /// <summary>
+        /// Return the priority that merge threads run at. This is always the same.
+        /// </summary>
+        public int MergeThreadPriority
+        {
+            get
+            {
+                return (int)ThreadPriority.Normal;
+            }
+            set
+            {
+            }
+        }
+
+        /// <summary>
+        /// Called whenever the running merges have changed, to pause & unpause
+        /// threads. this method sorts the merge threads by their merge size in
+        /// descending order and then pauses/unpauses threads from first to last --
+        /// that way, smaller merges are guaranteed to run before larger ones.
+        /// </summary>
+        private void UpdateMergeThreads()
+        {
+            foreach (var merge in _mergeThreads.ToArray())
+            {
+                // Prune any dead threads
+                if (!merge.IsAlive)
+                {
+                    _mergeThreads.Remove(merge);
+                    merge.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns true if verbosing is enabled. this method is usually used in
+        /// conjunction with <seealso cref="#message(String)"/>, like that:
+        ///
+        /// <pre class="prettyprint">
+        /// if (verbose()) {
+        ///   message(&quot;your message&quot;);
+        /// }
+        /// </pre>
+        /// </summary>
+        protected internal bool Verbose()
+        {
+            return _writer != null && _writer.infoStream.IsEnabled(COMPONENT_NAME);
+        }
+
+        /// <summary>
+        /// Outputs the given message - this method assumes <seealso cref="#verbose()"/> was
+        /// called and returned true.
+        /// </summary>
+        protected internal virtual void Message(string message)
+        {
+            _writer.infoStream.Message(COMPONENT_NAME, message);
+        }
+
+        public override void Dispose()
+        {
+            Sync();
+            _manualResetEvent.Dispose();
+        }
+
+        /// <summary>
+        /// Wait for any running merge threads to finish. 
+        /// This call is not interruptible as used by <seealso cref="#Dispose()"/>.
+        /// </summary>
+        public virtual void Sync()
+        {
+            foreach (var merge in _mergeThreads.ToArray())
+            {
+                if (!merge.IsAlive)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    merge.Wait();
+                }
+                catch (OperationCanceledException)
+                {
+                    // expected when we cancel.
+                }
+                catch (AggregateException ae)
+                {
+                    ae.Handle(x => x is OperationCanceledException);
+
+                    foreach (var exception in ae.InnerExceptions)
+                    {
+                        HandleMergeException(ae);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the number of merge threads that are alive. Note that this number
+        /// is &lt;= <seealso cref="#mergeThreads"/> size.
+        /// </summary>
+        private int MergeThreadCount()
+        {
+            return _mergeThreads.Count(x => x.IsAlive && x.CurrentMerge != null);
+        }
+
+        public override void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound)
+        {
+            using (_lock.Write())
+            {
+                _writer = writer;
+                _directory = writer.Directory;
+
+                if (Verbose())
+                {
+                    Message("now merge");
+                    Message("  index: " + writer.SegString());
+                }
+
+                // First, quickly run through the newly proposed merges
+                // and add any orthogonal merges (ie a merge not
+                // involving segments already pending to be merged) to
+                // the queue.  If we are way behind on merging, many of
+                // these newly proposed merges will likely already be
+                // registered.
+
+                // Iterate, pulling from the IndexWriter's queue of
+                // pending merges, until it's empty:
+                while (true)
+                {
+                    long startStallTime = 0;
+                    while (writer.HasPendingMerges() && MergeThreadCount() >= MaxMergeCount)
+                    {
+                        // this means merging has fallen too far behind: we
+                        // have already created maxMergeCount threads, and
+                        // now there's at least one more merge pending.
+                        // Note that only maxThreadCount of
+                        // those created merge threads will actually be
+                        // running; the rest will be paused (see
+                        // updateMergeThreads).  We stall this producer
+                        // thread to prevent creation of new segments,
+                        // until merging has caught up:
+                        startStallTime = Environment.TickCount;
+                        if (Verbose())
+                        {
+                            Message("    too many merges; stalling...");
+                        }
+
+                        _manualResetEvent.Reset();
+                        _manualResetEvent.Wait();
+                    }
+
+                    if (Verbose())
+                    {
+                        if (startStallTime != 0)
+                        {
+                            Message("  stalled for " + (Environment.TickCount - startStallTime) + " msec");
+                        }
+                    }
+
+                    MergePolicy.OneMerge merge = writer.NextMerge;
+                    if (merge == null)
+                    {
+                        if (Verbose())
+                        {
+                            Message("  no more merges pending; now return");
+                        }
+                        return;
+                    }
+
+                    bool success = false;
+                    try
+                    {
+                        if (Verbose())
+                        {
+                            Message("  consider merge " + writer.SegString(merge.Segments));
+                        }
+
+                        // OK to spawn a new merge thread to handle this
+                        // merge:
+                        var merger = CreateTask(writer, merge);
+
+                        merger.MergeThreadCompleted += OnMergeThreadCompleted;
+
+                        _mergeThreads.Add(merger);
+
+                        if (Verbose())
+                        {
+                            Message("    launch new thread [" + merger.Name + "]");
+                        }
+
+                        merger.Start(_taskScheduler);
+
+                        // Must call this after starting the thread else
+                        // the new thread is removed from mergeThreads
+                        // (since it's not alive yet):
+                        UpdateMergeThreads();
+
+                        success = true;
+                    }
+                    finally
+                    {
+                        if (!success)
+                        {
+                            writer.MergeFinish(merge);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void OnMergeThreadCompleted(object sender, EventArgs e)
+        {
+            var mergeThread = sender as MergeThread;
+
+            if (mergeThread == null)
+            {
+                return;
+            }
+
+            mergeThread.MergeThreadCompleted -= OnMergeThreadCompleted;
+
+            using (_lock.Write())
+            {
+                UpdateMergeThreads();
+            }
+        }
+
+        /// <summary>
+        /// Create and return a new MergeThread </summary>
+        private MergeThread CreateTask(IndexWriter writer, MergePolicy.OneMerge merge)
+        {
+            var count = Interlocked.Increment(ref _mergeThreadCount);
+            var name = string.Format("Lucene Merge Task #{0}", count);
+
+            return new MergeThread(name, writer, merge, writer.infoStream, _manualResetEvent, HandleMergeException);
+        }
+
+        /// <summary>
+        /// Called when an exception is hit in a background merge
+        ///  thread
+        /// </summary>
+        protected internal virtual void HandleMergeException(Exception exc)
+        {
+            // suppressExceptions is normally only set during testing
+            if (SuppressExceptions)
+            {
+                return;
+            }
+
+            try
+            {
+                // When an exception is hit during merge, IndexWriter
+                // removes any partial files and then allows another
+                // merge to run.  If whatever caused the error is not
+                // transient then the exception will keep happening,
+                // so, we sleep here to avoid saturating CPU in such
+                // cases:
+                Thread.Sleep(250);
+            }
+            catch (ThreadInterruptedException ie)
+            {
+                throw new ThreadInterruptedException("Thread Interrupted Exception", ie);
+            }
+            throw new MergePolicy.MergeException(exc, _directory);
+        }
+
+        private bool SuppressExceptions;
+
+        /// <summary>
+        /// Used for testing </summary>
+        public virtual void SetSuppressExceptions()
+        {
+            SuppressExceptions = true;
+        }
+
+        /// <summary>
+        /// Used for testing </summary>
+        public virtual void ClearSuppressExceptions()
+        {
+            SuppressExceptions = false;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder(this.GetType().Name + ": ");
+            sb.AppendFormat("maxThreadCount={0}, ", MaxThreadCount);
+            sb.AppendFormat("maxMergeCount={0}", MaxMergeCount);
+            return sb.ToString();
+        }
+
+        public override IMergeScheduler Clone()
+        {
+            TaskMergeScheduler clone = (TaskMergeScheduler)base.Clone();
+            clone._writer = null;
+            clone._directory = null;
+            clone._mergeThreads.Clear();
+            return clone;
+        }
+
+        /// <summary>
+        /// Runs a merge thread, which may run one or more merges
+        ///  in sequence.
+        /// </summary>
+        internal class MergeThread : IDisposable
+        {
+            public event EventHandler MergeThreadCompleted;
+
+            private readonly CancellationTokenSource _cancellationTokenSource;
+            private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
+            private readonly ManualResetEventSlim _resetEvent;
+            private readonly Action<Exception> _exceptionHandler;
+            private readonly InfoStream _logger;
+            private readonly IndexWriter _writer;
+            private readonly MergePolicy.OneMerge _startingMerge;
+
+            private Task _task;
+            private MergePolicy.OneMerge _runningMerge;
+            private volatile bool _isDisposed = false;
+            private volatile bool _isDone;
+
+            /// <summary>
+            /// Sole constructor. </summary>
+            public MergeThread(string name, IndexWriter writer, MergePolicy.OneMerge startMerge, InfoStream logger,
+                ManualResetEventSlim resetEvent, Action<Exception> exceptionHandler)
+            {
+                Name = name;
+                _cancellationTokenSource = new CancellationTokenSource();
+                _writer = writer;
+                _startingMerge = startMerge;
+                _logger = logger;
+                _resetEvent = resetEvent;
+                _exceptionHandler = exceptionHandler;
+            }
+
+            private bool IsLoggingEnabled
+            {
+                get
+                {
+                    return _logger != null && _logger.IsEnabled(COMPONENT_NAME);
+                }
+            }
+
+            public string Name { get; private set; }
+
+            public Task Instance
+            {
+                get
+                {
+                    using (_lock.Read())
+                    {
+                        return _task;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Record the currently running merge. </summary>
+            public virtual MergePolicy.OneMerge RunningMerge
+            {
+                set
+                {
+                    Interlocked.Exchange(ref _runningMerge, value);
+                }
+                get
+                {
+                    using (_lock.Read())
+                    {
+                        return _runningMerge;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Return the current merge, or null if this {@code
+            ///  MergeThread} is done.
+            /// </summary>
+            public virtual MergePolicy.OneMerge CurrentMerge
+            {
+                get
+                {
+                    using (_lock.Read())
+                    {
+                        if (_isDone)
+                        {
+                            return null;
+                        }
+
+                        return _runningMerge ?? _startingMerge;
+                    }
+                }
+            }
+
+            public bool IsAlive
+            {
+                get
+                {
+                    if (_isDisposed || _isDone)
+                    {
+                        return false;
+                    }
+
+                    using (_lock.Read())
+                    {
+                        return _task != null
+                            && (_task.Status != TaskStatus.Canceled
+                            || _task.Status != TaskStatus.Faulted
+                            || _task.Status != TaskStatus.RanToCompletion);
+                    }
+                }
+            }
+
+            public void Start(TaskScheduler taskScheduler)
+            {
+                using (_lock.Write())
+                {
+                    if (_task == null && !_cancellationTokenSource.IsCancellationRequested)
+                    {
+                        _task = Task.Factory.StartNew(() => Run(_cancellationTokenSource.Token), _cancellationTokenSource.Token, TaskCreationOptions.None, taskScheduler);
+                    }
+                }
+            }
+
+            public void Wait()
+            {
+                if (!IsAlive)
+                {
+                    return;
+                }
+
+                _task.Wait(_cancellationTokenSource.Token);
+            }
+
+            public void Cancel()
+            {
+                if (!IsAlive)
+                {
+                    return;
+                }
+
+                using (_lock.Write())
+                {
+                    if (!_cancellationTokenSource.IsCancellationRequested)
+                    {
+                        _cancellationTokenSource.Cancel();
+                    }
+                }
+            }
+
+            private void Run(CancellationToken cancellationToken)
+            {
+                // First time through the while loop we do the merge
+                // that we were started with:
+                MergePolicy.OneMerge merge = _startingMerge;
+
+                try
+                {
+                    if (IsLoggingEnabled)
+                    {
+                        _logger.Message(COMPONENT_NAME, "  merge thread: start");
+                    }
+
+                    while (true && !cancellationToken.IsCancellationRequested)
+                    {
+                        RunningMerge = merge;
+                        _writer.Merge(merge);
+
+                        // Subsequent times through the loop we do any new
+                        // merge that writer says is necessary:
+                        merge = _writer.NextMerge;
+
+                        // Notify here in case any threads were stalled;
+                        // they will notice that the pending merge has
+                        // been pulled and possibly resume:
+                        _resetEvent.Set();
+
+                        if (merge != null)
+                        {
+                            if (IsLoggingEnabled)
+                            {
+                                _logger.Message(COMPONENT_NAME, "  merge thread: do another merge " + _writer.SegString(merge.Segments));
+                            }
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    if (IsLoggingEnabled)
+                    {
+                        _logger.Message(COMPONENT_NAME, "  merge thread: done");
+                    }
+                }
+                catch (Exception exc)
+                {
+                    // Ignore the exception if it was due to abort:
+                    if (!(exc is MergePolicy.MergeAbortedException))
+                    {
+                        //System.out.println(Thread.currentThread().getName() + ": CMS: exc");
+                        //exc.printStackTrace(System.out)
+                        _exceptionHandler(exc);
+                    }
+                }
+                finally
+                {
+                    _isDone = true;
+
+                    if (MergeThreadCompleted != null)
+                    {
+                        MergeThreadCompleted(this, EventArgs.Empty);
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_isDisposed)
+                {
+                    return;
+                }
+
+                _isDisposed = true;
+                _lock.Dispose();
+                _cancellationTokenSource.Dispose();
+            }
+
+            public override string ToString()
+            {
+                return _task == null
+                    ? string.Format("Task[{0}], Task has not been started yet.", Name)
+                    : string.Format("Task[{0}], Id[{1}], Status[{2}]", Name, _task.Id, _task.Status);
+            }
+
+            public override bool Equals(object obj)
+            {
+                var compared = obj as MergeThread;
+
+                if (compared == null
+                    || (Instance == null && compared.Instance != null)
+                    || (Instance != null && compared.Instance == null))
+                {
+                    return false;
+                }
+
+                return Instance.Id == compared.Instance.Id;
+            }
+
+            public override int GetHashCode()
+            {
+                return Instance == null
+                    ? base.GetHashCode()
+                    : Instance.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/Lucene.Net.Core/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/TaskMergeScheduler.cs
@@ -37,6 +37,8 @@ namespace Lucene.Net.Index
     ///  requested then this class will forcefully throttle the
     ///  incoming threads by pausing until one more more merges
     ///  complete.</p>
+    ///  
+    /// LUCENENET specific
     /// </summary>
     public class TaskMergeScheduler : MergeScheduler, IConcurrentMergeScheduler
     {

--- a/src/Lucene.Net.Core/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/TaskMergeScheduler.cs
@@ -340,7 +340,7 @@ namespace Lucene.Net.Index
             var count = Interlocked.Increment(ref _mergeThreadCount);
             var name = string.Format("Lucene Merge Task #{0}", count);
 
-            return new MergeThread(name, writer, merge, writer.infoStream, _manualResetEvent, HandleMergeException);
+            return new MergeThread(name, writer, merge, writer.infoStream, Verbose(), _manualResetEvent, HandleMergeException);
         }
 
         /// <summary>
@@ -420,6 +420,7 @@ namespace Lucene.Net.Index
             private readonly InfoStream _logger;
             private readonly IndexWriter _writer;
             private readonly MergePolicy.OneMerge _startingMerge;
+            private readonly bool _isLoggingEnabled;
 
             private Task _task;
             private MergePolicy.OneMerge _runningMerge;
@@ -428,7 +429,8 @@ namespace Lucene.Net.Index
 
             /// <summary>
             /// Sole constructor. </summary>
-            public MergeThread(string name, IndexWriter writer, MergePolicy.OneMerge startMerge, InfoStream logger,
+            public MergeThread(string name, IndexWriter writer, MergePolicy.OneMerge startMerge,
+                InfoStream logger, bool isLoggingEnabled,
                 ManualResetEventSlim resetEvent, Action<Exception> exceptionHandler)
             {
                 Name = name;
@@ -436,16 +438,9 @@ namespace Lucene.Net.Index
                 _writer = writer;
                 _startingMerge = startMerge;
                 _logger = logger;
+                _isLoggingEnabled = isLoggingEnabled;
                 _resetEvent = resetEvent;
                 _exceptionHandler = exceptionHandler;
-            }
-
-            private bool IsLoggingEnabled
-            {
-                get
-                {
-                    return _logger != null && _logger.IsEnabled(COMPONENT_NAME);
-                }
             }
 
             public string Name { get; private set; }
@@ -562,7 +557,7 @@ namespace Lucene.Net.Index
 
                 try
                 {
-                    if (IsLoggingEnabled)
+                    if (_isLoggingEnabled)
                     {
                         _logger.Message(COMPONENT_NAME, "  merge thread: start");
                     }
@@ -583,7 +578,7 @@ namespace Lucene.Net.Index
 
                         if (merge != null)
                         {
-                            if (IsLoggingEnabled)
+                            if (_isLoggingEnabled)
                             {
                                 _logger.Message(COMPONENT_NAME, "  merge thread: do another merge " + _writer.SegString(merge.Segments));
                             }
@@ -594,7 +589,7 @@ namespace Lucene.Net.Index
                         }
                     }
 
-                    if (IsLoggingEnabled)
+                    if (_isLoggingEnabled)
                     {
                         _logger.Message(COMPONENT_NAME, "  merge thread: done");
                     }

--- a/src/Lucene.Net.Core/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net.Core/Index/TaskMergeScheduler.cs
@@ -1,34 +1,31 @@
-﻿using System;
+﻿/*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+using Lucene.Net.Support;
+using Lucene.Net.Util;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
+using Directory = Lucene.Net.Store.Directory;
 
 namespace Lucene.Net.Index
 {
-    using Lucene.Net.Support;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Util;
-
-    /*
-         * Licensed to the Apache Software Foundation (ASF) under one or more
-         * contributor license agreements.  See the NOTICE file distributed with
-         * this work for additional information regarding copyright ownership.
-         * The ASF licenses this file to You under the Apache License, Version 2.0
-         * (the "License"); you may not use this file except in compliance with
-         * the License.  You may obtain a copy of the License at
-         *
-         *     http://www.apache.org/licenses/LICENSE-2.0
-         *
-         * Unless required by applicable law or agreed to in writing, software
-         * distributed under the License is distributed on an "AS IS" BASIS,
-         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-         * See the License for the specific language governing permissions and
-         * limitations under the License.
-         */
-
-    using Directory = Lucene.Net.Store.Directory;
-
     /// <summary>
     ///  A <seealso cref="MergeScheduler"/> that runs each merge using
     ///  Tasks on the default TaskScheduler.

--- a/src/Lucene.Net.Core/Lucene.Net.csproj
+++ b/src/Lucene.Net.Core/Lucene.Net.csproj
@@ -286,6 +286,8 @@
     <Compile Include="Index\FreqProxTermsWriter.cs" />
     <Compile Include="Index\FreqProxTermsWriterPerField.cs" />
     <Compile Include="Index\FrozenBufferedUpdates.cs" />
+    <Compile Include="Index\IConcurrentMergeScheduler.cs" />
+    <Compile Include="Index\IMergeScheduler.cs" />
     <Compile Include="Index\IndexableField.cs" />
     <Compile Include="Index\IndexableFieldType.cs" />
     <Compile Include="Index\IndexCommit.cs" />

--- a/src/Lucene.Net.Core/Lucene.Net.csproj
+++ b/src/Lucene.Net.Core/Lucene.Net.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <NoStandardLibraries>false</NoStandardLibraries>
     <AssemblyName>Lucene.Net</AssemblyName>
+    <RootNamespace>Lucene.Net</RootNamespace>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
@@ -34,10 +35,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <RootNamespace>Lucene.Net</RootNamespace>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
@@ -368,6 +365,7 @@
     <Compile Include="Index\StoredFieldsConsumer.cs" />
     <Compile Include="Index\StoredFieldsProcessor.cs" />
     <Compile Include="Index\StoredFieldVisitor.cs" />
+    <Compile Include="Index\TaskMergeScheduler.cs" />
     <Compile Include="Index\Term.cs" />
     <Compile Include="Index\TermContext.cs" />
     <Compile Include="Index\Terms.cs" />
@@ -841,6 +839,7 @@
     <Compile Include="Util\PriorityQueue.cs" />
     <Compile Include="Util\QueryBuilder.cs" />
     <Compile Include="Util\RamUsageEstimator.cs" />
+    <Compile Include="Util\ReaderWriterLockSlimExtension.cs" />
     <Compile Include="Util\RecyclingByteBlockAllocator.cs" />
     <Compile Include="Util\RecyclingIntBlockAllocator.cs" />
     <Compile Include="Util\RefCount.cs" />

--- a/src/Lucene.Net.Core/Util/ReaderWriterLockSlimExtension.cs
+++ b/src/Lucene.Net.Core/Util/ReaderWriterLockSlimExtension.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lucene.Net.Util
+{
+    /// <summary>
+    /// From:
+    /// http://stackoverflow.com/questions/170028/how-would-you-simplify-entering-and-exiting-a-readerwriterlock
+    /// </summary>
+    internal static class ReaderWriterExtension
+    {
+        sealed class ReadLockToken : IDisposable
+        {
+            private ReaderWriterLockSlim _readerWriterLockSlim;
+
+            public ReadLockToken(ReaderWriterLockSlim sync)
+            {
+                _readerWriterLockSlim = sync;
+                sync.EnterReadLock();
+            }
+
+            public void Dispose()
+            {
+                if (_readerWriterLockSlim != null)
+                {
+                    _readerWriterLockSlim.ExitReadLock();
+                    _readerWriterLockSlim = null;
+                }
+            }
+        }
+
+        sealed class WriteLockToken : IDisposable
+        {
+            private ReaderWriterLockSlim _readerWriterLockSlim;
+
+            public WriteLockToken(ReaderWriterLockSlim sync)
+            {
+                _readerWriterLockSlim = sync;
+                sync.EnterWriteLock();
+            }
+
+            public void Dispose()
+            {
+                if (_readerWriterLockSlim != null)
+                {
+                    _readerWriterLockSlim.ExitWriteLock();
+                    _readerWriterLockSlim = null;
+                }
+            }
+        }
+
+        public static IDisposable Read(this ReaderWriterLockSlim obj)
+        {
+            return new ReadLockToken(obj);
+        }
+
+        public static IDisposable Write(this ReaderWriterLockSlim obj)
+        {
+            return new WriteLockToken(obj);
+        }
+    }
+}

--- a/src/Lucene.Net.Core/Util/ReaderWriterLockSlimExtension.cs
+++ b/src/Lucene.Net.Core/Util/ReaderWriterLockSlimExtension.cs
@@ -1,15 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Lucene.Net.Util
 {
     /// <summary>
-    /// From:
+    /// Extensions to help obtain/release from a ReaderWriterSlimLock.
+    /// Taken from:
     /// http://stackoverflow.com/questions/170028/how-would-you-simplify-entering-and-exiting-a-readerwriterlock
+    /// 
+    /// LUCENENET specific
     /// </summary>
     internal static class ReaderWriterExtension
     {

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -872,9 +872,19 @@ namespace Lucene.Net.Util
             {
                 int maxThreadCount = TestUtil.NextInt(Random(), 1, 4);
                 int maxMergeCount = TestUtil.NextInt(Random(), maxThreadCount, maxThreadCount + 4);
-                ConcurrentMergeScheduler cms = new ConcurrentMergeScheduler();
-                cms.SetMaxMergesAndThreads(maxMergeCount, maxThreadCount);
-                c.SetMergeScheduler(cms);
+                IConcurrentMergeScheduler mergeScheduler;
+
+                if (r.NextBoolean())
+                {
+                    mergeScheduler = new ConcurrentMergeScheduler();
+                }
+                else
+                {
+                    mergeScheduler = new TaskMergeScheduler();
+                }
+
+                mergeScheduler.SetMaxMergesAndThreads(maxMergeCount, maxThreadCount);
+                c.SetMergeScheduler(mergeScheduler);
             }
             if (r.NextBoolean())
             {
@@ -983,7 +993,7 @@ namespace Lucene.Net.Util
         public static LogMergePolicy NewLogMergePolicy(Random r)
         {
             LogMergePolicy logmp = r.NextBoolean() ? (LogMergePolicy)new LogDocMergePolicy() : new LogByteSizeMergePolicy();
-            
+
             logmp.CalibrateSizeByDeletes = r.NextBoolean();
             if (Rarely(r))
             {

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -2675,6 +2675,17 @@ namespace Lucene.Net.Util
                 }
             }
         }
+
+        /// <summary>
+        /// Contains a list of all the IConcurrentMergeSchedulers to be tested.
+        /// </summary>
+        public class ConcurrentMergeSchedulers
+        {
+            public readonly IConcurrentMergeScheduler[] Values = new IConcurrentMergeScheduler[] {
+                new ConcurrentMergeScheduler(),
+                new TaskMergeScheduler()
+            };
+        }
     }
 
     /*internal class ReaderClosedListenerAnonymousInnerClassHelper : IndexReader.ReaderClosedListener

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -2688,6 +2688,8 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Contains a list of all the IConcurrentMergeSchedulers to be tested.
+        /// 
+        /// LUCENENET specific
         /// </summary>
         public class ConcurrentMergeSchedulers
         {

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -128,11 +128,11 @@ namespace Lucene.Net.Util
             SyncConcurrentMerges(writer.Config.MergeScheduler);
         }
 
-        public static void SyncConcurrentMerges(MergeScheduler ms)
+        public static void SyncConcurrentMerges(IMergeScheduler ms)
         {
-            if (ms is ConcurrentMergeScheduler)
+            if (ms is IConcurrentMergeScheduler)
             {
-                ((ConcurrentMergeScheduler)ms).Sync();
+                ((IConcurrentMergeScheduler)ms).Sync();
             }
         }
 
@@ -916,11 +916,11 @@ namespace Lucene.Net.Util
                 tmp.SegmentsPerTier = Math.Min(5, tmp.SegmentsPerTier);
                 tmp.NoCFSRatio = 1.0;
             }
-            MergeScheduler ms = w.Config.MergeScheduler;
-            if (ms is ConcurrentMergeScheduler)
+            IMergeScheduler ms = w.Config.MergeScheduler;
+            if (ms is IConcurrentMergeScheduler)
             {
                 // wtf... shouldnt it be even lower since its 1 by default?!?!
-                ((ConcurrentMergeScheduler)ms).SetMaxMergesAndThreads(3, 2);
+                ((IConcurrentMergeScheduler)ms).SetMaxMergesAndThreads(3, 2);
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Lucene.Net.Tests.Analysis.Common.csproj
+++ b/src/Lucene.Net.Tests.Analysis.Common/Lucene.Net.Tests.Analysis.Common.csproj
@@ -116,6 +116,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Lucene.Net.Tests.Classification/Lucene.Net.Tests.Classification.csproj
+++ b/src/Lucene.Net.Tests.Classification/Lucene.Net.Tests.Classification.csproj
@@ -66,7 +66,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Lucene.Net.Tests.Expressions/Lucene.Net.Tests.Expressions.csproj
+++ b/src/Lucene.Net.Tests.Expressions/Lucene.Net.Tests.Expressions.csproj
@@ -76,6 +76,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Lucene.Net.Tests.Facet/Lucene.Net.Tests.Facet.csproj
+++ b/src/Lucene.Net.Tests.Facet/Lucene.Net.Tests.Facet.csproj
@@ -85,7 +85,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Lucene.Net.Tests.Join/Lucene.Net.Tests.Join.csproj
+++ b/src/Lucene.Net.Tests.Join/Lucene.Net.Tests.Join.csproj
@@ -71,6 +71,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Lucene.Net.Tests.Queries/Lucene.Net.Tests.Queries.csproj
+++ b/src/Lucene.Net.Tests.Queries/Lucene.Net.Tests.Queries.csproj
@@ -77,7 +77,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Lucene.Net.Tests/core/Index/Test2BBinaryDocValues.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BBinaryDocValues.cs
@@ -42,16 +42,20 @@ namespace Lucene.Net.Index
     {
         // indexes Integer.MAX_VALUE docs with a fixed binary field
         [Test]
-        public virtual void TestFixedBinary()
+        public virtual void TestFixedBinary([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BFixedBinary"));
             if (dir is MockDirectoryWrapper)
             {
                 ((MockDirectoryWrapper)dir).Throttling = MockDirectoryWrapper.Throttling_e.NEVER;
             }
-
-            IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
-           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
+            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                            .SetRAMBufferSizeMB(256.0)
+                            .SetMergeScheduler(scheduler)
+                            .SetMergePolicy(NewLogMergePolicy(false, 10))
+                            .SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE);
+            IndexWriter w = new IndexWriter(dir, config);
 
             Document doc = new Document();
             var bytes = new byte[4];
@@ -104,7 +108,7 @@ namespace Lucene.Net.Index
 
         // indexes Integer.MAX_VALUE docs with a variable binary field
         [Test]
-        public virtual void TestVariableBinary()
+        public virtual void TestVariableBinary([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BVariableBinary"));
             if (dir is MockDirectoryWrapper)
@@ -112,8 +116,13 @@ namespace Lucene.Net.Index
                 ((MockDirectoryWrapper)dir).Throttling = MockDirectoryWrapper.Throttling_e.NEVER;
             }
 
-            IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
-           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
+            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                            .SetRAMBufferSizeMB(256.0)
+                            .SetMergeScheduler(scheduler)
+                            .SetMergePolicy(NewLogMergePolicy(false, 10))
+                            .SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE);
+            IndexWriter w = new IndexWriter(dir, config);
 
             Document doc = new Document();
             var bytes = new byte[4];

--- a/src/Lucene.Net.Tests/core/Index/Test2BNumericDocValues.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BNumericDocValues.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Index
     {
         // indexes Integer.MAX_VALUE docs with an increasing dv field
         [Test]
-        public virtual void TestNumerics()
+        public virtual void TestNumerics([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BNumerics"));
             if (dir is MockDirectoryWrapper)
@@ -49,7 +49,7 @@ namespace Lucene.Net.Index
             }
 
             IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
-           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
+           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(scheduler).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
 
             Document doc = new Document();
             NumericDocValuesField dvField = new NumericDocValuesField("dv", 0);

--- a/src/Lucene.Net.Tests/core/Index/Test2BPositions.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BPositions.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Index
     {
         //ORIGINAL LINE: @Ignore("Very slow. Enable manually by removing @Ignore.") public void test() throws Exception
         [Test]
-        public virtual void Test()
+        public virtual void Test([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BPositions"));
             if (dir is MockDirectoryWrapper)
@@ -59,7 +59,7 @@ namespace Lucene.Net.Index
             }
 
             IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
-           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
+           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(scheduler).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
 
             MergePolicy mp = w.Config.MergePolicy;
             if (mp is LogByteSizeMergePolicy)

--- a/src/Lucene.Net.Tests/core/Index/Test2BPostings.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BPostings.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Index
     public class Test2BPostings : LuceneTestCase
     {
         [Test, LongRunningTest, Timeout(int.MaxValue)]
-        public virtual void Test()
+        public virtual void Test([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BPostings"));
             if (dir is MockDirectoryWrapper)
@@ -52,9 +52,14 @@ namespace Lucene.Net.Index
                 ((MockDirectoryWrapper)dir).Throttling = MockDirectoryWrapper.Throttling_e.NEVER;
             }
 
-            IndexWriterConfig iwc = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))).SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE);
+            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                            .SetRAMBufferSizeMB(256.0)
+                            .SetMergeScheduler(scheduler)
+                            .SetMergePolicy(NewLogMergePolicy(false, 10))
+                            .SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE);
 
-            IndexWriter w = new IndexWriter(dir, iwc);
+            IndexWriter w = new IndexWriter(dir, config);
 
             MergePolicy mp = w.Config.MergePolicy;
             if (mp is LogByteSizeMergePolicy)

--- a/src/Lucene.Net.Tests/core/Index/Test2BPostingsBytes.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BPostingsBytes.cs
@@ -52,7 +52,7 @@ namespace Lucene.Net.Index
     {
         //ORIGINAL LINE: @Ignore("Very slow. Enable manually by removing @Ignore.") public void test() throws Exception
         [Test]
-        public virtual void Test()
+        public virtual void Test([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BPostingsBytes1"));
             if (dir is MockDirectoryWrapper)
@@ -60,8 +60,13 @@ namespace Lucene.Net.Index
                 ((MockDirectoryWrapper)dir).Throttling = MockDirectoryWrapper.Throttling_e.NEVER;
             }
 
-            IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
-           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
+            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                            .SetRAMBufferSizeMB(256.0)
+                            .SetMergeScheduler(scheduler)
+                            .SetMergePolicy(NewLogMergePolicy(false, 10))
+                            .SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE);
+            IndexWriter w = new IndexWriter(dir, config);
 
             MergePolicy mp = w.Config.MergePolicy;
             if (mp is LogByteSizeMergePolicy)

--- a/src/Lucene.Net.Tests/core/Index/Test2BSortedDocValues.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BSortedDocValues.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Index
     {
         // indexes Integer.MAX_VALUE docs with a fixed binary field
         [Test]
-        public virtual void TestFixedSorted()
+        public virtual void TestFixedSorted([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BFixedSorted"));
             if (dir is MockDirectoryWrapper)
@@ -48,7 +48,11 @@ namespace Lucene.Net.Index
             }
 
             IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
-           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
+                                .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                                .SetRAMBufferSizeMB(256.0)
+                                .SetMergeScheduler(scheduler)
+                                .SetMergePolicy(NewLogMergePolicy(false, 10))
+                                .SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
 
             Document doc = new Document();
             var bytes = new byte[2];
@@ -97,7 +101,7 @@ namespace Lucene.Net.Index
 
         // indexes Integer.MAX_VALUE docs with a fixed binary field
         [Test]
-        public virtual void Test2BOrds()
+        public virtual void Test2BOrds([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BOrds"));
             if (dir is MockDirectoryWrapper)
@@ -105,8 +109,13 @@ namespace Lucene.Net.Index
                 ((MockDirectoryWrapper)dir).Throttling = MockDirectoryWrapper.Throttling_e.NEVER;
             }
 
-            IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
-           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
+            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                            .SetRAMBufferSizeMB(256.0)
+                            .SetMergeScheduler(scheduler)
+                            .SetMergePolicy(NewLogMergePolicy(false, 10))
+                            .SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE);
+            IndexWriter w = new IndexWriter(dir, config);
 
             Document doc = new Document();
             var bytes = new byte[4];

--- a/src/Lucene.Net.Tests/core/Index/Test2BTerms.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BTerms.cs
@@ -168,7 +168,7 @@ namespace Lucene.Net.Index
         //ORIGINAL LINE: @Ignore("Very slow. Enable manually by removing @Ignore.") public void test2BTerms() throws java.io.IOException
         [Ignore]
         [Test]
-        public virtual void Test2BTerms_Mem()
+        public virtual void Test2BTerms_Mem([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             if ("Lucene3x".Equals(Codec.Default.Name))
             {
@@ -192,7 +192,11 @@ namespace Lucene.Net.Index
             if (true)
             {
                 IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
-                                           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
+                                           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                                           .SetRAMBufferSizeMB(256.0)
+                                           .SetMergeScheduler(scheduler)
+                                           .SetMergePolicy(NewLogMergePolicy(false, 10))
+                                           .SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
 
                 MergePolicy mp = w.Config.MergePolicy;
                 if (mp is LogByteSizeMergePolicy)

--- a/src/Lucene.Net.Tests/core/Index/Test4GBStoredFields.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test4GBStoredFields.cs
@@ -40,12 +40,18 @@ namespace Lucene.Net.Index
     public class Test4GBStoredFields : LuceneTestCase
     {
         [Test]
-        public virtual void Test()
+        public virtual void Test([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             MockDirectoryWrapper dir = new MockDirectoryWrapper(Random(), new MMapDirectory(CreateTempDir("4GBStoredFields")));
             dir.Throttling = MockDirectoryWrapper.Throttling_e.NEVER;
 
-            IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH).SetRAMBufferSizeMB(256.0).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(false, 10)).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE));
+            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                            .SetRAMBufferSizeMB(256.0)
+                            .SetMergeScheduler(scheduler)
+                            .SetMergePolicy(NewLogMergePolicy(false, 10))
+                            .SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE);
+            IndexWriter w = new IndexWriter(dir, config);
 
             MergePolicy mp = w.Config.MergePolicy;
             if (mp is LogByteSizeMergePolicy)

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -222,13 +222,14 @@ namespace Lucene.Net.Index
         }
 
         [Test]
-        public virtual void TestChangesAfterClose()
+        public virtual void TestChangesAfterClose([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             Directory dir = NewDirectory();
 
             IndexWriter writer = null;
 
-            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())));
+            var config = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMergeScheduler(scheduler);
+            writer = new IndexWriter(dir, config);
             AddDoc(writer);
 
             // close

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterConfig.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterConfig.cs
@@ -61,7 +61,11 @@ namespace Lucene.Net.Index
             Assert.AreEqual(typeof(MockAnalyzer), conf.Analyzer.GetType());
             Assert.IsNull(conf.IndexCommit);
             Assert.AreEqual(typeof(KeepOnlyLastCommitDeletionPolicy), conf.DelPolicy.GetType());
+#if FEATURE_TASKMERGESCHEDULER
+            Assert.AreEqual(typeof(TaskMergeScheduler), conf.MergeScheduler.GetType());
+#else
             Assert.AreEqual(typeof(ConcurrentMergeScheduler), conf.MergeScheduler.GetType());
+#endif
             Assert.AreEqual(OpenMode_e.CREATE_OR_APPEND, conf.OpenMode);
             // we don't need to assert this, it should be unspecified
             Assert.IsTrue(IndexSearcher.DefaultSimilarity == conf.Similarity);
@@ -284,7 +288,11 @@ namespace Lucene.Net.Index
             Assert.IsTrue(mergeSched.GetType() == mergeSchedClone.GetType() && (mergeSched != mergeSchedClone || mergeSched.Clone() == mergeSchedClone.Clone()));
 
             conf.SetMergeScheduler(new SerialMergeScheduler());
+#if FEATURE_TASKMERGESCHEDULER
+            Assert.AreEqual(typeof(TaskMergeScheduler), clone.MergeScheduler.GetType());
+#else
             Assert.AreEqual(typeof(ConcurrentMergeScheduler), clone.MergeScheduler.GetType());
+#endif
         }
 
         [Test]
@@ -307,7 +315,11 @@ namespace Lucene.Net.Index
             }
 
             // Test MergeScheduler
+#if FEATURE_TASKMERGESCHEDULER
+            Assert.AreEqual(typeof(TaskMergeScheduler), conf.MergeScheduler.GetType());
+#else
             Assert.AreEqual(typeof(ConcurrentMergeScheduler), conf.MergeScheduler.GetType());
+#endif
             conf.SetMergeScheduler(new SerialMergeScheduler());
             Assert.AreEqual(typeof(SerialMergeScheduler), conf.MergeScheduler.GetType());
             try

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterConfig.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterConfig.cs
@@ -279,8 +279,8 @@ namespace Lucene.Net.Index
             MergePolicy mergePolicyClone = clone.MergePolicy;
             Assert.IsTrue(mergePolicy.GetType() == mergePolicyClone.GetType() && (mergePolicy != mergePolicyClone || mergePolicy.Clone() == mergePolicyClone.Clone()));
 
-            MergeScheduler mergeSched = conf.MergeScheduler;
-            MergeScheduler mergeSchedClone = clone.MergeScheduler;
+            IMergeScheduler mergeSched = conf.MergeScheduler;
+            IMergeScheduler mergeSchedClone = clone.MergeScheduler;
             Assert.IsTrue(mergeSched.GetType() == mergeSchedClone.GetType() && (mergeSched != mergeSchedClone || mergeSched.Clone() == mergeSchedClone.Clone()));
 
             conf.SetMergeScheduler(new SerialMergeScheduler());

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterConfig.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterConfig.cs
@@ -61,11 +61,7 @@ namespace Lucene.Net.Index
             Assert.AreEqual(typeof(MockAnalyzer), conf.Analyzer.GetType());
             Assert.IsNull(conf.IndexCommit);
             Assert.AreEqual(typeof(KeepOnlyLastCommitDeletionPolicy), conf.DelPolicy.GetType());
-#if FEATURE_TASKMERGESCHEDULER
-            Assert.AreEqual(typeof(TaskMergeScheduler), conf.MergeScheduler.GetType());
-#else
             Assert.AreEqual(typeof(ConcurrentMergeScheduler), conf.MergeScheduler.GetType());
-#endif
             Assert.AreEqual(OpenMode_e.CREATE_OR_APPEND, conf.OpenMode);
             // we don't need to assert this, it should be unspecified
             Assert.IsTrue(IndexSearcher.DefaultSimilarity == conf.Similarity);
@@ -288,11 +284,7 @@ namespace Lucene.Net.Index
             Assert.IsTrue(mergeSched.GetType() == mergeSchedClone.GetType() && (mergeSched != mergeSchedClone || mergeSched.Clone() == mergeSchedClone.Clone()));
 
             conf.SetMergeScheduler(new SerialMergeScheduler());
-#if FEATURE_TASKMERGESCHEDULER
-            Assert.AreEqual(typeof(TaskMergeScheduler), clone.MergeScheduler.GetType());
-#else
             Assert.AreEqual(typeof(ConcurrentMergeScheduler), clone.MergeScheduler.GetType());
-#endif
         }
 
         [Test]
@@ -315,11 +307,7 @@ namespace Lucene.Net.Index
             }
 
             // Test MergeScheduler
-#if FEATURE_TASKMERGESCHEDULER
-            Assert.AreEqual(typeof(TaskMergeScheduler), conf.MergeScheduler.GetType());
-#else
             Assert.AreEqual(typeof(ConcurrentMergeScheduler), conf.MergeScheduler.GetType());
-#endif
             conf.SetMergeScheduler(new SerialMergeScheduler());
             Assert.AreEqual(typeof(SerialMergeScheduler), conf.MergeScheduler.GetType());
             try

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -310,7 +310,7 @@ namespace Lucene.Net.Index
         }
 
         [Test]
-        public virtual void TestRandomExceptions()
+        public virtual void TestRandomExceptions([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             if (VERBOSE)
             {
@@ -321,8 +321,14 @@ namespace Lucene.Net.Index
             MockAnalyzer analyzer = new MockAnalyzer(Random());
             analyzer.EnableChecks = false; // disable workflow checking as we forcefully close() in exceptional cases.
 
-            IndexWriter writer = RandomIndexWriter.MockIndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer).SetRAMBufferSizeMB(0.1).SetMergeScheduler(new ConcurrentMergeScheduler()), new TestPoint1(this));
-            ((ConcurrentMergeScheduler)writer.Config.MergeScheduler).SetSuppressExceptions();
+
+            var config = NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer)
+                            .SetRAMBufferSizeMB(0.1)
+                            .SetMergeScheduler(scheduler);
+
+            scheduler.SetSuppressExceptions();
+
+            IndexWriter writer = RandomIndexWriter.MockIndexWriter(dir, config , new TestPoint1(this));
             //writer.SetMaxBufferedDocs(10);
             if (VERBOSE)
             {
@@ -366,13 +372,19 @@ namespace Lucene.Net.Index
         }
 
         [Test]
-        public virtual void TestRandomExceptionsThreads()
+        public virtual void TestRandomExceptionsThreads([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             Directory dir = NewDirectory();
             MockAnalyzer analyzer = new MockAnalyzer(Random());
             analyzer.EnableChecks = false; // disable workflow checking as we forcefully close() in exceptional cases.
-            IndexWriter writer = RandomIndexWriter.MockIndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer).SetRAMBufferSizeMB(0.2).SetMergeScheduler(new ConcurrentMergeScheduler()), new TestPoint1(this));
-            ((ConcurrentMergeScheduler)writer.Config.MergeScheduler).SetSuppressExceptions();
+
+            var config = NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer)
+                            .SetRAMBufferSizeMB(0.2)
+                            .SetMergeScheduler(scheduler);
+
+            IndexWriter writer = RandomIndexWriter.MockIndexWriter(dir, config, new TestPoint1(this));
+            scheduler.SetSuppressExceptions();
+
             //writer.SetMaxBufferedDocs(10);
             writer.Commit();
 
@@ -553,13 +565,13 @@ namespace Lucene.Net.Index
 
         // LUCENE-1210
         [Test]
-        public virtual void TestExceptionOnMergeInit()
+        public virtual void TestExceptionOnMergeInit([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             Directory dir = NewDirectory();
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(2).SetMergePolicy(NewLogMergePolicy());
-            ConcurrentMergeScheduler cms = new ConcurrentMergeScheduler();
-            cms.SetSuppressExceptions();
-            conf.SetMergeScheduler(cms);
+
+            scheduler.SetSuppressExceptions();
+            conf.SetMergeScheduler(scheduler);
             ((LogMergePolicy)conf.MergePolicy).MergeFactor = 2;
             TestPoint3 testPoint = new TestPoint3();
             IndexWriter w = RandomIndexWriter.MockIndexWriter(dir, conf, testPoint);
@@ -572,13 +584,13 @@ namespace Lucene.Net.Index
                 {
                     w.AddDocument(doc);
                 }
-                catch (Exception re)
+                catch (Exception)
                 {
                     break;
                 }
             }
 
-            ((ConcurrentMergeScheduler)w.Config.MergeScheduler).Sync();
+            ((IConcurrentMergeScheduler)w.Config.MergeScheduler).Sync();
             Assert.IsTrue(testPoint.Failed);
             w.Dispose();
             dir.Dispose();
@@ -1088,13 +1100,18 @@ namespace Lucene.Net.Index
 
         // LUCENE-1044: test exception during sync
         [Test]
-        public virtual void TestExceptionDuringSync()
+        public virtual void TestExceptionDuringSync([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             MockDirectoryWrapper dir = NewMockDirectory();
             FailOnlyInSync failure = new FailOnlyInSync();
             dir.FailOn(failure);
 
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(2).SetMergeScheduler(new ConcurrentMergeScheduler()).SetMergePolicy(NewLogMergePolicy(5)));
+            var config = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                            .SetMaxBufferedDocs(2)
+                            .SetMergeScheduler(scheduler)
+                            .SetMergePolicy(NewLogMergePolicy(5));
+
+            IndexWriter writer = new IndexWriter(dir, config);
             failure.SetDoFail();
 
             for (int i = 0; i < 23; i++)
@@ -1112,7 +1129,7 @@ namespace Lucene.Net.Index
                     }
                 }
             }
-            ((ConcurrentMergeScheduler)writer.Config.MergeScheduler).Sync();
+            ((IConcurrentMergeScheduler)writer.Config.MergeScheduler).Sync();
             Assert.IsTrue(failure.DidFail);
             failure.ClearDoFail();
             writer.Dispose();
@@ -1221,7 +1238,7 @@ namespace Lucene.Net.Index
         }
 
         [Test]
-        public virtual void TestForceMergeExceptions()
+        public virtual void TestForceMergeExceptions([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             Directory startDir = NewDirectory();
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(2).SetMergePolicy(NewLogMergePolicy());
@@ -1241,8 +1258,8 @@ namespace Lucene.Net.Index
                     Console.WriteLine("TEST: iter " + i);
                 }
                 MockDirectoryWrapper dir = new MockDirectoryWrapper(Random(), new RAMDirectory(startDir, NewIOContext(Random())));
-                conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMergeScheduler(new ConcurrentMergeScheduler());
-                ((ConcurrentMergeScheduler)conf.MergeScheduler).SetSuppressExceptions();
+                conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMergeScheduler(scheduler);
+                scheduler.SetSuppressExceptions();
                 w = new IndexWriter(dir, conf);
                 dir.RandomIOExceptionRate = 0.5;
                 try

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -2150,11 +2150,11 @@ namespace Lucene.Net.Index
                 if (w == null)
                 {
                     IndexWriterConfig iwc = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()));
-                    MergeScheduler ms = iwc.MergeScheduler;
-                    if (ms is ConcurrentMergeScheduler)
+                    IMergeScheduler ms = iwc.MergeScheduler;
+                    if (ms is IConcurrentMergeScheduler)
                     {
                         ConcurrentMergeScheduler suppressFakeIOE = new ConcurrentMergeSchedulerAnonymousInnerClassHelper(this);
-                        ConcurrentMergeScheduler cms = (ConcurrentMergeScheduler)ms;
+                        IConcurrentMergeScheduler cms = (IConcurrentMergeScheduler)ms;
                         suppressFakeIOE.SetMaxMergesAndThreads(cms.MaxMergeCount, cms.MaxThreadCount);
                         suppressFakeIOE.MergeThreadPriority = cms.MergeThreadPriority;
                         iwc.SetMergeScheduler(suppressFakeIOE);

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterForceMerge.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterForceMerge.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Index
         }
 
         [Test]
-        public virtual void TestMaxNumSegments2()
+        public virtual void TestMaxNumSegments2([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             Directory dir = NewDirectory();
 
@@ -91,7 +91,11 @@ namespace Lucene.Net.Index
             LogDocMergePolicy ldmp = new LogDocMergePolicy();
             ldmp.MinMergeDocs = 1;
             ldmp.MergeFactor = 4;
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(2).SetMergePolicy(ldmp).SetMergeScheduler(new ConcurrentMergeScheduler()));
+            var config = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                            .SetMaxBufferedDocs(2)
+                            .SetMergePolicy(ldmp)
+                            .SetMergeScheduler(scheduler);
+            IndexWriter writer = new IndexWriter(dir, config);
 
             for (int iter = 0; iter < 10; iter++)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterMergePolicy.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterMergePolicy.cs
@@ -178,7 +178,7 @@ namespace Lucene.Net.Index
 
         // Test the case where a merge results in no doc at all
         [Test]
-        public virtual void TestMergeDocCount0()
+        public virtual void TestMergeDocCount0([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             Directory dir = NewDirectory();
 
@@ -200,7 +200,12 @@ namespace Lucene.Net.Index
 
             ldmp = new LogDocMergePolicy();
             ldmp.MergeFactor = 5;
-            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetOpenMode(OpenMode_e.APPEND).SetMaxBufferedDocs(10).SetMergePolicy(ldmp).SetMergeScheduler(new ConcurrentMergeScheduler()));
+            var config = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                .SetOpenMode(OpenMode_e.APPEND)
+                .SetMaxBufferedDocs(10)
+                .SetMergePolicy(ldmp)
+                .SetMergeScheduler(scheduler);
+            writer = new IndexWriter(dir, config);
 
             // merge factor is changed, so check invariants after all adds
             for (int i = 0; i < 10; i++)

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterOnDiskFull.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterOnDiskFull.cs
@@ -631,10 +631,13 @@ namespace Lucene.Net.Index
         // an IndexWriter (hit during DW.ThreadState.Init()) is
         // OK:
         [Test]
-        public virtual void TestImmediateDiskFull()
+        public virtual void TestImmediateDiskFull([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             MockDirectoryWrapper dir = NewMockDirectory();
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(2).SetMergeScheduler(new ConcurrentMergeScheduler()));
+            var config = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                            .SetMaxBufferedDocs(2)
+                            .SetMergeScheduler(scheduler);
+            IndexWriter writer = new IndexWriter(dir, config);
             dir.MaxSizeInBytes = Math.Max(1, dir.RecomputedActualSizeInBytes);
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);
@@ -644,7 +647,7 @@ namespace Lucene.Net.Index
                 writer.AddDocument(doc);
                 Assert.Fail("did not hit disk full");
             }
-            catch (IOException ioe)
+            catch (IOException)
             {
             }
             // Without fix for LUCENE-1130: this call will hang:
@@ -653,7 +656,7 @@ namespace Lucene.Net.Index
                 writer.AddDocument(doc);
                 Assert.Fail("did not hit disk full");
             }
-            catch (IOException ioe)
+            catch (IOException)
             {
             }
             try
@@ -661,7 +664,7 @@ namespace Lucene.Net.Index
                 writer.Dispose(false);
                 Assert.Fail("did not hit disk full");
             }
-            catch (IOException ioe)
+            catch (IOException)
             {
             }
 

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterOnDiskFull.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterOnDiskFull.cs
@@ -72,13 +72,13 @@ namespace Lucene.Net.Index
                     MockDirectoryWrapper dir = new MockDirectoryWrapper(Random(), new RAMDirectory());
                     dir.MaxSizeInBytes = diskFree;
                     IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())));
-                    MergeScheduler ms = writer.Config.MergeScheduler;
-                    if (ms is ConcurrentMergeScheduler)
+                    IMergeScheduler ms = writer.Config.MergeScheduler;
+                    if (ms is IConcurrentMergeScheduler)
                     {
                         // this test intentionally produces exceptions
                         // in the threads that CMS launches; we don't
                         // want to pollute test output with these.
-                        ((ConcurrentMergeScheduler)ms).SetSuppressExceptions();
+                        ((IConcurrentMergeScheduler)ms).SetSuppressExceptions();
                     }
 
                     bool hitError = false;
@@ -297,21 +297,21 @@ namespace Lucene.Net.Index
                     indWriter = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetOpenMode(OpenMode_e.APPEND).SetMergePolicy(NewLogMergePolicy(false)));
                     IOException err = null;
 
-                    MergeScheduler ms = indWriter.Config.MergeScheduler;
+                    IMergeScheduler ms = indWriter.Config.MergeScheduler;
                     for (int x = 0; x < 2; x++)
                     {
-                        if (ms is ConcurrentMergeScheduler)
+                        if (ms is IConcurrentMergeScheduler)
                         // this test intentionally produces exceptions
                         // in the threads that CMS launches; we don't
                         // want to pollute test output with these.
                         {
                             if (0 == x)
                             {
-                                ((ConcurrentMergeScheduler)ms).SetSuppressExceptions();
+                                ((IConcurrentMergeScheduler)ms).SetSuppressExceptions();
                             }
                             else
                             {
-                                ((ConcurrentMergeScheduler)ms).ClearSuppressExceptions();
+                                ((IConcurrentMergeScheduler)ms).ClearSuppressExceptions();
                             }
                         }
 

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterOutOfFileDescriptors.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterOutOfFileDescriptors.cs
@@ -70,10 +70,10 @@ namespace Lucene.Net.Index
                         // we see incrementing messageID:
                         iwc.InfoStream = new PrintStreamInfoStream(Console.Out);
                     }
-                    MergeScheduler ms = iwc.MergeScheduler;
-                    if (ms is ConcurrentMergeScheduler)
+                    var ms = iwc.MergeScheduler;
+                    if (ms is IConcurrentMergeScheduler)
                     {
-                        ((ConcurrentMergeScheduler)ms).SetSuppressExceptions();
+                        ((IConcurrentMergeScheduler)ms).SetSuppressExceptions();
                     }
                     w = new IndexWriter(dir, iwc);
                     if (r != null && Random().Next(5) == 3)

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
@@ -147,7 +147,7 @@ namespace Lucene.Net.Index
           stress test.
         */
 
-        public virtual void RunStressTest(Directory directory, MergeScheduler mergeScheduler)
+        public virtual void RunStressTest(Directory directory, IConcurrentMergeScheduler mergeScheduler)
         {
             IndexWriter modifier = new IndexWriter(directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetOpenMode(OpenMode_e.CREATE).SetMaxBufferedDocs(10).SetMergeScheduler(mergeScheduler));
             modifier.Commit();
@@ -198,7 +198,7 @@ namespace Lucene.Net.Index
         */
 
         [Test]
-        public virtual void TestStressIndexAndSearching()
+        public virtual void TestStressIndexAndSearching([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {
             Directory directory = NewDirectory();
             MockDirectoryWrapper wrapper = directory as MockDirectoryWrapper;
@@ -207,7 +207,7 @@ namespace Lucene.Net.Index
                 wrapper.AssertNoUnrefencedFilesOnClose = true;
             }
 
-            RunStressTest(directory, new ConcurrentMergeScheduler());
+            RunStressTest(directory, scheduler);
             directory.Dispose();
         }
     }

--- a/src/Lucene.Net.Tests/core/TestMergeSchedulerExternal.cs
+++ b/src/Lucene.Net.Tests/core/TestMergeSchedulerExternal.cs
@@ -76,7 +76,9 @@ namespace Lucene.Net.Tests
             {
                 MergeThread thread = new MyMergeThread(this, writer, merge);
                 thread.ThreadPriority = MergeThreadPriority;
+#if !FEATURE_TASKMERGESCHEDULER
                 thread.SetDaemon(true);
+#endif
                 thread.Name = "MyMergeThread";
                 return thread;
             }

--- a/src/Lucene.Net.Tests/core/TestMergeSchedulerExternal.cs
+++ b/src/Lucene.Net.Tests/core/TestMergeSchedulerExternal.cs
@@ -76,9 +76,7 @@ namespace Lucene.Net.Tests
             {
                 MergeThread thread = new MyMergeThread(this, writer, merge);
                 thread.ThreadPriority = MergeThreadPriority;
-#if !FEATURE_TASKMERGESCHEDULER
                 thread.SetDaemon(true);
-#endif
                 thread.Name = "MyMergeThread";
                 return thread;
             }


### PR DESCRIPTION
- Adds a MergeScheduler that uses Tasks (default is still ConcurrentMergeScheduler)
- Adds tests to test TaskMergeScheduler

- Added the NUnit Project Guid that was continuously added by Visual Studio