### PR TITLE
IndexableField API Consistency Fix

### DIFF
--- a/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
+++ b/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
@@ -97,19 +97,19 @@ namespace Lucene.Net.Classification.Utils
                         {
                             if (storableField.ReaderValue != null)
                             {
-                                doc.Add(new Field(storableField.Name(), storableField.ReaderValue, ft));
+                                doc.Add(new Field(storableField.Name, storableField.ReaderValue, ft));
                             }
                             else if (storableField.BinaryValue() != null)
                             {
-                                doc.Add(new Field(storableField.Name(), storableField.BinaryValue(), ft));
+                                doc.Add(new Field(storableField.Name, storableField.BinaryValue(), ft));
                             }
                             else if (storableField.StringValue != null)
                             {
-                                doc.Add(new Field(storableField.Name(), storableField.StringValue, ft));
+                                doc.Add(new Field(storableField.Name, storableField.StringValue, ft));
                             }
                             else if (storableField.NumericValue != null)
                             {
-                                doc.Add(new Field(storableField.Name(), storableField.NumericValue.ToString(), ft));
+                                doc.Add(new Field(storableField.Name, storableField.NumericValue.ToString(), ft));
                             }
                         }
                     }

--- a/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
+++ b/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
@@ -99,9 +99,9 @@ namespace Lucene.Net.Classification.Utils
                             {
                                 doc.Add(new Field(storableField.Name, storableField.ReaderValue, ft));
                             }
-                            else if (storableField.BinaryValue() != null)
+                            else if (storableField.BinaryValue != null)
                             {
-                                doc.Add(new Field(storableField.Name, storableField.BinaryValue(), ft));
+                                doc.Add(new Field(storableField.Name, storableField.BinaryValue, ft));
                             }
                             else if (storableField.StringValue != null)
                             {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsWriter.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsWriter.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Codecs.SimpleText
             NewLine();
 
             Write(NAME);
-            Write(field.Name());
+            Write(field.Name);
             NewLine();
 
             Write(TYPE);
@@ -166,7 +166,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 }
                 else if (field.StringValue == null)
                 {
-                    throw new ArgumentException("field " + field.Name() +
+                    throw new ArgumentException("field " + field.Name +
                                                        " is stored but does not have binaryValue, stringValue nor numericValue");
                 }
                 else

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsWriter.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsWriter.cs
@@ -154,7 +154,7 @@ namespace Lucene.Net.Codecs.SimpleText
             }
             else
             {
-                BytesRef bytes = field.BinaryValue();
+                BytesRef bytes = field.BinaryValue;
                 if (bytes != null)
                 {
                     Write(TYPE_BINARY);

--- a/src/Lucene.Net.Core/Codecs/Compressing/CompressingStoredFieldsWriter.cs
+++ b/src/Lucene.Net.Core/Codecs/Compressing/CompressingStoredFieldsWriter.cs
@@ -328,7 +328,7 @@ namespace Lucene.Net.Codecs.Compressing
                     @string = field.StringValue;
                     if (@string == null)
                     {
-                        throw new System.ArgumentException("field " + field.Name() + " is stored but does not have binaryValue, stringValue nor numericValue");
+                        throw new System.ArgumentException("field " + field.Name + " is stored but does not have binaryValue, stringValue nor numericValue");
                     }
                 }
             }

--- a/src/Lucene.Net.Core/Codecs/Compressing/CompressingStoredFieldsWriter.cs
+++ b/src/Lucene.Net.Core/Codecs/Compressing/CompressingStoredFieldsWriter.cs
@@ -316,7 +316,7 @@ namespace Lucene.Net.Codecs.Compressing
             }
             else
             {
-                bytes = field.BinaryValue();
+                bytes = field.BinaryValue;
                 if (bytes != null)
                 {
                     bits = BYTE_ARR;

--- a/src/Lucene.Net.Core/Codecs/Lucene40/Lucene40StoredFieldsWriter.cs
+++ b/src/Lucene.Net.Core/Codecs/Lucene40/Lucene40StoredFieldsWriter.cs
@@ -188,7 +188,7 @@ namespace Lucene.Net.Codecs.Lucene40
             }
             else
             {
-                bytes = field.BinaryValue();
+                bytes = field.BinaryValue;
                 if (bytes != null)
                 {
                     bits |= FIELD_IS_BINARY;

--- a/src/Lucene.Net.Core/Codecs/Lucene40/Lucene40StoredFieldsWriter.cs
+++ b/src/Lucene.Net.Core/Codecs/Lucene40/Lucene40StoredFieldsWriter.cs
@@ -199,7 +199,7 @@ namespace Lucene.Net.Codecs.Lucene40
                     @string = field.StringValue;
                     if (@string == null)
                     {
-                        throw new System.ArgumentException("field " + field.Name() + " is stored but does not have binaryValue, stringValue nor numericValue");
+                        throw new System.ArgumentException("field " + field.Name + " is stored but does not have binaryValue, stringValue nor numericValue");
                     }
                 }
             }

--- a/src/Lucene.Net.Core/Codecs/StoredFieldsWriter.cs
+++ b/src/Lucene.Net.Core/Codecs/StoredFieldsWriter.cs
@@ -145,7 +145,7 @@ namespace Lucene.Net.Codecs
             {
                 if (field.FieldType().Stored)
                 {
-                    WriteField(fieldInfos.FieldInfo(field.Name()), field);
+                    WriteField(fieldInfos.FieldInfo(field.Name), field);
                 }
             }
 

--- a/src/Lucene.Net.Core/Codecs/StoredFieldsWriter.cs
+++ b/src/Lucene.Net.Core/Codecs/StoredFieldsWriter.cs
@@ -133,7 +133,7 @@ namespace Lucene.Net.Codecs
             int storedCount = 0;
             foreach (IndexableField field in doc)
             {
-                if (field.FieldType().Stored)
+                if (field.FieldType.Stored)
                 {
                     storedCount++;
                 }
@@ -143,7 +143,7 @@ namespace Lucene.Net.Codecs
 
             foreach (IndexableField field in doc)
             {
-                if (field.FieldType().Stored)
+                if (field.FieldType.Stored)
                 {
                     WriteField(fieldInfos.FieldInfo(field.Name), field);
                 }

--- a/src/Lucene.Net.Core/Document/Document.cs
+++ b/src/Lucene.Net.Core/Document/Document.cs
@@ -134,7 +134,7 @@ namespace Lucene.Net.Documents
             {
                 if (field.Name.Equals(name))
                 {
-                    BytesRef bytes = field.BinaryValue();
+                    BytesRef bytes = field.BinaryValue;
 
                     if (bytes != null)
                     {
@@ -160,7 +160,7 @@ namespace Lucene.Net.Documents
             {
                 if (field.Name.Equals(name))
                 {
-                    BytesRef bytes = field.BinaryValue();
+                    BytesRef bytes = field.BinaryValue;
                     if (bytes != null)
                     {
                         return bytes;

--- a/src/Lucene.Net.Core/Document/Document.cs
+++ b/src/Lucene.Net.Core/Document/Document.cs
@@ -88,7 +88,7 @@ namespace Lucene.Net.Documents
             {
                 IndexableField field = fields[i];
 
-                if (field.Name().Equals(name))
+                if (field.Name.Equals(name))
                 {
                     fields.RemoveAt(i);
                     return;
@@ -111,7 +111,7 @@ namespace Lucene.Net.Documents
             {
                 IndexableField field = fields[i];
 
-                if (field.Name().Equals(name))
+                if (field.Name.Equals(name))
                 {
                     fields.RemoveAt(i);
                 }
@@ -132,7 +132,7 @@ namespace Lucene.Net.Documents
 
             foreach (IndexableField field in fields)
             {
-                if (field.Name().Equals(name))
+                if (field.Name.Equals(name))
                 {
                     BytesRef bytes = field.BinaryValue();
 
@@ -158,7 +158,7 @@ namespace Lucene.Net.Documents
         {
             foreach (IndexableField field in fields)
             {
-                if (field.Name().Equals(name))
+                if (field.Name.Equals(name))
                 {
                     BytesRef bytes = field.BinaryValue();
                     if (bytes != null)
@@ -179,7 +179,7 @@ namespace Lucene.Net.Documents
         {
             foreach (IndexableField field in fields)
             {
-                if (field.Name().Equals(name))
+                if (field.Name.Equals(name))
                 {
                     return field;
                 }
@@ -199,7 +199,7 @@ namespace Lucene.Net.Documents
             var result = new List<IndexableField>();
             foreach (IndexableField field in fields)
             {
-                if (field.Name().Equals(name))
+                if (field.Name.Equals(name))
                 {
                     result.Add(field);
                 }
@@ -239,7 +239,7 @@ namespace Lucene.Net.Documents
             var result = new List<string>();
             foreach (IndexableField field in fields)
             {
-                if (field.Name().Equals(name) && field.StringValue != null)
+                if (field.Name.Equals(name) && field.StringValue != null)
                 {
                     result.Add(field.StringValue);
                 }
@@ -266,7 +266,7 @@ namespace Lucene.Net.Documents
         {
             foreach (IndexableField field in fields)
             {
-                if (field.Name().Equals(name) && field.StringValue != null)
+                if (field.Name.Equals(name) && field.StringValue != null)
                 {
                     return field.StringValue;
                 }

--- a/src/Lucene.Net.Core/Document/Field.cs
+++ b/src/Lucene.Net.Core/Document/Field.cs
@@ -571,18 +571,18 @@ namespace Lucene.Net.Documents
 
         /// <summary>
         /// Returns the <seealso cref="FieldType"/> for this field. </summary>
-        public IndexableFieldType FieldType()
+        public IndexableFieldType FieldType
         {
-            return Type;
+            get { return Type; }
         }
 
         public TokenStream GetTokenStream(Analyzer analyzer)
         {
-            if (!((FieldType)FieldType()).Indexed)
+            if (!((FieldType)FieldType).Indexed)
             {
                 return null;
             }
-            FieldType.NumericType? numericType = ((FieldType)FieldType()).NumericTypeValue;
+            FieldType.NumericType? numericType = ((FieldType)FieldType).NumericTypeValue;
             if (numericType != null)
             {
                 if (!(InternalTokenStream is NumericTokenStream))
@@ -618,7 +618,7 @@ namespace Lucene.Net.Documents
                 return InternalTokenStream;
             }
 
-            if (!((FieldType)FieldType()).Tokenized)
+            if (!((FieldType)FieldType).Tokenized)
             {
                 if (StringValue == null)
                 {

--- a/src/Lucene.Net.Core/Document/Field.cs
+++ b/src/Lucene.Net.Core/Document/Field.cs
@@ -486,22 +486,17 @@ namespace Lucene.Net.Documents
         }
 
         /// <summary>
-        /// {@inheritDoc}
-        /// <p>
-        /// The default value is <code>1.0f</code> (no boost). </summary>
-        /// <seealso> cref= #setBoost(float) </seealso>
-        public float GetBoost()
-        {
-            return Boost_Renamed;
-        }
-
-        /// <summary>
-        /// Sets the boost factor on this field. </summary>
+        /// Gets or sets the boost factor on this field. </summary>
+        /// <remarks>The default value is <code>1.0f</code> (no boost).</remarks>
         /// <exception cref="IllegalArgumentException"> if this field is not indexed,
         ///         or if it omits norms. </exception>
         /// <seealso> cref= #boost() </seealso>
         public virtual float Boost
         {
+            get
+            {
+                return Boost_Renamed;
+            }
             set
             {
                 if (value != 1.0f)

--- a/src/Lucene.Net.Core/Document/Field.cs
+++ b/src/Lucene.Net.Core/Document/Field.cs
@@ -533,15 +533,18 @@ namespace Lucene.Net.Documents
             }
         }
 
-        public BytesRef BinaryValue()
+        public BytesRef BinaryValue
         {
-            if (FieldsData is BytesRef)
+            get
             {
-                return (BytesRef)FieldsData;
-            }
-            else
-            {
-                return null;
+                if (FieldsData is BytesRef)
+                {
+                    return (BytesRef)FieldsData;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 

--- a/src/Lucene.Net.Core/Document/Field.cs
+++ b/src/Lucene.Net.Core/Document/Field.cs
@@ -480,9 +480,9 @@ namespace Lucene.Net.Documents
             }
         }
 
-        public string Name()
+        public string Name
         {
-            return Name_Renamed;
+            get { return Name_Renamed; }
         }
 
         /// <summary>
@@ -640,12 +640,12 @@ namespace Lucene.Net.Documents
             }
             else if (ReaderValue != null)
             {
-                return analyzer.TokenStream(Name(), ReaderValue);
+                return analyzer.TokenStream(Name, ReaderValue);
             }
             else if (StringValue != null)
             {
                 TextReader sr = new StringReader(StringValue);
-                return analyzer.TokenStream(Name(), sr);
+                return analyzer.TokenStream(Name, sr);
             }
 
             throw new System.ArgumentException("Field must have either TokenStream, String, Reader or Number value; got " + this);

--- a/src/Lucene.Net.Core/Index/DocFieldProcessor.cs
+++ b/src/Lucene.Net.Core/Index/DocFieldProcessor.cs
@@ -208,7 +208,7 @@ namespace Lucene.Net.Index
 
             foreach (IndexableField field in DocState.Doc)
             {
-                string fieldName = field.Name();
+                string fieldName = field.Name;
 
                 // Make sure we have a PerField allocated
                 int hashPos = fieldName.GetHashCode() & HashMask;

--- a/src/Lucene.Net.Core/Index/DocFieldProcessor.cs
+++ b/src/Lucene.Net.Core/Index/DocFieldProcessor.cs
@@ -225,7 +225,7 @@ namespace Lucene.Net.Index
                     // needs to be more "pluggable" such that if I want
                     // to have a new "thing" my Fields can do, I can
                     // easily add it
-                    FieldInfo fi = fieldInfos.AddOrUpdate(fieldName, field.FieldType());
+                    FieldInfo fi = fieldInfos.AddOrUpdate(fieldName, field.FieldType);
 
                     fp = new DocFieldProcessorPerField(this, fi);
                     fp.Next = FieldHash[hashPos];
@@ -241,7 +241,7 @@ namespace Lucene.Net.Index
                 {
                     // need to addOrUpdate so that FieldInfos can update globalFieldNumbers
                     // with the correct DocValue type (LUCENE-5192)
-                    FieldInfo fi = fieldInfos.AddOrUpdate(fieldName, field.FieldType());
+                    FieldInfo fi = fieldInfos.AddOrUpdate(fieldName, field.FieldType);
                     Debug.Assert(fi == fp.FieldInfo, "should only have updated an existing FieldInfo instance");
                 }
 

--- a/src/Lucene.Net.Core/Index/DocInverterPerField.cs
+++ b/src/Lucene.Net.Core/Index/DocInverterPerField.cs
@@ -79,7 +79,7 @@ namespace Lucene.Net.Index
                     bool analyzed = fieldType.Tokenized && DocState.Analyzer != null;
 
                     // if the field omits norms, the boost cannot be indexed.
-                    if (fieldType.OmitNorms && field.GetBoost() != 1.0f)
+                    if (fieldType.OmitNorms && field.Boost != 1.0f)
                     {
                         throw new System.NotSupportedException("You cannot set an index-time boost: norms are omitted for field '" + field.Name + "'");
                     }
@@ -234,7 +234,7 @@ namespace Lucene.Net.Index
                     }
 
                     FieldState.Offset_Renamed += analyzed ? DocState.Analyzer.GetOffsetGap(fieldInfo.Name) : 0;
-                    FieldState.Boost_Renamed *= field.GetBoost();
+                    FieldState.Boost_Renamed *= field.Boost;
                 }
 
                 // LUCENE-2387: don't hang onto the field, so GC can

--- a/src/Lucene.Net.Core/Index/DocInverterPerField.cs
+++ b/src/Lucene.Net.Core/Index/DocInverterPerField.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Index
             for (int i = 0; i < count; i++)
             {
                 IndexableField field = fields[i];
-                IndexableFieldType fieldType = field.FieldType();
+                IndexableFieldType fieldType = field.FieldType;
 
                 // TODO FI: this should be "genericized" to querying
                 // consumer if it wants to see this particular field

--- a/src/Lucene.Net.Core/Index/DocInverterPerField.cs
+++ b/src/Lucene.Net.Core/Index/DocInverterPerField.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Index
                     // if the field omits norms, the boost cannot be indexed.
                     if (fieldType.OmitNorms && field.GetBoost() != 1.0f)
                     {
-                        throw new System.NotSupportedException("You cannot set an index-time boost: norms are omitted for field '" + field.Name() + "'");
+                        throw new System.NotSupportedException("You cannot set an index-time boost: norms are omitted for field '" + field.Name + "'");
                     }
 
                     // only bother checking offsets if something will consume them.
@@ -131,11 +131,11 @@ namespace Lucene.Net.Index
                                 int posIncr = posIncrAttribute.PositionIncrement;
                                 if (posIncr < 0)
                                 {
-                                    throw new System.ArgumentException("position increment must be >=0 (got " + posIncr + ") for field '" + field.Name() + "'");
+                                    throw new System.ArgumentException("position increment must be >=0 (got " + posIncr + ") for field '" + field.Name + "'");
                                 }
                                 if (FieldState.Position_Renamed == 0 && posIncr == 0)
                                 {
-                                    throw new System.ArgumentException("first position increment must be > 0 (got 0) for field '" + field.Name() + "'");
+                                    throw new System.ArgumentException("first position increment must be > 0 (got 0) for field '" + field.Name + "'");
                                 }
                                 int position = FieldState.Position_Renamed + posIncr;
                                 if (position > 0)
@@ -146,7 +146,7 @@ namespace Lucene.Net.Index
                                 }
                                 else if (position < 0)
                                 {
-                                    throw new System.ArgumentException("position overflow for field '" + field.Name() + "'");
+                                    throw new System.ArgumentException("position overflow for field '" + field.Name + "'");
                                 }
 
                                 // position is legal, we can safely place it in fieldState now.
@@ -164,11 +164,11 @@ namespace Lucene.Net.Index
                                     int endOffset = FieldState.Offset_Renamed + offsetAttribute.EndOffset();
                                     if (startOffset < 0 || endOffset < startOffset)
                                     {
-                                        throw new System.ArgumentException("startOffset must be non-negative, and endOffset must be >= startOffset, " + "startOffset=" + startOffset + ",endOffset=" + endOffset + " for field '" + field.Name() + "'");
+                                        throw new System.ArgumentException("startOffset must be non-negative, and endOffset must be >= startOffset, " + "startOffset=" + startOffset + ",endOffset=" + endOffset + " for field '" + field.Name + "'");
                                     }
                                     if (startOffset < lastStartOffset)
                                     {
-                                        throw new System.ArgumentException("offsets must not go backwards startOffset=" + startOffset + " is < lastStartOffset=" + lastStartOffset + " for field '" + field.Name() + "'");
+                                        throw new System.ArgumentException("offsets must not go backwards startOffset=" + startOffset + " is < lastStartOffset=" + lastStartOffset + " for field '" + field.Name + "'");
                                     }
                                     lastStartOffset = startOffset;
                                 }

--- a/src/Lucene.Net.Core/Index/DocValuesProcessor.cs
+++ b/src/Lucene.Net.Core/Index/DocValuesProcessor.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Index
 
         public override void AddField(int docID, IndexableField field, FieldInfo fieldInfo)
         {
-            DocValuesType_e? dvType = field.FieldType().DocValueType;
+            DocValuesType_e? dvType = field.FieldType.DocValueType;
             if (dvType != null)
             {
                 fieldInfo.DocValuesType = dvType;

--- a/src/Lucene.Net.Core/Index/DocValuesProcessor.cs
+++ b/src/Lucene.Net.Core/Index/DocValuesProcessor.cs
@@ -59,15 +59,15 @@ namespace Lucene.Net.Index
                 fieldInfo.DocValuesType = dvType;
                 if (dvType == DocValuesType_e.BINARY)
                 {
-                    AddBinaryField(fieldInfo, docID, field.BinaryValue());
+                    AddBinaryField(fieldInfo, docID, field.BinaryValue);
                 }
                 else if (dvType == DocValuesType_e.SORTED)
                 {
-                    AddSortedField(fieldInfo, docID, field.BinaryValue());
+                    AddSortedField(fieldInfo, docID, field.BinaryValue);
                 }
                 else if (dvType == DocValuesType_e.SORTED_SET)
                 {
-                    AddSortedSetField(fieldInfo, docID, field.BinaryValue());
+                    AddSortedSetField(fieldInfo, docID, field.BinaryValue);
                 }
                 else if (dvType == DocValuesType_e.NUMERIC)
                 {

--- a/src/Lucene.Net.Core/Index/FreqProxTermsWriterPerField.cs
+++ b/src/Lucene.Net.Core/Index/FreqProxTermsWriterPerField.cs
@@ -123,7 +123,7 @@ namespace Lucene.Net.Index
         {
             for (int i = 0; i < count; i++)
             {
-                if (fields[i].FieldType().Indexed)
+                if (fields[i].FieldType.Indexed)
                 {
                     return true;
                 }

--- a/src/Lucene.Net.Core/Index/IndexableField.cs
+++ b/src/Lucene.Net.Core/Index/IndexableField.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Index
         /// </summary>
         /// <seealso cref= Similarity#computeNorm(FieldInvertState) </seealso>
         /// <seealso cref= DefaultSimilarity#encodeNormValue(float) </seealso>
-        float GetBoost();
+        float Boost { get; }
 
         /// <summary>
         /// Non-null if this field has a binary value </summary>

--- a/src/Lucene.Net.Core/Index/IndexableField.cs
+++ b/src/Lucene.Net.Core/Index/IndexableField.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Non-null if this field has a binary value </summary>
-        BytesRef BinaryValue();
+        BytesRef BinaryValue { get; }
 
         /// <summary>
         /// Non-null if this field has a string value </summary>

--- a/src/Lucene.Net.Core/Index/IndexableField.cs
+++ b/src/Lucene.Net.Core/Index/IndexableField.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Index
     {
         /// <summary>
         /// Field name </summary>
-        string Name();
+        string Name { get; }
 
         /// <summary>
         /// <seealso cref="IndexableFieldType"/> describing the properties

--- a/src/Lucene.Net.Core/Index/IndexableField.cs
+++ b/src/Lucene.Net.Core/Index/IndexableField.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Index
         /// <seealso cref="IndexableFieldType"/> describing the properties
         /// of this field.
         /// </summary>
-        IndexableFieldType FieldType();
+        IndexableFieldType FieldType { get; }
 
         /// <summary>
         /// Returns the field's index-time boost.

--- a/src/Lucene.Net.Core/Index/StoredFieldsProcessor.cs
+++ b/src/Lucene.Net.Core/Index/StoredFieldsProcessor.cs
@@ -158,7 +158,7 @@ namespace Lucene.Net.Index
 
         public override void AddField(int docID, IndexableField field, FieldInfo fieldInfo)
         {
-            if (field.FieldType().Stored)
+            if (field.FieldType.Stored)
             {
                 if (NumStoredFields == StoredFields.Length)
                 {

--- a/src/Lucene.Net.Core/Index/TermVectorsConsumerPerField.cs
+++ b/src/Lucene.Net.Core/Index/TermVectorsConsumerPerField.cs
@@ -75,18 +75,18 @@ namespace Lucene.Net.Index
             for (int i = 0; i < count; i++)
             {
                 IndexableField field = fields[i];
-                if (field.FieldType().Indexed)
+                if (field.FieldType.Indexed)
                 {
-                    if (field.FieldType().StoreTermVectors)
+                    if (field.FieldType.StoreTermVectors)
                     {
                         DoVectors = true;
-                        DoVectorPositions |= field.FieldType().StoreTermVectorPositions;
-                        DoVectorOffsets |= field.FieldType().StoreTermVectorOffsets;
+                        DoVectorPositions |= field.FieldType.StoreTermVectorPositions;
+                        DoVectorOffsets |= field.FieldType.StoreTermVectorOffsets;
                         if (DoVectorPositions)
                         {
-                            DoVectorPayloads |= field.FieldType().StoreTermVectorPayloads;
+                            DoVectorPayloads |= field.FieldType.StoreTermVectorPayloads;
                         }
-                        else if (field.FieldType().StoreTermVectorPayloads)
+                        else if (field.FieldType.StoreTermVectorPayloads)
                         {
                             // TODO: move this check somewhere else, and impl the other missing ones
                             throw new System.ArgumentException("cannot index term vector payloads without term vector positions (field=\"" + field.Name + "\")");
@@ -94,15 +94,15 @@ namespace Lucene.Net.Index
                     }
                     else
                     {
-                        if (field.FieldType().StoreTermVectorOffsets)
+                        if (field.FieldType.StoreTermVectorOffsets)
                         {
                             throw new System.ArgumentException("cannot index term vector offsets when term vectors are not indexed (field=\"" + field.Name + "\")");
                         }
-                        if (field.FieldType().StoreTermVectorPositions)
+                        if (field.FieldType.StoreTermVectorPositions)
                         {
                             throw new System.ArgumentException("cannot index term vector positions when term vectors are not indexed (field=\"" + field.Name + "\")");
                         }
-                        if (field.FieldType().StoreTermVectorPayloads)
+                        if (field.FieldType.StoreTermVectorPayloads)
                         {
                             throw new System.ArgumentException("cannot index term vector payloads when term vectors are not indexed (field=\"" + field.Name + "\")");
                         }
@@ -110,19 +110,19 @@ namespace Lucene.Net.Index
                 }
                 else
                 {
-                    if (field.FieldType().StoreTermVectors)
+                    if (field.FieldType.StoreTermVectors)
                     {
                         throw new System.ArgumentException("cannot index term vectors when field is not indexed (field=\"" + field.Name + "\")");
                     }
-                    if (field.FieldType().StoreTermVectorOffsets)
+                    if (field.FieldType.StoreTermVectorOffsets)
                     {
                         throw new System.ArgumentException("cannot index term vector offsets when field is not indexed (field=\"" + field.Name + "\")");
                     }
-                    if (field.FieldType().StoreTermVectorPositions)
+                    if (field.FieldType.StoreTermVectorPositions)
                     {
                         throw new System.ArgumentException("cannot index term vector positions when field is not indexed (field=\"" + field.Name + "\")");
                     }
-                    if (field.FieldType().StoreTermVectorPayloads)
+                    if (field.FieldType.StoreTermVectorPayloads)
                     {
                         throw new System.ArgumentException("cannot index term vector payloads when field is not indexed (field=\"" + field.Name + "\")");
                     }

--- a/src/Lucene.Net.Core/Index/TermVectorsConsumerPerField.cs
+++ b/src/Lucene.Net.Core/Index/TermVectorsConsumerPerField.cs
@@ -89,22 +89,22 @@ namespace Lucene.Net.Index
                         else if (field.FieldType().StoreTermVectorPayloads)
                         {
                             // TODO: move this check somewhere else, and impl the other missing ones
-                            throw new System.ArgumentException("cannot index term vector payloads without term vector positions (field=\"" + field.Name() + "\")");
+                            throw new System.ArgumentException("cannot index term vector payloads without term vector positions (field=\"" + field.Name + "\")");
                         }
                     }
                     else
                     {
                         if (field.FieldType().StoreTermVectorOffsets)
                         {
-                            throw new System.ArgumentException("cannot index term vector offsets when term vectors are not indexed (field=\"" + field.Name() + "\")");
+                            throw new System.ArgumentException("cannot index term vector offsets when term vectors are not indexed (field=\"" + field.Name + "\")");
                         }
                         if (field.FieldType().StoreTermVectorPositions)
                         {
-                            throw new System.ArgumentException("cannot index term vector positions when term vectors are not indexed (field=\"" + field.Name() + "\")");
+                            throw new System.ArgumentException("cannot index term vector positions when term vectors are not indexed (field=\"" + field.Name + "\")");
                         }
                         if (field.FieldType().StoreTermVectorPayloads)
                         {
-                            throw new System.ArgumentException("cannot index term vector payloads when term vectors are not indexed (field=\"" + field.Name() + "\")");
+                            throw new System.ArgumentException("cannot index term vector payloads when term vectors are not indexed (field=\"" + field.Name + "\")");
                         }
                     }
                 }
@@ -112,19 +112,19 @@ namespace Lucene.Net.Index
                 {
                     if (field.FieldType().StoreTermVectors)
                     {
-                        throw new System.ArgumentException("cannot index term vectors when field is not indexed (field=\"" + field.Name() + "\")");
+                        throw new System.ArgumentException("cannot index term vectors when field is not indexed (field=\"" + field.Name + "\")");
                     }
                     if (field.FieldType().StoreTermVectorOffsets)
                     {
-                        throw new System.ArgumentException("cannot index term vector offsets when field is not indexed (field=\"" + field.Name() + "\")");
+                        throw new System.ArgumentException("cannot index term vector offsets when field is not indexed (field=\"" + field.Name + "\")");
                     }
                     if (field.FieldType().StoreTermVectorPositions)
                     {
-                        throw new System.ArgumentException("cannot index term vector positions when field is not indexed (field=\"" + field.Name() + "\")");
+                        throw new System.ArgumentException("cannot index term vector positions when field is not indexed (field=\"" + field.Name + "\")");
                     }
                     if (field.FieldType().StoreTermVectorPayloads)
                     {
-                        throw new System.ArgumentException("cannot index term vector payloads when field is not indexed (field=\"" + field.Name() + "\")");
+                        throw new System.ArgumentException("cannot index term vector payloads when field is not indexed (field=\"" + field.Name + "\")");
                     }
                 }
             }

--- a/src/Lucene.Net.Facet/FacetsConfig.cs
+++ b/src/Lucene.Net.Facet/FacetsConfig.cs
@@ -290,7 +290,7 @@ namespace Lucene.Net.Facet
 
             foreach (IndexableField field in doc.Fields)
             {
-                if (field.FieldType() == FacetField.TYPE)
+                if (field.FieldType == FacetField.TYPE)
                 {
                     FacetField facetField = (FacetField)field;
                     FacetsConfig.DimConfig dimConfig = GetDimConfig(facetField.dim);
@@ -308,7 +308,7 @@ namespace Lucene.Net.Facet
                     fields.Add(facetField);
                 }
 
-                if (field.FieldType() == SortedSetDocValuesFacetField.TYPE)
+                if (field.FieldType == SortedSetDocValuesFacetField.TYPE)
                 {
                     var facetField = (SortedSetDocValuesFacetField)field;
                     FacetsConfig.DimConfig dimConfig = GetDimConfig(facetField.Dim);
@@ -326,7 +326,7 @@ namespace Lucene.Net.Facet
                     fields.Add(facetField);
                 }
 
-                if (field.FieldType() == AssociationFacetField.TYPE)
+                if (field.FieldType == AssociationFacetField.TYPE)
                 {
                     AssociationFacetField facetField = (AssociationFacetField)field;
                     FacetsConfig.DimConfig dimConfig = GetDimConfig(facetField.dim);
@@ -390,7 +390,7 @@ namespace Lucene.Net.Facet
 
             foreach (IndexableField field in doc.Fields)
             {
-                IndexableFieldType ft = field.FieldType();
+                IndexableFieldType ft = field.FieldType;
                 if (ft != FacetField.TYPE && ft != SortedSetDocValuesFacetField.TYPE && ft != AssociationFacetField.TYPE)
                 {
                     result.Add(field);

--- a/src/Lucene.Net.Suggest/Suggest/DocumentDictionary.cs
+++ b/src/Lucene.Net.Suggest/Suggest/DocumentDictionary.cs
@@ -172,11 +172,11 @@ namespace Lucene.Net.Search.Suggest
                     if (hasPayloads)
                     {
                         IndexableField payload = doc.GetField(outerInstance.payloadField);
-                        if (payload == null || (payload.BinaryValue() == null && payload.StringValue == null))
+                        if (payload == null || (payload.BinaryValue == null && payload.StringValue == null))
                         {
                             continue;
                         }
-                        tempPayload = payload.BinaryValue() ?? new BytesRef(payload.StringValue);
+                        tempPayload = payload.BinaryValue ?? new BytesRef(payload.StringValue);
                     }
 
                     if (hasContexts)
@@ -184,23 +184,23 @@ namespace Lucene.Net.Search.Suggest
                         IndexableField[] contextFields = doc.GetFields(outerInstance.contextsField);
                         foreach (IndexableField contextField in contextFields)
                         {
-                            if (contextField.BinaryValue() == null && contextField.StringValue == null)
+                            if (contextField.BinaryValue == null && contextField.StringValue == null)
                             {
                                 continue;
                             }
                             else
                             {
-                                tempContexts.Add(contextField.BinaryValue() ?? new BytesRef(contextField.StringValue));
+                                tempContexts.Add(contextField.BinaryValue ?? new BytesRef(contextField.StringValue));
                             }
                         }
                     }
 
                     IndexableField fieldVal = doc.GetField(outerInstance.field);
-                    if (fieldVal == null || (fieldVal.BinaryValue() == null && fieldVal.StringValue == null))
+                    if (fieldVal == null || (fieldVal.BinaryValue == null && fieldVal.StringValue == null))
                     {
                         continue;
                     }
-                    tempTerm = (fieldVal.StringValue != null) ? new BytesRef(fieldVal.StringValue) : fieldVal.BinaryValue();
+                    tempTerm = (fieldVal.StringValue != null) ? new BytesRef(fieldVal.StringValue) : fieldVal.BinaryValue;
 
                     currentPayload = tempPayload;
                     currentContexts = tempContexts;

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -769,7 +769,7 @@ namespace Lucene.Net.Analysis
                             if (random.Next(7) == 0)
                             {
                                 // pile up a multivalued field
-                                var ft = (FieldType)field.FieldType();
+                                var ft = (FieldType)field.FieldType;
                                 currentField = new Field("dummy", bogus, ft);
                                 doc.Add(currentField);
                             }

--- a/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWStoredFieldsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWStoredFieldsWriter.cs
@@ -142,7 +142,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             }
             else
             {
-                bytes = field.BinaryValue();
+                bytes = field.BinaryValue;
                 if (bytes != null)
                 {
                     bits |= Lucene3xStoredFieldsReader.FIELD_IS_BINARY;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWStoredFieldsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWStoredFieldsWriter.cs
@@ -153,7 +153,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                     @string = field.StringValue;
                     if (@string == null)
                     {
-                        throw new System.ArgumentException("field " + field.Name() + " is stored but does not have binaryValue, stringValue nor numericValue");
+                        throw new System.ArgumentException("field " + field.Name + " is stored but does not have binaryValue, stringValue nor numericValue");
                     }
                 }
             }

--- a/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
@@ -357,8 +357,8 @@ namespace Lucene.Net.Index
             w.AddDocument(doc);
             IndexReader r = w.Reader;
             w.Dispose();
-            Assert.IsFalse(r.Document(0).GetField("field").FieldType().Indexed);
-            Assert.IsTrue(r.Document(0).GetField("field2").FieldType().Indexed);
+            Assert.IsFalse(r.Document(0).GetField("field").FieldType.Indexed);
+            Assert.IsTrue(r.Document(0).GetField("field2").FieldType.Indexed);
             r.Dispose();
             dir.Dispose();
         }

--- a/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
@@ -208,17 +208,17 @@ namespace Lucene.Net.Index
             IEnumerator<IndexableField> it = doc2.Fields.GetEnumerator();
             Assert.IsTrue(it.MoveNext());
             Field f = (Field)it.Current;
-            Assert.AreEqual(f.Name(), "zzz");
+            Assert.AreEqual(f.Name, "zzz");
             Assert.AreEqual(f.StringValue, "a b c");
 
             Assert.IsTrue(it.MoveNext());
             f = (Field)it.Current;
-            Assert.AreEqual(f.Name(), "aaa");
+            Assert.AreEqual(f.Name, "aaa");
             Assert.AreEqual(f.StringValue, "a b c");
 
             Assert.IsTrue(it.MoveNext());
             f = (Field)it.Current;
-            Assert.AreEqual(f.Name(), "zzz");
+            Assert.AreEqual(f.Name, "zzz");
             Assert.AreEqual(f.StringValue, "1 2 3");
             Assert.IsFalse(it.MoveNext());
             r.Dispose();
@@ -400,7 +400,7 @@ namespace Lucene.Net.Index
             int docID = Random().Next(100);
             foreach (Field fld in fields)
             {
-                string fldName = fld.Name();
+                string fldName = fld.Name;
                 Document sDoc = reader.Document(docID, Collections.Singleton(fldName));
                 IndexableField sField = sDoc.GetField(fldName);
                 if (typeof(Field) == fld.GetType())

--- a/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
@@ -240,11 +240,11 @@ namespace Lucene.Net.Index
 
             Document doc = new Document();
             Field f = new StoredField("binary", b, 10, 17);
-            var bx = f.BinaryValue().Bytes;
+            var bx = f.BinaryValue.Bytes;
             Assert.IsTrue(bx != null);
             Assert.AreEqual(50, bx.Length);
-            Assert.AreEqual(10, f.BinaryValue().Offset);
-            Assert.AreEqual(17, f.BinaryValue().Length);
+            Assert.AreEqual(10, f.BinaryValue.Offset);
+            Assert.AreEqual(17, f.BinaryValue.Length);
             doc.Add(f);
             w.AddDocument(doc);
             w.Dispose();
@@ -252,7 +252,7 @@ namespace Lucene.Net.Index
             IndexReader ir = DirectoryReader.Open(dir);
             Document doc2 = ir.Document(0);
             IndexableField f2 = doc2.GetField("binary");
-            b = f2.BinaryValue().Bytes;
+            b = f2.BinaryValue.Bytes;
             Assert.IsTrue(b != null);
             Assert.AreEqual(17, b.Length, 17);
             Assert.AreEqual(87, b[0]);
@@ -405,7 +405,7 @@ namespace Lucene.Net.Index
                 IndexableField sField = sDoc.GetField(fldName);
                 if (typeof(Field) == fld.GetType())
                 {
-                    Assert.AreEqual(fld.BinaryValue(), sField.BinaryValue());
+                    Assert.AreEqual(fld.BinaryValue, sField.BinaryValue);
                     Assert.AreEqual(fld.StringValue, sField.StringValue);
                 }
                 else
@@ -737,7 +737,7 @@ namespace Lucene.Net.Index
                 Assert.AreEqual(docs[i].GetFields("fld").Length, fieldValues.Length);
                 if (fieldValues.Length > 0)
                 {
-                    Assert.AreEqual(docs[i].GetFields("fld")[0].BinaryValue(), fieldValues[0].BinaryValue());
+                    Assert.AreEqual(docs[i].GetFields("fld")[0].BinaryValue, fieldValues[0].BinaryValue);
                 }
             }
             rd.Dispose();

--- a/src/Lucene.Net.TestFramework/Index/DocHelper.cs
+++ b/src/Lucene.Net.TestFramework/Index/DocHelper.cs
@@ -261,7 +261,7 @@ namespace Lucene.Net.Index
             {
                 IndexableField f = Fields[i];
                 Add(All, f);
-                if (f.FieldType().Indexed)
+                if (f.FieldType.Indexed)
                 {
                     Add(Indexed, f);
                 }
@@ -269,15 +269,15 @@ namespace Lucene.Net.Index
                 {
                     Add(Unindexed, f);
                 }
-                if (f.FieldType().StoreTermVectors)
+                if (f.FieldType.StoreTermVectors)
                 {
                     Add(Termvector, f);
                 }
-                if (f.FieldType().Indexed && !f.FieldType().StoreTermVectors)
+                if (f.FieldType.Indexed && !f.FieldType.StoreTermVectors)
                 {
                     Add(Notermvector, f);
                 }
-                if (f.FieldType().Stored)
+                if (f.FieldType.Stored)
                 {
                     Add(Stored, f);
                 }
@@ -285,15 +285,15 @@ namespace Lucene.Net.Index
                 {
                     Add(Unstored, f);
                 }
-                if (f.FieldType().IndexOptions == FieldInfo.IndexOptions.DOCS_ONLY)
+                if (f.FieldType.IndexOptions == FieldInfo.IndexOptions.DOCS_ONLY)
                 {
                     Add(NoTf, f);
                 }
-                if (f.FieldType().OmitNorms)
+                if (f.FieldType.OmitNorms)
                 {
                     Add(NoNorms, f);
                 }
-                if (f.FieldType().IndexOptions == FieldInfo.IndexOptions.DOCS_ONLY)
+                if (f.FieldType.IndexOptions == FieldInfo.IndexOptions.DOCS_ONLY)
                 {
                     Add(NoTf, f);
                 }

--- a/src/Lucene.Net.TestFramework/Index/DocHelper.cs
+++ b/src/Lucene.Net.TestFramework/Index/DocHelper.cs
@@ -131,7 +131,7 @@ namespace Lucene.Net.Index
 
         private static void Add(IDictionary<string, IndexableField> map, IndexableField field)
         {
-            map[field.Name()] = field;
+            map[field.Name] = field;
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -2227,7 +2227,7 @@ namespace Lucene.Net.Util
         public void AssertStoredFieldEquals(string info, IndexableField leftField, IndexableField rightField)
         {
             Assert.AreEqual(leftField.Name, rightField.Name, info);
-            Assert.AreEqual(leftField.BinaryValue(), rightField.BinaryValue(), info);
+            Assert.AreEqual(leftField.BinaryValue, rightField.BinaryValue, info);
             Assert.AreEqual(leftField.StringValue, rightField.StringValue, info);
             Assert.AreEqual(leftField.NumericValue, rightField.NumericValue, info);
             // TODO: should we check the FT at all?

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -2206,7 +2206,7 @@ namespace Lucene.Net.Util
                 // in whatever way it wants (e.g. maybe it packs related fields together or something)
                 // To fix this, we sort the fields in both documents by name, but
                 // we still assume that all instances with same name are in order:
-                Comparison<IndexableField> comp = (a, b) => String.Compare(a.Name(), b.Name(), StringComparison.Ordinal);
+                Comparison<IndexableField> comp = (a, b) => String.Compare(a.Name, b.Name, StringComparison.Ordinal);
                 leftDoc.Fields.Sort(comp);
                 rightDoc.Fields.Sort(comp);
 
@@ -2226,7 +2226,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public void AssertStoredFieldEquals(string info, IndexableField leftField, IndexableField rightField)
         {
-            Assert.AreEqual(leftField.Name(), rightField.Name(), info);
+            Assert.AreEqual(leftField.Name, rightField.Name, info);
             Assert.AreEqual(leftField.BinaryValue(), rightField.BinaryValue(), info);
             Assert.AreEqual(leftField.StringValue, rightField.StringValue, info);
             Assert.AreEqual(leftField.NumericValue, rightField.NumericValue, info);
@@ -2726,7 +2726,7 @@ namespace Lucene.Net.Util
 
         public virtual int Compare(object arg0, object arg1)
         {
-            return System.String.Compare(((IndexableField)arg0).Name(), ((IndexableField)arg1).Name(), System.StringComparison.Ordinal);
+            return System.String.Compare(((IndexableField)arg0).Name, ((IndexableField)arg1).Name, System.StringComparison.Ordinal);
         }
     }
 }

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -993,8 +993,8 @@ namespace Lucene.Net.Util
             {
                 Field field1 = (Field)f;
                 Field field2;
-                DocValuesType_e? dvType = field1.FieldType().DocValueType;
-                NumericType? numType = field1.FieldType().NumericTypeValue;
+                DocValuesType_e? dvType = field1.FieldType.DocValueType;
+                NumericType? numType = field1.FieldType.NumericTypeValue;
                 if (dvType != null)
                 {
                     switch (dvType)
@@ -1020,19 +1020,19 @@ namespace Lucene.Net.Util
                     switch (numType)
                     {
                         case NumericType.INT:
-                            field2 = new IntField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType());
+                            field2 = new IntField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType);
                             break;
 
                         case NumericType.FLOAT:
-                            field2 = new FloatField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType());
+                            field2 = new FloatField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType);
                             break;
 
                         case NumericType.LONG:
-                            field2 = new LongField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType());
+                            field2 = new LongField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType);
                             break;
 
                         case NumericType.DOUBLE:
-                            field2 = new DoubleField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType());
+                            field2 = new DoubleField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType);
                             break;
 
                         default:
@@ -1041,7 +1041,7 @@ namespace Lucene.Net.Util
                 }
                 else
                 {
-                    field2 = new Field(field1.Name, field1.StringValue, (FieldType)field1.FieldType());
+                    field2 = new Field(field1.Name, field1.StringValue, (FieldType)field1.FieldType);
                 }
                 doc2.Add(field2);
             }

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -1004,11 +1004,11 @@ namespace Lucene.Net.Util
                             break;
 
                         case DocValuesType_e.BINARY:
-                            field2 = new BinaryDocValuesField(field1.Name, field1.BinaryValue());
+                            field2 = new BinaryDocValuesField(field1.Name, field1.BinaryValue);
                             break;
 
                         case DocValuesType_e.SORTED:
-                            field2 = new SortedDocValuesField(field1.Name, field1.BinaryValue());
+                            field2 = new SortedDocValuesField(field1.Name, field1.BinaryValue);
                             break;
 
                         default:

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -1000,15 +1000,15 @@ namespace Lucene.Net.Util
                     switch (dvType)
                     {
                         case DocValuesType_e.NUMERIC:
-                            field2 = new NumericDocValuesField(field1.Name(), (long)field1.NumericValue);
+                            field2 = new NumericDocValuesField(field1.Name, (long)field1.NumericValue);
                             break;
 
                         case DocValuesType_e.BINARY:
-                            field2 = new BinaryDocValuesField(field1.Name(), field1.BinaryValue());
+                            field2 = new BinaryDocValuesField(field1.Name, field1.BinaryValue());
                             break;
 
                         case DocValuesType_e.SORTED:
-                            field2 = new SortedDocValuesField(field1.Name(), field1.BinaryValue());
+                            field2 = new SortedDocValuesField(field1.Name, field1.BinaryValue());
                             break;
 
                         default:
@@ -1020,19 +1020,19 @@ namespace Lucene.Net.Util
                     switch (numType)
                     {
                         case NumericType.INT:
-                            field2 = new IntField(field1.Name(), (int)field1.NumericValue, (FieldType)field1.FieldType());
+                            field2 = new IntField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType());
                             break;
 
                         case NumericType.FLOAT:
-                            field2 = new FloatField(field1.Name(), (int)field1.NumericValue, (FieldType)field1.FieldType());
+                            field2 = new FloatField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType());
                             break;
 
                         case NumericType.LONG:
-                            field2 = new LongField(field1.Name(), (int)field1.NumericValue, (FieldType)field1.FieldType());
+                            field2 = new LongField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType());
                             break;
 
                         case NumericType.DOUBLE:
-                            field2 = new DoubleField(field1.Name(), (int)field1.NumericValue, (FieldType)field1.FieldType());
+                            field2 = new DoubleField(field1.Name, (int)field1.NumericValue, (FieldType)field1.FieldType());
                             break;
 
                         default:
@@ -1041,7 +1041,7 @@ namespace Lucene.Net.Util
                 }
                 else
                 {
-                    field2 = new Field(field1.Name(), field1.StringValue, (FieldType)field1.FieldType());
+                    field2 = new Field(field1.Name, field1.StringValue, (FieldType)field1.FieldType());
                 }
                 doc2.Add(field2);
             }

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestBlockPostingsFormat2.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestBlockPostingsFormat2.cs
@@ -100,7 +100,7 @@ namespace Lucene.Net.Codecs.Lucene41
             {
                 foreach (IndexableField f in doc.Fields)
                 {
-                    ((Field)f).StringValue = f.Name() + " " + f.Name() + "_2";
+                    ((Field)f).StringValue = f.Name + " " + f.Name + "_2";
                 }
                 Iw.AddDocument(doc);
             }
@@ -116,7 +116,7 @@ namespace Lucene.Net.Codecs.Lucene41
             {
                 foreach (IndexableField f in doc.Fields)
                 {
-                    ((Field)f).StringValue = f.Name() + " " + f.Name() + "_2";
+                    ((Field)f).StringValue = f.Name + " " + f.Name + "_2";
                 }
                 Iw.AddDocument(doc);
             }
@@ -132,7 +132,7 @@ namespace Lucene.Net.Codecs.Lucene41
             {
                 foreach (IndexableField f in doc.Fields)
                 {
-                    ((Field)f).StringValue = f.Name() + " " + f.Name() + " " + f.Name() + "_2 " + f.Name() + "_2";
+                    ((Field)f).StringValue = f.Name + " " + f.Name + " " + f.Name + "_2 " + f.Name + "_2";
                 }
                 Iw.AddDocument(doc);
             }
@@ -148,7 +148,7 @@ namespace Lucene.Net.Codecs.Lucene41
             {
                 foreach (IndexableField f in doc.Fields)
                 {
-                    string proto = (f.Name() + " " + f.Name() + " " + f.Name() + " " + f.Name() + " " + f.Name() + "_2 " + f.Name() + "_2 " + f.Name() + "_2 " + f.Name() + "_2");
+                    string proto = (f.Name + " " + f.Name + " " + f.Name + " " + f.Name + " " + f.Name + "_2 " + f.Name + "_2 " + f.Name + "_2 " + f.Name + "_2");
                     StringBuilder val = new StringBuilder();
                     for (int j = 0; j < 16; j++)
                     {

--- a/src/Lucene.Net.Tests/core/Document/TestDocument.cs
+++ b/src/Lucene.Net.Tests/core/Document/TestDocument.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Document
 
             Assert.AreEqual(2, doc.Fields.Count);
 
-            Assert.IsTrue(binaryFld.BinaryValue() != null);
+            Assert.IsTrue(binaryFld.BinaryValue != null);
             Assert.IsTrue(binaryFld.FieldType.Stored);
             Assert.IsFalse(binaryFld.FieldType.Indexed);
 

--- a/src/Lucene.Net.Tests/core/Document/TestDocument.cs
+++ b/src/Lucene.Net.Tests/core/Document/TestDocument.cs
@@ -69,8 +69,8 @@ namespace Lucene.Net.Document
             Assert.AreEqual(2, doc.Fields.Count);
 
             Assert.IsTrue(binaryFld.BinaryValue() != null);
-            Assert.IsTrue(binaryFld.FieldType().Stored);
-            Assert.IsFalse(binaryFld.FieldType().Indexed);
+            Assert.IsTrue(binaryFld.FieldType.Stored);
+            Assert.IsFalse(binaryFld.FieldType.Indexed);
 
             string binaryTest = doc.GetBinaryValue("binary").Utf8ToString();
             Assert.IsTrue(binaryTest.Equals(BinaryVal));

--- a/src/Lucene.Net.Tests/core/Document/TestField.cs
+++ b/src/Lucene.Net.Tests/core/Document/TestField.cs
@@ -280,7 +280,7 @@ namespace Lucene.Net.Document
                 field.TokenStream = new CannedTokenStream(new Token("foo", 0, 3));
 
                 Assert.AreEqual("baz", field.StringValue);
-                Assert.AreEqual(5f, field.GetBoost(), 0f);
+                Assert.AreEqual(5f, field.Boost, 0f);
             }
         }
 
@@ -303,7 +303,7 @@ namespace Lucene.Net.Document
             field.TokenStream = new CannedTokenStream(new Token("foo", 0, 3));
 
             Assert.IsNotNull(field.ReaderValue);
-            Assert.AreEqual(5f, field.GetBoost(), 0f);
+            Assert.AreEqual(5f, field.Boost, 0f);
         }
 
         /* TODO: this is pretty expert and crazy

--- a/src/Lucene.Net.Tests/core/Document/TestField.cs
+++ b/src/Lucene.Net.Tests/core/Document/TestField.cs
@@ -211,7 +211,7 @@ namespace Lucene.Net.Document
             TrySetStringValue(field);
             TrySetTokenStreamValue(field);
 
-            Assert.AreEqual(new BytesRef("baz"), field.BinaryValue());
+            Assert.AreEqual(new BytesRef("baz"), field.BinaryValue);
         }
 
         [Test]
@@ -232,7 +232,7 @@ namespace Lucene.Net.Document
             TrySetStringValue(field);
             TrySetTokenStreamValue(field);
 
-            Assert.AreEqual(new BytesRef("baz"), field.BinaryValue());
+            Assert.AreEqual(new BytesRef("baz"), field.BinaryValue);
         }
 
         [Test]
@@ -332,7 +332,7 @@ namespace Lucene.Net.Document
                 TrySetStringValue(field);
                 TrySetTokenStreamValue(field);
 
-                Assert.AreEqual(new BytesRef("baz"), field.BinaryValue());
+                Assert.AreEqual(new BytesRef("baz"), field.BinaryValue);
             }
         }
 

--- a/src/Lucene.Net.Tests/core/Index/TestBagOfPositions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBagOfPositions.cs
@@ -91,7 +91,7 @@ namespace Lucene.Net.Index
             }
 
             Field prototype = NewTextField("field", "", Field.Store.NO);
-            FieldType fieldType = new FieldType((FieldType)prototype.FieldType());
+            FieldType fieldType = new FieldType((FieldType)prototype.FieldType);
             if (Random().NextBoolean())
             {
                 fieldType.OmitNorms = true;

--- a/src/Lucene.Net.Tests/core/Index/TestConsistentFieldNumbers.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestConsistentFieldNumbers.cs
@@ -283,8 +283,8 @@ namespace Lucene.Net.Index
                 foreach (FieldInfo fi in fis)
                 {
                     Field expected = GetField(Convert.ToInt32(fi.Name));
-                    Assert.AreEqual(expected.FieldType().Indexed, fi.Indexed);
-                    Assert.AreEqual(expected.FieldType().StoreTermVectors, fi.HasVectors());
+                    Assert.AreEqual(expected.FieldType.Indexed, fi.Indexed);
+                    Assert.AreEqual(expected.FieldType.StoreTermVectors, fi.HasVectors());
                 }
             }
 

--- a/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
@@ -389,8 +389,8 @@ namespace Lucene.Net.Index
             Assert.IsNotNull(fields);
             Assert.AreEqual(1, fields.Length);
             IndexableField b1 = fields[0];
-            Assert.IsTrue(b1.BinaryValue() != null);
-            BytesRef bytesRef = b1.BinaryValue();
+            Assert.IsTrue(b1.BinaryValue != null);
+            BytesRef bytesRef = b1.BinaryValue;
             Assert.AreEqual(bin.Length, bytesRef.Length);
             for (int i = 0; i < bin.Length; i++)
             {
@@ -408,8 +408,8 @@ namespace Lucene.Net.Index
             Assert.IsNotNull(fields);
             Assert.AreEqual(1, fields.Length);
             b1 = fields[0];
-            Assert.IsTrue(b1.BinaryValue() != null);
-            bytesRef = b1.BinaryValue();
+            Assert.IsTrue(b1.BinaryValue != null);
+            bytesRef = b1.BinaryValue;
             Assert.AreEqual(bin.Length, bytesRef.Length);
             for (int i = 0; i < bin.Length; i++)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
@@ -620,7 +620,7 @@ namespace Lucene.Net.Index
                         Field curField1 = (Field)itField1.Current;
                         itField2.MoveNext();
                         Field curField2 = (Field)itField2.Current;
-                        Assert.AreEqual(curField1.Name(), curField2.Name(), "Different fields names for doc " + i + ".");
+                        Assert.AreEqual(curField1.Name, curField2.Name, "Different fields names for doc " + i + ".");
                         Assert.AreEqual(curField1.StringValue, curField2.StringValue, "Different field values for doc " + i + ".");
                     }
                 }

--- a/src/Lucene.Net.Tests/core/Index/TestDocumentWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocumentWriter.cs
@@ -80,12 +80,12 @@ namespace Lucene.Net.Index
             IndexableField[] fields = doc.GetFields("textField2");
             Assert.IsTrue(fields != null && fields.Length == 1);
             Assert.IsTrue(fields[0].StringValue.Equals(DocHelper.FIELD_2_TEXT));
-            Assert.IsTrue(fields[0].FieldType().StoreTermVectors);
+            Assert.IsTrue(fields[0].FieldType.StoreTermVectors);
 
             fields = doc.GetFields("textField1");
             Assert.IsTrue(fields != null && fields.Length == 1);
             Assert.IsTrue(fields[0].StringValue.Equals(DocHelper.FIELD_1_TEXT));
-            Assert.IsFalse(fields[0].FieldType().StoreTermVectors);
+            Assert.IsFalse(fields[0].FieldType.StoreTermVectors);
 
             fields = doc.GetFields("keyField");
             Assert.IsTrue(fields != null && fields.Length == 1);

--- a/src/Lucene.Net.Tests/core/Index/TestFieldInfos.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFieldInfos.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Index
             FieldInfos.Builder builder = new FieldInfos.Builder();
             foreach (IndexableField field in TestDoc)
             {
-                builder.AddOrUpdate(field.Name(), field.FieldType());
+                builder.AddOrUpdate(field.Name, field.FieldType());
             }
             FieldInfos fieldInfos = builder.Finish();
             //Since the complement is stored as well in the fields map

--- a/src/Lucene.Net.Tests/core/Index/TestFieldInfos.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFieldInfos.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Index
             FieldInfos.Builder builder = new FieldInfos.Builder();
             foreach (IndexableField field in TestDoc)
             {
-                builder.AddOrUpdate(field.Name, field.FieldType());
+                builder.AddOrUpdate(field.Name, field.FieldType);
             }
             FieldInfos fieldInfos = builder.Finish();
             //Since the complement is stored as well in the fields map

--- a/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Index
             DocHelper.SetupDoc(TestDoc);
             foreach (IndexableField field in TestDoc)
             {
-                FieldInfos.AddOrUpdate(field.Name(), field.FieldType());
+                FieldInfos.AddOrUpdate(field.Name, field.FieldType());
             }
             Dir = NewDirectory();
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMergePolicy(NewLogMergePolicy());
@@ -106,7 +106,7 @@ namespace Lucene.Net.Index
             reader.Document(0, visitor);
             IList<IndexableField> fields = visitor.Document.Fields;
             Assert.AreEqual(1, fields.Count);
-            Assert.AreEqual(DocHelper.TEXT_FIELD_3_KEY, fields[0].Name());
+            Assert.AreEqual(DocHelper.TEXT_FIELD_3_KEY, fields[0].Name);
             reader.Dispose();
         }
 

--- a/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Index
             DocHelper.SetupDoc(TestDoc);
             foreach (IndexableField field in TestDoc)
             {
-                FieldInfos.AddOrUpdate(field.Name, field.FieldType());
+                FieldInfos.AddOrUpdate(field.Name, field.FieldType);
             }
             Dir = NewDirectory();
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMergePolicy(NewLogMergePolicy());
@@ -85,22 +85,22 @@ namespace Lucene.Net.Index
 
             Field field = (Field)doc.GetField(DocHelper.TEXT_FIELD_2_KEY);
             Assert.IsTrue(field != null);
-            Assert.IsTrue(field.FieldType().StoreTermVectors);
+            Assert.IsTrue(field.FieldType.StoreTermVectors);
 
-            Assert.IsFalse(field.FieldType().OmitNorms);
-            Assert.IsTrue(field.FieldType().IndexOptions == FieldInfo.IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+            Assert.IsFalse(field.FieldType.OmitNorms);
+            Assert.IsTrue(field.FieldType.IndexOptions == FieldInfo.IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
 
             field = (Field)doc.GetField(DocHelper.TEXT_FIELD_3_KEY);
             Assert.IsTrue(field != null);
-            Assert.IsFalse(field.FieldType().StoreTermVectors);
-            Assert.IsTrue(field.FieldType().OmitNorms);
-            Assert.IsTrue(field.FieldType().IndexOptions == FieldInfo.IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+            Assert.IsFalse(field.FieldType.StoreTermVectors);
+            Assert.IsTrue(field.FieldType.OmitNorms);
+            Assert.IsTrue(field.FieldType.IndexOptions == FieldInfo.IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
 
             field = (Field)doc.GetField(DocHelper.NO_TF_KEY);
             Assert.IsTrue(field != null);
-            Assert.IsFalse(field.FieldType().StoreTermVectors);
-            Assert.IsFalse(field.FieldType().OmitNorms);
-            Assert.IsTrue(field.FieldType().IndexOptions == FieldInfo.IndexOptions.DOCS_ONLY);
+            Assert.IsFalse(field.FieldType.StoreTermVectors);
+            Assert.IsFalse(field.FieldType.OmitNorms);
+            Assert.IsTrue(field.FieldType.IndexOptions == FieldInfo.IndexOptions.DOCS_ONLY);
 
             DocumentStoredFieldVisitor visitor = new DocumentStoredFieldVisitor(DocHelper.TEXT_FIELD_3_KEY);
             reader.Document(0, visitor);

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -1508,14 +1508,14 @@ namespace Lucene.Net.Index
             IndexReader ir = DirectoryReader.Open(dir);
             Document doc2 = ir.Document(0);
             IndexableField f3 = doc2.GetField("binary");
-            b = f3.BinaryValue().Bytes;
+            b = f3.BinaryValue.Bytes;
             Assert.IsTrue(b != null);
             Assert.AreEqual(17, b.Length, 17);
             Assert.AreEqual(87, b[0]);
 
-            Assert.IsTrue(ir.Document(0).GetField("binary").BinaryValue() != null);
-            Assert.IsTrue(ir.Document(1).GetField("binary").BinaryValue() != null);
-            Assert.IsTrue(ir.Document(2).GetField("binary").BinaryValue() != null);
+            Assert.IsTrue(ir.Document(0).GetField("binary").BinaryValue != null);
+            Assert.IsTrue(ir.Document(1).GetField("binary").BinaryValue != null);
+            Assert.IsTrue(ir.Document(2).GetField("binary").BinaryValue != null);
 
             Assert.AreEqual("value", ir.Document(0).Get("string"));
             Assert.AreEqual("value", ir.Document(1).Get("string"));

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -2014,9 +2014,9 @@ namespace Lucene.Net.Index
                 get { return StringField.TYPE_NOT_STORED; }
             }
 
-            public float GetBoost()
+            public float Boost
             {
-                return 5f;
+                get { return 5f; }
             }
 
             public BytesRef BinaryValue()

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -1628,7 +1628,7 @@ namespace Lucene.Net.Index
                         try
                         {
                             w.AddDocument(doc);
-                            Assert.IsFalse(field.FieldType().StoreTermVectors);
+                            Assert.IsFalse(field.FieldType.StoreTermVectors);
                         }
                         catch (Exception e)
                         {
@@ -1653,7 +1653,7 @@ namespace Lucene.Net.Index
                         try
                         {
                             w.AddDocument(doc);
-                            Assert.IsFalse(field.FieldType().StoreTermVectors);
+                            Assert.IsFalse(field.FieldType.StoreTermVectors);
                         }
                         catch (Exception e)
                         {
@@ -2009,9 +2009,9 @@ namespace Lucene.Net.Index
                 get { return "foo"; }
             }
 
-            public IndexableFieldType FieldType()
+            public IndexableFieldType FieldType
             {
-                return StringField.TYPE_NOT_STORED;
+                get { return StringField.TYPE_NOT_STORED; }
             }
 
             public float GetBoost()

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -2019,9 +2019,9 @@ namespace Lucene.Net.Index
                 get { return 5f; }
             }
 
-            public BytesRef BinaryValue()
+            public BytesRef BinaryValue
             {
-                return null;
+                get { return null; }
             }
 
             public string StringValue

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -2004,9 +2004,9 @@ namespace Lucene.Net.Index
                 this.OuterInstance = outerInstance;
             }
 
-            public string Name()
+            public string Name
             {
-                return "foo";
+                get { return "foo"; }
             }
 
             public IndexableFieldType FieldType()

--- a/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
@@ -157,9 +157,9 @@ namespace Lucene.Net.Index
                 get { return "f" + Counter; }
             }
 
-            public float GetBoost()
+            public float Boost
             {
-                return 1.0f + (float)Random().NextDouble();
+                get { return 1.0f + (float)Random().NextDouble(); }
             }
 
             public BytesRef BinaryValue()

--- a/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
@@ -162,20 +162,23 @@ namespace Lucene.Net.Index
                 get { return 1.0f + (float)Random().NextDouble(); }
             }
 
-            public BytesRef BinaryValue()
+            public BytesRef BinaryValue
             {
-                if ((Counter % 10) == 3)
+                get
                 {
-                    var bytes = new byte[10];
-                    for (int idx = 0; idx < bytes.Length; idx++)
+                    if ((Counter % 10) == 3)
                     {
-                        bytes[idx] = (byte)(Counter + idx);
+                        var bytes = new byte[10];
+                        for (int idx = 0; idx < bytes.Length; idx++)
+                        {
+                            bytes[idx] = (byte)(Counter + idx);
+                        }
+                        return new BytesRef(bytes, 0, bytes.Length);
                     }
-                    return new BytesRef(bytes, 0, bytes.Length);
-                }
-                else
-                {
-                    return null;
+                    else
+                    {
+                        return null;
+                    }
                 }
             }
 
@@ -302,7 +305,7 @@ namespace Lucene.Net.Index
                         if (binary)
                         {
                             Assert.IsNotNull(f, "doc " + id + " doesn't have field f" + counter);
-                            BytesRef b = f.BinaryValue();
+                            BytesRef b = f.BinaryValue;
                             Assert.IsNotNull(b);
                             Assert.AreEqual(10, b.Length);
                             for (int idx = 0; idx < 10; idx++)

--- a/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
@@ -152,9 +152,9 @@ namespace Lucene.Net.Index
                 this.Counter = counter;
             }
 
-            public string Name()
+            public string Name
             {
-                return "f" + Counter;
+                get { return "f" + Counter; }
             }
 
             public float GetBoost()
@@ -222,7 +222,7 @@ namespace Lucene.Net.Index
 
             public TokenStream GetTokenStream(Analyzer analyzer)
             {
-                return ReaderValue != null ? analyzer.TokenStream(Name(), ReaderValue) : analyzer.TokenStream(Name(), new StringReader(StringValue));
+                return ReaderValue != null ? analyzer.TokenStream(Name, ReaderValue) : analyzer.TokenStream(Name, new StringReader(StringValue));
             }
         }
 

--- a/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
@@ -215,9 +215,9 @@ namespace Lucene.Net.Index
                 get { return null; }
             }
 
-            public IndexableFieldType FieldType()
+            public IndexableFieldType FieldType
             {
-                return fieldType;
+                get { return fieldType; }
             }
 
             public TokenStream GetTokenStream(Analyzer analyzer)

--- a/src/Lucene.Net.Tests/core/Index/TestSegmentReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSegmentReader.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Index
             foreach (IndexableField field in fields)
             {
                 Assert.IsTrue(field != null);
-                Assert.IsTrue(DocHelper.NameValues.ContainsKey(field.Name()));
+                Assert.IsTrue(DocHelper.NameValues.ContainsKey(field.Name));
             }
         }
 
@@ -193,12 +193,12 @@ namespace Lucene.Net.Index
                 IndexableField f = DocHelper.Fields[i];
                 if (f.FieldType().Indexed)
                 {
-                    Assert.AreEqual(reader.GetNormValues(f.Name()) != null, !f.FieldType().OmitNorms);
-                    Assert.AreEqual(reader.GetNormValues(f.Name()) != null, !DocHelper.NoNorms.ContainsKey(f.Name()));
-                    if (reader.GetNormValues(f.Name()) == null)
+                    Assert.AreEqual(reader.GetNormValues(f.Name) != null, !f.FieldType().OmitNorms);
+                    Assert.AreEqual(reader.GetNormValues(f.Name) != null, !DocHelper.NoNorms.ContainsKey(f.Name));
+                    if (reader.GetNormValues(f.Name) == null)
                     {
                         // test for norms of null
-                        NumericDocValues norms = MultiDocValues.GetNormValues(reader, f.Name());
+                        NumericDocValues norms = MultiDocValues.GetNormValues(reader, f.Name);
                         Assert.IsNull(norms);
                     }
                 }

--- a/src/Lucene.Net.Tests/core/Index/TestSegmentReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSegmentReader.cs
@@ -191,9 +191,9 @@ namespace Lucene.Net.Index
             for (int i = 0; i < DocHelper.Fields.Length; i++)
             {
                 IndexableField f = DocHelper.Fields[i];
-                if (f.FieldType().Indexed)
+                if (f.FieldType.Indexed)
                 {
-                    Assert.AreEqual(reader.GetNormValues(f.Name) != null, !f.FieldType().OmitNorms);
+                    Assert.AreEqual(reader.GetNormValues(f.Name) != null, !f.FieldType.OmitNorms);
                     Assert.AreEqual(reader.GetNormValues(f.Name) != null, !DocHelper.NoNorms.ContainsKey(f.Name));
                     if (reader.GetNormValues(f.Name) == null)
                     {

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
@@ -681,9 +681,9 @@ namespace Lucene.Net.Index
             {
                 IndexableField f1 = ff1[i];
                 IndexableField f2 = ff2[i];
-                if (f1.BinaryValue() != null)
+                if (f1.BinaryValue != null)
                 {
-                    Debug.Assert(f2.BinaryValue() != null);
+                    Debug.Assert(f2.BinaryValue != null);
                 }
                 else
                 {

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
@@ -158,7 +158,7 @@ namespace Lucene.Net.Index
 
             public virtual int Compare(IndexableField o1, IndexableField o2)
             {
-                return o1.Name().CompareTo(o2.Name());
+                return o1.Name.CompareTo(o2.Name);
             }
         }
 


### PR DESCRIPTION
Made `Name()`, `FieldType()`, `GetBoost()` and `BinaryValue()` into property getters for consistency with the other getters in the `IndexableField` type. So we have all properties instead of a mixed bag of properties and methods. For example...

```c#
public SerializableField(IndexableField field)
{
	name = field.Name();
	if (field.NumericValue != null)
	{
		fieldsData = field.NumericValue;
	}
	else if (field.StringValue != null)
	{
		fieldsData = field.StringValue;
	}
	else if (field.BinaryValue() != null)
	{
		fieldsData = field.BinaryValue().Bytes;
	}
	else
	{
		throw new NotSupportedException("Doesn't support this field type so far");
	}
}
```

now looks like...

```c#
public SerializableField(IndexableField field)
{
	name = field.Name;
	if (field.NumericValue != null)
	{
		fieldsData = field.NumericValue;
	}
	else if (field.StringValue != null)
	{
		fieldsData = field.StringValue;
	}
	else if (field.BinaryValue != null)
	{
		fieldsData = field.BinaryValue.Bytes;
	}
	else
	{
		throw new NotSupportedException("Doesn't support this field type so far");
	}
}
```