### PR TITLE
Limiting uses of static variables and methods in Testcases

### DIFF
--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -528,22 +528,37 @@ namespace Lucene.Net.Analysis
         }
 
         /// <summary>
-        /// utility method for blasting tokenstreams with data to make sure they don't do anything crazy </summary>
+        /// utility method for blasting tokenstreams with data to make sure they don't do anything crazy
+        ///
+        /// LUCENENET specific
+        /// Non-static to reduce the inter-class dependencies due to use of
+        /// static variables
+        /// </summary>
         public void CheckRandomData(Random random, Analyzer a, int iterations)
         {
             CheckRandomData(random, a, iterations, 20, false, true);
         }
 
         /// <summary>
-        /// utility method for blasting tokenstreams with data to make sure they don't do anything crazy </summary>
+        /// utility method for blasting tokenstreams with data to make sure they don't do anything crazy
+        ///
+        /// LUCENENET specific
+        /// Non-static to reduce the inter-class dependencies due to use of
+        /// static variables
+        /// </summary>
         public void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength)
         {
             CheckRandomData(random, a, iterations, maxWordLength, false, true);
         }
 
         /// <summary>
-        /// utility method for blasting tokenstreams with data to make sure they don't do anything crazy </summary>
-        /// <param name="simple"> true if only ascii strings will be used (try to avoid) </param>
+        /// utility method for blasting tokenstreams with data to make sure they don't do anything crazy
+        /// 
+        /// LUCENENET specific
+        /// Non-static to reduce the inter-class dependencies due to use of
+        /// static variables
+        /// </summary>
+        /// <param name="simple"> true if only ascii strings will be used (try to avoid)</param>
         public void CheckRandomData(Random random, Analyzer a, int iterations, bool simple)
         {
             CheckRandomData(random, a, iterations, 20, simple, true);
@@ -567,6 +582,11 @@ namespace Lucene.Net.Analysis
             // interact)... so this is just "best effort":
             public bool Failed;
 
+            /// <summary>
+            /// <param name="outerInstance">
+            /// LUCENENET specific
+            /// Added to remove a call to the then-static BaseTokenStreamTestCase methods</param>
+            /// </summary>
             internal AnalysisThread(long seed, /*CountdownEvent latch,*/ Analyzer a, int iterations, int maxWordLength, 
                 bool useCharFilter, bool simple, bool offsetsAreCorrect, RandomIndexWriter iw, BaseTokenStreamTestCase outerInstance)
             {

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -529,14 +529,14 @@ namespace Lucene.Net.Analysis
 
         /// <summary>
         /// utility method for blasting tokenstreams with data to make sure they don't do anything crazy </summary>
-        public static void CheckRandomData(Random random, Analyzer a, int iterations)
+        public void CheckRandomData(Random random, Analyzer a, int iterations)
         {
             CheckRandomData(random, a, iterations, 20, false, true);
         }
 
         /// <summary>
         /// utility method for blasting tokenstreams with data to make sure they don't do anything crazy </summary>
-        public static void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength)
+        public void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength)
         {
             CheckRandomData(random, a, iterations, maxWordLength, false, true);
         }
@@ -544,13 +544,14 @@ namespace Lucene.Net.Analysis
         /// <summary>
         /// utility method for blasting tokenstreams with data to make sure they don't do anything crazy </summary>
         /// <param name="simple"> true if only ascii strings will be used (try to avoid) </param>
-        public static void CheckRandomData(Random random, Analyzer a, int iterations, bool simple)
+        public void CheckRandomData(Random random, Analyzer a, int iterations, bool simple)
         {
             CheckRandomData(random, a, iterations, 20, simple, true);
         }
 
         internal class AnalysisThread : ThreadClass
         {
+            private readonly BaseTokenStreamTestCase OuterInstance;
             internal readonly int Iterations;
             internal readonly int MaxWordLength;
             internal readonly long Seed;
@@ -566,7 +567,8 @@ namespace Lucene.Net.Analysis
             // interact)... so this is just "best effort":
             public bool Failed;
 
-            internal AnalysisThread(long seed, /*CountdownEvent latch,*/ Analyzer a, int iterations, int maxWordLength, bool useCharFilter, bool simple, bool offsetsAreCorrect, RandomIndexWriter iw)
+            internal AnalysisThread(long seed, /*CountdownEvent latch,*/ Analyzer a, int iterations, int maxWordLength, 
+                bool useCharFilter, bool simple, bool offsetsAreCorrect, RandomIndexWriter iw, BaseTokenStreamTestCase outerInstance)
             {
                 this.Seed = seed;
                 this.a = a;
@@ -577,6 +579,7 @@ namespace Lucene.Net.Analysis
                 this.OffsetsAreCorrect = offsetsAreCorrect;
                 this.Iw = iw;
                 this._latch = null;
+                this.OuterInstance = outerInstance;
             }
 
             public override void Run()
@@ -587,7 +590,7 @@ namespace Lucene.Net.Analysis
                     if (_latch != null) _latch.Wait();
                     // see the part in checkRandomData where it replays the same text again
                     // to verify reproducability/reuse: hopefully this would catch thread hazards.
-                    CheckRandomData(new Random((int)Seed), a, Iterations, MaxWordLength, UseCharFilter, Simple, OffsetsAreCorrect, Iw);
+                    OuterInstance.CheckRandomData(new Random((int)Seed), a, Iterations, MaxWordLength, UseCharFilter, Simple, OffsetsAreCorrect, Iw);
                     success = true;
                 }
                 catch (Exception e)
@@ -602,12 +605,12 @@ namespace Lucene.Net.Analysis
             }
         }
 
-        public static void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength, bool simple)
+        public void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength, bool simple)
         {
             CheckRandomData(random, a, iterations, maxWordLength, simple, true);
         }
 
-        public static void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength, bool simple, bool offsetsAreCorrect)
+        public void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength, bool simple, bool offsetsAreCorrect)
         {
             CheckResetException(a, "best effort");
             long seed = random.Next();
@@ -620,7 +623,7 @@ namespace Lucene.Net.Analysis
             if (Rarely(random) && codecOk)
             {
                 dir = NewFSDirectory(CreateTempDir("bttc"));
-                iw = new RandomIndexWriter(new Random((int)seed), dir, a);
+                iw = new RandomIndexWriter(new Random((int)seed), dir, a, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             }
 
             bool success = false;
@@ -634,7 +637,7 @@ namespace Lucene.Net.Analysis
                 var threads = new AnalysisThread[numThreads];
                 for (int i = 0; i < threads.Length; i++)
                 {
-                    threads[i] = new AnalysisThread(seed, /*startingGun,*/ a, iterations, maxWordLength, useCharFilter, simple, offsetsAreCorrect, iw);
+                    threads[i] = new AnalysisThread(seed, /*startingGun,*/ a, iterations, maxWordLength, useCharFilter, simple, offsetsAreCorrect, iw, this);
                 }
                 
                 Array.ForEach(threads, thread => thread.Start());                
@@ -671,7 +674,7 @@ namespace Lucene.Net.Analysis
             }
         }
 
-        private static void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength, bool useCharFilter, bool simple, bool offsetsAreCorrect, RandomIndexWriter iw)
+        private void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength, bool useCharFilter, bool simple, bool offsetsAreCorrect, RandomIndexWriter iw)
         {
             LineFileDocs docs = new LineFileDocs(random);
             Document doc = null;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWCodec.cs
@@ -33,6 +33,12 @@ namespace Lucene.Net.Codecs.Lucene3x
         private readonly StoredFieldsFormat StoredFields = new PreFlexRWStoredFieldsFormat();
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <summary>
+        /// </summary>
+        /// <param name="oldFormatImpersonationIsActive">
+        /// LUCENENET specific
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// </param>
         public PreFlexRWCodec(bool oldFormatImpersonationIsActive) : base()
         {
             _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWCodec.cs
@@ -31,10 +31,16 @@ namespace Lucene.Net.Codecs.Lucene3x
         private readonly TermVectorsFormat TermVectors = new PreFlexRWTermVectorsFormat();
         private readonly SegmentInfoFormat SegmentInfos = new PreFlexRWSegmentInfoFormat();
         private readonly StoredFieldsFormat StoredFields = new PreFlexRWStoredFieldsFormat();
+        private readonly bool _oldFormatImpersonationIsActive;
+
+        public PreFlexRWCodec(bool oldFormatImpersonationIsActive) : base()
+        {
+            _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
+        }
 
         public override PostingsFormat PostingsFormat()
         {
-            if (LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (_oldFormatImpersonationIsActive)
             {
                 return Postings;
             }
@@ -46,7 +52,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override NormsFormat NormsFormat()
         {
-            if (LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (_oldFormatImpersonationIsActive)
             {
                 return Norms;
             }
@@ -58,7 +64,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override SegmentInfoFormat SegmentInfoFormat()
         {
-            if (LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (_oldFormatImpersonationIsActive)
             {
                 return SegmentInfos;
             }
@@ -70,7 +76,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override FieldInfosFormat FieldInfosFormat()
         {
-            if (LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (_oldFormatImpersonationIsActive)
             {
                 return FieldInfos;
             }
@@ -82,7 +88,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override TermVectorsFormat TermVectorsFormat()
         {
-            if (LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (_oldFormatImpersonationIsActive)
             {
                 return TermVectors;
             }
@@ -94,7 +100,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override StoredFieldsFormat StoredFieldsFormat()
         {
-            if (LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (_oldFormatImpersonationIsActive)
             {
                 return StoredFields;
             }

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWCodec.cs
@@ -24,7 +24,11 @@ namespace Lucene.Net.Codecs.Lucene40
     public sealed class Lucene40RWCodec : Lucene40Codec
     {
         private readonly FieldInfosFormat fieldInfos;
-		
+
+        /// <param name="oldFormatImpersonationIsActive">
+        /// LUCENENET specific
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// </param>
         public Lucene40RWCodec(bool oldFormatImpersonationIsActive) : base()
         {
             fieldInfos = new Lucene40FieldInfosFormatAnonymousInnerClassHelper(oldFormatImpersonationIsActive);
@@ -36,6 +40,10 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             private readonly bool _oldFormatImpersonationIsActive;
 
+            /// <param name="oldFormatImpersonationIsActive">
+            /// LUCENENET specific
+            /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+            /// </param>
             public Lucene40FieldInfosFormatAnonymousInnerClassHelper(bool oldFormatImpersonationIsActive) : base()
             {
                 _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWCodec.cs
@@ -23,19 +23,29 @@ namespace Lucene.Net.Codecs.Lucene40
     /// Read-write version of Lucene40Codec for testing </summary>
     public sealed class Lucene40RWCodec : Lucene40Codec
     {
-        private readonly FieldInfosFormat fieldInfos = new Lucene40FieldInfosFormatAnonymousInnerClassHelper();
+        private readonly FieldInfosFormat fieldInfos;
+		
+        public Lucene40RWCodec(bool oldFormatImpersonationIsActive) : base()
+        {
+            fieldInfos = new Lucene40FieldInfosFormatAnonymousInnerClassHelper(oldFormatImpersonationIsActive);
+            DocValues = new Lucene40RWDocValuesFormat(oldFormatImpersonationIsActive);
+            Norms = new Lucene40RWNormsFormat(oldFormatImpersonationIsActive);
+    }
 
         private class Lucene40FieldInfosFormatAnonymousInnerClassHelper : Lucene40FieldInfosFormat
         {
-            public Lucene40FieldInfosFormatAnonymousInnerClassHelper()
+            private readonly bool _oldFormatImpersonationIsActive;
+
+            public Lucene40FieldInfosFormatAnonymousInnerClassHelper(bool oldFormatImpersonationIsActive) : base()
             {
+                _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
             }
 
             public override FieldInfosWriter FieldInfosWriter
             {
                 get
                 {
-                    if (!LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+                    if (!_oldFormatImpersonationIsActive)
                     {
                         return base.FieldInfosWriter;
                     }
@@ -47,8 +57,8 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        private readonly DocValuesFormat DocValues = new Lucene40RWDocValuesFormat();
-        private readonly NormsFormat Norms = new Lucene40RWNormsFormat();
+        private readonly DocValuesFormat DocValues;
+        private readonly NormsFormat Norms;
 
         public override FieldInfosFormat FieldInfosFormat()
         {

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWDocValuesFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWDocValuesFormat.cs
@@ -25,9 +25,16 @@ namespace Lucene.Net.Codecs.Lucene40
     /// Read-write version of <seealso cref="Lucene40DocValuesFormat"/> for testing </summary>
     public class Lucene40RWDocValuesFormat : Lucene40DocValuesFormat
     {
+        private readonly bool _oldFormatImpersonationIsActive;
+
+        public Lucene40RWDocValuesFormat(bool oldFormatImpersonationIsActive) : base()
+        {
+            _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
+        }
+
         public override DocValuesConsumer FieldsConsumer(SegmentWriteState state)
         {
-            if (!LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (!_oldFormatImpersonationIsActive)
             {
                 return base.FieldsConsumer(state);
             }

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWDocValuesFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWDocValuesFormat.cs
@@ -27,6 +27,10 @@ namespace Lucene.Net.Codecs.Lucene40
     {
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <param name="oldFormatImpersonationIsActive">
+        /// LUCENENET specific
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// </param>
         public Lucene40RWDocValuesFormat(bool oldFormatImpersonationIsActive) : base()
         {
             _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWNormsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWNormsFormat.cs
@@ -25,9 +25,16 @@ namespace Lucene.Net.Codecs.Lucene40
     /// Read-write version of <seealso cref="Lucene40NormsFormat"/> for testing </summary>
     public class Lucene40RWNormsFormat : Lucene40NormsFormat
     {
+        private readonly bool _oldFormatImpersonationIsActive;
+
+        public Lucene40RWNormsFormat(bool oldFormatImpersonationIsActive) : base()
+        {
+            _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
+        }
+
         public override DocValuesConsumer NormsConsumer(SegmentWriteState state)
         {
-            if (!LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (!_oldFormatImpersonationIsActive)
             {
                 return base.NormsConsumer(state);
             }

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWNormsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWNormsFormat.cs
@@ -27,6 +27,10 @@ namespace Lucene.Net.Codecs.Lucene40
     {
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <param name="oldFormatImpersonationIsActive">
+        /// LUCENENET specific
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// </param>
         public Lucene40RWNormsFormat(bool oldFormatImpersonationIsActive) : base()
         {
             _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWPostingsFormat.cs
@@ -27,6 +27,10 @@ namespace Lucene.Net.Codecs.Lucene40
     {
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <param name="oldFormatImpersonationIsActive">
+        /// LUCENENET specific
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// </param>
         public Lucene40RWPostingsFormat(bool oldFormatImpersonationIsActive) : base()
         {
             _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWPostingsFormat.cs
@@ -25,9 +25,16 @@ namespace Lucene.Net.Codecs.Lucene40
     /// </summary>
     public class Lucene40RWPostingsFormat : Lucene40PostingsFormat
     {
+        private readonly bool _oldFormatImpersonationIsActive;
+
+        public Lucene40RWPostingsFormat(bool oldFormatImpersonationIsActive) : base()
+        {
+            _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
+        }
+
         public override FieldsConsumer FieldsConsumer(SegmentWriteState state)
         {
-            if (!LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (!_oldFormatImpersonationIsActive)
             {
                 return base.FieldsConsumer(state);
             }

--- a/src/Lucene.Net.TestFramework/Codecs/lucene41/Lucene41RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene41/Lucene41RWCodec.cs
@@ -34,6 +34,10 @@ namespace Lucene.Net.Codecs.Lucene41
         private readonly NormsFormat Norms;
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <param name="oldFormatImpersonationIsActive">
+        /// LUCENENET specific
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// </param>
         public Lucene41RWCodec(bool oldFormatImpersonationIsActive) : base()
         {
             _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
@@ -47,6 +51,10 @@ namespace Lucene.Net.Codecs.Lucene41
         {
             private readonly bool _oldFormatImpersonationIsActive;
 
+            /// <param name="oldFormatImpersonationIsActive">
+            /// LUCENENET specific
+            /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+            /// </param>
             public Lucene40FieldInfosFormatAnonymousInnerClassHelper(bool oldFormatImpersonationIsActive) : base()
             {
                 _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene41/Lucene41RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene41/Lucene41RWCodec.cs
@@ -29,19 +29,34 @@ namespace Lucene.Net.Codecs.Lucene41
     public class Lucene41RWCodec : Lucene41Codec
     {
         private readonly StoredFieldsFormat FieldsFormat = new Lucene41StoredFieldsFormat();
-        private readonly FieldInfosFormat fieldInfos = new Lucene40FieldInfosFormatAnonymousInnerClassHelper();
+        private readonly FieldInfosFormat fieldInfos;
+        private readonly DocValuesFormat DocValues;
+        private readonly NormsFormat Norms;
+        private readonly bool _oldFormatImpersonationIsActive;
+
+        public Lucene41RWCodec(bool oldFormatImpersonationIsActive) : base()
+        {
+            _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
+
+            Norms = new Lucene40RWNormsFormat(oldFormatImpersonationIsActive);
+            fieldInfos = new Lucene40FieldInfosFormatAnonymousInnerClassHelper(oldFormatImpersonationIsActive);
+            DocValues = new Lucene40RWDocValuesFormat(oldFormatImpersonationIsActive);
+        }
 
         private class Lucene40FieldInfosFormatAnonymousInnerClassHelper : Lucene40FieldInfosFormat
         {
-            public Lucene40FieldInfosFormatAnonymousInnerClassHelper()
+            private readonly bool _oldFormatImpersonationIsActive;
+
+            public Lucene40FieldInfosFormatAnonymousInnerClassHelper(bool oldFormatImpersonationIsActive) : base()
             {
+                _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
             }
 
             public override FieldInfosWriter FieldInfosWriter
             {
                 get
                 {
-                    if (!LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+                    if (!_oldFormatImpersonationIsActive)
                     {
                         return base.FieldInfosWriter;
                     }
@@ -52,9 +67,6 @@ namespace Lucene.Net.Codecs.Lucene41
                 }
             }
         }
-
-        private readonly DocValuesFormat DocValues = new Lucene40RWDocValuesFormat();
-        private readonly NormsFormat Norms = new Lucene40RWNormsFormat();
 
         public override FieldInfosFormat FieldInfosFormat()
         {

--- a/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWCodec.cs
@@ -24,22 +24,30 @@ namespace Lucene.Net.Codecs.Lucene42
     /// </summary>
     public class Lucene42RWCodec : Lucene42Codec
     {
-        private static readonly DocValuesFormat Dv = new Lucene42RWDocValuesFormat();
-        private static readonly NormsFormat Norms = new Lucene42NormsFormat();
+        private readonly DocValuesFormat Dv;
+        private readonly NormsFormat Norms = new Lucene42NormsFormat();
+        private readonly FieldInfosFormat fieldInfosFormat;
 
-        private readonly FieldInfosFormat fieldInfosFormat = new Lucene42FieldInfosFormatAnonymousInnerClassHelper();
+        public Lucene42RWCodec(bool oldFormatImpersonationIsActive) : base()
+        {
+            Dv = new Lucene42RWDocValuesFormat(oldFormatImpersonationIsActive);
+            fieldInfosFormat = new Lucene42FieldInfosFormatAnonymousInnerClassHelper(oldFormatImpersonationIsActive);
+        }
 
         private class Lucene42FieldInfosFormatAnonymousInnerClassHelper : Lucene42FieldInfosFormat
         {
-            public Lucene42FieldInfosFormatAnonymousInnerClassHelper()
+            private readonly bool _oldFormatImpersonationIsActive;
+
+            public Lucene42FieldInfosFormatAnonymousInnerClassHelper(bool oldFormatImpersonationIsActive) : base()
             {
+                _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
             }
 
             public override FieldInfosWriter FieldInfosWriter
             {
                 get
                 {
-                    if (!LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+                    if (!_oldFormatImpersonationIsActive)
                     {
                         return base.FieldInfosWriter;
                     }

--- a/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWCodec.cs
@@ -28,6 +28,10 @@ namespace Lucene.Net.Codecs.Lucene42
         private readonly NormsFormat Norms = new Lucene42NormsFormat();
         private readonly FieldInfosFormat fieldInfosFormat;
 
+        /// <param name="oldFormatImpersonationIsActive">
+        /// LUCENENET specific
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// </param>
         public Lucene42RWCodec(bool oldFormatImpersonationIsActive) : base()
         {
             Dv = new Lucene42RWDocValuesFormat(oldFormatImpersonationIsActive);
@@ -38,6 +42,10 @@ namespace Lucene.Net.Codecs.Lucene42
         {
             private readonly bool _oldFormatImpersonationIsActive;
 
+            /// <param name="oldFormatImpersonationIsActive">
+            /// LUCENENET specific
+            /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+            /// </param>
             public Lucene42FieldInfosFormatAnonymousInnerClassHelper(bool oldFormatImpersonationIsActive) : base()
             {
                 _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWDocValuesFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWDocValuesFormat.cs
@@ -26,9 +26,16 @@ namespace Lucene.Net.Codecs.Lucene42
     /// </summary>
     public class Lucene42RWDocValuesFormat : Lucene42DocValuesFormat
     {
+        private readonly bool _oldFormatImpersonationIsActive;
+
+        public Lucene42RWDocValuesFormat(bool oldFormatImpersonationIsActive) : base()
+        {
+            _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
+        }
+
         public override DocValuesConsumer FieldsConsumer(SegmentWriteState state)
         {
-            if (!LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            if (!_oldFormatImpersonationIsActive)
             {
                 return base.FieldsConsumer(state);
             }

--- a/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWDocValuesFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWDocValuesFormat.cs
@@ -28,6 +28,10 @@ namespace Lucene.Net.Codecs.Lucene42
     {
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <param name="oldFormatImpersonationIsActive">
+        /// LUCENENET specific
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// </param>
         public Lucene42RWDocValuesFormat(bool oldFormatImpersonationIsActive) : base()
         {
             _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;

--- a/src/Lucene.Net.TestFramework/Codecs/lucene45/Lucene45RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene45/Lucene45RWCodec.cs
@@ -26,19 +26,27 @@ namespace Lucene.Net.Codecs.Lucene45
     /// </summary>
     public class Lucene45RWCodec : Lucene45Codec
     {
-        private readonly FieldInfosFormat fieldInfosFormat = new Lucene42FieldInfosFormatAnonymousInnerClassHelper();
+        private readonly FieldInfosFormat fieldInfosFormat;
+
+        public Lucene45RWCodec(bool oldFormatImpersonationIsActive) : base()
+        {
+             fieldInfosFormat = new Lucene42FieldInfosFormatAnonymousInnerClassHelper(oldFormatImpersonationIsActive);
+        }
 
         private class Lucene42FieldInfosFormatAnonymousInnerClassHelper : Lucene42FieldInfosFormat
         {
-            public Lucene42FieldInfosFormatAnonymousInnerClassHelper()
+            private readonly bool _oldFormatImpersonationIsActive;
+
+            public Lucene42FieldInfosFormatAnonymousInnerClassHelper(bool oldFormatImpersonationIsActive) : base()
             {
+                _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;
             }
 
             public override FieldInfosWriter FieldInfosWriter
             {
                 get
                 {
-                    if (!LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+                    if (!_oldFormatImpersonationIsActive)
                     {
                         return base.FieldInfosWriter;
                     }

--- a/src/Lucene.Net.TestFramework/Codecs/lucene45/Lucene45RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene45/Lucene45RWCodec.cs
@@ -28,6 +28,10 @@ namespace Lucene.Net.Codecs.Lucene45
     {
         private readonly FieldInfosFormat fieldInfosFormat;
 
+        /// <param name="oldFormatImpersonationIsActive">
+        /// LUCENENET specific
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// </param>
         public Lucene45RWCodec(bool oldFormatImpersonationIsActive) : base()
         {
              fieldInfosFormat = new Lucene42FieldInfosFormatAnonymousInnerClassHelper(oldFormatImpersonationIsActive);
@@ -37,6 +41,10 @@ namespace Lucene.Net.Codecs.Lucene45
         {
             private readonly bool _oldFormatImpersonationIsActive;
 
+            /// <param name="oldFormatImpersonationIsActive">
+            /// LUCENENET specific
+            /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+            /// </param>
             public Lucene42FieldInfosFormatAnonymousInnerClassHelper(bool oldFormatImpersonationIsActive) : base()
             {
                 _oldFormatImpersonationIsActive = oldFormatImpersonationIsActive;

--- a/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
@@ -88,7 +88,7 @@ namespace Lucene.Net.Index
         public void TestOneNumber()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             string longTerm = "longtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongterm";
             string text = "this is the text to be indexed. " + longTerm;
@@ -123,7 +123,7 @@ namespace Lucene.Net.Index
         public void TestOneFloat()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             string longTerm = "longtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongterm";
             string text = "this is the text to be indexed. " + longTerm;
@@ -158,7 +158,7 @@ namespace Lucene.Net.Index
         public void TestTwoNumbers()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             string longTerm = "longtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongterm";
             string text = "this is the text to be indexed. " + longTerm;
@@ -196,7 +196,7 @@ namespace Lucene.Net.Index
         public void TestTwoBinaryValues()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             string longTerm = "longtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongterm";
             string text = "this is the text to be indexed. " + longTerm;
@@ -237,7 +237,7 @@ namespace Lucene.Net.Index
         public void TestTwoFieldsMixed()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             string longTerm = "longtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongterm";
             string text = "this is the text to be indexed. " + longTerm;
@@ -277,7 +277,7 @@ namespace Lucene.Net.Index
         public void TestThreeFieldsMixed()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             string longTerm = "longtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongterm";
             string text = "this is the text to be indexed. " + longTerm;
@@ -322,7 +322,7 @@ namespace Lucene.Net.Index
         public void TestThreeFieldsMixed2()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             string longTerm = "longtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongtermlongterm";
             string text = "this is the text to be indexed. " + longTerm;
@@ -1835,7 +1835,7 @@ namespace Lucene.Net.Index
         {
             AssumeTrue("Codec does not support SORTED_SET", DefaultCodecSupportsSortedSet());
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new SortedSetDocValuesField("field", new BytesRef("hello")));
@@ -1863,7 +1863,7 @@ namespace Lucene.Net.Index
         {
             AssumeTrue("Codec does not support SORTED_SET", DefaultCodecSupportsSortedSet());
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new SortedSetDocValuesField("field", new BytesRef("hello")));
@@ -1946,7 +1946,7 @@ namespace Lucene.Net.Index
         {
             AssumeTrue("Codec does not support SORTED_SET", DefaultCodecSupportsSortedSet());
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new SortedSetDocValuesField("field", new BytesRef("hello")));
@@ -1979,7 +1979,7 @@ namespace Lucene.Net.Index
         {
             AssumeTrue("Codec does not support SORTED_SET", DefaultCodecSupportsSortedSet());
             Directory directory = NewDirectory();
-            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter iwriter = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new SortedSetDocValuesField("field", new BytesRef("world")));
@@ -3476,7 +3476,7 @@ namespace Lucene.Net.Index
                     break;
                 }
                 Directory dir = NewDirectory();
-                RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+                RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
                 BytesRef bytes = new BytesRef();
                 bytes.Bytes = new byte[1 << i];
                 bytes.Length = 1 << i;

--- a/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
@@ -263,7 +263,7 @@ namespace Lucene.Net.Index
         public void TestNumericField()
         {
             Directory dir = NewDirectory();
-            var w = new RandomIndexWriter(Random(), dir);
+            var w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             var numDocs = AtLeast(500);
             var answers = new object[numDocs];
             FieldType.NumericType[] typeAnswers = new FieldType.NumericType[numDocs];
@@ -348,7 +348,7 @@ namespace Lucene.Net.Index
         public void TestIndexedBit()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType onlyStored = new FieldType();
             onlyStored.Stored = true;
@@ -766,7 +766,7 @@ namespace Lucene.Net.Index
             }
             w.Commit();
             w.Dispose();
-            w = new RandomIndexWriter(Random(), dir);
+            w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             w.ForceMerge(TestUtil.NextInt(Random(), 1, 3));
             w.Commit();
             w.Dispose();

--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -675,7 +675,7 @@ namespace Lucene.Net.Index
                 int docWithVectors = Random().Next(numDocs);
                 Document emptyDoc = new Document();
                 Directory dir = NewDirectory();
-                RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+                RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
                 RandomDocument doc = docFactory.NewDocument(TestUtil.NextInt(Random(), 1, 3), 20, options);
                 for (int i = 0; i < numDocs; ++i)
                 {
@@ -722,7 +722,7 @@ namespace Lucene.Net.Index
                     continue;
                 }
                 using (Directory dir = NewDirectory())
-                using (RandomIndexWriter writer = new RandomIndexWriter(Random(), dir))
+                using (RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone))
                 {
                     RandomDocument doc = docFactory.NewDocument(TestUtil.NextInt(Random(), 1, 2), AtLeast(20000),
                         options);
@@ -740,7 +740,7 @@ namespace Lucene.Net.Index
             foreach (Options options in ValidOptions())
             {
                 Directory dir = NewDirectory();
-                RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+                RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
                 RandomDocument doc = docFactory.NewDocument(AtLeast(100), 5, options);
                 writer.AddDocument(doc.ToDocument());
                 IndexReader reader = writer.Reader;
@@ -767,7 +767,7 @@ namespace Lucene.Net.Index
                     }
                     using (Directory dir = NewDirectory())
                     {
-                        using (var writer = new RandomIndexWriter(Random(), dir))
+                        using (var writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone))
                         {
                             RandomDocument doc1 = docFactory.NewDocument(numFields, 20, options1);
                             RandomDocument doc2 = docFactory.NewDocument(numFields, 20, options2);
@@ -797,7 +797,7 @@ namespace Lucene.Net.Index
                 docs[i] = docFactory.NewDocument(TestUtil.NextInt(Random(), 1, 3), TestUtil.NextInt(Random(), 10, 50), RandomOptions());
             }
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < numDocs; ++i)
             {
                 writer.AddDocument(AddId(docs[i].ToDocument(), "" + i));
@@ -832,7 +832,7 @@ namespace Lucene.Net.Index
                     docs[i] = docFactory.NewDocument(TestUtil.NextInt(Random(), 1, 3), AtLeast(10), options);
                 }
                 Directory dir = NewDirectory();
-                RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+                RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
                 for (int i = 0; i < numDocs; ++i)
                 {
                     writer.AddDocument(AddId(docs[i].ToDocument(), "" + i));
@@ -877,7 +877,7 @@ namespace Lucene.Net.Index
                     docs[i] = docFactory.NewDocument(TestUtil.NextInt(Random(), 1, 3), AtLeast(10), options);
                 }
                 Directory dir = NewDirectory();
-                RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+                RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
                 for (int i = 0; i < numDocs; ++i)
                 {
                     writer.AddDocument(AddId(docs[i].ToDocument(), "" + i));

--- a/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
@@ -8,21 +8,21 @@ using Lucene.Net.Util;
 namespace Lucene.Net.Index
 {
     /*
-     * Licensed to the Apache Software Foundation (ASF) under one or more
-     * contributor license agreements.  See the NOTICE file distributed with
-     * this work for additional information regarding copyright ownership.
-     * The ASF licenses this file to You under the Apache License, Version 2.0
-     * (the "License"); you may not use this file except in compliance with
-     * the License.  You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
     using Analyzer = Lucene.Net.Analysis.Analyzer;
     using BytesRef = Lucene.Net.Util.BytesRef;
@@ -33,6 +33,7 @@ namespace Lucene.Net.Index
     using MockAnalyzer = Lucene.Net.Analysis.MockAnalyzer;
     using NullInfoStream = Lucene.Net.Util.NullInfoStream;
     using Query = Lucene.Net.Search.Query;
+    using Similarity = Search.Similarities.Similarity;
     using TestUtil = Lucene.Net.Util.TestUtil;
 
     /// <summary>
@@ -85,22 +86,22 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// create a RandomIndexWriter with a random config: Uses TEST_VERSION_CURRENT and MockAnalyzer </summary>
-        public RandomIndexWriter(Random r, Directory dir)
-            : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, LuceneTestCase.TEST_VERSION_CURRENT, new MockAnalyzer(r)))
+        public RandomIndexWriter(Random r, Directory dir, Similarity similarity, TimeZone timezone)
+            : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, LuceneTestCase.TEST_VERSION_CURRENT, new MockAnalyzer(r), similarity, timezone))
         {
         }
 
         /// <summary>
         /// create a RandomIndexWriter with a random config: Uses TEST_VERSION_CURRENT </summary>
-        public RandomIndexWriter(Random r, Directory dir, Analyzer a)
-            : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, LuceneTestCase.TEST_VERSION_CURRENT, a))
+        public RandomIndexWriter(Random r, Directory dir, Analyzer a, Similarity similarity, TimeZone timezone)
+            : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, LuceneTestCase.TEST_VERSION_CURRENT, a, similarity, timezone))
         {
         }
 
         /// <summary>
         /// create a RandomIndexWriter with a random config </summary>
-        public RandomIndexWriter(Random r, Directory dir, LuceneVersion v, Analyzer a)
-            : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, v, a))
+        public RandomIndexWriter(Random r, Directory dir, LuceneVersion v, Analyzer a, Similarity similarity, TimeZone timezone)
+            : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, v, a, similarity, timezone))
         {
         }
 

--- a/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
@@ -85,14 +85,28 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// create a RandomIndexWriter with a random config: Uses TEST_VERSION_CURRENT and MockAnalyzer </summary>
+        /// create a RandomIndexWriter with a random config: Uses TEST_VERSION_CURRENT and MockAnalyzer
+        ///
+        /// LUCENENET specific
+        /// Similarity and TimeZone parameters allow a RandomIndexWriter to be
+        /// created without adding a dependency on 
+        /// <see cref="LuceneTestCase.ClassEnv.Similarity"/> and
+        /// <see cref="LuceneTestCase.ClassEnv.TimeZone"/>
+        /// </summary>
         public RandomIndexWriter(Random r, Directory dir, Similarity similarity, TimeZone timezone)
             : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, LuceneTestCase.TEST_VERSION_CURRENT, new MockAnalyzer(r), similarity, timezone))
         {
         }
 
         /// <summary>
-        /// create a RandomIndexWriter with a random config: Uses TEST_VERSION_CURRENT </summary>
+        /// create a RandomIndexWriter with a random config: Uses TEST_VERSION_CURRENT
+        ///
+        /// LUCENENET specific
+        /// Similarity and TimeZone parameters allow a RandomIndexWriter to be
+        /// created without adding a dependency on 
+        /// <see cref="LuceneTestCase.ClassEnv.Similarity"/> and
+        /// <see cref="LuceneTestCase.ClassEnv.TimeZone"/>
+        /// </summary>
         public RandomIndexWriter(Random r, Directory dir, Analyzer a, Similarity similarity, TimeZone timezone)
             : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, LuceneTestCase.TEST_VERSION_CURRENT, a, similarity, timezone))
         {
@@ -100,11 +114,12 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Creates a RandomIndexWriter with a random config
-        /// 
+        ///
         /// LUCENENET specific
-        /// This override allows a RandomIndexWriter to be created without
-        /// adding a dependency on the LuceneTestCase.ClassEnv.Similarity and
-        /// LuceneTestCase.ClassEnv.TimeZone property
+        /// Similarity and TimeZone parameters allow a RandomIndexWriter to be
+        /// created without adding a dependency on 
+        /// <see cref="LuceneTestCase.ClassEnv.Similarity"/> and
+        /// <see cref="LuceneTestCase.ClassEnv.TimeZone"/>
         /// </summary>
         public RandomIndexWriter(Random r, Directory dir, LuceneVersion v, Analyzer a, Similarity similarity, TimeZone timezone)
             : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, v, a, similarity, timezone))

--- a/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
@@ -8,21 +8,21 @@ using Lucene.Net.Util;
 namespace Lucene.Net.Index
 {
     /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The ASF licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
 
     using Analyzer = Lucene.Net.Analysis.Analyzer;
     using BytesRef = Lucene.Net.Util.BytesRef;
@@ -99,7 +99,13 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// create a RandomIndexWriter with a random config </summary>
+        /// Creates a RandomIndexWriter with a random config
+        /// 
+        /// LUCENENET specific
+        /// This override allows a RandomIndexWriter to be created without
+        /// adding a dependency on the LuceneTestCase.ClassEnv.Similarity and
+        /// LuceneTestCase.ClassEnv.TimeZone property
+        /// </summary>
         public RandomIndexWriter(Random r, Directory dir, LuceneVersion v, Analyzer a, Similarity similarity, TimeZone timezone)
             : this(r, dir, LuceneTestCase.NewIndexWriterConfig(r, v, a, similarity, timezone))
         {

--- a/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
@@ -801,7 +801,7 @@ namespace Lucene.Net.Index
                     }
                 }
 
-                IndexSearcher searcher = NewSearcher(reader);
+                IndexSearcher searcher = OuterInstance.NewSearcher(reader);
                 sum += searcher.Search(new TermQuery(new Term("body", "united")), 10).TotalHits;
 
                 if (VERBOSE)

--- a/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
@@ -202,7 +202,7 @@ namespace Lucene.Net.Index
                         if (Random().NextBoolean())
                         {
                             addedField = "extra" + Random().Next(40);
-                            doc.Add(NewTextField(addedField, "a random field", Field.Store.YES));
+                            doc.Add(OuterInstance.NewTextField(addedField, "a random field", Field.Store.YES));
                         }
                         else
                         {
@@ -231,7 +231,7 @@ namespace Lucene.Net.Index
                                     packID = OuterInstance.PackCount.IncrementAndGet() + "";
                                 }
 
-                                Field packIDField = NewStringField("packID", packID, Field.Store.YES);
+                                Field packIDField = OuterInstance.NewStringField("packID", packID, Field.Store.YES);
                                 IList<string> docIDs = new List<string>();
                                 SubDocs subDocs = new SubDocs(packID, docIDs);
                                 IList<Document> docsList = new List<Document>();

--- a/src/Lucene.Net.TestFramework/Search/CheckHits.cs
+++ b/src/Lucene.Net.TestFramework/Search/CheckHits.cs
@@ -91,7 +91,11 @@ namespace Lucene.Net.Search
         /// <param name="searcher"> the searcher to test the query against </param>
         /// <param name="defaultFieldName"> used for displaying the query in assertion messages </param>
         /// <param name="results"> a list of documentIds that must match the query </param>
-        /// <seealso cref= #checkHits </seealso>
+        /// <param name="similarity">
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
+        /// <seealso cref=#checkHits </seealso>
         public static void CheckHitCollector(Random random, Query query, string defaultFieldName, IndexSearcher searcher, int[] results, Similarity similarity)
         {
             QueryUtils.Check(random, query, searcher, similarity);
@@ -170,6 +174,10 @@ namespace Lucene.Net.Search
         /// <param name="searcher"> the searcher to test the query against </param>
         /// <param name="defaultFieldName"> used for displaing the query in assertion messages </param>
         /// <param name="results"> a list of documentIds that must match the query </param>
+        /// <param name="similarity">
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
         /// <seealso cref= #checkHitCollector </seealso>
         public static void DoCheckHits(Random random, Query query, string defaultFieldName, IndexSearcher searcher, int[] results, Similarity similarity)
         {

--- a/src/Lucene.Net.TestFramework/Search/CheckHits.cs
+++ b/src/Lucene.Net.TestFramework/Search/CheckHits.cs
@@ -7,6 +7,7 @@ using System.Text;
 namespace Lucene.Net.Search
 {
     using NUnit.Framework;
+    using Similarities;
     using System.IO;
 
     /*
@@ -91,9 +92,9 @@ namespace Lucene.Net.Search
         /// <param name="defaultFieldName"> used for displaying the query in assertion messages </param>
         /// <param name="results"> a list of documentIds that must match the query </param>
         /// <seealso cref= #checkHits </seealso>
-        public static void CheckHitCollector(Random random, Query query, string defaultFieldName, IndexSearcher searcher, int[] results)
+        public static void CheckHitCollector(Random random, Query query, string defaultFieldName, IndexSearcher searcher, int[] results, Similarity similarity)
         {
-            QueryUtils.Check(random, query, searcher);
+            QueryUtils.Check(random, query, searcher, similarity);
 
             Trace.TraceInformation("Checked");
 
@@ -112,7 +113,7 @@ namespace Lucene.Net.Search
             for (int i = -1; i < 2; i++)
             {
                 actual.Clear();
-                IndexSearcher s = QueryUtils.WrapUnderlyingReader(random, searcher, i);
+                IndexSearcher s = QueryUtils.WrapUnderlyingReader(random, searcher, i, similarity);
                 s.Search(query, c);
                 Assert.AreEqual(correct, actual, "Wrap Reader " + i + ": " + query.ToString(defaultFieldName));
             }
@@ -170,7 +171,7 @@ namespace Lucene.Net.Search
         /// <param name="defaultFieldName"> used for displaing the query in assertion messages </param>
         /// <param name="results"> a list of documentIds that must match the query </param>
         /// <seealso cref= #checkHitCollector </seealso>
-        public static void DoCheckHits(Random random, Query query, string defaultFieldName, IndexSearcher searcher, int[] results)
+        public static void DoCheckHits(Random random, Query query, string defaultFieldName, IndexSearcher searcher, int[] results, Similarity similarity)
         {
             ScoreDoc[] hits = searcher.Search(query, 1000).ScoreDocs;
 
@@ -188,7 +189,7 @@ namespace Lucene.Net.Search
 
             Assert.AreEqual(correct, actual, query.ToString(defaultFieldName));
 
-            QueryUtils.Check(random, query, searcher, LuceneTestCase.Rarely(random));
+            QueryUtils.Check(random, query, searcher, LuceneTestCase.Rarely(random), similarity);
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Search/QueryUtils.cs
+++ b/src/Lucene.Net.TestFramework/Search/QueryUtils.cs
@@ -118,6 +118,10 @@ namespace Lucene.Net.Search
         /// Various query sanity checks on a searcher, some checks are only done for
         /// instanceof IndexSearcher.
         /// </summary>
+        /// <param name = "similarity" >
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
         /// <seealso cref= #check(Query) </seealso>
         /// <seealso cref= #checkFirstSkipTo </seealso>
         /// <seealso cref= #checkSkipTo </seealso>
@@ -128,6 +132,10 @@ namespace Lucene.Net.Search
             Check(random, q1, s, true, similarity);
         }
 
+        /// <param name = "similarity" >
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
         public static void Check(Random random, Query q1, IndexSearcher s, bool wrap, Similarity similarity)
         {
             try
@@ -200,6 +208,10 @@ namespace Lucene.Net.Search
         /// behave exactly the same as the original IndexSearcher. </summary>
         /// <param name="s"> the searcher to wrap </param>
         /// <param name="edge"> if negative, s will be the first sub; if 0, s will be in the middle, if positive s will be the last sub </param>
+        /// <param name="similarity">
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
         public static IndexSearcher WrapUnderlyingReader(Random random, IndexSearcher s, int edge, Similarity similarity)
         {
             IndexReader r = s.IndexReader;
@@ -251,6 +263,10 @@ namespace Lucene.Net.Search
         /// alternate scorer skipTo(),skipTo(),next(),next(),skipTo(),skipTo(), etc
         /// and ensure a hitcollector receives same docs and scores
         /// </summary>
+        /// <param name = "similarity" >
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
         public static void CheckSkipTo(Query q, IndexSearcher s, Similarity similarity)
         {
             //System.out.println("Checking "+q);
@@ -412,7 +428,11 @@ namespace Lucene.Net.Search
         }
 
         /// <summary>
-        /// check that first skip on just created scorers always goes to the right doc </summary>
+        /// check that first skip on just created scorers always goes to the right doc</summary>
+        /// <param name = "similarity" >
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
         public static void CheckFirstSkipTo(Query q, IndexSearcher s, Similarity similarity)
         {
             //System.out.println("checkFirstSkipTo: "+q);

--- a/src/Lucene.Net.TestFramework/Search/QueryUtils.cs
+++ b/src/Lucene.Net.TestFramework/Search/QueryUtils.cs
@@ -43,6 +43,7 @@ namespace Lucene.Net.Search
     using MultiReader = Lucene.Net.Index.MultiReader;
     using RAMDirectory = Lucene.Net.Store.RAMDirectory;
     using SlowCompositeReaderWrapper = Lucene.Net.Index.SlowCompositeReaderWrapper;
+    using Similarities;
 
     /// <summary>
     /// Utility class for sanity-checking queries.
@@ -127,20 +128,20 @@ namespace Lucene.Net.Search
             Check(random, q1, s, true);
         }
 
-        public static void Check(Random random, Query q1, IndexSearcher s, bool wrap)
+        public static void Check(Random random, Query q1, IndexSearcher s, bool wrap, Similarity similarity)
         {
             try
             {
                 Check(q1);
                 if (s != null)
                 {
-                    CheckFirstSkipTo(q1, s);
-                    CheckSkipTo(q1, s);
+                    CheckFirstSkipTo(q1, s, similarity);
+                    CheckSkipTo(q1, s, similarity);
                     if (wrap)
                     {
-                        Check(random, q1, WrapUnderlyingReader(random, s, -1), false);
-                        Check(random, q1, WrapUnderlyingReader(random, s, 0), false);
-                        Check(random, q1, WrapUnderlyingReader(random, s, +1), false);
+                        Check(random, q1, WrapUnderlyingReader(random, s, -1, similarity), false, similarity);
+                        Check(random, q1, WrapUnderlyingReader(random, s, 0, similarity), false, similarity);
+                        Check(random, q1, WrapUnderlyingReader(random, s, +1, similarity), false, similarity);
                     }
                     CheckExplanations(q1, s);
 
@@ -199,7 +200,7 @@ namespace Lucene.Net.Search
         /// behave exactly the same as the original IndexSearcher. </summary>
         /// <param name="s"> the searcher to wrap </param>
         /// <param name="edge"> if negative, s will be the first sub; if 0, s will be in the middle, if positive s will be the last sub </param>
-        public static IndexSearcher WrapUnderlyingReader(Random random, IndexSearcher s, int edge)
+        public static IndexSearcher WrapUnderlyingReader(Random random, IndexSearcher s, int edge, Similarity similarity)
         {
             IndexReader r = s.IndexReader;
 
@@ -207,7 +208,7 @@ namespace Lucene.Net.Search
             // it will throw off the docIds
             IndexReader[] readers = new IndexReader[] { edge < 0 ? r : EmptyReaders[0], EmptyReaders[0], new FCInvisibleMultiReader(edge < 0 ? EmptyReaders[4] : EmptyReaders[0], EmptyReaders[0], 0 == edge ? r : EmptyReaders[0]), 0 < edge ? EmptyReaders[0] : EmptyReaders[7], EmptyReaders[0], new FCInvisibleMultiReader(0 < edge ? EmptyReaders[0] : EmptyReaders[5], EmptyReaders[0], 0 < edge ? r : EmptyReaders[0]) };
 
-            IndexSearcher @out = LuceneTestCase.NewSearcher(new FCInvisibleMultiReader(readers));
+            IndexSearcher @out = LuceneTestCase.NewSearcher(new FCInvisibleMultiReader(readers), similarity);
             @out.Similarity = s.Similarity;
             return @out;
         }
@@ -250,7 +251,7 @@ namespace Lucene.Net.Search
         /// alternate scorer skipTo(),skipTo(),next(),next(),skipTo(),skipTo(), etc
         /// and ensure a hitcollector receives same docs and scores
         /// </summary>
-        public static void CheckSkipTo(Query q, IndexSearcher s)
+        public static void CheckSkipTo(Query q, IndexSearcher s, Similarity similarity)
         {
             //System.out.println("Checking "+q);
             IList<AtomicReaderContext> readerContextArray = s.TopReaderContext.Leaves;
@@ -276,14 +277,14 @@ namespace Lucene.Net.Search
                 const float maxDiff = 1e-5f;
                 AtomicReader[] lastReader = new AtomicReader[] { null };
 
-                s.Search(q, new CollectorAnonymousInnerClassHelper(q, s, readerContextArray, skip_op, order, opidx, lastDoc, maxDiff, lastReader));
+                s.Search(q, new CollectorAnonymousInnerClassHelper(q, s, readerContextArray, skip_op, order, opidx, lastDoc, maxDiff, lastReader, similarity));
 
                 if (lastReader[0] != null)
                 {
                     // confirm that skipping beyond the last doc, on the
                     // previous reader, hits NO_MORE_DOCS
                     AtomicReader previousReader = lastReader[0];
-                    IndexSearcher indexSearcher = LuceneTestCase.NewSearcher(previousReader, false);
+                    IndexSearcher indexSearcher = LuceneTestCase.NewSearcher(previousReader, false, similarity);
                     indexSearcher.Similarity = s.Similarity;
                     Weight w = indexSearcher.CreateNormalizedWeight(q);
                     AtomicReaderContext ctx = (AtomicReaderContext)previousReader.Context;
@@ -308,8 +309,11 @@ namespace Lucene.Net.Search
             private int[] LastDoc;
             private float MaxDiff;
             private AtomicReader[] LastReader;
+            private readonly Similarity Similarity;
 
-            public CollectorAnonymousInnerClassHelper(Query q, IndexSearcher s, IList<AtomicReaderContext> readerContextArray, int skip_op, int[] order, int[] opidx, int[] lastDoc, float maxDiff, AtomicReader[] lastReader)
+            public CollectorAnonymousInnerClassHelper(Query q, IndexSearcher s, IList<AtomicReaderContext> readerContextArray, 
+                int skip_op, int[] order, int[] opidx, int[] lastDoc, float maxDiff, AtomicReader[] lastReader,
+                Similarity similarity)
             {
                 this.q = q;
                 this.s = s;
@@ -320,6 +324,7 @@ namespace Lucene.Net.Search
                 this.LastDoc = lastDoc;
                 this.MaxDiff = maxDiff;
                 this.LastReader = lastReader;
+                this.Similarity = similarity;
             }
 
             private Scorer sc;
@@ -381,7 +386,7 @@ namespace Lucene.Net.Search
                     if (LastReader[0] != null)
                     {
                         AtomicReader previousReader = LastReader[0];
-                        IndexSearcher indexSearcher = LuceneTestCase.NewSearcher(previousReader);
+                        IndexSearcher indexSearcher = LuceneTestCase.NewSearcher(previousReader, Similarity);
                         indexSearcher.Similarity = s.Similarity;
                         Weight w = indexSearcher.CreateNormalizedWeight(q);
                         AtomicReaderContext ctx = (AtomicReaderContext)indexSearcher.TopReaderContext;
@@ -408,21 +413,21 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// check that first skip on just created scorers always goes to the right doc </summary>
-        public static void CheckFirstSkipTo(Query q, IndexSearcher s)
+        public static void CheckFirstSkipTo(Query q, IndexSearcher s, Similarity similarity)
         {
             //System.out.println("checkFirstSkipTo: "+q);
             const float maxDiff = 1e-3f;
             int[] lastDoc = new int[] { -1 };
             AtomicReader[] lastReader = new AtomicReader[] { null };
             IList<AtomicReaderContext> context = s.TopReaderContext.Leaves;
-            s.Search(q, new CollectorAnonymousInnerClassHelper2(q, s, maxDiff, lastDoc, lastReader, context));
+            s.Search(q, new CollectorAnonymousInnerClassHelper2(q, s, maxDiff, lastDoc, lastReader, context, similarity));
 
             if (lastReader[0] != null)
             {
                 // confirm that skipping beyond the last doc, on the
                 // previous reader, hits NO_MORE_DOCS
                 AtomicReader previousReader = lastReader[0];
-                IndexSearcher indexSearcher = LuceneTestCase.NewSearcher(previousReader);
+                IndexSearcher indexSearcher = LuceneTestCase.NewSearcher(previousReader, similarity);
                 indexSearcher.Similarity = s.Similarity;
                 Weight w = indexSearcher.CreateNormalizedWeight(q);
                 Scorer scorer = w.Scorer((AtomicReaderContext)indexSearcher.TopReaderContext, previousReader.LiveDocs);
@@ -442,8 +447,9 @@ namespace Lucene.Net.Search
             private int[] LastDoc;
             private AtomicReader[] LastReader;
             private IList<AtomicReaderContext> Context;
+            private readonly Similarity Similarity;
 
-            public CollectorAnonymousInnerClassHelper2(Query q, IndexSearcher s, float maxDiff, int[] lastDoc, AtomicReader[] lastReader, IList<AtomicReaderContext> context)
+            public CollectorAnonymousInnerClassHelper2(Query q, IndexSearcher s, float maxDiff, int[] lastDoc, AtomicReader[] lastReader, IList<AtomicReaderContext> context, Similarity similarity)
             {
                 this.q = q;
                 this.s = s;
@@ -451,6 +457,7 @@ namespace Lucene.Net.Search
                 this.LastDoc = lastDoc;
                 this.LastReader = lastReader;
                 this.Context = context;
+                this.Similarity = similarity;
             }
 
             private Scorer scorer;
@@ -505,7 +512,7 @@ namespace Lucene.Net.Search
                     if (LastReader[0] != null)
                     {
                         AtomicReader previousReader = LastReader[0];
-                        IndexSearcher indexSearcher = LuceneTestCase.NewSearcher(previousReader);
+                        IndexSearcher indexSearcher = LuceneTestCase.NewSearcher(previousReader, Similarity);
                         indexSearcher.Similarity = s.Similarity;
                         Weight w = indexSearcher.CreateNormalizedWeight(q);
                         Scorer scorer = w.Scorer((AtomicReaderContext)indexSearcher.TopReaderContext, previousReader.LiveDocs);

--- a/src/Lucene.Net.TestFramework/Search/QueryUtils.cs
+++ b/src/Lucene.Net.TestFramework/Search/QueryUtils.cs
@@ -123,9 +123,9 @@ namespace Lucene.Net.Search
         /// <seealso cref= #checkSkipTo </seealso>
         /// <seealso cref= #checkExplanations </seealso>
         /// <seealso cref= #checkEqual </seealso>
-        public static void Check(Random random, Query q1, IndexSearcher s)
+        public static void Check(Random random, Query q1, IndexSearcher s, Similarity similarity)
         {
-            Check(random, q1, s, true);
+            Check(random, q1, s, true, similarity);
         }
 
         public static void Check(Random random, Query q1, IndexSearcher s, bool wrap, Similarity similarity)

--- a/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Search
             Stopword = "" + RandomChar();
             CharacterRunAutomaton stopset = new CharacterRunAutomaton(BasicAutomata.MakeString(Stopword));
             Analyzer = new MockAnalyzer(random, MockTokenizer.WHITESPACE, false, stopset);
-            RandomIndexWriter iw = new RandomIndexWriter(random, Directory, Analyzer);
+            RandomIndexWriter iw = new RandomIndexWriter(random, Directory, Analyzer, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             Field id = new StringField("id", "", Field.Store.NO);
             Field field = new TextField("field", "", Field.Store.NO);

--- a/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
@@ -57,6 +57,10 @@ namespace Lucene.Net.Search
         protected internal static Analyzer Analyzer;
         protected internal static string Stopword; // we always pick a character as a stopword
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because ClassEnvRule is no longer static.
+        /// </summary>
         [SetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1267,32 +1267,32 @@ namespace Lucene.Net.Util
             }
         }
 
-        public static Field NewStringField(string name, string value, Field.Store stored)
+        public Field NewStringField(string name, string value, Field.Store stored)
         {
             return NewField(Random(), name, value, stored == Field.Store.YES ? StringField.TYPE_STORED : StringField.TYPE_NOT_STORED);
         }
 
-        public static Field NewTextField(string name, string value, Field.Store stored)
+        public Field NewTextField(string name, string value, Field.Store stored)
         {
             return NewField(Random(), name, value, stored == Field.Store.YES ? TextField.TYPE_STORED : TextField.TYPE_NOT_STORED);
         }
 
-        public static Field NewStringField(Random random, string name, string value, Field.Store stored)
+        public Field NewStringField(Random random, string name, string value, Field.Store stored)
         {
             return NewField(random, name, value, stored == Field.Store.YES ? StringField.TYPE_STORED : StringField.TYPE_NOT_STORED);
         }
 
-        public static Field NewTextField(Random random, string name, string value, Field.Store stored)
+        public Field NewTextField(Random random, string name, string value, Field.Store stored)
         {
             return NewField(random, name, value, stored == Field.Store.YES ? TextField.TYPE_STORED : TextField.TYPE_NOT_STORED);
         }
 
-        public static Field NewField(string name, string value, FieldType type)
+        public Field NewField(string name, string value, FieldType type)
         {
             return NewField(Random(), name, value, type);
         }
 
-        public static Field NewField(Random random, string name, string value, FieldType type)
+        public Field NewField(Random random, string name, string value, FieldType type)
         {
             name = new string(name.ToCharArray());
             if (Usually(random) || !type.Indexed)

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -842,7 +842,7 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// create a new index writer config with random defaults </summary>
-        public static IndexWriterConfig NewIndexWriterConfig(LuceneVersion v, Analyzer a)
+        public IndexWriterConfig NewIndexWriterConfig(LuceneVersion v, Analyzer a)
         {
             return NewIndexWriterConfig(Random(), v, a);
         }

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -440,6 +440,16 @@ namespace Lucene.Net.Util
         /// </summary>
         internal TestRuleSetupAndRestoreClassEnv ClassEnvRule { get; private set; }
 
+        /// <summary>
+        /// Gets the Similarity from the Class Environment setup rule
+        /// </summary>
+        public Similarity Similarity { get { return ClassEnvRule.Similarity; } }
+
+        /// <summary>
+        /// Gets the Timezone from the Class Environment setup rule
+        /// </summary>
+        public TimeZone TimeZone { get { return ClassEnvRule.TimeZone; } }
+
         // LUCENENET TODO
         /// <summary>
         /// Suite failure marker (any error in the test or suite scope).

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -423,6 +423,9 @@ namespace Lucene.Net.Util
         /// specific tests on demand.
         ///
         /// @lucene.internal
+        /// 
+        /// LUCENENET specific
+        /// Is non-static to remove inter-class dependencies on this variable
         /// </summary>
         public bool OLD_FORMAT_IMPERSONATION_IS_ACTIVE { get; protected set; }
 
@@ -437,16 +440,27 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Class environment setup rule.
+        /// 
+        /// LUCENENET specific
+        /// Is non-static to remove inter-class dependencies on this variable
         /// </summary>
         internal TestRuleSetupAndRestoreClassEnv ClassEnvRule { get; private set; }
 
         /// <summary>
         /// Gets the Similarity from the Class Environment setup rule
+        /// 
+        /// LUCENENET specific
+        /// Exposed because <see cref="TestRuleSetupAndRestoreClassEnv"/> is
+        /// internal and this field is needed by other classes.
         /// </summary>
         public Similarity Similarity { get { return ClassEnvRule.Similarity; } }
 
         /// <summary>
         /// Gets the Timezone from the Class Environment setup rule
+        /// 
+        /// LUCENENET specific
+        /// Exposed because <see cref="TestRuleSetupAndRestoreClassEnv"/> is
+        /// internal and this field is needed by other classes.
         /// </summary>
         public TimeZone TimeZone { get { return ClassEnvRule.TimeZone; } }
 
@@ -851,19 +865,32 @@ namespace Lucene.Net.Util
         }
 
         /// <summary>
-        /// create a new index writer config with random defaults </summary>
+        /// create a new index writer config with random defaults
+        /// 
+        /// LUCENENET specific
+        /// Non-static so that we do not depend on any hidden static dependencies
+        /// </summary>
         public IndexWriterConfig NewIndexWriterConfig(LuceneVersion v, Analyzer a)
         {
             return NewIndexWriterConfig(Random(), v, a);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Non-static so that we do not depend on any hidden static dependencies
+        /// </summary>
         public IndexWriterConfig NewIndexWriterConfig(Random r, LuceneVersion v, Analyzer a)
         {
             return NewIndexWriterConfig(r, v, a, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
         }
 
         /// <summary>
-        /// create a new index writer config with random defaults using the specified random </summary>
+        /// create a new index writer config with random defaults using the specified random
+        /// 
+        /// LUCENENET specific
+        /// This is the only static ctor for IndexWriterConfig because it removes the dependency
+        /// on ClassEnvRule by using parameters Similarity and TimeZone.
+        /// </summary>
         public static IndexWriterConfig NewIndexWriterConfig(Random r, LuceneVersion v, Analyzer a, Similarity similarity, TimeZone timezone)
         {
             IndexWriterConfig c = new IndexWriterConfig(v, a);
@@ -963,24 +990,10 @@ namespace Lucene.Net.Util
             return c;
         }
 
-        /// <summary>
-        /// Gets an IndexWriterConfig using the current TEST_LUCENE_VERSION and a MockAnalyzer
-        /// </summary>
-        public IndexWriterConfig NewIndexWriterConfig()
-        {
-            var random = Random();
-
-            return NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random));
-        }
-
-        /// <summary>
-        /// Gets an IndexWriterConfig using the current TEST_LUCENE_VERSION and the given analyzer
-        /// </summary>
-        public IndexWriterConfig NewIndexWriterConfig(Analyzer a)
-        {
-            return NewIndexWriterConfig(Random(), TEST_VERSION_CURRENT, a);
-        }
-
+        /// <param name="timezone">
+        /// LUCENENET specific
+        /// Timezone added to remove dependency on the then-static <see cref="ClassEnvRule"/>
+        /// </param>
         public static MergePolicy NewMergePolicy(Random r, TimeZone timezone)
         {
             if (Rarely(r))
@@ -998,6 +1011,10 @@ namespace Lucene.Net.Util
             return NewLogMergePolicy(r);
         }
 
+        /// <param name="timezone">
+        /// LUCENENET specific
+        /// Timezone added to remove dependency on the then-static <see cref="ClassEnvRule"/>
+        /// </param>
         public static MergePolicy NewMergePolicy(TimeZone timezone)
         {
             return NewMergePolicy(Random(), timezone);
@@ -1277,31 +1294,61 @@ namespace Lucene.Net.Util
             }
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because <see cref="OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/>
+        /// is now non-static.
+        /// </summary>
         public Field NewStringField(string name, string value, Field.Store stored)
         {
             return NewField(Random(), name, value, stored == Field.Store.YES ? StringField.TYPE_STORED : StringField.TYPE_NOT_STORED);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because <see cref="OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/>
+        /// is now non-static.
+        /// </summary>
         public Field NewTextField(string name, string value, Field.Store stored)
         {
             return NewField(Random(), name, value, stored == Field.Store.YES ? TextField.TYPE_STORED : TextField.TYPE_NOT_STORED);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because <see cref="OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/>
+        /// is now non-static.
+        /// </summary>
         public Field NewStringField(Random random, string name, string value, Field.Store stored)
         {
             return NewField(random, name, value, stored == Field.Store.YES ? StringField.TYPE_STORED : StringField.TYPE_NOT_STORED);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because <see cref="OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/>
+        /// is also non-static to reduce hidden dependencies on this variable.
+        /// </summary>
         public Field NewTextField(Random random, string name, string value, Field.Store stored)
         {
             return NewField(random, name, value, stored == Field.Store.YES ? TextField.TYPE_STORED : TextField.TYPE_NOT_STORED);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because <see cref="OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/>
+        /// is now non-static.
+        /// </summary>
         public Field NewField(string name, string value, FieldType type)
         {
             return NewField(Random(), name, value, type);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because <see cref="OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/>
+        /// is now non-static.
+        /// </summary>
         public Field NewField(Random random, string name, string value, FieldType type)
         {
             name = new string(name.ToCharArray());
@@ -1577,12 +1624,19 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Create a new searcher over the reader. this searcher might randomly use
         /// threads.
+        /// 
+        /// LUCENENET specific
+        /// Is non-static because <see cref="ClassEnvRule"/> is now non-static.
         /// </summary>
         public IndexSearcher NewSearcher(IndexReader r)
         {
             return NewSearcher(r, ClassEnvRule.Similarity);
         }
 
+        /// <param name="similarity">
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
         public static IndexSearcher NewSearcher(IndexReader r, Similarity similarity)
         {
             return NewSearcher(r, true, similarity);
@@ -1592,6 +1646,10 @@ namespace Lucene.Net.Util
         /// Create a new searcher over the reader. this searcher might randomly use
         /// threads.
         /// </summary>
+        /// <param name="similarity">
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
         public static IndexSearcher NewSearcher(IndexReader r, bool maybeWrap, Similarity similarity)
         {
             return NewSearcher(r, maybeWrap, true, similarity);
@@ -1609,6 +1667,10 @@ namespace Lucene.Net.Util
         /// <code>wrapWithAssertions</code> is true, this searcher might be an
         /// <seealso cref="AssertingIndexSearcher"/> instance.
         /// </summary>
+        /// <param name="similarity">
+        /// LUCENENET specific
+        /// Removes dependency on <see cref="LuceneTestCase.ClassEnv.Similarity"/>
+        /// </param>
         public static IndexSearcher NewSearcher(IndexReader r, bool maybeWrap, bool wrapWithAssertions, Similarity similarity)
         {
             Random random = Random();

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -196,8 +196,8 @@ namespace Lucene.Net.Util
 
         public LuceneTestCase()
         {
+            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = false;
             String directory = Paths.TempDirectory;
-
             TEMP_DIR = new System.IO.FileInfo(directory);
         }
 
@@ -423,7 +423,7 @@ namespace Lucene.Net.Util
         ///
         /// @lucene.internal
         /// </summary>
-        public static bool OLD_FORMAT_IMPERSONATION_IS_ACTIVE = false;
+        public bool OLD_FORMAT_IMPERSONATION_IS_ACTIVE { get; protected set; }
 
         // -----------------------------------------------------------------
         // Class level (suite) rules.

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -197,6 +197,7 @@ namespace Lucene.Net.Util
         public LuceneTestCase()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = false;
+            ClassEnvRule = new TestRuleSetupAndRestoreClassEnv();
             String directory = Paths.TempDirectory;
             TEMP_DIR = new System.IO.FileInfo(directory);
         }
@@ -564,7 +565,6 @@ namespace Lucene.Net.Util
         {
             // LUCENENET TODO: Not sure how to convert these
             //ParentChainCallRule.SetupCalled = true;
-            ClassEnvRule = new TestRuleSetupAndRestoreClassEnv();
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -364,8 +364,6 @@ namespace Lucene.Net.Util
 
         static LuceneTestCase()
         {
-            ClassEnvRule = new TestRuleSetupAndRestoreClassEnv();
-
             bool defaultValue = false;
             foreach (string property in Arrays.AsList("tests.leaveTemporary", "tests.leavetemporary", "tests.leavetmpdir", "solr.test.leavetmpdir")) // Solr's legacy -  default -  lowercase -  ANT tasks's (junit4) flag.
             {
@@ -437,7 +435,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Class environment setup rule.
         /// </summary>
-        private static TestRuleSetupAndRestoreClassEnv ClassEnvRule;
+        internal TestRuleSetupAndRestoreClassEnv ClassEnvRule { get; private set; }
 
         // LUCENENET TODO
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -286,13 +286,13 @@ namespace Lucene.Net.Util
         /// Use this constant when creating Analyzers and any other version-dependent stuff.
         /// <p><b>NOTE:</b> Change this when development starts for new Lucene version:
         /// </summary>
-        public static LuceneVersion TEST_VERSION_CURRENT = LuceneVersion.LUCENE_48;
+        public static readonly LuceneVersion TEST_VERSION_CURRENT = LuceneVersion.LUCENE_48;
 
         /// <summary>
         /// True if and only if tests are run in verbose mode. If this flag is false
         /// tests are not expected to print any messages.
         /// </summary>
-        public static bool VERBOSE = RandomizedTest.SystemPropertyAsBoolean("tests.verbose",
+        public static readonly bool VERBOSE = RandomizedTest.SystemPropertyAsBoolean("tests.verbose",
 #if DEBUG
  true
 #else
@@ -302,65 +302,65 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// TODO: javadoc? </summary>
-        public static bool INFOSTREAM = RandomizedTest.SystemPropertyAsBoolean("tests.infostream", VERBOSE);
+        public static readonly bool INFOSTREAM = RandomizedTest.SystemPropertyAsBoolean("tests.infostream", VERBOSE);
 
         /// <summary>
         /// A random multiplier which you should use when writing random tests:
         /// multiply it by the number of iterations to scale your tests (for nightly builds).
         /// </summary>
-        public static int RANDOM_MULTIPLIER = RandomizedTest.SystemPropertyAsInt("tests.multiplier", 1);
+        public static readonly int RANDOM_MULTIPLIER = RandomizedTest.SystemPropertyAsInt("tests.multiplier", 1);
 
         /// <summary>
         /// TODO: javadoc? </summary>
-        public static string DEFAULT_LINE_DOCS_FILE = "europarl.lines.txt.gz";
+        public static readonly string DEFAULT_LINE_DOCS_FILE = "europarl.lines.txt.gz";
 
         /// <summary>
         /// TODO: javadoc? </summary>
-        public static string JENKINS_LARGE_LINE_DOCS_FILE = "enwiki.random.lines.txt";
+        public static readonly string JENKINS_LARGE_LINE_DOCS_FILE = "enwiki.random.lines.txt";
 
         /// <summary>
         /// Gets the codec to run tests with. </summary>
-        public static string TEST_CODEC = SystemProperties.GetProperty("tests.codec", "random");
+        public static readonly string TEST_CODEC = SystemProperties.GetProperty("tests.codec", "random");
 
         /// <summary>
         /// Gets the postingsFormat to run tests with. </summary>
-        public static string TEST_POSTINGSFORMAT = SystemProperties.GetProperty("tests.postingsformat", "random");
+        public static readonly string TEST_POSTINGSFORMAT = SystemProperties.GetProperty("tests.postingsformat", "random");
 
         /// <summary>
         /// Gets the docValuesFormat to run tests with </summary>
-        public static string TEST_DOCVALUESFORMAT = SystemProperties.GetProperty("tests.docvaluesformat", "random");
+        public static readonly string TEST_DOCVALUESFORMAT = SystemProperties.GetProperty("tests.docvaluesformat", "random");
 
         /// <summary>
         /// Gets the directory to run tests with </summary>
-        public static string TEST_DIRECTORY = SystemProperties.GetProperty("tests.directory", "random");
+        public static readonly string TEST_DIRECTORY = SystemProperties.GetProperty("tests.directory", "random");
 
         /// <summary>
         /// the line file used by LineFileDocs </summary>
-        public static string TEST_LINE_DOCS_FILE = SystemProperties.GetProperty("tests.linedocsfile", DEFAULT_LINE_DOCS_FILE);
+        public static readonly string TEST_LINE_DOCS_FILE = SystemProperties.GetProperty("tests.linedocsfile", DEFAULT_LINE_DOCS_FILE);
 
         /// <summary>
         /// Whether or not <seealso cref="Nightly"/> tests should run. </summary>
-        public static bool TEST_NIGHTLY = RandomizedTest.SystemPropertyAsBoolean(SYSPROP_NIGHTLY, false);
+        public static readonly bool TEST_NIGHTLY = RandomizedTest.SystemPropertyAsBoolean(SYSPROP_NIGHTLY, false);
 
         /// <summary>
         /// Whether or not <seealso cref="Weekly"/> tests should run. </summary>
-        public static bool TEST_WEEKLY = RandomizedTest.SystemPropertyAsBoolean(SYSPROP_WEEKLY, false);
+        public static readonly bool TEST_WEEKLY = RandomizedTest.SystemPropertyAsBoolean(SYSPROP_WEEKLY, false);
 
         /// <summary>
         /// Whether or not <seealso cref="AwaitsFix"/> tests should run. </summary>
-        public static bool TEST_AWAITSFIX = RandomizedTest.SystemPropertyAsBoolean(SYSPROP_AWAITSFIX, false);
+        public static readonly bool TEST_AWAITSFIX = RandomizedTest.SystemPropertyAsBoolean(SYSPROP_AWAITSFIX, false);
 
         /// <summary>
         /// Whether or not <seealso cref="Slow"/> tests should run. </summary>
-        public static bool TEST_SLOW = RandomizedTest.SystemPropertyAsBoolean(SYSPROP_SLOW, false);
+        public static readonly bool TEST_SLOW = RandomizedTest.SystemPropertyAsBoolean(SYSPROP_SLOW, false);
 
         /// <summary>
         /// Throttling, see <seealso cref="MockDirectoryWrapper#setThrottling(Throttling)"/>. </summary>
-        public static MockDirectoryWrapper.Throttling_e TEST_THROTTLING = TEST_NIGHTLY ? MockDirectoryWrapper.Throttling_e.SOMETIMES : MockDirectoryWrapper.Throttling_e.NEVER;
+        public static readonly MockDirectoryWrapper.Throttling_e TEST_THROTTLING = TEST_NIGHTLY ? MockDirectoryWrapper.Throttling_e.SOMETIMES : MockDirectoryWrapper.Throttling_e.NEVER;
 
         /// <summary>
         /// Leave temporary files on disk, even on successful runs. </summary>
-        public static bool LEAVE_TEMPORARY;
+        public static readonly bool LEAVE_TEMPORARY;
 
         static LuceneTestCase()
         {
@@ -400,17 +400,17 @@ namespace Lucene.Net.Util
         /// <seealso> cref= SystemPropertiesInvariantRule </seealso>
         /// <seealso> cref= #ruleChain </seealso>
         /// <seealso> cref= #classRules </seealso>
-        private static string[] IGNORED_INVARIANT_PROPERTIES = { "user.timezone", "java.rmi.server.randomIDs" };
+        private static readonly string[] IGNORED_INVARIANT_PROPERTIES = { "user.timezone", "java.rmi.server.randomIDs" };
 
         /// <summary>
         /// Filesystem-based <seealso cref="Directory"/> implementations. </summary>
-        private static IList<string> FS_DIRECTORIES = Arrays.AsList("SimpleFSDirectory", "NIOFSDirectory", "MMapDirectory");
+        private static readonly IList<string> FS_DIRECTORIES = Arrays.AsList("SimpleFSDirectory", "NIOFSDirectory", "MMapDirectory");
 
         /// <summary>
         /// All <seealso cref="Directory"/> implementations. </summary>
-        private static IList<string> CORE_DIRECTORIES;
+        private static readonly IList<string> CORE_DIRECTORIES;
 
-        protected static HashSet<string> DoesntSupportOffsets = new HashSet<string>(Arrays.AsList("Lucene3x", "MockFixedIntBlock", "MockVariableIntBlock", "MockSep", "MockRandom"));
+        protected static readonly HashSet<string> DoesntSupportOffsets = new HashSet<string>(Arrays.AsList("Lucene3x", "MockFixedIntBlock", "MockVariableIntBlock", "MockSep", "MockRandom"));
 
         // -----------------------------------------------------------------
         // Fields initialized in class or instance rules.
@@ -443,7 +443,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Suite failure marker (any error in the test or suite scope).
         /// </summary>
-        public static /*TestRuleMarkFailure*/ bool SuiteFailureMarker = true; // Means: was successful
+        public static readonly /*TestRuleMarkFailure*/ bool SuiteFailureMarker = true; // Means: was successful
 
         /// <summary>
         /// Ignore tests after hitting a designated number of initial failures. this
@@ -473,7 +473,7 @@ namespace Lucene.Net.Util
         /// Max 10mb of static data stored in a test suite class after the suite is complete.
         /// Prevents static data structures leaking and causing OOMs in subsequent tests.
         /// </summary>
-        private static long STATIC_LEAK_THRESHOLD = 10 * 1024 * 1024;
+        private static readonly long STATIC_LEAK_THRESHOLD = 10 * 1024 * 1024;
 
         /// <summary>
         /// By-name list of ignored types like loggers etc. </summary>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1570,7 +1570,12 @@ namespace Lucene.Net.Util
         /// </summary>
         public IndexSearcher NewSearcher(IndexReader r)
         {
-            return NewSearcher(r, true, ClassEnvRule.Similarity);
+            return NewSearcher(r, ClassEnvRule.Similarity);
+        }
+
+        public static IndexSearcher NewSearcher(IndexReader r, Similarity similarity)
+        {
+            return NewSearcher(r, true, similarity);
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1003,7 +1003,7 @@ namespace Lucene.Net.Util
             return NewTieredMergePolicy(Random());
         }
 
-        public static AlcoholicMergePolicy NewAlcoholicMergePolicy()
+        public AlcoholicMergePolicy NewAlcoholicMergePolicy()
         {
             return NewAlcoholicMergePolicy(Random(), ClassEnvRule.TimeZone);
         }
@@ -1568,18 +1568,23 @@ namespace Lucene.Net.Util
         /// Create a new searcher over the reader. this searcher might randomly use
         /// threads.
         /// </summary>
-        public static IndexSearcher NewSearcher(IndexReader r)
+        public IndexSearcher NewSearcher(IndexReader r)
         {
-            return NewSearcher(r, true);
+            return NewSearcher(r, true, ClassEnvRule.Similarity);
         }
 
         /// <summary>
         /// Create a new searcher over the reader. this searcher might randomly use
         /// threads.
         /// </summary>
-        public static IndexSearcher NewSearcher(IndexReader r, bool maybeWrap)
+        public static IndexSearcher NewSearcher(IndexReader r, bool maybeWrap, Similarity similarity)
         {
-            return NewSearcher(r, maybeWrap, true);
+            return NewSearcher(r, maybeWrap, true, similarity);
+        }
+
+        public IndexSearcher NewSearcher(IndexReader r, bool maybeWrap, bool wrapWithAssertions)
+        {
+            return NewSearcher(r, maybeWrap, wrapWithAssertions, ClassEnvRule.Similarity);
         }
 
         /// <summary>
@@ -1589,7 +1594,7 @@ namespace Lucene.Net.Util
         /// <code>wrapWithAssertions</code> is true, this searcher might be an
         /// <seealso cref="AssertingIndexSearcher"/> instance.
         /// </summary>
-        public static IndexSearcher NewSearcher(IndexReader r, bool maybeWrap, bool wrapWithAssertions)
+        public static IndexSearcher NewSearcher(IndexReader r, bool maybeWrap, bool wrapWithAssertions, Similarity similarity)
         {
             Random random = Random();
             if (Usually())
@@ -1615,7 +1620,7 @@ namespace Lucene.Net.Util
                 {
                     ret = random.NextBoolean() ? new IndexSearcher(r) : new IndexSearcher(r.Context);
                 }
-                ret.Similarity = ClassEnvRule.Similarity;
+                ret.Similarity = similarity;
                 return ret;
             }
             else
@@ -1650,7 +1655,7 @@ namespace Lucene.Net.Util
                 {
                     ret = random.NextBoolean() ? new IndexSearcher(r, ex) : new IndexSearcher(r.Context, ex);
                 }
-                ret.Similarity = ClassEnvRule.Similarity;
+                ret.Similarity = similarity;
                 return ret;
             }
         }

--- a/src/Lucene.Net.Tests.Classification/ClassificationTestBase.cs
+++ b/src/Lucene.Net.Tests.Classification/ClassificationTestBase.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Classification
         {
             base.SetUp();
             dir = NewDirectory();
-            indexWriter = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            indexWriter = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             textFieldName = "text";
             categoryFieldName = "cat";
             booleanFieldName = "bool";

--- a/src/Lucene.Net.Tests.Classification/ClassificationTestBase.cs
+++ b/src/Lucene.Net.Tests.Classification/ClassificationTestBase.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Classification
         {
             base.SetUp();
             dir = NewDirectory();
-            indexWriter = new RandomIndexWriter(Random(), dir);
+            indexWriter = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             textFieldName = "text";
             categoryFieldName = "cat";
             booleanFieldName = "bool";

--- a/src/Lucene.Net.Tests.Classification/Utils/DataSplitterTest.cs
+++ b/src/Lucene.Net.Tests.Classification/Utils/DataSplitterTest.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Classification
         {
             base.SetUp();
             _dir = NewDirectory();
-            _indexWriter = new RandomIndexWriter(Random(), _dir, new MockAnalyzer(Random()));
+            _indexWriter = new RandomIndexWriter(Random(), _dir, new MockAnalyzer(Random()), Similarity, TimeZone);
 
             FieldType ft = new FieldType(TextField.TYPE_STORED);
             ft.StoreTermVectors = true;

--- a/src/Lucene.Net.Tests.Expressions/TestDemoExpressions.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestDemoExpressions.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Tests.Expressions
 		{
 			base.SetUp();
 			dir = NewDirectory();
-			var iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+			var iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 			var doc = new Document
 			{
 			    NewStringField("id", "1", Field.Store.YES),

--- a/src/Lucene.Net.Tests.Expressions/TestDemoExpressions.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestDemoExpressions.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Tests.Expressions
 		{
 			base.SetUp();
 			dir = NewDirectory();
-			var iw = new RandomIndexWriter(Random(), dir);
+			var iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 			var doc = new Document
 			{
 			    NewStringField("id", "1", Field.Store.YES),

--- a/src/Lucene.Net.Tests.Expressions/TestExpressionRescorer.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestExpressionRescorer.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Tests.Expressions
 		{
 			base.SetUp();
 			dir = NewDirectory();
-			var iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+			var iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 			var doc = new Document
 			{
 			    NewStringField("id", "1", Field.Store.YES),

--- a/src/Lucene.Net.Tests.Expressions/TestExpressionRescorer.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestExpressionRescorer.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Tests.Expressions
 		{
 			base.SetUp();
 			dir = NewDirectory();
-			var iw = new RandomIndexWriter(Random(), dir);
+			var iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 			var doc = new Document
 			{
 			    NewStringField("id", "1", Field.Store.YES),

--- a/src/Lucene.Net.Tests.Expressions/TestExpressionSorts.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestExpressionSorts.cs
@@ -32,7 +32,7 @@ namespace Lucene.Net.Tests.Expressions
         {
             base.SetUp();
             dir = NewDirectory();
-            var iw = new RandomIndexWriter(Random(), dir);
+            var iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int numDocs = TestUtil.NextInt(Random(), 2049, 4000);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests.Expressions/TestExpressionSorts.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestExpressionSorts.cs
@@ -32,7 +32,7 @@ namespace Lucene.Net.Tests.Expressions
         {
             base.SetUp();
             dir = NewDirectory();
-            var iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            var iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int numDocs = TestUtil.NextInt(Random(), 2049, 4000);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests.Facet/Range/TestRangeFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Range/TestRangeFacetCounts.cs
@@ -386,7 +386,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestRandomLongs()
         {
             Directory dir = NewDirectory();
-            var w = new RandomIndexWriter(Random(), dir);
+            var w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             int numDocs = AtLeast(1000);
             if (VERBOSE)
@@ -579,7 +579,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestRandomFloats()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             int numDocs = AtLeast(1000);
             float[] values = new float[numDocs];
@@ -784,7 +784,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestRandomDoubles()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             int numDocs = AtLeast(1000);
             double[] values = new double[numDocs];
@@ -1006,7 +1006,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestCustomDoublesValueSource()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests.Facet/Range/TestRangeFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Range/TestRangeFacetCounts.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestBasicLong()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             NumericDocValuesField field = new NumericDocValuesField("field", 0L);
             doc.Add(field);
@@ -149,7 +149,7 @@ namespace Lucene.Net.Facet.Range
         {
 
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             NumericDocValuesField field = new NumericDocValuesField("field", 0L);
             doc.Add(field);
@@ -180,7 +180,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestOverlappedEndStart()
         {
             Directory d = NewDirectory();
-            var w = new RandomIndexWriter(Random(), d);
+            var w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             NumericDocValuesField field = new NumericDocValuesField("field", 0L);
             doc.Add(field);
@@ -216,7 +216,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestMixedRangeAndNonRangeTaxonomy()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Directory td = NewDirectory();
             DirectoryTaxonomyWriter tw = new DirectoryTaxonomyWriter(td, IndexWriterConfig.OpenMode_e.CREATE);
 
@@ -331,7 +331,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestBasicDouble()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             DoubleDocValuesField field = new DoubleDocValuesField("field", 0.0);
             doc.Add(field);
@@ -358,7 +358,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestBasicFloat()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             FloatDocValuesField field = new FloatDocValuesField("field", 0.0f);
             doc.Add(field);
@@ -386,7 +386,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestRandomLongs()
         {
             Directory dir = NewDirectory();
-            var w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            var w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             int numDocs = AtLeast(1000);
             if (VERBOSE)
@@ -579,7 +579,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestRandomFloats()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             int numDocs = AtLeast(1000);
             float[] values = new float[numDocs];
@@ -784,7 +784,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestRandomDoubles()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             int numDocs = AtLeast(1000);
             double[] values = new double[numDocs];
@@ -973,7 +973,7 @@ namespace Lucene.Net.Facet.Range
         {
             AssumeTrue("codec does not support docsWithField", DefaultCodecSupportsDocsWithField());
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             NumericDocValuesField field = new NumericDocValuesField("field", 0L);
             doc.Add(field);
@@ -1006,7 +1006,7 @@ namespace Lucene.Net.Facet.Range
         public virtual void TestCustomDoublesValueSource()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests.Facet/SortedSet/TestSortedSetDocValuesFacets.cs
+++ b/src/Lucene.Net.Tests.Facet/SortedSet/TestSortedSetDocValuesFacets.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Facet.SortedSet
 
             FacetsConfig config = new FacetsConfig();
             config.SetMultiValued("a", true);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(new SortedSetDocValuesFacetField("a", "foo"));
@@ -105,7 +105,7 @@ namespace Lucene.Net.Facet.SortedSet
             AssumeTrue("Test requires SortedSetDV support", DefaultCodecSupportsSortedSet());
             Directory dir = NewDirectory();
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 
@@ -153,7 +153,7 @@ namespace Lucene.Net.Facet.SortedSet
             AssumeTrue("Test requires SortedSetDV support", DefaultCodecSupportsSortedSet());
             Directory dir = NewDirectory();
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 
@@ -211,7 +211,7 @@ namespace Lucene.Net.Facet.SortedSet
             AssumeTrue("Test requires SortedSetDV support", DefaultCodecSupportsSortedSet());
             Directory dir = NewDirectory();
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 
@@ -253,7 +253,7 @@ namespace Lucene.Net.Facet.SortedSet
             AssumeTrue("Test requires SortedSetDV support", DefaultCodecSupportsSortedSet());
             Directory dir = NewDirectory();
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 
@@ -292,7 +292,7 @@ namespace Lucene.Net.Facet.SortedSet
             Directory indexDir = NewDirectory();
             Directory taxoDir = NewDirectory();
 
-            RandomIndexWriter w = new RandomIndexWriter(Random(), indexDir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), indexDir, Similarity, TimeZone);
             FacetsConfig config = new FacetsConfig();
             int numDocs = AtLeast(1000);
             int numDims = TestUtil.NextInt(Random(), 1, 7);

--- a/src/Lucene.Net.Tests.Facet/SortedSet/TestSortedSetDocValuesFacets.cs
+++ b/src/Lucene.Net.Tests.Facet/SortedSet/TestSortedSetDocValuesFacets.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Facet.SortedSet
 
             FacetsConfig config = new FacetsConfig();
             config.SetMultiValued("a", true);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new SortedSetDocValuesFacetField("a", "foo"));
@@ -105,7 +105,7 @@ namespace Lucene.Net.Facet.SortedSet
             AssumeTrue("Test requires SortedSetDV support", DefaultCodecSupportsSortedSet());
             Directory dir = NewDirectory();
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 
@@ -153,7 +153,7 @@ namespace Lucene.Net.Facet.SortedSet
             AssumeTrue("Test requires SortedSetDV support", DefaultCodecSupportsSortedSet());
             Directory dir = NewDirectory();
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 
@@ -211,7 +211,7 @@ namespace Lucene.Net.Facet.SortedSet
             AssumeTrue("Test requires SortedSetDV support", DefaultCodecSupportsSortedSet());
             Directory dir = NewDirectory();
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 
@@ -253,7 +253,7 @@ namespace Lucene.Net.Facet.SortedSet
             AssumeTrue("Test requires SortedSetDV support", DefaultCodecSupportsSortedSet());
             Directory dir = NewDirectory();
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             dir = NewDirectory();
             taxoDir = NewDirectory();
@@ -62,7 +62,7 @@ namespace Lucene.Net.Facet.Taxonomy
             config.SetIndexFieldName("float", "$facets.float");
             config.SetMultiValued("float", true);
 
-            var writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            var writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             // index documents, 50% have only 'b' and all have 'a'
             for (int i = 0; i < 110; i++)
@@ -190,7 +190,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
             TaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir);
             FacetsConfig config = new FacetsConfig();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(new IntAssociationFacetField(14, "a", "x"));
@@ -216,7 +216,7 @@ namespace Lucene.Net.Facet.Taxonomy
             TaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir);
             FacetsConfig config = new FacetsConfig();
             config.SetHierarchical("a", true);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(new IntAssociationFacetField(14, "a", "x"));
@@ -241,7 +241,7 @@ namespace Lucene.Net.Facet.Taxonomy
             TaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir);
             FacetsConfig config = new FacetsConfig();
             config.SetRequireDimCount("a", true);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(new IntAssociationFacetField(14, "a", "x"));

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Facet.Taxonomy
             config.SetIndexFieldName("float", "$facets.float");
             config.SetMultiValued("float", true);
 
-            var writer = new RandomIndexWriter(Random(), dir);
+            var writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             // index documents, 50% have only 'b' and all have 'a'
             for (int i = 0; i < 110; i++)
@@ -190,7 +190,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
             TaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir);
             FacetsConfig config = new FacetsConfig();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new IntAssociationFacetField(14, "a", "x"));
@@ -216,7 +216,7 @@ namespace Lucene.Net.Facet.Taxonomy
             TaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir);
             FacetsConfig config = new FacetsConfig();
             config.SetHierarchical("a", true);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new IntAssociationFacetField(14, "a", "x"));
@@ -241,7 +241,7 @@ namespace Lucene.Net.Facet.Taxonomy
             TaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir);
             FacetsConfig config = new FacetsConfig();
             config.SetRequireDimCount("a", true);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new IntAssociationFacetField(14, "a", "x"));

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
@@ -45,7 +45,10 @@ namespace Lucene.Net.Facet.Taxonomy
 
         private static FacetsConfig config;
 
-
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because Similarity and TimeZone are not static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Facet.Taxonomy
             FacetsConfig config = new FacetsConfig();
             config.SetHierarchical("Publish Date", true);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new FacetField("Author", "Bob"));
@@ -152,7 +152,7 @@ namespace Lucene.Net.Facet.Taxonomy
             // main index:
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             Document doc = new Document();
@@ -214,7 +214,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
             FacetsConfig config = new FacetsConfig();
             config.SetIndexFieldName("a", "$facets2");
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new FacetField("a", "foo1"));
@@ -318,7 +318,7 @@ namespace Lucene.Net.Facet.Taxonomy
             FacetsConfig config = new FacetsConfig();
             config.SetHierarchical("a", true);
             config.SetMultiValued("a", true);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(NewTextField("field", "text", Field.Store.NO));
@@ -364,7 +364,7 @@ namespace Lucene.Net.Facet.Taxonomy
         {
             Store.Directory dir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
             FacetsConfig config = new FacetsConfig();
@@ -399,7 +399,7 @@ namespace Lucene.Net.Facet.Taxonomy
         {
             Store.Directory dir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
             FacetsConfig config = new FacetsConfig();
@@ -510,7 +510,7 @@ namespace Lucene.Net.Facet.Taxonomy
             Store.Directory dir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
-            var writer = new RandomIndexWriter(Random(), dir);
+            var writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             Document doc = new Document();
@@ -536,7 +536,7 @@ namespace Lucene.Net.Facet.Taxonomy
             Store.Directory dir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
             TaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             Document doc = new Document();

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Facet.Taxonomy
             FacetsConfig config = new FacetsConfig();
             config.SetHierarchical("Publish Date", true);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(new FacetField("Author", "Bob"));
@@ -152,7 +152,7 @@ namespace Lucene.Net.Facet.Taxonomy
             // main index:
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             Document doc = new Document();
@@ -214,7 +214,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
             FacetsConfig config = new FacetsConfig();
             config.SetIndexFieldName("a", "$facets2");
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(new FacetField("a", "foo1"));
@@ -318,7 +318,7 @@ namespace Lucene.Net.Facet.Taxonomy
             FacetsConfig config = new FacetsConfig();
             config.SetHierarchical("a", true);
             config.SetMultiValued("a", true);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(NewTextField("field", "text", Field.Store.NO));
@@ -364,7 +364,7 @@ namespace Lucene.Net.Facet.Taxonomy
         {
             Store.Directory dir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
             FacetsConfig config = new FacetsConfig();
@@ -399,7 +399,7 @@ namespace Lucene.Net.Facet.Taxonomy
         {
             Store.Directory dir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
             FacetsConfig config = new FacetsConfig();
@@ -510,7 +510,7 @@ namespace Lucene.Net.Facet.Taxonomy
             Store.Directory dir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
-            var writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            var writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             Document doc = new Document();
@@ -536,7 +536,7 @@ namespace Lucene.Net.Facet.Taxonomy
             Store.Directory dir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
             TaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             Document doc = new Document();
@@ -749,7 +749,7 @@ namespace Lucene.Net.Facet.Taxonomy
             Store.Directory indexDir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
 
-            RandomIndexWriter w = new RandomIndexWriter(Random(), indexDir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), indexDir, Similarity, TimeZone);
             var tw = new DirectoryTaxonomyWriter(taxoDir);
             FacetsConfig config = new FacetsConfig();
             int numDocs = AtLeast(1000);

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
@@ -246,7 +246,7 @@ namespace Lucene.Net.Facet.Taxonomy
         }
 
         [TestFixtureSetUp]
-        public static void BeforeClassCountingFacetsAggregatorTest()
+        public void BeforeClassCountingFacetsAggregatorTest()
         {
             indexDir = NewDirectory();
             taxoDir = NewDirectory();

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Facet.Taxonomy
             // main index:
             DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             // Reused across documents, to add the necessary facet
@@ -144,7 +144,7 @@ namespace Lucene.Net.Facet.Taxonomy
             // main index:
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             Document doc = new Document();
@@ -213,7 +213,7 @@ namespace Lucene.Net.Facet.Taxonomy
             FacetsConfig config = new FacetsConfig();
             config.SetIndexFieldName("a", "$facets2");
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new IntField("num", 10, Field.Store.NO));

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Facet.Taxonomy
             // main index:
             DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             // Reused across documents, to add the necessary facet
@@ -144,7 +144,7 @@ namespace Lucene.Net.Facet.Taxonomy
             // main index:
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             FacetsConfig config = new FacetsConfig();
 
             Document doc = new Document();
@@ -213,7 +213,7 @@ namespace Lucene.Net.Facet.Taxonomy
             FacetsConfig config = new FacetsConfig();
             config.SetIndexFieldName("a", "$facets2");
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(new IntField("num", 10, Field.Store.NO));
@@ -498,7 +498,7 @@ namespace Lucene.Net.Facet.Taxonomy
             Store.Directory indexDir = NewDirectory();
             Store.Directory taxoDir = NewDirectory();
 
-            RandomIndexWriter w = new RandomIndexWriter(Random(), indexDir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), indexDir, Similarity, TimeZone);
             var tw = new DirectoryTaxonomyWriter(taxoDir);
             FacetsConfig config = new FacetsConfig();
             int numDocs = AtLeast(1000);

--- a/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Facet
         }
 
         [TestFixtureSetUp]
-        public static void BeforeClassDrillDownQueryTest()
+        public void BeforeClassDrillDownQueryTest()
         {
             dir = NewDirectory();
             Random r = Random();

--- a/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Facet
             FacetsConfig config = new FacetsConfig();
             config.SetHierarchical("Publish Date", true);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(new FacetField("Author", "Bob"));
@@ -252,7 +252,7 @@ namespace Lucene.Net.Facet
         {
             Directory dir = NewDirectory();
             Directory taxoDir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             // Writes facet ords to a separate directory from the
             // main index:
@@ -308,7 +308,7 @@ namespace Lucene.Net.Facet
         {
             Directory dir = NewDirectory();
             Directory taxoDir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             // Writes facet ords to a separate directory from the
             // main index:
@@ -1307,7 +1307,7 @@ namespace Lucene.Net.Facet
             // LUCENE-5045: make sure DrillSideways works with an empty index
             Directory dir = NewDirectory();
             Directory taxoDir = NewDirectory();
-            var writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            var writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
             IndexSearcher searcher = NewSearcher(writer.Reader);
             var taxoReader = new DirectoryTaxonomyReader(taxoWriter);

--- a/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Facet
             FacetsConfig config = new FacetsConfig();
             config.SetHierarchical("Publish Date", true);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(new FacetField("Author", "Bob"));
@@ -252,7 +252,7 @@ namespace Lucene.Net.Facet
         {
             Directory dir = NewDirectory();
             Directory taxoDir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             // Writes facet ords to a separate directory from the
             // main index:
@@ -308,7 +308,7 @@ namespace Lucene.Net.Facet
         {
             Directory dir = NewDirectory();
             Directory taxoDir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             // Writes facet ords to a separate directory from the
             // main index:
@@ -1307,7 +1307,7 @@ namespace Lucene.Net.Facet
             // LUCENE-5045: make sure DrillSideways works with an empty index
             Directory dir = NewDirectory();
             Directory taxoDir = NewDirectory();
-            var writer = new RandomIndexWriter(Random(), dir);
+            var writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode_e.CREATE);
             IndexSearcher searcher = NewSearcher(writer.Reader);
             var taxoReader = new DirectoryTaxonomyReader(taxoWriter);

--- a/src/Lucene.Net.Tests.Facet/TestRandomSamplingFacetsCollector.cs
+++ b/src/Lucene.Net.Tests.Facet/TestRandomSamplingFacetsCollector.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Facet
             Directory taxoDir = NewDirectory();
 
             DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 

--- a/src/Lucene.Net.Tests.Facet/TestRandomSamplingFacetsCollector.cs
+++ b/src/Lucene.Net.Tests.Facet/TestRandomSamplingFacetsCollector.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Facet
             Directory taxoDir = NewDirectory();
 
             DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir);
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             FacetsConfig config = new FacetsConfig();
 

--- a/src/Lucene.Net.Tests.Join/Lucene.Net.Tests.Join.csproj
+++ b/src/Lucene.Net.Tests.Join/Lucene.Net.Tests.Join.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Lucene.Net.Tests.Join/TestBlockJoin.cs
+++ b/src/Lucene.Net.Tests.Join/TestBlockJoin.cs
@@ -131,7 +131,7 @@ namespace Lucene.Net.Tests.Join
         public void TestSimple()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             IList<Document> docs = new List<Document>();
 
@@ -221,7 +221,7 @@ namespace Lucene.Net.Tests.Join
         public void TestBugCausedByRewritingTwice()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             IList<Document> docs = new List<Document>();
 
@@ -278,7 +278,7 @@ namespace Lucene.Net.Tests.Join
         public virtual void TestSimpleFilter()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             IList<Document> docs = new List<Document>();
             docs.Add(MakeJob("java", 2007));
@@ -376,7 +376,7 @@ namespace Lucene.Net.Tests.Join
         public void TestBoostBug()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             IndexReader r = w.Reader;
             w.Dispose();
             IndexSearcher s = NewSearcher(r);
@@ -521,7 +521,7 @@ namespace Lucene.Net.Tests.Join
             IList<int> toDelete = new List<int>();
 
             // TODO: parallel star join, nested join cases too!
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             RandomIndexWriter joinW = new RandomIndexWriter(Random(), joinDir);
             for (int parentDocID = 0; parentDocID < numParentDocs; parentDocID++)
             {
@@ -1125,7 +1125,7 @@ namespace Lucene.Net.Tests.Join
         public void TestMultiChildTypes()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             IList<Document> docs = new List<Document>();
 
@@ -1212,7 +1212,7 @@ namespace Lucene.Net.Tests.Join
         public void TestAdvanceSingleParentSingleChild()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document childDoc = new Document();
             childDoc.Add(NewStringField("child", "1", Field.Store.NO));
             Document parentDoc = new Document();
@@ -1271,7 +1271,7 @@ namespace Lucene.Net.Tests.Join
         {
 
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             IList<Document> docs = new List<Document>();
             docs.Add(MakeJob("ruby", 2005));
@@ -1547,7 +1547,7 @@ namespace Lucene.Net.Tests.Join
         public void TestAdvanceSingleDeletedParentNoChild()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             // First doc with 1 children
             Document parentDoc = new Document();

--- a/src/Lucene.Net.Tests.Join/TestBlockJoin.cs
+++ b/src/Lucene.Net.Tests.Join/TestBlockJoin.cs
@@ -131,7 +131,7 @@ namespace Lucene.Net.Tests.Join
         public void TestSimple()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             IList<Document> docs = new List<Document>();
 
@@ -221,7 +221,7 @@ namespace Lucene.Net.Tests.Join
         public void TestBugCausedByRewritingTwice()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             IList<Document> docs = new List<Document>();
 
@@ -278,7 +278,7 @@ namespace Lucene.Net.Tests.Join
         public virtual void TestSimpleFilter()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             IList<Document> docs = new List<Document>();
             docs.Add(MakeJob("java", 2007));
@@ -376,13 +376,13 @@ namespace Lucene.Net.Tests.Join
         public void TestBoostBug()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             IndexReader r = w.Reader;
             w.Dispose();
             IndexSearcher s = NewSearcher(r);
 
             ToParentBlockJoinQuery q = new ToParentBlockJoinQuery(new MatchAllDocsQuery(), new QueryWrapperFilter(new MatchAllDocsQuery()), ScoreMode.Avg);
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
             s.Search(q, 10);
             BooleanQuery bq = new BooleanQuery();
             bq.Boost = 2f; // we boost the BQ
@@ -521,8 +521,8 @@ namespace Lucene.Net.Tests.Join
             IList<int> toDelete = new List<int>();
 
             // TODO: parallel star join, nested join cases too!
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
-            RandomIndexWriter joinW = new RandomIndexWriter(Random(), joinDir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
+            RandomIndexWriter joinW = new RandomIndexWriter(Random(), joinDir, Similarity, TimeZone);
             for (int parentDocID = 0; parentDocID < numParentDocs; parentDocID++)
             {
                 Document parentDoc = new Document();
@@ -1125,7 +1125,7 @@ namespace Lucene.Net.Tests.Join
         public void TestMultiChildTypes()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             IList<Document> docs = new List<Document>();
 
@@ -1212,7 +1212,7 @@ namespace Lucene.Net.Tests.Join
         public void TestAdvanceSingleParentSingleChild()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document childDoc = new Document();
             childDoc.Add(NewStringField("child", "1", Field.Store.NO));
             Document parentDoc = new Document();
@@ -1271,7 +1271,7 @@ namespace Lucene.Net.Tests.Join
         {
 
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             IList<Document> docs = new List<Document>();
             docs.Add(MakeJob("ruby", 2005));
@@ -1365,7 +1365,7 @@ namespace Lucene.Net.Tests.Join
         public void TestSometimesParentOnlyMatches()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document parent = new Document();
             parent.Add(new StoredField("parentID", "0"));
             parent.Add(NewTextField("parentText", "text", Field.Store.NO));
@@ -1430,7 +1430,7 @@ namespace Lucene.Net.Tests.Join
         public void TestChildQueryNeverMatches()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document parent = new Document();
             parent.Add(new StoredField("parentID", "0"));
             parent.Add(NewTextField("parentText", "text", Field.Store.NO));
@@ -1496,7 +1496,7 @@ namespace Lucene.Net.Tests.Join
         public void TestChildQueryMatchesParent()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document parent = new Document();
             parent.Add(new StoredField("parentID", "0"));
             parent.Add(NewTextField("parentText", "text", Field.Store.NO));
@@ -1547,7 +1547,7 @@ namespace Lucene.Net.Tests.Join
         public void TestAdvanceSingleDeletedParentNoChild()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             // First doc with 1 children
             Document parentDoc = new Document();

--- a/src/Lucene.Net.Tests.Join/TestBlockJoinValidation.cs
+++ b/src/Lucene.Net.Tests.Join/TestBlockJoinValidation.cs
@@ -128,7 +128,7 @@ namespace Lucene.Net.Tests.Join
             StringAssert.Contains(ToChildBlockJoinQuery.InvalidQueryMessage, ex.Message);
         }
 
-        private static IList<Document> CreateDocsForSegment(int segmentNumber)
+        private IList<Document> CreateDocsForSegment(int segmentNumber)
         {
             IList<IList<Document>> blocks = new List<IList<Document>>(AMOUNT_OF_PARENT_DOCS);
             for (int i = 0; i < AMOUNT_OF_PARENT_DOCS; i++)
@@ -143,7 +143,7 @@ namespace Lucene.Net.Tests.Join
             return result;
         }
 
-        private static IList<Document> CreateParentDocWithChildren(int segmentNumber, int parentNumber)
+        private IList<Document> CreateParentDocWithChildren(int segmentNumber, int parentNumber)
         {
             IList<Document> result = new List<Document>(AMOUNT_OF_CHILD_DOCS + 1);
             for (int i = 0; i < AMOUNT_OF_CHILD_DOCS; i++)
@@ -154,7 +154,7 @@ namespace Lucene.Net.Tests.Join
             return result;
         }
 
-        private static Document CreateParentDoc(int segmentNumber, int parentNumber)
+        private Document CreateParentDoc(int segmentNumber, int parentNumber)
         {
             Document result = new Document();
             result.Add(NewStringField("id", CreateFieldValue(segmentNumber * AMOUNT_OF_PARENT_DOCS + parentNumber), Field.Store.YES));
@@ -162,7 +162,7 @@ namespace Lucene.Net.Tests.Join
             return result;
         }
 
-        private static Document CreateChildDoc(int segmentNumber, int parentNumber, int childNumber)
+        private Document CreateChildDoc(int segmentNumber, int parentNumber, int childNumber)
         {
             Document result = new Document();
             result.Add(NewStringField("id", CreateFieldValue(segmentNumber * AMOUNT_OF_PARENT_DOCS + parentNumber, childNumber), Field.Store.YES));

--- a/src/Lucene.Net.Tests.Queries/BooleanFilterTest.cs
+++ b/src/Lucene.Net.Tests.Queries/BooleanFilterTest.cs
@@ -19,7 +19,7 @@ namespace Lucene.Net.Tests.Queries
         {
             base.SetUp();
             directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, new MockAnalyzer(Random(), MockTokenizer.WHITESPACE, false));
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, new MockAnalyzer(Random(), MockTokenizer.WHITESPACE, false), Similarity, TimeZone);
 
             AddDoc(writer, @"admin guest", @"010", @"20040101", @"Y");
             AddDoc(writer, @"guest", @"020", @"20040101", @"Y");

--- a/src/Lucene.Net.Tests.Queries/ChainedFilterTest.cs
+++ b/src/Lucene.Net.Tests.Queries/ChainedFilterTest.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Tests.Queries
         {
             base.SetUp();
             directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             // we use the default Locale/TZ since LuceneTestCase randomizes it
             var cal = new DateTime(1970, 1, 1, 0, 0, 0, (int)TestUtil.NextLong(Random(), 0, long.MaxValue), new GregorianCalendar());
 
@@ -160,7 +160,7 @@ namespace Lucene.Net.Tests.Queries
         public virtual void TestWithCachingFilter()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             IndexReader reader = writer.Reader;
             writer.Dispose();
 

--- a/src/Lucene.Net.Tests.Queries/ChainedFilterTest.cs
+++ b/src/Lucene.Net.Tests.Queries/ChainedFilterTest.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Tests.Queries
         {
             base.SetUp();
             directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             // we use the default Locale/TZ since LuceneTestCase randomizes it
             var cal = new DateTime(1970, 1, 1, 0, 0, 0, (int)TestUtil.NextLong(Random(), 0, long.MaxValue), new GregorianCalendar());
 
@@ -160,7 +160,7 @@ namespace Lucene.Net.Tests.Queries
         public virtual void TestWithCachingFilter()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             IndexReader reader = writer.Reader;
             writer.Dispose();
 

--- a/src/Lucene.Net.Tests.Queries/CommonTermsQueryTest.cs
+++ b/src/Lucene.Net.Tests.Queries/CommonTermsQueryTest.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Tests.Queries
         {
             Directory dir = NewDirectory();
             MockAnalyzer analyzer = new MockAnalyzer(Random());
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, analyzer);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, analyzer, Similarity, TimeZone);
             var docs = new string[]
             {
                 @"this is the end of the world right", @"is this it or maybe not",
@@ -153,7 +153,7 @@ namespace Lucene.Net.Tests.Queries
         {
             Directory dir = NewDirectory();
             MockAnalyzer analyzer = new MockAnalyzer(Random());
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, analyzer);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, analyzer, Similarity, TimeZone);
             string[] docs = new string[]
             {
                 @"this is the end of the world right", @"is this it or maybe not",
@@ -305,7 +305,7 @@ namespace Lucene.Net.Tests.Queries
         {
             Directory dir = NewDirectory();
             MockAnalyzer analyzer = new MockAnalyzer(Random());
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, analyzer);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, analyzer, Similarity, TimeZone);
             var docs = new string[]
             {
                 @"this is the end of the world right", @"is this it or maybe not",

--- a/src/Lucene.Net.Tests.Queries/Function/FunctionTestSetup.cs
+++ b/src/Lucene.Net.Tests.Queries/Function/FunctionTestSetup.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Tests.Queries.Function
         }
 
         
-        protected internal static void CreateIndex(bool doMultiSegment)
+        protected internal void CreateIndex(bool doMultiSegment)
         {
             if (VERBOSE)
             {
@@ -111,7 +111,7 @@ namespace Lucene.Net.Tests.Queries.Function
             }
         }
         
-        private static void AddDoc(RandomIndexWriter iw, int i)
+        private void AddDoc(RandomIndexWriter iw, int i)
         {
             Document d = new Document();
             Field f;

--- a/src/Lucene.Net.Tests.Queries/Function/FunctionTestSetup.cs
+++ b/src/Lucene.Net.Tests.Queries/Function/FunctionTestSetup.cs
@@ -65,7 +65,10 @@ namespace Lucene.Net.Tests.Queries.Function
             anlzr = null;
         }
 
-        
+        /// <summary>
+        /// LUCENENET specific
+        /// Non-static because NewIndexWriterConfig is now non-static
+        /// </summary>
         protected internal void CreateIndex(bool doMultiSegment)
         {
             if (VERBOSE)
@@ -110,7 +113,11 @@ namespace Lucene.Net.Tests.Queries.Function
                 Console.WriteLine("TEST: setUp done close");
             }
         }
-        
+
+        /// <summary>
+        /// LUCENENET specific
+        /// Non-static because NewField is now non-static
+        /// </summary>
         private void AddDoc(RandomIndexWriter iw, int i)
         {
             Document d = new Document();

--- a/src/Lucene.Net.Tests.Queries/Function/TestBoostedQuery.cs
+++ b/src/Lucene.Net.Tests.Queries/Function/TestBoostedQuery.cs
@@ -71,7 +71,7 @@ namespace Lucene.Net.Tests.Queries.Function
                 expected[i] = new ScoreDoc(i, scores[i]);
             }
             TopDocs docs = @is.Search(q, 10, new Sort(new SortField("id", SortField.Type_e.STRING)));
-            CheckHits.DoCheckHits(Random(), q, "", @is, expectedDocs);
+            CheckHits.DoCheckHits(Random(), q, "", @is, expectedDocs, Similarity);
             CheckHits.CheckHitsQuery(q, expected, docs.ScoreDocs, expectedDocs);
             CheckHits.CheckExplanations(q, "", @is);
         }

--- a/src/Lucene.Net.Tests.Queries/Function/TestFieldScoreQuery.cs
+++ b/src/Lucene.Net.Tests.Queries/Function/TestFieldScoreQuery.cs
@@ -76,7 +76,7 @@ namespace Lucene.Net.Tests.Queries.Function
             IndexReader r = DirectoryReader.Open(dir);
             IndexSearcher s = NewSearcher(r);
             Log("test: " + functionQuery);
-            QueryUtils.Check(Random(), functionQuery, s);
+            QueryUtils.Check(Random(), functionQuery, s, Similarity);
             ScoreDoc[] h = s.Search(functionQuery, null, 1000).ScoreDocs;
             assertEquals("All docs should be matched!", N_DOCS, h.Length);
             string prevID = "ID" + (N_DOCS + 1); // greater than all ids of docs in this test

--- a/src/Lucene.Net.Tests.Queries/Function/TestLongNormValueSource.cs
+++ b/src/Lucene.Net.Tests.Queries/Function/TestLongNormValueSource.cs
@@ -89,7 +89,7 @@ namespace Lucene.Net.Tests.Queries.Function
             }
             */
 
-            CheckHits.DoCheckHits(Random(), q, "", searcher, expectedDocs);
+            CheckHits.DoCheckHits(Random(), q, "", searcher, expectedDocs, Similarity);
             CheckHits.CheckHitsQuery(q, expected, docs.ScoreDocs, expectedDocs);
             CheckHits.CheckExplanations(q, "", searcher);
         }

--- a/src/Lucene.Net.Tests.Queries/Function/TestOrdValues.cs
+++ b/src/Lucene.Net.Tests.Queries/Function/TestOrdValues.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Tests.Queries.Function
         /// </summary>
         /// <param name="field"></param>
         /// <param name="inOrder"></param>
-        private static void DoTestRank(string field, bool inOrder)
+        private void DoTestRank(string field, bool inOrder)
         {
             IndexReader r = DirectoryReader.Open(dir);
             IndexSearcher s = NewSearcher(r);
@@ -65,7 +65,7 @@ namespace Lucene.Net.Tests.Queries.Function
 
             Query q = new FunctionQuery(vs);
             Log("test: " + q);
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
             ScoreDoc[] h = s.Search(q, null, 1000).ScoreDocs;
             assertEquals("All docs should be matched!", N_DOCS, h.Length);
             string prevID = inOrder ? "IE" : "IC"; // smaller than all ids of docs in this test ("ID0001", etc.) -  greater than all ids of docs in this test ("ID0001", etc.)

--- a/src/Lucene.Net.Tests.Queries/Function/TestValueSources.cs
+++ b/src/Lucene.Net.Tests.Queries/Function/TestValueSources.cs
@@ -321,7 +321,7 @@ namespace Lucene.Net.Tests.Queries.Function
             }
         }
 
-        private static void AssertHits(Query q, float[] scores)
+        private void AssertHits(Query q, float[] scores)
         {
             ScoreDoc[] expected = new ScoreDoc[scores.Length];
             int[] expectedDocs = new int[scores.Length];
@@ -331,7 +331,7 @@ namespace Lucene.Net.Tests.Queries.Function
                 expected[i] = new ScoreDoc(i, scores[i]);
             }
             TopDocs docs = searcher.Search(q, null, documents.Count, new Sort(new SortField("id", SortField.Type_e.STRING)), true, false);
-            CheckHits.DoCheckHits(Random(), q, "", searcher, expectedDocs);
+            CheckHits.DoCheckHits(Random(), q, "", searcher, expectedDocs, Similarity);
             CheckHits.CheckHitsQuery(q, expected, docs.ScoreDocs, expectedDocs);
             CheckHits.CheckExplanations(q, "", searcher);
         }

--- a/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
+++ b/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Tests.Queries.Mlt
         {
             base.SetUp();
             directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
 
             // Add series of docs with specific information for MoreLikeThis
             AddDoc(writer, "lucene");
@@ -126,7 +126,7 @@ namespace Lucene.Net.Tests.Queries.Mlt
         public void TestMoreLikeThisQuery()
         {
             Query query = new MoreLikeThisQuery("this is a test", new[] { "text" }, new MockAnalyzer(Random()), "text");
-            QueryUtils.Check(Random(), query, searcher);
+            QueryUtils.Check(Random(), query, searcher, Similarity);
         }
 
         // TODO: add tests for the MoreLikeThisQuery

--- a/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
+++ b/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Tests.Queries.Mlt
             base.TearDown();
         }
         
-        private static void AddDoc(RandomIndexWriter writer, string text)
+        private void AddDoc(RandomIndexWriter writer, string text)
         {
             Document doc = new Document();
             doc.Add(NewTextField("text", text, Field.Store.YES));

--- a/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
+++ b/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Tests.Queries.Mlt
         {
             base.SetUp();
             directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             // Add series of docs with specific information for MoreLikeThis
             AddDoc(writer, "lucene");

--- a/src/Lucene.Net.Tests.Queries/TermFilterTest.cs
+++ b/src/Lucene.Net.Tests.Queries/TermFilterTest.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Tests.Queries
         public void TestRandom()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int num = AtLeast(100);
             var terms = new List<Term>();
             for (int i = 0; i < num; i++)

--- a/src/Lucene.Net.Tests.Queries/TermFilterTest.cs
+++ b/src/Lucene.Net.Tests.Queries/TermFilterTest.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Tests.Queries
         {
             string fieldName = @"field1";
             Directory rd = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), rd);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), rd, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField(fieldName, @"value1", Field.Store.NO));
             w.AddDocument(doc);
@@ -54,7 +54,7 @@ namespace Lucene.Net.Tests.Queries
         public void TestRandom()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int num = AtLeast(100);
             var terms = new List<Term>();
             for (int i = 0; i < num; i++)

--- a/src/Lucene.Net.Tests.Queries/TermsFilterTest.cs
+++ b/src/Lucene.Net.Tests.Queries/TermsFilterTest.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Tests.Queries
         {
             string fieldName = "field1";
             Directory rd = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), rd);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), rd, Similarity, TimeZone);
             for (int i = 0; i < 100; i++)
             {
                 Document doc = new Document();
@@ -72,7 +72,7 @@ namespace Lucene.Net.Tests.Queries
         {
             string fieldName = "field1";
             Directory rd1 = NewDirectory();
-            RandomIndexWriter w1 = new RandomIndexWriter(Random(), rd1);
+            RandomIndexWriter w1 = new RandomIndexWriter(Random(), rd1, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField(fieldName, "content1", Field.Store.YES));
             w1.AddDocument(doc);
@@ -81,7 +81,7 @@ namespace Lucene.Net.Tests.Queries
 
             fieldName = "field2";
             Directory rd2 = NewDirectory();
-            RandomIndexWriter w2 = new RandomIndexWriter(Random(), rd2);
+            RandomIndexWriter w2 = new RandomIndexWriter(Random(), rd2, Similarity, TimeZone);
             doc = new Document();
             doc.Add(NewStringField(fieldName, "content2", Field.Store.YES));
             w2.AddDocument(doc);
@@ -114,7 +114,7 @@ namespace Lucene.Net.Tests.Queries
         public void TestFieldNotPresent()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int num = AtLeast(3);
             int skip = Random().Next(num);
             var terms = new List<Term>();
@@ -150,7 +150,7 @@ namespace Lucene.Net.Tests.Queries
         public void TestSkipField()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int num = AtLeast(10);
             var terms = new HashSet<Term>();
             for (int i = 0; i < num; i++)
@@ -192,7 +192,7 @@ namespace Lucene.Net.Tests.Queries
         public void TestRandom()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int num = AtLeast(100);
             bool singleField = Random().NextBoolean();
             IList<Term> terms = new List<Term>();

--- a/src/Lucene.Net.Tests.Queries/TermsFilterTest.cs
+++ b/src/Lucene.Net.Tests.Queries/TermsFilterTest.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Tests.Queries
         public void TestFieldNotPresent()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int num = AtLeast(3);
             int skip = Random().Next(num);
             var terms = new List<Term>();
@@ -150,7 +150,7 @@ namespace Lucene.Net.Tests.Queries
         public void TestSkipField()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int num = AtLeast(10);
             var terms = new HashSet<Term>();
             for (int i = 0; i < num; i++)
@@ -192,7 +192,7 @@ namespace Lucene.Net.Tests.Queries
         public void TestRandom()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int num = AtLeast(100);
             bool singleField = Random().NextBoolean();
             IList<Term> terms = new List<Term>();

--- a/src/Lucene.Net.Tests.Queries/TestCustomScoreQuery.cs
+++ b/src/Lucene.Net.Tests.Queries/TestCustomScoreQuery.cs
@@ -334,11 +334,11 @@ namespace Lucene.Net.Tests.Queries
             assertEquals("queries should have same #hits", h1.Count, h4CustomAdd.Count);
             assertEquals("queries should have same #hits", h1.Count, h5CustomMulAdd.Count);
 
-            QueryUtils.Check(Random(), q1, s, Rarely());
-            QueryUtils.Check(Random(), q2, s, Rarely());
-            QueryUtils.Check(Random(), q3, s, Rarely());
-            QueryUtils.Check(Random(), q4, s, Rarely());
-            QueryUtils.Check(Random(), q5, s, Rarely());
+            QueryUtils.Check(Random(), q1, s, Rarely(), Similarity);
+            QueryUtils.Check(Random(), q2, s, Rarely(), Similarity);
+            QueryUtils.Check(Random(), q3, s, Rarely(), Similarity);
+            QueryUtils.Check(Random(), q4, s, Rarely(), Similarity);
+            QueryUtils.Check(Random(), q5, s, Rarely(), Similarity);
 
             // verify scores ratios
             foreach (int doc in h1.Keys)

--- a/src/Lucene.Net.Tests/core/Analysis/TestCachingTokenFilter.cs
+++ b/src/Lucene.Net.Tests/core/Analysis/TestCachingTokenFilter.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Analysis
         public virtual void TestCaching()
         {
             Directory dir = new RAMDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             TokenStream stream = new TokenStreamAnonymousInnerClassHelper(this);
 

--- a/src/Lucene.Net.Tests/core/Analysis/TestCachingTokenFilter.cs
+++ b/src/Lucene.Net.Tests/core/Analysis/TestCachingTokenFilter.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Analysis
         public virtual void TestCaching()
         {
             Directory dir = new RAMDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             TokenStream stream = new TokenStreamAnonymousInnerClassHelper(this);
 

--- a/src/Lucene.Net.Tests/core/Analysis/TestMockAnalyzer.cs
+++ b/src/Lucene.Net.Tests/core/Analysis/TestMockAnalyzer.cs
@@ -349,7 +349,7 @@ namespace Lucene.Net.Analysis
             Analyzer @delegate = new MockAnalyzer(Random());
             Analyzer a = new AnalyzerWrapperAnonymousInnerClassHelper2(this, @delegate.Strategy, positionGap, offsetGap, @delegate);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), NewDirectory());
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), NewDirectory(), Similarity, TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType();
             ft.Indexed = true;

--- a/src/Lucene.Net.Tests/core/Codecs/Compressing/TestCompressingTermVectorsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Compressing/TestCompressingTermVectorsFormat.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Codecs.Compressing
         public virtual void TestNoOrds()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.StoreTermVectors = true;

--- a/src/Lucene.Net.Tests/core/Codecs/Compressing/TestCompressingTermVectorsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Compressing/TestCompressingTermVectorsFormat.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Codecs.Compressing
         public virtual void TestNoOrds()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.StoreTermVectors = true;

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xPostingsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xPostingsFormat.cs
@@ -27,12 +27,12 @@ namespace Lucene.Net.Codecs.Lucene3x
     /// </summary>
     public class TestLucene3xPostingsFormat : BasePostingsFormatTestCase
     {
-        private readonly Codec Codec_Renamed = new PreFlexRWCodec();
+        private readonly Codec Codec_Renamed;
 
-        [TestFixtureSetUp]
-        public static void BeforeClass()
+        public TestLucene3xPostingsFormat() : base()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
+            Codec_Renamed = new PreFlexRWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE);
         }
 
         protected override Codec Codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xStoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xStoredFieldsFormat.cs
@@ -25,6 +25,10 @@ namespace Lucene.Net.Codecs.Lucene3x
     [TestFixture]
     public class TestLucene3xStoredFieldsFormat : BaseStoredFieldsFormatTestCase
     {
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xStoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xStoredFieldsFormat.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Codecs.Lucene3x
     public class TestLucene3xStoredFieldsFormat : BaseStoredFieldsFormatTestCase
     {
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
         }
@@ -35,7 +35,8 @@ namespace Lucene.Net.Codecs.Lucene3x
         {
             get
             {
-                return new PreFlexRWCodec();
+                Assert.IsTrue(OLD_FORMAT_IMPERSONATION_IS_ACTIVE, "This should have been set up in the test fixture");
+                return new PreFlexRWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE);
             }
         }
 

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xTermVectorsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xTermVectorsFormat.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         [SetUp]
         public override void SetUp()
         {
-            LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
+            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
             base.SetUp();
         }
 
@@ -37,7 +37,8 @@ namespace Lucene.Net.Codecs.Lucene3x
         {
             get
             {
-                return new PreFlexRWCodec();
+                Assert.IsTrue(OLD_FORMAT_IMPERSONATION_IS_ACTIVE, "This should have been set up in the test fixture");
+                return new PreFlexRWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE);
             }
         }
 

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestSurrogates.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestSurrogates.cs
@@ -35,9 +35,9 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// <summary>
         /// we will manually instantiate preflex-rw here </summary>
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
-            LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
+            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
         }
 
         private static string MakeDifficultRandomUnicodeString(Random r)
@@ -340,7 +340,8 @@ namespace Lucene.Net.Codecs.Lucene3x
         public virtual void TestSurrogatesOrder()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetCodec(new PreFlexRWCodec()));
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                .SetCodec(new PreFlexRWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE)));
 
             int numField = TestUtil.NextInt(Random(), 2, 5);
 

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestSurrogates.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestSurrogates.cs
@@ -33,7 +33,11 @@ namespace Lucene.Net.Codecs.Lucene3x
     public class TestSurrogates : LuceneTestCase
     {
         /// <summary>
-        /// we will manually instantiate preflex-rw here </summary>
+        /// we will manually instantiate preflex-rw here
+        /// 
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
@@ -64,7 +64,11 @@ namespace Lucene.Net.Codecs.Lucene3x
         private static IList<Term> SampleTerms;
 
         /// <summary>
-        /// we will manually instantiate preflex-rw here </summary>
+        /// we will manually instantiate preflex-rw here
+        /// 
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
@@ -66,10 +66,10 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// <summary>
         /// we will manually instantiate preflex-rw here </summary>
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             // NOTE: turn off compound file, this test will open some index files directly.
-            LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
+            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
             IndexWriterConfig config = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random(), MockTokenizer.KEYWORD, false)).SetUseCompoundFile(false);
 
             TermIndexInterval = config.TermIndexInterval;
@@ -79,7 +79,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
             Directory = NewDirectory();
 
-            config.SetCodec(new PreFlexRWCodec());
+            config.SetCodec(new PreFlexRWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE));
             LogMergePolicy mp = NewLogMergePolicy();
             // NOTE: turn off compound file, this test will open some index files directly.
             mp.NoCFSRatio = 0.0;
@@ -92,7 +92,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             string segment = r.SegmentName;
             r.Dispose();
 
-            FieldInfosReader infosReader = (new PreFlexRWCodec()).FieldInfosFormat().FieldInfosReader;
+            FieldInfosReader infosReader = (new PreFlexRWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE)).FieldInfosFormat().FieldInfosReader;
             FieldInfos fieldInfos = infosReader.Read(Directory, segment, "", IOContext.READONCE);
             string segmentFileName = IndexFileNames.SegmentFileName(segment, "", Lucene3xPostingsFormat.TERMS_INDEX_EXTENSION);
             long tiiFileLength = Directory.FileLength(segmentFileName);
@@ -202,7 +202,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             return term;
         }
 
-        private static void Populate(Directory directory, IndexWriterConfig config)
+        private void Populate(Directory directory, IndexWriterConfig config)
         {
             RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, config);
             for (int i = 0; i < NUMBER_OF_DOCUMENTS; i++)

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40DocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40DocValuesFormat.cs
@@ -26,10 +26,8 @@ namespace Lucene.Net.Codecs.Lucene40
     /// </summary>
     public class TestLucene40DocValuesFormat : BaseDocValuesFormatTestCase
     {
-        private readonly Codec Codec_Renamed = new Lucene40RWCodec();
-
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
         }
@@ -38,7 +36,8 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             get
             {
-                return Codec_Renamed;
+                Assert.True(OLD_FORMAT_IMPERSONATION_IS_ACTIVE, "Expecting that this is true");
+                return new Lucene40RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE);
             }
         }
 

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40DocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40DocValuesFormat.cs
@@ -26,6 +26,10 @@ namespace Lucene.Net.Codecs.Lucene40
     /// </summary>
     public class TestLucene40DocValuesFormat : BaseDocValuesFormatTestCase
     {
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsFormat.cs
@@ -26,6 +26,10 @@ namespace Lucene.Net.Codecs.Lucene40
     /// </summary>
     public class TestLucene40PostingsFormat : BasePostingsFormatTestCase
     {
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsFormat.cs
@@ -26,10 +26,8 @@ namespace Lucene.Net.Codecs.Lucene40
     /// </summary>
     public class TestLucene40PostingsFormat : BasePostingsFormatTestCase
     {
-        private readonly Codec Codec_Renamed = new Lucene40RWCodec();
-
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
         }
@@ -38,7 +36,8 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             get
             {
-                return Codec_Renamed;
+                Assert.True(OLD_FORMAT_IMPERSONATION_IS_ACTIVE, "Expecting this to be set already before creating codec");
+                return new Lucene40RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE);
             }
         }
     }

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsReader.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsReader.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Codecs.Lucene40
         }
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
         }

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsReader.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsReader.cs
@@ -53,6 +53,10 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40StoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40StoredFieldsFormat.cs
@@ -23,6 +23,10 @@ namespace Lucene.Net.Codecs.Lucene40
 
     public class TestLucene40StoredFieldsFormat : BaseStoredFieldsFormatTestCase
     {
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40StoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40StoredFieldsFormat.cs
@@ -24,7 +24,7 @@ namespace Lucene.Net.Codecs.Lucene40
     public class TestLucene40StoredFieldsFormat : BaseStoredFieldsFormatTestCase
     {
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
         }
@@ -33,7 +33,8 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             get
             {
-                return new Lucene40RWCodec();
+                Assert.True(OLD_FORMAT_IMPERSONATION_IS_ACTIVE, "Expecting this to be set already");
+                return new Lucene40RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE);
             }
         }
     }

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40TermVectorsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40TermVectorsFormat.cs
@@ -23,6 +23,10 @@ namespace Lucene.Net.Codecs.Lucene40
 
     public class TestLucene40TermVectorsFormat : BaseTermVectorsFormatTestCase
     {
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40TermVectorsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40TermVectorsFormat.cs
@@ -24,7 +24,7 @@ namespace Lucene.Net.Codecs.Lucene40
     public class TestLucene40TermVectorsFormat : BaseTermVectorsFormatTestCase
     {
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
         }
@@ -33,7 +33,8 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             get
             {
-                return new Lucene40RWCodec();
+                Assert.True(OLD_FORMAT_IMPERSONATION_IS_ACTIVE, "Expecting this to be set already");
+                return new Lucene40RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE);
             }
         }
     }

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestReuseDocsEnum.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestReuseDocsEnum.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Codecs.Lucene40
     public class TestReuseDocsEnum : LuceneTestCase
     {
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
         }
@@ -56,7 +56,7 @@ namespace Lucene.Net.Codecs.Lucene40
         public virtual void TestReuseDocsEnumNoReuse()
         {
             Directory dir = NewDirectory();
-            Codec cp = TestUtil.AlwaysPostingsFormat(new Lucene40RWPostingsFormat());
+            Codec cp = TestUtil.AlwaysPostingsFormat(new Lucene40RWPostingsFormat(OLD_FORMAT_IMPERSONATION_IS_ACTIVE));
             RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetCodec(cp));
             int numdocs = AtLeast(20);
             CreateRandomIndex(numdocs, writer, Random());
@@ -86,7 +86,7 @@ namespace Lucene.Net.Codecs.Lucene40
         public virtual void TestReuseDocsEnumSameBitsOrNull()
         {
             Directory dir = NewDirectory();
-            Codec cp = TestUtil.AlwaysPostingsFormat(new Lucene40RWPostingsFormat());
+            Codec cp = TestUtil.AlwaysPostingsFormat(new Lucene40RWPostingsFormat(OLD_FORMAT_IMPERSONATION_IS_ACTIVE));
             RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetCodec(cp));
             int numdocs = AtLeast(20);
             CreateRandomIndex(numdocs, writer, Random());
@@ -135,7 +135,7 @@ namespace Lucene.Net.Codecs.Lucene40
         public virtual void TestReuseDocsEnumDifferentReader()
         {
             Directory dir = NewDirectory();
-            Codec cp = TestUtil.AlwaysPostingsFormat(new Lucene40RWPostingsFormat());
+            Codec cp = TestUtil.AlwaysPostingsFormat(new Lucene40RWPostingsFormat(OLD_FORMAT_IMPERSONATION_IS_ACTIVE));
             MockAnalyzer analyzer = new MockAnalyzer(Random());
             analyzer.MaxTokenLength = TestUtil.NextInt(Random(), 1, IndexWriter.MAX_TERM_LENGTH);
 

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestReuseDocsEnum.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestReuseDocsEnum.cs
@@ -46,6 +46,10 @@ namespace Lucene.Net.Codecs.Lucene40
     [TestFixture]
     public class TestReuseDocsEnum : LuceneTestCase
     {
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
@@ -24,7 +24,7 @@ namespace Lucene.Net.Codecs.Lucene41
     public class TestLucene41StoredFieldsFormat : BaseStoredFieldsFormatTestCase
     {
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
         }

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
@@ -23,6 +23,10 @@ namespace Lucene.Net.Codecs.Lucene41
 
     public class TestLucene41StoredFieldsFormat : BaseStoredFieldsFormatTestCase
     {
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Codecs.Lucene41
         {
             get
             {
-                return new Lucene41RWCodec();
+                return new Lucene41RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE);
             }
         }
     }

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
@@ -28,6 +28,10 @@ namespace Lucene.Net.Codecs.Lucene42
     {
         private Codec Codec_Renamed;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
@@ -26,12 +26,13 @@ namespace Lucene.Net.Codecs.Lucene42
     /// </summary>
     public class TestLucene42DocValuesFormat : BaseCompressingDocValuesFormatTestCase
     {
-        private readonly Codec Codec_Renamed = new Lucene42RWCodec();
+        private Codec Codec_Renamed;
 
         [TestFixtureSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
+            Codec_Renamed = new Lucene42RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE);
         }
 
         protected override Codec Codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Codecs.Lucene42
         private readonly Codec Codec_Renamed = new Lucene42RWCodec();
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec
         }

--- a/src/Lucene.Net.Tests/core/Document/TestBinaryDocument.cs
+++ b/src/Lucene.Net.Tests/core/Document/TestBinaryDocument.cs
@@ -98,7 +98,7 @@ namespace Lucene.Net.Document
             var doc = new Documents.Document {binaryFldCompressed, stringFldCompressed};
 
             using (Directory dir = NewDirectory())
-            using (RandomIndexWriter writer = new RandomIndexWriter(Random(), dir))
+            using (RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone))
             {
                 writer.AddDocument(doc);
 

--- a/src/Lucene.Net.Tests/core/Document/TestBinaryDocument.cs
+++ b/src/Lucene.Net.Tests/core/Document/TestBinaryDocument.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Document
             /// add the doc to a ram index </summary>
             Directory dir = NewDirectory();
             Random r = Random();
-            RandomIndexWriter writer = new RandomIndexWriter(r, dir);
+            RandomIndexWriter writer = new RandomIndexWriter(r, dir, Similarity, TimeZone);
             writer.AddDocument(doc);
 
             /// <summary>
@@ -98,7 +98,7 @@ namespace Lucene.Net.Document
             var doc = new Documents.Document {binaryFldCompressed, stringFldCompressed};
 
             using (Directory dir = NewDirectory())
-            using (RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone))
+            using (RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone))
             {
                 writer.AddDocument(doc);
 

--- a/src/Lucene.Net.Tests/core/Document/TestDocument.cs
+++ b/src/Lucene.Net.Tests/core/Document/TestDocument.cs
@@ -190,7 +190,7 @@ namespace Lucene.Net.Document
         public virtual void TestGetValuesForIndexedDocument()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             writer.AddDocument(MakeDocumentWithFields());
             IndexReader reader = writer.Reader;
 
@@ -223,7 +223,7 @@ namespace Lucene.Net.Document
         public virtual void TestPositionIncrementMultiFields()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             writer.AddDocument(MakeDocumentWithFields());
             IndexReader reader = writer.Reader;
 
@@ -303,7 +303,7 @@ namespace Lucene.Net.Document
             doc.Add(new StringField("keyword", "test", Field.Store.YES));
 
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             writer.AddDocument(doc);
             field.StringValue = "id2";
             writer.AddDocument(doc);
@@ -366,7 +366,7 @@ namespace Lucene.Net.Document
         public virtual void TestTransitionAPI()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Documents.Document doc = new Documents.Document();
             doc.Add(new Field("stored", "abc", Field.Store.YES, Field.Index.NO));
@@ -443,7 +443,7 @@ namespace Lucene.Net.Document
             Assert.AreEqual(new string[] { "5", "4" }, doc.GetValues("int"));
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             iw.AddDocument(doc);
             DirectoryReader ir = iw.Reader;
             Documents.Document sdoc = ir.Document(0);

--- a/src/Lucene.Net.Tests/core/Document/TestDocument.cs
+++ b/src/Lucene.Net.Tests/core/Document/TestDocument.cs
@@ -190,7 +190,7 @@ namespace Lucene.Net.Document
         public virtual void TestGetValuesForIndexedDocument()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.AddDocument(MakeDocumentWithFields());
             IndexReader reader = writer.Reader;
 
@@ -223,7 +223,7 @@ namespace Lucene.Net.Document
         public virtual void TestPositionIncrementMultiFields()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.AddDocument(MakeDocumentWithFields());
             IndexReader reader = writer.Reader;
 
@@ -303,7 +303,7 @@ namespace Lucene.Net.Document
             doc.Add(new StringField("keyword", "test", Field.Store.YES));
 
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.AddDocument(doc);
             field.StringValue = "id2";
             writer.AddDocument(doc);
@@ -366,7 +366,7 @@ namespace Lucene.Net.Document
         public virtual void TestTransitionAPI()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Documents.Document doc = new Documents.Document();
             doc.Add(new Field("stored", "abc", Field.Store.YES, Field.Index.NO));
@@ -443,7 +443,7 @@ namespace Lucene.Net.Document
             Assert.AreEqual(new string[] { "5", "4" }, doc.GetValues("int"));
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             iw.AddDocument(doc);
             DirectoryReader ir = iw.Reader;
             Documents.Document sdoc = ir.Document(0);

--- a/src/Lucene.Net.Tests/core/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestAddIndexes.cs
@@ -1267,7 +1267,7 @@ namespace Lucene.Net.Index
         public virtual void TestFieldNamesChanged()
         {
             Directory d1 = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d1);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d1, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("f1", "doc1 field1", Field.Store.YES));
             doc.Add(NewStringField("id", "1", Field.Store.YES));
@@ -1276,7 +1276,7 @@ namespace Lucene.Net.Index
             w.Dispose();
 
             Directory d2 = NewDirectory();
-            w = new RandomIndexWriter(Random(), d2);
+            w = new RandomIndexWriter(Random(), d2, Similarity, TimeZone);
             doc = new Document();
             doc.Add(NewStringField("f2", "doc2 field2", Field.Store.YES));
             doc.Add(NewStringField("id", "2", Field.Store.YES));
@@ -1285,7 +1285,7 @@ namespace Lucene.Net.Index
             w.Dispose();
 
             Directory d3 = NewDirectory();
-            w = new RandomIndexWriter(Random(), d3);
+            w = new RandomIndexWriter(Random(), d3, Similarity, TimeZone);
             w.AddIndexes(r1, r2);
             r1.Dispose();
             d1.Dispose();
@@ -1315,7 +1315,7 @@ namespace Lucene.Net.Index
         public virtual void TestAddEmpty()
         {
             Directory d1 = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d1);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d1, Similarity, TimeZone);
             MultiReader empty = new MultiReader();
             w.AddIndexes(empty);
             w.Dispose();
@@ -1336,12 +1336,12 @@ namespace Lucene.Net.Index
         public virtual void TestFakeAllDeleted()
         {
             Directory src = NewDirectory(), dest = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), src);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), src, Similarity, TimeZone);
             w.AddDocument(new Document());
             IndexReader allDeletedReader = new AllDeletedFilterReader((AtomicReader)w.Reader.Leaves[0].Reader);
             w.Dispose();
 
-            w = new RandomIndexWriter(Random(), dest);
+            w = new RandomIndexWriter(Random(), dest, Similarity, TimeZone);
             w.AddIndexes(allDeletedReader);
             w.Dispose();
             DirectoryReader dr = DirectoryReader.Open(src);
@@ -1363,7 +1363,7 @@ namespace Lucene.Net.Index
         public virtual void TestLocksBlock()
         {
             Directory src = NewDirectory();
-            RandomIndexWriter w1 = new RandomIndexWriter(Random(), src);
+            RandomIndexWriter w1 = new RandomIndexWriter(Random(), src, Similarity, TimeZone);
             w1.AddDocument(new Document());
             w1.Commit();
 

--- a/src/Lucene.Net.Tests/core/Index/TestBagOfPostings.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBagOfPostings.cs
@@ -151,7 +151,7 @@ namespace Lucene.Net.Index
                 try
                 {
                     Document document = new Document();
-                    Field field = NewTextField("field", "", Field.Store.NO);
+                    Field field = OuterInstance.NewTextField("field", "", Field.Store.NO);
                     document.Add(field);
                     StartingGun.Wait();
                     while (!(Postings.Count == 0))

--- a/src/Lucene.Net.Tests/core/Index/TestBinaryDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBinaryDocValuesUpdates.cs
@@ -1131,6 +1131,11 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Split from <see cref="TestUpdateOldSegments"/> because OLD_FORMAT_IMPERSONATION_IS_ACTIVE
+        /// is no longer static and the existing codecs have to be remade.
+        /// </summary>
         [Test]
         public virtual void TestUpdateOldSegments_OldFormatNotActive()
         {

--- a/src/Lucene.Net.Tests/core/Index/TestBinaryDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBinaryDocValuesUpdates.cs
@@ -1110,6 +1110,7 @@ namespace Lucene.Net.Index
         public virtual void TestUpdateOldSegments()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
+
             Codec[] oldCodecs = new Codec[] {
                 new Lucene40RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE),
                 new Lucene41RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE),
@@ -1128,8 +1129,6 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
             writer.Dispose();
             dir.Dispose();
-
-            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = false;
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/core/Index/TestBinaryDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBinaryDocValuesUpdates.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-    using System.Threading;
+using System.Threading;
 using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 
@@ -1109,25 +1109,55 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestUpdateOldSegments()
         {
-            Codec[] oldCodecs = new Codec[] { new Lucene40RWCodec(), new Lucene41RWCodec(), new Lucene42RWCodec(), new Lucene45RWCodec() };
+            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
+            Codec[] oldCodecs = new Codec[] {
+                new Lucene40RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE),
+                new Lucene41RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE),
+                new Lucene42RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE),
+                new Lucene45RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            };
             Directory dir = NewDirectory();
 
-            bool oldValue = OLD_FORMAT_IMPERSONATION_IS_ACTIVE;
             // create a segment with an old Codec
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()));
             conf.SetCodec(oldCodecs[Random().Next(oldCodecs.Length)]);
-            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
             IndexWriter writer = new IndexWriter(dir, conf);
             Document doc = new Document();
             doc.Add(new StringField("id", "doc", Store.NO));
             doc.Add(new BinaryDocValuesField("f", ToBytes(5L)));
             writer.AddDocument(doc);
             writer.Dispose();
+            dir.Dispose();
 
-            conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()));
-            writer = new IndexWriter(dir, conf);
-            writer.UpdateBinaryDocValue(new Term("id", "doc"), "f", ToBytes(4L));
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = false;
+        }
+
+        [Test]
+        public virtual void TestUpdateOldSegments_OldFormatNotActive()
+        {
+            bool oldValue = OLD_FORMAT_IMPERSONATION_IS_ACTIVE;
+
+            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = false;
+
+            Codec[] oldCodecs = new Codec[] {
+                new Lucene40RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE),
+                new Lucene41RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE),
+                new Lucene42RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE),
+                new Lucene45RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE)
+            };
+
+            Directory dir = NewDirectory();
+            Document doc = new Document();
+            doc.Add(new StringField("id", "doc", Store.NO));
+            doc.Add(new BinaryDocValuesField("f", ToBytes(5L)));
+
+            var conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()));
+            conf.SetCodec(oldCodecs[Random().Next(oldCodecs.Length)]);
+
+            var writer = new IndexWriter(dir, conf);
+            writer.AddDocument(doc);
+            writer.UpdateBinaryDocValue(new Term("id", "doc"), "f", ToBytes(4L));
+
             try
             {
                 writer.Dispose();

--- a/src/Lucene.Net.Tests/core/Index/TestBinaryTerms.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBinaryTerms.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Index
         public virtual void TestBinary()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             BytesRef bytes = new BytesRef(2);
             BinaryTokenStream tokenStream = new BinaryTokenStream(bytes);
 

--- a/src/Lucene.Net.Tests/core/Index/TestBinaryTerms.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBinaryTerms.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Index
         public virtual void TestBinary()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             BytesRef bytes = new BytesRef(2);
             BinaryTokenStream tokenStream = new BinaryTokenStream(bytes);
 

--- a/src/Lucene.Net.Tests/core/Index/TestCodecHoldsOpenFiles.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestCodecHoldsOpenFiles.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Index
         public virtual void Test()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             int numDocs = AtLeast(100);
             for (int i = 0; i < numDocs; i++)
             {
@@ -73,7 +73,7 @@ namespace Lucene.Net.Index
         public virtual void TestExposeUnclosedFiles()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             //int numDocs = AtLeast(100);
             int numDocs = 5;
             for (int i = 0; i < numDocs; i++)

--- a/src/Lucene.Net.Tests/core/Index/TestCodecs.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestCodecs.cs
@@ -890,7 +890,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestDisableImpersonation()
         {
-            Codec[] oldCodecs = new Codec[] { new Lucene40RWCodec(), new Lucene41RWCodec(), new Lucene42RWCodec() };
+            Codec[] oldCodecs = new Codec[] { new Lucene40RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE), new Lucene41RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE), new Lucene42RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE) };
             Directory dir = NewDirectory();
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()));
             conf.SetCodec(oldCodecs[Random().Next(oldCodecs.Length)]);

--- a/src/Lucene.Net.Tests/core/Index/TestCompoundFile.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestCompoundFile.cs
@@ -850,7 +850,7 @@ namespace Lucene.Net.Index
         {
             Directory dir = NewDirectory();
             // riw should sometimes create docvalues fields, etc
-            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             // these fields should sometimes get term vectors, etc
             Field idField = NewStringField("id", "", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Index/TestCompoundFile.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestCompoundFile.cs
@@ -850,7 +850,7 @@ namespace Lucene.Net.Index
         {
             Directory dir = NewDirectory();
             // riw should sometimes create docvalues fields, etc
-            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             // these fields should sometimes get term vectors, etc
             Field idField = NewStringField("id", "", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Index/TestCrash.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestCrash.cs
@@ -101,7 +101,7 @@ namespace Lucene.Net.Index
             Directory dir2 = NewDirectory(dir);
             dir.Dispose();
 
-            (new RandomIndexWriter(Random(), dir2)).Dispose();
+            (new RandomIndexWriter(Random(), dir2, Similarity, TimeZone)).Dispose();
             dir2.Dispose();
         }
 
@@ -137,7 +137,7 @@ namespace Lucene.Net.Index
             Directory dir2 = NewDirectory(dir);
             dir.Dispose();
 
-            (new RandomIndexWriter(Random(), dir2)).Dispose();
+            (new RandomIndexWriter(Random(), dir2, Similarity, TimeZone)).Dispose();
             dir2.Dispose();
         }
 
@@ -176,7 +176,7 @@ namespace Lucene.Net.Index
             Directory dir2 = NewDirectory(dir);
             dir.Dispose();
 
-            (new RandomIndexWriter(Random(), dir2)).Dispose();
+            (new RandomIndexWriter(Random(), dir2, Similarity, TimeZone)).Dispose();
             dir2.Dispose();
         }
 

--- a/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
@@ -1206,7 +1206,7 @@ namespace Lucene.Net.Index
         public virtual void TestLoadCertainFields()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("field1", "foobar", Field.Store.YES));
             doc.Add(NewStringField("field2", "foobaz", Field.Store.YES));

--- a/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
@@ -497,6 +497,11 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewStringField, NewTextField, NewField methods
+        /// are no longer static.
+        /// </summary>
         internal void AddDocumentWithFields(IndexWriter writer)
         {
             Document doc = new Document();
@@ -510,6 +515,11 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewStringField, NewTextField, NewField methods
+        /// are no longer static.
+        /// </summary>
         internal void AddDocumentWithDifferentFields(IndexWriter writer)
         {
             Document doc = new Document();
@@ -523,6 +533,11 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewTextField, NewField methods are no longer
+        /// static.
+        /// </summary>
         internal void AddDocumentWithTermVectorFields(IndexWriter writer)
         {
             Document doc = new Document();
@@ -547,6 +562,10 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewTextField is no longer static.
+        /// </summary>
         internal void AddDoc(IndexWriter writer, string value)
         {
             Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
@@ -497,7 +497,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        internal static void AddDocumentWithFields(IndexWriter writer)
+        internal void AddDocumentWithFields(IndexWriter writer)
         {
             Document doc = new Document();
 
@@ -510,7 +510,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        internal static void AddDocumentWithDifferentFields(IndexWriter writer)
+        internal void AddDocumentWithDifferentFields(IndexWriter writer)
         {
             Document doc = new Document();
 
@@ -523,7 +523,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        internal static void AddDocumentWithTermVectorFields(IndexWriter writer)
+        internal void AddDocumentWithTermVectorFields(IndexWriter writer)
         {
             Document doc = new Document();
             FieldType customType5 = new FieldType(TextField.TYPE_STORED);
@@ -547,7 +547,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        internal static void AddDoc(IndexWriter writer, string value)
+        internal void AddDoc(IndexWriter writer, string value)
         {
             Document doc = new Document();
             doc.Add(NewTextField("content", value, Field.Store.NO));
@@ -718,7 +718,7 @@ namespace Lucene.Net.Index
             d.Dispose();
         }
 
-        internal static Document CreateDocument(string id)
+        internal Document CreateDocument(string id)
         {
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);

--- a/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDirectoryReader.cs
@@ -1206,7 +1206,7 @@ namespace Lucene.Net.Index
         public virtual void TestLoadCertainFields()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("field1", "foobar", Field.Store.YES));
             doc.Add(NewStringField("field2", "foobaz", Field.Store.YES));

--- a/src/Lucene.Net.Tests/core/Index/TestDirectoryReaderReopen.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDirectoryReaderReopen.cs
@@ -400,7 +400,7 @@ namespace Lucene.Net.Index
                             refreshed = r;
                         }
 
-                        IndexSearcher searcher = NewSearcher(refreshed);
+                        IndexSearcher searcher = OuterInstance.NewSearcher(refreshed);
                         ScoreDoc[] hits = searcher.Search(new TermQuery(new Term("field1", "a" + rnd.Next(refreshed.MaxDoc))), null, 1000).ScoreDocs;
                         if (hits.Length > 0)
                         {
@@ -559,10 +559,10 @@ namespace Lucene.Net.Index
             }
         }
 
-        public static void CreateIndex(Random random, Directory dir, bool multiSegment)
+        public void CreateIndex(Random random, Directory dir, bool multiSegment)
         {
             IndexWriter.Unlock(dir);
-            IndexWriter w = new IndexWriter(dir, LuceneTestCase.NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random)).SetMergePolicy(new LogDocMergePolicy()));
+            IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random)).SetMergePolicy(new LogDocMergePolicy()));
 
             for (int i = 0; i < 100; i++)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestDirectoryReaderReopen.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDirectoryReaderReopen.cs
@@ -559,6 +559,10 @@ namespace Lucene.Net.Index
             }
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         public void CreateIndex(Random random, Directory dir, bool multiSegment)
         {
             IndexWriter.Unlock(dir);

--- a/src/Lucene.Net.Tests/core/Index/TestDocCount.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocCount.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Index
         public virtual void TestSimple()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int numDocs = AtLeast(100);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestDocCount.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocCount.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Index
         public virtual void TestSimple()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int numDocs = AtLeast(100);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestDocValuesIndexing.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocValuesIndexing.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Index
         public virtual void TestAddIndexes()
         {
             Directory d1 = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d1);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d1, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("id", "1", Field.Store.YES));
             doc.Add(new NumericDocValuesField("dv", 1));
@@ -66,7 +66,7 @@ namespace Lucene.Net.Index
             w.Dispose();
 
             Directory d2 = NewDirectory();
-            w = new RandomIndexWriter(Random(), d2);
+            w = new RandomIndexWriter(Random(), d2, Similarity, TimeZone);
             doc = new Document();
             doc.Add(NewStringField("id", "2", Field.Store.YES));
             doc.Add(new NumericDocValuesField("dv", 2));
@@ -75,7 +75,7 @@ namespace Lucene.Net.Index
             w.Dispose();
 
             Directory d3 = NewDirectory();
-            w = new RandomIndexWriter(Random(), d3);
+            w = new RandomIndexWriter(Random(), d3, Similarity, TimeZone);
             w.AddIndexes(SlowCompositeReaderWrapper.Wrap(r1), SlowCompositeReaderWrapper.Wrap(r2));
             r1.Dispose();
             d1.Dispose();
@@ -97,7 +97,7 @@ namespace Lucene.Net.Index
         public virtual void TestMultiValuedDocValuesField()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             Field f = new NumericDocValuesField("field", 17);
             // Index doc values are single-valued so we should not
@@ -129,7 +129,7 @@ namespace Lucene.Net.Index
         public virtual void TestDifferentTypedDocValuesField()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             // Index doc values are single-valued so we should not
             // be able to add same field more than once:
@@ -161,7 +161,7 @@ namespace Lucene.Net.Index
         public virtual void TestDifferentTypedDocValuesField2()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             // Index doc values are single-valued so we should not
             // be able to add same field more than once:

--- a/src/Lucene.Net.Tests/core/Index/TestDocValuesWithThreads.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocValuesWithThreads.cs
@@ -181,7 +181,7 @@ namespace Lucene.Net.Index
             Random random = Random();
             int NUM_DOCS = AtLeast(100);
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(random, dir);
+            RandomIndexWriter writer = new RandomIndexWriter(random, dir, Similarity, TimeZone);
             bool allowDups = random.NextBoolean();
             HashSet<string> seen = new HashSet<string>();
             if (VERBOSE)

--- a/src/Lucene.Net.Tests/core/Index/TestDocsAndPositions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocsAndPositions.cs
@@ -377,7 +377,7 @@ namespace Lucene.Net.Index
         public virtual void TestDocsEnumStart()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("foo", "bar", Field.Store.NO));
             writer.AddDocument(doc);
@@ -404,7 +404,7 @@ namespace Lucene.Net.Index
         public virtual void TestDocsAndPositionsEnumStart()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("foo", "bar", Field.Store.NO));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Index/TestDocsAndPositions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestDocsAndPositions.cs
@@ -377,7 +377,7 @@ namespace Lucene.Net.Index
         public virtual void TestDocsEnumStart()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("foo", "bar", Field.Store.NO));
             writer.AddDocument(doc);
@@ -404,7 +404,7 @@ namespace Lucene.Net.Index
         public virtual void TestDocsAndPositionsEnumStart()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("foo", "bar", Field.Store.NO));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Index
         private static FieldInfos.Builder FieldInfos = null;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             TestDoc = new Document();
             FieldInfos = new FieldInfos.Builder();

--- a/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
@@ -45,6 +45,10 @@ namespace Lucene.Net.Index
         private static Document TestDoc;
         private static FieldInfos.Builder FieldInfos = null;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -147,7 +147,6 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// LUCENENET specific
-        /// 
         /// Changed from internal static method to private to remove
         /// inter-dependencies between TestIndexWriter*.cs, TestAddIndexes.cs
         /// and TestDeletionPolicy.cs tests
@@ -161,7 +160,6 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// LUCENENET specific
-        /// 
         /// Changed from internal static method to private to remove
         /// inter-dependencies between TestIndexWriter*.cs, TestAddIndexes.cs
         /// and TestDeletionPolicy.cs tests

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -145,6 +145,13 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// 
+        /// Changed from internal static method to private to remove
+        /// inter-dependencies between TestIndexWriter*.cs, TestAddIndexes.cs
+        /// and TestDeletionPolicy.cs tests
+        /// </summary>
         private void AddDoc(IndexWriter writer)
         {
             Document doc = new Document();
@@ -152,6 +159,13 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// 
+        /// Changed from internal static method to private to remove
+        /// inter-dependencies between TestIndexWriter*.cs, TestAddIndexes.cs
+        /// and TestDeletionPolicy.cs tests
+        /// </summary>
         private void AddDocWithIndex(IndexWriter writer, int index)
         {
             Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -2278,7 +2278,7 @@ namespace Lucene.Net.Index
         {
             Directory dir = NewDirectory();
             Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, a);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, a, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new TextField("body", "just a", Field.Store.NO));
             doc.Add(new TextField("body", "test of gaps", Field.Store.NO));
@@ -2320,7 +2320,7 @@ namespace Lucene.Net.Index
             Directory dir = NewDirectory();
             Automaton secondSet = BasicAutomata.MakeString("foobar");
             Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this, secondSet);
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, a);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, a, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new TextField("body", "just a foobar", Field.Store.NO));
             doc.Add(new TextField("body", "test of gaps", Field.Store.NO));

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -145,14 +145,14 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        internal static void AddDoc(IndexWriter writer)
+        private void AddDoc(IndexWriter writer)
         {
             Document doc = new Document();
             doc.Add(NewTextField("content", "aaa", Field.Store.NO));
             writer.AddDocument(doc);
         }
 
-        internal static void AddDocWithIndex(IndexWriter writer, int index)
+        private void AddDocWithIndex(IndexWriter writer, int index)
         {
             Document doc = new Document();
             doc.Add(NewField("content", "aaa " + index, StoredTextType));
@@ -1137,11 +1137,11 @@ namespace Lucene.Net.Index
                 // make a little directory for addIndexes
                 // LUCENE-2239: won't work with NIOFS/MMAP
                 Adder = new MockDirectoryWrapper(this.Random, new RAMDirectory());
-                IndexWriterConfig conf = NewIndexWriterConfig(this.Random, TEST_VERSION_CURRENT, new MockAnalyzer(this.Random));
+                IndexWriterConfig conf = OuterInstance.NewIndexWriterConfig(this.Random, TEST_VERSION_CURRENT, new MockAnalyzer(this.Random));
                 IndexWriter w = new IndexWriter(Adder, conf);
                 Document doc = new Document();
-                doc.Add(NewStringField(this.Random, "id", "500", Field.Store.NO));
-                doc.Add(NewField(this.Random, "field", "some prepackaged text contents", StoredTextType));
+                doc.Add(OuterInstance.NewStringField(this.Random, "id", "500", Field.Store.NO));
+                doc.Add(OuterInstance.NewField(this.Random, "field", "some prepackaged text contents", StoredTextType));
                 if (DefaultCodecSupportsDocValues())
                 {
                     doc.Add(new BinaryDocValuesField("binarydv", new BytesRef("500")));
@@ -1155,8 +1155,8 @@ namespace Lucene.Net.Index
                 }
                 w.AddDocument(doc);
                 doc = new Document();
-                doc.Add(NewStringField(this.Random, "id", "501", Field.Store.NO));
-                doc.Add(NewField(this.Random, "field", "some more contents", StoredTextType));
+                doc.Add(OuterInstance.NewStringField(this.Random, "id", "501", Field.Store.NO));
+                doc.Add(OuterInstance.NewField(this.Random, "field", "some more contents", StoredTextType));
                 if (DefaultCodecSupportsDocValues())
                 {
                     doc.Add(new BinaryDocValuesField("binarydv", new BytesRef("501")));
@@ -1199,17 +1199,17 @@ namespace Lucene.Net.Index
                                 w.Dispose();
                                 w = null;
                             }
-                            IndexWriterConfig conf = NewIndexWriterConfig(Random, TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2);
+                            IndexWriterConfig conf = OuterInstance.NewIndexWriterConfig(Random, TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2);
                             w = new IndexWriter(dir, conf);
 
                             Document doc = new Document();
-                            Field idField = NewStringField(Random, "id", "", Field.Store.NO);
+                            Field idField = OuterInstance.NewStringField(Random, "id", "", Field.Store.NO);
                             Field binaryDVField = null;
                             Field numericDVField = null;
                             Field sortedDVField = null;
                             Field sortedSetDVField = new SortedSetDocValuesField("sortedsetdv", new BytesRef());
                             doc.Add(idField);
-                            doc.Add(NewField(Random, "field", "some text contents", StoredTextType));
+                            doc.Add(OuterInstance.NewField(Random, "field", "some text contents", StoredTextType));
                             if (DefaultCodecSupportsDocValues())
                             {
                                 binaryDVField = new BinaryDocValuesField("binarydv", new BytesRef());
@@ -1933,7 +1933,7 @@ namespace Lucene.Net.Index
         public virtual void TestWickedLongTerm()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, new StringSplitAnalyzer());
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, new StringSplitAnalyzer(), Similarity, TimeZone);
 
             char[] chars = new char[DocumentsWriterPerThread.MAX_TERM_LENGTH_UTF8];
             Arrays.Fill(chars, 'x');
@@ -1986,7 +1986,7 @@ namespace Lucene.Net.Index
             Field contentField = new Field("content", "", customType);
             doc.Add(contentField);
 
-            w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             contentField.StringValue = "other";
             w.AddDocument(doc);
@@ -2090,7 +2090,7 @@ namespace Lucene.Net.Index
             // somehow "knows" a lock is held against write.lock
             // even if you remove that file:
             d.LockFactory = new SimpleFSLockFactory();
-            RandomIndexWriter w1 = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w1 = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             w1.DeleteAll();
             try
             {
@@ -2854,7 +2854,7 @@ namespace Lucene.Net.Index
                 dir.DeleteFile(fileName);
             }
 
-            w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             w.AddDocument(doc);
             w.Dispose();
             r.Dispose();

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriter.cs
@@ -1986,7 +1986,7 @@ namespace Lucene.Net.Index
             Field contentField = new Field("content", "", customType);
             doc.Add(contentField);
 
-            w = new RandomIndexWriter(Random(), dir);
+            w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             contentField.StringValue = "other";
             w.AddDocument(doc);
@@ -2854,7 +2854,7 @@ namespace Lucene.Net.Index
                 dir.DeleteFile(fileName);
             }
 
-            w = new RandomIndexWriter(Random(), dir);
+            w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             w.AddDocument(doc);
             w.Dispose();
             r.Dispose();

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterCommit.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterCommit.cs
@@ -40,6 +40,8 @@ namespace Lucene.Net.Index
     [TestFixture]
     public class TestIndexWriterCommit : LuceneTestCase
     {
+        private static readonly FieldType StoredTextType = new FieldType(TextField.TYPE_NOT_STORED);
+
         /*
          * Simple test for "commit on close": open writer then
          * add a bunch of docs, making sure reader does not see
@@ -53,7 +55,7 @@ namespace Lucene.Net.Index
             IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())));
             for (int i = 0; i < 14; i++)
             {
-                TestIndexWriter.AddDoc(writer);
+                AddDoc(writer);
             }
             writer.Dispose();
 
@@ -71,7 +73,7 @@ namespace Lucene.Net.Index
             {
                 for (int j = 0; j < 11; j++)
                 {
-                    TestIndexWriter.AddDoc(writer);
+                    AddDoc(writer);
                 }
                 IndexReader r = DirectoryReader.Open(dir);
                 searcher = NewSearcher(r);
@@ -110,7 +112,7 @@ namespace Lucene.Net.Index
             IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(10));
             for (int i = 0; i < 14; i++)
             {
-                TestIndexWriter.AddDoc(writer);
+                AddDoc(writer);
             }
             writer.Dispose();
 
@@ -124,7 +126,7 @@ namespace Lucene.Net.Index
             writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetOpenMode(OpenMode_e.APPEND).SetMaxBufferedDocs(10));
             for (int j = 0; j < 17; j++)
             {
-                TestIndexWriter.AddDoc(writer);
+                AddDoc(writer);
             }
             // Delete all docs:
             writer.DeleteDocuments(searchTerm);
@@ -161,7 +163,7 @@ namespace Lucene.Net.Index
             {
                 for (int j = 0; j < 17; j++)
                 {
-                    TestIndexWriter.AddDoc(writer);
+                    AddDoc(writer);
                 }
                 IndexReader r = DirectoryReader.Open(dir);
                 searcher = NewSearcher(r);
@@ -217,7 +219,7 @@ namespace Lucene.Net.Index
             IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer).SetMaxBufferedDocs(10).SetReaderPooling(false).SetMergePolicy(NewLogMergePolicy(10)));
             for (int j = 0; j < 30; j++)
             {
-                TestIndexWriter.AddDocWithIndex(writer, j);
+                AddDocWithIndex(writer, j);
             }
             writer.Dispose();
             dir.ResetMaxUsedSizeInBytes();
@@ -227,7 +229,7 @@ namespace Lucene.Net.Index
             writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer).SetOpenMode(OpenMode_e.APPEND).SetMaxBufferedDocs(10).SetMergeScheduler(new SerialMergeScheduler()).SetReaderPooling(false).SetMergePolicy(NewLogMergePolicy(10)));
             for (int j = 0; j < 1470; j++)
             {
-                TestIndexWriter.AddDocWithIndex(writer, j);
+                AddDocWithIndex(writer, j);
             }
             long midDiskUsage = dir.MaxUsedSizeInBytes;
             dir.ResetMaxUsedSizeInBytes();
@@ -303,7 +305,7 @@ namespace Lucene.Net.Index
             IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(10).SetMergePolicy(NewLogMergePolicy(10)));
             for (int j = 0; j < 17; j++)
             {
-                TestIndexWriter.AddDocWithIndex(writer, j);
+                AddDocWithIndex(writer, j);
             }
             writer.Dispose();
 
@@ -370,7 +372,7 @@ namespace Lucene.Net.Index
             for (int i = 0; i < NUM_THREADS; i++)
             {
                 int finalI = i;
-                threads[i] = new ThreadAnonymousInnerClassHelper(dir, w, failed, endTime, finalI);
+                threads[i] = new ThreadAnonymousInnerClassHelper(dir, w, failed, endTime, finalI, NewStringField);
                 threads[i].Start();
             }
             for (int i = 0; i < NUM_THREADS; i++)
@@ -384,14 +386,16 @@ namespace Lucene.Net.Index
 
         private class ThreadAnonymousInnerClassHelper : ThreadClass
         {
+            private readonly Func<string, string, Field.Store, Field> NewStringField;
             private Directory Dir;
             private RandomIndexWriter w;
             private AtomicBoolean Failed;
             private long EndTime;
             private int FinalI;
 
-            public ThreadAnonymousInnerClassHelper(Directory dir, RandomIndexWriter w, AtomicBoolean failed, long endTime, int finalI)
+            public ThreadAnonymousInnerClassHelper(Directory dir, RandomIndexWriter w, AtomicBoolean failed, long endTime, int finalI, Func<string, string, Field.Store, Field> newStringField)
             {
+                NewStringField = newStringField;
                 this.Dir = dir;
                 this.w = w;
                 this.Failed = failed;
@@ -449,7 +453,7 @@ namespace Lucene.Net.Index
 
             for (int i = 0; i < 23; i++)
             {
-                TestIndexWriter.AddDoc(writer);
+                AddDoc(writer);
             }
 
             DirectoryReader reader = DirectoryReader.Open(dir);
@@ -463,7 +467,7 @@ namespace Lucene.Net.Index
 
             for (int i = 0; i < 17; i++)
             {
-                TestIndexWriter.AddDoc(writer);
+                AddDoc(writer);
             }
             Assert.AreEqual(23, reader2.NumDocs);
             reader2.Dispose();
@@ -573,7 +577,7 @@ namespace Lucene.Net.Index
 
             for (int i = 0; i < 23; i++)
             {
-                TestIndexWriter.AddDoc(writer);
+                AddDoc(writer);
             }
 
             DirectoryReader reader = DirectoryReader.Open(dir);
@@ -596,7 +600,7 @@ namespace Lucene.Net.Index
 
             for (int i = 0; i < 17; i++)
             {
-                TestIndexWriter.AddDoc(writer);
+                AddDoc(writer);
             }
 
             Assert.AreEqual(23, reader3.NumDocs);
@@ -634,7 +638,7 @@ namespace Lucene.Net.Index
 
             for (int i = 0; i < 23; i++)
             {
-                TestIndexWriter.AddDoc(writer);
+                AddDoc(writer);
             }
 
             DirectoryReader reader = DirectoryReader.Open(dir);
@@ -657,7 +661,7 @@ namespace Lucene.Net.Index
             writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())));
             for (int i = 0; i < 17; i++)
             {
-                TestIndexWriter.AddDoc(writer);
+                AddDoc(writer);
             }
 
             reader = DirectoryReader.Open(dir);
@@ -703,7 +707,7 @@ namespace Lucene.Net.Index
             IndexWriter w = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(2));
             for (int j = 0; j < 17; j++)
             {
-                TestIndexWriter.AddDoc(w);
+                AddDoc(w);
             }
             w.Dispose();
 
@@ -715,7 +719,7 @@ namespace Lucene.Net.Index
             w = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(2));
             for (int j = 0; j < 17; j++)
             {
-                TestIndexWriter.AddDoc(w);
+                AddDoc(w);
             }
             IDictionary<string, string> data = new Dictionary<string, string>();
             data["label"] = "test1";
@@ -732,5 +736,21 @@ namespace Lucene.Net.Index
 
             dir.Dispose();
         }
+
+        private void AddDoc(IndexWriter writer)
+        {
+            Document doc = new Document();
+            doc.Add(NewTextField("content", "aaa", Field.Store.NO));
+            writer.AddDocument(doc);
+        }
+
+        private void AddDocWithIndex(IndexWriter writer, int index)
+        {
+            Document doc = new Document();
+            doc.Add(NewField("content", "aaa " + index, StoredTextType));
+            doc.Add(NewField("id", "" + index, StoredTextType));
+            writer.AddDocument(doc);
+        }
+
     }
 }

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterCommit.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterCommit.cs
@@ -393,6 +393,11 @@ namespace Lucene.Net.Index
             private long EndTime;
             private int FinalI;
 
+            /// <param name="newStringField">
+            /// LUCENENET specific
+            /// This is passed in because <see cref="LuceneTestCase.NewStringField(string, string, Field.Store)"/>
+            /// is no longer static.
+            /// </param>
             public ThreadAnonymousInnerClassHelper(Directory dir, RandomIndexWriter w, AtomicBoolean failed, long endTime, int finalI, Func<string, string, Field.Store, Field> newStringField)
             {
                 NewStringField = newStringField;
@@ -739,7 +744,6 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// LUCENENET specific
-        ///
         /// Copied from <see cref="TestIndexWriter.AddDoc(IndexWriter)"/>
         /// to remove inter-class dependency on <see cref="TestIndexWriter"/>
         /// </summary>
@@ -752,7 +756,6 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// LUCENENET specific
-        ///
         /// Copied from <seealso cref="TestIndexWriter.AddDocWithIndex(IndexWriter, int)"/>
         /// to remove inter-class dependency on <see cref="TestIndexWriter"/>.
         /// </summary>

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterCommit.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterCommit.cs
@@ -737,6 +737,12 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        ///
+        /// Copied from <see cref="TestIndexWriter.AddDoc(IndexWriter)"/>
+        /// to remove inter-class dependency on <see cref="TestIndexWriter"/>
+        /// </summary>
         private void AddDoc(IndexWriter writer)
         {
             Document doc = new Document();
@@ -744,6 +750,12 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        ///
+        /// Copied from <seealso cref="TestIndexWriter.AddDocWithIndex(IndexWriter, int)"/>
+        /// to remove inter-class dependency on <see cref="TestIndexWriter"/>.
+        /// </summary>
         private void AddDocWithIndex(IndexWriter writer, int index)
         {
             Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterDelete.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterDelete.cs
@@ -332,7 +332,7 @@ namespace Lucene.Net.Index
         public virtual void TestDeleteAllNoDeadLock()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter modifier = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter modifier = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int numThreads = AtLeast(2);
             ThreadClass[] threads = new ThreadClass[numThreads];
             CountdownEvent latch = new CountdownEvent(1);
@@ -1106,7 +1106,7 @@ namespace Lucene.Net.Index
         public virtual void TestDeleteAllSlowly()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int NUM_DOCS = AtLeast(1000);
             IList<int?> ids = new List<int?>(NUM_DOCS);
             for (int id = 0; id < NUM_DOCS; id++)

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterDelete.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterDelete.cs
@@ -398,9 +398,9 @@ namespace Lucene.Net.Index
                     for (int j = 0; j < 1000; j++)
                     {
                         Document doc = new Document();
-                        doc.Add(NewTextField("content", "aaa", Field.Store.NO));
-                        doc.Add(NewStringField("id", Convert.ToString(id++), Field.Store.YES));
-                        doc.Add(NewStringField("value", Convert.ToString(value), Field.Store.NO));
+                        doc.Add(OuterInstance.NewTextField("content", "aaa", Field.Store.NO));
+                        doc.Add(OuterInstance.NewStringField("id", Convert.ToString(id++), Field.Store.YES));
+                        doc.Add(OuterInstance.NewStringField("value", Convert.ToString(value), Field.Store.NO));
                         if (DefaultCodecSupportsDocValues())
                         {
                             doc.Add(new NumericDocValuesField("dv", value));

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterDelete.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterDelete.cs
@@ -332,7 +332,7 @@ namespace Lucene.Net.Index
         public virtual void TestDeleteAllNoDeadLock()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter modifier = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter modifier = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int numThreads = AtLeast(2);
             ThreadClass[] threads = new ThreadClass[numThreads];
             CountdownEvent latch = new CountdownEvent(1);
@@ -1106,7 +1106,7 @@ namespace Lucene.Net.Index
         public virtual void TestDeleteAllSlowly()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int NUM_DOCS = AtLeast(1000);
             IList<int?> ids = new List<int?>(NUM_DOCS);
             for (int id = 0; id < NUM_DOCS; id++)

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -181,13 +181,13 @@ namespace Lucene.Net.Index
             {
                 Document doc = new Document();
 
-                doc.Add(NewTextField(r, "content1", "aaa bbb ccc ddd", Field.Store.YES));
-                doc.Add(NewField(r, "content6", "aaa bbb ccc ddd", DocCopyIterator.Custom1));
-                doc.Add(NewField(r, "content2", "aaa bbb ccc ddd", DocCopyIterator.Custom2));
-                doc.Add(NewField(r, "content3", "aaa bbb ccc ddd", DocCopyIterator.Custom3));
+                doc.Add(OuterInstance.NewTextField(r, "content1", "aaa bbb ccc ddd", Field.Store.YES));
+                doc.Add(OuterInstance.NewField(r, "content6", "aaa bbb ccc ddd", DocCopyIterator.Custom1));
+                doc.Add(OuterInstance.NewField(r, "content2", "aaa bbb ccc ddd", DocCopyIterator.Custom2));
+                doc.Add(OuterInstance.NewField(r, "content3", "aaa bbb ccc ddd", DocCopyIterator.Custom3));
 
-                doc.Add(NewTextField(r, "content4", "aaa bbb ccc ddd", Field.Store.NO));
-                doc.Add(NewStringField(r, "content5", "aaa bbb ccc ddd", Field.Store.NO));
+                doc.Add(OuterInstance.NewTextField(r, "content4", "aaa bbb ccc ddd", Field.Store.NO));
+                doc.Add(OuterInstance.NewStringField(r, "content5", "aaa bbb ccc ddd", Field.Store.NO));
                 if (DefaultCodecSupportsDocValues())
                 {
                     doc.Add(new NumericDocValuesField("numericdv", 5));
@@ -200,9 +200,9 @@ namespace Lucene.Net.Index
                     doc.Add(new SortedSetDocValuesField("sortedsetdv", new BytesRef("again")));
                 }
 
-                doc.Add(NewField(r, "content7", "aaa bbb ccc ddd", DocCopyIterator.Custom4));
+                doc.Add(OuterInstance.NewField(r, "content7", "aaa bbb ccc ddd", DocCopyIterator.Custom4));
 
-                Field idField = NewField(r, "id", "", DocCopyIterator.Custom2);
+                Field idField = OuterInstance.NewField(r, "id", "", DocCopyIterator.Custom2);
                 doc.Add(idField);
 
                 long stopTime = ((long)(DateTime.UtcNow - unixEpoch).TotalMilliseconds) + 500;
@@ -1026,11 +1026,11 @@ namespace Lucene.Net.Index
                     for (int iter = 0; iter < NUM_ITER; iter++)
                     {
                         Document doc = new Document();
-                        doc.Add(NewField("contents", "here are some contents", DocCopyIterator.Custom5));
+                        doc.Add(OuterInstance.NewField("contents", "here are some contents", DocCopyIterator.Custom5));
                         Writer.AddDocument(doc);
                         Writer.AddDocument(doc);
-                        doc.Add(NewField("crash", "this should crash after 4 terms", DocCopyIterator.Custom5));
-                        doc.Add(NewField("other", "this will not get indexed", DocCopyIterator.Custom5));
+                        doc.Add(OuterInstance.NewField("crash", "this should crash after 4 terms", DocCopyIterator.Custom5));
+                        doc.Add(OuterInstance.NewField("other", "this will not get indexed", DocCopyIterator.Custom5));
                         try
                         {
                             Writer.AddDocument(doc);
@@ -1043,7 +1043,7 @@ namespace Lucene.Net.Index
                         if (0 == FinalI)
                         {
                             doc = new Document();
-                            doc.Add(NewField("contents", "here are some contents", DocCopyIterator.Custom5));
+                            doc.Add(OuterInstance.NewField("contents", "here are some contents", DocCopyIterator.Custom5));
                             Writer.AddDocument(doc);
                             Writer.AddDocument(doc);
                         }

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -1720,7 +1720,7 @@ namespace Lucene.Net.Index
         public virtual void TestAddDocsNonAbortingException()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int numDocs1 = Random().Next(25);
             for (int docCount = 0; docCount < numDocs1; docCount++)
             {
@@ -1786,7 +1786,7 @@ namespace Lucene.Net.Index
         public virtual void TestUpdateDocsNonAbortingException()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             int numDocs1 = Random().Next(25);
             for (int docCount = 0; docCount < numDocs1; docCount++)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterExceptions.cs
@@ -1720,7 +1720,7 @@ namespace Lucene.Net.Index
         public virtual void TestAddDocsNonAbortingException()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int numDocs1 = Random().Next(25);
             for (int docCount = 0; docCount < numDocs1; docCount++)
             {
@@ -1786,7 +1786,7 @@ namespace Lucene.Net.Index
         public virtual void TestUpdateDocsNonAbortingException()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int numDocs1 = Random().Next(25);
             for (int docCount = 0; docCount < numDocs1; docCount++)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterForceMerge.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterForceMerge.cs
@@ -236,6 +236,12 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        ///
+        /// Copied from <seealso cref="TestIndexWriter.AddDoc(IndexWriter)"/>
+        /// to remove inter-class dependency on TestIndexWriter.
+        /// </summary>
         private void AddDoc(IndexWriter writer)
         {
             Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterForceMerge.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterForceMerge.cs
@@ -34,6 +34,8 @@ namespace Lucene.Net.Index
     [TestFixture]
     public class TestIndexWriterForceMerge : LuceneTestCase
     {
+        private static readonly FieldType StoredTextType = new FieldType(TextField.TYPE_NOT_STORED);
+
         [Test]
         public virtual void TestPartialMerge()
         {
@@ -150,13 +152,13 @@ namespace Lucene.Net.Index
 
             for (int j = 0; j < 500; j++)
             {
-                TestIndexWriter.AddDocWithIndex(writer, j);
+                AddDocWithIndex(writer, j);
             }
             int termIndexInterval = writer.Config.TermIndexInterval;
             // force one extra segment w/ different doc store so
             // we see the doc stores get merged
             writer.Commit();
-            TestIndexWriter.AddDocWithIndex(writer, 500);
+            AddDocWithIndex(writer, 500);
             writer.Dispose();
 
             if (VERBOSE)
@@ -233,5 +235,21 @@ namespace Lucene.Net.Index
 
             dir.Dispose();
         }
+
+        private void AddDoc(IndexWriter writer)
+        {
+            Document doc = new Document();
+            doc.Add(NewTextField("content", "aaa", Field.Store.NO));
+            writer.AddDocument(doc);
+        }
+
+        private void AddDocWithIndex(IndexWriter writer, int index)
+        {
+            Document doc = new Document();
+            doc.Add(NewField("content", "aaa " + index, StoredTextType));
+            doc.Add(NewField("id", "" + index, StoredTextType));
+            writer.AddDocument(doc);
+        }
+
     }
 }

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterReader.cs
@@ -488,7 +488,7 @@ namespace Lucene.Net.Index
                 this.NumDirs = numDirs;
                 this.MainWriter = mainWriter;
                 AddDir = NewDirectory();
-                IndexWriter writer = new IndexWriter(AddDir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(2));
+                IndexWriter writer = new IndexWriter(AddDir, OuterInstance.NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMaxBufferedDocs(2));
                 TestUtil.ReduceOpenFiles(writer);
                 for (int i = 0; i < NUM_INIT_DOCS; i++)
                 {
@@ -704,9 +704,9 @@ namespace Lucene.Net.Index
          * //} //writer.DeleteDocuments(term); td.Dispose(); return doc; }
          */
 
-        public static void CreateIndex(Random random, Directory dir1, string indexName, bool multiSegment)
+        public void CreateIndex(Random random, Directory dir1, string indexName, bool multiSegment)
         {
-            IndexWriter w = new IndexWriter(dir1, LuceneTestCase.NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random)).SetMergePolicy(new LogDocMergePolicy()));
+            IndexWriter w = new IndexWriter(dir1, NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random)).SetMergePolicy(new LogDocMergePolicy()));
             for (int i = 0; i < 100; i++)
             {
                 w.AddDocument(DocHelper.CreateDocument(i, indexName, 4));
@@ -1186,7 +1186,7 @@ namespace Lucene.Net.Index
 
             public override void Warm(AtomicReader r)
             {
-                IndexSearcher s = NewSearcher(r);
+                IndexSearcher s = OuterInstance.NewSearcher(r);
                 TopDocs hits = s.Search(new TermQuery(new Term("foo", "bar")), 10);
                 Assert.AreEqual(20, hits.TotalHits);
                 DidWarm.Set(true);

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterUnicode.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterUnicode.cs
@@ -317,7 +317,7 @@ namespace Lucene.Net.Index
         {
             Random rnd = Random();
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(rnd, dir);
+            RandomIndexWriter writer = new RandomIndexWriter(rnd, dir, Similarity, TimeZone);
             Document d = new Document();
             // Single segment
             Field f = NewStringField("f", "", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexWriterWithThreads.cs
@@ -65,6 +65,11 @@ namespace Lucene.Net.Index
             internal bool NoErrors;
             internal volatile int AddCount;
 
+            /// <param name="newField">
+            /// LUCENENET specific
+            /// Passed in because <see cref="LuceneTestCase.NewField(string, string, FieldType)"/>
+            /// is no longer static.
+            /// </param>
             public IndexerThread(IndexWriter writer, bool noErrors, Func<string, string, FieldType, Field> newField)
             {
                 this.Writer = writer;
@@ -602,6 +607,11 @@ namespace Lucene.Net.Index
             internal CountdownEvent IwConstructed;
             private readonly LuceneTestCase OuterInstance;
 
+            /// <param name="outerInstance">
+            /// LUCENENET specific
+            /// Passed in because this class acceses non-static methods,
+            /// NewTextField and NewIndexWriterConfig
+            /// </param>
             public DelayedIndexAndCloseRunnable(Directory dir, CountdownEvent iwConstructed, LuceneTestCase outerInstance)
             {
                 this.Dir = dir;

--- a/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
@@ -232,7 +232,7 @@ namespace Lucene.Net.Index
         public virtual void TestArbitraryFields()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             int NUM_DOCS = AtLeast(27);
             if (VERBOSE)

--- a/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
@@ -423,7 +423,7 @@ namespace Lucene.Net.Index
                     if (fieldUpto == 0)
                     {
                         fieldUpto = 1;
-                        current = NewStringField("id", "" + OuterInstance.FinalDocCount, Field.Store.YES);
+                        current = OuterTextIndexableField.NewStringField("id", "" + OuterInstance.FinalDocCount, Field.Store.YES);
                     }
                     else
                     {

--- a/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexableField.cs
@@ -232,7 +232,7 @@ namespace Lucene.Net.Index
         public virtual void TestArbitraryFields()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             int NUM_DOCS = AtLeast(27);
             if (VERBOSE)

--- a/src/Lucene.Net.Tests/core/Index/TestIsCurrent.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIsCurrent.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Index
 
             // initialize directory
             Directory = NewDirectory();
-            Writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            Writer = new RandomIndexWriter(Random(), Directory, Similarity, TimeZone);
 
             // write document
             Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestIsCurrent.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIsCurrent.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Index
 
             // initialize directory
             Directory = NewDirectory();
-            Writer = new RandomIndexWriter(Random(), Directory);
+            Writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             // write document
             Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestNeverDelete.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestNeverDelete.cs
@@ -110,6 +110,16 @@ namespace Lucene.Net.Index
             private RandomIndexWriter w;
             private long StopTime;
 
+            /// <param name="newStringField">
+            /// LUCENENET specific
+            /// Passed in because <see cref="LuceneTestCase.NewStringField(string, string, Field.Store)"/>
+            /// is no longer static
+            /// </param>
+            /// <param name="newTextField">
+            /// LUCENENET specific
+            /// Passed in because <see cref="LuceneTestCase.NewTextField(string, string, Field.Store)"/>
+            /// is no longer static
+            /// </param>
             public ThreadAnonymousInnerClassHelper(RandomIndexWriter w, long stopTime, 
                 Func<string, string, Field.Store, Field> newStringField, Func<string, string, Field.Store, Field> newTextField)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestNeverDelete.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestNeverDelete.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Index
             long stopTime = Environment.TickCount + AtLeast(1000);
             for (int x = 0; x < indexThreads.Length; x++)
             {
-                indexThreads[x] = new ThreadAnonymousInnerClassHelper(w, stopTime);
+                indexThreads[x] = new ThreadAnonymousInnerClassHelper(w, stopTime, NewStringField, NewTextField);
                 indexThreads[x].Name = "Thread " + x;
                 indexThreads[x].Start();
             }
@@ -104,13 +104,19 @@ namespace Lucene.Net.Index
 
         private class ThreadAnonymousInnerClassHelper : ThreadClass
         {
+            private readonly Func<string, string, Field.Store, Field> NewStringField;
+            private readonly Func<string, string, Field.Store, Field> NewTextField;
+
             private RandomIndexWriter w;
             private long StopTime;
 
-            public ThreadAnonymousInnerClassHelper(RandomIndexWriter w, long stopTime)
+            public ThreadAnonymousInnerClassHelper(RandomIndexWriter w, long stopTime, 
+                Func<string, string, Field.Store, Field> newStringField, Func<string, string, Field.Store, Field> newTextField)
             {
                 this.w = w;
                 this.StopTime = stopTime;
+                NewStringField = newStringField;
+                NewTextField = newTextField;
             }
 
             public override void Run()

--- a/src/Lucene.Net.Tests/core/Index/TestNumericDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestNumericDocValuesUpdates.cs
@@ -1062,14 +1062,15 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestUpdateOldSegments()
         {
-            Codec[] oldCodecs = new Codec[] { new Lucene40RWCodec(), new Lucene41RWCodec(), new Lucene42RWCodec(), new Lucene45RWCodec() };
+            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
+
+            Codec[] oldCodecs = new Codec[] { new Lucene40RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE), new Lucene41RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE), new Lucene42RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE), new Lucene45RWCodec(OLD_FORMAT_IMPERSONATION_IS_ACTIVE) };
             Directory dir = NewDirectory();
 
             bool oldValue = OLD_FORMAT_IMPERSONATION_IS_ACTIVE;
             // create a segment with an old Codec
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()));
             conf.SetCodec(oldCodecs[Random().Next(oldCodecs.Length)]);
-            OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;
             IndexWriter writer = new IndexWriter(dir, conf);
             Document doc = new Document();
             doc.Add(new StringField("id", "doc", Store.NO));

--- a/src/Lucene.Net.Tests/core/Index/TestOmitPositions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestOmitPositions.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Index
         public virtual void TestBasic()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.IndexOptions = FieldInfo.IndexOptions.DOCS_AND_FREQS;
@@ -254,7 +254,7 @@ namespace Lucene.Net.Index
             ft.IndexOptions = FieldInfo.IndexOptions.DOCS_AND_FREQS;
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             for (int i = 0; i < 20; i++)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestOmitPositions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestOmitPositions.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Index
         public virtual void TestBasic()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.IndexOptions = FieldInfo.IndexOptions.DOCS_AND_FREQS;
@@ -254,7 +254,7 @@ namespace Lucene.Net.Index
             ft.IndexOptions = FieldInfo.IndexOptions.DOCS_AND_FREQS;
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             for (int i = 0; i < 20; i++)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestPayloads.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestPayloads.cs
@@ -696,7 +696,7 @@ namespace Lucene.Net.Index
         public virtual void TestMixupMultiValued()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             Field field = new TextField("field", "", Field.Store.NO);
             TokenStream ts = new MockTokenizer(new StringReader("here we go"), MockTokenizer.WHITESPACE, true);

--- a/src/Lucene.Net.Tests/core/Index/TestPayloads.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestPayloads.cs
@@ -636,13 +636,13 @@ namespace Lucene.Net.Index
         public virtual void TestAcrossFields()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, new MockAnalyzer(Random(), MockTokenizer.WHITESPACE, true));
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, new MockAnalyzer(Random(), MockTokenizer.WHITESPACE, true), Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new TextField("hasMaybepayload", "here we go", Field.Store.YES));
             writer.AddDocument(doc);
             writer.Dispose();
 
-            writer = new RandomIndexWriter(Random(), dir, new MockAnalyzer(Random(), MockTokenizer.WHITESPACE, true));
+            writer = new RandomIndexWriter(Random(), dir, new MockAnalyzer(Random(), MockTokenizer.WHITESPACE, true), Similarity, TimeZone);
             doc = new Document();
             doc.Add(new TextField("hasMaybepayload2", "here we go", Field.Store.YES));
             writer.AddDocument(doc);
@@ -696,7 +696,7 @@ namespace Lucene.Net.Index
         public virtual void TestMixupMultiValued()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             Field field = new TextField("field", "", Field.Store.NO);
             TokenStream ts = new MockTokenizer(new StringReader("here we go"), MockTokenizer.WHITESPACE, true);

--- a/src/Lucene.Net.Tests/core/Index/TestPayloadsOnVectors.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestPayloadsOnVectors.cs
@@ -95,7 +95,7 @@ namespace Lucene.Net.Index
         public virtual void TestMixupMultiValued()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_NOT_STORED);
             customType.StoreTermVectors = true;
@@ -138,7 +138,7 @@ namespace Lucene.Net.Index
         public virtual void TestPayloadsWithoutPositions()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_NOT_STORED);
             customType.StoreTermVectors = true;

--- a/src/Lucene.Net.Tests/core/Index/TestPayloadsOnVectors.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestPayloadsOnVectors.cs
@@ -95,7 +95,7 @@ namespace Lucene.Net.Index
         public virtual void TestMixupMultiValued()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_NOT_STORED);
             customType.StoreTermVectors = true;
@@ -138,7 +138,7 @@ namespace Lucene.Net.Index
         public virtual void TestPayloadsWithoutPositions()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_NOT_STORED);
             customType.StoreTermVectors = true;

--- a/src/Lucene.Net.Tests/core/Index/TestPostingsOffsets.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestPostingsOffsets.cs
@@ -438,7 +438,7 @@ namespace Lucene.Net.Index
         public virtual void TestAddFieldTwice()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             FieldType customType3 = new FieldType(TextField.TYPE_STORED);
             customType3.StoreTermVectors = true;

--- a/src/Lucene.Net.Tests/core/Index/TestPostingsOffsets.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestPostingsOffsets.cs
@@ -438,7 +438,7 @@ namespace Lucene.Net.Index
         public virtual void TestAddFieldTwice()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType customType3 = new FieldType(TextField.TYPE_STORED);
             customType3.StoreTermVectors = true;

--- a/src/Lucene.Net.Tests/core/Index/TestRollback.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestRollback.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Index
         public virtual void TestRollbackIntegrityWithBufferFlush()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter rw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter rw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             for (int i = 0; i < 5; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestRollback.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestRollback.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Index
         public virtual void TestRollbackIntegrityWithBufferFlush()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter rw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter rw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < 5; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestRollingUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestRollingUpdates.cs
@@ -204,7 +204,7 @@ namespace Lucene.Net.Index
                 IndexingThread[] threads = new IndexingThread[numThreads];
                 for (int i = 0; i < numThreads; i++)
                 {
-                    threads[i] = new IndexingThread(docs, w, numUpdates);
+                    threads[i] = new IndexingThread(docs, w, numUpdates, NewStringField);
                     threads[i].Start();
                 }
 
@@ -229,12 +229,15 @@ namespace Lucene.Net.Index
             internal readonly IndexWriter Writer;
             internal readonly int Num;
 
-            public IndexingThread(LineFileDocs docs, IndexWriter writer, int num)
+            private readonly Func<string, string, Field.Store, Field> NewStringField;
+
+            public IndexingThread(LineFileDocs docs, IndexWriter writer, int num, Func<string, string, Field.Store, Field> newStringField)
                 : base()
             {
                 this.Docs = docs;
                 this.Writer = writer;
                 this.Num = num;
+                NewStringField = newStringField;
             }
 
             public override void Run()

--- a/src/Lucene.Net.Tests/core/Index/TestRollingUpdates.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestRollingUpdates.cs
@@ -231,6 +231,11 @@ namespace Lucene.Net.Index
 
             private readonly Func<string, string, Field.Store, Field> NewStringField;
 
+            /// <param name="newStringField">
+            /// LUCENENET specific
+            /// Passed in because <see cref="LuceneTestCase.NewStringField(string, string, Field.Store)"/>
+            /// is no longer static.
+            /// </param>
             public IndexingThread(LineFileDocs docs, IndexWriter writer, int num, Func<string, string, Field.Store, Field> newStringField)
                 : base()
             {

--- a/src/Lucene.Net.Tests/core/Index/TestSameTokenSamePosition.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSameTokenSamePosition.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Index
         public virtual void Test()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new TextField("eng", new BugReproTokenStream()));
             riw.AddDocument(doc);
@@ -54,7 +54,7 @@ namespace Lucene.Net.Index
         public virtual void TestMoreDocs()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < 100; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestSameTokenSamePosition.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSameTokenSamePosition.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Index
         public virtual void Test()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new TextField("eng", new BugReproTokenStream()));
             riw.AddDocument(doc);
@@ -54,7 +54,7 @@ namespace Lucene.Net.Index
         public virtual void TestMoreDocs()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter riw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             for (int i = 0; i < 100; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestSizeBoundedForceMerge.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSizeBoundedForceMerge.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Index
             writer.Commit();
         }
 
-        private static IndexWriterConfig NewWriterConfig()
+        private IndexWriterConfig NewWriterConfig()
         {
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, null);
             conf.SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH);

--- a/src/Lucene.Net.Tests/core/Index/TestSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSnapshotDeletionPolicy.cs
@@ -148,7 +148,7 @@ namespace Lucene.Net.Index
             dp = (SnapshotDeletionPolicy)writer.Config.DelPolicy;
             writer.Commit();
 
-            ThreadClass t = new ThreadAnonymousInnerClassHelper(stopTime, writer);
+            ThreadClass t = new ThreadAnonymousInnerClassHelper(stopTime, writer, NewField);
 
             t.Start();
 
@@ -183,11 +183,13 @@ namespace Lucene.Net.Index
         {
             private long StopTime;
             private IndexWriter Writer;
+            private readonly Func<string, string, FieldType, Field> _newFieldFunc;
 
-            public ThreadAnonymousInnerClassHelper(long stopTime, IndexWriter writer)
+            public ThreadAnonymousInnerClassHelper(long stopTime, IndexWriter writer, Func<string, string, FieldType, Field> newFieldFunc)
             {
                 this.StopTime = stopTime;
                 this.Writer = writer;
+                _newFieldFunc = newFieldFunc;
             }
 
             public override void Run()
@@ -197,7 +199,7 @@ namespace Lucene.Net.Index
                 customType.StoreTermVectors = true;
                 customType.StoreTermVectorPositions = true;
                 customType.StoreTermVectorOffsets = true;
-                doc.Add(NewField("content", "aaa", customType));
+                doc.Add(_newFieldFunc("content", "aaa", customType));
                 do
                 {
                     for (int i = 0; i < 27; i++)

--- a/src/Lucene.Net.Tests/core/Index/TestSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSnapshotDeletionPolicy.cs
@@ -185,6 +185,11 @@ namespace Lucene.Net.Index
             private IndexWriter Writer;
             private readonly Func<string, string, FieldType, Field> _newFieldFunc;
 
+            /// <param name="newFieldFunc">
+            /// LUCENENET specific
+            /// Passed in because <see cref="LuceneTestCase.NewField(string, string, FieldType)"/>
+            /// is no longer static. 
+            /// </param>
             public ThreadAnonymousInnerClassHelper(long stopTime, IndexWriter writer, Func<string, string, FieldType, Field> newFieldFunc)
             {
                 this.StopTime = stopTime;

--- a/src/Lucene.Net.Tests/core/Index/TestStressAdvance.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressAdvance.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Index
                     Console.WriteLine("\nTEST: iter=" + iter);
                 }
                 Directory dir = NewDirectory();
-                RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+                RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
                 HashSet<int> aDocs = new HashSet<int>();
                 Documents.Document doc = new Documents.Document();
                 Field f = NewStringField("field", "", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Index/TestStressAdvance.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressAdvance.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Index
                     Console.WriteLine("\nTEST: iter=" + iter);
                 }
                 Directory dir = NewDirectory();
-                RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+                RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
                 HashSet<int> aDocs = new HashSet<int>();
                 Documents.Document doc = new Documents.Document();
                 Field f = NewStringField("field", "", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
@@ -92,10 +92,14 @@ namespace Lucene.Net.Index
             internal IndexWriter Writer;
             internal int NextID;
 
-            public IndexerThread(IndexWriter writer, TimedThread[] threads)
+            public IndexerThread(IndexWriter writer, TimedThread[] threads,
+                Func<string, string, Field.Store, Field> newStringField,
+                Func<string, string, Field.Store, Field> newTextField)
                 : base(threads)
             {
                 this.Writer = writer;
+                NewStringField = newStringField;
+                NewTextField = newTextField;
             }
 
             public override void DoWork()

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
@@ -130,10 +130,12 @@ namespace Lucene.Net.Index
         private class SearcherThread : TimedThread
         {
             internal Directory Directory;
+            private readonly LuceneTestCase OuterInstance;
 
-            public SearcherThread(Directory directory, TimedThread[] threads)
+            public SearcherThread(Directory directory, TimedThread[] threads, LuceneTestCase outerInstance)
                 : base(threads)
             {
+                OuterInstance = outerInstance;
                 this.Directory = directory;
             }
 
@@ -142,7 +144,7 @@ namespace Lucene.Net.Index
                 for (int i = 0; i < 100; i++)
                 {
                     IndexReader ir = DirectoryReader.Open(Directory);
-                    IndexSearcher @is = NewSearcher(ir);
+                    IndexSearcher @is = OuterInstance.NewSearcher(ir);
                     ir.Dispose();
                 }
                 Count += 100;
@@ -174,11 +176,11 @@ namespace Lucene.Net.Index
 
             // Two searchers that constantly just re-instantiate the
             // searcher:
-            SearcherThread searcherThread1 = new SearcherThread(directory, threads);
+            SearcherThread searcherThread1 = new SearcherThread(directory, threads, this);
             threads[numThread++] = searcherThread1;
             searcherThread1.Start();
 
-            SearcherThread searcherThread2 = new SearcherThread(directory, threads);
+            SearcherThread searcherThread2 = new SearcherThread(directory, threads, this);
             threads[numThread++] = searcherThread2;
             searcherThread2.Start();
 

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
@@ -89,6 +89,9 @@ namespace Lucene.Net.Index
 
         private class IndexerThread : TimedThread
         {
+            private readonly Func<string, string, Field.Store, Field> NewStringFieldFunc;
+            private readonly Func<string, string, Field.Store, Field> NewTextFieldFunc;
+
             internal IndexWriter Writer;
             internal int NextID;
 
@@ -98,8 +101,8 @@ namespace Lucene.Net.Index
                 : base(threads)
             {
                 this.Writer = writer;
-                NewStringField = newStringField;
-                NewTextField = newTextField;
+                NewStringFieldFunc = newStringField;
+                NewTextFieldFunc = newTextField;
             }
 
             public override void DoWork()
@@ -109,8 +112,8 @@ namespace Lucene.Net.Index
                 {
                     Documents.Document d = new Documents.Document();
                     int n = Random().Next();
-                    d.Add(NewStringField("id", Convert.ToString(NextID++), Field.Store.YES));
-                    d.Add(NewTextField("contents", English.IntToEnglish(n), Field.Store.NO));
+                    d.Add(NewStringFieldFunc("id", Convert.ToString(NextID++), Field.Store.YES));
+                    d.Add(NewTextFieldFunc("contents", English.IntToEnglish(n), Field.Store.NO));
                     Writer.AddDocument(d);
                 }
 
@@ -161,11 +164,11 @@ namespace Lucene.Net.Index
 
             // One modifier that writes 10 docs then removes 5, over
             // and over:
-            IndexerThread indexerThread = new IndexerThread(modifier, threads);
+            IndexerThread indexerThread = new IndexerThread(modifier, threads, NewStringField, NewTextField);
             threads[numThread++] = indexerThread;
             indexerThread.Start();
 
-            IndexerThread indexerThread2 = new IndexerThread(modifier, threads);
+            IndexerThread indexerThread2 = new IndexerThread(modifier, threads, NewStringField, NewTextField);
             threads[numThread++] = indexerThread2;
             indexerThread2.Start();
 

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing.cs
@@ -95,6 +95,16 @@ namespace Lucene.Net.Index
             internal IndexWriter Writer;
             internal int NextID;
 
+            /// <param name="newStringField">
+            /// LUCENENET specific
+            /// Passed in because <see cref="LuceneTestCase.NewStringField(string, string, Field.Store)"/>
+            /// is no longer static.
+            /// </param>
+            /// <param name="newTextField">
+            /// LUCENENET specific
+            /// Passed in because <see cref="LuceneTestCase.NewTextField(string, string, Field.Store)"/>
+            /// is no longer static.
+            /// </param>
             public IndexerThread(IndexWriter writer, TimedThread[] threads,
                 Func<string, string, Field.Store, Field> newStringField,
                 Func<string, string, Field.Store, Field> newTextField)
@@ -132,6 +142,11 @@ namespace Lucene.Net.Index
             internal Directory Directory;
             private readonly LuceneTestCase OuterInstance;
 
+            /// <param name="outerInstance">
+            /// LUCENENET specific
+            /// Passed in because <see cref="LuceneTestCase.NewSearcher(IndexReader)"/>
+            /// is no longer static.
+            /// </param>
             public SearcherThread(Directory directory, TimedThread[] threads, LuceneTestCase outerInstance)
                 : base(threads)
             {

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
@@ -272,9 +272,9 @@ namespace Lucene.Net.Index
             return docs;
         }
 
-        public static void IndexSerial(Random random, IDictionary<string, Document> docs, Directory dir)
+        public void IndexSerial(Random random, IDictionary<string, Document> docs, Directory dir)
         {
-            IndexWriter w = new IndexWriter(dir, LuceneTestCase.NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random)).SetMergePolicy(NewLogMergePolicy()));
+            IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random)).SetMergePolicy(NewLogMergePolicy()));
 
             // index all docs in a single thread
             IEnumerator<Document> iter = docs.Values.GetEnumerator();

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
@@ -917,7 +917,7 @@ namespace Lucene.Net.Index
 
                 List<Field> fields = new List<Field>();
                 string idString = IdString;
-                Field idField = NewField("id", idString, customType1);
+                Field idField = OuterInstance.NewField("id", idString, customType1);
                 fields.Add(idField);
 
                 int nFields = NextInt(MaxFields);
@@ -950,13 +950,13 @@ namespace Lucene.Net.Index
                             customType.Stored = true;
                             customType.OmitNorms = true;
                             customType.Indexed = true;
-                            fields.Add(NewField("f" + NextInt(100), GetString(1), customType));
+                            fields.Add(OuterInstance.NewField("f" + NextInt(100), GetString(1), customType));
                             break;
 
                         case 1:
                             customType.Indexed = true;
                             customType.Tokenized = true;
-                            fields.Add(NewField("f" + NextInt(100), GetString(0), customType));
+                            fields.Add(OuterInstance.NewField("f" + NextInt(100), GetString(0), customType));
                             break;
 
                         case 2:
@@ -964,14 +964,14 @@ namespace Lucene.Net.Index
                             customType.StoreTermVectors = false;
                             customType.StoreTermVectorOffsets = false;
                             customType.StoreTermVectorPositions = false;
-                            fields.Add(NewField("f" + NextInt(100), GetString(0), customType));
+                            fields.Add(OuterInstance.NewField("f" + NextInt(100), GetString(0), customType));
                             break;
 
                         case 3:
                             customType.Stored = true;
                             customType.Indexed = true;
                             customType.Tokenized = true;
-                            fields.Add(NewField("f" + NextInt(100), GetString(BigFieldSize), customType));
+                            fields.Add(OuterInstance.NewField("f" + NextInt(100), GetString(BigFieldSize), customType));
                             break;
                     }
                 }

--- a/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressIndexing2.cs
@@ -272,6 +272,10 @@ namespace Lucene.Net.Index
             return docs;
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         public void IndexSerial(Random random, IDictionary<string, Document> docs, Directory dir)
         {
             IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random)).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/core/Index/TestStressNRT.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressNRT.cs
@@ -337,8 +337,8 @@ namespace Lucene.Net.Index
                                     if (Tombstones)
                                     {
                                         Document d = new Document();
-                                        d.Add(NewStringField("id", "-" + Convert.ToString(id), Documents.Field.Store.YES));
-                                        d.Add(NewField(OuterInstance.Field, Convert.ToString(nextVal), StoredOnlyType));
+                                        d.Add(OuterInstance.NewStringField("id", "-" + Convert.ToString(id), Documents.Field.Store.YES));
+                                        d.Add(OuterInstance.NewField(OuterInstance.Field, Convert.ToString(nextVal), StoredOnlyType));
                                         Writer.UpdateDocument(new Term("id", "-" + Convert.ToString(id)), d);
                                     }
 
@@ -357,8 +357,8 @@ namespace Lucene.Net.Index
                                     if (Tombstones)
                                     {
                                         Document d = new Document();
-                                        d.Add(NewStringField("id", "-" + Convert.ToString(id), Documents.Field.Store.YES));
-                                        d.Add(NewField(OuterInstance.Field, Convert.ToString(nextVal), StoredOnlyType));
+                                        d.Add(OuterInstance.NewStringField("id", "-" + Convert.ToString(id), Documents.Field.Store.YES));
+                                        d.Add(OuterInstance.NewField(OuterInstance.Field, Convert.ToString(nextVal), StoredOnlyType));
                                         Writer.UpdateDocument(new Term("id", "-" + Convert.ToString(id)), d);
                                     }
 
@@ -373,8 +373,8 @@ namespace Lucene.Net.Index
                                 {
                                     // assertU(adoc("id",Integer.toString(id), field, Long.toString(nextVal)));
                                     Document d = new Document();
-                                    d.Add(NewStringField("id", Convert.ToString(id), Documents.Field.Store.YES));
-                                    d.Add(NewField(OuterInstance.Field, Convert.ToString(nextVal), StoredOnlyType));
+                                    d.Add(OuterInstance.NewStringField("id", Convert.ToString(id), Documents.Field.Store.YES));
+                                    d.Add(OuterInstance.NewField(OuterInstance.Field, Convert.ToString(nextVal), StoredOnlyType));
                                     if (VERBOSE)
                                     {
                                         Console.WriteLine("TEST: " + Thread.CurrentThread.Name + ": u id:" + id + " val=" + nextVal);

--- a/src/Lucene.Net.Tests/core/Index/TestStressNRT.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestStressNRT.cs
@@ -465,7 +465,7 @@ namespace Lucene.Net.Index
                         }
                         else
                         {
-                            searcher = NewSearcher(r);
+                            searcher = OuterInstance.NewSearcher(r);
                             lastReader = r;
                             lastSearcher = searcher;
                         }

--- a/src/Lucene.Net.Tests/core/Index/TestSumDocFreq.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSumDocFreq.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Index
             int numDocs = AtLeast(500);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             Field id = NewStringField("id", "", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Index/TestSumDocFreq.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestSumDocFreq.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Index
             int numDocs = AtLeast(500);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             Field id = NewStringField("id", "", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Index/TestTermVectorsReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTermVectorsReader.cs
@@ -410,7 +410,7 @@ namespace Lucene.Net.Index
         public virtual void TestIllegalIndexableField()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.StoreTermVectors = true;
             ft.StoreTermVectorPayloads = true;

--- a/src/Lucene.Net.Tests/core/Index/TestTermVectorsReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTermVectorsReader.cs
@@ -410,7 +410,7 @@ namespace Lucene.Net.Index
         public virtual void TestIllegalIndexableField()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.StoreTermVectors = true;
             ft.StoreTermVectorPayloads = true;

--- a/src/Lucene.Net.Tests/core/Index/TestTermsEnum.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTermsEnum.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Index
             Directory d = NewDirectory();
             MockAnalyzer analyzer = new MockAnalyzer(Random());
             analyzer.MaxTokenLength = TestUtil.NextInt(Random(), 1, IndexWriter.MAX_TERM_LENGTH);
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d, analyzer);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, analyzer, Similarity, TimeZone);
             int numDocs = AtLeast(10);
             for (int docCount = 0; docCount < numDocs; docCount++)
             {
@@ -230,7 +230,7 @@ namespace Lucene.Net.Index
         public virtual void TestIntersectRandom()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             int numTerms = AtLeast(300);
             //final int numTerms = 50;
@@ -583,7 +583,7 @@ namespace Lucene.Net.Index
         public virtual void TestZeroTerms()
         {
             var d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "one two three", Field.Store.NO));
             doc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestTermsEnum.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTermsEnum.cs
@@ -230,7 +230,7 @@ namespace Lucene.Net.Index
         public virtual void TestIntersectRandom()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             int numTerms = AtLeast(300);
             //final int numTerms = 50;

--- a/src/Lucene.Net.Tests/core/Index/TestThreadedForceMerge.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestThreadedForceMerge.cs
@@ -148,8 +148,8 @@ namespace Lucene.Net.Index
                         for (int k = 0; k < 17 * (1 + IFinal); k++)
                         {
                             Document d = new Document();
-                            d.Add(NewField("id", IterFinal + "_" + IFinal + "_" + j + "_" + k, CustomType));
-                            d.Add(NewField("contents", English.IntToEnglish(IFinal + k), CustomType));
+                            d.Add(OuterInstance.NewField("id", IterFinal + "_" + IFinal + "_" + j + "_" + k, CustomType));
+                            d.Add(OuterInstance.NewField("contents", English.IntToEnglish(IFinal + k), CustomType));
                             WriterFinal.AddDocument(d);
                         }
                         for (int k = 0; k < 9 * (1 + IFinal); k++)

--- a/src/Lucene.Net.Tests/core/Index/TestTransactions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTransactions.cs
@@ -134,7 +134,7 @@ namespace Lucene.Net.Index
 
             public override void DoWork()
             {
-                var config = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                var config = OuterInstance.NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
                                 .SetMaxBufferedDocs(3)
                                 .SetMergeScheduler(_scheduler1)
                                 .SetMergePolicy(NewLogMergePolicy(2));
@@ -143,7 +143,7 @@ namespace Lucene.Net.Index
 
                 // Intentionally use different params so flush/merge
                 // happen @ different times
-                var config2 = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                var config2 = OuterInstance.NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
                                 .SetMaxBufferedDocs(2)
                                 .SetMergeScheduler(_scheduler2)
                                 .SetMergePolicy(NewLogMergePolicy(3));

--- a/src/Lucene.Net.Tests/core/Index/TestTransactions.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestTransactions.cs
@@ -201,8 +201,8 @@ namespace Lucene.Net.Index
                 {
                     Document d = new Document();
                     int n = Random().Next();
-                    d.Add(NewField("id", Convert.ToString(NextID++), customType));
-                    d.Add(NewTextField("contents", English.IntToEnglish(n), Field.Store.NO));
+                    d.Add(OuterInstance.NewField("id", Convert.ToString(NextID++), customType));
+                    d.Add(OuterInstance.NewTextField("contents", English.IntToEnglish(n), Field.Store.NO));
                     writer.AddDocument(d);
                 }
 

--- a/src/Lucene.Net.Tests/core/Search/BaseTestRangeFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/BaseTestRangeFilter.cs
@@ -95,6 +95,11 @@ namespace Lucene.Net.Search
             return b.ToString();
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because <see cref="Build(Random, TestIndex)"/> is no
+        /// longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClassBaseTestRangeFilter()
         {
@@ -118,6 +123,11 @@ namespace Lucene.Net.Search
             UnsignedIndexDir = null;
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Passed in because NewStringField and NewIndexWriterConfig are no
+        /// longer static.
+        /// </summary>
         private IndexReader Build(Random random, TestIndex index)
         {
             /* build an index */

--- a/src/Lucene.Net.Tests/core/Search/BaseTestRangeFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/BaseTestRangeFilter.cs
@@ -96,7 +96,7 @@ namespace Lucene.Net.Search
         }
 
         [TestFixtureSetUp]
-        public static void BeforeClassBaseTestRangeFilter()
+        public void BeforeClassBaseTestRangeFilter()
         {
             MaxId = AtLeast(500);
             SignedIndexDir = new TestIndex(Random(), int.MaxValue, int.MinValue, true);
@@ -118,7 +118,7 @@ namespace Lucene.Net.Search
             UnsignedIndexDir = null;
         }
 
-        private static IndexReader Build(Random random, TestIndex index)
+        private IndexReader Build(Random random, TestIndex index)
         {
             /* build an index */
 

--- a/src/Lucene.Net.Tests/core/Search/FuzzyTermOnShortTermsTest.cs
+++ b/src/Lucene.Net.Tests/core/Search/FuzzyTermOnShortTermsTest.cs
@@ -96,6 +96,10 @@ namespace Lucene.Net.Search
             }
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         public Directory GetDirectory(Analyzer analyzer, string[] vals)
         {
             Directory directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/FuzzyTermOnShortTermsTest.cs
+++ b/src/Lucene.Net.Tests/core/Search/FuzzyTermOnShortTermsTest.cs
@@ -96,7 +96,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        public static Directory GetDirectory(Analyzer analyzer, string[] vals)
+        public Directory GetDirectory(Analyzer analyzer, string[] vals)
         {
             Directory directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer).SetMaxBufferedDocs(TestUtil.NextInt(Random(), 100, 1000)).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/core/Search/Payloads/PayloadHelper.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/PayloadHelper.cs
@@ -144,7 +144,7 @@ namespace Lucene.Net.Search.Payloads
             Reader = DirectoryReader.Open(writer, true);
             writer.Dispose();
 
-            IndexSearcher searcher = LuceneTestCase.NewSearcher(Reader);
+            IndexSearcher searcher = LuceneTestCase.NewSearcher(Reader, similarity);
             searcher.Similarity = similarity;
             return searcher;
         }

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadNearQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadNearQuery.cs
@@ -110,6 +110,10 @@ namespace Lucene.Net.Search.Payloads
             return new PayloadNearQuery(clauses, 0, inOrder, function);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadNearQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadNearQuery.cs
@@ -111,7 +111,7 @@ namespace Lucene.Net.Search.Payloads
         }
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new PayloadAnalyzer()).SetSimilarity(Similarity));

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
@@ -116,7 +116,7 @@ namespace Lucene.Net.Search.Payloads
         }
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new PayloadAnalyzer()).SetSimilarity(Similarity).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
@@ -115,6 +115,10 @@ namespace Lucene.Net.Search.Payloads
             }
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
@@ -305,7 +305,7 @@ namespace Lucene.Net.Search.Payloads
             Assert.IsTrue(hits.TotalHits == 1, "hits Size: " + hits.TotalHits + " is not: " + 1);
             int[] results = new int[1];
             results[0] = 0; //hits.ScoreDocs[0].Doc;
-            CheckHits.CheckHitCollector(Random(), query, PayloadHelper.NO_PAYLOAD_FIELD, Searcher, results);
+            CheckHits.CheckHitCollector(Random(), query, PayloadHelper.NO_PAYLOAD_FIELD, Searcher, results, Similarity);
         }
 
         internal class BoostingSimilarity : DefaultSimilarity

--- a/src/Lucene.Net.Tests/core/Search/Similarities/TestSimilarity2.cs
+++ b/src/Lucene.Net.Tests/core/Search/Similarities/TestSimilarity2.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestEmptyIndex()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             IndexReader ir = iw.Reader;
             iw.Dispose();
             IndexSearcher @is = NewSearcher(ir);
@@ -104,7 +104,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestEmptyField()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("foo", "bar", Field.Store.NO));
             iw.AddDocument(doc);
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestEmptyTerm()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("foo", "bar", Field.Store.NO));
             iw.AddDocument(doc);
@@ -156,7 +156,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestNoNorms()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.OmitNorms = true;
@@ -184,7 +184,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestOmitTF()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.IndexOptions = FieldInfo.IndexOptions.DOCS_ONLY;
@@ -213,7 +213,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestOmitTFAndNorms()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.IndexOptions = FieldInfo.IndexOptions.DOCS_ONLY;
@@ -247,7 +247,7 @@ namespace Lucene.Net.Search.Similarities
             // however with spans, there is only one scorer for the whole hierarchy:
             // inner queries are not real queries, their boosts are ignored, etc.
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             doc.Add(NewField("foo", "bar", ft));

--- a/src/Lucene.Net.Tests/core/Search/Similarities/TestSimilarity2.cs
+++ b/src/Lucene.Net.Tests/core/Search/Similarities/TestSimilarity2.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestEmptyIndex()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             IndexReader ir = iw.Reader;
             iw.Dispose();
             IndexSearcher @is = NewSearcher(ir);
@@ -104,7 +104,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestEmptyField()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("foo", "bar", Field.Store.NO));
             iw.AddDocument(doc);
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestEmptyTerm()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("foo", "bar", Field.Store.NO));
             iw.AddDocument(doc);
@@ -156,7 +156,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestNoNorms()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.OmitNorms = true;
@@ -184,7 +184,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestOmitTF()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.IndexOptions = FieldInfo.IndexOptions.DOCS_ONLY;
@@ -213,7 +213,7 @@ namespace Lucene.Net.Search.Similarities
         public virtual void TestOmitTFAndNorms()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             ft.IndexOptions = FieldInfo.IndexOptions.DOCS_ONLY;
@@ -247,7 +247,7 @@ namespace Lucene.Net.Search.Similarities
             // however with spans, there is only one scorer for the whole hierarchy:
             // inner queries are not real queries, their boosts are ignored, etc.
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
             doc.Add(NewField("foo", "bar", ft));

--- a/src/Lucene.Net.Tests/core/Search/Similarities/TestSimilarityBase.cs
+++ b/src/Lucene.Net.Tests/core/Search/Similarities/TestSimilarityBase.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Search.Similarities
             base.SetUp();
 
             Dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             for (int i = 0; i < Docs.Length; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/Similarities/TestSimilarityBase.cs
+++ b/src/Lucene.Net.Tests/core/Search/Similarities/TestSimilarityBase.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Search.Similarities
             base.SetUp();
 
             Dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
 
             for (int i = 0; i < Docs.Length; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
@@ -606,7 +606,7 @@ namespace Lucene.Net.Search.Spans
 
         private void CheckHits(Query query, int[] results)
         {
-            Search.CheckHits.DoCheckHits(Random(), query, "field", Searcher, results);
+            Search.CheckHits.DoCheckHits(Random(), query, "field", Searcher, results, Similarity);
         }
     }
 }

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
@@ -93,6 +93,10 @@ namespace Lucene.Net.Search.Spans
 
         internal static Analyzer SimplePayloadAnalyzer;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Search.Spans
         internal static Analyzer SimplePayloadAnalyzer;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             SimplePayloadAnalyzer = new AnalyzerAnonymousInnerClassHelper();
 

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
@@ -54,6 +54,10 @@ namespace Lucene.Net.Search.Spans
         protected internal static Directory Directory;
         protected internal static IndexReader Reader;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Search.Spans
             return doc;
         }
 
-        protected internal static Field GetField(string name, string value)
+        protected internal Field GetField(string name, string value)
         {
             return NewTextField(name, value, Field.Store.NO);
         }
@@ -55,7 +55,7 @@ namespace Lucene.Net.Search.Spans
         protected internal static IndexReader Reader;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
@@ -86,7 +86,7 @@ namespace Lucene.Net.Search.Spans
 
         protected internal virtual void Check(SpanQuery q, int[] docs)
         {
-            CheckHits.CheckHitCollector(Random(), q, null, Searcher, docs);
+            CheckHits.CheckHitCollector(Random(), q, null, Searcher, docs, Similarity);
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestNearSpansOrdered.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestNearSpansOrdered.cs
@@ -83,7 +83,7 @@ namespace Lucene.Net.Search.Spans
         public virtual void TestSpanNearQuery()
         {
             SpanNearQuery q = MakeQuery();
-            CheckHits.DoCheckHits(Random(), q, FIELD, Searcher, new int[] { 0, 1 });
+            CheckHits.DoCheckHits(Random(), q, FIELD, Searcher, new int[] { 0, 1 }, Similarity);
         }
 
         public virtual string s(Spans span)

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestSpanFirstQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestSpanFirstQuery.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Search.Spans
             CharacterRunAutomaton stopSet = new CharacterRunAutomaton((new RegExp("the|a|of")).ToAutomaton());
             Analyzer analyzer = new MockAnalyzer(Random(), MockTokenizer.SIMPLE, true, stopSet);
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, analyzer);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, analyzer, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "the quick brown fox", Field.Store.NO));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestSpanMultiTermQueryWrapper.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestSpanMultiTermQueryWrapper.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Search.Spans
         {
             base.SetUp();
             Directory = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), Directory, Similarity, TimeZone);
             Document doc = new Document();
             Field field = NewTextField("field", "", Field.Store.NO);
             doc.Add(field);

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestSpanMultiTermQueryWrapper.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestSpanMultiTermQueryWrapper.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Search.Spans
         {
             base.SetUp();
             Directory = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), Directory);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             Field field = NewTextField("field", "", Field.Store.NO);
             doc.Add(field);

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestSpans.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestSpans.cs
@@ -83,7 +83,7 @@ namespace Lucene.Net.Search.Spans
 
         private void CheckHits(Query query, int[] results)
         {
-            Search.CheckHits.DoCheckHits(Random(), query, field, Searcher, results);
+            Search.CheckHits.DoCheckHits(Random(), query, field, Searcher, results, Similarity);
         }
 
         private void OrderedSlopTest3SQ(SpanQuery q1, SpanQuery q2, SpanQuery q3, int slop, int[] expectedDocs)

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestSpansAdvanced.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestSpansAdvanced.cs
@@ -123,6 +123,9 @@ namespace Lucene.Net.Search.Spans
 
         /// <summary>
         /// Checks to see if the hits are what we expected.
+        /// 
+        /// LUCENENET specific
+        /// Is non-static because it depends on the non-static variable, <see cref="LuceneTestCase.Similarity"/>
         /// </summary>
         /// <param name="query"> the query to execute </param>
         /// <param name="description"> the description of the search </param>

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestSpansAdvanced.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestSpansAdvanced.cs
@@ -128,9 +128,9 @@ namespace Lucene.Net.Search.Spans
         /// <param name="description"> the description of the search </param>
         /// <param name="expectedIds"> the expected document ids of the hits </param>
         /// <param name="expectedScores"> the expected scores of the hits </param>
-        protected internal static void AssertHits(IndexSearcher s, Query query, string description, string[] expectedIds, float[] expectedScores)
+        protected internal void AssertHits(IndexSearcher s, Query query, string description, string[] expectedIds, float[] expectedScores)
         {
-            QueryUtils.Check(Random(), query, s);
+            QueryUtils.Check(Random(), query, s, Similarity);
 
             const float tolerance = 1e-5f;
 

--- a/src/Lucene.Net.Tests/core/Search/TestAutomatonQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestAutomatonQuery.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             Field titleField = NewTextField("title", "some title", Field.Store.NO);
             Field field = NewTextField(FN, "this is document one 2345", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Search/TestAutomatonQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestAutomatonQuery.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, Similarity, TimeZone);
             Document doc = new Document();
             Field titleField = NewTextField("title", "some title", Field.Store.NO);
             Field field = NewTextField(FN, "this is document one 2345", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Search/TestAutomatonQueryUnicode.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestAutomatonQueryUnicode.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, Similarity, TimeZone);
             Document doc = new Document();
             Field titleField = NewTextField("title", "some title", Field.Store.NO);
             Field field = NewTextField(FN, "", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Search/TestAutomatonQueryUnicode.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestAutomatonQueryUnicode.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             Field titleField = NewTextField("title", "some title", Field.Store.NO);
             Field field = NewTextField(FN, "", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
@@ -91,7 +91,7 @@ namespace Lucene.Net.Search
                     Console.WriteLine("\nTEST: cycle...");
                 }
                 Directory copy = new MockDirectoryWrapper(Random(), new RAMDirectory(Dir2, IOContext.DEFAULT));
-                RandomIndexWriter w = new RandomIndexWriter(Random(), Dir2);
+                RandomIndexWriter w = new RandomIndexWriter(Random(), Dir2, Similarity, TimeZone);
                 w.AddIndexes(copy);
                 docCount = w.MaxDoc();
                 w.Dispose();
@@ -302,12 +302,12 @@ namespace Lucene.Net.Search
                     // match up.
                     Sort sort = Sort.INDEXORDER;
 
-                    QueryUtils.Check(Random(), q1, Searcher); // baseline sim
+                    QueryUtils.Check(Random(), q1, Searcher, Similarity); // baseline sim
                     try
                     {
                         // a little hackish, QueryUtils.check is too costly to do on bigSearcher in this loop.
                         Searcher.Similarity = BigSearcher.Similarity; // random sim
-                        QueryUtils.Check(Random(), q1, Searcher);
+                        QueryUtils.Check(Random(), q1, Searcher, Similarity);
                     }
                     finally
                     {

--- a/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Search
         private static int MulFactor;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
@@ -57,6 +57,10 @@ namespace Lucene.Net.Search
         private static Directory Dir2;
         private static int MulFactor;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Search
         private static IndexSearcher s;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             string[] data = new string[] { "A 1 2 3 4 5 6", "Z       4 5 6", null, "B   2   4 5 6", "Y     3   5 6", null, "C     3     6", "X       4 5 6" };
 

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Search
             string[] data = new string[] { "A 1 2 3 4 5 6", "Z       4 5 6", null, "B   2   4 5 6", "Y     3   5 6", null, "C     3     6", "X       4 5 6" };
 
             Index = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), Index);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), Index, Similarity, TimeZone);
 
             for (int i = 0; i < data.Length; i++)
             {
@@ -100,7 +100,7 @@ namespace Lucene.Net.Search
             }
             Assert.AreEqual(expected, h2.Length, "result count (bs2)");
 
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
         }
 
         [Test]
@@ -352,8 +352,8 @@ namespace Lucene.Net.Search
                 TopDocs top2 = s.Search(q2, null, 100);
                 if (i < 100)
                 {
-                    QueryUtils.Check(Random(), q1, s);
-                    QueryUtils.Check(Random(), q2, s);
+                    QueryUtils.Check(Random(), q1, s, Similarity);
+                    QueryUtils.Check(Random(), q2, s, Similarity);
                 }
                 AssertSubsetOfSameScores(q2, top1, top2);
             }

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
@@ -44,6 +44,10 @@ namespace Lucene.Net.Search
         private static IndexReader r;
         private static IndexSearcher s;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewStringField is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanOr.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanOr.cs
@@ -145,7 +145,7 @@ namespace Lucene.Net.Search
             Dir = NewDirectory();
 
             //
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             //
             Document d = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanOr.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanOr.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Search
 
         private int Search(Query q)
         {
-            QueryUtils.Check(Random(), q, Searcher);
+            QueryUtils.Check(Random(), q, Searcher, Similarity);
             return Searcher.Search(q, null, 1000).TotalHits;
         }
 
@@ -145,7 +145,7 @@ namespace Lucene.Net.Search
             Dir = NewDirectory();
 
             //
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
 
             //
             Document d = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanQuery.cs
@@ -86,7 +86,7 @@ namespace Lucene.Net.Search
         public virtual void TestNullOrSubScorer()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "a b c d", Field.Store.NO));
             w.AddDocument(doc);
@@ -369,7 +369,7 @@ namespace Lucene.Net.Search
         public virtual void TestInOrderWithMinShouldMatch()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "some text here", Field.Store.NO));
             w.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanQuery.cs
@@ -86,7 +86,7 @@ namespace Lucene.Net.Search
         public virtual void TestNullOrSubScorer()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "a b c d", Field.Store.NO));
             w.AddDocument(doc);
@@ -200,7 +200,7 @@ namespace Lucene.Net.Search
         public virtual void TestBS2DisjunctionNextVsAdvance()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             int numDocs = AtLeast(300);
             for (int docUpto = 0; docUpto < numDocs; docUpto++)
             {
@@ -369,7 +369,7 @@ namespace Lucene.Net.Search
         public virtual void TestInOrderWithMinShouldMatch()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "some text here", Field.Store.NO));
             w.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanScorer.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanScorer.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Search
 
             string[] values = new string[] { "1", "2", "3", "4" };
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             for (int i = 0; i < values.Length; i++)
             {
                 Document doc = new Document();
@@ -83,7 +83,7 @@ namespace Lucene.Net.Search
             // changes, we have a test to back it up.
 
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             writer.Commit();
             IndexReader ir = writer.Reader;
             writer.Dispose();
@@ -166,7 +166,7 @@ namespace Lucene.Net.Search
         public virtual void TestMoreThan32ProhibitedClauses()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new TextField("field", "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33", Field.Store.NO));
             w.AddDocument(doc);
@@ -321,7 +321,7 @@ namespace Lucene.Net.Search
         public virtual void TestEmbeddedBooleanScorer()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "doctors are people who prescribe medicines of which they know little, to cure diseases of which they know less, in human beings of whom they know nothing", Field.Store.NO));
             w.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanScorer.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanScorer.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Search
 
             string[] values = new string[] { "1", "2", "3", "4" };
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < values.Length; i++)
             {
                 Document doc = new Document();
@@ -83,7 +83,7 @@ namespace Lucene.Net.Search
             // changes, we have a test to back it up.
 
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.Commit();
             IndexReader ir = writer.Reader;
             writer.Dispose();
@@ -321,7 +321,7 @@ namespace Lucene.Net.Search
         public virtual void TestEmbeddedBooleanScorer()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "doctors are people who prescribe medicines of which they know little, to cure diseases of which they know less, in human beings of whom they know nothing", Field.Store.NO));
             w.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestCachingWrapperFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestCachingWrapperFilter.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            Iw = new RandomIndexWriter(Random(), Dir);
+            Iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             Field idField = new StringField("id", "", Field.Store.NO);
             doc.Add(idField);
@@ -173,7 +173,7 @@ namespace Lucene.Net.Search
         public virtual void TestCachingWorks()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.Dispose();
 
             IndexReader reader = SlowCompositeReaderWrapper.Wrap(DirectoryReader.Open(dir));
@@ -201,7 +201,7 @@ namespace Lucene.Net.Search
         public virtual void TestNullDocIdSet()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.Dispose();
 
             IndexReader reader = SlowCompositeReaderWrapper.Wrap(DirectoryReader.Open(dir));
@@ -240,7 +240,7 @@ namespace Lucene.Net.Search
         public virtual void TestNullDocIdSetIterator()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.Dispose();
 
             IndexReader reader = SlowCompositeReaderWrapper.Wrap(DirectoryReader.Open(dir));
@@ -324,7 +324,7 @@ namespace Lucene.Net.Search
         public virtual void TestIsCacheAble()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.AddDocument(new Document());
             writer.Dispose();
 

--- a/src/Lucene.Net.Tests/core/Search/TestCachingWrapperFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestCachingWrapperFilter.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            Iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            Iw = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
             Document doc = new Document();
             Field idField = new StringField("id", "", Field.Store.NO);
             doc.Add(idField);
@@ -173,7 +173,7 @@ namespace Lucene.Net.Search
         public virtual void TestCachingWorks()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             writer.Dispose();
 
             IndexReader reader = SlowCompositeReaderWrapper.Wrap(DirectoryReader.Open(dir));
@@ -201,7 +201,7 @@ namespace Lucene.Net.Search
         public virtual void TestNullDocIdSet()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             writer.Dispose();
 
             IndexReader reader = SlowCompositeReaderWrapper.Wrap(DirectoryReader.Open(dir));
@@ -240,7 +240,7 @@ namespace Lucene.Net.Search
         public virtual void TestNullDocIdSetIterator()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             writer.Dispose();
 
             IndexReader reader = SlowCompositeReaderWrapper.Wrap(DirectoryReader.Open(dir));
@@ -324,7 +324,7 @@ namespace Lucene.Net.Search
         public virtual void TestIsCacheAble()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             writer.AddDocument(new Document());
             writer.Dispose();
 
@@ -371,7 +371,7 @@ namespace Lucene.Net.Search
             // (must) get an NRT reader:
             DirectoryReader reader = DirectoryReader.Open(writer.w, true);
             // same reason we don't wrap?
-            IndexSearcher searcher = NewSearcher(reader, false);
+            IndexSearcher searcher = NewSearcher(reader, false, Similarity);
 
             // add a doc, refresh the reader, and check that it's there
             Document doc = new Document();
@@ -379,7 +379,7 @@ namespace Lucene.Net.Search
             writer.AddDocument(doc);
 
             reader = RefreshReader(reader);
-            searcher = NewSearcher(reader, false);
+            searcher = NewSearcher(reader, false, Similarity);
 
             TopDocs docs = searcher.Search(new MatchAllDocsQuery(), 1);
             Assert.AreEqual(1, docs.TotalHits, "Should find a hit...");
@@ -422,7 +422,7 @@ namespace Lucene.Net.Search
             oldReader = reader;
             reader = RefreshReader(reader);
 
-            searcher = NewSearcher(reader, false);
+            searcher = NewSearcher(reader, false, Similarity);
 
             missCount = filter.MissCount;
             docs = searcher.Search(new MatchAllDocsQuery(), filter, 1);
@@ -437,7 +437,7 @@ namespace Lucene.Net.Search
             filter = new CachingWrapperFilter(startFilter);
             writer.AddDocument(doc);
             reader = RefreshReader(reader);
-            searcher = NewSearcher(reader, false);
+            searcher = NewSearcher(reader, false, Similarity);
 
             docs = searcher.Search(new MatchAllDocsQuery(), filter, 1);
             Assert.AreEqual(1, docs.TotalHits, "[query + filter] Should find a hit...");
@@ -456,7 +456,7 @@ namespace Lucene.Net.Search
             oldReader = reader;
 
             reader = RefreshReader(reader);
-            searcher = NewSearcher(reader, false);
+            searcher = NewSearcher(reader, false, Similarity);
 
             docs = searcher.Search(new MatchAllDocsQuery(), filter, 1);
             Assert.AreEqual(2, docs.TotalHits, "[query + filter] Should find 2 hits...");
@@ -472,7 +472,7 @@ namespace Lucene.Net.Search
             writer.DeleteDocuments(new Term("id", "1"));
 
             reader = RefreshReader(reader);
-            searcher = NewSearcher(reader, false);
+            searcher = NewSearcher(reader, false, Similarity);
 
             docs = searcher.Search(new MatchAllDocsQuery(), filter, 1);
             Assert.AreEqual(0, docs.TotalHits, "[query + filter] Should *not* find a hit...");

--- a/src/Lucene.Net.Tests/core/Search/TestConstantScoreQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestConstantScoreQuery.cs
@@ -125,7 +125,7 @@ namespace Lucene.Net.Search
             try
             {
                 directory = NewDirectory();
-                RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+                RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
 
                 Document doc = new Document();
                 doc.Add(NewStringField("field", "term", Field.Store.NO));
@@ -191,7 +191,7 @@ namespace Lucene.Net.Search
         public virtual void TestConstantScoreQueryAndFilter()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("field", "a", Field.Store.NO));
             w.AddDocument(doc);
@@ -222,7 +222,7 @@ namespace Lucene.Net.Search
         public virtual void TestQueryWrapperFilter()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("field", "a", Field.Store.NO));
             w.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestConstantScoreQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestConstantScoreQuery.cs
@@ -125,7 +125,7 @@ namespace Lucene.Net.Search
             try
             {
                 directory = NewDirectory();
-                RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+                RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
                 Document doc = new Document();
                 doc.Add(NewStringField("field", "term", Field.Store.NO));

--- a/src/Lucene.Net.Tests/core/Search/TestCustomSearcherSort.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestCustomSearcherSort.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Search
             base.SetUp();
             INDEX_SIZE = AtLeast(2000);
             Index = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Index);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Index, Similarity, TimeZone);
             RandomGen random = new RandomGen(this, Random());
             for (int i = 0; i < INDEX_SIZE; ++i) // don't decrease; if to low the
             {

--- a/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Search
         {
             // create an index
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
 
             long now = DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
 
@@ -109,7 +109,7 @@ namespace Lucene.Net.Search
         {
             // create an index
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
 
             long now = DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
 

--- a/src/Lucene.Net.Tests/core/Search/TestDateSort.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDateSort.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Search
             base.SetUp();
             // Create an index writer.
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             // oldest doc:
             // Add the first document.  text = "Document 1"  dateTime = Oct 10 03:25:22 EDT 2007

--- a/src/Lucene.Net.Tests/core/Search/TestDateSort.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDateSort.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Search
             base.SetUp();
             // Create an index writer.
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, Similarity, TimeZone);
 
             // oldest doc:
             // Add the first document.  text = "Document 1"  dateTime = Oct 10 03:25:22 EDT 2007

--- a/src/Lucene.Net.Tests/core/Search/TestDisjunctionMaxQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDisjunctionMaxQuery.cs
@@ -185,7 +185,7 @@ namespace Lucene.Net.Search
             dq.Add(Tq("id", "d1"));
             dq.Add(Tq("dek", "DOES_NOT_EXIST"));
 
-            QueryUtils.Check(Random(), dq, s);
+            QueryUtils.Check(Random(), dq, s, Similarity);
             Assert.IsTrue(s.TopReaderContext is AtomicReaderContext);
             Weight dw = s.CreateNormalizedWeight(dq);
             AtomicReaderContext context = (AtomicReaderContext)s.TopReaderContext;
@@ -204,7 +204,7 @@ namespace Lucene.Net.Search
             dq.Add(Tq("dek", "albino"));
             dq.Add(Tq("dek", "DOES_NOT_EXIST"));
             Assert.IsTrue(s.TopReaderContext is AtomicReaderContext);
-            QueryUtils.Check(Random(), dq, s);
+            QueryUtils.Check(Random(), dq, s, Similarity);
             Weight dw = s.CreateNormalizedWeight(dq);
             AtomicReaderContext context = (AtomicReaderContext)s.TopReaderContext;
             Scorer ds = dw.Scorer(context, (context.AtomicReader).LiveDocs);
@@ -218,7 +218,7 @@ namespace Lucene.Net.Search
             DisjunctionMaxQuery q = new DisjunctionMaxQuery(0.0f);
             q.Add(Tq("hed", "albino"));
             q.Add(Tq("hed", "elephant"));
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
 
             ScoreDoc[] h = s.Search(q, null, 1000).ScoreDocs;
 
@@ -245,7 +245,7 @@ namespace Lucene.Net.Search
             DisjunctionMaxQuery q = new DisjunctionMaxQuery(0.0f);
             q.Add(Tq("dek", "albino"));
             q.Add(Tq("dek", "elephant"));
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
 
             ScoreDoc[] h = s.Search(q, null, 1000).ScoreDocs;
 
@@ -273,7 +273,7 @@ namespace Lucene.Net.Search
             q.Add(Tq("hed", "elephant"));
             q.Add(Tq("dek", "albino"));
             q.Add(Tq("dek", "elephant"));
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
 
             ScoreDoc[] h = s.Search(q, null, 1000).ScoreDocs;
 
@@ -299,7 +299,7 @@ namespace Lucene.Net.Search
             DisjunctionMaxQuery q = new DisjunctionMaxQuery(0.01f);
             q.Add(Tq("dek", "albino"));
             q.Add(Tq("dek", "elephant"));
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
 
             ScoreDoc[] h = s.Search(q, null, 1000).ScoreDocs;
 
@@ -329,17 +329,17 @@ namespace Lucene.Net.Search
                 q1.Add(Tq("hed", "albino"));
                 q1.Add(Tq("dek", "albino"));
                 q.Add(q1, BooleanClause.Occur.MUST); // true,false);
-                QueryUtils.Check(Random(), q1, s);
+                QueryUtils.Check(Random(), q1, s, Similarity);
             }
             {
                 DisjunctionMaxQuery q2 = new DisjunctionMaxQuery(0.0f);
                 q2.Add(Tq("hed", "elephant"));
                 q2.Add(Tq("dek", "elephant"));
                 q.Add(q2, BooleanClause.Occur.MUST); // true,false);
-                QueryUtils.Check(Random(), q2, s);
+                QueryUtils.Check(Random(), q2, s, Similarity);
             }
 
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
 
             ScoreDoc[] h = s.Search(q, null, 1000).ScoreDocs;
 
@@ -375,7 +375,7 @@ namespace Lucene.Net.Search
                 q2.Add(Tq("dek", "elephant"));
                 q.Add(q2, BooleanClause.Occur.SHOULD); // false,false);
             }
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
 
             ScoreDoc[] h = s.Search(q, null, 1000).ScoreDocs;
 
@@ -414,7 +414,7 @@ namespace Lucene.Net.Search
                 q2.Add(Tq("dek", "elephant"));
                 q.Add(q2, BooleanClause.Occur.SHOULD); // false,false);
             }
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
 
             ScoreDoc[] h = s.Search(q, null, 1000).ScoreDocs;
 
@@ -464,7 +464,7 @@ namespace Lucene.Net.Search
                 q2.Add(Tq("dek", "elephant"));
                 q.Add(q2, BooleanClause.Occur.SHOULD); // false,false);
             }
-            QueryUtils.Check(Random(), q, s);
+            QueryUtils.Check(Random(), q, s, Similarity);
 
             ScoreDoc[] h = s.Search(q, null, 1000).ScoreDocs;
 

--- a/src/Lucene.Net.Tests/core/Search/TestDocIdSet.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDocIdSet.cs
@@ -147,7 +147,7 @@ namespace Lucene.Net.Search
             // Tests that if a Filter produces a null DocIdSet, which is given to
             // IndexSearcher, everything works fine. this came up in LUCENE-1754.
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("c", "val", Field.Store.NO));
             writer.AddDocument(doc);
@@ -185,7 +185,7 @@ namespace Lucene.Net.Search
         public virtual void TestNullIteratorFilteredDocIdSet()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("c", "val", Field.Store.NO));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestDocIdSet.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDocIdSet.cs
@@ -147,7 +147,7 @@ namespace Lucene.Net.Search
             // Tests that if a Filter produces a null DocIdSet, which is given to
             // IndexSearcher, everything works fine. this came up in LUCENE-1754.
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("c", "val", Field.Store.NO));
             writer.AddDocument(doc);
@@ -185,7 +185,7 @@ namespace Lucene.Net.Search
         public virtual void TestNullIteratorFilteredDocIdSet()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("c", "val", Field.Store.NO));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestDocValuesScoring.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDocValuesScoring.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Search
         public virtual void TestSimple()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             Field field = NewTextField("foo", "", Field.Store.NO);
             doc.Add(field);

--- a/src/Lucene.Net.Tests/core/Search/TestDocValuesScoring.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDocValuesScoring.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Search
         public virtual void TestSimple()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             Field field = NewTextField("foo", "", Field.Store.NO);
             doc.Add(field);
@@ -72,16 +72,16 @@ namespace Lucene.Net.Search
             iw.Dispose();
 
             // no boosting
-            IndexSearcher searcher1 = NewSearcher(ir, false);
+            IndexSearcher searcher1 = NewSearcher(ir, false, Similarity);
             Similarity @base = searcher1.Similarity;
             // boosting
-            IndexSearcher searcher2 = NewSearcher(ir, false);
+            IndexSearcher searcher2 = NewSearcher(ir, false, Similarity);
             searcher2.Similarity = new PerFieldSimilarityWrapperAnonymousInnerClassHelper(this, field, @base);
 
             // in this case, we searched on field "foo". first document should have 2x the score.
             TermQuery tq = new TermQuery(new Term("foo", "quick"));
-            QueryUtils.Check(Random(), tq, searcher1);
-            QueryUtils.Check(Random(), tq, searcher2);
+            QueryUtils.Check(Random(), tq, searcher1, Similarity);
+            QueryUtils.Check(Random(), tq, searcher2, Similarity);
 
             TopDocs noboost = searcher1.Search(tq, 10);
             TopDocs boost = searcher2.Search(tq, 10);
@@ -93,8 +93,8 @@ namespace Lucene.Net.Search
 
             // this query matches only the second document, which should have 4x the score.
             tq = new TermQuery(new Term("foo", "jumps"));
-            QueryUtils.Check(Random(), tq, searcher1);
-            QueryUtils.Check(Random(), tq, searcher2);
+            QueryUtils.Check(Random(), tq, searcher1, Similarity);
+            QueryUtils.Check(Random(), tq, searcher2, Similarity);
 
             noboost = searcher1.Search(tq, 10);
             boost = searcher2.Search(tq, 10);
@@ -106,8 +106,8 @@ namespace Lucene.Net.Search
             // search on on field bar just for kicks, nothing should happen, since we setup
             // our sim provider to only use foo_boost for field foo.
             tq = new TermQuery(new Term("bar", "quick"));
-            QueryUtils.Check(Random(), tq, searcher1);
-            QueryUtils.Check(Random(), tq, searcher2);
+            QueryUtils.Check(Random(), tq, searcher1, Similarity);
+            QueryUtils.Check(Random(), tq, searcher2, Similarity);
 
             noboost = searcher1.Search(tq, 10);
             boost = searcher2.Search(tq, 10);

--- a/src/Lucene.Net.Tests/core/Search/TestEarlyTermination.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestEarlyTermination.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            Writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            Writer = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
             int numDocs = AtLeast(100);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestEarlyTermination.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestEarlyTermination.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            Writer = new RandomIndexWriter(Random(), Dir);
+            Writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int numDocs = AtLeast(100);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
@@ -73,6 +73,11 @@ namespace Lucene.Net.Search
             Directory = null;
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig, NewTextField and
+        /// NewStringField are no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClassTestExplanations()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Search
         /// check the expDocNrs first, then check the query (and the explanations) </summary>
         public virtual void Qtest(Query q, int[] expDocNrs)
         {
-            CheckHits.CheckHitCollector(Random(), q, FIELD, Searcher, expDocNrs);
+            CheckHits.CheckHitCollector(Random(), q, FIELD, Searcher, expDocNrs, Similarity);
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Search
         }
 
         [TestFixtureSetUp]
-        public static void BeforeClassTestExplanations()
+        public void BeforeClassTestExplanations()
         {
             Directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/core/Search/TestFieldCacheTermsFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestFieldCacheTermsFilter.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Search
         {
             string fieldName = "field1";
             Directory rd = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), rd);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), rd, Similarity, TimeZone);
             for (int i = 0; i < 100; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestFilteredQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestFilteredQuery.cs
@@ -280,7 +280,7 @@ namespace Lucene.Net.Search
             bq.Add(query, BooleanClause.Occur.MUST);
             ScoreDoc[] hits = Searcher.Search(bq, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length);
-            QueryUtils.Check(Random(), Query, Searcher, Similarity);
+            QueryUtils.Check(Random(), query, Searcher, Similarity);
         }
 
         [Test]
@@ -301,7 +301,7 @@ namespace Lucene.Net.Search
             bq.Add(query, BooleanClause.Occur.SHOULD);
             ScoreDoc[] hits = Searcher.Search(bq, null, 1000).ScoreDocs;
             Assert.AreEqual(2, hits.Length);
-            QueryUtils.Check(Random(), Query, Searcher, Similarity);
+            QueryUtils.Check(Random(), query, Searcher, Similarity);
         }
 
         // Make sure BooleanQuery, which does out-of-order
@@ -323,7 +323,7 @@ namespace Lucene.Net.Search
             bq.Add(new TermQuery(new Term("field", "two")), BooleanClause.Occur.SHOULD);
             ScoreDoc[] hits = Searcher.Search(query, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
-            QueryUtils.Check(Random(), Query, Searcher, Similarity);
+            QueryUtils.Check(Random(), query, Searcher, Similarity);
         }
 
         [Test]
@@ -340,13 +340,13 @@ namespace Lucene.Net.Search
             Query query = new FilteredQuery(new FilteredQuery(new MatchAllDocsQuery(), new CachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("field", "three")))), RandomFilterStrategy(Random(), useRandomAccess)), new CachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("field", "four")))), RandomFilterStrategy(Random(), useRandomAccess));
             ScoreDoc[] hits = Searcher.Search(query, 10).ScoreDocs;
             Assert.AreEqual(2, hits.Length);
-            QueryUtils.Check(Random(), Query, Searcher, Similarity);
+            QueryUtils.Check(Random(), query, Searcher, Similarity);
 
             // one more:
             query = new FilteredQuery(query, new CachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("field", "five")))), RandomFilterStrategy(Random(), useRandomAccess));
             hits = Searcher.Search(query, 10).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
-            QueryUtils.Check(Random(), Query, Searcher, Similarity);
+            QueryUtils.Check(Random(), query, Searcher, Similarity);
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/core/Search/TestFilteredQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestFilteredQuery.cs
@@ -156,7 +156,7 @@ namespace Lucene.Net.Search
             ScoreDoc[] hits = Searcher.Search(filteredquery, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
             Assert.AreEqual(1, hits[0].Doc);
-            QueryUtils.Check(Random(), filteredquery, Searcher);
+            QueryUtils.Check(Random(), filteredquery, Searcher, Similarity);
 
             hits = Searcher.Search(filteredquery, null, 1000, new Sort(new SortField("sorter", SortField.Type_e.STRING))).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
@@ -165,23 +165,23 @@ namespace Lucene.Net.Search
             filteredquery = new FilteredQuery(new TermQuery(new Term("field", "one")), Filter, RandomFilterStrategy(Random(), useRandomAccess));
             hits = Searcher.Search(filteredquery, null, 1000).ScoreDocs;
             Assert.AreEqual(2, hits.Length);
-            QueryUtils.Check(Random(), filteredquery, Searcher);
+            QueryUtils.Check(Random(), filteredquery, Searcher, Similarity);
 
             filteredquery = new FilteredQuery(new MatchAllDocsQuery(), Filter, RandomFilterStrategy(Random(), useRandomAccess));
             hits = Searcher.Search(filteredquery, null, 1000).ScoreDocs;
             Assert.AreEqual(2, hits.Length);
-            QueryUtils.Check(Random(), filteredquery, Searcher);
+            QueryUtils.Check(Random(), filteredquery, Searcher, Similarity);
 
             filteredquery = new FilteredQuery(new TermQuery(new Term("field", "x")), Filter, RandomFilterStrategy(Random(), useRandomAccess));
             hits = Searcher.Search(filteredquery, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
             Assert.AreEqual(3, hits[0].Doc);
-            QueryUtils.Check(Random(), filteredquery, Searcher);
+            QueryUtils.Check(Random(), filteredquery, Searcher, Similarity);
 
             filteredquery = new FilteredQuery(new TermQuery(new Term("field", "y")), Filter, RandomFilterStrategy(Random(), useRandomAccess));
             hits = Searcher.Search(filteredquery, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length);
-            QueryUtils.Check(Random(), filteredquery, Searcher);
+            QueryUtils.Check(Random(), filteredquery, Searcher, Similarity);
 
             // test boost
             Filter f = NewStaticFilterA();
@@ -259,7 +259,7 @@ namespace Lucene.Net.Search
             Query filteredquery = new FilteredQuery(rq, Filter, RandomFilterStrategy(Random(), useRandomAccess));
             ScoreDoc[] hits = Searcher.Search(filteredquery, null, 1000).ScoreDocs;
             Assert.AreEqual(2, hits.Length);
-            QueryUtils.Check(Random(), filteredquery, Searcher);
+            QueryUtils.Check(Random(), filteredquery, Searcher, Similarity);
         }
 
         [Test]
@@ -280,7 +280,7 @@ namespace Lucene.Net.Search
             bq.Add(query, BooleanClause.Occur.MUST);
             ScoreDoc[] hits = Searcher.Search(bq, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length);
-            QueryUtils.Check(Random(), query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         [Test]
@@ -301,7 +301,7 @@ namespace Lucene.Net.Search
             bq.Add(query, BooleanClause.Occur.SHOULD);
             ScoreDoc[] hits = Searcher.Search(bq, null, 1000).ScoreDocs;
             Assert.AreEqual(2, hits.Length);
-            QueryUtils.Check(Random(), query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         // Make sure BooleanQuery, which does out-of-order
@@ -323,7 +323,7 @@ namespace Lucene.Net.Search
             bq.Add(new TermQuery(new Term("field", "two")), BooleanClause.Occur.SHOULD);
             ScoreDoc[] hits = Searcher.Search(query, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
-            QueryUtils.Check(Random(), query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         [Test]
@@ -340,13 +340,13 @@ namespace Lucene.Net.Search
             Query query = new FilteredQuery(new FilteredQuery(new MatchAllDocsQuery(), new CachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("field", "three")))), RandomFilterStrategy(Random(), useRandomAccess)), new CachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("field", "four")))), RandomFilterStrategy(Random(), useRandomAccess));
             ScoreDoc[] hits = Searcher.Search(query, 10).ScoreDocs;
             Assert.AreEqual(2, hits.Length);
-            QueryUtils.Check(Random(), query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             // one more:
             query = new FilteredQuery(query, new CachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("field", "five")))), RandomFilterStrategy(Random(), useRandomAccess));
             hits = Searcher.Search(query, 10).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
-            QueryUtils.Check(Random(), query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/core/Search/TestFuzzyQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestFuzzyQuery.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Search
         public virtual void TestFuzziness()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             AddDoc("aaaaa", writer);
             AddDoc("aaaab", writer);
             AddDoc("aaabb", writer);
@@ -200,7 +200,7 @@ namespace Lucene.Net.Search
         public virtual void Test2()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, new MockAnalyzer(Random(), MockTokenizer.KEYWORD, false));
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, new MockAnalyzer(Random(), MockTokenizer.KEYWORD, false), Similarity, TimeZone);
             AddDoc("LANGE", writer);
             AddDoc("LUETH", writer);
             AddDoc("PIRSING", writer);
@@ -244,14 +244,14 @@ namespace Lucene.Net.Search
         public virtual void TestTieBreaker()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             AddDoc("a123456", writer);
             AddDoc("c123456", writer);
             AddDoc("d123456", writer);
             AddDoc("e123456", writer);
 
             Directory directory2 = NewDirectory();
-            RandomIndexWriter writer2 = new RandomIndexWriter(Random(), directory2);
+            RandomIndexWriter writer2 = new RandomIndexWriter(Random(), directory2, Similarity, TimeZone);
             AddDoc("a123456", writer2);
             AddDoc("b123456", writer2);
             AddDoc("b123456", writer2);
@@ -282,7 +282,7 @@ namespace Lucene.Net.Search
         public virtual void TestBoostOnlyRewrite()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             AddDoc("Lucene", writer);
             AddDoc("Lucene", writer);
             AddDoc("Lucenne", writer);
@@ -308,7 +308,7 @@ namespace Lucene.Net.Search
         {
             MockAnalyzer analyzer = new MockAnalyzer(Random());
             Directory index = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), index);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), index, Similarity, TimeZone);
 
             AddDoc("Lucene in Action", w);
             AddDoc("Lucene for Dummies", w);
@@ -345,7 +345,7 @@ namespace Lucene.Net.Search
         public virtual void TestDistanceAsEditsSearching()
         {
             Directory index = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), index);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), index, Similarity, TimeZone);
             AddDoc("foobar", w);
             AddDoc("test", w);
             AddDoc("working", w);

--- a/src/Lucene.Net.Tests/core/Search/TestFuzzyQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestFuzzyQuery.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Search
         public virtual void TestFuzziness()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             AddDoc("aaaaa", writer);
             AddDoc("aaaab", writer);
             AddDoc("aaabb", writer);
@@ -244,7 +244,7 @@ namespace Lucene.Net.Search
         public virtual void TestTieBreaker()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             AddDoc("a123456", writer);
             AddDoc("c123456", writer);
             AddDoc("d123456", writer);
@@ -282,7 +282,7 @@ namespace Lucene.Net.Search
         public virtual void TestBoostOnlyRewrite()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             AddDoc("Lucene", writer);
             AddDoc("Lucene", writer);
             AddDoc("Lucenne", writer);

--- a/src/Lucene.Net.Tests/core/Search/TestIndexSearcher.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestIndexSearcher.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
             for (int i = 0; i < 100; i++)
             {
                 Document doc = new Document();
@@ -117,7 +117,7 @@ namespace Lucene.Net.Search
         {
             // LUCENE-5128: ensure we get a meaningful message if searchAfter exceeds maxDoc
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             w.AddDocument(new Document());
             IndexReader r = w.Reader;
             w.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestIndexSearcher.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestIndexSearcher.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < 100; i++)
             {
                 Document doc = new Document();
@@ -117,7 +117,7 @@ namespace Lucene.Net.Search
         {
             // LUCENE-5128: ensure we get a meaningful message if searchAfter exceeds maxDoc
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             w.AddDocument(new Document());
             IndexReader r = w.Reader;
             w.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
@@ -61,10 +61,10 @@ namespace Lucene.Net.Search
         internal static readonly string[] RareTerms = new string[] { "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z" };
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
             int numDocs = AtLeast(300);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
@@ -60,6 +60,10 @@ namespace Lucene.Net.Search
         internal static readonly string[] MediumTerms = new string[] { "e", "f", "g" };
         internal static readonly string[] RareTerms = new string[] { "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z" };
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because Similarity and TimeZone are not static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
@@ -64,7 +64,7 @@ namespace Lucene.Net.Search
         public static void BeforeClass()
         {
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int numDocs = AtLeast(300);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestMultiPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiPhraseQuery.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Search
         public virtual void TestPhrasePrefix()
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             Add("blueberry pie", writer);
             Add("blueberry strudel", writer);
             Add("blueberry pizza", writer);
@@ -157,7 +157,7 @@ namespace Lucene.Net.Search
         public virtual void TestTall()
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             Add("blueberry chocolate pie", writer);
             Add("blueberry chocolate tart", writer);
             IndexReader r = writer.Reader;
@@ -179,7 +179,7 @@ namespace Lucene.Net.Search
         public virtual void TestMultiSloppyWithRepeats() //LUCENE-3821 fixes sloppy phrase scoring, except for this known problem
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             Add("a b c d e f g h i k", writer);
             IndexReader r = writer.Reader;
             writer.Dispose();
@@ -201,7 +201,7 @@ namespace Lucene.Net.Search
         public virtual void TestMultiExactWithRepeats()
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             Add("a b c d e f g h i k", writer);
             IndexReader r = writer.Reader;
             writer.Dispose();
@@ -230,7 +230,7 @@ namespace Lucene.Net.Search
             // and all terms required.
             // The contained PhraseMultiQuery must contain exactly one term array.
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             Add("blueberry pie", writer);
             Add("blueberry chewing gum", writer);
             Add("blue raspberry pie", writer);
@@ -262,7 +262,7 @@ namespace Lucene.Net.Search
         public virtual void TestPhrasePrefixWithBooleanQuery()
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             Add("this is a test", "object", writer);
             Add("a note", "note", writer);
 
@@ -290,7 +290,7 @@ namespace Lucene.Net.Search
         public virtual void TestNoDocs()
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             Add("a note", "note", writer);
 
             IndexReader reader = writer.Reader;
@@ -359,7 +359,7 @@ namespace Lucene.Net.Search
         public virtual void TestCustomIDF()
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             Add("this is a test", "object", writer);
             Add("a note", "note", writer);
 
@@ -408,7 +408,7 @@ namespace Lucene.Net.Search
             tokens[2].Append("c");
             tokens[2].PositionIncrement = 0;
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new TextField("field", new CannedTokenStream(tokens)));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestMultiPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiPhraseQuery.cs
@@ -408,7 +408,7 @@ namespace Lucene.Net.Search
             tokens[2].Append("c");
             tokens[2].PositionIncrement = 0;
 
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new TextField("field", new CannedTokenStream(tokens)));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestMultiTermConstantScore.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiTermConstantScore.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Search
         }
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             string[] data = new string[] { "A 1 2 3 4 5 6", "Z       4 5 6", null, "B   2   4 5 6", "Y     3   5 6", null, "C     3     6", "X       4 5 6" };
 

--- a/src/Lucene.Net.Tests/core/Search/TestMultiTermConstantScore.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiTermConstantScore.cs
@@ -50,6 +50,10 @@ namespace Lucene.Net.Search
             Assert.AreEqual(e, a, m);
         }
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
@@ -45,6 +45,10 @@ namespace Lucene.Net.Search
         internal static IndexReader Reader, MultiReader, MultiReaderDupls;
         internal static IndexSearcher Searcher, MultiSearcher, MultiSearcherDupls;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because Similarity and TimeZone are not static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
@@ -51,9 +51,9 @@ namespace Lucene.Net.Search
             Dir = NewDirectory();
             Sdir1 = NewDirectory();
             Sdir2 = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Dir, new MockAnalyzer(Random()));
-            RandomIndexWriter swriter1 = new RandomIndexWriter(Random(), Sdir1, new MockAnalyzer(Random()));
-            RandomIndexWriter swriter2 = new RandomIndexWriter(Random(), Sdir2, new MockAnalyzer(Random()));
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Dir, new MockAnalyzer(Random()), Similarity, TimeZone);
+            RandomIndexWriter swriter1 = new RandomIndexWriter(Random(), Sdir1, new MockAnalyzer(Random()), Similarity, TimeZone);
+            RandomIndexWriter swriter2 = new RandomIndexWriter(Random(), Sdir2, new MockAnalyzer(Random()), Similarity, TimeZone);
 
             for (int i = 0; i < 10; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Search
         internal static IndexSearcher Searcher, MultiSearcher, MultiSearcherDupls;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Dir = NewDirectory();
             Sdir1 = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
@@ -33,10 +33,10 @@ namespace Lucene.Net.Search
         private static Directory Directory;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, Similarity, TimeZone);
             writer.Dispose();
             Reader = DirectoryReader.Open(Directory);
         }

--- a/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
@@ -32,6 +32,10 @@ namespace Lucene.Net.Search
         private static IndexReader Reader;
         private static Directory Directory;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because Similarity and TimeZone are not static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Search
         public static void BeforeClass()
         {
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.Dispose();
             Reader = DirectoryReader.Open(Directory);
         }

--- a/src/Lucene.Net.Tests/core/Search/TestNot.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNot.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Search
         public virtual void TestNot_Mem()
         {
             Directory store = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), store);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), store, Similarity, TimeZone);
 
             Document d1 = new Document();
             d1.Add(NewTextField("field", "a b", Field.Store.YES));

--- a/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery32.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery32.cs
@@ -61,6 +61,10 @@ namespace Lucene.Net.Search
         private static IndexReader Reader = null;
         private static IndexSearcher Searcher = null;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery32.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery32.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Search
         private static IndexSearcher Searcher = null;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             NoDocs = AtLeast(4096);
             Distance = (1 << 30) / NoDocs;

--- a/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery64.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery64.cs
@@ -61,6 +61,10 @@ namespace Lucene.Net.Search
         private static IndexReader Reader = null;
         private static IndexSearcher Searcher = null;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery64.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery64.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Search
         private static IndexSearcher Searcher = null;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             NoDocs = AtLeast(4096);
             Distance = (1L << 60) / NoDocs;

--- a/src/Lucene.Net.Tests/core/Search/TestPhrasePrefixQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPhrasePrefixQuery.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Search
         public virtual void TestPhrasePrefix()
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             Document doc1 = new Document();
             Document doc2 = new Document();
             Document doc3 = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Search
         private static Directory Directory;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Directory = NewDirectory();
             Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();

--- a/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
@@ -380,7 +380,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, hits[1].Doc);
             Assert.AreEqual(0.31, hits[2].Score, 0.01);
             Assert.AreEqual(2, hits[2].Doc);
-            QueryUtils.Check(Random(), query, Searcher, Similarity);
+            QueryUtils.Check(Random(), query, searcher, Similarity);
             reader.Dispose();
             directory.Dispose();
         }

--- a/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Search
         {
             Directory = NewDirectory();
             Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, analyzer);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, analyzer, Similarity, TimeZone);
 
             Documents.Document doc = new Documents.Document();
             doc.Add(NewTextField("field", "one two three four five", Field.Store.YES));
@@ -126,7 +126,7 @@ namespace Lucene.Net.Search
             Query.Add(new Term("field", "five"));
             ScoreDoc[] hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length);
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace Lucene.Net.Search
             Query.Add(new Term("field", "five"));
             ScoreDoc[] hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         /// <summary>
@@ -151,14 +151,14 @@ namespace Lucene.Net.Search
             Query.Add(new Term("field", "five"));
             ScoreDoc[] hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length, "exact match");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             Query = new PhraseQuery();
             Query.Add(new Term("field", "two"));
             Query.Add(new Term("field", "one"));
             hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length, "reverse not exact");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         [Test]
@@ -170,7 +170,7 @@ namespace Lucene.Net.Search
             Query.Add(new Term("field", "two"));
             ScoreDoc[] hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length, "in order");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             // Ensures slop of 1 does not work for phrases out of order;
             // must be at least 2.
@@ -180,7 +180,7 @@ namespace Lucene.Net.Search
             Query.Add(new Term("field", "one"));
             hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length, "reversed, slop not 2 or more");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace Lucene.Net.Search
             Query.Add(new Term("field", "one"));
             ScoreDoc[] hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length, "just sloppy enough");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             Query = new PhraseQuery();
             Query.Slop = 2;
@@ -202,7 +202,7 @@ namespace Lucene.Net.Search
             Query.Add(new Term("field", "one"));
             hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length, "not sloppy enough");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace Lucene.Net.Search
             Query.Add(new Term("field", "five"));
             ScoreDoc[] hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length, "two total moves");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             Query = new PhraseQuery();
             Query.Slop = 5; // it takes six moves to match this phrase
@@ -227,12 +227,12 @@ namespace Lucene.Net.Search
             Query.Add(new Term("field", "one"));
             hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length, "slop of 5 not close enough");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             Query.Slop = 6;
             hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length, "slop of 6 just right");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         [Test]
@@ -255,7 +255,7 @@ namespace Lucene.Net.Search
             query.Add(new Term("field", "words"));
             ScoreDoc[] hits = searcher.Search(query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
-            QueryUtils.Check(Random(), query, searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             reader.Dispose();
             directory.Dispose();
@@ -265,7 +265,7 @@ namespace Lucene.Net.Search
         public virtual void TestPhraseQueryInConjunctionScorer()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
 
             Documents.Document doc = new Documents.Document();
             doc.Add(NewTextField("source", "marketing info", Field.Store.YES));
@@ -286,7 +286,7 @@ namespace Lucene.Net.Search
             phraseQuery.Add(new Term("source", "info"));
             ScoreDoc[] hits = searcher.Search(phraseQuery, null, 1000).ScoreDocs;
             Assert.AreEqual(2, hits.Length);
-            QueryUtils.Check(Random(), phraseQuery, searcher);
+            QueryUtils.Check(Random(), phraseQuery, searcher, Similarity);
 
             TermQuery termQuery = new TermQuery(new Term("contents", "foobar"));
             BooleanQuery booleanQuery = new BooleanQuery();
@@ -294,7 +294,7 @@ namespace Lucene.Net.Search
             booleanQuery.Add(phraseQuery, BooleanClause.Occur.MUST);
             hits = searcher.Search(booleanQuery, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
-            QueryUtils.Check(Random(), termQuery, searcher);
+            QueryUtils.Check(Random(), termQuery, searcher, Similarity);
 
             reader.Dispose();
 
@@ -337,7 +337,7 @@ namespace Lucene.Net.Search
             booleanQuery.Add(termQuery, BooleanClause.Occur.MUST);
             hits = searcher.Search(booleanQuery, null, 1000).ScoreDocs;
             Assert.AreEqual(2, hits.Length);
-            QueryUtils.Check(Random(), booleanQuery, searcher);
+            QueryUtils.Check(Random(), booleanQuery, searcher, Similarity);
 
             reader.Dispose();
             directory.Dispose();
@@ -380,7 +380,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, hits[1].Doc);
             Assert.AreEqual(0.31, hits[2].Score, 0.01);
             Assert.AreEqual(2, hits[2].Doc);
-            QueryUtils.Check(Random(), query, searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
             reader.Dispose();
             directory.Dispose();
         }
@@ -408,13 +408,13 @@ namespace Lucene.Net.Search
 
             ScoreDoc[] hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length, "slop of 100 just right");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             Query.Slop = 99;
 
             hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length, "slop of 99 not enough");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         // work on two docs like this: "phrase exist notexist exist found"
@@ -429,7 +429,7 @@ namespace Lucene.Net.Search
 
             ScoreDoc[] hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(2, hits.Length, "phrase without repetitions exists in 2 docs");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             // phrase with repetitions that exists in 2 docs
             Query = new PhraseQuery();
@@ -440,7 +440,7 @@ namespace Lucene.Net.Search
 
             hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(2, hits.Length, "phrase with repetitions exists in two docs");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             // phrase I with repetitions that does not exist in any doc
             Query = new PhraseQuery();
@@ -451,7 +451,7 @@ namespace Lucene.Net.Search
 
             hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length, "nonexisting phrase with repetitions does not exist in any doc");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             // phrase II with repetitions that does not exist in any doc
             Query = new PhraseQuery();
@@ -463,7 +463,7 @@ namespace Lucene.Net.Search
 
             hits = Searcher.Search(Query, null, 1000).ScoreDocs;
             Assert.AreEqual(0, hits.Length, "nonexisting phrase with repetitions does not exist in any doc");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
         }
 
         /// <summary>
@@ -486,7 +486,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, hits.Length, "phrase found with exact phrase scorer");
             float score0 = hits[0].Score;
             //System.out.println("(exact) field: two three: "+score0);
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             // search on non palyndrome, find phrase with slop 2, though no slop required here.
             Query.Slop = 2; // to use sloppy scorer
@@ -495,7 +495,7 @@ namespace Lucene.Net.Search
             float score1 = hits[0].Score;
             //System.out.println("(sloppy) field: two three: "+score1);
             Assert.AreEqual(score0, score1, SCORE_COMP_THRESH, "exact scorer and sloppy scorer score the same when slop does not matter");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             // search ordered in palyndrome, find it twice
             Query = new PhraseQuery();
@@ -506,7 +506,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, hits.Length, "just sloppy enough");
             //float score2 = hits[0].Score;
             //System.out.println("palindrome: two three: "+score2);
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             //commented out for sloppy-phrase efficiency (issue 736) - see SloppyPhraseScorer.phraseFreq().
             //Assert.IsTrue("ordered scores higher in palindrome",score1+SCORE_COMP_THRESH<score2);
@@ -520,7 +520,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, hits.Length, "just sloppy enough");
             //float score3 = hits[0].Score;
             //System.out.println("palindrome: three two: "+score3);
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             //commented out for sloppy-phrase efficiency (issue 736) - see SloppyPhraseScorer.phraseFreq().
             //Assert.IsTrue("reversed scores higher in palindrome",score1+SCORE_COMP_THRESH<score3);
@@ -548,7 +548,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, hits.Length, "phrase found with exact phrase scorer");
             float score0 = hits[0].Score;
             //System.out.println("(exact) field: one two three: "+score0);
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             // just make sure no exc:
             Searcher.Explain(Query, 0);
@@ -560,7 +560,7 @@ namespace Lucene.Net.Search
             float score1 = hits[0].Score;
             //System.out.println("(sloppy) field: one two three: "+score1);
             Assert.AreEqual(score0, score1, SCORE_COMP_THRESH, "exact scorer and sloppy scorer score the same when slop does not matter");
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             // search ordered in palyndrome, find it twice
             Query = new PhraseQuery();
@@ -576,7 +576,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, hits.Length, "just sloppy enough");
             //float score2 = hits[0].Score;
             //System.out.println("palindrome: one two three: "+score2);
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             //commented out for sloppy-phrase efficiency (issue 736) - see SloppyPhraseScorer.phraseFreq().
             //Assert.IsTrue("ordered scores higher in palindrome",score1+SCORE_COMP_THRESH<score2);
@@ -591,7 +591,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, hits.Length, "just sloppy enough");
             //float score3 = hits[0].Score;
             //System.out.println("palindrome: three two one: "+score3);
-            QueryUtils.Check(Random(), Query, Searcher);
+            QueryUtils.Check(Random(), Query, Searcher, Similarity);
 
             //commented out for sloppy-phrase efficiency (issue 736) - see SloppyPhraseScorer.phraseFreq().
             //Assert.IsTrue("reversed scores higher in palindrome",score1+SCORE_COMP_THRESH<score3);

--- a/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
@@ -255,7 +255,7 @@ namespace Lucene.Net.Search
             query.Add(new Term("field", "words"));
             ScoreDoc[] hits = searcher.Search(query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
-            QueryUtils.Check(Random(), query, Searcher, Similarity);
+            QueryUtils.Check(Random(), query, searcher, Similarity);
 
             reader.Dispose();
             directory.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
@@ -255,7 +255,7 @@ namespace Lucene.Net.Search
             query.Add(new Term("field", "words"));
             ScoreDoc[] hits = searcher.Search(query, null, 1000).ScoreDocs;
             Assert.AreEqual(1, hits.Length);
-            QueryUtils.Check(Random(), Query, Searcher, Similarity);
+            QueryUtils.Check(Random(), query, Searcher, Similarity);
 
             reader.Dispose();
             directory.Dispose();
@@ -380,7 +380,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, hits[1].Doc);
             Assert.AreEqual(0.31, hits[2].Score, 0.01);
             Assert.AreEqual(2, hits[2].Doc);
-            QueryUtils.Check(Random(), Query, Searcher, Similarity);
+            QueryUtils.Check(Random(), query, Searcher, Similarity);
             reader.Dispose();
             directory.Dispose();
         }

--- a/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
@@ -265,7 +265,7 @@ namespace Lucene.Net.Search
         public virtual void TestPhraseQueryInConjunctionScorer()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Documents.Document doc = new Documents.Document();
             doc.Add(NewTextField("source", "marketing info", Field.Store.YES));

--- a/src/Lucene.Net.Tests/core/Search/TestPositionIncrement.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPositionIncrement.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Search
         {
             Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper(this);
             Directory store = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), store, analyzer);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), store, analyzer, Similarity, TimeZone);
             Document d = new Document();
             d.Add(NewTextField("field", "bogus", Field.Store.YES));
             writer.AddDocument(d);
@@ -230,7 +230,7 @@ namespace Lucene.Net.Search
         public virtual void TestPayloadsPos0()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, new MockPayloadAnalyzer());
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, new MockPayloadAnalyzer(), Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new TextField("content", new StringReader("a a b c d e a f g h i j a b k k")));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestPositiveScoresOnlyCollector.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPositiveScoresOnlyCollector.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Search
             }
 
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.Commit();
             IndexReader ir = writer.Reader;
             writer.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestPositiveScoresOnlyCollector.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPositiveScoresOnlyCollector.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Search
             }
 
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             writer.Commit();
             IndexReader ir = writer.Reader;
             writer.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixFilter.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Search
             Directory directory = NewDirectory();
 
             string[] categories = new string[] { "/Computers/Linux", "/Computers/Mac/One", "/Computers/Mac/Two", "/Computers/Windows" };
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             for (int i = 0; i < categories.Length; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixFilter.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Search
             Directory directory = NewDirectory();
 
             string[] categories = new string[] { "/Computers/Linux", "/Computers/Mac/One", "/Computers/Mac/Two", "/Computers/Windows" };
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < categories.Length; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Search
         public void BeforeClass()
         {
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, Similarity, TimeZone);
 
             Document doc = new Document();
             Field field = NewStringField(FIELD, "meaninglessnames", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Search
         public static void BeforeClass()
         {
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             Field field = NewStringField(FIELD, "meaninglessnames", Field.Store.NO);

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
@@ -46,6 +46,10 @@ namespace Lucene.Net.Search
         private static IndexReader Reader;
         private static IndexSearcher Searcher;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because Similarity and TimeZone are not static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Search
         private static IndexSearcher Searcher;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixQuery.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Search
             Directory directory = NewDirectory();
 
             string[] categories = new string[] { "/Computers", "/Computers/Mac", "/Computers/Windows" };
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             for (int i = 0; i < categories.Length; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixQuery.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Search
             Directory directory = NewDirectory();
 
             string[] categories = new string[] { "/Computers", "/Computers/Mac", "/Computers/Windows" };
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < categories.Length; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestQueryRescorer.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestQueryRescorer.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Search
         public virtual void TestBasic()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "0", Field.Store.YES));
@@ -120,7 +120,7 @@ namespace Lucene.Net.Search
         public virtual void TestCustomCombine()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "0", Field.Store.YES));
@@ -189,7 +189,7 @@ namespace Lucene.Net.Search
         public virtual void TestExplain()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "0", Field.Store.YES));
@@ -277,7 +277,7 @@ namespace Lucene.Net.Search
         public virtual void TestMissingSecondPassScore()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "0", Field.Store.YES));
@@ -335,7 +335,7 @@ namespace Lucene.Net.Search
         {
             Directory dir = NewDirectory();
             int numDocs = AtLeast(1000);
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             int[] idToNum = new int[numDocs];
             int maxValue = TestUtil.NextInt(Random(), 10, 1000000);

--- a/src/Lucene.Net.Tests/core/Search/TestQueryRescorer.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestQueryRescorer.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Search
         public virtual void TestBasic()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "0", Field.Store.YES));
@@ -120,7 +120,7 @@ namespace Lucene.Net.Search
         public virtual void TestCustomCombine()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "0", Field.Store.YES));
@@ -189,7 +189,7 @@ namespace Lucene.Net.Search
         public virtual void TestExplain()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "0", Field.Store.YES));
@@ -277,7 +277,7 @@ namespace Lucene.Net.Search
         public virtual void TestMissingSecondPassScore()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "0", Field.Store.YES));
@@ -335,7 +335,7 @@ namespace Lucene.Net.Search
         {
             Directory dir = NewDirectory();
             int numDocs = AtLeast(1000);
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             int[] idToNum = new int[numDocs];
             int maxValue = TestUtil.NextInt(Random(), 10, 1000000);

--- a/src/Lucene.Net.Tests/core/Search/TestQueryWrapperFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestQueryWrapperFilter.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Search
         public virtual void TestBasic()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "value", Field.Store.NO));
             writer.AddDocument(doc);
@@ -92,7 +92,7 @@ namespace Lucene.Net.Search
         public virtual void TestRandom()
         {
             Directory d = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), d);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), d, Similarity, TimeZone);
             w.w.Config.SetMaxBufferedDocs(17);
             int numDocs = AtLeast(100);
             HashSet<string> aDocs = new HashSet<string>();
@@ -139,7 +139,7 @@ namespace Lucene.Net.Search
         public virtual void TestThousandDocuments()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             for (int i = 0; i < 1000; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestQueryWrapperFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestQueryWrapperFilter.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Search
         public virtual void TestBasic()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("field", "value", Field.Store.NO));
             writer.AddDocument(doc);
@@ -139,7 +139,7 @@ namespace Lucene.Net.Search
         public virtual void TestThousandDocuments()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < 1000; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestRegexpQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestRegexpQuery.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField(FN, "the quick brown fox jumps over the lazy ??? dog 493432 49344", Field.Store.NO));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestRegexpQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestRegexpQuery.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField(FN, "the quick brown fox jumps over the lazy ??? dog 493432 49344", Field.Store.NO));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestSameScoresWithThreads.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSameScoresWithThreads.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Search
             Directory dir = NewDirectory();
             MockAnalyzer analyzer = new MockAnalyzer(Random());
             analyzer.MaxTokenLength = TestUtil.NextInt(Random(), 1, IndexWriter.MAX_TERM_LENGTH);
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, analyzer);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, analyzer, Similarity, TimeZone);
             LineFileDocs docs = new LineFileDocs(Random(), DefaultCodecSupportsDocValues());
             int charsToIndex = AtLeast(100000);
             int charsIndexed = 0;

--- a/src/Lucene.Net.Tests/core/Search/TestScoreCachingWrappingScorer.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestScoreCachingWrappingScorer.cs
@@ -128,7 +128,7 @@ namespace Lucene.Net.Search
         public virtual void TestGetScores()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, Similarity, TimeZone);
             writer.Commit();
             IndexReader ir = writer.Reader;
             writer.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestScoreCachingWrappingScorer.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestScoreCachingWrappingScorer.cs
@@ -128,7 +128,7 @@ namespace Lucene.Net.Search
         public virtual void TestGetScores()
         {
             Directory directory = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), directory, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             writer.Commit();
             IndexReader ir = writer.Reader;
             writer.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestSearchAfter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSearchAfter.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Search
             }
 
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int numDocs = AtLeast(200);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestSearchAfter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSearchAfter.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Search
             }
 
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
             int numDocs = AtLeast(200);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestSearchWithThreads.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSearchWithThreads.cs
@@ -52,7 +52,7 @@ namespace Lucene.Net.Search
         public virtual void Test()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             long startTime = Environment.TickCount;
 

--- a/src/Lucene.Net.Tests/core/Search/TestSearchWithThreads.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSearchWithThreads.cs
@@ -52,7 +52,7 @@ namespace Lucene.Net.Search
         public virtual void Test()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             long startTime = Environment.TickCount;
 

--- a/src/Lucene.Net.Tests/core/Search/TestSearcherManager.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSearcherManager.cs
@@ -581,7 +581,7 @@ namespace Lucene.Net.Search
             // make sure that maybeRefreshBlocking releases the lock, otherwise other
             // threads cannot obtain it.
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             w.Dispose();
 
             SearcherManager sm = new SearcherManager(dir, null);

--- a/src/Lucene.Net.Tests/core/Search/TestSearcherManager.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSearcherManager.cs
@@ -529,7 +529,7 @@ namespace Lucene.Net.Search
         {
             Random random = Random();
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(random, dir);
+            RandomIndexWriter w = new RandomIndexWriter(random, dir, Similarity, TimeZone);
             w.Commit();
 
             IndexReader other = DirectoryReader.Open(dir);
@@ -571,7 +571,7 @@ namespace Lucene.Net.Search
 
             public override IndexSearcher NewSearcher(IndexReader ignored)
             {
-                return LuceneTestCase.NewSearcher(Other);
+                return OuterInstance.NewSearcher(Other);
             }
         }
 
@@ -581,7 +581,7 @@ namespace Lucene.Net.Search
             // make sure that maybeRefreshBlocking releases the lock, otherwise other
             // threads cannot obtain it.
             Directory dir = NewDirectory();
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             w.Dispose();
 
             SearcherManager sm = new SearcherManager(dir, null);

--- a/src/Lucene.Net.Tests/core/Search/TestSloppyPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSloppyPhraseQuery.cs
@@ -290,7 +290,7 @@ namespace Lucene.Net.Search
         public virtual void TestSlopWithHoles()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             FieldType customType = new FieldType(TextField.TYPE_NOT_STORED);
             customType.OmitNorms = true;
             Field f = new Field("lyrics", "", customType);
@@ -329,7 +329,7 @@ namespace Lucene.Net.Search
             string document = "drug druggy drug drug drug";
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewField("lyrics", document, new FieldType(TextField.TYPE_NOT_STORED)));
             iw.AddDocument(doc);
@@ -355,7 +355,7 @@ namespace Lucene.Net.Search
 
             Directory dir = NewDirectory();
 
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewField("lyrics", document, new FieldType(TextField.TYPE_NOT_STORED)));
             iw.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestSloppyPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSloppyPhraseQuery.cs
@@ -164,7 +164,7 @@ namespace Lucene.Net.Search
             query.Slop = slop;
 
             Directory ramDir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), ramDir, new MockAnalyzer(Random(), MockTokenizer.WHITESPACE, false));
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), ramDir, new MockAnalyzer(Random(), MockTokenizer.WHITESPACE, false), Similarity, TimeZone);
             writer.AddDocument(doc);
 
             IndexReader reader = writer.Reader;
@@ -243,7 +243,7 @@ namespace Lucene.Net.Search
         private void AssertSaneScoring(PhraseQuery pq, IndexSearcher searcher)
         {
             searcher.Search(pq, new CollectorAnonymousInnerClassHelper(this));
-            QueryUtils.Check(Random(), pq, searcher);
+            QueryUtils.Check(Random(), pq, searcher, Similarity);
         }
 
         private class CollectorAnonymousInnerClassHelper : Collector
@@ -290,7 +290,7 @@ namespace Lucene.Net.Search
         public virtual void TestSlopWithHoles()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             FieldType customType = new FieldType(TextField.TYPE_NOT_STORED);
             customType.OmitNorms = true;
             Field f = new Field("lyrics", "", customType);
@@ -329,7 +329,7 @@ namespace Lucene.Net.Search
             string document = "drug druggy drug drug drug";
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewField("lyrics", document, new FieldType(TextField.TYPE_NOT_STORED)));
             iw.AddDocument(doc);
@@ -355,7 +355,7 @@ namespace Lucene.Net.Search
 
             Directory dir = NewDirectory();
 
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewField("lyrics", document, new FieldType(TextField.TYPE_NOT_STORED)));
             iw.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestSort.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSort.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Search
         public virtual void TestString()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
             writer.AddDocument(doc);
@@ -98,7 +98,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
             writer.AddDocument(doc);
@@ -159,7 +159,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringVal()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
             writer.AddDocument(doc);
@@ -188,7 +188,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -222,7 +222,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringMissingSortedFirst()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -257,7 +257,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringMissingSortedFirstReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -292,7 +292,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValMissingSortedLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -328,7 +328,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValMissingSortedLastReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -362,7 +362,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
             writer.AddDocument(doc);
@@ -391,7 +391,7 @@ namespace Lucene.Net.Search
         public virtual void TestFieldDoc()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.NO));
             writer.AddDocument(doc);
@@ -420,7 +420,7 @@ namespace Lucene.Net.Search
         public virtual void TestFieldDocReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.NO));
             writer.AddDocument(doc);
@@ -449,7 +449,7 @@ namespace Lucene.Net.Search
         public virtual void TestFieldScore()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("value", "foo bar bar bar bar", Field.Store.NO));
             writer.AddDocument(doc);
@@ -483,7 +483,7 @@ namespace Lucene.Net.Search
         public virtual void TestFieldScoreReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("value", "foo bar bar bar bar", Field.Store.NO));
             writer.AddDocument(doc);
@@ -515,7 +515,7 @@ namespace Lucene.Net.Search
         public virtual void TestByte()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "23", Field.Store.YES));
             writer.AddDocument(doc);
@@ -548,7 +548,7 @@ namespace Lucene.Net.Search
         public virtual void TestByteMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -580,7 +580,7 @@ namespace Lucene.Net.Search
         public virtual void TestByteMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -614,7 +614,7 @@ namespace Lucene.Net.Search
         public virtual void TestByteReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "23", Field.Store.YES));
             writer.AddDocument(doc);
@@ -647,7 +647,7 @@ namespace Lucene.Net.Search
         public virtual void TestShort()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "300", Field.Store.YES));
             writer.AddDocument(doc);
@@ -680,7 +680,7 @@ namespace Lucene.Net.Search
         public virtual void TestShortMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -712,7 +712,7 @@ namespace Lucene.Net.Search
         public virtual void TestShortMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -746,7 +746,7 @@ namespace Lucene.Net.Search
         public virtual void TestShortReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "300", Field.Store.YES));
             writer.AddDocument(doc);
@@ -779,7 +779,7 @@ namespace Lucene.Net.Search
         public virtual void TestInt()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "300000", Field.Store.YES));
             writer.AddDocument(doc);
@@ -812,7 +812,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -844,7 +844,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -878,7 +878,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "300000", Field.Store.YES));
             writer.AddDocument(doc);
@@ -911,7 +911,7 @@ namespace Lucene.Net.Search
         public virtual void TestLong()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "3000000000", Field.Store.YES));
             writer.AddDocument(doc);
@@ -944,7 +944,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -976,7 +976,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1010,7 +1010,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "3000000000", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1043,7 +1043,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloat()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1076,7 +1076,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1108,7 +1108,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1142,7 +1142,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1175,7 +1175,7 @@ namespace Lucene.Net.Search
         public virtual void TestDouble()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1212,7 +1212,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleSignedZero()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "+0", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1242,7 +1242,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1278,7 +1278,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1316,7 +1316,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1480,7 +1480,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1537,7 +1537,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1595,7 +1595,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1652,7 +1652,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1709,7 +1709,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1767,7 +1767,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1821,7 +1821,7 @@ namespace Lucene.Net.Search
         public virtual void TestSortOneDocument()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1845,7 +1845,7 @@ namespace Lucene.Net.Search
         public virtual void TestSortOneDocumentWithScores()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1872,7 +1872,7 @@ namespace Lucene.Net.Search
         public virtual void TestSortTwoFields()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("tievalue", "tied", Field.Store.NO));
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
@@ -1902,7 +1902,7 @@ namespace Lucene.Net.Search
         public virtual void TestScore()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "bar", Field.Store.NO));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestSort.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSort.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Search
         public virtual void TestString()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
             writer.AddDocument(doc);
@@ -98,7 +98,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
             writer.AddDocument(doc);
@@ -159,7 +159,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringVal()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
             writer.AddDocument(doc);
@@ -188,7 +188,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -222,7 +222,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringMissingSortedFirst()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -257,7 +257,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringMissingSortedFirstReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -292,7 +292,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValMissingSortedLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -328,7 +328,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValMissingSortedLastReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -362,7 +362,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
             writer.AddDocument(doc);
@@ -391,7 +391,7 @@ namespace Lucene.Net.Search
         public virtual void TestFieldDoc()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.NO));
             writer.AddDocument(doc);
@@ -420,7 +420,7 @@ namespace Lucene.Net.Search
         public virtual void TestFieldDocReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.NO));
             writer.AddDocument(doc);
@@ -449,7 +449,7 @@ namespace Lucene.Net.Search
         public virtual void TestFieldScore()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("value", "foo bar bar bar bar", Field.Store.NO));
             writer.AddDocument(doc);
@@ -483,7 +483,7 @@ namespace Lucene.Net.Search
         public virtual void TestFieldScoreReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewTextField("value", "foo bar bar bar bar", Field.Store.NO));
             writer.AddDocument(doc);
@@ -515,7 +515,7 @@ namespace Lucene.Net.Search
         public virtual void TestByte()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "23", Field.Store.YES));
             writer.AddDocument(doc);
@@ -548,7 +548,7 @@ namespace Lucene.Net.Search
         public virtual void TestByteMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -580,7 +580,7 @@ namespace Lucene.Net.Search
         public virtual void TestByteMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -614,7 +614,7 @@ namespace Lucene.Net.Search
         public virtual void TestByteReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "23", Field.Store.YES));
             writer.AddDocument(doc);
@@ -647,7 +647,7 @@ namespace Lucene.Net.Search
         public virtual void TestShort()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "300", Field.Store.YES));
             writer.AddDocument(doc);
@@ -680,7 +680,7 @@ namespace Lucene.Net.Search
         public virtual void TestShortMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -712,7 +712,7 @@ namespace Lucene.Net.Search
         public virtual void TestShortMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -746,7 +746,7 @@ namespace Lucene.Net.Search
         public virtual void TestShortReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "300", Field.Store.YES));
             writer.AddDocument(doc);
@@ -779,7 +779,7 @@ namespace Lucene.Net.Search
         public virtual void TestInt()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "300000", Field.Store.YES));
             writer.AddDocument(doc);
@@ -812,7 +812,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -844,7 +844,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -878,7 +878,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "300000", Field.Store.YES));
             writer.AddDocument(doc);
@@ -911,7 +911,7 @@ namespace Lucene.Net.Search
         public virtual void TestLong()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "3000000000", Field.Store.YES));
             writer.AddDocument(doc);
@@ -944,7 +944,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -976,7 +976,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1010,7 +1010,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "3000000000", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1043,7 +1043,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloat()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1076,7 +1076,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1108,7 +1108,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1142,7 +1142,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1175,7 +1175,7 @@ namespace Lucene.Net.Search
         public virtual void TestDouble()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1212,7 +1212,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleSignedZero()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "+0", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1242,7 +1242,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1278,7 +1278,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -1316,7 +1316,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1480,7 +1480,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1537,7 +1537,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1595,7 +1595,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1652,7 +1652,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1709,7 +1709,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1767,7 +1767,7 @@ namespace Lucene.Net.Search
             letters = (List<string>)CollectionsHelper.Shuffle(letters);
 
             Directory dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             foreach (string letter in letters)
             {
                 Document doc = new Document();
@@ -1821,7 +1821,7 @@ namespace Lucene.Net.Search
         public virtual void TestSortOneDocument()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1845,7 +1845,7 @@ namespace Lucene.Net.Search
         public virtual void TestSortOneDocumentWithScores()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
             writer.AddDocument(doc);
@@ -1872,7 +1872,7 @@ namespace Lucene.Net.Search
         public virtual void TestSortTwoFields()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("tievalue", "tied", Field.Store.NO));
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
@@ -1902,7 +1902,7 @@ namespace Lucene.Net.Search
         public virtual void TestScore()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(NewStringField("value", "bar", Field.Store.NO));
             writer.AddDocument(doc);

--- a/src/Lucene.Net.Tests/core/Search/TestSortDocValues.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSortDocValues.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Search
         public virtual void TestString()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new SortedDocValuesField("value", new BytesRef("foo")));
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
@@ -94,7 +94,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new SortedDocValuesField("value", new BytesRef("bar")));
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
@@ -126,7 +126,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringVal()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new BinaryDocValuesField("value", new BytesRef("foo")));
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
@@ -158,7 +158,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new BinaryDocValuesField("value", new BytesRef("bar")));
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
@@ -190,7 +190,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValSorted()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new SortedDocValuesField("value", new BytesRef("foo")));
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
@@ -222,7 +222,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValReverseSorted()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new SortedDocValuesField("value", new BytesRef("bar")));
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
@@ -254,7 +254,7 @@ namespace Lucene.Net.Search
         public virtual void TestByte()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 23));
             doc.Add(NewStringField("value", "23", Field.Store.YES));
@@ -291,7 +291,7 @@ namespace Lucene.Net.Search
         public virtual void TestByteReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 23));
             doc.Add(NewStringField("value", "23", Field.Store.YES));
@@ -328,7 +328,7 @@ namespace Lucene.Net.Search
         public virtual void TestShort()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 300));
             doc.Add(NewStringField("value", "300", Field.Store.YES));
@@ -365,7 +365,7 @@ namespace Lucene.Net.Search
         public virtual void TestShortReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 300));
             doc.Add(NewStringField("value", "300", Field.Store.YES));
@@ -402,7 +402,7 @@ namespace Lucene.Net.Search
         public virtual void TestInt()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 300000));
             doc.Add(NewStringField("value", "300000", Field.Store.YES));
@@ -439,7 +439,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 300000));
             doc.Add(NewStringField("value", "300000", Field.Store.YES));
@@ -476,7 +476,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -510,7 +510,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -546,7 +546,7 @@ namespace Lucene.Net.Search
         public virtual void TestLong()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 3000000000L));
             doc.Add(NewStringField("value", "3000000000", Field.Store.YES));
@@ -583,7 +583,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 3000000000L));
             doc.Add(NewStringField("value", "3000000000", Field.Store.YES));
@@ -620,7 +620,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -654,7 +654,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -690,7 +690,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloat()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new FloatDocValuesField("value", 30.1F));
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
@@ -727,7 +727,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new FloatDocValuesField("value", 30.1F));
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
@@ -764,7 +764,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -798,7 +798,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -834,7 +834,7 @@ namespace Lucene.Net.Search
         public virtual void TestDouble()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new DoubleDocValuesField("value", 30.1));
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
@@ -876,7 +876,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleSignedZero()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new DoubleDocValuesField("value", +0D));
             doc.Add(NewStringField("value", "+0", Field.Store.YES));
@@ -908,7 +908,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             doc.Add(new DoubleDocValuesField("value", 30.1));
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
@@ -950,7 +950,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -989,7 +989,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestSortDocValues.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSortDocValues.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Search
         public virtual void TestString()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new SortedDocValuesField("value", new BytesRef("foo")));
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
@@ -94,7 +94,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new SortedDocValuesField("value", new BytesRef("bar")));
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
@@ -126,7 +126,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringVal()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new BinaryDocValuesField("value", new BytesRef("foo")));
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
@@ -158,7 +158,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new BinaryDocValuesField("value", new BytesRef("bar")));
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
@@ -190,7 +190,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValSorted()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new SortedDocValuesField("value", new BytesRef("foo")));
             doc.Add(NewStringField("value", "foo", Field.Store.YES));
@@ -222,7 +222,7 @@ namespace Lucene.Net.Search
         public virtual void TestStringValReverseSorted()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new SortedDocValuesField("value", new BytesRef("bar")));
             doc.Add(NewStringField("value", "bar", Field.Store.YES));
@@ -254,7 +254,7 @@ namespace Lucene.Net.Search
         public virtual void TestByte()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 23));
             doc.Add(NewStringField("value", "23", Field.Store.YES));
@@ -291,7 +291,7 @@ namespace Lucene.Net.Search
         public virtual void TestByteReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 23));
             doc.Add(NewStringField("value", "23", Field.Store.YES));
@@ -328,7 +328,7 @@ namespace Lucene.Net.Search
         public virtual void TestShort()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 300));
             doc.Add(NewStringField("value", "300", Field.Store.YES));
@@ -365,7 +365,7 @@ namespace Lucene.Net.Search
         public virtual void TestShortReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 300));
             doc.Add(NewStringField("value", "300", Field.Store.YES));
@@ -402,7 +402,7 @@ namespace Lucene.Net.Search
         public virtual void TestInt()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 300000));
             doc.Add(NewStringField("value", "300000", Field.Store.YES));
@@ -439,7 +439,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 300000));
             doc.Add(NewStringField("value", "300000", Field.Store.YES));
@@ -476,7 +476,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -510,7 +510,7 @@ namespace Lucene.Net.Search
         public virtual void TestIntMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -546,7 +546,7 @@ namespace Lucene.Net.Search
         public virtual void TestLong()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 3000000000L));
             doc.Add(NewStringField("value", "3000000000", Field.Store.YES));
@@ -583,7 +583,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new NumericDocValuesField("value", 3000000000L));
             doc.Add(NewStringField("value", "3000000000", Field.Store.YES));
@@ -620,7 +620,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -654,7 +654,7 @@ namespace Lucene.Net.Search
         public virtual void TestLongMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -690,7 +690,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloat()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new FloatDocValuesField("value", 30.1F));
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
@@ -727,7 +727,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new FloatDocValuesField("value", 30.1F));
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
@@ -764,7 +764,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -798,7 +798,7 @@ namespace Lucene.Net.Search
         public virtual void TestFloatMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -834,7 +834,7 @@ namespace Lucene.Net.Search
         public virtual void TestDouble()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new DoubleDocValuesField("value", 30.1));
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
@@ -876,7 +876,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleSignedZero()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new DoubleDocValuesField("value", +0D));
             doc.Add(NewStringField("value", "+0", Field.Store.YES));
@@ -908,7 +908,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleReverse()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             doc.Add(new DoubleDocValuesField("value", 30.1));
             doc.Add(NewStringField("value", "30.1", Field.Store.YES));
@@ -950,7 +950,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleMissing()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();
@@ -989,7 +989,7 @@ namespace Lucene.Net.Search
         public virtual void TestDoubleMissingLast()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             Document doc = new Document();
             writer.AddDocument(doc);
             doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestSortRandom.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSortRandom.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Search
 
             int NUM_DOCS = AtLeast(100);
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(random, dir);
+            RandomIndexWriter writer = new RandomIndexWriter(random, dir, Similarity, TimeZone);
             bool allowDups = random.NextBoolean();
             HashSet<string> seen = new HashSet<string>();
             int maxLength = TestUtil.NextInt(random, 5, 100);
@@ -148,7 +148,7 @@ namespace Lucene.Net.Search
                 Console.WriteLine("  reader=" + r);
             }
 
-            IndexSearcher idxS = NewSearcher(r, false);
+            IndexSearcher idxS = NewSearcher(r, false, Similarity);
             int ITERS = AtLeast(100);
             for (int iter = 0; iter < ITERS; iter++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestSortRescorer.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSortRescorer.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "1", Field.Store.YES));
@@ -121,7 +121,7 @@ namespace Lucene.Net.Search
         {
             Directory dir = NewDirectory();
             int numDocs = AtLeast(1000);
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
 
             int[] idToNum = new int[numDocs];
             int maxValue = TestUtil.NextInt(Random(), 10, 1000000);

--- a/src/Lucene.Net.Tests/core/Search/TestSortRescorer.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSortRescorer.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             Document doc = new Document();
             doc.Add(NewStringField("id", "1", Field.Store.YES));
@@ -121,7 +121,7 @@ namespace Lucene.Net.Search
         {
             Directory dir = NewDirectory();
             int numDocs = AtLeast(1000);
-            RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
 
             int[] idToNum = new int[numDocs];
             int maxValue = TestUtil.NextInt(Random(), 10, 1000000);

--- a/src/Lucene.Net.Tests/core/Search/TestSubScorerFreqs.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSubScorerFreqs.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Search
         private static IndexSearcher s;
 
         [TestFixtureSetUp]
-        public static void MakeIndex()
+        public void MakeIndex()
         {
             Dir = new RAMDirectory();
             RandomIndexWriter w = new RandomIndexWriter(Random(), Dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/core/Search/TestTermVectors.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTermVectors.cs
@@ -47,6 +47,10 @@ namespace Lucene.Net.Search
         private static IndexReader Reader;
         private static Directory Directory;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Is non-static because NewIndexWriterConfig is no longer static.
+        /// </summary>
         [TestFixtureSetUp]
         public void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/core/Search/TestTermVectors.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTermVectors.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Search
         private static Directory Directory;
 
         [TestFixtureSetUp]
-        public static void BeforeClass()
+        public void BeforeClass()
         {
             Directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random(), Directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random(), MockTokenizer.SIMPLE, true)).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/core/Search/TestTopDocsCollector.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTopDocsCollector.cs
@@ -117,7 +117,7 @@ namespace Lucene.Net.Search
             // populate an index with 30 documents, this should be enough for the test.
             // The documents have no content - the test uses MatchAllDocsQuery().
             Dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), Dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < 30; i++)
             {
                 writer.AddDocument(new Document());

--- a/src/Lucene.Net.Tests/core/Search/TestTopDocsCollector.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTopDocsCollector.cs
@@ -117,7 +117,7 @@ namespace Lucene.Net.Search
             // populate an index with 30 documents, this should be enough for the test.
             // The documents have no content - the test uses MatchAllDocsQuery().
             Dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
             for (int i = 0; i < 30; i++)
             {
                 writer.AddDocument(new Document());

--- a/src/Lucene.Net.Tests/core/Search/TestTopDocsMerge.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTopDocsMerge.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Search
 
             {
                 dir = NewDirectory();
-                RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+                RandomIndexWriter w = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
                 // w.setDoRandomForceMerge(false);
 
                 // w.w.getConfig().SetMaxBufferedDocs(AtLeast(100));

--- a/src/Lucene.Net.Tests/core/Search/TestTopDocsMerge.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTopDocsMerge.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Search
 
             {
                 dir = NewDirectory();
-                RandomIndexWriter w = new RandomIndexWriter(Random(), dir);
+                RandomIndexWriter w = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
                 // w.setDoRandomForceMerge(false);
 
                 // w.w.getConfig().SetMaxBufferedDocs(AtLeast(100));

--- a/src/Lucene.Net.Tests/core/Search/TestTopFieldCollector.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTopFieldCollector.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             int numDocs = AtLeast(100);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestTopFieldCollector.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTopFieldCollector.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Search
         {
             base.SetUp();
             Dir = NewDirectory();
-            RandomIndexWriter iw = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter iw = new RandomIndexWriter(Random(), Dir, Similarity, TimeZone);
             int numDocs = AtLeast(100);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/core/Search/TestTopScoreDocCollector.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTopScoreDocCollector.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Search
         public virtual void TestOutOfOrderCollection()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, Similarity, TimeZone);
             for (int i = 0; i < 10; i++)
             {
                 writer.AddDocument(new Document());

--- a/src/Lucene.Net.Tests/core/Search/TestTopScoreDocCollector.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTopScoreDocCollector.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Search
         public virtual void TestOutOfOrderCollection()
         {
             Directory dir = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), dir, ClassEnvRule.Similarity, ClassEnvRule.TimeZone);
             for (int i = 0; i < 10; i++)
             {
                 writer.AddDocument(new Document());

--- a/src/Lucene.Net.Tests/core/Search/TestTotalHitCountCollector.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTotalHitCountCollector.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Search
         public virtual void TestBasics()
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             for (int i = 0; i < 5; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Search/TestWildcard.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestWildcard.cs
@@ -260,7 +260,7 @@ namespace Lucene.Net.Search
         private Directory GetIndexStore(string field, string[] contents)
         {
             Directory indexStore = NewDirectory();
-            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore);
+            RandomIndexWriter writer = new RandomIndexWriter(Random(), indexStore, Similarity, TimeZone);
             for (int i = 0; i < contents.Length; ++i)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/core/Store/TestLockFactory.cs
+++ b/src/Lucene.Net.Tests/core/Store/TestLockFactory.cs
@@ -388,7 +388,7 @@ namespace Lucene.Net.Store
                     try
                     {
                         reader = DirectoryReader.Open(Dir);
-                        searcher = NewSearcher(reader);
+                        searcher = OuterInstance.NewSearcher(reader);
                     }
                     catch (Exception e)
                     {

--- a/src/Lucene.Net.Tests/core/Store/TestRAMDirectory.cs
+++ b/src/Lucene.Net.Tests/core/Store/TestRAMDirectory.cs
@@ -158,7 +158,7 @@ namespace Lucene.Net.Store
                 for (int j = 1; j < OuterInstance.DocsPerThread; j++)
                 {
                     Document doc = new Document();
-                    doc.Add(NewStringField("sizeContent", English.IntToEnglish(Num * OuterInstance.DocsPerThread + j).Trim(), Field.Store.YES));
+                    doc.Add(OuterInstance.NewStringField("sizeContent", English.IntToEnglish(Num * OuterInstance.DocsPerThread + j).Trim(), Field.Store.YES));
                     try
                     {
                         Writer.AddDocument(doc);


### PR DESCRIPTION
This is an improvement from PR #172.  The difference is that all the existing constructors are maintained with some additions. 

This PR would allow an easier transition to using xUnit. xUnit by default, runs its tests in parallel and asynchronously. The current use of mutable static fields limits in test cases the ability to utilise this.

* Changing existing static variables to static readonly so we are explicit that these variables are set once and do not change.
* Change OLD_FORMAT_IMPERSONATION_IS_ACTIVE to non-static field since other tests share and use this variable
* Change ClassEnvRule to non-static since every test class generates its own rule during test
* Change dependent static methods in LuceneTestCase to non-static because their state depended on the state of these non-static variables