### PR TITLE
Ported Core.Codecs.Perfield.TestPerFieldPostingsFormat2

### DIFF
--- a/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSepPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSepPostingsFormat.cs
@@ -1,0 +1,136 @@
+﻿using Lucene.Net.Codecs.BlockTerms;
+using Lucene.Net.Codecs.Sep;
+using Lucene.Net.Index;
+using Lucene.Net.Util;
+
+namespace Lucene.Net.Codecs.MockSep
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// A silly codec that simply writes each file separately as
+    /// single vInts.Don't use this (performance will be poor)!
+    /// This is here just to test the core sep codec
+    /// classes.
+    /// </summary>
+    public sealed class MockSepPostingsFormat : PostingsFormat
+    {
+        public MockSepPostingsFormat()
+            : base("MockSep")
+        {
+        }
+
+        public override FieldsConsumer FieldsConsumer(SegmentWriteState state)
+        {
+
+            PostingsWriterBase postingsWriter = new SepPostingsWriter(state, new MockSingleIntFactory());
+
+            bool success = false;
+            TermsIndexWriterBase indexWriter;
+            try
+            {
+                indexWriter = new FixedGapTermsIndexWriter(state);
+                success = true;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    postingsWriter.Dispose();
+                }
+            }
+
+            success = false;
+            try
+            {
+                FieldsConsumer ret = new BlockTermsWriter(indexWriter, state, postingsWriter);
+                success = true;
+                return ret;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    try
+                    {
+                        postingsWriter.Dispose();
+                    }
+                    finally
+                    {
+                        indexWriter.Dispose();
+                    }
+                }
+            }
+        }
+
+        public override FieldsProducer FieldsProducer(SegmentReadState state)
+        {
+
+            PostingsReaderBase postingsReader = new SepPostingsReader(state.Directory, state.FieldInfos, state.SegmentInfo,
+                state.Context, new MockSingleIntFactory(), state.SegmentSuffix);
+
+            TermsIndexReaderBase indexReader;
+            bool success = false;
+            try
+            {
+                indexReader = new FixedGapTermsIndexReader(state.Directory,
+                                                                 state.FieldInfos,
+                                                                 state.SegmentInfo.Name,
+                                                                 state.TermsIndexDivisor,
+                                                                 BytesRef.UTF8SortedAsUnicodeComparer,
+                                                                 state.SegmentSuffix, state.Context);
+                success = true;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    postingsReader.Dispose();
+                }
+            }
+
+            success = false;
+            try
+            {
+                FieldsProducer ret = new BlockTermsReader(indexReader,
+                                                          state.Directory,
+                                                          state.FieldInfos,
+                                                          state.SegmentInfo,
+                                                          postingsReader,
+                                                          state.Context,
+                                                          state.SegmentSuffix);
+                success = true;
+                return ret;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    try
+                    {
+                        postingsReader.Dispose();
+                    }
+                    finally
+                    {
+                        indexReader.Dispose();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSingleIntFactory.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSingleIntFactory.cs
@@ -1,0 +1,35 @@
+﻿using Lucene.Net.Codecs.Sep;
+using Lucene.Net.Store;
+
+namespace Lucene.Net.Codecs.MockSep
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public class MockSingleIntFactory : IntStreamFactory
+    {
+        public override IntIndexInput OpenInput(Directory dir, string fileName, IOContext context)
+        {
+            return new MockSingleIntIndexInput(dir, fileName, context);
+        }
+
+        public override IntIndexOutput CreateOutput(Directory dir, string fileName, IOContext context)
+        {
+            return new MockSingleIntIndexOutput(dir, fileName, context);
+        }
+    }
+}

--- a/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSingleIntIndexInput.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSingleIntIndexInput.cs
@@ -1,0 +1,118 @@
+﻿using Lucene.Net.Codecs.Sep;
+using Lucene.Net.Store;
+
+namespace Lucene.Net.Codecs.MockSep
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Reads IndexInputs written with {@link
+    /// MockSingleIntIndexOutput}.  NOTE: this class is just for
+    /// demonstration purposes(it is a very slow way to read a
+    /// block of ints).
+    /// 
+    /// @lucene.experimental
+    /// </summary>
+    public class MockSingleIntIndexInput : IntIndexInput
+    {
+        private readonly IndexInput @in;
+
+        public MockSingleIntIndexInput(Directory dir, string fileName, IOContext context)
+        {
+            @in = dir.OpenInput(fileName, context);
+            CodecUtil.CheckHeader(@in, MockSingleIntIndexOutput.CODEC,
+                          MockSingleIntIndexOutput.VERSION_START,
+                          MockSingleIntIndexOutput.VERSION_START);
+        }
+
+        public override IntIndexInputReader Reader()
+        {
+            return new MockReader((IndexInput)@in.Clone());
+        }
+
+        public override void Dispose()
+        {
+            @in.Dispose();
+        }
+
+        /**
+         * Just reads a vInt directly from the file.
+         */
+        public class MockReader : IntIndexInputReader
+        {
+            // clone:
+            internal readonly IndexInput @in;
+
+            public MockReader(IndexInput @in)
+            {
+                this.@in = @in;
+            }
+
+            /** Reads next single int */
+            public override int Next()
+            {
+                //System.out.println("msii.next() fp=" + in.getFilePointer() + " vs " + in.length());
+                return @in.ReadVInt();
+            }
+        }
+
+        internal class MockSingleIntIndexInputIndex : IntIndexInputIndex
+        {
+            private long fp;
+
+            public override void Read(DataInput indexIn, bool absolute)
+            {
+                if (absolute)
+                {
+                    fp = indexIn.ReadVLong();
+                }
+                else
+                {
+                    fp += indexIn.ReadVLong();
+                }
+            }
+
+            public override void CopyFrom(IntIndexInputIndex other)
+            {
+                fp = ((MockSingleIntIndexInputIndex)other).fp;
+            }
+
+            public override void Seek(IntIndexInputReader other)
+            {
+                ((MockReader)other).@in.Seek(fp);
+            }
+
+            public override string ToString()
+            {
+                return fp.ToString();
+            }
+
+
+            public override IntIndexInputIndex Clone()
+            {
+                MockSingleIntIndexInputIndex other = new MockSingleIntIndexInputIndex();
+                other.fp = fp;
+                return other;
+            }
+        }
+        public override IntIndexInputIndex Index()
+        {
+            return new MockSingleIntIndexInputIndex();
+        }
+    }
+}

--- a/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSingleIntIndexOutput.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSingleIntIndexOutput.cs
@@ -1,0 +1,102 @@
+﻿using Lucene.Net.Codecs.Sep;
+using Lucene.Net.Store;
+using Lucene.Net.Util;
+
+namespace Lucene.Net.Codecs.MockSep
+{
+    /// <summary>
+    /// Writes ints directly to the file (not in blocks) as
+    /// vInt.
+    /// 
+    /// @lucene.experimental
+    /// </summary>
+    public class MockSingleIntIndexOutput : IntIndexOutput
+    {
+        private readonly IndexOutput @out;
+        internal const string CODEC = "SINGLE_INTS";
+        internal const int VERSION_START = 0;
+        internal const int VERSION_CURRENT = VERSION_START;
+
+        public MockSingleIntIndexOutput(Directory dir, string fileName, IOContext context)
+        {
+            @out = dir.CreateOutput(fileName, context);
+            bool success = false;
+            try
+            {
+                CodecUtil.WriteHeader(@out, CODEC, VERSION_CURRENT);
+                success = true;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    IOUtils.CloseWhileHandlingException(@out);
+                }
+            }
+        }
+
+        public override void Write(int v)
+        {
+            @out.WriteVInt(v);
+        }
+
+        public override IntIndexOutputIndex Index()
+        {
+            return new MockSingleIntIndexOutputIndex(this);
+        }
+
+        public override void Dispose()
+        {
+            @out.Dispose();
+        }
+
+        public override string ToString()
+        {
+            return "MockSingleIntIndexOutput fp=" + @out.FilePointer;
+        }
+
+        private class MockSingleIntIndexOutputIndex : IntIndexOutputIndex
+        {
+            internal long fp;
+            internal long lastFP;
+            private readonly MockSingleIntIndexOutput outerClass;
+
+            public MockSingleIntIndexOutputIndex(MockSingleIntIndexOutput outerClass)
+            {
+                this.outerClass = outerClass;
+            }
+
+            public override void Mark()
+            {
+                fp = outerClass.@out.FilePointer;
+            }
+
+            public override void CopyFrom(IntIndexOutputIndex other, bool copyLast)
+            {
+                fp = ((MockSingleIntIndexOutputIndex)other).fp;
+                if (copyLast)
+                {
+                    lastFP = ((MockSingleIntIndexOutputIndex)other).fp;
+                }
+            }
+
+            public override void Write(DataOutput indexOut, bool absolute)
+            {
+                if (absolute)
+                {
+                    indexOut.WriteVLong(fp);
+                }
+                else
+                {
+                    indexOut.WriteVLong(fp - lastFP);
+                }
+                lastFP = fp;
+            }
+
+            public override string ToString()
+            {
+                return fp.ToString();
+            }
+        }
+    }
+}

--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -248,6 +248,10 @@
     <Compile Include="Codecs\MissingOrdRemapper.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Codecs\MockSep\MockSepPostingsFormat.cs" />
+    <Compile Include="Codecs\MockSep\MockSingleIntFactory.cs" />
+    <Compile Include="Codecs\MockSep\MockSingleIntIndexInput.cs" />
+    <Compile Include="Codecs\MockSep\MockSingleIntIndexOutput.cs" />
     <Compile Include="Codecs\ramonly\RAMOnlyPostingsFormat.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -468,6 +472,10 @@
     <Compile Include="Util\VirtualMethod.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Lucene.Net.Codecs\Lucene.Net.Codecs.csproj">
+      <Project>{3f79b6d4-4359-4f83-b64f-07f4f6262425}</Project>
+      <Name>Lucene.Net.Codecs</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Lucene.Net.Core\Lucene.Net.csproj">
       <Project>{5d4ad9be-1ffb-41ab-9943-25737971bf57}</Project>
       <Name>Lucene.Net</Name>

--- a/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
+++ b/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
@@ -59,6 +59,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Lucene.Net.Codecs\Lucene.Net.Codecs.csproj">
+      <Project>{3f79b6d4-4359-4f83-b64f-07f4f6262425}</Project>
+      <Name>Lucene.Net.Codecs</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Lucene.Net.Facet\Lucene.Net.Facet.csproj">
       <Project>{48f7884a-9454-4e88-8413-9d35992cb440}</Project>
       <Name>Lucene.Net.Facet</Name>

--- a/src/Lucene.Net.Tests/core/Codecs/Perfield/TestPerFieldPostingsFormat2.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Perfield/TestPerFieldPostingsFormat2.cs
@@ -1,51 +1,37 @@
 using System;
 using Lucene.Net.Documents;
+using Lucene.Net.Codecs.Lucene41;
+using Lucene.Net.Codecs.Lucene46;
+using Lucene.Net.Codecs.SimpleText;
+using Lucene.Net.Codecs.Pulsing;
+using Lucene.Net.Codecs.MockSep;
+using Lucene.Net.Util;
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using Lucene.Net.Analysis;
+using Lucene.Net.Randomized.Generators;
+using NUnit.Framework;
+using Lucene.Net.Store;
 
 namespace Lucene.Net.Codecs.Perfield
 {
-    using Lucene.Net.Randomized.Generators;
-    using NUnit.Framework;
-    using Directory = Lucene.Net.Store.Directory;
-    using DirectoryReader = Lucene.Net.Index.DirectoryReader;
-
-    /*using MockSepPostingsFormat = Lucene.Net.Codecs.mocksep.MockSepPostingsFormat;
-        using Pulsing41PostingsFormat = Lucene.Net.Codecs.pulsing.Pulsing41PostingsFormat;
-        using SimpleTextPostingsFormat = Lucene.Net.Codecs.simpletext.SimpleTextPostingsFormat;*/
-
-    using Document = Documents.Document;
-    using Field = Field;
-    using FieldType = FieldType;
-    using IndexReader = Lucene.Net.Index.IndexReader;
-    using IndexSearcher = Lucene.Net.Search.IndexSearcher;
-    using IndexWriter = Lucene.Net.Index.IndexWriter;
-    using IndexWriterConfig = Lucene.Net.Index.IndexWriterConfig;
-    using LogDocMergePolicy = Lucene.Net.Index.LogDocMergePolicy;
-    using LuceneTestCase = Lucene.Net.Util.LuceneTestCase;
-
     /*
-         * Licensed to the Apache Software Foundation (ASF) under one or more
-         * contributor license agreements.  See the NOTICE file distributed with
-         * this work for additional information regarding copyright ownership.
-         * The ASF licenses this file to You under the Apache License, Version 2.0
-         * (the "License"); you may not use this file except in compliance with
-         * the License.  You may obtain a copy of the License at
-         *
-         *     http://www.apache.org/licenses/LICENSE-2.0
-         *
-         * Unless required by applicable law or agreed to in writing, software
-         * distributed under the License is distributed on an "AS IS" BASIS,
-         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-         * See the License for the specific language governing permissions and
-         * limitations under the License.
-         */
-
-    using MockAnalyzer = Lucene.Net.Analysis.MockAnalyzer;
-    using RandomIndexWriter = Lucene.Net.Index.RandomIndexWriter;
-    using Term = Lucene.Net.Index.Term;
-    using TermQuery = Lucene.Net.Search.TermQuery;
-    using TestUtil = Lucene.Net.Util.TestUtil;
-    using TextField = TextField;
-    using TopDocs = Lucene.Net.Search.TopDocs;
+    * Licensed to the Apache Software Foundation (ASF) under one or more
+    * contributor license agreements.  See the NOTICE file distributed with
+    * this work for additional information regarding copyright ownership.
+    * The ASF licenses this file to You under the Apache License, Version 2.0
+    * (the "License"); you may not use this file except in compliance with
+    * the License.  You may obtain a copy of the License at
+    *
+    *     http://www.apache.org/licenses/LICENSE-2.0
+    *
+    * Unless required by applicable law or agreed to in writing, software
+    * distributed under the License is distributed on an "AS IS" BASIS,
+    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    * See the License for the specific language governing permissions and
+    * limitations under the License.
+    */
+    using Document = Documents.Document;
 
     //TODO: would be better in this test to pull termsenums and instanceof or something?
     // this way we can verify PFPF is doing the right thing.
@@ -95,103 +81,108 @@ namespace Lucene.Net.Codecs.Perfield
             }
         }
 
-        /*
-         * Test that heterogeneous index segments are merge successfully
-         */
-        /*public virtual void TestMergeUnusedPerFieldCodec()
+        /// <summary>
+        /// Test that heterogeneous index segments are merge successfully
+        /// </summary>
+        [Test]
+        public virtual void TestMergeUnusedPerFieldCodec()
         {
-          Directory dir = NewDirectory();
-          IndexWriterConfig iwconf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE).SetCodec(new MockCodec());
-          IndexWriter writer = NewWriter(dir, iwconf);
-          AddDocs(writer, 10);
-          writer.Commit();
-          AddDocs3(writer, 10);
-          writer.Commit();
-          AddDocs2(writer, 10);
-          writer.Commit();
-          Assert.AreEqual(30, writer.MaxDoc());
-          TestUtil.CheckIndex(dir);
-          writer.ForceMerge(1);
-          Assert.AreEqual(30, writer.MaxDoc());
-          writer.Dispose();
-          dir.Dispose();
-        }*/
+            Directory dir = NewDirectory();
+            IndexWriterConfig iwconf = NewIndexWriterConfig(TEST_VERSION_CURRENT, 
+                new MockAnalyzer(Random())).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE).SetCodec(new MockCodec());
+            IndexWriter writer = NewWriter(dir, iwconf);
+            AddDocs(writer, 10);
+            writer.Commit();
+            AddDocs3(writer, 10);
+            writer.Commit();
+            AddDocs2(writer, 10);
+            writer.Commit();
+            Assert.AreEqual(30, writer.MaxDoc);
+            TestUtil.CheckIndex(dir);
+            writer.ForceMerge(1);
+            Assert.AreEqual(30, writer.MaxDoc);
+            writer.Dispose();
+            dir.Dispose();
+        }
 
-        /*
-         * Test that heterogeneous index segments are merged sucessfully
-         */
+        /// <summary>
+        /// Test that heterogeneous index segments are merged sucessfully
+        /// </summary>
         // TODO: not sure this test is that great, we should probably peek inside PerFieldPostingsFormat or something?!
-        /*public virtual void TestChangeCodecAndMerge()
+        [Test]
+        public virtual void TestChangeCodecAndMerge()
         {
-          Directory dir = NewDirectory();
-          if (VERBOSE)
-          {
-            Console.WriteLine("TEST: make new index");
-          }
-          IndexWriterConfig iwconf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE).SetCodec(new MockCodec());
-          iwconf.SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH);
-          //((LogMergePolicy) iwconf.getMergePolicy()).setMergeFactor(10);
-          IndexWriter writer = NewWriter(dir, iwconf);
+            Directory dir = NewDirectory();
+            if (VERBOSE)
+            {
+                Console.WriteLine("TEST: make new index");
+            }
+            IndexWriterConfig iwconf = NewIndexWriterConfig(TEST_VERSION_CURRENT, 
+                new MockAnalyzer(Random())).SetOpenMode(IndexWriterConfig.OpenMode_e.CREATE).SetCodec(new MockCodec());
+            iwconf.SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH);
+            // ((LogMergePolicy)iwconf.getMergePolicy()).setMergeFactor(10);
+            IndexWriter writer = NewWriter(dir, iwconf);
 
-          AddDocs(writer, 10);
-          writer.Commit();
-          AssertQuery(new Term("content", "aaa"), dir, 10);
-          if (VERBOSE)
-          {
-            Console.WriteLine("TEST: addDocs3");
-          }
-          AddDocs3(writer, 10);
-          writer.Commit();
-          writer.Dispose();
+            AddDocs(writer, 10);
+            writer.Commit();
+            AssertQuery(new Term("content", "aaa"), dir, 10);
+            if (VERBOSE)
+            {
+                Console.WriteLine("TEST: addDocs3");
+            }
+            AddDocs3(writer, 10);
+            writer.Commit();
+            writer.Dispose();
 
-          AssertQuery(new Term("content", "ccc"), dir, 10);
-          AssertQuery(new Term("content", "aaa"), dir, 10);
-          Codec codec = iwconf.Codec;
+            AssertQuery(new Term("content", "ccc"), dir, 10);
+            AssertQuery(new Term("content", "aaa"), dir, 10);
+            Codec codec = iwconf.Codec;
 
-          iwconf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random())).SetOpenMode(IndexWriterConfig.OpenMode_e.APPEND).SetCodec(codec);
-          //((LogMergePolicy) iwconf.getMergePolicy()).setNoCFSRatio(0.0);
-          //((LogMergePolicy) iwconf.getMergePolicy()).setMergeFactor(10);
-          iwconf.SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH);
+            iwconf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()))
+                .SetOpenMode(IndexWriterConfig.OpenMode_e.APPEND).SetCodec(codec);
+            // ((LogMergePolicy)iwconf.getMergePolicy()).setNoCFSRatio(0.0);
+            // ((LogMergePolicy)iwconf.getMergePolicy()).setMergeFactor(10);
+            iwconf.SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH);
 
-          iwconf.SetCodec(new MockCodec2()); // uses standard for field content
-          writer = NewWriter(dir, iwconf);
-          // swap in new codec for currently written segments
-          if (VERBOSE)
-          {
-            Console.WriteLine("TEST: add docs w/ Standard codec for content field");
-          }
-          AddDocs2(writer, 10);
-          writer.Commit();
-          codec = iwconf.Codec;
-          Assert.AreEqual(30, writer.MaxDoc());
-          AssertQuery(new Term("content", "bbb"), dir, 10);
-          AssertQuery(new Term("content", "ccc"), dir, 10); ////
-          AssertQuery(new Term("content", "aaa"), dir, 10);
+            iwconf.SetCodec(new MockCodec2()); // uses standard for field content
+            writer = NewWriter(dir, iwconf);
+            // swap in new codec for currently written segments
+            if (VERBOSE)
+            {
+                Console.WriteLine("TEST: add docs w/ Standard codec for content field");
+            }
+            AddDocs2(writer, 10);
+            writer.Commit();
+            codec = iwconf.Codec;
+            Assert.AreEqual(30, writer.MaxDoc);
+            AssertQuery(new Term("content", "bbb"), dir, 10);
+            AssertQuery(new Term("content", "ccc"), dir, 10); ////
+            AssertQuery(new Term("content", "aaa"), dir, 10);
 
-          if (VERBOSE)
-          {
-            Console.WriteLine("TEST: add more docs w/ new codec");
-          }
-          AddDocs2(writer, 10);
-          writer.Commit();
-          AssertQuery(new Term("content", "ccc"), dir, 10);
-          AssertQuery(new Term("content", "bbb"), dir, 20);
-          AssertQuery(new Term("content", "aaa"), dir, 10);
-          Assert.AreEqual(40, writer.MaxDoc());
+            if (VERBOSE)
+            {
+                Console.WriteLine("TEST: add more docs w/ new codec");
+            }
+            AddDocs2(writer, 10);
+            writer.Commit();
+            AssertQuery(new Term("content", "ccc"), dir, 10);
+            AssertQuery(new Term("content", "bbb"), dir, 20);
+            AssertQuery(new Term("content", "aaa"), dir, 10);
+            Assert.AreEqual(40, writer.MaxDoc);
 
-          if (VERBOSE)
-          {
-            Console.WriteLine("TEST: now optimize");
-          }
-          writer.ForceMerge(1);
-          Assert.AreEqual(40, writer.MaxDoc());
-          writer.Dispose();
-          AssertQuery(new Term("content", "ccc"), dir, 10);
-          AssertQuery(new Term("content", "bbb"), dir, 20);
-          AssertQuery(new Term("content", "aaa"), dir, 10);
+            if (VERBOSE)
+            {
+                Console.WriteLine("TEST: now optimize");
+            }
+            writer.ForceMerge(1);
+            Assert.AreEqual(40, writer.MaxDoc);
+            writer.Dispose();
+            AssertQuery(new Term("content", "ccc"), dir, 10);
+            AssertQuery(new Term("content", "bbb"), dir, 20);
+            AssertQuery(new Term("content", "aaa"), dir, 10);
 
-          dir.Dispose();
-        }*/
+            dir.Dispose();
+        }
 
         public virtual void AssertQuery(Term t, Directory dir, int num)
         {
@@ -206,51 +197,50 @@ namespace Lucene.Net.Codecs.Perfield
             reader.Dispose();
         }
 
-        /*public class MockCodec : Lucene46Codec
+        public class MockCodec : Lucene46Codec
         {
-          internal readonly PostingsFormat Lucene40 = new Lucene41PostingsFormat();
-          internal readonly PostingsFormat SimpleText = new SimpleTextPostingsFormat();
-          internal readonly PostingsFormat MockSep = new MockSepPostingsFormat();
+            internal readonly PostingsFormat Lucene40 = new Lucene41PostingsFormat();
+            internal readonly PostingsFormat SimpleText = new SimpleTextPostingsFormat();
+            internal readonly PostingsFormat MockSep = new MockSepPostingsFormat();
 
-          public override PostingsFormat GetPostingsFormatForField(string field)
-          {
-            if (field.Equals("id"))
+            public override PostingsFormat GetPostingsFormatForField(string field)
             {
-              return SimpleText;
+                if (field.Equals("id"))
+                {
+                    return SimpleText;
+                }
+                else if (field.Equals("content"))
+                {
+                    return MockSep;
+                }
+                else
+                {
+                    return Lucene40;
+                }
             }
-            else if (field.Equals("content"))
-            {
-              return MockSep;
-            }
-            else
-            {
-              return Lucene40;
-            }
-          }
-        }*/
+        }
 
-        /*public class MockCodec2 : Lucene46Codec
+        public class MockCodec2 : Lucene46Codec
         {
-          internal readonly PostingsFormat Lucene40 = new Lucene41PostingsFormat();
-          internal readonly PostingsFormat SimpleText = new SimpleTextPostingsFormat();
+            internal readonly PostingsFormat Lucene40 = new Lucene41PostingsFormat();
+            internal readonly PostingsFormat SimpleText = new SimpleTextPostingsFormat();
 
-          public override PostingsFormat GetPostingsFormatForField(string field)
-          {
-            if (field.Equals("id"))
+            public override PostingsFormat GetPostingsFormatForField(string field)
             {
-              return SimpleText;
+                if (field.Equals("id"))
+                {
+                    return SimpleText;
+                }
+                else
+                {
+                    return Lucene40;
+                }
             }
-            else
-            {
-              return Lucene40;
-            }
-          }
-        }*/
+        }
 
-        /*
-         * Test per field codec support - adding fields with random codecs
-         */
-
+        /// <summary>
+        /// Test per field codec support - adding fields with random codecs
+        /// </summary>
         [Test]
         public virtual void TestStressPerFieldCodec()
         {
@@ -287,13 +277,14 @@ namespace Lucene.Net.Codecs.Perfield
             dir.Dispose();
         }
 
-        /*public virtual void TestSameCodecDifferentInstance()
+        [Test]
+        public virtual void TestSameCodecDifferentInstance()
         {
-          Codec codec = new Lucene46CodecAnonymousInnerClassHelper(this);
-          DoTestMixedPostings(codec);
-        }*/
+            Codec codec = new Lucene46CodecAnonymousInnerClassHelper(this);
+            DoTestMixedPostings(codec);
+        }
 
-        /*private class Lucene46CodecAnonymousInnerClassHelper : Lucene46Codec
+        private class Lucene46CodecAnonymousInnerClassHelper : Lucene46Codec
         {
             private readonly TestPerFieldPostingsFormat2 OuterInstance;
 
@@ -304,28 +295,29 @@ namespace Lucene.Net.Codecs.Perfield
 
             public override PostingsFormat GetPostingsFormatForField(string field)
             {
-              if ("id".Equals(field))
-              {
-                return new Pulsing41PostingsFormat(1);
-              }
-              else if ("date".Equals(field))
-              {
-                return new Pulsing41PostingsFormat(1);
-              }
-              else
-              {
-                return base.GetPostingsFormatForField(field);
-              }
+                if ("id".Equals(field))
+                {
+                    return new Pulsing41PostingsFormat(1);
+                }
+                else if ("date".Equals(field))
+                {
+                    return new Pulsing41PostingsFormat(1);
+                }
+                else
+                {
+                    return base.GetPostingsFormatForField(field);
+                }
             }
-        }*/
+        }
 
-        /*public virtual void TestSameCodecDifferentParams()
+        [Test]
+        public virtual void TestSameCodecDifferentParams()
         {
           Codec codec = new Lucene46CodecAnonymousInnerClassHelper2(this);
           DoTestMixedPostings(codec);
-        }*/
+        }
 
-        /*private class Lucene46CodecAnonymousInnerClassHelper2 : Lucene46Codec
+        private class Lucene46CodecAnonymousInnerClassHelper2 : Lucene46Codec
         {
             private readonly TestPerFieldPostingsFormat2 OuterInstance;
 
@@ -336,23 +328,22 @@ namespace Lucene.Net.Codecs.Perfield
 
             public override PostingsFormat GetPostingsFormatForField(string field)
             {
-              if ("id".Equals(field))
-              {
-                return new Pulsing41PostingsFormat(1);
-              }
-              else if ("date".Equals(field))
-              {
-                return new Pulsing41PostingsFormat(2);
-              }
-              else
-              {
-                return base.GetPostingsFormatForField(field);
-              }
+                if ("id".Equals(field))
+                {
+                    return new Pulsing41PostingsFormat(1);
+                }
+                else if ("date".Equals(field))
+                {
+                    return new Pulsing41PostingsFormat(2);
+                }
+                else
+                {
+                    return base.GetPostingsFormatForField(field);
+                }
             }
-        }*/
+        }
 
-        [Test]
-        private void TestMixedPostings(Codec codec)
+        private void DoTestMixedPostings(Codec codec)
         {
             Directory dir = NewDirectory();
             IndexWriterConfig iwc = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random()));

--- a/src/Lucene.Net.Tests/core/Index/TestCrashCausesCorruptIndex.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestCrashCausesCorruptIndex.cs
@@ -63,7 +63,6 @@ namespace Lucene.Net.Index
         /// prepare for crashing.
         /// index 1 more document, and upon commit, creation of segments_2 will crash.
         /// </summary>
-        [Test]
         private void IndexAndCrashOnCreateOutputSegments2()
         {
             Directory realDirectory = FSDirectory.Open(Path);


### PR DESCRIPTION
Ported the Core.Codecs.Perfield.TestPerFieldPostingsFormat2 tests and removed [Test] attribute from a couple of methods where it didn't belong (methods that are called from other tests).