### PR TITLE
Fix test failures and making SPIClassIterator more performant

### DIFF
--- a/src/Lucene.Net.Core/Util/SPIClassIterator.cs
+++ b/src/Lucene.Net.Core/Util/SPIClassIterator.cs
@@ -92,31 +92,6 @@ namespace Lucene.Net.Util
                 {
                     // swallow
                 }
-
-                foreach (var assemblyName in loadedAssembly.GetReferencedAssemblies())
-                {
-                    try
-                    {
-                        var assembly = Assembly.Load(assemblyName);
-
-                        foreach (var type in assembly.GetTypes())
-                        {
-                            try
-                            {
-                                if (IsInvokableSubclassOf<S>(type))
-                                    types.Add(type);
-                            }
-                            catch
-                            {
-                                // swallow
-                            }
-                        }
-                    }
-                    catch
-                    {
-                        // swallow
-                    }
-                }
             }
         }
 

--- a/src/Lucene.Net.Core/Util/SPIClassIterator.cs
+++ b/src/Lucene.Net.Core/Util/SPIClassIterator.cs
@@ -80,7 +80,9 @@ namespace Lucene.Net.Util
                         try
                         {
                             if (IsInvokableSubclassOf<S>(type))
+                            {
                                 types.Add(type);
+                            }
                         }
                         catch
                         {

--- a/src/Lucene.Net.Core/Util/SPIClassIterator.cs
+++ b/src/Lucene.Net.Core/Util/SPIClassIterator.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace Lucene.Net.Util
 {
@@ -44,12 +47,35 @@ namespace Lucene.Net.Util
             // hoping would be loaded hasn't been loaded yet into the app domain,
             // it is unavailable. So we go to the next level on each and check each referenced
             // assembly.
+            var assembliesLoaded = AppDomain.CurrentDomain.GetAssemblies().Where(x => !DotNetFrameworkFilter.IsFrameworkAssembly(x));
+            var referencedAssemblies = assembliesLoaded
+                .SelectMany(assembly =>
+                {
+                    return assembly
+                        .GetReferencedAssemblies()
+                        .Where(reference => !DotNetFrameworkFilter.IsFrameworkAssembly(reference))
+                        .Select(assemblyName => {
+                            try
+                            {
+                                return Assembly.Load(assemblyName);
+                            }
+                            catch
+                            {
+                                // swallow
+                                return null;
+                            }
+                        });
+                })
+                .Where(x => x != null)
+                .Distinct();
 
-            foreach (var loadedAssembly in AppDomain.CurrentDomain.GetAssemblies())
+            var assembliesToExamine = assembliesLoaded.Concat(referencedAssemblies).Distinct();
+
+            foreach (var assembly in assembliesToExamine)
             {
                 try
                 {
-                    foreach (var type in loadedAssembly.GetTypes())
+                    foreach (var type in assembly.GetTypes().Where(x => x.IsPublic))
                     {
                         try
                         {
@@ -113,6 +139,61 @@ namespace Lucene.Net.Util
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Assembly filter logic from:
+        /// https://raw.githubusercontent.com/Microsoft/dotnet-apiport/master/src/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
+        /// </summary>
+        private static class DotNetFrameworkFilter
+        {
+            /// <summary>
+            /// These keys are a collection of public key tokens derived from all the reference assemblies in
+            /// "%ProgramFiles%\Reference Assemblies\Microsoft" on a Windows 10 machine with VS 2015 installed
+            /// </summary>
+            private static readonly ICollection<string> s_microsoftKeys = new HashSet<string>(new[] 
+            {
+                "b77a5c561934e089", // ECMA
+                "b03f5f7f11d50a3a", // DEVDIV
+                "7cec85d7bea7798e", // SLPLAT
+                "31bf3856ad364e35", // Windows
+                "24eec0d8c86cda1e", // Phone
+                "0738eb9f132ed756", // Mono
+                "ddd0da4d3e678217", // Component model
+                "84e04ff9cfb79065", // Mono Android
+                "842cf8be1de50553"  // Xamarin.iOS
+            }, StringComparer.OrdinalIgnoreCase);
+
+            private static readonly IEnumerable<string> s_frameworkAssemblyNamePrefixes = new[]
+            {
+                "System.",
+                "Microsoft.",
+                "Mono."
+            };
+
+            /// <summary>
+            /// Gets a best guess as to whether this assembly is a .NET Framework assembly or not.
+            /// </summary>
+            public static bool IsFrameworkAssembly(Assembly assembly)
+            {
+                return assembly != null && IsFrameworkAssembly(assembly.GetName());
+            }
+
+            /// <summary>
+            /// Gets a best guess as to whether this assembly is a .NET Framework assembly or not.
+            /// </summary>
+            public static bool IsFrameworkAssembly(AssemblyName assembly)
+            {
+                if (assembly == null)
+                {
+                    return false;
+                }
+
+                var publicKeyToken = string.Concat(assembly.GetPublicKeyToken().Select(i => i.ToString("x2")));
+
+                return s_microsoftKeys.Contains(publicKeyToken)
+                    || s_frameworkAssemblyNamePrefixes.Any(p => assembly.Name.StartsWith(p, StringComparison.OrdinalIgnoreCase));
+            }
         }
     }
 

--- a/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene3x/PreFlexRWCodec.cs
@@ -34,10 +34,22 @@ namespace Lucene.Net.Codecs.Lucene3x
         private readonly bool _oldFormatImpersonationIsActive;
 
         /// <summary>
+        /// LUCENENET specific
+        /// Creates the codec with OldFormatImpersonationIsActive = true.
+        /// </summary>
+        /// <remarks>
+        /// Added so that SPIClassIterator can locate this Codec.  The iterator
+        /// only recognises classes that have empty constructors.
+        /// </remarks>
+        public PreFlexRWCodec()
+            : this(true)
+        { }
+
+        /// <summary>
         /// </summary>
         /// <param name="oldFormatImpersonationIsActive">
         /// LUCENENET specific
-        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
+        /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/>
         /// </param>
         public PreFlexRWCodec(bool oldFormatImpersonationIsActive) : base()
         {

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWCodec.cs
@@ -25,6 +25,18 @@ namespace Lucene.Net.Codecs.Lucene40
     {
         private readonly FieldInfosFormat fieldInfos;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Creates the codec with OldFormatImpersonationIsActive = true.
+        /// </summary>
+        /// <remarks>
+        /// Added so that SPIClassIterator can locate this Codec.  The iterator
+        /// only recognises classes that have empty constructors.
+        /// </remarks>
+        public Lucene40RWCodec()
+            : this(true)
+        { }
+
         /// <param name="oldFormatImpersonationIsActive">
         /// LUCENENET specific
         /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 
@@ -34,7 +46,7 @@ namespace Lucene.Net.Codecs.Lucene40
             fieldInfos = new Lucene40FieldInfosFormatAnonymousInnerClassHelper(oldFormatImpersonationIsActive);
             DocValues = new Lucene40RWDocValuesFormat(oldFormatImpersonationIsActive);
             Norms = new Lucene40RWNormsFormat(oldFormatImpersonationIsActive);
-    }
+        }
 
         private class Lucene40FieldInfosFormatAnonymousInnerClassHelper : Lucene40FieldInfosFormat
         {

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWDocValuesFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWDocValuesFormat.cs
@@ -27,6 +27,18 @@ namespace Lucene.Net.Codecs.Lucene40
     {
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Creates the codec with OldFormatImpersonationIsActive = true.
+        /// </summary>
+        /// <remarks>
+        /// Added so that SPIClassIterator can locate this Codec.  The iterator
+        /// only recognises classes that have empty constructors.
+        /// </remarks>
+        public Lucene40RWDocValuesFormat()
+            : this(true)
+        { }
+
         /// <param name="oldFormatImpersonationIsActive">
         /// LUCENENET specific
         /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWNormsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWNormsFormat.cs
@@ -27,6 +27,18 @@ namespace Lucene.Net.Codecs.Lucene40
     {
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Creates the codec with OldFormatImpersonationIsActive = true.
+        /// </summary>
+        /// <remarks>
+        /// Added so that SPIClassIterator can locate this Codec.  The iterator
+        /// only recognises classes that have empty constructors.
+        /// </remarks>
+        public Lucene40RWNormsFormat()
+            : this(true)
+        { }
+
         /// <param name="oldFormatImpersonationIsActive">
         /// LUCENENET specific
         /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 

--- a/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene40/Lucene40RWPostingsFormat.cs
@@ -27,6 +27,18 @@ namespace Lucene.Net.Codecs.Lucene40
     {
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Creates the codec with OldFormatImpersonationIsActive = true.
+        /// </summary>
+        /// <remarks>
+        /// Added so that SPIClassIterator can locate this Codec.  The iterator
+        /// only recognises classes that have empty constructors.
+        /// </remarks>
+        public Lucene40RWPostingsFormat()
+            : this(true)
+        { }
+
         /// <param name="oldFormatImpersonationIsActive">
         /// LUCENENET specific
         /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 

--- a/src/Lucene.Net.TestFramework/Codecs/lucene41/Lucene41RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene41/Lucene41RWCodec.cs
@@ -34,6 +34,18 @@ namespace Lucene.Net.Codecs.Lucene41
         private readonly NormsFormat Norms;
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Creates the codec with OldFormatImpersonationIsActive = true.
+        /// </summary>
+        /// <remarks>
+        /// Added so that SPIClassIterator can locate this Codec.  The iterator
+        /// only recognises classes that have empty constructors.
+        /// </remarks>
+        public Lucene41RWCodec()
+            : this(true)
+        { }
+
         /// <param name="oldFormatImpersonationIsActive">
         /// LUCENENET specific
         /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 

--- a/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWCodec.cs
@@ -28,6 +28,18 @@ namespace Lucene.Net.Codecs.Lucene42
         private readonly NormsFormat Norms = new Lucene42NormsFormat();
         private readonly FieldInfosFormat fieldInfosFormat;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Creates the codec with OldFormatImpersonationIsActive = true.
+        /// </summary>
+        /// <remarks>
+        /// Added so that SPIClassIterator can locate this Codec.  The iterator
+        /// only recognises classes that have empty constructors.
+        /// </remarks>
+        public Lucene42RWCodec()
+            : this(true)
+        { }
+
         /// <param name="oldFormatImpersonationIsActive">
         /// LUCENENET specific
         /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 

--- a/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWDocValuesFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene42/Lucene42RWDocValuesFormat.cs
@@ -28,6 +28,18 @@ namespace Lucene.Net.Codecs.Lucene42
     {
         private readonly bool _oldFormatImpersonationIsActive;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Creates the codec with OldFormatImpersonationIsActive = true.
+        /// </summary>
+        /// <remarks>
+        /// Added so that SPIClassIterator can locate this Codec.  The iterator
+        /// only recognises classes that have empty constructors.
+        /// </remarks>
+        public Lucene42RWDocValuesFormat()
+            : this(true)
+        { }
+
         /// <param name="oldFormatImpersonationIsActive">
         /// LUCENENET specific
         /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 

--- a/src/Lucene.Net.TestFramework/Codecs/lucene45/Lucene45RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/lucene45/Lucene45RWCodec.cs
@@ -28,6 +28,18 @@ namespace Lucene.Net.Codecs.Lucene45
     {
         private readonly FieldInfosFormat fieldInfosFormat;
 
+        /// <summary>
+        /// LUCENENET specific
+        /// Creates the codec with OldFormatImpersonationIsActive = true.
+        /// </summary>
+        /// <remarks>
+        /// Added so that SPIClassIterator can locate this Codec.  The iterator
+        /// only recognises classes that have empty constructors.
+        /// </remarks>
+        public Lucene45RWCodec()
+            : this(true)
+        { }
+
         /// <param name="oldFormatImpersonationIsActive">
         /// LUCENENET specific
         /// Added to remove dependency on then-static <see cref="LuceneTestCase.OLD_FORMAT_IMPERSONATION_IS_ACTIVE"/> 

--- a/src/Lucene.Net.Tests/core/Codecs/Perfield/TestPerFieldPostingsFormat2.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Perfield/TestPerFieldPostingsFormat2.cs
@@ -197,7 +197,7 @@ namespace Lucene.Net.Codecs.Perfield
             reader.Dispose();
         }
 
-        public class MockCodec : Lucene46Codec
+        private class MockCodec : Lucene46Codec
         {
             internal readonly PostingsFormat Lucene40 = new Lucene41PostingsFormat();
             internal readonly PostingsFormat SimpleText = new SimpleTextPostingsFormat();
@@ -220,7 +220,7 @@ namespace Lucene.Net.Codecs.Perfield
             }
         }
 
-        public class MockCodec2 : Lucene46Codec
+        private class MockCodec2 : Lucene46Codec
         {
             internal readonly PostingsFormat Lucene40 = new Lucene41PostingsFormat();
             internal readonly PostingsFormat SimpleText = new SimpleTextPostingsFormat();


### PR DESCRIPTION
### SPIClassIterator
* Improve loading performance:
   * Filtering out Microsoft/System assemblies
   * Only iterating through distinct assemblies
   * Only adding public classes to the iterator:
       * This fixed test failures where [MockCodec](https://github.com/apache/lucenenet/blob/8ce8e81fb06d43a44974436d79dadd33197bf0e0/src/Lucene.Net.Tests/core/Codecs/Perfield/TestPerFieldPostingsFormat2.cs#L200) (which had a codec name "Lucene46") was being loaded instead of [Lucene46Codec](https://github.com/apache/lucenenet/blob/c6d7bec47383919793721ecf9ca5f6966fb86033/src/Lucene.Net.Core/Codecs/Lucene46/Lucene46Codec.cs#L83) because it was being found first in the iterator
* Consolidated assembly loading code

### Test Failure Fixes
*  Adding a default ctor to the Codecs that were not being found because SPIClassIterator was skipping over them

I tested these changes in Visual Studio 2013 so they should not fail again