### PR TITLE
Updating from NUnit 2.6.3 to NUnit 3.5.0

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
@@ -488,7 +488,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             AllTerms = null;

--- a/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
@@ -370,7 +370,7 @@ namespace Lucene.Net.Index
             return new SeedPostings(seed, minDocFreq, maxDocFreq, withLiveDocs ? GlobalLiveDocs : null, options);
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void CreatePostings()
         {
             TotalPostings = 0;

--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -43,8 +43,9 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/Lucene.Net.TestFramework/packages.config
+++ b/src/Lucene.Net.TestFramework/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -180,7 +180,7 @@ namespace Lucene.Net.Analysis.Core
             }
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             IEnumerable<Type> analysisClasses = typeof(StandardAnalyzer).Assembly.GetTypes()

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -249,7 +249,7 @@ namespace Lucene.Net.Analysis.Core
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             tokenizers = null;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCaseInsensitive.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCaseInsensitive.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestCaseInsensitive : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init(true, "simple.aff", "mixedcase.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCircumfix.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCircumfix.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestCircumfix_ : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("circumfix.aff", "circumfix.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestComplexPrefix.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestComplexPrefix.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestComplexPrefix : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("complexprefix.aff", "complexprefix.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCondition.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCondition.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestCondition : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("condition.aff", "condition.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestConv.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestConv.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestConv : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("conv.aff", "conv.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestDependencies.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestDependencies.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestDependencies_ : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("dependencies.aff", "dependencies.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestEscaped.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestEscaped.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestEscaped : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("escaped.aff", "escaped.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFlagLong.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFlagLong.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestFlagLong : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("flaglong.aff", "flaglong.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFlagNum.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFlagNum.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestFlagNum : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("flagnum.aff", "flagnum.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHomonyms.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHomonyms.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestHomonyms : StemmerTestBase
     {
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("homonyms.aff", "homonyms.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Analysis.Hunspell
     {
         private static Dictionary dictionary;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             System.IO.Stream affixStream = typeof(TestStemmer).getResourceAsStream("simple.aff");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Analysis.Hunspell
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void afterClass()
         {
             dictionary = null;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestIgnore.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestIgnore.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestIgnore : StemmerTestBase
     {
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("ignore.aff", "ignore.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestMorph.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestMorph.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestMorph : StemmerTestBase
     {
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("morph.aff", "morph.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestOptionalCondition.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestOptionalCondition.cs
@@ -21,7 +21,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestOptionalCondition : StemmerTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("optional-condition.aff", "condition.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestStemmer.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestStemmer : StemmerTestBase
     {
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("simple.aff", "simple.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestTwoFold.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestTwoFold.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestTwoFold : StemmerTestBase
     {
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("twofold.aff", "morph.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestTwoSuffixes.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestTwoSuffixes.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestTwoSuffixes : StemmerTestBase
     {
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Init("twosuffixes.aff", "twosuffixes.dic");

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCapitalizationFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCapitalizationFilter.cs
@@ -139,24 +139,24 @@ namespace Lucene.Net.Analysis.Miscellaneous
         /// checking the validity of constructor arguments
         /// </summary>
         [Test]
-        [ExpectedException(ExpectedException = typeof(ArgumentOutOfRangeException))]
         public virtual void TestIllegalArguments()
         {
-            new CapitalizationFilter(new MockTokenizer(new StringReader("accept only valid arguments"), MockTokenizer.WHITESPACE, false), true, null, true, null, -1, CapitalizationFilter.DEFAULT_MAX_WORD_COUNT, CapitalizationFilter.DEFAULT_MAX_TOKEN_LENGTH);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new CapitalizationFilter(new MockTokenizer(new StringReader("accept only valid arguments"), MockTokenizer.WHITESPACE, false), true, null, true, null, -1, CapitalizationFilter.DEFAULT_MAX_WORD_COUNT, CapitalizationFilter.DEFAULT_MAX_TOKEN_LENGTH));
         }
 
         [Test]
-        [ExpectedException(ExpectedException = typeof(ArgumentOutOfRangeException))]
         public virtual void TestIllegalArguments1()
         {
-            new CapitalizationFilter(new MockTokenizer(new StringReader("accept only valid arguments"), MockTokenizer.WHITESPACE, false), true, null, true, null, 0, -10, CapitalizationFilter.DEFAULT_MAX_TOKEN_LENGTH);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new CapitalizationFilter(new MockTokenizer(new StringReader("accept only valid arguments"), MockTokenizer.WHITESPACE, false), true, null, true, null, 0, -10, CapitalizationFilter.DEFAULT_MAX_TOKEN_LENGTH));
         }
 
         [Test]
-        [ExpectedException(ExpectedException = typeof(ArgumentOutOfRangeException))]
         public virtual void TestIllegalArguments2()
         {
-            new CapitalizationFilter(new MockTokenizer(new StringReader("accept only valid arguments"), MockTokenizer.WHITESPACE, false), true, null, true, null, 0, CapitalizationFilter.DEFAULT_MAX_WORD_COUNT, -50);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new CapitalizationFilter(new MockTokenizer(new StringReader("accept only valid arguments"), MockTokenizer.WHITESPACE, false), true, null, true, null, 0, CapitalizationFilter.DEFAULT_MAX_WORD_COUNT, -50));
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCodepointCountFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCodepointCountFilter.cs
@@ -86,10 +86,10 @@ namespace Lucene.Net.Analysis.Miscellaneous
         /// checking the validity of constructor arguments
         /// </summary>
         [Test]
-        [ExpectedException(ExpectedException = typeof(ArgumentOutOfRangeException))]
         public virtual void TestIllegalArguments()
         {
-            new CodepointCountFilter(TEST_VERSION_CURRENT, new MockTokenizer(new StringReader("accept only valid arguments"), MockTokenizer.WHITESPACE, false), 4, 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new CodepointCountFilter(TEST_VERSION_CURRENT, new MockTokenizer(new StringReader("accept only valid arguments"), MockTokenizer.WHITESPACE, false), 4, 1));
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLengthFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLengthFilter.cs
@@ -71,10 +71,10 @@ namespace Lucene.Net.Analysis.Miscellaneous
         /// checking the validity of constructor arguments
         /// </summary>
         [Test]
-        [ExpectedException(ExpectedException = typeof(ArgumentOutOfRangeException))]
         public virtual void TestIllegalArguments()
         {
-            new LengthFilter(TEST_VERSION_CURRENT, new MockTokenizer(new StringReader("accept only valid arguments")), -4, -1);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new LengthFilter(TEST_VERSION_CURRENT, new MockTokenizer(new StringReader("accept only valid arguments")), -4, -1));
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLimitTokenCountFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLimitTokenCountFilter.cs
@@ -37,10 +37,10 @@ namespace Lucene.Net.Analysis.Miscellaneous
         }
 
         [Test]
-        [ExpectedException(ExpectedException = typeof(ArgumentOutOfRangeException))]
         public virtual void TestIllegalArguments()
         {
-            new LimitTokenCountFilter(new MockTokenizer(new StringReader("A1 B2 C3 D4 E5 F6"), MockTokenizer.WHITESPACE, false), -1);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new LimitTokenCountFilter(new MockTokenizer(new StringReader("A1 B2 C3 D4 E5 F6"), MockTokenizer.WHITESPACE, false), -1));
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLimitTokenPositionFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLimitTokenPositionFilter.cs
@@ -92,10 +92,9 @@ namespace Lucene.Net.Analysis.Miscellaneous
         }
 
         [Test]
-        [ExpectedException(ExpectedException = typeof(ArgumentException))]
         public virtual void TestIllegalArguments()
         {
-            new LimitTokenPositionFilter(new MockTokenizer(new StringReader("one two three four five")), 0);
+            Assert.Throws<ArgumentException>(() => new LimitTokenPositionFilter(new MockTokenizer(new StringReader("one two three four five")), 0));
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestTruncateTokenFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestTruncateTokenFilter.cs
@@ -36,10 +36,9 @@ namespace Lucene.Net.Analysis.Miscellaneous
         }
 
         [Test]
-        [ExpectedException(ExpectedException = typeof(ArgumentOutOfRangeException))]
         public virtual void TestNonPositiveLength()
         {
-            new TruncateTokenFilter(new MockTokenizer(new StringReader("length must be a positive number")), -48);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>  new TruncateTokenFilter(new MockTokenizer(new StringReader("length must be a positive number")), -48));
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TokenRangeSinkTokenizerTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TokenRangeSinkTokenizerTest.cs
@@ -51,10 +51,9 @@ namespace Lucene.Net.Analysis.Sinks
         }
 
         [Test]
-        [ExpectedException(ExpectedException = typeof(ArgumentOutOfRangeException))]
         public virtual void TestIllegalArguments()
         {
-            new TokenRangeSinkFilter(4, 2);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new TokenRangeSinkFilter(4, 2));
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSolrSynonymParser.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSolrSynonymParser.cs
@@ -73,56 +73,51 @@ namespace Lucene.Net.Analysis.Synonym
         /// <summary>
         /// parse a syn file with bad syntax </summary>
         [Test]
-        [ExpectedException(ExpectedException = typeof(Exception))]
         public virtual void TestInvalidDoubleMap()
         {
             string testFile = "a => b => c";
             SolrSynonymParser parser = new SolrSynonymParser(true, true, new MockAnalyzer(Random()));
-            parser.Parse(new StringReader(testFile));
+            Assert.Throws<Exception>(() => parser.Parse(new StringReader(testFile)));
         }
 
         /// <summary>
         /// parse a syn file with bad syntax </summary>
         [Test]
-        [ExpectedException(ExpectedException = typeof(Exception))]
         public virtual void TestInvalidAnalyzesToNothingOutput()
         {
             string testFile = "a => 1";
             SolrSynonymParser parser = new SolrSynonymParser(true, true, new MockAnalyzer(Random(), MockTokenizer.SIMPLE, false));
-            parser.Parse(new StringReader(testFile));
+            Assert.Throws<Exception>(() => parser.Parse(new StringReader(testFile)));
         }
 
         /// <summary>
         /// parse a syn file with bad syntax </summary>
         [Test]
-        [ExpectedException(ExpectedException = typeof(Exception))]
         public virtual void TestInvalidAnalyzesToNothingInput()
         {
             string testFile = "1 => a";
             SolrSynonymParser parser = new SolrSynonymParser(true, true, new MockAnalyzer(Random(), MockTokenizer.SIMPLE, false));
-            parser.Parse(new StringReader(testFile));
+            Assert.Throws<Exception>(() => parser.Parse(new StringReader(testFile)));
         }
 
         /// <summary>
         /// parse a syn file with bad syntax </summary>
         [Test]
-        [ExpectedException(ExpectedException = typeof(Exception))]
         public virtual void TestInvalidPositionsInput()
         {
             string testFile = "testola => the test";
             SolrSynonymParser parser = new SolrSynonymParser(true, true, new EnglishAnalyzer(TEST_VERSION_CURRENT));
-            parser.Parse(new StringReader(testFile));
+            Assert.Throws<Exception>(() => parser.Parse(new StringReader(testFile)));
         }
 
         /// <summary>
         /// parse a syn file with bad syntax </summary>
         [Test]
-        [ExpectedException(ExpectedException = typeof(Exception))]
         public virtual void TestInvalidPositionsOutput()
         {
             string testFile = "the test => testola";
             SolrSynonymParser parser = new SolrSynonymParser(true, true, new EnglishAnalyzer(TEST_VERSION_CURRENT));
-            parser.Parse(new StringReader(testFile));
+            Assert.Throws<Exception>(() => parser.Parse(new StringReader(testFile)));
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Lucene.Net.Tests.Analysis.Common.csproj
+++ b/src/Lucene.Net.Tests.Analysis.Common/Lucene.Net.Tests.Analysis.Common.csproj
@@ -40,9 +40,9 @@
       <HintPath>..\..\packages\ICU4NET-ICU4C55.1-bin32.1.0.0\lib\net45\ICU4NETExtension.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Lucene.Net.Tests.Analysis.Common/packages.config
+++ b/src/Lucene.Net.Tests.Analysis.Common/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ICU4NET-ICU4C55.1-bin32" version="1.0.0" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Analysis.Stempel/Lucene.Net.Tests.Analysis.Stempel.csproj
+++ b/src/Lucene.Net.Tests.Analysis.Stempel/Lucene.Net.Tests.Analysis.Stempel.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Lucene.Net.Tests.Analysis.Stempel/packages.config
+++ b/src/Lucene.Net.Tests.Analysis.Stempel/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Classification/Lucene.Net.Tests.Classification.csproj
+++ b/src/Lucene.Net.Tests.Classification/Lucene.Net.Tests.Classification.csproj
@@ -30,9 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Lucene.Net.Tests.Classification/packages.config
+++ b/src/Lucene.Net.Tests.Classification/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Codecs/Lucene.Net.Tests.Codecs.csproj
+++ b/src/Lucene.Net.Tests.Codecs/Lucene.Net.Tests.Codecs.csproj
@@ -30,8 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Lucene.Net.Tests.Codecs/packages.config
+++ b/src/Lucene.Net.Tests.Codecs/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Expressions/Lucene.Net.Tests.Expressions.csproj
+++ b/src/Lucene.Net.Tests.Expressions/Lucene.Net.Tests.Expressions.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Lucene.Net.Tests.Expressions/packages.config
+++ b/src/Lucene.Net.Tests.Expressions/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Facet/Lucene.Net.Tests.Facet.csproj
+++ b/src/Lucene.Net.Tests.Facet/Lucene.Net.Tests.Facet.csproj
@@ -30,8 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Facet.Taxonomy
         /// LUCENENET specific
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             dir = NewDirectory();

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
@@ -92,7 +92,7 @@ namespace Lucene.Net.Facet.Taxonomy
             taxoReader = new DirectoryTaxonomyReader(taxoDir);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             reader.Dispose();

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
@@ -245,7 +245,7 @@ namespace Lucene.Net.Facet.Taxonomy
             return counts;
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClassCountingFacetsAggregatorTest()
         {
             indexDir = NewDirectory();

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Facet.Taxonomy
         private static Net.Store.Directory indexDir, taxoDir;
         private static IDictionary<string, int?> allExpectedCounts, termExpectedCounts;
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClassCountingFacetsAggregatorTest()
         {
             IOUtils.Close(indexDir, taxoDir);

--- a/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Facet
         private static FacetsConfig config;
 
       
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClassDrillDownQueryTest()
         {
             IOUtils.Close(reader, taxo, dir, taxoDir);

--- a/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Facet
             config = null;
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClassDrillDownQueryTest()
         {
             dir = NewDirectory();

--- a/src/Lucene.Net.Tests.Facet/packages.config
+++ b/src/Lucene.Net.Tests.Facet/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Grouping/Lucene.Net.Tests.Grouping.csproj
+++ b/src/Lucene.Net.Tests.Grouping/Lucene.Net.Tests.Grouping.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Lucene.Net.Tests.Grouping/packages.config
+++ b/src/Lucene.Net.Tests.Grouping/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Join/Lucene.Net.Tests.Join.csproj
+++ b/src/Lucene.Net.Tests.Join/Lucene.Net.Tests.Join.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Lucene.Net.Tests.Join/packages.config
+++ b/src/Lucene.Net.Tests.Join/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Memory/Lucene.Net.Tests.Memory.csproj
+++ b/src/Lucene.Net.Tests.Memory/Lucene.Net.Tests.Memory.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Lucene.Net.Tests.Memory/packages.config
+++ b/src/Lucene.Net.Tests.Memory/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
+++ b/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Documents
             }
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void CreateIndex()
         {
 

--- a/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
+++ b/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
@@ -20,7 +20,7 @@ namespace Lucene.Net.Documents
 
         public Directory dir = NewDirectory();
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void RemoveIndex()
         {
             if (null != dir)

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/IndexSortingTest.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/IndexSortingTest.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Index.Sorter
             new Sort(new SortField(null, SortField.Type_e.DOC, true))
         };
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClassSorterUtilTest()
         {
             // only read the values of the undeleted documents, since after addIndexes,

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
@@ -223,7 +223,7 @@ namespace Lucene.Net.Index.Sorter
             reader = SlowCompositeReaderWrapper.Wrap(DirectoryReader.Open(dir));
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClassSorterTestBase()
         {
             reader.Dispose();

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
@@ -213,7 +213,7 @@ namespace Lucene.Net.Index.Sorter
             }
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClassSorterTestBase()
         {
             dir = NewDirectory();

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/SortingAtomicReaderTest.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/SortingAtomicReaderTest.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Index.Sorter
 
     public class SortingAtomicReaderTest : SorterTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClassSortingAtomicReaderTest()
         {
 

--- a/src/Lucene.Net.Tests.Misc/Lucene.Net.Tests.Misc.csproj
+++ b/src/Lucene.Net.Tests.Misc/Lucene.Net.Tests.Misc.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
+++ b/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
@@ -14,7 +14,7 @@ namespace Lucene.Net.Misc
         private static Directory dir = null;
         private static IndexReader reader = null;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void SetUpClass()
         {
             dir = NewDirectory();

--- a/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
+++ b/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Misc
             TestUtil.CheckIndex(dir);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void TearDownClass()
         {
             reader.Dispose();

--- a/src/Lucene.Net.Tests.Misc/packages.config
+++ b/src/Lucene.Net.Tests.Misc/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Queries/Lucene.Net.Tests.Queries.csproj
+++ b/src/Lucene.Net.Tests.Queries/Lucene.Net.Tests.Queries.csproj
@@ -30,8 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Lucene.Net.Tests.Queries/packages.config
+++ b/src/Lucene.Net.Tests.Queries/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
@@ -52,7 +52,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
             qpAnalyzer = new QPTestAnalyzer();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void afterClass()
         {
             qpAnalyzer = null;

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
     {
         public static Analyzer qpAnalyzer;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void beforeClass()
         {
             qpAnalyzer = new QPTestAnalyzer();

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -567,7 +567,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             return NUMBER_FORMAT.Parse(NUMBER_FORMAT.Format(number));
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             searcher = null;

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                 dateFormat, CultureInfo.CurrentCulture, DateTimeStyles.RoundtripKind, out result);
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             ANALYZER = new MockAnalyzer(Random());

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             qpAnalyzer = new QPTestAnalyzer();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             qpAnalyzer = null;

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
     {
         public static Analyzer qpAnalyzer;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             qpAnalyzer = new QPTestAnalyzer();

--- a/src/Lucene.Net.Tests.QueryParser/Lucene.Net.Tests.QueryParser.csproj
+++ b/src/Lucene.Net.Tests.QueryParser/Lucene.Net.Tests.QueryParser.csproj
@@ -30,8 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.QueryParsers.Util
     {
         public static Analyzer qpAnalyzer;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             qpAnalyzer = new QPTestAnalyzer();

--- a/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.QueryParsers.Util
             qpAnalyzer = new QPTestAnalyzer();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             qpAnalyzer = null;

--- a/src/Lucene.Net.Tests.QueryParser/Xml/TestParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/TestParser.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.QueryParsers.Xml
 
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             reader.Dispose();

--- a/src/Lucene.Net.Tests.QueryParser/Xml/TestParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/TestParser.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.QueryParsers.Xml
         private static IndexReader reader;
         private static IndexSearcher searcher;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             // TODO: rewrite test (this needs to set QueryParser.enablePositionIncrements, too, for work with CURRENT):

--- a/src/Lucene.Net.Tests.QueryParser/packages.config
+++ b/src/Lucene.Net.Tests.QueryParser/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Sandbox/Lucene.Net.Tests.Sandbox.csproj
+++ b/src/Lucene.Net.Tests.Sandbox/Lucene.Net.Tests.Sandbox.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -76,10 +76,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <EmbeddedResource Include="Queries\fuzzyTestData.txt" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Queries\fuzzyTestData.txt" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Lucene.Net.Tests.Sandbox/Queries/TestSortedSetSortFieldSelectors.cs
+++ b/src/Lucene.Net.Tests.Sandbox/Queries/TestSortedSetSortFieldSelectors.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Sandbox.Queries
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void afterClass()
         {
             Codec.Default = (savedCodec);

--- a/src/Lucene.Net.Tests.Sandbox/Queries/TestSortedSetSortFieldSelectors.cs
+++ b/src/Lucene.Net.Tests.Sandbox/Queries/TestSortedSetSortFieldSelectors.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Sandbox.Queries
     {
         static Codec savedCodec;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void beforeClass()
         {
             savedCodec = Codec.Default;

--- a/src/Lucene.Net.Tests.Sandbox/packages.config
+++ b/src/Lucene.Net.Tests.Sandbox/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Spatial/Lucene.Net.Tests.Spatial.csproj
+++ b/src/Lucene.Net.Tests.Spatial/Lucene.Net.Tests.Spatial.csproj
@@ -38,8 +38,8 @@
       <HintPath>..\..\packages\NetTopologySuite.1.14\lib\net45\NetTopologySuite.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PowerCollections, Version=1.0.0.0, Culture=neutral, PublicKeyToken=2573bf8a1bdddcd5, processorArchitecture=MSIL">

--- a/src/Lucene.Net.Tests.Spatial/packages.config
+++ b/src/Lucene.Net.Tests.Spatial/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="GeoAPI" version="1.7.4" targetFramework="net451" />
   <package id="NetTopologySuite" version="1.14" targetFramework="net451" />
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
   <package id="Spatial4n.Core" version="0.4.1-beta" targetFramework="net451" />
   <package id="Spatial4n.Core.NTS" version="0.4.1-beta" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests.Suggest/Lucene.Net.Tests.Suggest.csproj
+++ b/src/Lucene.Net.Tests.Suggest/Lucene.Net.Tests.Suggest.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/TestFreeTextSuggester.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/TestFreeTextSuggester.cs
@@ -209,7 +209,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
         }
 
-        [Ignore]
+        [Test]
+        [Ignore("Ignored Test: TestWiki")]
         public void TestWiki()
         {
             LineFileDocs lfd = new LineFileDocs(null, "/lucenedata/enwiki/enwiki-20120502-lines-1k.txt", false);

--- a/src/Lucene.Net.Tests.Suggest/packages.config
+++ b/src/Lucene.Net.Tests.Suggest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
+++ b/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
@@ -39,8 +39,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/Lucene.Net.Tests/core/Codecs/Compressing/TestCompressingStoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Compressing/TestCompressingStoredFieldsFormat.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Documents;
+using System;
 using Field = Lucene.Net.Documents.Field;
 
 namespace Lucene.Net.Codecs.Compressing
@@ -45,7 +46,6 @@ namespace Lucene.Net.Codecs.Compressing
         }
 
         [Test]
-        [ExpectedException("System.ArgumentException")]
         public virtual void TestDeletePartiallyWrittenFilesIfAbort()
         {
             Directory dir = NewDirectory();
@@ -68,26 +68,29 @@ namespace Lucene.Net.Codecs.Compressing
             fieldType.Stored = true;
             invalidDoc.Add(new FieldAnonymousInnerClassHelper(this, fieldType));
 
-            try
+            Assert.Throws<ArgumentException>(() =>
             {
-                iw.AddDocument(invalidDoc);
-                iw.Commit();
-            }
-            finally
-            {
-                int counter = 0;
-                foreach (string fileName in dir.ListAll())
+                try
                 {
-                    if (fileName.EndsWith(".fdt") || fileName.EndsWith(".fdx"))
-                    {
-                        counter++;
-                    }
+                    iw.AddDocument(invalidDoc);
+                    iw.Commit();
                 }
-                // Only one .fdt and one .fdx files must have been found
-                Assert.AreEqual(2, counter);
-                iw.Dispose();
-                dir.Dispose();
-            }
+                finally
+                {
+                    int counter = 0;
+                    foreach (string fileName in dir.ListAll())
+                    {
+                        if (fileName.EndsWith(".fdt") || fileName.EndsWith(".fdx"))
+                        {
+                            counter++;
+                        }
+                    }
+                    // Only one .fdt and one .fdx files must have been found
+                    Assert.AreEqual(2, counter);
+                    iw.Dispose();
+                    dir.Dispose();
+                }
+            });
         }
 
         private class FieldAnonymousInnerClassHelper : Field

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xStoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestLucene3xStoredFieldsFormat.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestSurrogates.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestSurrogates.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true;

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             // NOTE: turn off compound file, this test will open some index files directly.

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
@@ -113,7 +113,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             SampleTerms = Sample(Random(), Reader, 1000);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             TermEnum.Dispose();

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40DocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40DocValuesFormat.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Codecs.Lucene40
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsFormat.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Codecs.Lucene40
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsReader.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40PostingsReader.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Codecs.Lucene40
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40StoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40StoredFieldsFormat.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Codecs.Lucene40
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40TermVectorsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestLucene40TermVectorsFormat.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Codecs.Lucene40
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestReuseDocsEnum.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene40/TestReuseDocsEnum.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Codecs.Lucene40
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Codecs.Lucene41
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec

--- a/src/Lucene.Net.Tests/core/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/core/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
@@ -32,7 +32,7 @@ namespace Lucene.Net.Codecs.Lucene42
         /// LUCENENET specific
         /// Is non-static because OLD_FORMAT_IMPERSONATION_IS_ACTIVE is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             OLD_FORMAT_IMPERSONATION_IS_ACTIVE = true; // explicitly instantiates ancient codec

--- a/src/Lucene.Net.Tests/core/Index/Test2BDocs.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BDocs.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Index
             iw.Dispose();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void AfterClass()
         {
             Dir.Dispose();

--- a/src/Lucene.Net.Tests/core/Index/Test2BDocs.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BDocs.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Index
     {
         internal static Directory Dir;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Dir = NewFSDirectory(CreateTempDir("2Bdocs"));

--- a/src/Lucene.Net.Tests/core/Index/Test2BTerms.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test2BTerms.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Index
     //   java -server -Xmx8g -d64 -cp .:lib/junit-4.10.jar:./build/classes/test:./build/classes/test-framework:./build/classes/java -Dlucene.version=4.0-dev -Dtests.directory=MMapDirectory -DtempDir=build -ea org.junit.runner.JUnitCore Lucene.Net.Index.Test2BTerms
     //
     [SuppressCodecs("SimpleText", "Memory", "Direct")]
-    [Ignore]
+    [Ignore("Ignored: Test2BTerms")]
     [TestFixture]
     public class Test2BTerms : LuceneTestCase
     {

--- a/src/Lucene.Net.Tests/core/Index/Test4GBStoredFields.cs
+++ b/src/Lucene.Net.Tests/core/Index/Test4GBStoredFields.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Index
     [TestFixture]
     public class Test4GBStoredFields : LuceneTestCase
     {
-        [Ignore] // LUCENENET NOTE: This was marked Nightly in Java
+        [Ignore("LUCENENET NOTE: This was marked Nightly in Java")] // LUCENENET NOTE: This was marked Nightly in Java
         [Test]
         public virtual void Test([ValueSource(typeof(ConcurrentMergeSchedulers), "Values")]IConcurrentMergeScheduler scheduler)
         {

--- a/src/Lucene.Net.Tests/core/Index/TestBackwardsCompatibility.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBackwardsCompatibility.cs
@@ -221,7 +221,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void AfterClass()
         {
             foreach (Directory d in OldIndexDirs.Values)

--- a/src/Lucene.Net.Tests/core/Index/TestBackwardsCompatibility.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBackwardsCompatibility.cs
@@ -202,7 +202,7 @@ namespace Lucene.Net.Index
             return null; // never get here
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Assert.IsFalse(OLD_FORMAT_IMPERSONATION_IS_ACTIVE, "test infra is broken!");

--- a/src/Lucene.Net.Tests/core/Index/TestBackwardsCompatibility3x.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBackwardsCompatibility3x.cs
@@ -148,7 +148,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void AfterClass()
         {
             foreach (Directory d in OldIndexDirs.Values)

--- a/src/Lucene.Net.Tests/core/Index/TestBackwardsCompatibility3x.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestBackwardsCompatibility3x.cs
@@ -129,7 +129,7 @@ namespace Lucene.Net.Index
 
         internal static IDictionary<string, Directory> OldIndexDirs;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Assert.IsFalse(OLD_FORMAT_IMPERSONATION_IS_ACTIVE, "test infra is broken!");

--- a/src/Lucene.Net.Tests/core/Index/TestCodecs.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestCodecs.cs
@@ -89,7 +89,7 @@ namespace Lucene.Net.Index
         private const int DOC_FREQ_RAND = 500; // must be > 16 to test skipping
         private const int TERM_DOC_FREQ_RAND = 20;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             NUM_TEST_ITER = AtLeast(20);

--- a/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Index
             FaultyIndexInput.DoFail = false;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Dir.Dispose();

--- a/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFieldsReader.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Index
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             TestDoc = new Document();

--- a/src/Lucene.Net.Tests/core/Index/TestFlushByRamOrCountsPolicy.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFlushByRamOrCountsPolicy.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Index
 
         private static LineFileDocs LineDocFile;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             LineDocFile = new LineFileDocs(Random(), DefaultCodecSupportsDocValues());

--- a/src/Lucene.Net.Tests/core/Index/TestFlushByRamOrCountsPolicy.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestFlushByRamOrCountsPolicy.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Index
             LineDocFile = new LineFileDocs(Random(), DefaultCodecSupportsDocValues());
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             LineDocFile.Dispose();

--- a/src/Lucene.Net.Tests/core/Index/TestIndexInput.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexInput.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             INTS = null;

--- a/src/Lucene.Net.Tests/core/Index/TestIndexInput.cs
+++ b/src/Lucene.Net.Tests/core/Index/TestIndexInput.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Index
         internal static long[] LONGS;
         internal static byte[] RANDOM_TEST_BYTES;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             Random random = Random();

--- a/src/Lucene.Net.Tests/core/Search/BaseTestRangeFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/BaseTestRangeFilter.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Search
             UnsignedIndexReader = Build(Random(), UnsignedIndexDir);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClassBaseTestRangeFilter()
         {
             SignedIndexReader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/BaseTestRangeFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/BaseTestRangeFilter.cs
@@ -100,7 +100,7 @@ namespace Lucene.Net.Search
         /// Is non-static because <see cref="Build(Random, TestIndex)"/> is no
         /// longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClassBaseTestRangeFilter()
         {
             MaxId = AtLeast(500);

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadNearQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadNearQuery.cs
@@ -135,7 +135,7 @@ namespace Lucene.Net.Search.Payloads
             Searcher.Similarity = Similarity;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Searcher = null;

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadNearQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadNearQuery.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Search.Payloads
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
@@ -142,7 +142,7 @@ namespace Lucene.Net.Search.Payloads
             Searcher.Similarity = Similarity;
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Searcher = null;

--- a/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Payloads/TestPayloadTermQuery.cs
@@ -119,7 +119,7 @@ namespace Lucene.Net.Search.Payloads
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
@@ -129,7 +129,7 @@ namespace Lucene.Net.Search.Spans
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Reader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestBasics.cs
@@ -97,7 +97,7 @@ namespace Lucene.Net.Search.Spans
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             SimplePayloadAnalyzer = new AnalyzerAnonymousInnerClassHelper();

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
@@ -78,7 +78,7 @@ namespace Lucene.Net.Search.Spans
             Searcher = NewSearcher(Reader);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Searcher = null;

--- a/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/Spans/TestFieldMaskingSpanQuery.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Search.Spans
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBoolean2.cs
@@ -120,7 +120,7 @@ namespace Lucene.Net.Search
             riw.Dispose();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Reader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because NewStringField is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             string[] data = new string[] { "A 1 2 3 4 5 6", "Z       4 5 6", null, "B   2   4 5 6", "Y     3   5 6", null, "C     3     6", "X       4 5 6" };

--- a/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestBooleanMinShouldMatch.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Search
             //System.out.println("Set up " + getName());
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             s = null;

--- a/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Search
     public class TestDateFilter : LuceneTestCase
     {
         ///
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public virtual void TestBefore()
         {
             // create an index

--- a/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDateFilter.cs
@@ -105,7 +105,7 @@ namespace Lucene.Net.Search
         }
 
         ///
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public virtual void TestAfter()
         {
             // create an index

--- a/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Search
         // same contents, but no field boost
         public const string ALTFIELD = "alt";
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClassTestExplanations()
         {
             Searcher = null;

--- a/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestExplanations.cs
@@ -78,7 +78,7 @@ namespace Lucene.Net.Search
         /// Is non-static because NewIndexWriterConfig, NewTextField and
         /// NewStringField are no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClassTestExplanations()
         {
             Directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestFieldCache.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestFieldCache.cs
@@ -101,7 +101,7 @@ namespace Lucene.Net.Search
 
 
         // LUCENENET: Changed to non-static because NewIndexWriterConfig is non-static
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             NUM_DOCS = AtLeast(500);

--- a/src/Lucene.Net.Tests/core/Search/TestFieldCache.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestFieldCache.cs
@@ -165,7 +165,7 @@ namespace Lucene.Net.Search
             writer.Dispose();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Reader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
@@ -111,7 +111,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             atomicReader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMinShouldMatch2.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Dir = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestMultiTermConstantScore.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiTermConstantScore.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             string[] data = new string[] { "A 1 2 3 4 5 6", "Z       4 5 6", null, "B   2   4 5 6", "Y     3   5 6", null, "C     3     6", "X       4 5 6" };

--- a/src/Lucene.Net.Tests/core/Search/TestMultiTermConstantScore.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiTermConstantScore.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Search
             writer.Dispose();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Reader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
@@ -83,7 +83,7 @@ namespace Lucene.Net.Search
             MultiSearcherDupls = NewSearcher(MultiReaderDupls);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Reader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestMultiTermQueryRewrites.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Dir = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNGramPhraseQuery.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Search
             Reader = DirectoryReader.Open(Directory);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Reader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery32.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery32.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             NoDocs = AtLeast(4096);

--- a/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery32.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery32.cs
@@ -134,7 +134,7 @@ namespace Lucene.Net.Search
             writer.Dispose();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Searcher = null;

--- a/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery64.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery64.cs
@@ -143,7 +143,7 @@ namespace Lucene.Net.Search
             writer.Dispose();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Searcher = null;

--- a/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery64.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestNumericRangeQuery64.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             NoDocs = AtLeast(4096);

--- a/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Search
         private PhraseQuery Query;
         private static Directory Directory;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPhraseQuery.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Search
             Query = new PhraseQuery();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Searcher = null;

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestPrefixInBooleanQuery.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Search
             writer.Dispose();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Searcher = null;

--- a/src/Lucene.Net.Tests/core/Search/TestSubScorerFreqs.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSubScorerFreqs.cs
@@ -59,7 +59,7 @@ namespace Lucene.Net.Search
             w.Dispose();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void Finish()
         {
             s.IndexReader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestSubScorerFreqs.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestSubScorerFreqs.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Search
         private static Directory Dir;
         private static IndexSearcher s;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void MakeIndex()
         {
             Dir = new RAMDirectory();

--- a/src/Lucene.Net.Tests/core/Search/TestTermVectors.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTermVectors.cs
@@ -93,7 +93,7 @@ namespace Lucene.Net.Search
             writer.Dispose();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public static void AfterClass()
         {
             Reader.Dispose();

--- a/src/Lucene.Net.Tests/core/Search/TestTermVectors.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestTermVectors.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void BeforeClass()
         {
             Directory = NewDirectory();

--- a/src/Lucene.Net.Tests/core/Support/TestLurchTable.cs
+++ b/src/Lucene.Net.Tests/core/Support/TestLurchTable.cs
@@ -504,7 +504,7 @@ namespace Lucene.Net.Support
             VerifyCollection(EqualityComparer<string>.Default, values.AsReadOnly(), dict.Values);
         }
 
-        [Test, ExpectedException(typeof(ObjectDisposedException))]
+        [Test]
         public void TestDisposed()
         {
             IDictionary<int, string> test = new LurchTableTest<int, string>();
@@ -513,7 +513,7 @@ namespace Lucene.Net.Support
             {
                 disposable.Dispose();
             }
-            test.Add(1, "");
+            Assert.Throws<ObjectDisposedException>(() => test.Add(1, ""));
         }
 
         class KeyValueEquality<TKey, TValue> : IEqualityComparer<KeyValuePair<TKey, TValue>>

--- a/src/Lucene.Net.Tests/core/Support/TestWeakDictionaryPerformance.cs
+++ b/src/Lucene.Net.Tests/core/Support/TestWeakDictionaryPerformance.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Support
                 dictionary.Add(key, "value");
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestSetup()
         {
             keys = new SmallObject[100000];

--- a/src/Lucene.Net.Tests/core/TestWorstCaseTestBehavior.cs
+++ b/src/Lucene.Net.Tests/core/TestWorstCaseTestBehavior.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net
 
     public class TestWorstCaseTestBehavior : LuceneTestCase
     {
-        [Ignore]
+        [Ignore("Ignored test: TestThreadLeak")]
         [Test]
         public virtual void TestThreadLeak()
         {
@@ -62,7 +62,7 @@ namespace Lucene.Net
             }
         }
 
-        [Ignore]
+        [Ignore("Ignored: TestLaaaaaargeOutput")]
         [Test]
         public virtual void TestLaaaaaargeOutput()
         {
@@ -81,7 +81,7 @@ namespace Lucene.Net
         }
 
 
-        [Ignore]
+        [Ignore("TestProgressiveOutput")]
         [Test]
         public virtual void TestProgressiveOutput()
         {
@@ -95,7 +95,7 @@ namespace Lucene.Net
             }
         }
 
-        [Ignore]
+        [Ignore("Ignored: TestUncaughtException")]
         [Test]
         public virtual void TestUncaughtException()
         {
@@ -119,7 +119,7 @@ namespace Lucene.Net
             }
         }
 
-        [Ignore]
+        [Ignore("Ignored: TestTimeout")]
         [Test, Timeout(500)]
         public virtual void TestTimeout()
         {
@@ -127,7 +127,7 @@ namespace Lucene.Net
         }
 
 
-        [Ignore]
+        [Ignore("Ignored: TestZombie")]
         [Test, Timeout(1000)]
         public virtual void TestZombie()
         {

--- a/src/Lucene.Net.Tests/core/Util/Packed/TestPackedInts.cs
+++ b/src/Lucene.Net.Tests/core/Util/Packed/TestPackedInts.cs
@@ -911,7 +911,7 @@ namespace Lucene.Net.Util.Packed
         }
 
         // memory hole
-        [Ignore]
+        [Ignore("memory hole")]
         [Test]
         public virtual void TestPagedGrowableWriterOverflow()
         {

--- a/src/Lucene.Net.Tests/core/Util/StressRamUsageEstimator.cs
+++ b/src/Lucene.Net.Tests/core/Util/StressRamUsageEstimator.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Util
         }
 
         // this shows an easy stack overflow because we're counting recursively.
-        [Ignore]
+        [Ignore("this shows an easy stack overflow because we're counting recursively.")]
         [Test]
         public virtual void TestChainedEstimation()
         {

--- a/src/Lucene.Net.Tests/core/Util/TestBytesRefHash.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestBytesRefHash.cs
@@ -323,7 +323,6 @@ namespace Lucene.Net.Util
         }
 
         [Test]
-        [ExpectedException(typeof(MaxBytesLengthExceededException))]
         public virtual void TestLargeValue()
         {
             int[] sizes = { Random().Next(5), ByteBlockPool.BYTE_BLOCK_SIZE - 33 + Random().Next(31), ByteBlockPool.BYTE_BLOCK_SIZE - 1 + Random().Next(37) };
@@ -333,18 +332,21 @@ namespace Lucene.Net.Util
                 @ref.Bytes = new byte[sizes[i]];
                 @ref.Offset = 0;
                 @ref.Length = sizes[i];
-                try
+                Assert.Throws<MaxBytesLengthExceededException>(() =>
                 {
-                    Assert.AreEqual(i, Hash.Add(@ref));
-                }
-                catch (MaxBytesLengthExceededException e)
-                {
-                    if (i < sizes.Length - 1)
+                    try
                     {
-                        Assert.Fail("unexpected exception at size: " + sizes[i]);
+                        Assert.AreEqual(i, Hash.Add(@ref));
                     }
-                    throw e;
-                }
+                    catch (MaxBytesLengthExceededException e)
+                    {
+                        if (i < sizes.Length - 1)
+                        {
+                            Assert.Fail("unexpected exception at size: " + sizes[i]);
+                        }
+                        throw e;
+                    }
+                });
             }
         }
 

--- a/src/Lucene.Net.Tests/core/Util/TestIndexableBinaryStringTools.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestIndexableBinaryStringTools.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Util
         private static int NUM_RANDOM_TESTS;
         private static int MAX_RANDOM_BINARY_LENGTH;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void BeforeClass()
         {
             NUM_RANDOM_TESTS = AtLeast(200);

--- a/src/Lucene.Net.Tests/core/Util/TestPagedBytes.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestPagedBytes.cs
@@ -178,7 +178,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        [Ignore] // memory hole
+        [Ignore("memory hole")] // memory hole
         [Test]
         [LongRunningTest, Timeout(120000)]
         public virtual void TestOverflow()

--- a/src/Lucene.Net.Tests/core/Util/TestPriorityQueue.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestPriorityQueue.cs
@@ -208,9 +208,9 @@ namespace Lucene.Net.Util
                 Assert.IsNotNull(b);
                 return (int) (a - b);
             }
-        } 
+        }
 
-        [Ignore] // Increase heap size to run this test
+        [Ignore("Increase heap size to run this test")] // Increase heap size to run this test
         [Test, LuceneNetSpecific]
         public static void TestMaxSizeBounds()
         {

--- a/src/Lucene.Net.Tests/core/Util/TestSetOnce.cs
+++ b/src/Lucene.Net.Tests/core/Util/TestSetOnce.cs
@@ -65,22 +65,26 @@ namespace Lucene.Net.Util
         }
 
         [Test]
-        [ExpectedException(typeof(SetOnce<int?>.AlreadySetException))]
         public virtual void TestSettingCtor()
         {
             SetOnce<int?> set = new SetOnce<int?>(new int?(5));
             Assert.AreEqual(5, (int)set.Get());
-            set.Set(new int?(7));
+            Assert.Throws<SetOnce<int?>.AlreadySetException>(() =>
+            {
+                set.Set(new int?(7));
+            });
         }
 
         [Test]
-        [ExpectedException(typeof(SetOnce<int?>.AlreadySetException))]
         public virtual void TestSetOnce_mem()
         {
             SetOnce<int?> set = new SetOnce<int?>();
             set.Set(new int?(5));
             Assert.AreEqual(5, (int)set.Get());
-            set.Set(new int?(7));
+            Assert.Throws<SetOnce<int?>.AlreadySetException>(() =>
+            {
+                set.Set(new int?(7));
+            });
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/packages.config
+++ b/src/Lucene.Net.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Updates the current test projects to NUnit 3.5.0.

* Replaces obsolete `TestFixtureSetUp` and `TestFixtureTearDown` with `OneTimeSetUp` and `OneTimeTearDown`
* Replaces `[ExpectedException]` with `Assert.Throws<T>`
* Adds a reason for [Ignore] tests because it is required now

Is there anything I need to edit in make it work in TeamCity?

PR #191 depends on this because [dotnet-test-nunit ](https://github.com/nunit/dotnet-test-nunit) uses NUnit 3.5.0
