### PR TITLE
Fixing build errors

### DIFF
--- a/src/Lucene.Net.Tests/core/Search/JustCompileSearch.cs
+++ b/src/Lucene.Net.Tests/core/Search/JustCompileSearch.cs
@@ -201,7 +201,7 @@ namespace Lucene.Net.Search
             {
             }
 
-            protected internal override bool Match(int docid)
+            protected override bool Match(int docid)
             {
                 throw new System.NotSupportedException(UNSUPPORTED_MSG);
             }

--- a/src/Lucene.Net.Tests/core/Search/TestDocIdSet.cs
+++ b/src/Lucene.Net.Tests/core/Search/TestDocIdSet.cs
@@ -135,7 +135,7 @@ namespace Lucene.Net.Search
                 this.OuterInstance = outerInstance;
             }
 
-            protected internal override bool Match(int docid)
+            protected override bool Match(int docid)
             {
                 return docid % 2 == 0; //validate only even docids
             }
@@ -244,7 +244,7 @@ namespace Lucene.Net.Search
                     this.OuterInstance = outerInstance;
                 }
 
-                protected internal override bool Match(int docid)
+                protected override bool Match(int docid)
                 {
                     return true;
                 }


### PR DESCRIPTION
Currently compiling master results in build errors:

```
  core\Search\JustCompileSearch.cs(204,46): error CS0507: 'JustCompileSearch.JustCompileFilteredDocIdSet.Match(int)': cannot change access modifiers when overriding 'protected' inherited member 'FilteredDocIdSet.Match(int)' [D:\git\conniey\lucenenet\src\Lucene.Net.Tests\Lucene.Net.Tests.csproj]`
```

This is due to changes in [FilteredDocIdSet](https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.Core/Search/FilteredDocIdSet.cs#L95) from: 
`protected internal abstract bool Match(int docid);` to `protected abstract bool Match(int docid);`

This fixes those errors.  An alternative would be to add the `internal` modifier back to FilteredDocIdSet.

@NightOwl888 Do you know why it was removed in the first place?