### PR TITLE
Made FSDirectory stale files set synchronized.

### DIFF
--- a/src/Lucene.Net.Tests/Store/TestDirectory.cs
+++ b/src/Lucene.Net.Tests/Store/TestDirectory.cs
@@ -426,7 +426,6 @@ namespace Lucene.Net.Store
         }
 
         [Test]
-        [Ignore("Not deterministic; depends on a race condition")]
         [LuceneNetSpecific]
         public virtual void ConcurrentIndexAccessThrowsWithoutSynchronizedStaleFiles()
         {

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;// Used only for WRITE_LOCK_NAME in deprecated create=true case:
+using Lucene.Net.Support;
 
 namespace Lucene.Net.Store
 {
@@ -91,7 +92,7 @@ namespace Lucene.Net.Store
         public const int DEFAULT_READ_CHUNK_SIZE = 8192;
 
         protected readonly DirectoryInfo m_directory; // The underlying filesystem directory
-        protected readonly ISet<string> m_staleFiles = new HashSet<string>(); // Files written, but not yet sync'ed
+        protected readonly ISet<string> m_staleFiles = new ConcurrentHashSet<string>(); // Files written, but not yet sync'ed
 #pragma warning disable 612, 618
         private int chunkSize = DEFAULT_READ_CHUNK_SIZE;
 #pragma warning restore 612, 618


### PR DESCRIPTION
`FSDirectory` has a hash set to track stale files. In the original Lucene source at e.g. https://github.com/apache/lucene-solr/blob/b7047694256a8e5808b9a9ddf480643ff768d8a9/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java#L126, this is a synchronized set. In the .NET version, it's not, causing unsynchronized access to this set.

Changed to a `Lucene.Net.Support.ConcurrentHashSet<>`.