### PR TITLE
API: Added ReferenceManager<G>.AcquireContext()

### DIFF
--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -653,6 +653,8 @@
     <Compile Include="Support\ICallable.cs" />
     <Compile Include="Support\ICharSequence.cs" />
     <Compile Include="Support\RectangularArrays.cs" />
+    <Compile Include="Support\Search\ReferenceContext.cs" />
+    <Compile Include="Support\Search\ReferenceManagerExtensions.cs" />
     <Compile Include="Support\Threading\ICompletionService.cs" />
     <Compile Include="Support\IO\IDataInput.cs" />
     <Compile Include="Support\IO\IDataOutput.cs" />

--- a/src/Lucene.Net/Support/Search/ReferenceContext.cs
+++ b/src/Lucene.Net/Support/Search/ReferenceContext.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+namespace Lucene.Net.Search
+{
+    /*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+    /// <summary>
+    /// <see cref="ReferenceContext{T}"/> holds a reference instance and
+    /// ensures it is properly de-referenced from its corresponding <see cref="ReferenceManager{G}"/>
+    /// when <see cref="Dispose()"/> is called. This class is primarily intended
+    /// to be used with a using block.
+    /// <para/>
+    /// LUCENENET specific
+    /// </summary>
+    /// <typeparam name="T">The reference type</typeparam>
+    public class ReferenceContext<T> : IDisposable
+        where T : class
+    {
+        private readonly ReferenceManager<T> referenceManager;
+        private T reference;
+
+        internal ReferenceContext(ReferenceManager<T> referenceManager)
+        {
+            this.referenceManager = referenceManager;
+            this.reference = referenceManager.Acquire();
+        }
+
+        /// <summary>
+        /// The reference acquired from the <see cref="ReferenceManager{G}"/>.
+        /// </summary>
+        public T Reference
+        {
+            get { return reference; }
+        }
+
+        /// <summary>
+        /// Ensures the reference is properly de-referenced from its <see cref="ReferenceManager{G}"/>.
+        /// After this call, <see cref="Reference"/> will be <c>null</c>.
+        /// </summary>
+        public void Dispose()
+        {
+            if (this.reference != null)
+            {
+                this.referenceManager.Release(this.reference);
+                this.reference = null;
+            }
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Search/ReferenceManagerExtensions.cs
+++ b/src/Lucene.Net/Support/Search/ReferenceManagerExtensions.cs
@@ -1,0 +1,47 @@
+﻿namespace Lucene.Net.Search
+{
+    /*
+	 * Licensed to the Apache Software Foundation (ASF) under one or more
+	 * contributor license agreements.  See the NOTICE file distributed with
+	 * this work for additional information regarding copyright ownership.
+	 * The ASF licenses this file to You under the Apache License, Version 2.0
+	 * (the "License"); you may not use this file except in compliance with
+	 * the License.  You may obtain a copy of the License at
+	 *
+	 *     http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 * See the License for the specific language governing permissions and
+	 * limitations under the License.
+	 */
+
+    public static class ReferenceManagerExtensions
+    {
+        /// <summary>
+        /// Obtain the current reference.
+        /// <para/>
+        /// Like <see cref="ReferenceManager{G}.Acquire()"/>, but intended for use in a using
+        /// block so calling <see cref="ReferenceManager{G}.Release(G)"/> happens implicitly.
+        /// For example:
+        /// <para/>
+        /// <code>
+        /// var searcherManager = new SearcherManager(indexWriter, true, null);
+        /// using (var context = searcherManager.AcquireContext())
+        /// {
+        ///     IndexSearcher searcher = context.Reference;
+        ///     
+        ///     // use searcher...
+        /// }
+        /// </code>
+        /// </summary>
+        /// <typeparam name="T">The reference type</typeparam>
+        /// <param name="referenceManager">this <see cref="ReferenceManager{G}"/></param>
+        /// <returns>A <see cref="ReferenceContext{T}"/> instance that holds the <see cref="ReferenceContext{T}.Reference"/> and ensures it is released properly when <see cref="ReferenceContext{T}.Dispose()"/> is called.</returns>
+        public static ReferenceContext<T> AcquireContext<T>(this ReferenceManager<T> referenceManager) where T : class
+        {
+            return new ReferenceContext<T>(referenceManager);
+        }
+    }
+}


### PR DESCRIPTION
Opening this as a pull request so the team can discuss this approach vs the previous `ExecuteSearch` method (that was inadvertently removed from the API).

## AcquireContext Example

```c#
var searcherManager = new SearcherManager(indexWriter, true, null);
using (var context = searcherManager.AcquireContext())
{
	IndexSearcher searcher = context.Reference;
	var topDocs = searcher.Search(query, 10);

       // use results...
}
```

### Pros

1. Eliminates the try-finally block.
2. Doesn't swallow exceptions by default.
3. Implicitly cleans up.
4. Since the extension method is on `ReferenceManager<G>`, all of its subclasses automatically gain this functionality.

### Cons

1. If the user forgets the using block, cleanup is not automatic.

## ExecuteSearch Example
```c#
var searcherManager = new SearcherManager(indexWriter, true, null);
searcherManager.ExecuteSearch(searcher =>
{
	var topDocs = searcher.Search(query, 10);

       // use results...
}, exception => { Console.WriteLine(exception.ToString()); });
```

### Pros

1. Eliminates the try-finally block.
2. Implicitly cleans up.
3. `ExecuteSearch` name makes it easier to find on the API.
4. The user doesn't need to remember any special syntax to clean up.

### Cons

1. Swallows exceptions by default. To make the exception bubble, you have to re-throw it.
2. API only applies to SearcherManager, so similar code needs to be repeated for other `ReferenceManager<G>` subclasses.

### Discussion

Although the `ExecuteSearch` method is well named and thus easier to find on the API, it has the disadvantage of swallowing exceptions by default. Exceptions do not automatically bubble - you have to re-throw the exception (in which case performance suffers and you lose the stack trace). Its main advantage is that there is no way for the user to accidentally forget to clean up.

The pattern seems to lend itself better to a using block. If all code examples are shown with a using block the user is not likely to forget it. However, admittedly, `AcquireContext` and `context.Reference` are probably not the most intuitive names (I was torn between `Context` or `Holder` for the name, but there might be a better choice than either of those). `context.Reference` was chosen because `ReferenceContext` is the name of the generic class that holds the reference and it applies to all subclasses of `ReferenceManager<G>`. Of course, the original API was named `Acquire()`, so it seems logical to use `AcquireContext()` or `AcquireHolder()` or something along those lines. Ideas welcome.