### PR TITLE
fix null reference exception in mono on linux

### DIFF
--- a/src/Lucene.Net/Lucene.Net.project.json
+++ b/src/Lucene.Net/Lucene.Net.project.json
@@ -4,5 +4,8 @@
   },  
   "frameworks": {
     "net451": {}
+  },
+  "dependencies": {
+    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
   }
 }

--- a/src/Lucene.Net/Util/Constants.cs
+++ b/src/Lucene.Net/Util/Constants.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 #if NETSTANDARD
 using System.Runtime.InteropServices;
 #else
@@ -226,12 +227,9 @@ namespace Lucene.Net.Util
 #endif
                 }
 				
-#if NETSTANDARD
                 if (variable == "PROCESSOR_ARCHITECTURE") {
-                    
                     return RuntimeInformation.OSArchitecture.ToString();
                 }
-#endif
 
                 if (variable == "RUNTIME_VERSION")
                 {


### PR DESCRIPTION
adding reference to System.Runtime.InteropServices.RuntimeInformation
using RuntimeInformation for all flavors of .Net instead of PROCESS_ARCHITECTURE environment variable