### PR TITLE
LUCENENET-469 - enumerables

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# Code Files
+[*.{cs,csx}]
+indent_style = space
+trim_trailing_whitespace = true
+csharp_style_var_for_built_in_types = true:suggestion

--- a/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
+++ b/src/Lucene.Net.Tests/Lucene.Net.Tests.csproj
@@ -524,6 +524,7 @@
     <Compile Include="Support\IO\TestStreamTokenizer.cs" />
     <Compile Include="Support\SmallObject.cs" />
     <Compile Include="Support\TestDictionaryExtensions.cs" />
+    <Compile Include="Support\TestEnumEnumerator.cs" />
     <Compile Include="Support\TestPriorityQueue.cs" />
     <Compile Include="Support\TestStringTokenizer.cs" />
     <Compile Include="Support\Threading\TestCloseableThreadLocal.cs" />

--- a/src/Lucene.Net.Tests/Support/TestEnumEnumerator.cs
+++ b/src/Lucene.Net.Tests/Support/TestEnumEnumerator.cs
@@ -1,0 +1,73 @@
+﻿/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+using System.Linq;
+using Lucene.Net.Analysis.Core;
+using Lucene.Net.Attributes;
+using Lucene.Net.Documents;
+using Lucene.Net.Index;
+using Lucene.Net.Store;
+using Lucene.Net.Util;
+using NUnit.Framework;
+
+#pragma warning disable 612, 618
+namespace Lucene.Net.Tests.Support
+{
+    [TestFixture]
+    public class TestEnumEnumerator : LuceneTestCase
+    {
+        [Test, LuceneNetSpecific]
+        public void TestTermsEnum()
+        {
+            BaseDirectory dir;
+
+            using (dir = new RAMDirectory())
+            {
+                Document doc;
+                IndexWriter writer;
+                IndexReader reader;
+                IndexWriterConfig conf = new IndexWriterConfig(
+                    Util.LuceneVersion.LUCENE_CURRENT,
+                    new WhitespaceAnalyzer(Util.LuceneVersion.LUCENE_CURRENT));
+
+                using (writer = new IndexWriter(dir, conf /*new WhitespaceAnalyzer(), true, IndexWriter.MaxFieldLength.UNLIMITED)*/))
+                {
+                    Field field = new TextField("name", "value", Field.Store.YES /*,Field.Index.ANALYZED*/);
+                    doc = new Document();
+                    doc.Add(field);
+                    writer.AddDocument(doc);
+                    writer.Commit();
+
+                    using (reader = writer.GetReader())
+                    {
+                        Terms terms = MultiFields.GetTerms(reader, "name");
+                        foreach (var bref in terms.GetIterator(null))
+                        {
+                            Assert.IsNotNull(bref);
+                        }
+                        Assert.AreEqual(1, terms.GetIterator(null).Count());
+                    }
+                }
+            }
+        }
+    }
+}
+#pragma warning restore 612, 618

--- a/src/Lucene.Net/Index/TermsEnum.cs
+++ b/src/Lucene.Net/Index/TermsEnum.cs
@@ -24,6 +24,8 @@ namespace Lucene.Net.Index
     using AttributeSource = Lucene.Net.Util.AttributeSource;
     using IBits = Lucene.Net.Util.IBits;
     using BytesRef = Lucene.Net.Util.BytesRef;
+    using System.Collections;
+    using Lucene.Net.Support;
 
     /// <summary>
     /// Iterator to seek (<see cref="SeekCeil(BytesRef)"/>, 
@@ -46,7 +48,7 @@ namespace Lucene.Net.Index
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
-    public abstract class TermsEnum : IBytesRefIterator
+    public abstract class TermsEnum : IBytesRefIterator, IEnumerable<BytesRef>
     {
         public abstract IComparer<BytesRef> Comparer { get; } // LUCENENET specific - must supply implementation for the interface
 
@@ -250,6 +252,16 @@ namespace Lucene.Net.Index
         public virtual TermState GetTermState() // LUCENENET NOTE: Renamed from TermState()
         {
             return new TermStateAnonymousInnerClassHelper(this);
+        }
+
+        public IEnumerator<BytesRef> GetEnumerator()
+        {
+            return EnumEnumerator<BytesRef>.CreateWithCapturedNext(Next);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
 
         private class TermStateAnonymousInnerClassHelper : TermState

--- a/src/Lucene.Net/Index/TermsEnum.cs
+++ b/src/Lucene.Net/Index/TermsEnum.cs
@@ -1,6 +1,9 @@
-using Lucene.Net.Util;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+
+using Lucene.Net.Util;
+using Lucene.Net.Support;
 
 namespace Lucene.Net.Index
 {
@@ -24,8 +27,6 @@ namespace Lucene.Net.Index
     using AttributeSource = Lucene.Net.Util.AttributeSource;
     using IBits = Lucene.Net.Util.IBits;
     using BytesRef = Lucene.Net.Util.BytesRef;
-    using System.Collections;
-    using Lucene.Net.Support;
 
     /// <summary>
     /// Iterator to seek (<see cref="SeekCeil(BytesRef)"/>, 

--- a/src/Lucene.Net/Index/TermsEnum.cs
+++ b/src/Lucene.Net/Index/TermsEnum.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Index
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
-    public abstract class TermsEnum : IBytesRefIterator, IEnumerable<BytesRef>
+    public abstract class TermsEnum : IBytesRefIterator
     {
         public abstract IComparer<BytesRef> Comparer { get; } // LUCENENET specific - must supply implementation for the interface
 

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -398,6 +398,7 @@
     <Compile Include="Support\Document\DocumentExtensions.cs" />
     <Compile Include="Support\Document\Field.cs" />
     <Compile Include="Support\Document\IndexableFieldExtensions.cs" />
+    <Compile Include="Support\EnumEnumerator.cs" />
     <Compile Include="Support\IO\Compression\LZOCompressor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Search\AutomatonQuery.cs" />

--- a/src/Lucene.Net/Support/EnumEnumerator.cs
+++ b/src/Lucene.Net/Support/EnumEnumerator.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Lucene.Net.Support
+{
+    public class EnumEnumerator<T> : IEnumerator<T>, IEnumerable<T>
+    {
+        public static EnumEnumerator<T> CreateWithCapturedNext(Func<T> next)
+        {
+            T current = default(T);
+            return new EnumEnumerator<T>(() => { current = next(); return current != null; }, () => current);
+        }
+
+        private readonly Func<bool> next;
+        private readonly Action dispose;
+        private readonly Func<T> currentFactory;
+
+        private bool started = false;
+
+        public EnumEnumerator(Func<bool> next, Func<T> currentFactory, Action dispose = null)
+        {
+            this.next = next;
+            this.dispose = dispose;
+            this.currentFactory = currentFactory;
+        }
+
+        public T Current => started ? currentFactory() : default(T);
+
+        object IEnumerator.Current => Current;
+
+        public bool MoveNext() => (started = next());
+
+        public void Reset() => throw new NotImplementedException();
+
+        public void Dispose() => dispose?.Invoke();
+
+        public IEnumerator<T> GetEnumerator() => this;
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Lucene.Net/Support/EnumEnumerator.cs
+++ b/src/Lucene.Net/Support/EnumEnumerator.cs
@@ -4,6 +4,27 @@ using System.Collections.Generic;
 
 namespace Lucene.Net.Support
 {
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Helper class to facilitate dotnet enumerables
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     public class EnumEnumerator<T> : IEnumerator<T>, IEnumerable<T>
     {
         public static EnumEnumerator<T> CreateWithCapturedNext(Func<T> next)

--- a/src/Lucene.Net/Util/BytesRefArray.cs
+++ b/src/Lucene.Net/Util/BytesRefArray.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Lucene.Net.Support;
 
 namespace Lucene.Net.Util
 {
@@ -236,6 +238,16 @@ namespace Lucene.Net.Util
                 {
                     return comp;
                 }
+            }
+
+            public IEnumerator<BytesRef> GetEnumerator()
+            {
+                return EnumEnumerator<BytesRef>.CreateWithCapturedNext(Next);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
             }
         }
     }

--- a/src/Lucene.Net/Util/BytesRefIterator.cs
+++ b/src/Lucene.Net/Util/BytesRefIterator.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using Lucene.Net.Support;
 
 namespace Lucene.Net.Util
 {
@@ -22,7 +25,7 @@ namespace Lucene.Net.Util
     /// <summary>
     /// A simple iterator interface for <see cref="BytesRef"/> iteration.
     /// </summary>
-    public interface IBytesRefIterator
+    public interface IBytesRefIterator : IEnumerable<BytesRef>
     {
         /// <summary>
         /// Increments the iteration to the next <see cref="BytesRef"/> in the iterator.
@@ -71,6 +74,16 @@ namespace Lucene.Net.Util
             public IComparer<BytesRef> Comparer
             {
                 get { return null; }
+            }
+
+            public IEnumerator<BytesRef> GetEnumerator()
+            {
+                return new EnumEnumerator<BytesRef>(() => false, () => null);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
             }
         }
     }

--- a/src/Lucene.Net/Util/BytesRefIterator.cs
+++ b/src/Lucene.Net/Util/BytesRefIterator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+
 using Lucene.Net.Support;
 
 namespace Lucene.Net.Util


### PR DESCRIPTION
See https://issues.apache.org/jira/projects/LUCENENET/issues/LUCENENET-469 for background.

This is an early stage proposal for implementing IEnumerable<T> on various "Enum" types. To enable `foreach` and linq style operators.

This prototype provides `EnumEnumerator<T>` as a helper. It can be used in various ways to make the implementation of `IEnumerable<T>` more straightforward.

I have modified `IBytesRefIterator` and `TermsEnum` to add `IEnumerable<BytesRef>` and therefore to all of it's descendants.

The test (such as it is) demonstrates retrieving a `TermsEnum` from a reader. Then using `foreach` and a simple `.Count()` linq operator.

If this approach is acceptable it ought to be adaptable to other Enum types