### PR TITLE
remove redundant termAtt initialization in UpperCaseFilter constructor

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Core/UpperCaseFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Core/UpperCaseFilter.cs
@@ -47,7 +47,6 @@ namespace Lucene.Net.Analysis.Core
             : base(@in)
         {
             termAtt = AddAttribute<ICharTermAttribute>();
-            termAtt = AddAttribute<ICharTermAttribute>();
             charUtils = CharacterUtils.GetInstance(matchVersion);
         }
 


### PR DESCRIPTION
Constructor of UpperCaseFilter has duplicated initalization code for termAttr field.
I have modified UpperCaseFilter constructor by removing duplicate.