### PR TITLE
Add support for netstandard2.0 for Queries and SandBox

### DIFF
--- a/src/Lucene.Net.Queries/Lucene.Net.Queries.csproj
+++ b/src/Lucene.Net.Queries/Lucene.Net.Queries.csproj
@@ -24,7 +24,7 @@
   <Import Project="..\..\Version.proj" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
 
     <AssemblyTitle>Lucene.Net.Queries</AssemblyTitle>
@@ -51,9 +51,9 @@
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />
   </ItemGroup>
 
-  <!--<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DebugType>portable</DebugType>
-  </PropertyGroup>-->
+  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <DebugType>portable</DebugType>

--- a/src/Lucene.Net.Sandbox/Lucene.Net.Sandbox.csproj
+++ b/src/Lucene.Net.Sandbox/Lucene.Net.Sandbox.csproj
@@ -24,7 +24,7 @@
   <Import Project="..\..\Version.proj" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
 
     <AssemblyTitle>Lucene.Net.Sandbox</AssemblyTitle>
@@ -51,9 +51,9 @@
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />
   </ItemGroup>
 
-  <!--<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DebugType>portable</DebugType>
-  </PropertyGroup>-->
+  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <DebugType>portable</DebugType>


### PR DESCRIPTION
I was trying to use Lucene.Net on a side project with Net Core 2 and Blazor for front end.
I needed the Queries and QueryParser (which requires SandBox). Those 2 libraries are were not built for netstandard2.0, now they work.