### PR TITLE
Fixed TestThreadInterruptDeadlock and TestTwoThreadsInterruptDeadlock

### DIFF
--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -580,7 +580,11 @@ namespace Lucene.Net.Store
         {
             if (RandomState.NextBoolean())
             {
+#if NETSTANDARD1_6
                 Thread.Sleep(0);
+#else
+                Thread.Yield();
+#endif
             }
         }
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
@@ -1350,7 +1350,7 @@ namespace Lucene.Net.Index
                         Console.WriteLine("TEST: now rollback");
                     }
                     // clear interrupt state:
-                    //Thread.interrupted();
+                    ThreadClass.Interrupted();
                     if (w != null)
                     {
                         try
@@ -1438,10 +1438,6 @@ namespace Lucene.Net.Index
 #endif
 #endif
 
-#if NETCOREAPP2_0
-            fail("LUCENENET TODO: Uncaught exceptions on background thread causing test runner crash");
-#endif
-
             IndexerThreadInterrupt t = new IndexerThreadInterrupt(this);
             t.SetDaemon(true);
             t.Start();
@@ -1484,10 +1480,6 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestTwoThreadsInterruptDeadlock()
         {
-#if NETCOREAPP2_0
-            fail("LUCENENET TODO: Uncaught exceptions on background thread causing test runner crash");
-#endif
-
             IndexerThreadInterrupt t1 = new IndexerThreadInterrupt(this);
             t1.SetDaemon(true);
             t1.Start();

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Support;
+using Lucene.Net.Support.Threading;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -1180,9 +1181,7 @@ namespace Lucene.Net.Index
                     try
                     {
                         // clean up merge scheduler in all cases, although flushing may have failed:
-                        //interrupted = Thread.Interrupted();
-                        //LUCENE TO-DO
-                        interrupted = false;
+                        interrupted = ThreadClass.Interrupted();
 
                         if (waitForMerges)
                         {

--- a/src/Lucene.Net/Support/Threading/ThreadClass.cs
+++ b/src/Lucene.Net/Support/Threading/ThreadClass.cs
@@ -300,6 +300,25 @@ namespace Lucene.Net.Support.Threading
             return This;
         }
 
+        /// <summary>
+        /// LUCENENET specific.
+        /// Java has Thread.interrupted() which returns, and clears, the interrupt
+        /// flag of the current thread. .NET has no such method, so we're calling
+        /// Thread.Sleep to provoke the exception which will also clear the flag.
+        /// </summary>
+        /// <returns></returns>
+        internal static bool Interrupted() {
+#if !NETSTANDARD1_6
+            try {
+                Thread.Sleep(0);
+            } catch (ThreadInterruptedException) {
+                return true;
+            }
+#endif
+
+            return false;
+        }
+
         public static bool operator ==(ThreadClass t1, object t2)
         {
             if (((object)t1) == null) return t2 == null;


### PR DESCRIPTION
This fixes the TestThreadInterruptDeadlock  and TestTwoThreadsInterruptDeadlock.

I've added a ThreadClass::interrupted() to match Java's Thread.interrupted(). Most of the issues seems related to the interrupt flag not being cleared, which will cause a ThreadInterruptedException next time the thread blocks.

Changing MaybeYield to actually yield seems to be needed to avoid some ThreadInterruptedException. It makes sense in my head, since a yield isn't a block and thus an exception isn't thrown, but I have no documentation or evidence that this argument actually holds true. Anyhow, changing to yield matches the Java behavior, so I think this is the correct behavior.