### PR TITLE
Fixes LUCENENET-597

### DIFF
--- a/src/Lucene.Net.Tests/Search/Spans/TestSpans.cs
+++ b/src/Lucene.Net.Tests/Search/Spans/TestSpans.cs
@@ -554,6 +554,22 @@ namespace Lucene.Net.Search.Spans
             Assert.AreEqual(0, SpanCount("s3", "s1", 8, 8), "SpanNotS3NotS1_8_8");
         }
 
+        [Test]
+        [Description("LUCENENET-597")]
+        public void TestToString_LUCENENET_597()
+        {
+            var clauses = new[]
+            {
+                new SpanTermQuery(new Term("f", "lucene")),
+                new SpanTermQuery(new Term("f", "net")),
+                new SpanTermQuery(new Term("f", "solr"))
+            };
+            var query = new SpanNearQuery(clauses, 0, true);
+            var queryString = query.ToString();
+
+            Assert.AreEqual("SpanNear([f:lucene, f:net, f:solr], 0, True)", queryString);
+        }
+
         private int SpanCount(string include, string exclude, int pre, int post)
         {
             SpanTermQuery iq = new SpanTermQuery(new Term(field, include));

--- a/src/Lucene.Net/Search/Spans/SpanNearQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanNearQuery.cs
@@ -134,11 +134,11 @@ namespace Lucene.Net.Search.Spans
             while (i.MoveNext())
             {
                 SpanQuery clause = i.Current;
-                buffer.Append(clause.ToString(field));
                 if (!isFirst)
                 {
                     buffer.Append(", ");
                 }
+                buffer.Append(clause.ToString(field));
                 isFirst = false;
             }
             buffer.Append("], ");


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/LUCENENET-597, a formatting issue of the output from SpanNearQuery.ToString().