### PR TITLE
Website updates - DOAP file and copy changes

### DIFF
--- a/websites/apidocs/docfx.json
+++ b/websites/apidocs/docfx.json
@@ -304,7 +304,7 @@
       "_appFaviconPath": "logo/favicon.ico",
       "_enableSearch": true,
       "_appLogoPath": "logo/lucene-net-color.png",
-      "_appFooter": "Copyright © 2018 Licensed to the Apache Software Foundation (ASF)"
+      "_appFooter": "Copyright © 2019 Licensed to the Apache Software Foundation (ASF)"
     },
     "overwrite": [
       {

--- a/websites/apidocs/toc.yml
+++ b/websites/apidocs/toc.yml
@@ -5,4 +5,4 @@
   href: ../../src/dotnet/tools/lucene-cli/docs/
   topicHref: ../../src/dotnet/tools/lucene-cli/docs/index.md
 - name: Lucene.Net Website
-  href: https://lucenenetsite.azurewebsites.net
+  href: https://lucenenet.apache.org/

--- a/websites/site/contributing/documentation.md
+++ b/websites/site/contributing/documentation.md
@@ -6,13 +6,19 @@ Documentation & Website
 
 ---------------
 
-_If you wish to help out with this website and the API documentation site, here's some info that you'll need_
+_Details about this website and the API documentation site and how to help contribute to them_
+
+## Overview
+
+The website and the api documentation source code is found in the same Git repository as the Lucene.Net code in the folder: `/websites/`. The site is built with a static site generator called [DocFx](https://dotnet.github.io/docfx/) and all of the content/pages are created using Markdown files.
+
+To submit changes for the website, create a Pull Request to the [Lucene Git repositoriy](https://github.com/apache/lucenenet). (See [Contributing](xref:contributing#submit-a-pull-request) for details)
 
 ## Website
 
-The website source code is found in the same Git repository as the Lucene.Net code in the folder: `/websites/site`. The site is built with a static site generator called [DocFx](https://dotnet.github.io/docfx/) and all of the content/pages are created using Markdown files.
+To build the website and run it on your machine, run the powershell script: `/websites/site/site.ps1`. You don't have to pass any parameters in and it will build the site and host it at [http://localhost:8080](http://localhost:8080). 
 
-To build the website and run it on your machine, run the powershell script: `/websites/site/site.ps1`. You don't have to pass any parameters in and it will build the site and host it at [http://localhost:8080](http://localhost:8080). There are 2 parameters that you can use:
+The script has 2 optional parameters:
 
 * `-ServeDocs` _(default is 1)_ The value of `1` means it will build the docs and host the site, if `0` is specified, it will build the static site to be hosted elsewhere.
 * `-Clean` _(default is 0)_ The value of `1` means that it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occuring with the incremental build.
@@ -21,9 +27,28 @@ The file/folder structure is within `/websites/site`:
 
 * `site.ps1` - the build script
 * `docfx.json` - the DocFx configuration file _(see docfx manual for further info)_
+* `lucenetemplate/*` - the custom template files to style the website
 * `*.md` - the root site content such as the index and download pages
 * `toc.yml` - these files determine the menu structures _(see docfx manual for further info)_
 * `contributing/*` - the Contributing section
+* `tools/*` - during the build process some tools will be downloaded which are stored here
+* `_site` - this is the exported static site that is generated
+
+## API Docs
+
+To build the api docs and run it on your machine, run the powershell script: `/websites/apidocs/docs.ps1`. You don't have to pass any parameters in and it will build the site and host it at [http://localhost:8080](http://localhost:8080). 
+
+The script has 2 optional parameters:
+
+* `-ServeDocs` _(default is 1)_ The value of `1` means it will build the docs and host the site, if `0` is specified, it will build the static site to be hosted elsewhere.
+* `-Clean` _(default is 0)_ The value of `1` means that it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occuring with the incremental build.
+
+The file/folder structure is within `/websites/apidocs`:
+
+* `docs.ps1` - the build script
+* `docfx.json` - the DocFx configuration file _(see docfx manual for further info)_
 * `lucenetemplate/*` - the custom template files to style the website
+* `*.md` - the root site content such as the index and download pages
+* `toc.yml` - these files determine the menu structures _(see docfx manual for further info)_
 * `tools/*` - during the build process some tools will be downloaded which are stored here
 * `_site` - this is the exported static site that is generated

--- a/websites/site/contributing/toc.yml
+++ b/websites/site/contributing/toc.yml
@@ -6,7 +6,7 @@
   href: issue-tracker.md
 - name: Wiki
   href: wiki.md
-- name: Documentation
+- name: Website & Docs
   href: documentation.md
 - name: Current status
   href: current-status.md

--- a/websites/site/docfx.json
+++ b/websites/site/docfx.json
@@ -20,6 +20,12 @@
           "logo/lucene-net-reverse-color.png"
         ],
         "src": "../../branding"
+      },
+      {
+        "files": [
+          "doap_Lucene_Net.rdf"
+        ],
+        "src": "lucenetemplate"
       }
     ],
     "globalMetadata": {

--- a/websites/site/lucenetemplate/doap_Lucene_Net.rdf
+++ b/websites/site/lucenetemplate/doap_Lucene_Net.rdf
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="http://lucenenet.apache.org/">
+    <created>2014-04-14</created>
+    <license rdf:resource="http://usefulinc.com/doap/licenses/asl20" />
+    <name>Apache Lucene.Net</name>
+    <homepage rdf:resource="http://lucenenet.apache.org/" />
+    <asfext:pmc rdf:resource="http://lucenenet.apache.org" />
+    <shortdesc>Lucene.Net is a port of the Lucene search engine library, written in C# and targeted at .NET runtime users.</shortdesc>
+    <description>Lucene.Net is a port of the Lucene search engine library, written in C# and targeted at .NET runtime users. The Lucene search library is based on an inverted index. Lucene.Net has three primary goals:
+
+1. Maintain the existing line-by-line port from Java to C#, fully automating and commoditizing the process such that the project can easily synchronize with the Java Lucene release schedule;
+2. Maintaining the high-performance requirements expected of a first class C# search engine library;
+3. Maximize usability and power when used within the .NET runtime. To that end, it will present a highly idiomatic, carefully tailored API that takes advantage of many of the special features of the .NET runtime.
+</description>
+    <bug-database rdf:resource="https://issues.apache.org/jira/browse/LUCENENET/" />
+    <mailing-list rdf:resource="http://lucenenet.apache.org/community.html" />
+    <download-page rdf:resource="http://lucenenet.apache.org/download.cgi" />
+    <programming-language>C#</programming-language>
+    <category rdf:resource="http://projects.apache.org/category/database" />
+    <release>
+      <Version>
+        <name>Apache Lucene.Net 3.0.3</name>
+        <created>2012-10-10</created>
+        <revision>3.0.3</revision>
+      </Version>
+    </release>
+  </Project>
+</rdf:RDF>

--- a/websites/site/lucenetemplate/index.html.tmpl
+++ b/websites/site/lucenetemplate/index.html.tmpl
@@ -31,7 +31,7 @@
                   <a href="https://stackoverflow.com/questions/tagged/lucene.net" target="_blank">
                       <i class="fa fa-stack-overflow"></i>
                   </a>
-                  <a href="download.html">
+                  <a href="download/download.html">
                       <i class="fa fa-download" target="_blank"></i>
                   </a>
               </div>


### PR DESCRIPTION
Commits some small pending changes that i forgot to previously push and adds the DOAP file to the website repo files so it's included in the build output.

If you want to test, run the powershell site build script: `/websites/site/site.ps1 -ServeDocs 0` then check the output directory `/websites/site/_site` and you'll see the `doap_Lucene_Net.rdf` there.