### PR TITLE
https://issues.apache.org/jira/browse/LUCENENET-607

### DIFF
--- a/src/Lucene.Net/Util/StringHelper.cs
+++ b/src/Lucene.Net/Util/StringHelper.cs
@@ -31,16 +31,15 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Pass this as the seed to <see cref="Murmurhash3_x86_32(byte[], int, int, int)"/>. </summary>
 
+        //Singleton-esque member. Only created once
+        public static readonly int GOOD_FAST_HASH_SEED = InitializeHashSeed();
+
         // Poached from Guava: set a different salt/seed
         // for each JVM instance, to frustrate hash key collision
         // denial of service attacks, and to catch any places that
         // somehow rely on hash function/order across JVM
         // instances:
-
-        //Singleton-esque member. Only created once
-        public static readonly int GOOD_FAST_HASH_SEED;
-
-        static StringHelper()
+        private static int InitializeHashSeed()
         {
             string prop = SystemProperties.GetProperty("tests.seed", null);
 
@@ -52,11 +51,11 @@ namespace Lucene.Net.Util
                 {
                     prop = prop.Substring(prop.Length - 8);
                 }
-                GOOD_FAST_HASH_SEED = (int)Convert.ToInt32(prop, 16);
+                return Convert.ToInt32(prop, 16);
             }
             else
             {
-                GOOD_FAST_HASH_SEED = (int)DateTime.Now.Millisecond;
+                return DateTime.Now.Millisecond;
             }
         }
 


### PR DESCRIPTION
StringHelper.GOOD_FAST_HASH_SEED property is not thread-safe and could return different values if called in severeal threads in one moment, so it could result in duplicate values in BytesRefHash (same values return different hashes because hashes were calcucated with different seeds).

There is another issue with GOOD_FAST_HASH_SEED. DateTime.Now.Millisecond is used to randomize the seed, but DateTime.Now.Millisecond could return 0 and this value is treated an "uninitialized" and the second GOOD_FAST_HASH_SEED call will return another value.