### PR TITLE
Changes the "Improve this doc" button to always point to the lucenene.net github repo

### DIFF
--- a/websites/site/docfx.json
+++ b/websites/site/docfx.json
@@ -35,7 +35,11 @@
       "_appFaviconPath": "logo/favicon.ico",
       "_enableSearch": false,
       "_appLogoPath": "logo/lucene-net-color.png",
-      "_appFooter": "Copyright © 2019 The Apache Software Foundation, Licensed under the <a href='http://www.apache.org/licenses/LICENSE-2.0' target='_blank'>Apache License, Version 2.0</a><br/> <small>Apache Lucene.Net, Lucene.Net, Apache, the Apache feather logo, and the Apache Lucene.Net project logo are trademarks of The Apache Software Foundation. <br/>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</small>"
+      "_appFooter": "Copyright © 2019 The Apache Software Foundation, Licensed under the <a href='http://www.apache.org/licenses/LICENSE-2.0' target='_blank'>Apache License, Version 2.0</a><br/> <small>Apache Lucene.Net, Lucene.Net, Apache, the Apache feather logo, and the Apache Lucene.Net project logo are trademarks of The Apache Software Foundation. <br/>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</small>",
+      "_gitContribute": {
+        "repo": "https://github.com/apache/lucenenet",
+        "branch": "master"
+      }
     },
     "dest": "_site",
     "globalMetadataFiles": [],


### PR DESCRIPTION
Currently the 'Improve this doc' button points to my own repo, it needs to point to this repo instead so this config change updates that.

I'll send another PR for the actual website update shortly with the new build.

Example:

![image](https://user-images.githubusercontent.com/1742685/55130229-2de8e180-516e-11e9-8157-3c5225a9403e.png)
