### PR TITLE
Support.IO.FileSupport::fileCanonPathCache needs to be threadsafe

### DIFF
--- a/src/Lucene.Net/Support/IO/FileSupport.cs
+++ b/src/Lucene.Net/Support/IO/FileSupport.cs
@@ -180,7 +180,7 @@ namespace Lucene.Net.Support.IO
             return Path.Combine(directory.FullName, string.Concat(prefix, randomFileName));
         }
 
-        private static readonly IDictionary<string, string> fileCanonPathCache = new ConcurrentDictionary<string, string>();
+        private static readonly ConcurrentDictionary<string, string> fileCanonPathCache = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Returns the absolute path of this <see cref="FileSystemInfo"/> with all references resolved and
@@ -299,7 +299,7 @@ namespace Lucene.Net.Support.IO
             //newResult = getCanonImpl(newResult);
             newLength = newResult.Length;
             canonPath = Encoding.UTF8.GetString(newResult, 0, newLength).TrimEnd('\0'); // LUCENENET: Eliminate null terminator char
-            fileCanonPathCache[absPath] = canonPath;
+            canonPath = fileCanonPathCache.GetOrAdd(absPath, canonPath); // It's possible that a concurrent call may have already added it to the cache.
             return canonPath;
         }
     }

--- a/src/Lucene.Net/Support/IO/FileSupport.cs
+++ b/src/Lucene.Net/Support/IO/FileSupport.cs
@@ -298,8 +298,9 @@ namespace Lucene.Net.Support.IO
             newResult[newLength] = 0;
             //newResult = getCanonImpl(newResult);
             newLength = newResult.Length;
-            canonPath = Encoding.UTF8.GetString(newResult, 0, newLength).TrimEnd('\0'); // LUCENENET: Eliminate null terminator char
-            canonPath = fileCanonPathCache.GetOrAdd(absPath, canonPath); // It's possible that a concurrent call may have already added it to the cache.
+            canonPath = fileCanonPathCache.GetOrAdd(
+                absPath,
+                k => Encoding.UTF8.GetString(newResult, 0, newLength).TrimEnd('\0')); // LUCENENET: Eliminate null terminator char
             return canonPath;
         }
     }

--- a/src/Lucene.Net/Support/IO/FileSupport.cs
+++ b/src/Lucene.Net/Support/IO/FileSupport.cs
@@ -1,5 +1,6 @@
 using Lucene.Net.Util;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -179,7 +180,7 @@ namespace Lucene.Net.Support.IO
             return Path.Combine(directory.FullName, string.Concat(prefix, randomFileName));
         }
 
-        private static readonly IDictionary<string, string> fileCanonPathCache = new Dictionary<string, string>();
+        private static readonly IDictionary<string, string> fileCanonPathCache = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Returns the absolute path of this <see cref="FileSystemInfo"/> with all references resolved and


### PR DESCRIPTION
Lucene.Net.Support.IO.FileSupport is a static class with a private static readonly dictionary used as a cache. If accessed by multiple threads, when the dictionary is resized requests will start to fail.

Reported [here](https://issues.apache.org/jira/browse/LUCENENET-609)