### PR TITLE
Add strong naming to Lucene.Net assemblies

### DIFF
--- a/Version.proj
+++ b/Version.proj
@@ -31,6 +31,9 @@
     <!-- .NET enforces AssemblyVersion as the "major" version (when strong-named),
       so AssemblyVersion should only be changed for each major version release. -->
     <AssemblyVersion>4.0.0</AssemblyVersion>
+
+    <AssemblyOriginatorKeyFile>..\..\Lucene.Net.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
 </Project>

--- a/Version.proj
+++ b/Version.proj
@@ -32,6 +32,8 @@
       so AssemblyVersion should only be changed for each major version release. -->
     <AssemblyVersion>4.0.0</AssemblyVersion>
 
+    <!-- This is the default location of Lucene.Net.snk relative to the project directory.
+      If the project is further nested from the repo root, override this value in the csproj. -->
     <AssemblyOriginatorKeyFile>..\..\Lucene.Net.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/src/CommonAssemblyKeys.cs
+++ b/src/CommonAssemblyKeys.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Reflection;
+
+namespace Lucene.Net
+{
+    internal static class AssemblyKeys
+    {
+        internal const string PublicKey =
+            "002400000480000094000000060200000024000052534131000400000100010075a07ce602f88e" +
+            "f263c7db8cb342c58ebd49ecdcc210fac874260b0213fb929ac3dcaf4f5b39744b800f99073eca" +
+            "72aebfac5f7284e1d5f2c82012a804a140f06d7d043d83e830cdb606a04da2ad5374cc92c0a495" +
+            "08437802fb4f8fb80a05e59f80afb99f4ccd0dfe44065743543c4b053b669509d29d332cd32a0c" +
+            "b1e97e84";
+    }
+}

--- a/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
+++ b/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
     <EmbeddedResource Include="Analysis\Gl\galician.rslp;Analysis\Pt\portuguese.rslp;Analysis\Compound\Hyphenation\hyphenation.dtd" />
     <EmbeddedResource Include="Analysis\**\stopwords.txt;Analysis\Snowball\*_stop.txt" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>

--- a/src/Lucene.Net.Analysis.Common/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Analysis.Common/Properties/AssemblyInfo.cs
@@ -41,7 +41,7 @@ using System.Runtime.InteropServices;
 [assembly: Guid("f57314a7-e71f-4b3c-860f-564046ca398b")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Analysis.Common")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Analysis.Common, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs
 

--- a/src/Lucene.Net.Analysis.Kuromoji/Lucene.Net.Analysis.Kuromoji.csproj
+++ b/src/Lucene.Net.Analysis.Kuromoji/Lucene.Net.Analysis.Kuromoji.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
     <EmbeddedResource Include="stoptags.txt;stopwords.txt;Dict\CharacterDefinition.dat;Dict\ConnectionCosts.dat;Dict\TokenInfoDictionary$buffer.dat;Dict\TokenInfoDictionary$fst.dat;Dict\TokenInfoDictionary$posDict.dat;Dict\TokenInfoDictionary$targetMap.dat;Dict\UnknownDictionary$buffer.dat;Dict\UnknownDictionary$posDict.dat;Dict\UnknownDictionary$targetMap.dat" />
   </ItemGroup>
 

--- a/src/Lucene.Net.Analysis.Kuromoji/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Properties/AssemblyInfo.cs
@@ -37,6 +37,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("8408625a-2508-46d5-8519-045183c43724")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Analysis.Kuromoji")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Analysis.Kuromoji, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Analysis.Phonetic/Lucene.Net.Analysis.Phonetic.csproj
+++ b/src/Lucene.Net.Analysis.Phonetic/Lucene.Net.Analysis.Phonetic.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
     <EmbeddedResource Include="Language\Bm\lang.txt;Language\dmrules.txt" />
     <EmbeddedResource Include="Language\Bm\ash_*.txt;Language\Bm\gen_*.txt;Language\Bm\sep_*.txt" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>

--- a/src/Lucene.Net.Analysis.Phonetic/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("dafe3b64-616a-4a2f-90e5-1f135e8a9af5")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Analysis.Phonetic")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Analysis.Phonetic, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Analysis.Stempel/Lucene.Net.Analysis.Stempel.csproj
+++ b/src/Lucene.Net.Analysis.Stempel/Lucene.Net.Analysis.Stempel.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
     <EmbeddedResource Include="Pl\stemmer_20000.tbl;Pl\stopwords.txt" />
   </ItemGroup>
 

--- a/src/Lucene.Net.Analysis.Stempel/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("a76dad88-e3a5-40f9-9114-facd77bd8265")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Analysis.Stempel")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Analysis.Stempel, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Benchmark/Lucene.Net.Benchmark.csproj
+++ b/src/Lucene.Net.Benchmark/Lucene.Net.Benchmark.csproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Benchmark/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Benchmark/Properties/AssemblyInfo.cs
@@ -38,6 +38,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("edc77cb4-597f-4818-8c83-3c006d12c384")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Benchmark")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Benchmark, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Demo/Lucene.Net.Demo.csproj
+++ b/src/Lucene.Net.Demo/Lucene.Net.Demo.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Demo/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Demo/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(true)]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Demo")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Demo, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Lucene.Net.Facet/Lucene.Net.Facet.csproj
+++ b/src/Lucene.Net.Facet/Lucene.Net.Facet.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Facet/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Facet/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("8dd11ab2-c5b3-4691-99da-2941f27e0e10")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Facet")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Facet, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Highlighter/Lucene.Net.Highlighter.csproj
+++ b/src/Lucene.Net.Highlighter/Lucene.Net.Highlighter.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Highlighter/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Highlighter/Properties/AssemblyInfo.cs
@@ -40,9 +40,9 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e9e769ea-8504-44bc-8dc9-ccf958765f8f")]
 
-[assembly: InternalsVisibleTo("Lucene.Net.ICU")]
+[assembly: InternalsVisibleTo("Lucene.Net.ICU, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Highlighter")]
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.ICU")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Highlighter, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.ICU, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Join/Lucene.Net.Join.csproj
+++ b/src/Lucene.Net.Join/Lucene.Net.Join.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Join/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Join/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("e8a339c7-fcf6-4a72-8586-56d8961d7b99")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Join")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Join, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Memory/Lucene.Net.Memory.csproj
+++ b/src/Lucene.Net.Memory/Lucene.Net.Memory.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Memory/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Memory/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("ca052094-4c45-44d7-9dcf-3d46ae6930fe")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Memory")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Memory, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Misc/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Misc/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("b2a3a8e1-a92a-4bd6-9f87-7747470615c3")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Misc")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Misc, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.QueryParser/Lucene.Net.QueryParser.csproj
+++ b/src/Lucene.Net.QueryParser/Lucene.Net.QueryParser.csproj
@@ -44,7 +44,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Lucene.Net.QueryParser/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.QueryParser/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("7c58cf05-89dd-4c02-a948-c28cdaf05247")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.QueryParser")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.QueryParser, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Spatial/Lucene.Net.Spatial.csproj
+++ b/src/Lucene.Net.Spatial/Lucene.Net.Spatial.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Spatial/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Spatial/Properties/AssemblyInfo.cs
@@ -38,6 +38,6 @@ using System.Security;
 [assembly: Guid("5c8e810f-4bf7-472f-9785-8d80a0de6ea8")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Spatial")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Spatial, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Suggest/Lucene.Net.Suggest.csproj
+++ b/src/Lucene.Net.Suggest/Lucene.Net.Suggest.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Suggest/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Suggest/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("0e1499f7-850e-4583-8994-623eb2480200")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Suggest")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Suggest, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.TestFramework/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.TestFramework/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5f36e3cf-82ac-4d97-af1a-6dabe60e9180")]
 
-// However, we need InternalsVisibleTo in order to prevent making everything public just for the sake of testing.
+// We need InternalsVisibleTo in order to prevent making everything public just for the sake of testing.
 // This has broad implications, though because many methods are marked "protected internal", which means other assemblies
 // must update overridden methods to match.
 [assembly: InternalsVisibleTo("Lucene.Net.Tests, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]

--- a/src/Lucene.Net.TestFramework/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.TestFramework/Properties/AssemblyInfo.cs
@@ -37,18 +37,10 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5f36e3cf-82ac-4d97-af1a-6dabe60e9180")]
 
-// for testing
-//[assembly: InternalsVisibleTo("Lucene.Net.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010075a07ce602f88e" +
-//                                                         "f263c7db8cb342c58ebd49ecdcc210fac874260b0213fb929ac3dcaf4f5b39744b800f99073eca" +
-//                                                         "72aebfac5f7284e1d5f2c82012a804a140f06d7d043d83e830cdb606a04da2ad5374cc92c0a495" +
-//                                                         "08437802fb4f8fb80a05e59f80afb99f4ccd0dfe44065743543c4b053b669509d29d332cd32a0c" +
-//                                                         "b1e97e84")]
-
-// LUCENENET NOTE: For now it is not possible to use a SNK because we have unmanaged references in Analysis.Common.
-// However, we still need InternalsVisibleTo in order to prevent making everything public just for the sake of testing.
+// However, we need InternalsVisibleTo in order to prevent making everything public just for the sake of testing.
 // This has broad implications, though because many methods are marked "protected internal", which means other assemblies
 // must update overridden methods to match.
-[assembly: InternalsVisibleTo("Lucene.Net.Tests")]
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Misc")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Misc, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/Lucene.Net.Tests/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests/Properties/AssemblyInfo.cs
@@ -31,36 +31,6 @@ using System.Runtime.CompilerServices;
 
 // NOTE: Version information is in CommonAssemblyInfo.cs
 
-//
-// In order to sign your assembly you must specify a key to use. Refer to the 
-// Microsoft .NET Framework documentation for more information on assembly signing.
-//
-// Use the attributes below to control which key is used for signing. 
-//
-// Notes: 
-//   (*) If no key is specified, the assembly is not signed.
-//   (*) KeyName refers to a key that has been installed in the Crypto Service
-//       Provider (CSP) on your machine. KeyFile refers to a file which contains
-//       a key.
-//   (*) If the KeyFile and the KeyName values are both specified, the 
-//       following processing occurs:
-//       (1) If the KeyName can be found in the CSP, that key is used.
-//       (2) If the KeyName does not exist and the KeyFile does exist, the key 
-//           in the KeyFile is installed into the CSP and used.
-//   (*) In order to create a KeyFile, you can use the sn.exe (Strong Name) utility.
-//       When specifying the KeyFile, the location of the KeyFile should be
-//       relative to the project output directory which is
-//       %Project Directory%\obj\<configuration>. For example, if your KeyFile is
-//       located in the project directory, you would specify the AssemblyKeyFile 
-//       attribute as [assembly: AssemblyKeyFile("..\\..\\mykey.snk")]
-//   (*) Delay Signing is an advanced option - see the Microsoft .NET Framework
-//       documentation for more information on this.
-//
-[assembly: AssemblyDelaySign(false)]
-[assembly: AssemblyKeyFile("")]
-[assembly: AssemblyKeyName("")]
-
-
 // LUCENENET specific - only allow tests in this assembly to run one at a time
 // to prevent polluting shared state.
 [assembly: LevelOfParallelism(1)]

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+    <Compile Include="..\CommonAssemblyKeys.cs" Link="Properties\CommonAssemblyKeys.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Lucene.Net/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net/Properties/AssemblyInfo.cs
@@ -29,52 +29,15 @@ using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(true)]
 
-// for testing
-//[assembly: InternalsVisibleTo("Lucene.Net.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010075a07ce602f88e" +
-//                                                         "f263c7db8cb342c58ebd49ecdcc210fac874260b0213fb929ac3dcaf4f5b39744b800f99073eca" +
-//                                                         "72aebfac5f7284e1d5f2c82012a804a140f06d7d043d83e830cdb606a04da2ad5374cc92c0a495" +
-//                                                         "08437802fb4f8fb80a05e59f80afb99f4ccd0dfe44065743543c4b053b669509d29d332cd32a0c" +
-//                                                         "b1e97e84")]
-
-// LUCENENET NOTE: For now we are not using a strong name key.
-// However, we still need InternalsVisibleTo in order to prevent making everything public just for the sake of testing.
+// Besides strong naming, we still need InternalsVisibleTo in order to prevent making everything public just for the sake of testing.
 // This has broad implications because many methods are marked "protected internal", which means other assemblies
 // must update overridden methods to match.
-[assembly: InternalsVisibleTo("Lucene.Net.Tests")]
-[assembly: InternalsVisibleTo("Lucene.Net.TestFramework")]
-[assembly: InternalsVisibleTo("Lucene.Net.Misc")]
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.ICU")] // For Analysis.Util.TestSegmentingTokenizerBase
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Misc")]
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.QueryParser")]
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.Cli")] // For lucene-cli
+[assembly: InternalsVisibleTo("Lucene.Net.Tests, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
+[assembly: InternalsVisibleTo("Lucene.Net.TestFramework, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
+[assembly: InternalsVisibleTo("Lucene.Net.Misc, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.ICU, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)] // For Analysis.Util.TestSegmentingTokenizerBase
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Misc, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.QueryParser, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.Cli, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)] // For lucene-cli
 
 // NOTE: Version information is in CommonAssemblyInfo.cs
-
-//
-// In order to sign your assembly you must specify a key to use. Refer to the 
-// Microsoft .NET Framework documentation for more information on assembly signing.
-//
-// Use the attributes below to control which key is used for signing. 
-//
-// Notes: 
-//   (*) If no key is specified, the assembly is not signed.
-//   (*) KeyName refers to a key that has been installed in the Crypto Service
-//       Provider (CSP) on your machine. KeyFile refers to a file which contains
-//       a key.
-//   (*) If the KeyFile and the KeyName values are both specified, the 
-//       following processing occurs:
-//       (1) If the KeyName can be found in the CSP, that key is used.
-//       (2) If the KeyName does not exist and the KeyFile does exist, the key 
-//           in the KeyFile is installed into the CSP and used.
-//   (*) In order to create a KeyFile, you can use the sn.exe (Strong Name) utility.
-//       When specifying the KeyFile, the location of the KeyFile should be
-//       relative to the project output directory which is
-//       %Project Directory%\obj\<configuration>. For example, if your KeyFile is
-//       located in the project directory, you would specify the AssemblyKeyFile 
-//       attribute as [assembly: AssemblyKeyFile("..\\..\\mykey.snk")]
-//   (*) Delay Signing is an advanced option - see the Microsoft .NET Framework
-//       documentation for more information on this.
-//
-//[assembly: AssemblyDelaySign(false)]
-//[assembly: AssemblyKeyFile("")]
-//[assembly: AssemblyKeyName("")]

--- a/src/Lucene.Net/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(true)]
 
-// Besides strong naming, we still need InternalsVisibleTo in order to prevent making everything public just for the sake of testing.
+// We need InternalsVisibleTo in order to prevent making everything public just for the sake of testing.
 // This has broad implications because many methods are marked "protected internal", which means other assemblies
 // must update overridden methods to match.
 [assembly: InternalsVisibleTo("Lucene.Net.Tests, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]

--- a/src/docs/LuceneDocsPlugins/LuceneDocsPlugins/LuceneDocsPlugins.csproj
+++ b/src/docs/LuceneDocsPlugins/LuceneDocsPlugins/LuceneDocsPlugins.csproj
@@ -104,4 +104,5 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
+  <Target Name="Pack" />
 </Project>

--- a/src/docs/LuceneDocsPlugins/LuceneDocsPlugins/LuceneDocsPlugins.csproj
+++ b/src/docs/LuceneDocsPlugins/LuceneDocsPlugins/LuceneDocsPlugins.csproj
@@ -104,5 +104,4 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
-  <Target Name="Pack" />
 </Project>

--- a/src/dotnet/Lucene.Net.ICU/Lucene.Net.ICU.csproj
+++ b/src/dotnet/Lucene.Net.ICU/Lucene.Net.ICU.csproj
@@ -22,6 +22,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\..\Version.proj" />
+  <PropertyGroup>
+    <!-- Override AssemblyOriginatorKeyFile specified in Version.proj because we're deeper from the root -->
+    <AssemblyOriginatorKeyFile>..\..\..\Lucene.Net.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>

--- a/src/dotnet/Lucene.Net.ICU/Properties/AssemblyInfo.cs
+++ b/src/dotnet/Lucene.Net.ICU/Properties/AssemblyInfo.cs
@@ -41,6 +41,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("349cb7c9-7534-4e1d-9b0a-5521441af0ae")]
 
 // for testing
-[assembly: InternalsVisibleTo("Lucene.Net.Tests.ICU")]
+[assembly: InternalsVisibleTo("Lucene.Net.Tests.ICU, PublicKey=" + Lucene.Net.AssemblyKeys.PublicKey)]
 
 // NOTE: Version information is in CommonAssemblyInfo.cs

--- a/src/dotnet/Lucene.Net.Replicator.AspNetCore/Lucene.Net.Replicator.AspNetCore.csproj
+++ b/src/dotnet/Lucene.Net.Replicator.AspNetCore/Lucene.Net.Replicator.AspNetCore.csproj
@@ -22,6 +22,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\..\Version.proj" />
+  <PropertyGroup>
+    <!-- Override AssemblyOriginatorKeyFile specified in Version.proj because we're deeper from the root -->
+    <AssemblyOriginatorKeyFile>..\..\..\Lucene.Net.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>

--- a/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj
+++ b/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj
@@ -23,6 +23,10 @@
 
   <Import Project="..\..\..\TestTargetFramework.proj" />
   <Import Project="..\..\..\Version.proj" />
+  <PropertyGroup>
+    <!-- Override AssemblyOriginatorKeyFile specified in Version.proj because we're deeper from the root -->
+    <AssemblyOriginatorKeyFile>..\..\..\Lucene.Net.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!--<TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>-->

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
@@ -22,6 +22,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\..\..\Version.proj" />
+  <PropertyGroup>
+    <!-- Override AssemblyOriginatorKeyFile specified in Version.proj because we're deeper from the root -->
+    <AssemblyOriginatorKeyFile>..\..\..\..\Lucene.Net.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>

--- a/src/dotnet/tools/lucene-cli/lucene-cli.csproj
+++ b/src/dotnet/tools/lucene-cli/lucene-cli.csproj
@@ -22,6 +22,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\..\..\Version.proj" />
+  <PropertyGroup>
+    <!-- Override AssemblyOriginatorKeyFile specified in Version.proj because we're deeper from the root -->
+    <AssemblyOriginatorKeyFile>..\..\..\..\Lucene.Net.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>


### PR DESCRIPTION
Per discussion on the dev mailing list (and in compliance with Microsoft recommendations for .NET libraries), this change adds strong naming to the Lucene.Net assemblies.

This is a breaking change to the assembly identity and needs to go in before the official 4.8.0 release.

Resolves the associated JIRA ticket: https://issues.apache.org/jira/browse/LUCENENET-608