### PR TITLE
Fixes build by excluding a csproj file that isn't supposed to be included in the build process

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -196,7 +196,7 @@ task Pack -depends Compile -description "This task creates the NuGet packages" {
 
 	try {
 		pushd $base_directory
-		$packages = Get-ChildItem -Path "$source_directory\**\*.csproj" -Recurse | ? { 
+		$packages = Get-ChildItem -Path "$source_directory\**\*.csproj" -Recurse -Exclude LuceneDocsPlugins.csproj | ? { 
 			!$_.Directory.Name.Contains(".Test") -and 
 			!$_.Directory.Name.Contains(".Demo") -and 
 			!$_.Directory.FullName.Contains("\tools\") -and 


### PR DESCRIPTION
During the `pack` command, the build process iterates over all csproj file but the `LuceneDocsPlugins.csproj` should not be included in this process. This excludes it and now the build.bat runs again.