### PR TITLE
Documentation: Update formatting of Lucene.Net and port code sample

### DIFF
--- a/src/Lucene.Net/overview.md
+++ b/src/Lucene.Net/overview.md
@@ -23,38 +23,41 @@ summary: *content
 Apache Lucene.NET is a high-performance, full-featured text search engine library. Here's a simple example how to use Lucene.NET for indexing and searching (Using NUnit for Asserts)
 
 ```
-   Analyzer analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
+Analyzer analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
 
-			// Store the index in memory:
-			Directory directory = new RAMDirectory();
-			// To store an index on disk, use this instead:
-			//Directory directory = FSDirectory.Open("/tmp/testindex");
-			IndexWriterConfig config = new IndexWriterConfig(LuceneVersion.LUCENE_48, analyzer);
-			using (IndexWriter writer = new IndexWriter(directory, config))
-			{
-				Document doc = new Document();
-				String text = "This is the text to be indexed.";
-				doc.Add(new Field("fieldname", text, TextField.TYPE_STORED));
-				writer.AddDocument(doc);
-			}
+// Store the index in memory:
+Directory directory = new RAMDirectory();
 
-			// Now search the index:
-			using (DirectoryReader reader = DirectoryReader.Open(directory))
-			{
-				IndexSearcher searcher = new IndexSearcher(reader);
-				// Parse a simple query that searches for "text":
-				QueryParser parser = new QueryParser(LuceneVersion.LUCENE_48, "fieldname", analyzer);
-				Query query = parser.Parse("text");
-				ScoreDoc[] hits = searcher.Search(query, null, 1000).ScoreDocs;
-				Assert.AreEqual(1, hits.Length);
+// To store an index on disk, use this instead:
+//Directory directory = FSDirectory.Open("/tmp/testindex");
 
-				// Iterate through the results:
-				for (int i = 0; i < hits.Length; i++)
-				{
-					var hitDoc = searcher.Doc(hits[i].Doc);
-					Assert.AreEqual("This is the text to be indexed.", hitDoc.Get("fieldname"));
-				}
-			}
+IndexWriterConfig config = new IndexWriterConfig(LuceneVersion.LUCENE_48, analyzer);
+using (IndexWriter writer = new IndexWriter(directory, config))
+{
+	Document doc = new Document();
+	String text = "This is the text to be indexed.";
+	doc.Add(new Field("fieldname", text, TextField.TYPE_STORED));
+	writer.AddDocument(doc);
+}
+
+// Now search the index:
+using (DirectoryReader reader = DirectoryReader.Open(directory))
+{
+	IndexSearcher searcher = new IndexSearcher(reader);
+	
+	// Parse a simple query that searches for "text":
+	QueryParser parser = new QueryParser(LuceneVersion.LUCENE_48, "fieldname", analyzer);
+	Query query = parser.Parse("text");
+	ScoreDoc[] hits = searcher.Search(query, null, 1000).ScoreDocs;
+	Assert.AreEqual(1, hits.Length);
+
+	// Iterate through the results:
+	for (int i = 0; i < hits.Length; i++)
+	{
+		var hitDoc = searcher.Doc(hits[i].Doc);
+		Assert.AreEqual("This is the text to be indexed.", hitDoc.Get("fieldname"));
+	}
+}
 ```
 
 The Lucene.NET API is divided into several packages:

--- a/src/Lucene.Net/overview.md
+++ b/src/Lucene.Net/overview.md
@@ -20,36 +20,44 @@ summary: *content
  limitations under the License.
 -->
 
-Apache Lucene is a high-performance, full-featured text search engine library. Here's a simple example how to use Lucene for indexing and searching (using JUnit to check if the results are what we expect):
+Apache Lucene.NET is a high-performance, full-featured text search engine library. Here's a simple example how to use Lucene.NET for indexing and searching (Using NUnit for Asserts)
 
-<!-- =   Java2Html Converter 5.0 [2006-03-04] by Markus Gebhard  markus@jave.de   = -->
+```
+   Analyzer analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
 
-        Analyzer analyzer = new StandardAnalyzer(Version.LUCENE_CURRENT);
-    
-    // Store the index in memory:
-        Directory directory = new RAMDirectory();
-        // To store an index on disk, use this instead:
-        //Directory directory = FSDirectory.open("/tmp/testindex");
-        IndexWriterConfig config = new IndexWriterConfig(Version.LUCENE_CURRENT, analyzer);
-        IndexWriter iwriter = new IndexWriter(directory, config);
-        Document doc = new Document();
-        String text = "This is the text to be indexed.";
-        doc.add(new Field("fieldname", text, TextField.TYPE_STORED));
-        iwriter.addDocument(doc);
-        iwriter.close();
+			// Store the index in memory:
+			Directory directory = new RAMDirectory();
+			// To store an index on disk, use this instead:
+			//Directory directory = FSDirectory.Open("/tmp/testindex");
+			IndexWriterConfig config = new IndexWriterConfig(LuceneVersion.LUCENE_48, analyzer);
+			using (IndexWriter writer = new IndexWriter(directory, config))
+			{
+				Document doc = new Document();
+				String text = "This is the text to be indexed.";
+				doc.Add(new Field("fieldname", text, TextField.TYPE_STORED));
+				writer.AddDocument(doc);
+			}
 
-        // Now search the index:
-        DirectoryReader ireader = DirectoryReader.open(directory);
-        IndexSearcher isearcher = new IndexSearcher(ireader);
-        // Parse a simple query that searches for "text":
-        QueryParser parser = new QueryParser(Version.LUCENE_CURRENT, "fieldname", analyzer);
-        Query query = parser.parse("text");
-        ScoreDoc[] hits = isearcher.search(query, null, 1000).scoreDocs;
-        assertEquals(1, hits.length);
-        // Iterate through the results:
-        for (int i = 0; i < hits.length;="" i++)="" {="" document="" hitdoc="isearcher.doc(hits[i].doc);" assertequals("this="" is="" the="" text="" to="" be="" indexed.",="" hitdoc.get("fieldname"));="" }="" ireader.close();="">
+			// Now search the index:
+			using (DirectoryReader reader = DirectoryReader.Open(directory))
+			{
+				IndexSearcher searcher = new IndexSearcher(reader);
+				// Parse a simple query that searches for "text":
+				QueryParser parser = new QueryParser(LuceneVersion.LUCENE_48, "fieldname", analyzer);
+				Query query = parser.Parse("text");
+				ScoreDoc[] hits = searcher.Search(query, null, 1000).ScoreDocs;
+				Assert.AreEqual(1, hits.Length);
 
-The Lucene API is divided into several packages:
+				// Iterate through the results:
+				for (int i = 0; i < hits.Length; i++)
+				{
+					var hitDoc = searcher.Doc(hits[i].Doc);
+					Assert.AreEqual("This is the text to be indexed.", hitDoc.Get("fieldname"));
+				}
+			}
+```
+
+The Lucene.NET API is divided into several packages:
 
 *   **<xref:Lucene.Net.Analysis>**
 defines an abstract [Analyzer](xref:Lucene.Net.Analysis.Analyzer)
@@ -64,9 +72,10 @@ Tokenizers and TokenFilters are strung together and applied with an [Analyzer](x
 and the grammar-based [StandardAnalyzer](../analyzers-common/org/apache/lucene/analysis/standard/StandardAnalyzer.html).
 *   **<xref:Lucene.Net.Codecs>**
 provides an abstraction over the encoding and decoding of the inverted index structure,
-as well as different implementations that can be chosen depending upon application needs.
+as well as different implementations that can be chosen depending upon application needs.
 
-    **<xref:Lucene.Net.Documents>**
+
+*   **<xref:Lucene.Net.Documents>**
 provides a simple [Document](xref:Lucene.Net.Documents.Document)
 class.  A Document is simply a set of named [Field](xref:Lucene.Net.Documents.Field)s,
 whose values may be strings or instances of {@link java.io.Reader}.
@@ -81,9 +90,10 @@ for phrases, and [BooleanQuery](xref:Lucene.Net.Search.BooleanQuery)
 for boolean combinations of queries) and the [IndexSearcher](xref:Lucene.Net.Search.IndexSearcher)
 which turns queries into [TopDocs](xref:Lucene.Net.Search.TopDocs).
 A number of [QueryParser](../queryparser/overview-summary.html)s are provided for producing
-query structures from strings or xml.
+query structures from strings or xml.
 
-    **<xref:Lucene.Net.Store>**
+
+*   **<xref:Lucene.Net.Store>**
 defines an abstract class for storing persistent data, the [Directory](xref:Lucene.Net.Store.Directory),
 which is a collection of named files written by an [IndexOutput](xref:Lucene.Net.Store.IndexOutput)
 and read by an [IndexInput](xref:Lucene.Net.Store.IndexInput). 
@@ -93,7 +103,8 @@ which implements files as memory-resident data structures.
 *   **<xref:Lucene.Net.Util>**
 contains a few handy data structures and util classes, ie [OpenBitSet](xref:Lucene.Net.Util.OpenBitSet)
 and [PriorityQueue](xref:Lucene.Net.Util.PriorityQueue).
-To use Lucene, an application should:
+
+To use Lucene.NET, an application should:
 
 1.  Create [Document](xref:Lucene.Net.Documents.Document)s by
 adding
@@ -105,6 +116,7 @@ to build a query from a string; and
 4.  Create an [IndexSearcher](xref:Lucene.Net.Search.IndexSearcher)
 and pass the query to its [Search](xref:Lucene.Net.Search.IndexSearcher#methods)
 method.
+
 Some simple examples of code which does this are:
 
 *    [IndexFiles.java](../demo/src-html/org/apache/lucene/demo/IndexFiles.html) creates an


### PR DESCRIPTION
1. Currently the code sample won't compile in Lucene.NET it's still the java syntax. I have updated to and tested this in C#
2. Also some formatting had been lost in translation, I have corrected the formatting