### PR TITLE
JavaDocToMarkdownConverter: Map Lucene.Net.Search.Join and Grouping correctly, upgrade Html2Markdown

### DIFF
--- a/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter.csproj
+++ b/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter.csproj
@@ -25,7 +25,8 @@
     <!-- Ensure this doesn't inherit the strong naming since this tool will no work with a signed assembly due to it's references -->
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
-    <AssemblyOriginatorKeyFile></AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -60,7 +61,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Html2Markdown, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Html2Markdown.3.0.0.223\lib\netstandard1.4\Html2Markdown.dll</HintPath>
+      <HintPath>..\packages\Html2Markdown.3.2.3.392\lib\net45\Html2Markdown.dll</HintPath>
+    </Reference>
+    <Reference Include="HtmlAgilityPack, Version=1.5.0.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.5.0\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack.NetCore, Version=1.5.0.1, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlAgilityPack.NetCore.1.5.0.1\lib\net45\HtmlAgilityPack.NetCore.dll</HintPath>

--- a/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/Program.cs
+++ b/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/Program.cs
@@ -30,11 +30,11 @@ namespace JavaDocToMarkdownConverter
             if (args == null || args.Length < 2)
             {
                 Usage();
+                return;
             }
 
             Console.WriteLine(string.Format("Converting '{0}' to '{1}'...", args[0], args[1]));
 
-            //new DocConverter().ConvertDoc(@"F:\Projects\_Test\lucene-solr-4.8.0\lucene\demo\src\java\overview.html", @"F:\Projects\lucenenet\");
             new DocConverter().Convert(args[0], args[1]);
 
             Console.WriteLine("Conversion complete!");

--- a/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/Program.cs
+++ b/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/Program.cs
@@ -35,6 +35,7 @@ namespace JavaDocToMarkdownConverter
 
             Console.WriteLine(string.Format("Converting '{0}' to '{1}'...", args[0], args[1]));
 
+            //new DocConverter().ConvertDoc(@"F:\Projects\_Test\lucene-solr-4.8.0\lucene\demo\src\java\overview.html", @"F:\Projects\lucenenet\");
             new DocConverter().Convert(args[0], args[1]);
 
             Console.WriteLine("Conversion complete!");

--- a/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/StringExtensions.cs
+++ b/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/StringExtensions.cs
@@ -135,6 +135,8 @@ namespace JavaDocToMarkdownConverter
             { "Lucene.Net.Document", "Lucene.Net.Documents" },
             { "Lucene.Net.Benchmark", "Lucene.Net.Benchmarks" },
             { "Lucene.Net.Queryparser", "Lucene.Net.QueryParsers" },
+            { "Lucene.Net.Search.Join", "Lucene.Net.Join" },
+            { "Lucene.Net.Search.Grouping", "Lucene.Net.Grouping" },
             { ".Tokenattributes", ".TokenAttributes" },
             { ".Charfilter", ".CharFilter" },
             { ".Commongrams", ".CommonGrams" },

--- a/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/packages.config
+++ b/src/dotnet/tools/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter/packages.config
@@ -20,7 +20,8 @@
 
 -->
 <packages>
-  <package id="Html2Markdown" version="3.0.0.223" targetFramework="net461" />
+  <package id="Html2Markdown" version="3.2.3.392" targetFramework="net461" />
+  <package id="HtmlAgilityPack" version="1.5.0" targetFramework="net461" />
   <package id="HtmlAgilityPack.NetCore" version="1.5.0.1" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
Also exit when no args passed to prevent exception showing

This should fix the following issues raised in https://github.com/apache/lucenenet/pull/231 :
* Issues with namespaces
* Lists rendering incorrectly