### PR TITLE
Fix for part of LUCENENET-640 JIRA Issue

### DIFF
--- a/src/Lucene.Net/Util/WeakIdentityMap.cs
+++ b/src/Lucene.Net/Util/WeakIdentityMap.cs
@@ -357,6 +357,7 @@ namespace Lucene.Net.Util
                 foreach (var key in keysToRemove)
                 {
                     backingStore.Remove(key);
+					key.Free();
                 }
         }
 


### PR DESCRIPTION
In relation to [LUCENENET-640](https://issues.apache.org/jira/projects/LUCENENET/issues/LUCENENET-640?filter=allopenissues)
Switching IdentityWeakReference from a class inheriting from the WeakReference class to a struct wrapping the GCHandle directly to avoid garbage collection bottleneck.