### PR TITLE
Minor updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,7 +129,7 @@ stages:
         if (!(Test-Path $dir)) { New-Item -ItemType Directory -Path "$dir" -Force }
         '$(PackageVersion)' | Out-File -FilePath "$dir/$(PackageVersionFileName)" -Force
         '$(FileVersion)' | Out-File -FilePath "$dir/$(FileVersionFileName)" -Force
-        '$(Build.BuildNumber)' | Out-File -FilePath "$dir/$(BuildNumberFileName)" -Force
+      # '$(Build.BuildNumber)' | Out-File -FilePath "$dir/$(BuildNumberFileName)" -Force
       displayName: 'Write Versions to Files'
 
     # If this is a release pipeline, copy the build.bat and Version.props files as version artifacts, which will 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -333,7 +333,7 @@ stages:
     - powershell: |
         $version = Get-Content '$(Build.ArtifactStagingDirectory)/$(VersionArtifactName)/$(PackageVersionFileName)' -Raw
         Write-Host "##vso[task.setvariable variable=PackageVersion;]$version"
-        Write-Host "##vso[task.setvariable variable=Build.BuildNumber;]$version"
+      # Write-Host "##vso[task.setvariable variable=Build.BuildNumber;]$version"
       displayName: 'Read PackageVersion from File to Build.BuildNumber'
 
     - template: 'build/azure-templates/show-all-environment-variables.yml'
@@ -378,7 +378,7 @@ stages:
         $vcsLabel = 'Lucene.Net_' + $version.Replace('.', '_').Replace('-', '_')
         Write-Host "##vso[task.setvariable variable=VCSLabel;]$vcsLabel"
         Write-Host "##vso[task.setvariable variable=PackageVersion;]$version"
-        Write-Host "##vso[task.setvariable variable=Build.BuildNumber;]$version"
+      # Write-Host "##vso[task.setvariable variable=Build.BuildNumber;]$version"
       displayName: 'Build VCS Label and Rehydrate Version Variables'
 
     - powershell: |

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -94,7 +94,7 @@ task Init -depends InstallSDK, UpdateLocalSDKVersion -description "This task mak
 	#Update TeamCity, MyGet, or Azure Pipelines with packageVersion
 	Write-Output "##teamcity[buildNumber '$packageVersion']"
 	Write-Output "##myget[buildNumber '$packageVersion']"
-	Write-Host "##vso[task.setvariable variable=Build.BuildNumber;]$packageVersion"
+	#Write-Host "##vso[task.setvariable variable=Build.BuildNumber;]$packageVersion"
 	Write-Host "##vso[build.updatebuildnumber]$packageVersion"
 
 	& dotnet.exe --version

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/HunspellStemFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/HunspellStemFilter.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Analysis.Hunspell
         /// <param name="dictionary"> Hunspell <see cref="Dictionary"/> containing the affix rules and words that will be used to stem the tokens </param>
         /// <param name="dedup"> remove duplicates </param>
         /// <param name="longestOnly"> true if only the longest term should be output. </param>
-        public HunspellStemFilter(TokenStream input, Dictionary dictionary, bool dedup, bool longestOnly) 
+        public HunspellStemFilter(TokenStream input, Dictionary dictionary, bool dedup, bool longestOnly)
             : base(input)
         {
             this.dedup = dedup && longestOnly == false; // don't waste time deduping if longestOnly is set
@@ -145,26 +145,17 @@ namespace Lucene.Net.Analysis.Hunspell
             buffer = null;
         }
 
-        internal static readonly IComparer<CharsRef> lengthComparer = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<CharsRef>
+        internal static readonly IComparer<CharsRef> lengthComparer = Comparer<CharsRef>.Create((o1, o2) =>
         {
-            public ComparerAnonymousInnerClassHelper()
+            if (o2.Length == o1.Length)
             {
+                // tie break on text
+                return o2.CompareTo(o1);
             }
-
-            public virtual int Compare(CharsRef o1, CharsRef o2)
+            else
             {
-                if (o2.Length == o1.Length)
-                {
-                    // tie break on text
-                    return o2.CompareTo(o1);
-                }
-                else
-                {
-                    return o2.Length < o1.Length ? -1 : 1;
-                }
+                return o2.Length < o1.Length ? -1 : 1;
             }
-        }
+        });
     }
 }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
@@ -78,10 +78,10 @@ namespace Lucene.Net.Analysis.Util
             return Append(csq, 0, csq.Length);
         }
 
-        public virtual OpenStringBuilder Append(ICharSequence csq, int start, int end) // LUCENENET TODO: API - change to startIndex/length to match .NET
+        public virtual OpenStringBuilder Append(ICharSequence csq, int startIndex, int length) // LUCENENET TODO: API - change to startIndex/length to match .NET
         {
-            EnsureCapacity(end - start);
-            for (int i = start; i < end; i++)
+            EnsureCapacity(length - startIndex);
+            for (int i = startIndex; i < length; i++)
             {
                 UnsafeWrite(csq[i]);
             }
@@ -95,10 +95,10 @@ namespace Lucene.Net.Analysis.Util
         }
 
         // LUCENENET specific - overload for string (more common in .NET than ICharSequence)
-        public virtual OpenStringBuilder Append(string csq, int start, int end) // LUCENENET TODO: API - change to startIndex/length to match .NET
+        public virtual OpenStringBuilder Append(string csq, int startIndex, int length) // LUCENENET TODO: API - change to startIndex/length to match .NET
         {
-            EnsureCapacity(end - start);
-            for (int i = start; i < end; i++)
+            EnsureCapacity(length - startIndex);
+            for (int i = startIndex; i < length; i++)
             {
                 UnsafeWrite(csq[i]);
             }
@@ -112,10 +112,10 @@ namespace Lucene.Net.Analysis.Util
         }
 
         // LUCENENET specific - overload for StringBuilder
-        public virtual OpenStringBuilder Append(StringBuilder csq, int start, int end) // LUCENENET TODO: API - change to startIndex/length to match .NET
+        public virtual OpenStringBuilder Append(StringBuilder csq, int startIndex, int length) // LUCENENET TODO: API - change to startIndex/length to match .NET
         {
-            EnsureCapacity(end - start);
-            for (int i = start; i < end; i++)
+            EnsureCapacity(length - startIndex);
+            for (int i = startIndex; i < length; i++)
             {
                 UnsafeWrite(csq[i]);
             }

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/UserDictionary.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/UserDictionary.cs
@@ -77,7 +77,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
 
             // TODO: should we allow multiple segmentations per input 'phrase'?
             // the old treemap didn't support this either, and i'm not sure if its needed/useful?
-            featureEntries.Sort(new ComparerAnonymousHelper());
+            featureEntries.Sort(Comparer<string[]>.Create((left, right) => left[0].CompareToOrdinal(right[0])));
 
             List<string> data = new List<string>(featureEntries.Count);
             List<int[]> segmentations = new List<int[]>(featureEntries.Count);
@@ -124,17 +124,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
             this.data = data.ToArray(/*new string[data.Count]*/);
             this.segmentations = segmentations.ToArray(/*new int[segmentations.Count][]*/);
         }
-
-        // LUCENENET TODO: Make an AnonymousComparer class in Support and
-        // replace all of these classes.
-        private class ComparerAnonymousHelper : IComparer<string[]>
-        {
-            public int Compare(string[] left, string[] right)
-            {
-                return left[0].CompareToOrdinal(right[0]);
-            }
-        }
-
+        
         /// <summary>
         /// Lookup words in text.
         /// </summary>

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
@@ -112,7 +112,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             Console.WriteLine("  sort...");
 
             // sort by term: we sorted the files already and use a stable sort.
-            lines.Sort(new ComparerAnonymousHelper());
+            lines.Sort(Comparer<string[]>.Create((left, right) => left[0].CompareToOrdinal(right[0])));
 
             Console.WriteLine("  encode...");
 
@@ -159,15 +159,7 @@ namespace Lucene.Net.Analysis.Ja.Util
 
             return dictionary;
         }
-
-        private class ComparerAnonymousHelper : IComparer<string[]>
-        {
-            public int Compare(string[] left, string[] right)
-            {
-                return left[0].CompareToOrdinal(right[0]);
-            }
-        }
-
+        
         /// <summary>
         /// IPADIC features
         /// 

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/UnknownDictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/UnknownDictionaryBuilder.cs
@@ -72,7 +72,12 @@ namespace Lucene.Net.Analysis.Ja.Util
                 }
             }
 
-            lines.Sort(new ComparerAnonymousHelper());
+            lines.Sort(Comparer<string[]>.Create((left, right) =>
+            {
+                int leftId = CharacterDefinition.LookupCharacterClass(left[0]);
+                int rightId = CharacterDefinition.LookupCharacterClass(right[0]);
+                return leftId - rightId;
+            }));
 
             foreach (string[] entry in lines)
             {
@@ -80,15 +85,6 @@ namespace Lucene.Net.Analysis.Ja.Util
             }
 
             return dictionary;
-        }
-        private class ComparerAnonymousHelper : IComparer<string[]>
-        {
-            public int Compare(string[] left, string[] right)
-            {
-                int leftId = CharacterDefinition.LookupCharacterClass(left[0]);
-                int rightId = CharacterDefinition.LookupCharacterClass(right[0]);
-                return leftId - rightId;
-            }
         }
 
         public virtual void ReadCharacterDefinition(string filename, UnknownDictionaryWriter dictionary)

--- a/src/Lucene.Net.Facet/SortedSet/SortedSetDocValuesFacetCounts.cs
+++ b/src/Lucene.Net.Facet/SortedSet/SortedSetDocValuesFacetCounts.cs
@@ -303,20 +303,7 @@ namespace Lucene.Net.Facet.SortedSet
             }
 
             // Sort by highest count:
-            results.Sort(new ComparerAnonymousInnerClassHelper(this));
-            return results;
-        }
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<FacetResult>
-        {
-            private readonly SortedSetDocValuesFacetCounts outerInstance;
-
-            public ComparerAnonymousInnerClassHelper(SortedSetDocValuesFacetCounts outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            public virtual int Compare(FacetResult a, FacetResult b)
+            results.Sort(Comparer<FacetResult>.Create((a, b) =>
             {
                 if ((int)a.Value > (int)b.Value)
                 {
@@ -330,7 +317,8 @@ namespace Lucene.Net.Facet.SortedSet
                 {
                     return a.Dim.CompareToOrdinal(b.Dim);
                 }
-            }
+            }));
+            return results;
         }
     }
 }

--- a/src/Lucene.Net.Facet/Taxonomy/TaxonomyFacets.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/TaxonomyFacets.cs
@@ -28,31 +28,22 @@ namespace Lucene.Net.Facet.Taxonomy
     /// </summary>
     public abstract class TaxonomyFacets : Facets
     {
-        private static readonly IComparer<FacetResult> BY_VALUE_THEN_DIM = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<FacetResult>
+        private static readonly IComparer<FacetResult> BY_VALUE_THEN_DIM = Comparer<FacetResult>.Create((a, b) =>
         {
-            public ComparerAnonymousInnerClassHelper()
+            if (a.Value > b.Value)
             {
+                return -1;
             }
-
-            public virtual int Compare(FacetResult a, FacetResult b)
+            else if (b.Value > a.Value)
             {
-                if (a.Value > b.Value)
-                {
-                    return -1;
-                }
-                else if (b.Value > a.Value)
-                {
-                    return 1;
-                }
-                else
-                {
-                    return a.Dim.CompareToOrdinal(b.Dim);
-                }
+                return 1;
             }
-        }
-
+            else
+            {
+                return a.Dim.CompareToOrdinal(b.Dim);
+            }
+        });
+                
         /// <summary>
         /// Index field name provided to the constructor.
         /// </summary>

--- a/src/Lucene.Net.Highlighter/PostingsHighlight/PostingsHighlighter.cs
+++ b/src/Lucene.Net.Highlighter/PostingsHighlight/PostingsHighlighter.cs
@@ -584,34 +584,7 @@ namespace Lucene.Net.Search.PostingsHighlight
 
             return highlights;
         }
-
-        internal class HighlightDocComparerAnonymousHelper1 : IComparer<Passage>
-        {
-            public int Compare(Passage left, Passage right)
-            {
-                if (left.score < right.score)
-                {
-                    return -1;
-                }
-                else if (left.score > right.score)
-                {
-                    return 1;
-                }
-                else
-                {
-                    return left.startOffset - right.startOffset;
-                }
-            }
-        }
-
-        internal class HighlightDocComparerAnonymousHelper2 : IComparer<Passage>
-        {
-            public int Compare(Passage left, Passage right)
-            {
-                return left.startOffset - right.startOffset;
-            }
-        }
-
+        
         // algorithm: treat sentence snippets as miniature documents
         // we can intersect these with the postings lists via BreakIterator.preceding(offset),s
         // score each sentence as norm(sentenceStartOffset) * sum(weight * tf(freq))
@@ -668,7 +641,21 @@ namespace Lucene.Net.Search.PostingsHighlight
 
             pq.Add(new OffsetsEnum(EMPTY, int.MaxValue)); // a sentinel for termination
 
-            JCG.PriorityQueue<Passage> passageQueue = new JCG.PriorityQueue<Passage>(n, new HighlightDocComparerAnonymousHelper1());
+            JCG.PriorityQueue<Passage> passageQueue = new JCG.PriorityQueue<Passage>(n, Comparer<Passage>.Create((left, right) =>
+            {
+                if (left.score < right.score)
+                {
+                    return -1;
+                }
+                else if (left.score > right.score)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return left.startOffset - right.startOffset;
+                }
+            }));
             Passage current = new Passage();
 
             while (pq.TryDequeue(out OffsetsEnum off))
@@ -722,7 +709,7 @@ namespace Lucene.Net.Search.PostingsHighlight
                             p.Sort();
                         }
                         // sort in ascending order
-                        ArrayUtil.TimSort(passages, new HighlightDocComparerAnonymousHelper2());
+                        ArrayUtil.TimSort(passages, Comparer<Passage>.Create((left, right) => left.startOffset - right.startOffset));
                         return passages;
                     }
                     // advance breakiterator

--- a/src/Lucene.Net.Highlighter/VectorHighlight/BaseFragmentsBuilder.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/BaseFragmentsBuilder.cs
@@ -342,7 +342,7 @@ namespace Lucene.Net.Search.VectorHighlight
                     WeightedFragInfo weightedFragInfo = new WeightedFragInfo(fragStart, fragEnd, subInfos, boost);
                     fieldNameToFragInfos[field.Name].Add(weightedFragInfo);
                 }
-                fragInfos_continue: { }
+            fragInfos_continue: { }
             }
 
             List<WeightedFragInfo> result = new List<WeightedFragInfo>();
@@ -350,19 +350,11 @@ namespace Lucene.Net.Search.VectorHighlight
             {
                 result.AddRange(weightedFragInfos);
             }
-            CollectionUtil.TimSort(result, new DiscreteMultiValueHighlightingComparerAnonymousHelper());
+            CollectionUtil.TimSort(result, Comparer<WeightedFragInfo>.Create((info1, info2) => info1.StartOffset - info2.StartOffset));
 
             return result;
         }
-
-        internal class DiscreteMultiValueHighlightingComparerAnonymousHelper : IComparer<WeightedFragInfo>
-        {
-            public int Compare(WeightedFragInfo info1, WeightedFragInfo info2)
-            {
-                return info1.StartOffset - info2.StartOffset;
-            }
-        }
-
+        
         public virtual char MultiValuedSeparator
         {
             get { return multiValuedSeparator; }

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
@@ -1034,14 +1034,6 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         }
 
         internal static readonly IComparer<PairOutputs<long?, BytesRef>.Pair> weightComparer =
-            new ComparerAnonymousInnerClassHelper();
-
-        private sealed class ComparerAnonymousInnerClassHelper : IComparer<PairOutputs<long?, BytesRef>.Pair>
-        {
-            public int Compare(PairOutputs<long?, BytesRef>.Pair left, PairOutputs<long?, BytesRef>.Pair right)
-            {
-                return Comparer<long?>.Default.Compare(left.Output1, right.Output1);
-            }
-        }
+            Comparer<PairOutputs<long?, BytesRef>.Pair>.Create((left, right) => Comparer<long?>.Default.Compare(left.Output1, right.Output1));
     }
 }

--- a/src/Lucene.Net.Suggest/Suggest/Fst/WFSTCompletionLookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/WFSTCompletionLookup.cs
@@ -316,20 +316,8 @@ namespace Lucene.Net.Search.Suggest.Fst
             }
         }
 
-        internal static readonly IComparer<long?> weightComparer = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<long?>
-        {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
-
-            public virtual int Compare(long? left, long? right)
-            {
-                return Comparer<long?>.Default.Compare(left, right);
-            }
-        }
-
+        internal static readonly IComparer<long?> weightComparer = Comparer<long?>.Create((left, right) => Comparer<long?>.Default.Compare(left, right));
+        
         /// <summary>
         /// Returns byte size of the underlying FST. </summary>
         public override long GetSizeInBytes()

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -244,7 +244,7 @@ namespace Lucene.Net.Analysis.Core
                 }
             }
 
-            IComparer<ConstructorInfo> ctorComp = new ComparerAnonymousInnerClassHelper();
+            IComparer<ConstructorInfo> ctorComp = Comparer<ConstructorInfo>.Create((arg0, arg1)=> arg0.ToString().CompareToOrdinal(arg1.ToString()));
             tokenizers.Sort(ctorComp);
             tokenfilters.Sort(ctorComp);
             charfilters.Sort(ctorComp);
@@ -255,19 +255,7 @@ namespace Lucene.Net.Analysis.Core
                 Console.WriteLine("charfilters = " + charfilters);
             }
         }
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<ConstructorInfo>
-        {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
-
-            public virtual int Compare(ConstructorInfo arg0, ConstructorInfo arg1)
-            {
-                return arg0.ToString().CompareToOrdinal(arg1.ToString());
-            }
-        }
-
+        
         [OneTimeTearDown]
         public override void AfterClass()
         {

--- a/src/Lucene.Net.Tests.Facet/FacetTestCase.cs
+++ b/src/Lucene.Net.Tests.Facet/FacetTestCase.cs
@@ -152,7 +152,10 @@ namespace Lucene.Net.Facet
                 {
                     if (numInRow > 1)
                     {
-                        Array.Sort(labelValues, i - numInRow, i - (i - numInRow), new ComparerAnonymousInnerClassHelper(this));
+                        Array.Sort(labelValues, i - numInRow, i - (i - numInRow), Comparer<LabelAndValue>.Create((a,b)=> {
+                            Debug.Assert((double)a.Value == (double)b.Value);
+                            return (new BytesRef(a.Label)).CompareTo(new BytesRef(b.Label));
+                        }));
                     }
                     numInRow = 1;
                     if (i < labelValues.Length)
@@ -163,39 +166,10 @@ namespace Lucene.Net.Facet
                 i++;
             }
         }
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<LabelAndValue>
-        {
-            private readonly FacetTestCase outerInstance;
-
-            public ComparerAnonymousInnerClassHelper(FacetTestCase outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            public virtual int Compare(LabelAndValue a, LabelAndValue b)
-            {
-                Debug.Assert((double)a.Value == (double)b.Value);
-                return (new BytesRef(a.Label)).CompareTo(new BytesRef(b.Label));
-            }
-        }
-
+        
         protected internal virtual void SortLabelValues(List<LabelAndValue> labelValues)
         {
-            labelValues.Sort(new ComparerAnonymousInnerClassHelper2(this));
-        }
-
-        private class ComparerAnonymousInnerClassHelper2 : IComparer<LabelAndValue>
-        {
-            private readonly FacetTestCase outerInstance;
-
-            public ComparerAnonymousInnerClassHelper2(FacetTestCase outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            public virtual int Compare(LabelAndValue a, LabelAndValue b)
-            {
+            labelValues.Sort(Comparer<LabelAndValue>.Create((a,b)=> {
                 if ((double)a.Value > (double)b.Value)
                 {
                     return -1;
@@ -208,24 +182,13 @@ namespace Lucene.Net.Facet
                 {
                     return (new BytesRef(a.Label)).CompareTo(new BytesRef(b.Label));
                 }
-            }
+            }));
         }
 
+       
         protected internal virtual void SortFacetResults(List<FacetResult> results)
         {
-            results.Sort(new ComparerAnonymousInnerClassHelper3(this));
-        }
-
-        private class ComparerAnonymousInnerClassHelper3 : IComparer<FacetResult>
-        {
-            private readonly FacetTestCase outerInstance;
-
-            public ComparerAnonymousInnerClassHelper3(FacetTestCase outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            public virtual int Compare(FacetResult a, FacetResult b)
+            results.Sort(Comparer<FacetResult>.Create((a, b) =>
             {
                 if ((double)a.Value > (double)b.Value)
                 {
@@ -239,7 +202,7 @@ namespace Lucene.Net.Facet
                 {
                     return 0;
                 }
-            }
+            }));
         }
 
         protected internal virtual void AssertFloatValuesEquals(IList<FacetResult> a, IList<FacetResult> b)

--- a/src/Lucene.Net.Tests.Grouping/AllGroupHeadsCollectorTest.cs
+++ b/src/Lucene.Net.Tests.Grouping/AllGroupHeadsCollectorTest.cs
@@ -557,23 +557,10 @@ namespace Lucene.Net.Search.Grouping
             return new Sort(sortFields.ToArray(/*new SortField[sortFields.size()]*/));
         }
 
-        internal class ComparerAnonymousHelper : IComparer<GroupDoc>
+        private IComparer<GroupDoc> GetComparer(Sort sort, bool sortByScoreOnly, int[] fieldIdToDocID)
         {
-            private readonly AllGroupHeadsCollectorTest outerInstance;
-            private readonly SortField[] sortFields;
-            private readonly bool sortByScoreOnly;
-            private readonly int[] fieldIdToDocID;
-
-            public ComparerAnonymousHelper(AllGroupHeadsCollectorTest outerInstance, SortField[] sortFields, bool sortByScoreOnly, int[] fieldIdToDocID)
-            {
-                this.outerInstance = outerInstance;
-                this.sortFields = sortFields;
-                this.sortByScoreOnly = sortByScoreOnly;
-                this.fieldIdToDocID = fieldIdToDocID;
-            }
-
-            public int Compare(GroupDoc d1, GroupDoc d2)
-            {
+            SortField[] sortFields = sort.GetSort();
+            return Comparer<GroupDoc>.Create((d1,d2)=> {
                 foreach (SortField sf in sortFields)
                 {
                     int cmp;
@@ -617,13 +604,7 @@ namespace Lucene.Net.Search.Grouping
                 // Our sort always fully tie breaks:
                 fail();
                 return 0;
-            }
-        }
-
-        private IComparer<GroupDoc> GetComparer(Sort sort, bool sortByScoreOnly, int[] fieldIdToDocID)
-        {
-            SortField[] sortFields = sort.GetSort();
-            return new ComparerAnonymousHelper(this, sortFields, sortByScoreOnly, fieldIdToDocID);
+            });
         }
 
         private AbstractAllGroupHeadsCollector CreateRandomCollector(string groupField, Sort sortWithinGroup, bool canUseIDV, DocValuesType valueType)

--- a/src/Lucene.Net.Tests.Grouping/DistinctValuesCollectorTest.cs
+++ b/src/Lucene.Net.Tests.Grouping/DistinctValuesCollectorTest.cs
@@ -45,36 +45,6 @@ namespace Lucene.Net.Search.Grouping
         private readonly string countField = "publisher";
         //private readonly string dvCountField = "publisher_dv"; // LUCENENET NOTE: Not used in Lucene
 
-        internal class ComparerAnonymousHelper1 : IComparer<AbstractDistinctValuesCollector.IGroupCount<IComparable>>
-        {
-            private readonly DistinctValuesCollectorTest outerInstance;
-
-            public ComparerAnonymousHelper1(DistinctValuesCollectorTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            public int Compare(AbstractDistinctValuesCollector.IGroupCount<IComparable> groupCount1, AbstractDistinctValuesCollector.IGroupCount<IComparable> groupCount2)
-            {
-                if (groupCount1.GroupValue == null)
-                {
-                    if (groupCount2.GroupValue == null)
-                    {
-                        return 0;
-                    }
-                    return -1;
-                }
-                else if (groupCount2.GroupValue == null)
-                {
-                    return 1;
-                }
-                else
-                {
-                    return groupCount1.GroupValue.CompareTo(groupCount2.GroupValue);
-                }
-            }
-        }
-
         [Test]
         public virtual void TestSimple()
         {
@@ -150,7 +120,24 @@ namespace Lucene.Net.Search.Grouping
             IndexSearcher indexSearcher = NewSearcher(w.GetReader());
             w.Dispose();
 
-            var cmp = new ComparerAnonymousHelper1(this);
+            var cmp = Comparer<AbstractDistinctValuesCollector.IGroupCount<IComparable>>.Create((groupCount1, groupCount2) => {
+                if (groupCount1.GroupValue == null)
+                {
+                    if (groupCount2.GroupValue == null)
+                    {
+                        return 0;
+                    }
+                    return -1;
+                }
+                else if (groupCount2.GroupValue == null)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return groupCount1.GroupValue.CompareTo(groupCount2.GroupValue);
+                }
+            });
 
             // === Search for content:random
             IAbstractFirstPassGroupingCollector<IComparable> firstCollector = CreateRandomFirstPassCollector(dvType, new Sort(), groupField, 10);

--- a/src/Lucene.Net.Tests.Grouping/TestGrouping.cs
+++ b/src/Lucene.Net.Tests.Grouping/TestGrouping.cs
@@ -435,17 +435,10 @@ namespace Lucene.Net.Search.Grouping
             return new Sort(sortFields.ToArray(/*new SortField[sortFields.size()]*/));
         }
 
-        internal class ComparerAnonymousHelper : IComparer<GroupDoc>
+        private IComparer<GroupDoc> GetComparer(Sort sort)
         {
-            private readonly TestGrouping outerInstance;
-            private readonly SortField[] sortFields;
-            internal ComparerAnonymousHelper(TestGrouping outerInstance, SortField[] sortFields)
-            {
-                this.outerInstance = outerInstance;
-                this.sortFields = sortFields;
-            }
-
-            public int Compare(GroupDoc d1, GroupDoc d2)
+            SortField[] sortFields = sort.GetSort();
+            return Comparer<GroupDoc>.Create((d1,d2) =>
             {
                 foreach (SortField sf in sortFields)
                 {
@@ -486,13 +479,7 @@ namespace Lucene.Net.Search.Grouping
                 // Our sort always fully tie breaks:
                 fail();
                 return 0;
-            }
-        }
-
-        private IComparer<GroupDoc> GetComparer(Sort sort)
-        {
-            SortField[] sortFields = sort.GetSort();
-            return new ComparerAnonymousHelper(this, sortFields);
+            });
         }
 
         private IComparable[] FillFields(GroupDoc d, Sort sort)

--- a/src/Lucene.Net.Tests/Index/TestStressIndexing2.cs
+++ b/src/Lucene.Net.Tests/Index/TestStressIndexing2.cs
@@ -152,19 +152,8 @@ namespace Lucene.Net.Index
 
         internal static Term IdTerm = new Term("id", "");
         internal IndexingThread[] Threads;
-        internal static IComparer<IIndexableField> fieldNameComparer = new ComparerAnonymousInnerClassHelper();
 
-        private class ComparerAnonymousInnerClassHelper : IComparer<IIndexableField>
-        {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
-
-            public virtual int Compare(IIndexableField o1, IIndexableField o2)
-            {
-                return o1.Name.CompareToOrdinal(o2.Name);
-            }
-        }
+        internal static IComparer<IIndexableField> fieldNameComparer = Comparer<IIndexableField>.Create((o1, o2) => o1.Name.CompareToOrdinal(o2.Name));
 
         // this test avoids using any extra synchronization in the multiple
         // indexing threads to test that IndexWriter does correctly synchronize

--- a/src/Lucene.Net.Tests/Search/TestSortRandom.cs
+++ b/src/Lucene.Net.Tests/Search/TestSortRandom.cs
@@ -224,7 +224,41 @@ namespace Lucene.Net.Search
 
                 // Compute expected results:
                 var expected = f.MatchValues.ToList();
-                expected.Sort(new ComparerAnonymousInnerClassHelper(this, sortMissingLast));
+                
+                expected.Sort(Comparer<BytesRef>.Create((a,b) =>
+                    {
+                        if (a == null)
+                        {
+                            if (b == null)
+                            {
+                                return 0;
+                            }
+                            if (sortMissingLast)
+                            {
+                                return 1;
+                            }
+                            else
+                            {
+                                return -1;
+                            }
+                        }
+                        else if (b == null)
+                        {
+                            if (sortMissingLast)
+                            {
+                                return -1;
+                            }
+                            else
+                            {
+                                return 1;
+                            }
+                        }
+                        else
+                        {
+                            return a.CompareTo(b);
+                        }
+                    }));
+
                 if (reverse)
                 {
                     expected.Reverse();
@@ -286,53 +320,6 @@ namespace Lucene.Net.Search
 
             r.Dispose();
             dir.Dispose();
-        }
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<BytesRef>
-        {
-            private readonly TestSortRandom OuterInstance;
-
-            private bool SortMissingLast;
-
-            public ComparerAnonymousInnerClassHelper(TestSortRandom outerInstance, bool sortMissingLast)
-            {
-                this.OuterInstance = outerInstance;
-                this.SortMissingLast = sortMissingLast;
-            }
-
-            public virtual int Compare(BytesRef a, BytesRef b)
-            {
-                if (a == null)
-                {
-                    if (b == null)
-                    {
-                        return 0;
-                    }
-                    if (SortMissingLast)
-                    {
-                        return 1;
-                    }
-                    else
-                    {
-                        return -1;
-                    }
-                }
-                else if (b == null)
-                {
-                    if (SortMissingLast)
-                    {
-                        return -1;
-                    }
-                    else
-                    {
-                        return 1;
-                    }
-                }
-                else
-                {
-                    return a.CompareTo(b);
-                }
-            }
         }
 
         private class RandomFilter : Filter

--- a/src/Lucene.Net.Tests/Search/TestSortRescorer.cs
+++ b/src/Lucene.Net.Tests/Search/TestSortRescorer.cs
@@ -169,7 +169,24 @@ namespace Lucene.Net.Search
 
             int reverseInt = reverse ? -1 : 1;
 
-            Array.Sort(expected, new ComparerAnonymousInnerClassHelper(this, idToNum, r, reverseInt));
+            Array.Sort(expected, Comparer<int>.Create((a, b) =>
+            {
+                int av = idToNum[Convert.ToInt32(r.Document(a).Get("id"))];
+                int bv = idToNum[Convert.ToInt32(r.Document(b).Get("id"))];
+                if (av < bv)
+                {
+                    return -reverseInt;
+                }
+                else if (bv < av)
+                {
+                    return reverseInt;
+                }
+                else
+                {
+                    // Tie break by docID, ascending
+                    return a - b;
+                }
+            }));
 
             bool fail = false;
             for (int i = 0; i < numHits; i++)
@@ -180,49 +197,6 @@ namespace Lucene.Net.Search
 
             r.Dispose();
             dir.Dispose();
-        }
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<int>
-        {
-            private readonly TestSortRescorer OuterInstance;
-
-            private int[] IdToNum;
-            private IndexReader r;
-            private int ReverseInt;
-
-            public ComparerAnonymousInnerClassHelper(TestSortRescorer outerInstance, int[] idToNum, IndexReader r, int reverseInt)
-            {
-                this.OuterInstance = outerInstance;
-                this.IdToNum = idToNum;
-                this.r = r;
-                this.ReverseInt = reverseInt;
-            }
-
-            public virtual int Compare(int a, int b)
-            {
-                try
-                {
-                    int av = IdToNum[Convert.ToInt32(r.Document(a).Get("id"))];
-                    int bv = IdToNum[Convert.ToInt32(r.Document(b).Get("id"))];
-                    if (av < bv)
-                    {
-                        return -ReverseInt;
-                    }
-                    else if (bv < av)
-                    {
-                        return ReverseInt;
-                    }
-                    else
-                    {
-                        // Tie break by docID
-                        return a - b;
-                    }
-                }
-                catch (IOException ioe)
-                {
-                    throw new Exception(ioe.ToString(), ioe);
-                }
-            }
-        }
+        }               
     }
 }

--- a/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
@@ -1458,20 +1458,8 @@ namespace Lucene.Net.Util.Fst
             Assert.AreEqual(42, arc.Output);
         }
 
-        internal static readonly IComparer<long?> minLongComparer = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<long?>
-        {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
-
-            public virtual int Compare(long? left, long? right)
-            {
-                return left.Value.CompareTo(right.Value);
-            }
-        }
-
+        internal static readonly IComparer<long?> minLongComparer = Comparer<long?>.Create((left, right)=> left.Value.CompareTo(right.Value));
+        
         [Test]
         public virtual void TestShortestPaths()
         {
@@ -1583,20 +1571,8 @@ namespace Lucene.Net.Util.Fst
         }
 
         // compares just the weight side of the pair
-        internal static readonly IComparer<Pair> minPairWeightComparer = new ComparerAnonymousInnerClassHelper2();
-
-        private class ComparerAnonymousInnerClassHelper2 : IComparer<Pair>
-        {
-            public ComparerAnonymousInnerClassHelper2()
-            {
-            }
-
-            public virtual int Compare(Pair left, Pair right)
-            {
-                return left.Output1.GetValueOrDefault().CompareTo(right.Output1.GetValueOrDefault());
-            }
-        }
-
+        internal static readonly IComparer<Pair> minPairWeightComparer = Comparer<Pair>.Create((left, right)=> left.Output1.GetValueOrDefault().CompareTo(right.Output1.GetValueOrDefault()));
+             
         /// <summary>
         /// like testShortestPaths, but uses pairoutputs so we have both a weight and an output </summary>
         [Test]

--- a/src/Lucene.Net.Tests/Util/TestOfflineSorter.cs
+++ b/src/Lucene.Net.Tests/Util/TestOfflineSorter.cs
@@ -114,28 +114,19 @@ namespace Lucene.Net.Util
             return bytes;
         }
 
-        internal static readonly IComparer<byte[]> unsignedByteOrderComparer = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<byte[]>
-        {
-            public ComparerAnonymousInnerClassHelper()
+        internal static readonly IComparer<byte[]> unsignedByteOrderComparer = Comparer<byte[]>.Create((left,right)=> {
+            int max = Math.Min(left.Length, right.Length);
+            for (int i = 0, j = 0; i < max; i++, j++)
             {
-            }
-
-            public virtual int Compare(byte[] left, byte[] right)
-            {
-                int max = Math.Min(left.Length, right.Length);
-                for (int i = 0, j = 0; i < max; i++, j++)
+                int diff = (left[i] & 0xff) - (right[j] & 0xff);
+                if (diff != 0)
                 {
-                    int diff = (left[i] & 0xff) - (right[j] & 0xff);
-                    if (diff != 0)
-                    {
-                        return diff;
-                    }
+                    return diff;
                 }
-                return left.Length - right.Length;
             }
-        }
+            return left.Length - right.Length;
+        });
+
         /// <summary>
         /// Check sorting data on an instance of <seealso cref="OfflineSorter"/>.
         /// </summary>

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -508,25 +508,10 @@ namespace Lucene.Net.Codecs.Lucene3x
                 ReadVectors();
                 if (unicodeSortOrder)
                 {
-                    Array.Sort(termAndPostings, new ComparerAnonymousInnerClassHelper(this));
+                    Array.Sort(termAndPostings, Comparer<TermAndPostings>.Create((left, right) => left.Term.CompareTo(right.Term)));
                 }
             }
-
-            private class ComparerAnonymousInnerClassHelper : IComparer<TermAndPostings>
-            {
-                private readonly TVTermsEnum outerInstance;
-
-                public ComparerAnonymousInnerClassHelper(TVTermsEnum outerInstance)
-                {
-                    this.outerInstance = outerInstance;
-                }
-
-                public virtual int Compare(TermAndPostings left, TermAndPostings right)
-                {
-                    return left.Term.CompareTo(right.Term);
-                }
-            }
-
+            
             private void ReadVectors()
             {
                 termAndPostings = new TermAndPostings[numTerms];

--- a/src/Lucene.Net/Index/BufferedUpdatesStream.cs
+++ b/src/Lucene.Net/Index/BufferedUpdatesStream.cs
@@ -140,15 +140,7 @@ namespace Lucene.Net.Index
         }
 
         // Sorts SegmentInfos from smallest to biggest bufferedDelGen:
-        private static readonly IComparer<SegmentCommitInfo> sortSegInfoByDelGen = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<SegmentCommitInfo>
-        {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
-
-            public virtual int Compare(SegmentCommitInfo si1, SegmentCommitInfo si2)
+        private static readonly IComparer<SegmentCommitInfo> sortSegInfoByDelGen = Comparer<SegmentCommitInfo>.Create((si1, si2) =>
             {
                 long cmp = si1.BufferedDeletesGen - si2.BufferedDeletesGen;
                 if (cmp > 0)
@@ -163,8 +155,7 @@ namespace Lucene.Net.Index
                 {
                     return 0;
                 }
-            }
-        }
+            });
 
         /// <summary>
         /// Resolves the buffered deleted Term/Query/docIDs, into

--- a/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
@@ -191,15 +191,7 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Sorts <see cref="MergeThread"/>s; larger merges come first. </summary>
-        protected internal static readonly IComparer<MergeThread> compareByMergeDocCount = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<MergeThread>
-        {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
-
-            public virtual int Compare(MergeThread t1, MergeThread t2)
+        protected internal static readonly IComparer<MergeThread> compareByMergeDocCount = Comparer<MergeThread>.Create((t1, t2) =>
             {
                 MergePolicy.OneMerge m1 = t1.CurrentMerge;
                 MergePolicy.OneMerge m2 = t2.CurrentMerge;
@@ -208,8 +200,7 @@ namespace Lucene.Net.Index
                 int c2 = m2 == null ? int.MaxValue : m2.TotalDocCount;
 
                 return c2 - c1;
-            }
-        }
+            });
 
         /// <summary>
         /// Called whenever the running merges have changed, to pause &amp; unpause
@@ -461,7 +452,7 @@ namespace Lucene.Net.Index
                         }
                         //try
                         //{
-                            Monitor.Wait(this);
+                        Monitor.Wait(this);
                         //}
                         //catch (ThreadInterruptedException ie) // LUCENENET NOTE: Senseless to catch and rethrow the same exception type
                         //{
@@ -720,13 +711,13 @@ namespace Lucene.Net.Index
         {
             //try
             //{
-                // When an exception is hit during merge, IndexWriter
-                // removes any partial files and then allows another
-                // merge to run.  If whatever caused the error is not
-                // transient then the exception will keep happening,
-                // so, we sleep here to avoid saturating CPU in such
-                // cases:
-                Thread.Sleep(250);
+            // When an exception is hit during merge, IndexWriter
+            // removes any partial files and then allows another
+            // merge to run.  If whatever caused the error is not
+            // transient then the exception will keep happening,
+            // so, we sleep here to avoid saturating CPU in such
+            // cases:
+            Thread.Sleep(250);
             //}
             //catch (ThreadInterruptedException ie) // LUCENENET NOTE: Senseless to catch and rethrow the same exception type
             //{

--- a/src/Lucene.Net/Index/DocFieldProcessor.cs
+++ b/src/Lucene.Net/Index/DocFieldProcessor.cs
@@ -284,19 +284,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private static readonly IComparer<DocFieldProcessorPerField> fieldsComp = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<DocFieldProcessorPerField>
-        {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
-
-            public virtual int Compare(DocFieldProcessorPerField o1, DocFieldProcessorPerField o2)
-            {
-                return o1.fieldInfo.Name.CompareToOrdinal(o2.fieldInfo.Name);
-            }
-        }
+        private static readonly IComparer<DocFieldProcessorPerField> fieldsComp = Comparer<DocFieldProcessorPerField>.Create((o1, o2) => o1.fieldInfo.Name.CompareToOrdinal(o2.fieldInfo.Name));
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void FinishDocument()

--- a/src/Lucene.Net/Search/ConjunctionScorer.cs
+++ b/src/Lucene.Net/Search/ConjunctionScorer.cs
@@ -46,21 +46,7 @@ namespace Lucene.Net.Search
             }
             // Sort the array the first time to allow the least frequent DocsEnum to
             // lead the matching.
-            ArrayUtil.TimSort(m_docsAndFreqs, new ComparerAnonymousInnerClassHelper(this));
-
-            lead = m_docsAndFreqs[0]; // least frequent DocsEnum leads the intersection
-        }
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<DocsAndFreqs>
-        {
-            private readonly ConjunctionScorer outerInstance;
-
-            public ComparerAnonymousInnerClassHelper(ConjunctionScorer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            public virtual int Compare(DocsAndFreqs o1, DocsAndFreqs o2)
+            ArrayUtil.TimSort(m_docsAndFreqs, Comparer<DocsAndFreqs>.Create((o1, o2) =>
             {
                 if (o1.Cost < o2.Cost)
                 {
@@ -74,7 +60,9 @@ namespace Lucene.Net.Search
                 {
                     return 0;
                 }
-            }
+            }));
+
+            lead = m_docsAndFreqs[0]; // least frequent DocsEnum leads the intersection
         }
 
         private int DoNext(int doc)

--- a/src/Lucene.Net/Search/MinShouldMatchSumScorer.cs
+++ b/src/Lucene.Net/Search/MinShouldMatchSumScorer.cs
@@ -100,7 +100,7 @@ namespace Lucene.Net.Search
             this.sortedSubScorers = subScorers.ToArray();
             // sorting by decreasing subscorer cost should be inversely correlated with
             // next docid (assuming costs are due to generating many postings)
-            ArrayUtil.TimSort(sortedSubScorers, new ComparerAnonymousInnerClassHelper(this));
+            ArrayUtil.TimSort(sortedSubScorers, Comparer<Scorer>.Create((o1,o2)=> (o2.GetCost() - o1.GetCost()).Signum()));
             // take mm-1 most costly subscorers aside
             this.mmStack = new Scorer[mm - 1];
             for (int i = 0; i < mm - 1; i++)
@@ -117,21 +117,6 @@ namespace Lucene.Net.Search
             }
             MinheapHeapify();
             Debug.Assert(MinheapCheck());
-        }
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<Scorer>
-        {
-            private readonly MinShouldMatchSumScorer outerInstance;
-
-            public ComparerAnonymousInnerClassHelper(MinShouldMatchSumScorer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            public virtual int Compare(Scorer o1, Scorer o2)
-            {
-                return (o2.GetCost() - o1.GetCost()).Signum();
-            }
         }
 
         /// <summary>

--- a/src/Lucene.Net/Search/SloppyPhraseScorer.cs
+++ b/src/Lucene.Net/Search/SloppyPhraseScorer.cs
@@ -434,7 +434,7 @@ namespace Lucene.Net.Search
         private void SortRptGroups(IList<IList<PhrasePositions>> rgs)
         {
             rptGroups = new PhrasePositions[rgs.Count][];
-            IComparer<PhrasePositions> cmprtr = new ComparerAnonymousInnerClassHelper(this);
+            IComparer<PhrasePositions> cmprtr = Comparer<PhrasePositions>.Create((pp1, pp2) => pp1.offset - pp2.offset);
             for (int i = 0; i < rptGroups.Length; i++)
             {
                 PhrasePositions[] rg = rgs[i].ToArray();
@@ -446,22 +446,7 @@ namespace Lucene.Net.Search
                 }
             }
         }
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<PhrasePositions>
-        {
-            private readonly SloppyPhraseScorer outerInstance;
-
-            public ComparerAnonymousInnerClassHelper(SloppyPhraseScorer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            public virtual int Compare(PhrasePositions pp1, PhrasePositions pp2)
-            {
-                return pp1.offset - pp2.offset;
-            }
-        }
-
+        
         /// <summary>
         /// Detect repetition groups. Done once - for first doc. </summary>
         private IList<IList<PhrasePositions>> GatherRptGroups(JCG.LinkedDictionary<Term, int?> rptTerms)

--- a/src/Lucene.Net/Search/SortRescorer.cs
+++ b/src/Lucene.Net/Search/SortRescorer.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Search
         {
             // Copy ScoreDoc[] and sort by ascending docID:
             ScoreDoc[] hits = (ScoreDoc[])firstPassTopDocs.ScoreDocs.Clone();
-            Array.Sort(hits, new ComparerAnonymousInnerClassHelper(this));
+            Array.Sort(hits, Comparer<ScoreDoc>.Create((a, b) => a.Doc - b.Doc));
 
             IList<AtomicReaderContext> leaves = searcher.IndexReader.Leaves;
 
@@ -86,21 +86,6 @@ namespace Lucene.Net.Search
             }
 
             return collector.GetTopDocs();
-        }
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<ScoreDoc>
-        {
-            private readonly SortRescorer outerInstance;
-
-            public ComparerAnonymousInnerClassHelper(SortRescorer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            public virtual int Compare(ScoreDoc a, ScoreDoc b)
-            {
-                return a.Doc - b.Doc;
-            }
         }
 
         public override Explanation Explain(IndexSearcher searcher, Explanation firstPassExplanation, int docID)

--- a/src/Lucene.Net/Search/TopTermsRewrite.cs
+++ b/src/Lucene.Net/Search/TopTermsRewrite.cs
@@ -244,21 +244,12 @@ namespace Lucene.Net.Search
             return false;
         }
 
-        private static readonly IComparer<ScoreTerm> scoreTermSortByTermComp = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<ScoreTerm>
+        private static readonly IComparer<ScoreTerm> scoreTermSortByTermComp = Comparer<ScoreTerm>.Create((st1, st2) =>
         {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
-
-            public virtual int Compare(ScoreTerm st1, ScoreTerm st2)
-            {
-                Debug.Assert(st1.TermComp == st2.TermComp, "term comparer should not change between segments");
-                return st1.TermComp.Compare(st1.Bytes, st2.Bytes);
-            }
-        }
-
+            Debug.Assert(st1.TermComp == st2.TermComp, "term comparer should not change between segments");
+            return st1.TermComp.Compare(st1.Bytes, st2.Bytes);
+        });
+        
         internal sealed class ScoreTerm : IComparable<ScoreTerm>
         {
             public IComparer<BytesRef> TermComp { get; private set; }

--- a/src/Lucene.Net/Util/StringHelper.cs
+++ b/src/Lucene.Net/Util/StringHelper.cs
@@ -102,52 +102,43 @@ namespace Lucene.Net.Util
             }
         }
 
-        private static readonly IComparer<string> versionComparer = new ComparerAnonymousInnerClassHelper();
-
-        private sealed class ComparerAnonymousInnerClassHelper : IComparer<string>
+        private static readonly IComparer<string> versionComparer = Comparer<string>.Create((a, b) =>
         {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
+            var aTokens = new StringTokenizer(a, ".");
+            var bTokens = new StringTokenizer(b, ".");
 
-            public int Compare(string a, string b)
+            while (aTokens.MoveNext())
             {
-                var aTokens = new StringTokenizer(a, ".");
-                var bTokens = new StringTokenizer(b, ".");
-
-                while (aTokens.MoveNext())
+                int aToken = Convert.ToInt32(aTokens.Current, CultureInfo.InvariantCulture);
+                if (bTokens.MoveNext())
                 {
-                    int aToken = Convert.ToInt32(aTokens.Current, CultureInfo.InvariantCulture);
-                    if (bTokens.MoveNext())
+                    int bToken = Convert.ToInt32(bTokens.Current, CultureInfo.InvariantCulture);
+                    if (aToken != bToken)
                     {
-                        int bToken = Convert.ToInt32(bTokens.Current, CultureInfo.InvariantCulture);
-                        if (aToken != bToken)
-                        {
-                            return aToken < bToken ? -1 : 1;
-                        }
-                    }
-                    else
-                    {
-                        // a has some extra trailing tokens. if these are all zeroes, thats ok.
-                        if (aToken != 0)
-                        {
-                            return 1;
-                        }
+                        return aToken < bToken ? -1 : 1;
                     }
                 }
-
-                // b has some extra trailing tokens. if these are all zeroes, thats ok.
-                while (bTokens.MoveNext())
+                else
                 {
-                    if (Convert.ToInt32(bTokens.Current, CultureInfo.InvariantCulture) != 0)
+                    // a has some extra trailing tokens. if these are all zeroes, thats ok.
+                    if (aToken != 0)
                     {
-                        return -1;
+                        return 1;
                     }
                 }
-
-                return 0;
             }
-        }
+
+            // b has some extra trailing tokens. if these are all zeroes, thats ok.
+            while (bTokens.MoveNext())
+            {
+                if (Convert.ToInt32(bTokens.Current, CultureInfo.InvariantCulture) != 0)
+                {
+                    return -1;
+                }
+            }
+
+            return 0;
+        });
 
         public static bool Equals(string s1, string s2)
         {

--- a/src/Lucene.Net/Util/WAH8DocIdSet.cs
+++ b/src/Lucene.Net/Util/WAH8DocIdSet.cs
@@ -98,20 +98,8 @@ namespace Lucene.Net.Util
             return buffer;
         }
 
-        private static readonly IComparer<Iterator> SERIALIZED_LENGTH_COMPARER = new ComparerAnonymousInnerClassHelper();
-
-        private class ComparerAnonymousInnerClassHelper : IComparer<Iterator>
-        {
-            public ComparerAnonymousInnerClassHelper()
-            {
-            }
-
-            public virtual int Compare(Iterator wi1, Iterator wi2)
-            {
-                return wi1.@in.Length - wi2.@in.Length;
-            }
-        }
-
+        private static readonly IComparer<Iterator> SERIALIZED_LENGTH_COMPARER = Comparer<Iterator>.Create((wi1, wi2) => wi1.@in.Length - wi2.@in.Length);
+        
         /// <summary>
         /// Same as <see cref="Intersect(ICollection{WAH8DocIdSet}, int)"/> with the default index interval. </summary>
         public static WAH8DocIdSet Intersect(ICollection<WAH8DocIdSet> docIdSets)
@@ -178,7 +166,7 @@ namespace Lucene.Net.Util
                 Debug.Assert(word != 0);
                 builder.AddWord(wordNum, word);
                 ++wordNum;
-            mainContinue: ;
+            mainContinue:;
             }
             //mainBreak:
             return builder.Build();
@@ -902,9 +890,9 @@ namespace Lucene.Net.Util
         /// Return the memory usage of this class in bytes. </summary>
         public long RamBytesUsed()
         {
-            return RamUsageEstimator.AlignObjectSize(3 * RamUsageEstimator.NUM_BYTES_OBJECT_REF + 2 * RamUsageEstimator.NUM_BYTES_INT32) 
-                + RamUsageEstimator.SizeOf(data) 
-                + positions.RamBytesUsed() 
+            return RamUsageEstimator.AlignObjectSize(3 * RamUsageEstimator.NUM_BYTES_OBJECT_REF + 2 * RamUsageEstimator.NUM_BYTES_INT32)
+                + RamUsageEstimator.SizeOf(data)
+                + positions.RamBytesUsed()
                 + wordNums.RamBytesUsed();
         }
     }


### PR DESCRIPTION
Hi Shad,

I have completed a couple of the tasks that you set: 

1. Replace all private/internal nested IComparer<T> implementations (usually including the word "Anonymous" in the name) with the Comparer.Create() method (see: https://stackoverflow.com/a/28533921). This will eliminate a lot of unnecessary classes and make the code correspond to Java better, which uses anonymous classes to achieve similar code inlining. If you are unsure if one needs to be converted to inline code rather than a concrete class, check the Java implementation to see if it is inline (https://github.com/apache/lucene-solr/tree/releases/lucene-solr/4.8.0/lucen
e).

2. Change overloads of OpenStringBuilder.Append(charsequence, start, end) to OpenStringBuilder.Append(charsequence, startIndex, charCount) to match the conventions in .NET
(https://github.com/apache/lucenenet/blob/1274197c39b4b229af7c6734d35840ff21
d47e97/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs#L98
). In Java, the convention is to use start index and end index to select text in a string, but in .NET, the corresponding convention is to use start index and length (count).

On building in Azure I noticed that the set BuildNumber step in the Build.ps1 file was failing. This is due to some changes to the Azure pipeline. These variables are now readonly. I commented this line to successfully run the build/test process but you may want to look at it in more detail.

Thanks
Michael
