### PR TITLE
Lucene.Net.Queries Culture Sensitivity (fixes #260)

### DIFF
--- a/src/Lucene.Net.Queries/Function/DocValues/DoubleDocValues.cs
+++ b/src/Lucene.Net.Queries/Function/DocValues/DoubleDocValues.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Index;
 using Lucene.Net.Util.Mutable;
 using System;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.DocValues
 {
@@ -78,9 +79,9 @@ namespace Lucene.Net.Queries.Function.DocValues
 
         public override abstract double DoubleVal(int doc);
 
-        public override string StrVal(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        public override string StrVal(int doc)
         {
-            return Convert.ToString(DoubleVal(doc));
+            return DoubleVal(doc).ToString("R", CultureInfo.InvariantCulture);
         }
 
         public override object ObjectVal(int doc)
@@ -94,7 +95,7 @@ namespace Lucene.Net.Queries.Function.DocValues
         }
 
         public override ValueSourceScorer GetRangeScorer(IndexReader reader, string lowerVal, string upperVal,
-            bool includeLower, bool includeUpper) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+            bool includeLower, bool includeUpper)
         {
             double lower, upper;
 
@@ -104,7 +105,7 @@ namespace Lucene.Net.Queries.Function.DocValues
             }
             else
             {
-                lower = Convert.ToDouble(lowerVal);
+                lower = Convert.ToDouble(lowerVal, CultureInfo.InvariantCulture);
             }
 
             if (upperVal == null)
@@ -113,7 +114,7 @@ namespace Lucene.Net.Queries.Function.DocValues
             }
             else
             {
-                upper = Convert.ToDouble(upperVal);
+                upper = Convert.ToDouble(upperVal, CultureInfo.InvariantCulture);
             }
 
             double l = lower;

--- a/src/Lucene.Net.Queries/Function/DocValues/FloatDocValues.cs
+++ b/src/Lucene.Net.Queries/Function/DocValues/FloatDocValues.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Util.Mutable;
 using System;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.DocValues
 {
@@ -74,9 +75,9 @@ namespace Lucene.Net.Queries.Function.DocValues
             return (double)SingleVal(doc);
         }
 
-        public override string StrVal(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        public override string StrVal(int doc)
         {
-            return Convert.ToString(SingleVal(doc));
+            return SingleVal(doc).ToString("R", CultureInfo.InvariantCulture);
         }
 
         public override object ObjectVal(int doc)

--- a/src/Lucene.Net.Queries/Function/DocValues/IntDocValues.cs
+++ b/src/Lucene.Net.Queries/Function/DocValues/IntDocValues.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Index;
 using Lucene.Net.Util.Mutable;
 using System;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.DocValues
 {
@@ -75,9 +76,9 @@ namespace Lucene.Net.Queries.Function.DocValues
             return (double)Int32Val(doc);
         }
 
-        public override string StrVal(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        public override string StrVal(int doc)
         {
-            return Convert.ToString(Int32Val(doc));
+            return Int32Val(doc).ToString(CultureInfo.InvariantCulture);
         }
 
         public override object ObjectVal(int doc)
@@ -90,7 +91,7 @@ namespace Lucene.Net.Queries.Function.DocValues
             return m_vs.GetDescription() + '=' + StrVal(doc);
         }
 
-        public override ValueSourceScorer GetRangeScorer(IndexReader reader, string lowerVal, string upperVal, bool includeLower, bool includeUpper) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        public override ValueSourceScorer GetRangeScorer(IndexReader reader, string lowerVal, string upperVal, bool includeLower, bool includeUpper)
         {
             int lower, upper;
 
@@ -102,7 +103,7 @@ namespace Lucene.Net.Queries.Function.DocValues
             }
             else
             {
-                lower = Convert.ToInt32(lowerVal);
+                lower = Convert.ToInt32(lowerVal, CultureInfo.InvariantCulture);
                 if (!includeLower && lower < int.MaxValue)
                 {
                     lower++;
@@ -115,7 +116,7 @@ namespace Lucene.Net.Queries.Function.DocValues
             }
             else
             {
-                upper = Convert.ToInt32(upperVal);
+                upper = Convert.ToInt32(upperVal, CultureInfo.InvariantCulture);
                 if (!includeUpper && upper > int.MinValue)
                 {
                     upper--;

--- a/src/Lucene.Net.Queries/Function/DocValues/LongDocValues.cs
+++ b/src/Lucene.Net.Queries/Function/DocValues/LongDocValues.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Index;
 using Lucene.Net.Util.Mutable;
 using System;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.DocValues
 {
@@ -77,9 +78,9 @@ namespace Lucene.Net.Queries.Function.DocValues
             return Int64Val(doc) != 0;
         }
 
-        public override string StrVal(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        public override string StrVal(int doc)
         {
-            return Convert.ToString(Int64Val(doc));
+            return Int64Val(doc).ToString(CultureInfo.InvariantCulture);
         }
 
         public override object ObjectVal(int doc)
@@ -95,9 +96,9 @@ namespace Lucene.Net.Queries.Function.DocValues
         /// <summary>
         /// NOTE: This was externalToLong() in Lucene
         /// </summary>
-        protected virtual long ExternalToInt64(string extVal) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        protected virtual long ExternalToInt64(string extVal)
         {
-            return Convert.ToInt64(extVal);
+            return Convert.ToInt64(extVal, CultureInfo.InvariantCulture);
         }
 
         public override ValueSourceScorer GetRangeScorer(IndexReader reader, string lowerVal, string upperVal, bool includeLower, bool includeUpper)

--- a/src/Lucene.Net.Queries/Function/FunctionValues.cs
+++ b/src/Lucene.Net.Queries/Function/FunctionValues.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
 using Lucene.Net.Util;
@@ -230,7 +231,7 @@ namespace Lucene.Net.Queries.Function
         }
 
         // TODO: should we make a termVal, fills BytesRef[]?
-        public virtual void StrVal(int doc, string[] vals) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        public virtual void StrVal(int doc, string[] vals)
         {
             throw new System.NotSupportedException();
         }
@@ -250,7 +251,7 @@ namespace Lucene.Net.Queries.Function
         // a setup cost - parsing and normalizing params, and doing a binary search on the StringIndex.
         // TODO: change "reader" to AtomicReaderContext
         public virtual ValueSourceScorer GetRangeScorer(IndexReader reader, string lowerVal, string upperVal,
-            bool includeLower, bool includeUpper) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+            bool includeLower, bool includeUpper)
         {
             float lower;
             float upper;
@@ -261,7 +262,7 @@ namespace Lucene.Net.Queries.Function
             }
             else
             {
-                lower = Convert.ToSingle(lowerVal);
+                lower = Convert.ToSingle(lowerVal, CultureInfo.InvariantCulture);
             }
             if (upperVal == null)
             {
@@ -269,7 +270,7 @@ namespace Lucene.Net.Queries.Function
             }
             else
             {
-                upper = Convert.ToSingle(upperVal);
+                upper = Convert.ToSingle(upperVal, CultureInfo.InvariantCulture);
             }
 
             float l = lower;

--- a/src/Lucene.Net.Queries/Function/ValueSources/ByteFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ByteFieldSource.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Search;
 using System;
 using System.Collections;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.ValueSources
 {
@@ -108,9 +109,9 @@ namespace Lucene.Net.Queries.Function.ValueSources
                 return (double)(sbyte)arr.Get(doc);
             }
 
-            public override string StrVal(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+            public override string StrVal(int doc)
             {
-                return Convert.ToString((sbyte)arr.Get(doc));
+                return Convert.ToString((sbyte)arr.Get(doc), CultureInfo.InvariantCulture);
             }
 
             public override string ToString(int doc)

--- a/src/Lucene.Net.Queries/Function/ValueSources/DocFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DocFreqValueSource.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Search;
 using Lucene.Net.Util;
 using System;
 using System.Collections;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.ValueSources
 {
@@ -36,14 +37,14 @@ namespace Lucene.Net.Queries.Function.ValueSources
         internal readonly string sval;
         internal readonly ValueSource parent;
 
-        internal ConstInt32DocValues(int val, ValueSource parent) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        internal ConstInt32DocValues(int val, ValueSource parent)
             : base(parent)
         {
             ival = val;
             fval = val;
             dval = val;
             lval = val;
-            sval = Convert.ToString(val);
+            sval = Convert.ToString(val, CultureInfo.InvariantCulture);
             this.parent = parent;
         }
 
@@ -93,14 +94,14 @@ namespace Lucene.Net.Queries.Function.ValueSources
         internal readonly string sval;
         internal readonly ValueSource parent;
 
-        internal ConstDoubleDocValues(double val, ValueSource parent) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        internal ConstDoubleDocValues(double val, ValueSource parent)
             : base(parent)
         {
             ival = (int)val;
             fval = (float)val;
             dval = val;
             lval = (long)val;
-            sval = Convert.ToString(val);
+            sval = val.ToString("R", CultureInfo.InvariantCulture);
             this.parent = parent;
         }
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/DoubleConstValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DoubleConstValueSource.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Queries.Function.DocValues;
 using System;
 using System.Collections;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.ValueSources
 {
@@ -87,9 +88,9 @@ namespace Lucene.Net.Queries.Function.ValueSources
                 return outerInstance.constant;
             }
 
-            public override string StrVal(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+            public override string StrVal(int doc)
             {
-                return Convert.ToString(outerInstance.constant);
+                return outerInstance.constant.ToString("R", CultureInfo.InvariantCulture);
             }
 
             public override object ObjectVal(int doc)

--- a/src/Lucene.Net.Queries/Function/ValueSources/EnumFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/EnumFieldSource.cs
@@ -48,20 +48,12 @@ namespace Lucene.Net.Queries.Function.ValueSources
             this.enumStringToIntMap = enumStringToIntMap;
         }
 
-        /// <summary>
-        /// NOTE: This was tryParseInt() in Lucene
-        /// </summary>
-        private static int? TryParseInt32(string valueStr) // LUCENENET TODO: API - Add overload to include CultureInfo ?
-        {
-            if (int.TryParse(valueStr, out int intValue))
-                return intValue;
-            return null;
-        }
+        // LUCENENET specific - removed TryParseInt in favor of int.TryParse()
 
         /// <summary>
         /// NOTE: This was intValueToStringValue() in Lucene
         /// </summary>
-        private string Int32ValueToStringValue(int? intVal) // LUCENENET TODO: API - Add overload to include CultureInfo
+        private string Int32ValueToStringValue(int? intVal)
         {
             if (intVal == null)
             {
@@ -80,14 +72,13 @@ namespace Lucene.Net.Queries.Function.ValueSources
         /// <summary>
         /// NOTE: This was stringValueToIntValue() in Lucene
         /// </summary>
-        private int? StringValueToInt32Value(string stringVal) // LUCENENET TODO: API - Add overload to include CultureInfo
+        private int? StringValueToInt32Value(string stringVal)
         {
             if (stringVal == null)
             {
                 return null;
             }
 
-            int? intValue;
             int? enumInt = enumStringToIntMap[stringVal];
             if (enumInt != null) //enum int found for str
             {
@@ -95,8 +86,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             }
 
             //enum int not found for str
-            intValue = TryParseInt32(stringVal);
-            if (intValue == null) //not Integer
+            if (!int.TryParse(stringVal, NumberStyles.Integer, CultureInfo.InvariantCulture, out int intValue)) //not Integer
             {
                 intValue = DEFAULT_VALUE;
             }
@@ -192,7 +182,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             }
 
 
-            public override ValueSourceScorer GetRangeScorer(IndexReader reader, string lowerVal, string upperVal, bool includeLower, bool includeUpper) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+            public override ValueSourceScorer GetRangeScorer(IndexReader reader, string lowerVal, string upperVal, bool includeLower, bool includeUpper)
             {
                 int? lower = outerInstance.StringValueToInt32Value(lowerVal);
                 int? upper = outerInstance.StringValueToInt32Value(upperVal);
@@ -291,6 +281,4 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return result;
         }
     }
-
-
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/IntFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/IntFieldSource.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Util;
 using Lucene.Net.Util.Mutable;
 using System;
 using System.Collections;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.ValueSources
 {
@@ -106,9 +107,9 @@ namespace Lucene.Net.Queries.Function.ValueSources
                 return (double)arr.Get(doc);
             }
 
-            public override string StrVal(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+            public override string StrVal(int doc)
             {
-                return Convert.ToString(arr.Get(doc));
+                return Convert.ToString(arr.Get(doc), CultureInfo.InvariantCulture);
             }
 
             public override object ObjectVal(int doc)

--- a/src/Lucene.Net.Queries/Function/ValueSources/LinearFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LinearFloatFunction.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Queries.Function.DocValues;
 using Lucene.Net.Search;
 using System.Collections;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.ValueSources
 {
@@ -73,9 +74,14 @@ namespace Lucene.Net.Queries.Function.ValueSources
             {
                 return vals.SingleVal(doc) * outerInstance.m_slope + outerInstance.m_intercept;
             }
-            public override string ToString(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+
+            public override string ToString(int doc)
             {
-                return outerInstance.m_slope + "*float(" + vals.ToString(doc) + ")+" + outerInstance.m_intercept;
+                // LUCENENET specific - changed formatting to ensure the same culture is used for each value.
+                return string.Format("{0}*float({1})+{2}",
+                    outerInstance.m_slope,
+                    vals.ToString(doc),
+                    outerInstance.m_intercept);
             }
         }
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/LongFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LongFieldSource.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Util;
 using Lucene.Net.Util.Mutable;
 using System;
 using System.Collections;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.ValueSources
 {
@@ -54,9 +55,9 @@ namespace Lucene.Net.Queries.Function.ValueSources
         /// <summary>
         /// NOTE: This was externalToLong() in Lucene
         /// </summary>
-        public virtual long ExternalToInt64(string extVal) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        public virtual long ExternalToInt64(string extVal)
         {
-            return Convert.ToInt64(extVal);
+            return Convert.ToInt64(extVal, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -70,9 +71,9 @@ namespace Lucene.Net.Queries.Function.ValueSources
         /// <summary>
         /// NOTE: This was longToString() in Lucene
         /// </summary>
-        public virtual string Int64ToString(long val) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        public virtual string Int64ToString(long val)
         {
-            return Int64ToObject(val).ToString();
+            return string.Format(CultureInfo.InvariantCulture, "{0}", Int64ToObject(val));
         }
 
         public override FunctionValues GetValues(IDictionary context, AtomicReaderContext readerContext)
@@ -115,7 +116,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
                 return valid.Get(doc) ? outerInstance.Int64ToObject(arr.Get(doc)) : null;
             }
 
-            public override string StrVal(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+            public override string StrVal(int doc)
             {
                 return valid.Get(doc) ? outerInstance.Int64ToString(arr.Get(doc)) : null;
             }

--- a/src/Lucene.Net.Queries/Function/ValueSources/ReciprocalFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ReciprocalFloatFunction.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Queries.Function.DocValues;
 using Lucene.Net.Search;
 using System;
 using System.Collections;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.ValueSources
 {
@@ -82,9 +83,15 @@ namespace Lucene.Net.Queries.Function.ValueSources
             {
                 return outerInstance.m_a / (outerInstance.m_m * vals.SingleVal(doc) + outerInstance.m_b);
             }
-            public override string ToString(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+
+            public override string ToString(int doc)
             {
-                return Convert.ToString(outerInstance.m_a) + "/(" + outerInstance.m_m + "*float(" + vals.ToString(doc) + ')' + '+' + outerInstance.m_b + ')';
+                // LUCENENET specific - changed formatting to ensure the same culture is used for each value.
+                return string.Format(CultureInfo.InvariantCulture, "{0}/({1}*float({2})+{3})",
+                    outerInstance.m_a,
+                    outerInstance.m_m,
+                    vals.ToString(doc),
+                    outerInstance.m_b);
             }
         }
 
@@ -93,9 +100,11 @@ namespace Lucene.Net.Queries.Function.ValueSources
             m_source.CreateWeight(context, searcher);
         }
 
-        public override string GetDescription() // LUCENENET TODO: API - Add overload to include CultureInfo ?
+        public override string GetDescription()
         {
-            return Convert.ToString(m_a) + "/(" + m_m + "*float(" + m_source.GetDescription() + ")" + "+" + m_b + ')';
+            return m_a.ToString(CultureInfo.InvariantCulture) + 
+                "/(" + m_m.ToString(CultureInfo.InvariantCulture) + 
+                "*float(" + m_source.GetDescription() + ")" + "+" + m_b.ToString(CultureInfo.InvariantCulture) + ')';
         }
 
         public override int GetHashCode()

--- a/src/Lucene.Net.Queries/Function/ValueSources/ScaleFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ScaleFloatFunction.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Queries.Function.DocValues;
 using Lucene.Net.Search;
 using System.Collections;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.ValueSources
 {
@@ -145,9 +146,15 @@ namespace Lucene.Net.Queries.Function.ValueSources
             {
                 return (vals.SingleVal(doc) - minSource) * scale + outerInstance.m_min;
             }
-            public override string ToString(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+
+            public override string ToString(int doc)
             {
-                return "scale(" + vals.ToString(doc) + ",toMin=" + outerInstance.m_min + ",toMax=" + outerInstance.m_max + ",fromMin=" + minSource + ",fromMax=" + maxSource + ")";
+                // LUCENENET specific - changed formatting to ensure the same culture is used for each value.
+                return string.Format(CultureInfo.InvariantCulture, "scale({0},toMin={1},toMax={2},fromMin={3})", 
+                    vals.ToString(doc),
+                    outerInstance.m_min,
+                    outerInstance.m_max,
+                    maxSource);
             }
         }
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/ShortFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ShortFieldSource.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Search;
 using System;
 using System.Collections;
+using System.Globalization;
 
 namespace Lucene.Net.Queries.Function.ValueSources
 {
@@ -109,9 +110,9 @@ namespace Lucene.Net.Queries.Function.ValueSources
                 return arr.Get(doc);
             }
 
-            public override string StrVal(int doc) // LUCENENET TODO: API - Add overload to include CultureInfo ?
+            public override string StrVal(int doc)
             {
-                return Convert.ToString(arr.Get(doc));
+                return Convert.ToString(arr.Get(doc), CultureInfo.InvariantCulture);
             }
 
             public override string ToString(int doc)


### PR DESCRIPTION
Converted types to use invariant culture when converting strings to numbers and numbers to strings.

After analysis, it looks like this is the right choice, as the places that utilize these queries are also using culture-insensitive conversions. If a user extends `FunctionValues`, they can build in their own culture sensitivity as needed per their requirements by adding overloads to these methods in a custom subclass.