### PR TITLE
The description for websie link under the title Lucene 2.9.4.1 is wrong.

### DIFF
--- a/websites/site/docs.md
+++ b/websites/site/docs.md
@@ -20,4 +20,4 @@ The documentation website for Lucene 3.0.3 is here [http://lucenenet.apache.org/
 
 ## Lucene 2.9.4.1
 
-The documentation website for Lucene 3.0.3 is here [http://lucenenet.apache.org/docs/2.9.4/Index.html](https://lucenenet.apache.org/docs/2.9.4/Index.html)
+The documentation website for Lucene 2.9.4 is here [http://lucenenet.apache.org/docs/2.9.4/Index.html](https://lucenenet.apache.org/docs/2.9.4/Index.html)


### PR DESCRIPTION
As per the title, I updated the display text from 3.0.3 to 2.9.4