### PR TITLE
Failing Asserts on .NET Standard 2.x (fixes #267, fixes #301)

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -63,7 +63,7 @@
 
     <MicrosoftExtensionsDependencyInjectionPackageVersion>3.1.4</MicrosoftExtensionsDependencyInjectionPackageVersion>
     
-    <MicrosoftNETTestSdkPackageVersion>16.2.0</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>16.6.1</MicrosoftNETTestSdkPackageVersion>
     <MorfologikFsaPackageVersion>2.1.6-beta-0005</MorfologikFsaPackageVersion>
     <MorfologikPolishPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikPolishPackageVersion>
     <MorfologikStemmingPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikStemmingPackageVersion>
@@ -72,8 +72,8 @@
     <NETStandardLibrary16PackageVersion>1.6.1</NETStandardLibrary16PackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <NewtonsoftJsonPackageVersion>10.0.3</NewtonsoftJsonPackageVersion>
-    <NUnit3TestAdapterPackageVersion>3.13.0</NUnit3TestAdapterPackageVersion>
-    <NUnitPackageVersion>3.9.0</NUnitPackageVersion>
+    <NUnit3TestAdapterPackageVersion>3.16.1</NUnit3TestAdapterPackageVersion>
+    <NUnitPackageVersion>3.12.0</NUnitPackageVersion>
     <OpenNLPNETPackageVersion>1.9.1</OpenNLPNETPackageVersion>
     <SharpZipLibPackageVersion>1.1.0</SharpZipLibPackageVersion>
     <SharpZipLibNETStandardPackageVersion>0.86.0.1</SharpZipLibNETStandardPackageVersion>

--- a/src/Lucene.Net.Benchmark/Quality/Trec/TrecJudge.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/TrecJudge.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
                     st.MoveNext();
                     bool relevant = !zero.Equals(st.Current, StringComparison.Ordinal);
                     // LUCENENET: don't call st.NextToken() unless the condition fails.
-                    Debug.Assert(st.RemainingTokens != 0, "wrong format: " + line + "  next: " + (st.MoveNext() ? st.Current : ""));
+                    Debug.Assert(st.RemainingTokens == 0, "wrong format: " + line + "  next: " + (st.MoveNext() ? st.Current : ""));
                     if (relevant)
                     { // only keep relevant docs
                         if (curr == null || !curr.queryID.Equals(queryID, StringComparison.Ordinal))

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
@@ -591,12 +591,19 @@ namespace Lucene.Net.Codecs.SimpleText
 
             public override int NextPosition()
             {
-                // LUCENENET NOTE: In Java, the assertion is being caught in the test (as an AssertionException).
-                // Technically, a "possible" (in fact "probable") scenario like this one, we should be throwing
-                // an exception, however doing that causes the checkIndex test to fail. The only logical thing we
-                // can do to make this compatible is to remove the assert.
                 //Debug.Assert((_positions != null && _nextPos < _positions.Length) ||
                 //             _startOffsets != null && _nextPos < _startOffsets.Length);
+
+                // LUCENENET: The above assertion was for control flow when testing. In Java, it would throw an AssertionError, which is
+                // caught by the BaseTermVectorsFormatTestCase.assertEquals(RandomTokenStream tk, FieldType ft, Terms terms) method in the
+                // part that is checking for an error after reading to the end of the enumerator.
+
+                // Since there is no way to turn on assertions in a release build in .NET, we are throwing an InvalidOperationException
+                // in this case, which matches the behavior of Lucene 8. See #267.
+
+                if (((_positions != null && _nextPos < _positions.Length) || _startOffsets != null && _nextPos < _startOffsets.Length) == false)
+                    throw new InvalidOperationException("Read past last position");
+
                 if (_positions != null)
                 {
                     return _positions[_nextPos++];

--- a/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
@@ -848,6 +848,11 @@ namespace Lucene.Net.TestFramework
             _NUnit.Assert.Greater(arg1, arg2);
         }
 
+        public static Exception Throws<TException>(Action action, string message, params string[] args)
+        {
+            return Throws(typeof(TException), action, message, args);
+        }
+
         public static Exception Throws<TException>(Action action)
         {
             return Throws(typeof(TException), action);
@@ -856,6 +861,11 @@ namespace Lucene.Net.TestFramework
         public static Exception Throws(Type expectedExceptionType, Action action)
         {
             return _NUnit.Assert.Throws(expectedExceptionType, () => action());
+        }
+
+        public static Exception Throws(Type expectedExceptionType, Action action, string message, params string[] args)
+        {
+            return _NUnit.Assert.Throws(expectedExceptionType, () => action(), message, args);
         }
 
         public static Exception ThrowsFileAlreadyExistsException(string filePath, Action action)
@@ -888,7 +898,6 @@ namespace Lucene.Net.TestFramework
 
         public static Exception ThrowsAnyOf(IEnumerable<Type> expectedExceptionTypes, Action action)
         {
-            var messagePrefix = $"Expected one of: {Collections.ToString(expectedExceptionTypes.Select(ex => ex.FullName).ToArray())}\nBut was:";
             Exception exception = null;
             try
             {
@@ -903,7 +912,7 @@ namespace Lucene.Net.TestFramework
                 return ex; // Success
             }
             string exString = exception == null ? "<null>" : exception.GetType().FullName;
-            throw new _NUnit.AssertionException($"{messagePrefix} {exString}");
+            throw new _NUnit.AssertionException($"Expected one of: {Collections.ToString(expectedExceptionTypes.Select(ex => ex.FullName).ToArray())}\nBut was: {exString}");
         }
     }
 }

--- a/src/Lucene.Net.TestFramework/Support/Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/Lucene.Net.TestFramework/Support/Configuration/ConfigurationBuilderExtensions.cs
@@ -28,40 +28,35 @@ namespace Lucene.Net.Configuration
     /// </summary>
     public static class ConfigurationBuilderExtensions
     {
+        /// <summary>
+        /// Helper Extension method to add a <see cref="TestParameterConfigurationSource"/>
+        /// Uses the <see cref="NUnit.Framework.TestContext.Parameters"/> to build provider.
+        /// </summary>
+        /// <param name="builder">This <see cref="IConfigurationBuilder"/>.</param>
+        /// <returns>This <see cref="IConfigurationBuilder"/>.</returns>
+        [CLSCompliant(false)]
+        public static IConfigurationBuilder AddNUnitTestRunSettings(this IConfigurationBuilder builder)
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
 
-        /// <summary>
-        /// Helper Extension method to add a LuceneDefaultConfigurationSource
-        /// </summary>
-        /// <param name="configurationBuilder"></param>
-        /// <param name="prefix">A prefix used to filter the environment variables.</param>
-        /// <returns></returns>
-        [CLSCompliant(false)]
-        public static IConfigurationBuilder AddLuceneDefaultSettings(this IConfigurationBuilder configurationBuilder, string prefix)
-        {
-            return configurationBuilder.Add(new LuceneDefaultConfigurationSource() { Prefix = prefix });
-        }
-        /// <summary>
-        /// Helper Extension method to add a TestParameterConfigurationSource
-        /// Uses the NUnit.Framework.TestContext.Parameters to build provider
-        /// </summary>
-        /// <param name="configurationBuilder"></param>
-        /// <returns></returns>
-        [CLSCompliant(false)]
-        public static IConfigurationBuilder AddNUnitTestRunSettings(this IConfigurationBuilder configurationBuilder)
-        {
-            return configurationBuilder.Add(new TestParameterConfigurationSource() { TestParameters = NUnit.Framework.TestContext.Parameters });
+            return builder.Add(new TestParameterConfigurationSource() { TestParameters = NUnit.Framework.TestContext.Parameters });
         }
 
         /// <summary>
-        /// Scans from currentPath to the root directory looking for fileName configuration settings. This loads a Json Configuration provider in ascending hierarchy.
+        /// Scans from <paramref name="currentPath"/> to the root directory looking for <paramref name="fileName"/> configuration settings.
+        /// This loads a Json Configuration provider in ascending hierarchy.
         /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="currentPath">The current path to start in</param>
-        /// <param name="fileName">The filename to be searched for</param>
-        /// <returns></returns>
+        /// <param name="builder">This <see cref="IConfigurationBuilder"/>.</param>
+        /// <param name="currentPath">The current path to start in.</param>
+        /// <param name="fileName">The filename to be searched for.</param>
+        /// <returns>This <see cref="IConfigurationBuilder"/>.</returns>
         [CLSCompliant(false)]
         public static IConfigurationBuilder AddJsonFilesFromRootDirectoryTo(this IConfigurationBuilder builder, string currentPath, string fileName)
         {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+
             Stack<string> locations = ScanConfigurationFiles(currentPath, fileName);
 
             while (locations.Count != 0)
@@ -72,15 +67,19 @@ namespace Lucene.Net.Configuration
         }
 
         /// <summary>
-        /// Scans from currentPath to the root directory looking for fileName configuration settings. This loads a XML Configuration provider in ascending hierarchy.
+        /// Scans from <paramref name="currentPath"/> to the root directory looking for <paramref name="fileName"/> configuration settings.
+        /// This loads a XML Configuration provider in ascending hierarchy.
         /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="currentPath">The current path to start in</param>
-        /// <param name="fileName">The filename to be searched for</param>
-        /// <returns></returns>
+        /// <param name="builder">This <see cref="IConfigurationBuilder"/>.</param>
+        /// <param name="currentPath">The current path to start in.</param>
+        /// <param name="fileName">The filename to be searched for.</param>
+        /// <returns>This <see cref="IConfigurationBuilder"/>.</returns>
         [CLSCompliant(false)]
         public static IConfigurationBuilder AddXmlFilesFromRootDirectoryTo(this IConfigurationBuilder builder, string currentPath, string fileName)
         {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+
             Stack<string> locations = ScanConfigurationFiles(currentPath, fileName);
 
             while (locations.Count != 0)

--- a/src/Lucene.Net.TestFramework/Support/Configuration/TestConfigurationFactory.cs
+++ b/src/Lucene.Net.TestFramework/Support/Configuration/TestConfigurationFactory.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Configuration
             return configurationCache.GetOrAdd(testDirectory, (key) =>
             {
                 return new ConfigurationBuilder()
-                    .AddLuceneDefaultSettings(EnvironmentVariablePrefix) // Use a custom prefix to only load Lucene.NET settings
+                    .AddEnvironmentVariables(EnvironmentVariablePrefix) // Use a custom prefix to only load Lucene.NET settings
                     .AddJsonFilesFromRootDirectoryTo(currentPath: key, JsonTestSettingsFileName)
 #if TESTFRAMEWORK_NUNIT
                     .AddNUnitTestRunSettings()

--- a/src/Lucene.Net.TestFramework/Support/Diagnostics/Debug.cs
+++ b/src/Lucene.Net.TestFramework/Support/Diagnostics/Debug.cs
@@ -28,7 +28,7 @@
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
         public static void Assert(bool condition)
         {
-            if (!condition)
+            if (Debugging.AssertsEnabled && !condition)
                 throw new AssertionException();
         }
 
@@ -39,7 +39,7 @@
         /// <param name="message">The message to use </param>
         public static void Assert(bool condition, string message)
         {
-            if (!condition)
+            if (Debugging.AssertsEnabled && !condition)
                 throw new AssertionException(message);
         }
     }

--- a/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
@@ -201,6 +201,12 @@ namespace Lucene.Net.Util
                 DocValuesFormat.SetDocValuesFormatFactory(DocValuesFormatFactory);
                 PostingsFormat.SetPostingsFormatFactory(PostingsFormatFactory);
 
+                // Enable "asserts" for tests. In Java, these were actual asserts,
+                // but in .NET we simply mock this as a boolean static setting that can be
+                // toggled on and off, even in release mode. Note this must be done after
+                // the ConfigurationFactory is set.
+                Lucene.Net.Diagnostics.Debugging.AssertsEnabled = SystemProperties.GetPropertyAsBoolean("assert", true);
+
                 IncrementInitalizationCount(); // For testing
 
                 return new object(); // Placeholder to indicate our initializer has been run already

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/Alt/AltPackageTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/Alt/AltPackageTaskTest.cs
@@ -28,6 +28,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks.Alt
     {
         /** Benchmark should fail loading the algorithm when alt is not specified */
         [Test]
+        [Ignore("In LUCENENET, we use all referenced assemblies by default. Currently, we don't support a scenario that loads external assemblies.")]
         public void TestWithoutAlt()
         {
             try

--- a/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
@@ -143,24 +143,29 @@ namespace Lucene.Net.QueryParsers.Classic
         [Test]
         public virtual void TestProtectedCtors()
         {
-            try
-            {
-                typeof(QueryParser).GetConstructor(new Type[] { typeof(ICharStream) });
-                fail("please switch public QueryParser(CharStream) to be protected");
-            }
-            catch (Exception /*nsme*/)
-            {
-                // expected
-            }
-            try
-            {
-                typeof(QueryParser).GetConstructor(new Type[] { typeof(QueryParserTokenManager) });
-                fail("please switch public QueryParser(QueryParserTokenManager) to be protected");
-            }
-            catch (Exception /*nsme*/)
-            {
-                // expected
-            }
+            // LUCENENET: .NET doesn't throw exceptions when public constructors don't exist, it simply returns null.
+
+            assertNull("please switch public QueryParser(ICharStream) to be protected", typeof(QueryParser).GetConstructor(new Type[] { typeof(ICharStream) }));
+            assertNull("please switch public QueryParser(QueryParserTokenManager) to be protected", typeof(QueryParser).GetConstructor(new Type[] { typeof(QueryParserTokenManager) }));
+
+            //try
+            //{
+            //    typeof(QueryParser).GetConstructor(new Type[] { typeof(ICharStream) });
+            //    fail("please switch public QueryParser(CharStream) to be protected");
+            //}
+            //catch (Exception /*nsme*/)
+            //{
+            //    // expected
+            //}
+            //try
+            //{
+            //    typeof(QueryParser).GetConstructor(new Type[] { typeof(QueryParserTokenManager) });
+            //    fail("please switch public QueryParser(QueryParserTokenManager) to be protected");
+            //}
+            //catch (Exception /*nsme*/)
+            //{
+            //    // expected
+            //}
         }
 
         private class TestFuzzySlopeExtendabilityQueryParser : QueryParser

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -503,17 +503,20 @@ namespace Lucene.Net.Index
             doc.Add(NewTextField("field", "a field", Field.Store.YES));
             w.AddDocument(doc);
             testPoint.DoFail = true;
-            try
-            {
-                w.AddDocument(doc);
-                Assert.Fail("did not hit exception");
-            }
-#pragma warning disable 168
-            catch (Exception re)
-#pragma warning restore 168
-            {
-                // expected
-            }
+
+            // LUCENENET: Don't swallow NUnit's assert exception
+            Assert.Throws<Exception>(() => w.AddDocument(doc), "did not hit exception");
+//            try
+//            {
+//                w.AddDocument(doc);
+//                Assert.Fail("did not hit exception");
+//            }
+//#pragma warning disable 168
+//            catch (Exception re)
+//#pragma warning restore 168
+//            {
+//                // expected
+//            }
             w.Dispose();
             dir.Dispose();
         }

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -115,7 +115,7 @@ namespace Lucene.Net.Analysis
                 throw new InvalidOperationException("TokenStream contract violation: Close() call missing");
             }
             this.inputPending = input;
-            Debug.Assert(SetReaderTestPoint());
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) SetReaderTestPoint();
         }
 
         public override void Reset()

--- a/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsIndexWriter.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsIndexWriter.cs
@@ -211,7 +211,7 @@ namespace Lucene.Net.Codecs.Compressing
         {
             if (numDocs != totalDocs)
             {
-                throw new Exception("Expected " + numDocs + " docs, but got " + totalDocs);
+                throw new InvalidOperationException("Expected " + numDocs + " docs, but got " + totalDocs);
             }
             if (blockChunks > 0)
             {

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
@@ -1071,11 +1071,11 @@ namespace Lucene.Net.Codecs.Compressing
             {
                 if (doc == NO_MORE_DOCS)
                 {
-                    throw new Exception("DocsEnum exhausted");
+                    throw new InvalidOperationException("DocsEnum exhausted");
                 }
                 else if (doc == -1)
                 {
-                    throw new Exception("DocsEnum not started");
+                    throw new InvalidOperationException("DocsEnum not started");
                 }
             }
 
@@ -1084,11 +1084,11 @@ namespace Lucene.Net.Codecs.Compressing
                 CheckDoc();
                 if (i < 0)
                 {
-                    throw new Exception("Position enum not started");
+                    throw new InvalidOperationException("Position enum not started");
                 }
                 else if (i >= termFreq)
                 {
-                    throw new Exception("Read past last position");
+                    throw new InvalidOperationException("Read past last position");
                 }
             }
 
@@ -1096,11 +1096,11 @@ namespace Lucene.Net.Codecs.Compressing
             {
                 if (doc != 0)
                 {
-                    throw new Exception();
+                    throw new InvalidOperationException();
                 }
                 else if (i >= termFreq - 1)
                 {
-                    throw new Exception("Read past last position");
+                    throw new InvalidOperationException("Read past last position");
                 }
 
                 ++i;

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -804,13 +804,16 @@ namespace Lucene.Net.Codecs.Lucene3x
 
             public override int NextPosition()
             {
-                // LUCENENET TODO: on .NET Core 2.0, this assert causes an uncatchable exception.
-                // See: https://github.com/Microsoft/vstest/issues/1022
-                // Once the issue has been identified and fixed we can remove this conditional
-                // compilation for it on .NET Core 2.0.
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
-                Debug.Assert((positions != null && nextPos < positions.Length) || startOffsets != null && nextPos < startOffsets.Length);
-#endif
+                //Debug.Assert((positions != null && nextPos < positions.Length) || startOffsets != null && nextPos < startOffsets.Length);
+
+                // LUCENENET: The above assertion was for control flow when testing. In Java, it would throw an AssertionError, which is
+                // caught by the BaseTermVectorsFormatTestCase.assertEquals(RandomTokenStream tk, FieldType ft, Terms terms) method in the
+                // part that is checking for an error after reading to the end of the enumerator.
+
+                // Since there is no way to turn on assertions in a release build in .NET, we are throwing an InvalidOperationException
+                // in this case, which matches the behavior of Lucene 8. See #267.
+                if (((positions != null && nextPos < positions.Length) || startOffsets != null && nextPos < startOffsets.Length) == false)
+                    throw new InvalidOperationException("Read past last position");
 
                 if (positions != null)
                 {

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
@@ -808,11 +808,16 @@ namespace Lucene.Net.Codecs.Lucene40
 
             public override int NextPosition()
             {
-                // LUCENENET TODO: BUG - Need to investigate why this assert sometimes fails
-                // which will cause the test runner to crash on .NET Core 2.0
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
-                Debug.Assert((positions != null && nextPos < positions.Length) || startOffsets != null && nextPos < startOffsets.Length);
-#endif
+                //Debug.Assert((positions != null && nextPos < positions.Length) || startOffsets != null && nextPos < startOffsets.Length);
+
+                // LUCENENET: The above assertion was for control flow when testing. In Java, it would throw an AssertionError, which is
+                // caught by the BaseTermVectorsFormatTestCase.assertEquals(RandomTokenStream tk, FieldType ft, Terms terms) method in the
+                // part that is checking for an error after reading to the end of the enumerator.
+
+                // Since there is no way to turn on assertions in a release build in .NET, we are throwing an InvalidOperationException
+                // in this case, which matches the behavior of Lucene 8. See #267.
+                if (((positions != null && nextPos < positions.Length) || startOffsets != null && nextPos < startOffsets.Length) == false)
+                    throw new InvalidOperationException("Read past last position");
 
                 if (positions != null)
                 {

--- a/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
@@ -276,7 +276,8 @@ namespace Lucene.Net.Index
 
         public virtual void UpdateDocument(IEnumerable<IIndexableField> doc, Analyzer analyzer, Term delTerm)
         {
-            Debug.Assert(TestPoint("DocumentsWriterPerThread addDocument start"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("DocumentsWriterPerThread addDocument start");
             Debug.Assert(deleteQueue != null);
             docState.doc = doc;
             docState.analyzer = analyzer;
@@ -332,7 +333,8 @@ namespace Lucene.Net.Index
 
         public virtual int UpdateDocuments(IEnumerable<IEnumerable<IIndexableField>> docs, Analyzer analyzer, Term delTerm)
         {
-            Debug.Assert(TestPoint("DocumentsWriterPerThread addDocuments start"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("DocumentsWriterPerThread addDocuments start");
             Debug.Assert(deleteQueue != null);
             docState.analyzer = analyzer;
             if (INFO_VERBOSE && infoStream.IsEnabled("DWPT"))

--- a/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
+++ b/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
@@ -199,7 +199,8 @@ namespace Lucene.Net.Index
         {
             // First time we're seeing this term since the last
             // flush
-            Debug.Assert(docState.TestPoint("FreqProxTermsWriterPerField.newTerm start"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docState.TestPoint("FreqProxTermsWriterPerField.newTerm start");
 
             FreqProxPostingsArray postings = (FreqProxPostingsArray)termsHashPerField.postingsArray;
             postings.lastDocIDs[termID] = docState.docID;
@@ -230,7 +231,8 @@ namespace Lucene.Net.Index
 
         internal override void AddTerm(int termID)
         {
-            Debug.Assert(docState.TestPoint("FreqProxTermsWriterPerField.addTerm start"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docState.TestPoint("FreqProxTermsWriterPerField.addTerm start");
 
             FreqProxPostingsArray postings = (FreqProxPostingsArray)termsHashPerField.postingsArray;
 

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -2573,8 +2573,8 @@ namespace Lucene.Net.Index
                         infoStream.Message("IW", "rollback: infos=" + SegString(segmentInfos.Segments));
                     }
 
-                    var tpResult = TestPoint("rollback before checkpoint");
-                    Debug.Assert(tpResult);
+                    // LUCENENET: .NET doesn't support asserts in release mode
+                    if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("rollback before checkpoint");
 
                     // Ask deleter to locate unreferenced files & remove
                     // them:
@@ -3541,8 +3541,8 @@ namespace Lucene.Net.Index
                 }
 
                 DoBeforeFlush();
-                var tpResult = TestPoint("startDoFlush");
-                Debug.Assert(tpResult);
+                // LUCENENET: .NET doesn't support asserts in release mode
+                if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("startDoFlush");
                 SegmentInfos toCommit = null;
                 bool anySegmentsFlushed = false;
 
@@ -3858,8 +3858,8 @@ namespace Lucene.Net.Index
             }
 
             DoBeforeFlush();
-            var tpResult = TestPoint("startDoFlush");
-            Debug.Assert(tpResult);
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("startDoFlush");
             bool success = false;
             try
             {
@@ -4101,8 +4101,8 @@ namespace Lucene.Net.Index
         {
             lock (this)
             {
-                var tpResult = TestPoint("startCommitMergeDeletes");
-                Debug.Assert(tpResult);
+                // LUCENENET: .NET doesn't support asserts in release mode
+                if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("startCommitMergeDeletes");
 
                 IList<SegmentCommitInfo> sourceSegments = merge.Segments;
 
@@ -4338,8 +4338,8 @@ namespace Lucene.Net.Index
         {
             lock (this)
             {
-                var tpResult = TestPoint("startCommitMerge");
-                Debug.Assert(tpResult);
+                // LUCENENET: .NET doesn't support asserts in release mode
+                if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("startCommitMerge");
 
                 if (hitOOM)
                 {
@@ -4759,8 +4759,8 @@ namespace Lucene.Net.Index
         {
             lock (this)
             {
-                var testPointResult = TestPoint("startMergeInit");
-                Debug.Assert(testPointResult);
+                // LUCENENET: .NET doesn't support asserts in release mode
+                if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("startMergeInit");
 
                 Debug.Assert(merge.registerDone);
                 Debug.Assert(merge.MaxNumSegments == -1 || merge.MaxNumSegments > 0);
@@ -5446,8 +5446,8 @@ namespace Lucene.Net.Index
         /// </summary>
         private void StartCommit(SegmentInfos toSync)
         {
-            var tpResult = TestPoint("startStartCommit");
-            Debug.Assert(tpResult);
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("startStartCommit");
             Debug.Assert(pendingCommit == null);
 
             if (hitOOM)
@@ -5485,15 +5485,15 @@ namespace Lucene.Net.Index
                     Debug.Assert(FilesExist(toSync));
                 }
 
-                tpResult = TestPoint("midStartCommit");
-                Debug.Assert(tpResult);
+                // LUCENENET: .NET doesn't support asserts in release mode
+                if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("midStartCommit");
 
                 bool pendingCommitSet = false;
 
                 try
                 {
-                    tpResult = TestPoint("midStartCommit2");
-                    Debug.Assert(tpResult);
+                    // LUCENENET: .NET doesn't support asserts in release mode
+                    if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("midStartCommit2");
 
                     lock (this)
                     {
@@ -5536,8 +5536,8 @@ namespace Lucene.Net.Index
                         infoStream.Message("IW", "done all syncs: " + string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", filesToSync));
                     }
 
-                    tpResult = TestPoint("midStartCommitSuccess");
-                    Debug.Assert(tpResult);
+                    // LUCENENET: .NET doesn't support asserts in release mode
+                    if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("midStartCommitSuccess");
                 }
                 finally
                 {
@@ -5567,8 +5567,8 @@ namespace Lucene.Net.Index
             {
                 HandleOOM(oom, "startCommit");
             }
-            tpResult = TestPoint("finishStartCommit");
-            Debug.Assert(tpResult);
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) TestPoint("finishStartCommit");
         }
 
         /// <summary>

--- a/src/Lucene.Net/Index/StoredFieldsProcessor.cs
+++ b/src/Lucene.Net/Index/StoredFieldsProcessor.cs
@@ -139,7 +139,8 @@ namespace Lucene.Net.Index
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void FinishDocument()
         {
-            Debug.Assert(docWriter.TestPoint("StoredFieldsWriter.finishDocument start"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docWriter.TestPoint("StoredFieldsWriter.finishDocument start");
 
             InitFieldsWriter(IOContext.DEFAULT);
             Fill(docState.docID);
@@ -156,7 +157,8 @@ namespace Lucene.Net.Index
             }
 
             Reset();
-            Debug.Assert(docWriter.TestPoint("StoredFieldsWriter.finishDocument end"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docWriter.TestPoint("StoredFieldsWriter.finishDocument end");
         }
 
         public override void AddField(int docID, IIndexableField field, FieldInfo fieldInfo)
@@ -179,7 +181,8 @@ namespace Lucene.Net.Index
                 fieldInfos[numStoredFields] = fieldInfo;
                 numStoredFields++;
 
-                Debug.Assert(docState.TestPoint("StoredFieldsWriterPerThread.processFields.writeField"));
+                // LUCENENET: .NET doesn't support asserts in release mode
+                if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docState.TestPoint("StoredFieldsWriterPerThread.processFields.writeField");
             }
         }
     }

--- a/src/Lucene.Net/Index/TermVectorsConsumer.cs
+++ b/src/Lucene.Net/Index/TermVectorsConsumer.cs
@@ -114,7 +114,8 @@ namespace Lucene.Net.Index
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void FinishDocument(TermsHash termsHash)
         {
-            Debug.Assert(docWriter.TestPoint("TermVectorsTermsWriter.finishDocument start"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docWriter.TestPoint("TermVectorsTermsWriter.finishDocument start");
 
             if (!hasVectors)
             {
@@ -139,7 +140,8 @@ namespace Lucene.Net.Index
 
             termsHash.Reset();
             Reset();
-            Debug.Assert(docWriter.TestPoint("TermVectorsTermsWriter.finishDocument end"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docWriter.TestPoint("TermVectorsTermsWriter.finishDocument end");
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
+++ b/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
@@ -172,7 +172,8 @@ namespace Lucene.Net.Index
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal void FinishDocument()
         {
-            Debug.Assert(docState.TestPoint("TermVectorsTermsWriterPerField.finish start"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docState.TestPoint("TermVectorsTermsWriterPerField.finish start");
 
             int numPostings = termsHashPerField.bytesHash.Count;
 
@@ -301,7 +302,8 @@ namespace Lucene.Net.Index
 
         internal override void NewTerm(int termID)
         {
-            Debug.Assert(docState.TestPoint("TermVectorsTermsWriterPerField.newTerm start"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docState.TestPoint("TermVectorsTermsWriterPerField.newTerm start");
             TermVectorsPostingsArray postings = (TermVectorsPostingsArray)termsHashPerField.postingsArray;
 
             postings.freqs[termID] = 1;
@@ -313,7 +315,8 @@ namespace Lucene.Net.Index
 
         internal override void AddTerm(int termID)
         {
-            Debug.Assert(docState.TestPoint("TermVectorsTermsWriterPerField.addTerm start"));
+            // LUCENENET: .NET doesn't support asserts in release mode
+            if (Lucene.Net.Diagnostics.Debugging.AssertsEnabled) docState.TestPoint("TermVectorsTermsWriterPerField.addTerm start");
             TermVectorsPostingsArray postings = (TermVectorsPostingsArray)termsHashPerField.postingsArray;
 
             postings.freqs[termID]++;

--- a/src/Lucene.Net/Support/Diagnostics/Debugging.cs
+++ b/src/Lucene.Net/Support/Diagnostics/Debugging.cs
@@ -1,0 +1,20 @@
+﻿using Lucene.Net.Util;
+
+namespace Lucene.Net.Diagnostics
+{
+    // LUCENENET: This can only be named Debug if we merge it with the Debug
+    // class from Lucene.Net.TestFramework because it is in the same namespace.
+    // But that class is dependent upon AssertionException, which is only for testing.
+    internal static class Debugging
+    {
+        /// <summary>
+        /// Allows toggling "assertions" on/off even in release builds. The default is <c>false</c>.
+        /// <para/>
+        /// This allows loggers and testing frameworks to enable test point messages ("TP")
+        /// from <see cref="Index.IndexWriter"/>, <see cref="Index.DocumentsWriterPerThread"/>,
+        /// <see cref="Index.FreqProxTermsWriterPerField"/>, <see cref="Index.StoredFieldsProcessor"/>,
+        /// <see cref="Index.TermVectorsConsumer"/>, and <see cref="Index.TermVectorsConsumerPerField"/>.
+        /// </summary>
+        public static bool AssertsEnabled { get; set; } = SystemProperties.GetPropertyAsBoolean("assert", false);
+    }
+}


### PR DESCRIPTION
This fixes #267 by converting these asserts that were intended for control flow during testing into `InvalidOperationException`s. In the test framework, we are still throwing `Lucene.Net.Diagnostics.AssertionException` in order to differentiate an "assert" from other cases that are throwing `InvalidOperationException`.

This is similar to how Lucene 8.x behaves, and only affects legacy codecs for `Lucene3x` and `Lucene40`.

As for `BlockTreeTermsWriter`, its assert was failing due to lack of validation on the `Prefix` to ensure it is valid UTF-8. Since the problem is only when building the string in the assert, a private method was added to generate the string by catching exceptions due to invalid UTF-8 and falling back to just writing out the display of bytes in `BytesRef`.