### PR TITLE
Fix for slow Lucene.Net.Util namespace tests (addresses #295)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,8 +19,10 @@
 
 -->
 <Project>
+  <!-- Features in .NET Standard and .NET Core only (no .NET Framework support) -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) ">
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ARRAYEMPTY</DefineConstants>
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
@@ -66,7 +68,11 @@
     
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4.5+ only -->
+  <!-- Features in .NET Framework 4.6+ only -->
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net46')) Or $(TargetFramework.StartsWith('net47')) Or $(TargetFramework.StartsWith('net48'))">
+    <DefineConstants>$(DefineConstants);FEATURE_ARRAYEMPTY</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_EXCEPTIONS</DefineConstants>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Snowball/SnowballFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Snowball/SnowballFilter.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Analysis.Snowball
             try
             {
                 string className = typeof(SnowballProgram).Namespace + ".Ext." +
-                    name + "Stemmer, " + this.GetType().GetTypeInfo().Assembly.GetName().Name;
+                    name + "Stemmer, " + this.GetType().Assembly.GetName().Name;
                 Type stemClass = Type.GetType(className);
 
                 stemmer = (SnowballProgram)Activator.CreateInstance(stemClass);

--- a/src/Lucene.Net.Analysis.Common/Analysis/Snowball/SnowballPorterFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Snowball/SnowballPorterFilterFactory.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Analysis.Snowball
         public virtual void Inform(IResourceLoader loader)
         {
             string className = typeof(SnowballProgram).Namespace + ".Ext." + 
-                language + "Stemmer, " + this.GetType().GetTypeInfo().Assembly.GetName().Name;
+                language + "Stemmer, " + this.GetType().Assembly.GetName().Name;
             stemClass = Type.GetType(className);
 
             if (wordFiles != null)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/ClasspathResourceLoader.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/ClasspathResourceLoader.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Analysis.Util
             // Stream stream = this.clazz.FindAndGetManifestResourceStream(resource);
             // causes TestMappingCharFilter.TestRandomMaps2 to run 2-3 times slower.
             // So, we are using the long-hand syntax in this one place.
-            Stream stream = this.clazz.GetTypeInfo().Assembly.FindAndGetManifestResourceStream(clazz, resource);
+            Stream stream = this.clazz.Assembly.FindAndGetManifestResourceStream(clazz, resource);
             if (stream == null)
             {
                 throw new IOException("Resource not found: " + resource);
@@ -70,7 +70,7 @@ namespace Lucene.Net.Analysis.Util
                     return Type.GetType(cname);
                 }
 
-                return this.clazz.GetTypeInfo().Assembly.GetType(cname, true);
+                return this.clazz.Assembly.GetType(cname, true);
             }
             catch (Exception e)
             {

--- a/src/Lucene.Net.Analysis.Common/Collation/CollationAttributeFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Collation/CollationAttributeFactory.cs
@@ -95,7 +95,7 @@ namespace Lucene.Net.Collation
 
 		public override Attribute CreateAttributeInstance<T>()
 		{
-			return typeof(T).GetTypeInfo().IsAssignableFrom(typeof(CollatedTermAttributeImpl))
+			return typeof(T).IsAssignableFrom(typeof(CollatedTermAttributeImpl))
 				? new CollatedTermAttributeImpl(this.collator)
 				: this.@delegate.CreateAttributeInstance<T>();
 		}

--- a/src/Lucene.Net.Analysis.ICU/Collation/ICUCollationAttributeFactory.cs
+++ b/src/Lucene.Net.Analysis.ICU/Collation/ICUCollationAttributeFactory.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Collation
 
         public override Util.Attribute CreateAttributeInstance<T>()
         {
-            return typeof(T).GetTypeInfo().IsAssignableFrom(typeof(ICUCollatedTermAttribute))
+            return typeof(T).IsAssignableFrom(typeof(ICUCollatedTermAttribute))
                 ? new ICUCollatedTermAttribute(collator)
                 : @delegate.CreateAttributeInstance<T>();
         }

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/ContentItemsSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/ContentItemsSource.cs
@@ -198,7 +198,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             string col = "                  ";
             StringBuilder sb = new StringBuilder();
             string newline = Environment.NewLine;
-            sb.Append("------------> ").Append(GetType().GetTypeInfo().Name).Append(" statistics (").Append(printNum).Append("): ").Append(newline);
+            sb.Append("------------> ").Append(GetType().Name).Append(" statistics (").Append(printNum).Append("): ").Append(newline);
             int nut = TotalItemsCount;
             if (nut > lastPrintedNumUniqueTexts)
             {

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
@@ -486,15 +486,15 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                     DirectoryInfo baseDir = new DirectoryInfo(RunData.Config.Get("work.dir", "work"));
                     ((IResourceLoaderAware)instance).Inform(new FilesystemResourceLoader(baseDir));
                 }
-                if (typeof(CharFilterFactory).GetTypeInfo().IsAssignableFrom(clazz))
+                if (typeof(CharFilterFactory).IsAssignableFrom(clazz))
                 {
                     charFilterFactories.Add((CharFilterFactory)instance);
                 }
-                else if (typeof(TokenizerFactory).GetTypeInfo().IsAssignableFrom(clazz))
+                else if (typeof(TokenizerFactory).IsAssignableFrom(clazz))
                 {
                     tokenizerFactory = (TokenizerFactory)instance;
                 }
-                else if (typeof(TokenFilterFactory).GetTypeInfo().IsAssignableFrom(clazz))
+                else if (typeof(TokenFilterFactory).IsAssignableFrom(clazz))
                 {
                     tokenFilterFactories.Add((TokenFilterFactory)instance);
                 }
@@ -551,15 +551,15 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             }
             // No dot - use analysis SPI lookup
             string analysisComponentName = ANALYSIS_COMPONENT_SUFFIX_PATTERN.Replace(className, "", 1);
-            if (typeof(CharFilterFactory).GetTypeInfo().IsAssignableFrom(expectedType))
+            if (typeof(CharFilterFactory).IsAssignableFrom(expectedType))
             {
                 return CharFilterFactory.LookupClass(analysisComponentName);
             }
-            else if (typeof(TokenizerFactory).GetTypeInfo().IsAssignableFrom(expectedType))
+            else if (typeof(TokenizerFactory).IsAssignableFrom(expectedType))
             {
                 return TokenizerFactory.LookupClass(analysisComponentName);
             }
-            else if (typeof(TokenFilterFactory).GetTypeInfo().IsAssignableFrom(expectedType))
+            else if (typeof(TokenFilterFactory).IsAssignableFrom(expectedType))
             {
                 return TokenFilterFactory.LookupClass(analysisComponentName);
             }

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/Algorithm.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/Algorithm.cs
@@ -366,7 +366,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
 
             ISet<string> result = new JCG.HashSet<string>();
             string alts = config.Get("alt.tasks.packages", null);
-            string dfltPkg = typeof(PerfTask).GetTypeInfo().Assembly.GetName().Name;
+            string dfltPkg = typeof(PerfTask).Assembly.GetName().Name;
             string[] referencedAssemblies = AssemblyUtils.GetReferencedAssemblies().Select(a => a.GetName().Name).ToArray();
             result.Add(dfltPkg);
 

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsReader.cs
@@ -224,7 +224,7 @@ namespace Lucene.Net.Codecs.SimpleText
         {
             if (_input == null)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this FieldsReader is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this FieldsReader is closed");
             }
             return new SimpleTextStoredFieldsReader(_offsets, (IndexInput) _input.Clone(), _fieldInfos);
         }

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
@@ -234,7 +234,7 @@ namespace Lucene.Net.Codecs.SimpleText
         {
             if (_input == null)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this TermVectorsReader is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this TermVectorsReader is closed");
             }
             return new SimpleTextTermVectorsReader(_offsets, (IndexInput)_input.Clone());
         }

--- a/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
@@ -660,7 +660,7 @@ namespace Lucene.Net.Expressions.JS
 #if NETSTANDARD
             var settings = new Dictionary<string, string>();
             var type = typeof(JavascriptCompiler);
-            using (var reader = new StreamReader(type.FindAndGetManifestResourceStream(type.GetTypeInfo().Name + ".properties")))
+            using (var reader = new StreamReader(type.FindAndGetManifestResourceStream(type.Name + ".properties")))
             {
                 string line;
                 while(!string.IsNullOrWhiteSpace(line = reader.ReadLine()))
@@ -695,10 +695,10 @@ namespace Lucene.Net.Expressions.JS
             {
                 throw new ArgumentException(method + " is not public.");
             }
-            if (!method.DeclaringType.GetTypeInfo().IsPublic)
+            if (!method.DeclaringType.IsPublic)
             {
                 //.NET Port. Inner class is being returned as not public even when declared public
-                if (method.DeclaringType.GetTypeInfo().IsNestedAssembly)
+                if (method.DeclaringType.IsNestedAssembly)
                 {
                     throw new ArgumentException(method.DeclaringType.FullName + " is not public.");
                 }

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -541,7 +541,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         {
             if (isClosed)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "The taxonomy writer has already been closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "The taxonomy writer has already been closed");
             }
         }
 

--- a/src/Lucene.Net.Facet/Taxonomy/TaxonomyReader.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/TaxonomyReader.cs
@@ -165,7 +165,7 @@ namespace Lucene.Net.Facet.Taxonomy
         {
             if (RefCount <= 0)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this TaxonomyReader is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this TaxonomyReader is closed");
             }
         }
 

--- a/src/Lucene.Net.Grouping/SearchGroup.cs
+++ b/src/Lucene.Net.Grouping/SearchGroup.cs
@@ -184,7 +184,7 @@ namespace Lucene.Net.Search.Grouping
 
             // LUCENENET specific - store whether T is value type
             // for optimization of GetHashCode() and Equals()
-            private readonly static bool groupValueIsValueType = typeof(T).GetTypeInfo().IsValueType;
+            private readonly static bool groupValueIsValueType = typeof(T).IsValueType;
 
             public MergedGroup(T groupValue)
             {

--- a/src/Lucene.Net.Grouping/TopGroups.cs
+++ b/src/Lucene.Net.Grouping/TopGroups.cs
@@ -148,7 +148,7 @@ namespace Lucene.Net.Search.Grouping
 
             // LUCENENET specific - store whether T is value type
             // for optimization of GetHashCode() and Equals()
-            bool shardGroupsIsValueType = typeof(T).GetTypeInfo().IsValueType;
+            bool shardGroupsIsValueType = typeof(T).IsValueType;
 
             int totalHitCount = 0;
             int totalGroupedHitCount = 0;

--- a/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
@@ -289,7 +289,7 @@ namespace Lucene.Net.QueryParsers.ComplexPhrase
                         AddComplexPhraseClause(sc, (BooleanQuery)qc);
                         if (sc.Count > 0)
                         {
-                            allSpanClauses[i] = sc.ElementAt(0);
+                            allSpanClauses[i] = sc[0];
                         }
                         else
                         {

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Builders/QueryTreeBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Builders/QueryTreeBuilder.cs
@@ -154,7 +154,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Builders
                             }
                         }
                     }
-                } while (builder == null && (clazz = clazz.GetTypeInfo().BaseType) != null);
+                } while (builder == null && (clazz = clazz.BaseType) != null);
             }
 
             return builder;

--- a/src/Lucene.Net.Suggest/Spell/SpellChecker.cs
+++ b/src/Lucene.Net.Suggest/Spell/SpellChecker.cs
@@ -668,7 +668,7 @@ namespace Lucene.Net.Search.Spell
         {
             if (disposed)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "Spellchecker has been closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "Spellchecker has been closed");
             }
         }
 
@@ -705,7 +705,7 @@ namespace Lucene.Net.Search.Spell
                 if (disposed)
                 {
                     indexSearcher.IndexReader.Dispose();
-                    throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "Spellchecker has been closed");
+                    throw new ObjectDisposedException(this.GetType().FullName, "Spellchecker has been closed");
                 }
                 if (searcher != null)
                 {

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FSTUtil.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FSTUtil.cs
@@ -79,7 +79,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             while (queue.Count != 0)
             {
-                Path<T> path = queue.ElementAt(queue.Count - 1);
+                Path<T> path = queue[queue.Count - 1];
                 queue.Remove(path);
                 if (path.State.Accept)
                 {

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 
 namespace Lucene.Net.Search.Suggest.Fst
 {
@@ -145,7 +144,7 @@ namespace Lucene.Net.Search.Suggest.Fst
         {
             try
             {
-                IList<FST.Arc<object>> rootArcs = new List<FST.Arc<object>>();
+                List<FST.Arc<object>> rootArcs = new List<FST.Arc<object>>();
                 FST.Arc<object> arc = automaton.GetFirstArc(new FST.Arc<object>());
                 FST.BytesReader fstReader = automaton.GetBytesReader();
                 automaton.ReadFirstTargetArc(arc, arc, fstReader);
@@ -160,7 +159,8 @@ namespace Lucene.Net.Search.Suggest.Fst
                 }
 
                 // we want highest weights first.
-                return rootArcs.Reverse().ToArray();
+                rootArcs.Reverse();
+                return rootArcs.ToArray();
             }
             catch (IOException e)
             {
@@ -355,7 +355,7 @@ namespace Lucene.Net.Search.Suggest.Fst
                     {
                         if (key.Equals(list[i].Utf8))
                         {
-                            var element = list.ElementAt(i);
+                            var element = list[i];
                             list.Remove(element);
                             list.Insert(0, element);
                         }

--- a/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
@@ -592,7 +592,7 @@ namespace Lucene.Net.TestFramework
         //     The evaluated condition
         public static void False(bool condition)
         {
-            _NUnit.Assert.That(condition, _NUnit.Is.False);
+            _NUnit.Assert.False(condition);
         }
 
         //
@@ -605,7 +605,7 @@ namespace Lucene.Net.TestFramework
         //     The evaluated condition
         public static void IsFalse(bool condition)
         {
-            _NUnit.Assert.That(condition, _NUnit.Is.False);
+            _NUnit.Assert.IsFalse(condition);
         }
 
         //
@@ -624,7 +624,7 @@ namespace Lucene.Net.TestFramework
         //     Array of objects to be used in formatting the message
         public static void IsFalse(bool condition, string message, params object[] args)
         {
-            _NUnit.Assert.That(condition, _NUnit.Is.False, message, args);
+            _NUnit.Assert.IsFalse(condition, message, args);
         }
 
         //

--- a/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
@@ -4,7 +4,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using J2N.Text;
 using NUnit.Framework.Constraints;
+using JCG = J2N.Collections.Generic;
 using _NUnit = NUnit.Framework;
 
 namespace Lucene.Net.TestFramework
@@ -330,6 +332,84 @@ namespace Lucene.Net.TestFramework
             _NUnit.Assert.True(expected.Equals(actual), message);
         }
 
+
+        private static JCG.SetEqualityComparer<T> GetSetComparer<T>(bool aggressive)
+        {
+            return aggressive
+                ? JCG.SetEqualityComparer<T>.Aggressive
+                : JCG.SetEqualityComparer<T>.Default;
+        }
+
+        private static JCG.ListEqualityComparer<T> GetListComparer<T>(bool aggressive)
+        {
+            return aggressive
+                ? JCG.ListEqualityComparer<T>.Aggressive
+                : JCG.ListEqualityComparer<T>.Default;
+        }
+
+        private static JCG.DictionaryEqualityComparer<TKey, TValue> GetDictionaryComparer<TKey, TValue>(bool aggressive)
+        {
+            return aggressive
+                ? JCG.DictionaryEqualityComparer<TKey, TValue>.Aggressive
+                : JCG.DictionaryEqualityComparer<TKey, TValue>.Default;
+        }
+
+        public static string FormatCollection(object collection)
+        {
+            return string.Format(StringFormatter.CurrentCulture, "{0}", collection);
+        }
+
+        public static void AreEqual<T>(ISet<T> expected, ISet<T> actual, bool aggressive = true)
+        {
+            if (!GetSetComparer<T>(aggressive).Equals(expected, actual))
+            {
+                _NUnit.Assert.Fail("Expected: '{0}', Actual: '{1}'", FormatCollection(expected), FormatCollection(actual));
+            }
+        }
+
+        public static void AreEqual<T>(ISet<T> expected, ISet<T> actual, bool aggressive, string message, params object[] args)
+        {
+            if (!GetSetComparer<T>(aggressive).Equals(expected, actual))
+            {
+                _NUnit.Assert.Fail(message, args);
+            }
+        }
+
+        public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive = true)
+        {
+            if (!GetListComparer<T>(aggressive).Equals(expected, actual))
+            {
+                _NUnit.Assert.Fail("Expected: '{0}', Actual: '{1}'", FormatCollection(expected), FormatCollection(actual));
+            }
+
+        }
+
+        public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive, string message, params object[] args)
+        {
+            if (!GetListComparer<T>(aggressive).Equals(expected, actual))
+            {
+                _NUnit.Assert.Fail(message, args);
+            }
+        }
+
+        public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive = true)
+        {
+            if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
+            {
+                _NUnit.Assert.Fail("Expected: '{0}', Actual: '{1}'", FormatCollection(expected), FormatCollection(actual));
+            }
+
+        } 
+
+        public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive, string message, params object[] args)
+        {
+            if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
+            {
+                _NUnit.Assert.Fail(message, args);
+            }
+        }
+
+
         // From CollectionAssert
         public static void AreEqual<T>(T[] expected, T[] actual)
         {
@@ -349,15 +429,6 @@ namespace Lucene.Net.TestFramework
             if (!J2N.Collections.ArrayEqualityComparer<T>.OneDimensional.Equals(expected, actual))
             {
                 _NUnit.CollectionAssert.AreEqual(expected, actual, message, args);
-            }
-        }
-
-        public static void AreEqual<T, S>(IDictionary<T, S> expected, IDictionary<T, S> actual)
-        {
-            AreEqual(expected.Count, actual.Count);
-            foreach (var key in expected.Keys)
-            {
-                AreEqual(expected[key], actual[key]);
             }
         }
 

--- a/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
@@ -373,6 +373,14 @@ namespace Lucene.Net.TestFramework
             }
         }
 
+        public static void AreEqual<T>(ISet<T> expected, ISet<T> actual, bool aggressive, Func<string> getMessage)
+        {
+            if (!GetSetComparer<T>(aggressive).Equals(expected, actual))
+            {
+                _NUnit.Assert.Fail(getMessage());
+            }
+        }
+
         public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive = true)
         {
             if (!GetListComparer<T>(aggressive).Equals(expected, actual))
@@ -390,13 +398,20 @@ namespace Lucene.Net.TestFramework
             }
         }
 
+        public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive, Func<string> getMessage)
+        {
+            if (!GetListComparer<T>(aggressive).Equals(expected, actual))
+            {
+                _NUnit.Assert.Fail(getMessage());
+            }
+        }
+
         public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive = true)
         {
             if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
             {
                 _NUnit.Assert.Fail("Expected: '{0}', Actual: '{1}'", FormatCollection(expected), FormatCollection(actual));
             }
-
         } 
 
         public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive, string message, params object[] args)
@@ -404,6 +419,14 @@ namespace Lucene.Net.TestFramework
             if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
             {
                 _NUnit.Assert.Fail(message, args);
+            }
+        }
+
+        public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive, Func<string> getMessage)
+        {
+            if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
+            {
+                _NUnit.Assert.Fail(getMessage());
             }
         }
 

--- a/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
@@ -1,13 +1,11 @@
-﻿using Lucene.Net.Support;
+﻿using J2N.Text;
+using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using J2N.Text;
-using NUnit.Framework.Constraints;
-using JCG = J2N.Collections.Generic;
 using _NUnit = NUnit.Framework;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.TestFramework
 {
@@ -413,35 +411,19 @@ namespace Lucene.Net.TestFramework
         // From CollectionAssert
         public static void AreEqual<T>(T[] expected, T[] actual)
         {
-            // LUCENENET: Do the initial check with the (fast) J2N array comparison. If it fails,
-            // then use CollectionAssert to re-do the check in a slower way and generate the assert message.
             if (!J2N.Collections.ArrayEqualityComparer<T>.OneDimensional.Equals(expected, actual))
             {
-                _NUnit.CollectionAssert.AreEqual(expected, actual);
+                _NUnit.Assert.Fail("Expected: '{0}', Actual: '{1}'", FormatCollection(expected), FormatCollection(actual));
             }
         }
 
         // From CollectionAssert
         public static void AreEqual<T>(T[] expected, T[] actual, string message, params object[] args)
         {
-            // LUCENENET: Do the initial check with the (fast) J2N array comparison. If it fails,
-            // then use CollectionAssert to re-do the check in a slower way and generate the assert message.
             if (!J2N.Collections.ArrayEqualityComparer<T>.OneDimensional.Equals(expected, actual))
             {
-                _NUnit.CollectionAssert.AreEqual(expected, actual, message, args);
+                _NUnit.Assert.Fail(message, args);
             }
-        }
-
-        // From CollectionAssert
-        public static void AreEqual(ICollection expected, ICollection actual)
-        {
-            _NUnit.CollectionAssert.AreEqual(expected, actual);
-        }
-
-        // From CollectionAssert
-        public static void AreEqual(ICollection expected, ICollection actual, string message, params object[] args)
-        {
-            _NUnit.CollectionAssert.AreEqual(expected, actual, message, args);
         }
 
         //

--- a/src/Lucene.Net.TestFramework/Analysis/MockBytesAttributeFactory.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockBytesAttributeFactory.cs
@@ -32,7 +32,7 @@ namespace Lucene.Net.Analysis
         public override Attribute CreateAttributeInstance<T>()
         {
             var attClass = typeof(T);
-            return attClass.GetTypeInfo().IsAssignableFrom(typeof(MockUTF16TermAttributeImpl))
+            return attClass.IsAssignableFrom(typeof(MockUTF16TermAttributeImpl))
                 ? new MockUTF16TermAttributeImpl()
                 : @delegate.CreateAttributeInstance<T>();
         }

--- a/src/Lucene.Net.TestFramework/Search/CheckHits.cs
+++ b/src/Lucene.Net.TestFramework/Search/CheckHits.cs
@@ -119,17 +119,17 @@ namespace Lucene.Net.Search
 
             Trace.TraceInformation("Checked");
 
-            JCG.SortedSet<int?> correct = new JCG.SortedSet<int?>();
+            JCG.SortedSet<int> correct = new JCG.SortedSet<int>();
             for (int i = 0; i < results.Length; i++)
             {
                 correct.Add(Convert.ToInt32(results[i], CultureInfo.InvariantCulture));
             }
-            JCG.SortedSet<int?> actual = new JCG.SortedSet<int?>();
+            JCG.SortedSet<int> actual = new JCG.SortedSet<int>();
             ICollector c = new SetCollector(actual);
 
             searcher.Search(query, c);
 
-            Assert.AreEqual(correct, actual, "Simple: " + query.ToString(defaultFieldName));
+            Assert.AreEqual(correct, actual, aggressive: false, "Simple: " + query.ToString(defaultFieldName));
 
             for (int i = -1; i < 2; i++)
             {
@@ -140,7 +140,7 @@ namespace Lucene.Net.Search
 #endif
                     random, searcher, i);
                 s.Search(query, c);
-                Assert.AreEqual(correct, actual, "Wrap Reader " + i + ": " + query.ToString(defaultFieldName));
+                Assert.AreEqual(correct, actual, aggressive: false, "Wrap Reader " + i + ": " + query.ToString(defaultFieldName));
             }
         }
 
@@ -181,19 +181,19 @@ namespace Lucene.Net.Search
         {
             ScoreDoc[] hits = searcher.Search(query, 1000).ScoreDocs;
 
-            SortedSet<int?> correct = new SortedSet<int?>();
+            JCG.SortedSet<int> correct = new JCG.SortedSet<int>();
             for (int i = 0; i < results.Length; i++)
             {
                 correct.Add(Convert.ToInt32(results[i], CultureInfo.InvariantCulture));
             }
 
-            SortedSet<int?> actual = new SortedSet<int?>();
+            JCG.SortedSet<int> actual = new JCG.SortedSet<int>();
             for (int i = 0; i < hits.Length; i++)
             {
                 actual.Add(Convert.ToInt32(hits[i].Doc, CultureInfo.InvariantCulture));
             }
 
-            Assert.AreEqual(correct, actual, query.ToString(defaultFieldName));
+            Assert.AreEqual(correct, actual, aggressive: false, query.ToString(defaultFieldName));
 
             QueryUtils.Check(
 #if FEATURE_INSTANCE_TESTDATA_INITIALIZATION
@@ -466,9 +466,9 @@ namespace Lucene.Net.Search
     /// </summary>
     public class SetCollector : ICollector
     {
-        internal readonly ISet<int?> bag;
+        internal readonly ISet<int> bag;
 
-        public SetCollector(ISet<int?> bag)
+        public SetCollector(ISet<int> bag)
         {
             this.bag = bag;
         }

--- a/src/Lucene.Net.TestFramework/Search/CheckHits.cs
+++ b/src/Lucene.Net.TestFramework/Search/CheckHits.cs
@@ -129,7 +129,7 @@ namespace Lucene.Net.Search
 
             searcher.Search(query, c);
 
-            Assert.AreEqual(correct, actual, aggressive: false, "Simple: " + query.ToString(defaultFieldName));
+            Assert.AreEqual(correct, actual, aggressive: false, () => "Simple: " + query.ToString(defaultFieldName));
 
             for (int i = -1; i < 2; i++)
             {
@@ -140,7 +140,7 @@ namespace Lucene.Net.Search
 #endif
                     random, searcher, i);
                 s.Search(query, c);
-                Assert.AreEqual(correct, actual, aggressive: false, "Wrap Reader " + i + ": " + query.ToString(defaultFieldName));
+                Assert.AreEqual(correct, actual, aggressive: false, () => "Wrap Reader " + i + ": " + query.ToString(defaultFieldName));
             }
         }
 
@@ -193,7 +193,7 @@ namespace Lucene.Net.Search
                 actual.Add(Convert.ToInt32(hits[i].Doc, CultureInfo.InvariantCulture));
             }
 
-            Assert.AreEqual(correct, actual, aggressive: false, query.ToString(defaultFieldName));
+            Assert.AreEqual(correct, actual, aggressive: false, () => query.ToString(defaultFieldName));
 
             QueryUtils.Check(
 #if FEATURE_INSTANCE_TESTDATA_INITIALIZATION

--- a/src/Lucene.Net.TestFramework/Search/RandomSimilarityProvider.cs
+++ b/src/Lucene.Net.TestFramework/Search/RandomSimilarityProvider.cs
@@ -1,8 +1,8 @@
 using J2N.Collections.Generic.Extensions;
 using Lucene.Net.Search.Similarities;
-using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Debug = Lucene.Net.Diagnostics.Debug; // LUCENENET NOTE: We cannot use System.Diagnostics.Debug because those calls will be optimized out of the release!
 
 namespace Lucene.Net.Search
@@ -140,21 +140,21 @@ namespace Lucene.Net.Search
         {
             lock (this)
             {
-                string coordMethod;
+                // LUCENENET: Use StringBuilder for better efficiency
+                var sb = new StringBuilder();
+                sb.Append(nameof(RandomSimilarityProvider));
+                sb.Append("(queryNorm=");
+                sb.Append(shouldQueryNorm);
+                sb.Append(",coord=");
                 if (coordType == 0)
-                {
-                    coordMethod = "no";
-                }
+                    sb.Append("no");
                 else if (coordType == 1)
-                {
-                    coordMethod = "yes";
-                }
+                    sb.Append("yes");
                 else
-                {
-                    coordMethod = "crazy";
-                }
-                return "RandomSimilarityProvider(queryNorm=" + shouldQueryNorm + ",coord=" + coordMethod + "): " + 
-                    string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", previousMappings);
+                    sb.Append("crazy");
+                sb.Append("): ");
+                sb.AppendFormat(J2N.Text.StringFormatter.InvariantCulture, "{0}", previousMappings);
+                return sb.ToString();
             }
         }
     }

--- a/src/Lucene.Net.TestFramework/Support/ApiScanTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Support/ApiScanTestBase.cs
@@ -101,7 +101,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestProtectedFieldNames(Type typeFromTargetAssembly)
         {
-            var names = GetInvalidProtectedFields(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetInvalidProtectedFields(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -124,7 +124,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestPrivateFieldNames(Type typeFromTargetAssembly, string exceptionRegex)
         {
-            var names = GetInvalidPrivateFields(typeFromTargetAssembly.GetTypeInfo().Assembly, exceptionRegex);
+            var names = GetInvalidPrivateFields(typeFromTargetAssembly.Assembly, exceptionRegex);
 
             //if (VERBOSE)
             //{
@@ -141,7 +141,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestPublicFields(Type typeFromTargetAssembly)
         {
-            var names = GetInvalidPublicFields(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetInvalidPublicFields(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -158,7 +158,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestMethodParameterNames(Type typeFromTargetAssembly)
         {
-            var names = GetInvalidMethodParameterNames(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetInvalidMethodParameterNames(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -175,7 +175,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestInterfaceNames(Type typeFromTargetAssembly)
         {
-            var names = GetInvalidInterfaceNames(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetInvalidInterfaceNames(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -192,7 +192,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestClassNames(Type typeFromTargetAssembly)
         {
-            var names = GetInvalidClassNames(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetInvalidClassNames(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -210,7 +210,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestForPropertiesWithNoGetter(Type typeFromTargetAssembly)
         {
-            var names = GetPropertiesWithNoGetter(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetPropertiesWithNoGetter(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -228,7 +228,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestForPropertiesThatReturnArray(Type typeFromTargetAssembly)
         {
-            var names = GetPropertiesThatReturnArray(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetPropertiesThatReturnArray(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -249,7 +249,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestForMethodsThatReturnWritableArray(Type typeFromTargetAssembly)
         {
-            var names = GetMethodsThatReturnWritableArray(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetMethodsThatReturnWritableArray(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -270,8 +270,8 @@ namespace Lucene.Net.Util
         {
             var names = new List<string>();
 
-            names.AddRange(GetProtectedFieldsContainingComparer(typeFromTargetAssembly.GetTypeInfo().Assembly));
-            names.AddRange(GetMembersContainingComparer(typeFromTargetAssembly.GetTypeInfo().Assembly));
+            names.AddRange(GetProtectedFieldsContainingComparer(typeFromTargetAssembly.Assembly));
+            names.AddRange(GetMembersContainingComparer(typeFromTargetAssembly.Assembly));
 
             //if (VERBOSE)
             //{
@@ -288,7 +288,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestForPublicMembersNamedSize(Type typeFromTargetAssembly)
         {
-            var names = GetMembersNamedSize(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetMembersNamedSize(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -308,7 +308,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestForPublicMembersContainingNonNetNumeric(Type typeFromTargetAssembly)
         {
-            var names = GetMembersContainingNonNetNumeric(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetMembersContainingNonNetNumeric(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -326,7 +326,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestForTypesContainingNonNetNumeric(Type typeFromTargetAssembly)
         {
-            var names = GetTypesContainingNonNetNumeric(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetTypesContainingNonNetNumeric(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -345,7 +345,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestForPublicMembersWithNullableEnum(Type typeFromTargetAssembly)
         {
-            var names = GetPublicNullableEnumMembers(typeFromTargetAssembly.GetTypeInfo().Assembly);
+            var names = GetPublicNullableEnumMembers(typeFromTargetAssembly.Assembly);
 
             //if (VERBOSE)
             //{
@@ -370,7 +370,7 @@ namespace Lucene.Net.Util
         //[Test, LuceneNetSpecific]
         public virtual void TestForMembersAcceptingOrReturningIEnumerable(Type typeFromTargetAssembly, string exceptionRegex)
         {
-            var names = GetMembersAcceptingOrReturningType(typeof(IEnumerable<>), typeFromTargetAssembly.GetTypeInfo().Assembly, false, exceptionRegex);
+            var names = GetMembersAcceptingOrReturningType(typeof(IEnumerable<>), typeFromTargetAssembly.Assembly, false, exceptionRegex);
 
             //if (VERBOSE)
             //{
@@ -393,8 +393,8 @@ namespace Lucene.Net.Util
         public virtual void TestForMembersAcceptingOrReturningListOrDictionary(Type typeFromTargetAssembly, string exceptionRegex)
         {
             var names = new List<string>();
-            names.AddRange(GetMembersAcceptingOrReturningType(typeof(List<>), typeFromTargetAssembly.GetTypeInfo().Assembly, true, exceptionRegex));
-            names.AddRange(GetMembersAcceptingOrReturningType(typeof(Dictionary<,>), typeFromTargetAssembly.GetTypeInfo().Assembly, true, exceptionRegex));
+            names.AddRange(GetMembersAcceptingOrReturningType(typeof(List<>), typeFromTargetAssembly.Assembly, true, exceptionRegex));
+            names.AddRange(GetMembersAcceptingOrReturningType(typeof(Dictionary<,>), typeFromTargetAssembly.Assembly, true, exceptionRegex));
 
             //if (VERBOSE)
             //{
@@ -412,7 +412,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var classes = assembly.GetTypes().Where(t => t.GetTypeInfo().IsClass);
+            var classes = assembly.GetTypes().Where(t => t.IsClass);
 
             foreach (var c in classes)
             {
@@ -430,7 +430,7 @@ namespace Lucene.Net.Util
                         continue;
                     }
 
-                    if ((field.IsPrivate || field.IsAssembly) && !PrivateFieldName.IsMatch(field.Name) && field.DeclaringType.Equals(c.GetTypeInfo().UnderlyingSystemType))
+                    if ((field.IsPrivate || field.IsAssembly) && !PrivateFieldName.IsMatch(field.Name) && field.DeclaringType.Equals(c.UnderlyingSystemType))
                     {
                         var name = string.Concat(c.FullName, ".", field.Name);
                         //bool hasExceptions = !string.IsNullOrWhiteSpace(exceptionRegex);
@@ -453,7 +453,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var classes = assembly.GetTypes().Where(t => t.GetTypeInfo().IsClass);
+            var classes = assembly.GetTypes().Where(t => t.IsClass);
 
             foreach (var c in classes)
             {
@@ -480,7 +480,7 @@ namespace Lucene.Net.Util
                         continue;
                     }
 
-                    if ((field.IsFamily || field.IsFamilyOrAssembly) && !ProtectedFieldName.IsMatch(field.Name) && field.DeclaringType.Equals(c.GetTypeInfo().UnderlyingSystemType))
+                    if ((field.IsFamily || field.IsFamilyOrAssembly) && !ProtectedFieldName.IsMatch(field.Name) && field.DeclaringType.Equals(c.UnderlyingSystemType))
                     {
                         result.Add(string.Concat(c.FullName, ".", field.Name));
                     }
@@ -499,7 +499,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var classes = assembly.GetTypes().Where(t => t.GetTypeInfo().IsClass);
+            var classes = assembly.GetTypes().Where(t => t.IsClass);
 
             foreach (var c in classes)
             {
@@ -527,7 +527,7 @@ namespace Lucene.Net.Util
                         continue;
                     }
 
-                    if (field.IsPublic && field.DeclaringType.Equals(c.GetTypeInfo().UnderlyingSystemType))
+                    if (field.IsPublic && field.DeclaringType.Equals(c.UnderlyingSystemType))
                     {
                         result.Add(string.Concat(c.FullName, ".", field.Name));
                     }
@@ -541,7 +541,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var classes = assembly.GetTypes().Where(t => t.GetTypeInfo().IsClass);
+            var classes = assembly.GetTypes().Where(t => t.IsClass);
 
             foreach (var c in classes)
             {
@@ -558,7 +558,7 @@ namespace Lucene.Net.Util
 
                     foreach (var parameter in parameters)
                     {
-                        if (!MethodParameterName.IsMatch(parameter.Name) && method.DeclaringType.Equals(c.GetTypeInfo().UnderlyingSystemType))
+                        if (!MethodParameterName.IsMatch(parameter.Name) && method.DeclaringType.Equals(c.UnderlyingSystemType))
                         {
                             result.Add(string.Concat(c.FullName, ".", method.Name, " -parameter- ", parameter.Name));
                         }
@@ -573,7 +573,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var interfaces = assembly.GetTypes().Where(t => t.GetTypeInfo().IsInterface);
+            var interfaces = assembly.GetTypes().Where(t => t.IsInterface);
 
             foreach (var i in interfaces)
             {
@@ -590,7 +590,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var classes = assembly.GetTypes().Where(t => t.GetTypeInfo().IsClass);
+            var classes = assembly.GetTypes().Where(t => t.IsClass);
 
             foreach (var c in classes)
             {
@@ -599,7 +599,7 @@ namespace Lucene.Net.Util
                     continue;
                 }
 
-                if (c.GetTypeInfo().IsDefined(typeof(ExceptionToClassNameConventionAttribute)))
+                if (c.IsDefined(typeof(ExceptionToClassNameConventionAttribute)))
                 {
                     continue;
                 }
@@ -617,7 +617,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var classes = assembly.GetTypes().Where(t => t.GetTypeInfo().IsClass);
+            var classes = assembly.GetTypes().Where(t => t.IsClass);
 
             foreach (var c in classes)
             {
@@ -625,7 +625,7 @@ namespace Lucene.Net.Util
 
                 foreach (var property in properties)
                 {
-                    if (property.GetSetMethod(true) != null && property.GetGetMethod(true) == null && property.DeclaringType.Equals(c.GetTypeInfo().UnderlyingSystemType))
+                    if (property.GetSetMethod(true) != null && property.GetGetMethod(true) == null && property.DeclaringType.Equals(c.UnderlyingSystemType))
                     {
                         result.Add(string.Concat(c.FullName, ".", property.Name));
                     }
@@ -639,7 +639,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var classes = assembly.GetTypes().Where(t => t.GetTypeInfo().IsClass);
+            var classes = assembly.GetTypes().Where(t => t.IsClass);
 
             foreach (var c in classes)
             {
@@ -658,7 +658,7 @@ namespace Lucene.Net.Util
 
                     var getMethod = property.GetGetMethod();
                     
-                    if (getMethod != null && getMethod.ReturnParameter != null && getMethod.ReturnParameter.ParameterType.IsArray && property.DeclaringType.Equals(c.GetTypeInfo().UnderlyingSystemType))
+                    if (getMethod != null && getMethod.ReturnParameter != null && getMethod.ReturnParameter.ParameterType.IsArray && property.DeclaringType.Equals(c.UnderlyingSystemType))
                     {
                         result.Add(string.Concat(c.FullName, ".", property.Name));
                     }
@@ -673,7 +673,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var classes = assembly.GetTypes().Where(t => t.GetTypeInfo().IsClass);
+            var classes = assembly.GetTypes().Where(t => t.IsClass);
 
             foreach (var c in classes)
             {
@@ -691,7 +691,7 @@ namespace Lucene.Net.Util
                         continue;
                     }
 
-                    if ((field.IsFamily || field.IsFamilyOrAssembly) && ContainsComparer.IsMatch(field.Name) && field.DeclaringType.Equals(c.GetTypeInfo().UnderlyingSystemType))
+                    if ((field.IsFamily || field.IsFamilyOrAssembly) && ContainsComparer.IsMatch(field.Name) && field.DeclaringType.Equals(c.UnderlyingSystemType))
                     {
                         result.Add(string.Concat(c.FullName, ".", field.Name));
                     }
@@ -709,7 +709,7 @@ namespace Lucene.Net.Util
 
             foreach (var t in types)
             {
-                if (ContainsComparer.IsMatch(t.Name) && t.GetTypeInfo().IsVisible)
+                if (ContainsComparer.IsMatch(t.Name) && t.IsVisible)
                 {
                     result.Add(t.FullName);
                 }
@@ -718,7 +718,7 @@ namespace Lucene.Net.Util
 
                 foreach (var member in members)
                 {
-                    if (ContainsComparer.IsMatch(member.Name) && member.DeclaringType.Equals(t.GetTypeInfo().UnderlyingSystemType))
+                    if (ContainsComparer.IsMatch(member.Name) && member.DeclaringType.Equals(t.UnderlyingSystemType))
                     {
                         if (member.MemberType == MemberTypes.Method && !(member.Name.StartsWith("get_", StringComparison.Ordinal) || member.Name.StartsWith("set_", StringComparison.Ordinal)))
                         {
@@ -751,7 +751,7 @@ namespace Lucene.Net.Util
 
                 foreach (var member in members)
                 {
-                    if ("Size".Equals(member.Name, StringComparison.OrdinalIgnoreCase) && member.DeclaringType.Equals(t.GetTypeInfo().UnderlyingSystemType))
+                    if ("Size".Equals(member.Name, StringComparison.OrdinalIgnoreCase) && member.DeclaringType.Equals(t.UnderlyingSystemType))
                     {
                         if (member.MemberType == MemberTypes.Method && !(member.Name.StartsWith("get_", StringComparison.Ordinal) || member.Name.StartsWith("set_", StringComparison.Ordinal)))
                         {
@@ -797,7 +797,7 @@ namespace Lucene.Net.Util
                         continue;
                     }
 
-                    if (ContainsNonNetNumeric.IsMatch(member.Name) && member.DeclaringType.Equals(t.GetTypeInfo().UnderlyingSystemType))
+                    if (ContainsNonNetNumeric.IsMatch(member.Name) && member.DeclaringType.Equals(t.UnderlyingSystemType))
                     {
                         if (member.MemberType == MemberTypes.Method && !(member.Name.StartsWith("get_", StringComparison.Ordinal) || member.Name.StartsWith("set_", StringComparison.Ordinal)))
                         {
@@ -826,7 +826,7 @@ namespace Lucene.Net.Util
 
             foreach (var t in types)
             {
-                if (t.GetTypeInfo().IsDefined(typeof(ExceptionToNetNumericConventionAttribute)))
+                if (t.IsDefined(typeof(ExceptionToNetNumericConventionAttribute)))
                 {
                     continue;
                 }
@@ -845,7 +845,7 @@ namespace Lucene.Net.Util
         {
             var result = new List<string>();
 
-            var classes = assembly.GetTypes().Where(t => t.GetTypeInfo().IsClass);
+            var classes = assembly.GetTypes().Where(t => t.IsClass);
 
             foreach (var c in classes)
             {
@@ -875,7 +875,7 @@ namespace Lucene.Net.Util
 
                     if (method != null && method.ReturnParameter != null 
                         && method.ReturnParameter.ParameterType.IsArray 
-                        && method.DeclaringType.Equals(c.GetTypeInfo().UnderlyingSystemType))
+                        && method.DeclaringType.Equals(c.UnderlyingSystemType))
                     {
 
                         var methodBody = method.GetMethodBody();
@@ -919,7 +919,7 @@ namespace Lucene.Net.Util
                         continue;
                     }
 
-                    if (member.DeclaringType.Equals(t.GetTypeInfo().UnderlyingSystemType))
+                    if (member.DeclaringType.Equals(t.UnderlyingSystemType))
                     {
                         if (member.MemberType == MemberTypes.Method && !(member.Name.StartsWith("get_", StringComparison.Ordinal) || member.Name.StartsWith("set_", StringComparison.Ordinal)))
                         {
@@ -929,7 +929,7 @@ namespace Lucene.Net.Util
                             {
                                 if (method.ReturnParameter != null
                                     && Nullable.GetUnderlyingType(method.ReturnParameter.ParameterType) != null
-                                    && method.ReturnParameter.ParameterType.GetGenericArguments()[0].GetTypeInfo().IsEnum)
+                                    && method.ReturnParameter.ParameterType.GetGenericArguments()[0].IsEnum)
                                 {
                                     result.Add(string.Concat(t.FullName, ".", member.Name, "()"));
                                 }
@@ -939,8 +939,8 @@ namespace Lucene.Net.Util
                                 foreach (var parameter in parameters)
                                 {
                                     if (Nullable.GetUnderlyingType(parameter.ParameterType) != null
-                                        && parameter.ParameterType.GetGenericArguments()[0].GetTypeInfo().IsEnum
-                                        && member.DeclaringType.Equals(t.GetTypeInfo().UnderlyingSystemType))
+                                        && parameter.ParameterType.GetGenericArguments()[0].IsEnum
+                                        && member.DeclaringType.Equals(t.UnderlyingSystemType))
                                     {
                                         result.Add(string.Concat(t.FullName, ".", member.Name, "()", " -parameter- ", parameter.Name));
                                     }
@@ -958,8 +958,8 @@ namespace Lucene.Net.Util
                                 foreach (var parameter in parameters)
                                 {
                                     if (Nullable.GetUnderlyingType(parameter.ParameterType) != null
-                                        && parameter.ParameterType.GetGenericArguments()[0].GetTypeInfo().IsEnum
-                                        && member.DeclaringType.Equals(t.GetTypeInfo().UnderlyingSystemType))
+                                        && parameter.ParameterType.GetGenericArguments()[0].IsEnum
+                                        && member.DeclaringType.Equals(t.UnderlyingSystemType))
                                     {
                                         result.Add(string.Concat(t.FullName, ".", member.Name, "()", " -parameter- ", parameter.Name));
                                     }
@@ -968,14 +968,14 @@ namespace Lucene.Net.Util
                         }
                         else if (member.MemberType == MemberTypes.Property 
                             && Nullable.GetUnderlyingType(((PropertyInfo)member).PropertyType) != null 
-                            && ((PropertyInfo)member).PropertyType.GetGenericArguments()[0].GetTypeInfo().IsEnum 
+                            && ((PropertyInfo)member).PropertyType.GetGenericArguments()[0].IsEnum 
                             && IsNonPrivateProperty((PropertyInfo)member))
                         {
                             result.Add(string.Concat(t.FullName, ".", member.Name));
                         }
                         else if (member.MemberType == MemberTypes.Field 
                             && Nullable.GetUnderlyingType(((FieldInfo)member).FieldType) != null 
-                            && ((FieldInfo)member).FieldType.GetGenericArguments()[0].GetTypeInfo().IsEnum 
+                            && ((FieldInfo)member).FieldType.GetGenericArguments()[0].IsEnum 
                             && (((FieldInfo)member).IsFamily || ((FieldInfo)member).IsFamilyOrAssembly))
                         {
                             result.Add(string.Concat(t.FullName, ".", member.Name, " (field)"));
@@ -1025,7 +1025,7 @@ namespace Lucene.Net.Util
                         continue;
                     }
 
-                    if (member.DeclaringType.Equals(t.GetTypeInfo().UnderlyingSystemType))
+                    if (member.DeclaringType.Equals(t.UnderlyingSystemType))
                     {
                         if (member.MemberType == MemberTypes.Method && !(member.Name.StartsWith("get_", StringComparison.Ordinal) || member.Name.StartsWith("set_", StringComparison.Ordinal)))
                         {
@@ -1035,7 +1035,7 @@ namespace Lucene.Net.Util
                             {
 
                                 if (method.ReturnParameter != null
-                                    && method.ReturnParameter.ParameterType.GetTypeInfo().IsGenericType
+                                    && method.ReturnParameter.ParameterType.IsGenericType
                                     && method.ReturnParameter.ParameterType.GetGenericTypeDefinition().IsAssignableFrom(lookFor))
                                 {
                                     var name = string.Concat(t.FullName, ".", member.Name, "()");
@@ -1050,9 +1050,9 @@ namespace Lucene.Net.Util
 
                                 foreach (var parameter in parameters)
                                 {
-                                    if (parameter.ParameterType.GetTypeInfo().IsGenericType
+                                    if (parameter.ParameterType.IsGenericType
                                         && parameter.ParameterType.GetGenericTypeDefinition().IsAssignableFrom(lookFor)
-                                        && member.DeclaringType.Equals(t.GetTypeInfo().UnderlyingSystemType))
+                                        && member.DeclaringType.Equals(t.UnderlyingSystemType))
                                     {
                                         var name = string.Concat(t.FullName, ".", member.Name, "()", " -parameter- ", parameter.Name);
 
@@ -1074,9 +1074,9 @@ namespace Lucene.Net.Util
 
                                 foreach (var parameter in parameters)
                                 {
-                                    if (parameter.ParameterType.GetTypeInfo().IsGenericType
+                                    if (parameter.ParameterType.IsGenericType
                                         && parameter.ParameterType.GetGenericTypeDefinition().IsAssignableFrom(lookFor)
-                                        && member.DeclaringType.Equals(t.GetTypeInfo().UnderlyingSystemType))
+                                        && member.DeclaringType.Equals(t.UnderlyingSystemType))
                                     {
                                         var name = string.Concat(t.FullName, ".", member.Name, "()", " -parameter- ", parameter.Name);
 
@@ -1089,7 +1089,7 @@ namespace Lucene.Net.Util
                             }
                         }
                         else if (member.MemberType == MemberTypes.Property
-                            && ((PropertyInfo)member).PropertyType.GetTypeInfo().IsGenericType
+                            && ((PropertyInfo)member).PropertyType.IsGenericType
                             && ((PropertyInfo)member).PropertyType.GetGenericTypeDefinition().IsAssignableFrom(lookFor)
                             && (!publiclyVisibleOnly || IsNonPrivateProperty((PropertyInfo)member)))
                         {

--- a/src/Lucene.Net.TestFramework/Support/Codecs/TestCodecFactory.cs
+++ b/src/Lucene.Net.TestFramework/Support/Codecs/TestCodecFactory.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Codecs
         protected override void Initialize()
         {
             base.Initialize();
-            base.ScanForCodecs(this.GetType().GetTypeInfo().Assembly);
+            base.ScanForCodecs(this.GetType().Assembly);
         }
 
         protected override bool IsServiceType(Type type)

--- a/src/Lucene.Net.TestFramework/Support/Codecs/TestDocValuesFormatFactory.cs
+++ b/src/Lucene.Net.TestFramework/Support/Codecs/TestDocValuesFormatFactory.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Codecs
         protected override void Initialize()
         {
             base.Initialize();
-            base.ScanForDocValuesFormats(this.GetType().GetTypeInfo().Assembly);
+            base.ScanForDocValuesFormats(this.GetType().Assembly);
         }
     }
 }

--- a/src/Lucene.Net.TestFramework/Support/Codecs/TestPostingsFormatFactory.cs
+++ b/src/Lucene.Net.TestFramework/Support/Codecs/TestPostingsFormatFactory.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Codecs
         protected override void Initialize()
         {
             base.Initialize();
-            base.ScanForPostingsFormats(this.GetType().GetTypeInfo().Assembly);
+            base.ScanForPostingsFormats(this.GetType().Assembly);
         }
     }
 }

--- a/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
@@ -138,24 +138,24 @@ namespace Lucene.Net.Util
             Assert.AreEqual(d1, d2, delta, msg);
         }
 
-        internal static void assertEquals<T>(ISet<T> expected, ISet<T> actual)
+        internal static void assertEquals<T>(ISet<T> expected, ISet<T> actual, bool aggressive = true)
         {
-            Assert.True(JCG.SetEqualityComparer<T>.Aggressive.Equals(expected, actual));
+            Assert.AreEqual(expected, actual, aggressive);
         }
 
-        internal static void assertEquals<T>(string message, ISet<T> expected, ISet<T> actual)
+        internal static void assertEquals<T>(string message, ISet<T> expected, ISet<T> actual, bool aggressive = true)
         {
-            Assert.True(JCG.SetEqualityComparer<T>.Aggressive.Equals(expected, actual), message);
+            Assert.AreEqual(expected, actual, aggressive, message);
         }
 
-        internal static void assertEquals<T>(IList<T> expected, IList<T> actual)
+        internal static void assertEquals<T>(IList<T> expected, IList<T> actual, bool aggressive = true)
         {
-            Assert.True(JCG.ListEqualityComparer<T>.Aggressive.Equals(expected, actual));
+            Assert.AreEqual(expected, actual, aggressive);
         }
 
-        internal static void assertEquals<T>(string message, IList<T> expected, IList<T> actual)
+        internal static void assertEquals<T>(string message, IList<T> expected, IList<T> actual, bool aggressive = true)
         {
-            Assert.True(JCG.SetEqualityComparer<T>.Aggressive.Equals(expected, actual), message);
+            Assert.AreEqual(expected, actual, aggressive, message);
         }
 
         internal static void assertEquals<T>(T[] expected, T[] actual)
@@ -168,9 +168,14 @@ namespace Lucene.Net.Util
             Assert.AreEqual(expected, actual, message);
         }
 
-        internal static void assertEquals<T, S>(IDictionary<T, S> expected, IDictionary<T, S> actual)
+        internal static void assertEquals<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive = true)
         {
-            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(expected, actual, aggressive);
+        }
+
+        internal static void assertEquals<TKey, TValue>(string message, IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive = true)
+        {
+            Assert.AreEqual(expected, actual, aggressive, message);
         }
 
         internal static void assertNotSame(object unexpected, object actual)

--- a/src/Lucene.Net.TestFramework/Support/RandomExtensions.cs
+++ b/src/Lucene.Net.TestFramework/Support/RandomExtensions.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using J2N.Numerics;
 
 namespace Lucene.Net
 {
@@ -68,6 +69,36 @@ namespace Lucene.Net
         public static long NextInt64(this Random random, long start, long end)
         {
             return TestUtil.NextInt64(random, start, end);
+        }
+
+        /// <summary>
+        /// Generates a random <see cref="long"/> between <c>0</c> (inclusive)
+        /// and <paramref name="n"/> (exclusive).
+        /// </summary>
+        /// <param name="random">This <see cref="Random"/>.</param>
+        /// <param name="n">The bound on the random number to be returned. Must be positive.</param>
+        /// <returns>A random <see cref="long"/> between 0 and <paramref name="n"/>-1.</returns>
+        public static long NextInt64(this Random random, long n)
+        {
+            if (n <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(n), $"{n} <= 0: " + n);
+            }
+
+            long value = NextInt64(random);
+            long range = n - 1;
+            if ((n & range) == 0L)
+            {
+                value &= range;
+            }
+            else
+            {
+                for (long u = value.TripleShift(1); u + range - (value = u % n) < 0L;)
+                {
+                    u = NextInt64(random).TripleShift(1);
+                }
+            }
+            return value;
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Support/Randomized/Attributes/SeedDecoratorAttribute.cs
+++ b/src/Lucene.Net.TestFramework/Support/Randomized/Attributes/SeedDecoratorAttribute.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Randomized.Attributes
 
             foreach (Type item in decorators)
             {
-                if (item.GetTypeInfo().ImplementedInterfaces.Contains(typeof(ISeedDecorator)))
+                if (item.ImplementedInterfaces.Contains(typeof(ISeedDecorator)))
                     this.Decorators.Add(item);
             }
         }

--- a/src/Lucene.Net.TestFramework/Support/Randomized/Generators/RandomInts.cs
+++ b/src/Lucene.Net.TestFramework/Support/Randomized/Generators/RandomInts.cs
@@ -1,6 +1,9 @@
 using Lucene.Net.Support;
 using System;
-using Debug = Lucene.Net.Diagnostics.Debug; // LUCENENET NOTE: We cannot use System.Diagnostics.Debug because those calls will be optimized out of the release!
+using System.Diagnostics;
+using System.Globalization;
+// LUCENENET NOTE: The asserts here need to be from System.Diagnostics, since they are not meant for end users.
+//using Debug = Lucene.Net.Diagnostics.Debug;
 
 namespace Lucene.Net.Randomized.Generators
 {
@@ -33,9 +36,9 @@ namespace Lucene.Net.Randomized.Generators
         public static int RandomInt32Between(Random random, int min, int max)
         {
             Debug.Assert(min <= max,
-                $"Min must be less than or equal max int. min: {min.ToString()}, max: {max.ToString()}");
+                $"Min must be less than or equal max int. min: {min.ToString(CultureInfo.InvariantCulture)}, max: {max.ToString(CultureInfo.InvariantCulture)}");
             var range = max - min;
-            if (range < Int32.MaxValue)
+            if (range < int.MaxValue)
                 return min + random.Next(1 + range);
 
             return min + (int)Math.Round(random.NextDouble() * range);

--- a/src/Lucene.Net.TestFramework/Support/Randomized/RandomizedRunner.cs
+++ b/src/Lucene.Net.TestFramework/Support/Randomized/RandomizedRunner.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Randomized
             this.suiteClass = testClass;
 
             var list = new List<ISeedDecorator>();
-            var attrs = this.suiteClass.GetTypeInfo().GetCustomAttributes<SeedDecoratorAttribute>(true);
+            var attrs = this.suiteClass.GetCustomAttributes<SeedDecoratorAttribute>(true);
             foreach (var attr in attrs)
             {
                 foreach (var decoratorType in attr.Decorators)

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -648,6 +648,12 @@ namespace Lucene.Net.Util
         // Suite and test case setup/ cleanup.
         // -----------------------------------------------------------------
 
+        // LUCENENET specific: Temporary storage for random selections so they
+        // can be set once per OneTimeSetUp and reused multiple times in SetUp
+        // where they are written to the output.
+        private string codecType;
+        private string similarityName;
+
         /// <summary>
         /// For subclasses to override. Overrides must call <c>base.SetUp()</c>.
         /// </summary>
@@ -671,11 +677,11 @@ namespace Lucene.Net.Util
             Console.Write("Default Codec: ");
             Console.Write(ClassEnvRule.codec.Name);
             Console.Write(" (");
-            Console.Write(ClassEnvRule.codec.GetType().ToString());
+            Console.Write(codecType);
             Console.WriteLine(")");
 
             Console.Write("Default Similarity: ");
-            Console.WriteLine(ClassEnvRule.similarity.ToString());
+            Console.WriteLine(similarityName);
         }
 
         /// <summary>
@@ -736,6 +742,9 @@ namespace Lucene.Net.Util
 
                 ClassEnvRule.Before(null);
 
+                // LUCENENET: Generate the info once so it can be printed out for each test
+                codecType = ClassEnvRule.codec.GetType().Name;
+                similarityName = ClassEnvRule.similarity.ToString();
 
                 // LUCENENET TODO: Scan for a custom attribute and setup ordering to
                 // initialize data from this class to the top class
@@ -767,6 +776,10 @@ namespace Lucene.Net.Util
                 LuceneTestFrameworkInitializer.EnsureInitialized();
 
                 ClassEnvRule.Before(this);
+
+                // LUCENENET: Generate the info once so it can be printed out for each test
+                codecType = ClassEnvRule.codec.GetType().Name;
+                similarityName = ClassEnvRule.similarity.ToString();
             }
             catch (Exception ex)
             {

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -2951,7 +2951,7 @@ namespace Lucene.Net.Util
                 right.Add(fi.Name);
             }
 
-            Assert.AreEqual(left, right, info);
+            Assert.AreEqual(left, right, aggressive: false, info);
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -927,7 +927,7 @@ namespace Lucene.Net.Util
                 return _testName;
 #else
                 //return ThreadAndTestNameRule.TestMethodName;
-                return this.GetType().GetTypeInfo().Name; // LUCENENET TODO: return the current test method name if the test framework supports such a thing.
+                return this.GetType().Name; // LUCENENET TODO: return the current test method name if the test framework supports such a thing.
 #endif
             }
         }
@@ -1250,8 +1250,8 @@ namespace Lucene.Net.Util
                 {
                     //// Retrieve the package-private setIndexerThreadPool
                     //// method:
-                    ////MethodInfo setIndexerThreadPoolMethod = typeof(IndexWriterConfig).GetTypeInfo().GetMethod("SetIndexerThreadPool", new Type[] { typeof(DocumentsWriterPerThreadPool) });
-                    //MethodInfo setIndexerThreadPoolMethod = typeof(IndexWriterConfig).GetTypeInfo().GetMethod(
+                    ////MethodInfo setIndexerThreadPoolMethod = typeof(IndexWriterConfig).GetMethod("SetIndexerThreadPool", new Type[] { typeof(DocumentsWriterPerThreadPool) });
+                    //MethodInfo setIndexerThreadPoolMethod = typeof(IndexWriterConfig).GetMethod(
                     //    "SetIndexerThreadPool", 
                     //    BindingFlags.NonPublic | BindingFlags.Instance, 
                     //    null, 
@@ -1259,7 +1259,7 @@ namespace Lucene.Net.Util
                     //    null);
                     ////setIndexerThreadPoolMethod.setAccessible(true);
                     //Type clazz = typeof(RandomDocumentsWriterPerThreadPool);
-                    //ConstructorInfo ctor = clazz.GetTypeInfo().GetConstructor(new[] { typeof(int), typeof(Random) });
+                    //ConstructorInfo ctor = clazz.GetConstructor(new[] { typeof(int), typeof(Random) });
                     ////ctor.Accessible = true;
                     //// random thread pool
                     //setIndexerThreadPoolMethod.Invoke(c, new[] { ctor.Invoke(new object[] { maxNumThreadStates, r }) });

--- a/src/Lucene.Net.TestFramework/Util/TestRuleSetupAndRestoreClassEnv.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleSetupAndRestoreClassEnv.cs
@@ -153,7 +153,7 @@ namespace Lucene.Net.Util
 
             Type targetClass = testInstance?.GetType() ?? LuceneTestCase.GetTestClass();
             avoidCodecs = new JCG.HashSet<string>();
-            var suppressCodecsAttribute = targetClass.GetTypeInfo().GetCustomAttribute<LuceneTestCase.SuppressCodecsAttribute>();
+            var suppressCodecsAttribute = targetClass.GetCustomAttribute<LuceneTestCase.SuppressCodecsAttribute>();
             if (suppressCodecsAttribute != null)
             {
                 avoidCodecs.UnionWith(suppressCodecsAttribute.Value);

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -1031,12 +1031,12 @@ namespace Lucene.Net.Util
         /// <param name="reflectedValues"> Contains a <see cref="IDictionary{String, Object}"/> with "AttributeSubclassType/key" as values.</param>
         public static void AssertAttributeReflection(Attribute att, IDictionary<string, object> reflectedValues)
         {
-            IDictionary<string, object> map = new Dictionary<string, object>();
+            IDictionary<string, object> map = new JCG.Dictionary<string, object>();
             att.ReflectWith(new AttributeReflectorAnonymousInnerClassHelper(map));
-            IDictionary<string, object> newReflectedObjects = new Dictionary<string, object>();
+            IDictionary<string, object> newReflectedObjects = new JCG.Dictionary<string, object>();
             foreach (KeyValuePair<string, object> de in reflectedValues)
                 newReflectedObjects.Add(de.Key, (object)de.Value);
-            Assert.AreEqual((ICollection)newReflectedObjects, (ICollection)map, "Reflection does not produce same map");
+            Assert.AreEqual(newReflectedObjects, map, aggressive: false, "Reflection does not produce same map");
         }
 
         private class AttributeReflectorAnonymousInnerClassHelper : IAttributeReflector

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
@@ -550,7 +550,7 @@ namespace Lucene.Net.Analysis.CharFilters
 
                     // Verify:
                     assertEquals(expected, actual);
-                    assertEquals(inputOffsets, actualInputOffsets);
+                    assertEquals(inputOffsets, actualInputOffsets, aggressive: false);
                 }
             }
         }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAllAnalyzersHaveFactories.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAllAnalyzersHaveFactories.cs
@@ -98,10 +98,10 @@ namespace Lucene.Net.Analysis.Core
         [Test]
         public virtual void Test()
         {
-            IList<Type> analysisClasses = typeof(StandardAnalyzer).GetTypeInfo().Assembly.GetTypes()
+            IList<Type> analysisClasses = typeof(StandardAnalyzer).Assembly.GetTypes()
                     .Where(c =>
                     {
-                        var typeInfo = c.GetTypeInfo();
+                        var typeInfo = c;
 
                         return !typeInfo.IsAbstract && typeInfo.IsPublic && !typeInfo.IsInterface && typeInfo.IsClass && (typeInfo.GetCustomAttribute<ObsoleteAttribute>() == null)
                             && !testComponents.Contains(c) && !crazyComponents.Contains(c) && !oddlyNamedComponents.Contains(c) && !deprecatedDuplicatedComponents.Contains(c)
@@ -116,7 +116,7 @@ namespace Lucene.Net.Analysis.Core
                 IDictionary<string, string> args = new Dictionary<string, string>();
                 args["luceneMatchVersion"] = TEST_VERSION_CURRENT.ToString();
 
-                if (c.GetTypeInfo().IsSubclassOf(typeof(Tokenizer)))
+                if (c.IsSubclassOf(typeof(Tokenizer)))
                 {
                     string clazzName = c.Name;
                     assertTrue(clazzName.EndsWith("Tokenizer", StringComparison.Ordinal));
@@ -143,7 +143,7 @@ namespace Lucene.Net.Analysis.Core
                         // TODO: For now pass because some factories have not yet a default config that always works
                     }
                 }
-                else if (c.GetTypeInfo().IsSubclassOf(typeof(TokenFilter)))
+                else if (c.IsSubclassOf(typeof(TokenFilter)))
                 {
                     string clazzName = c.Name;
                     assertTrue(clazzName.EndsWith("Filter", StringComparison.Ordinal));
@@ -175,7 +175,7 @@ namespace Lucene.Net.Analysis.Core
                         // TODO: For now pass because some factories have not yet a default config that always works
                     }
                 }
-                else if (c.GetTypeInfo().IsSubclassOf(typeof(CharFilter)))
+                else if (c.IsSubclassOf(typeof(CharFilter)))
                 {
                     string clazzName = c.Name;
                     assertTrue(clazzName.EndsWith("CharFilter", StringComparison.Ordinal));

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -196,9 +196,9 @@ namespace Lucene.Net.Analysis.Core
         {
             base.BeforeClass();
 
-            IEnumerable<Type> analysisClasses = typeof(StandardAnalyzer).GetTypeInfo().Assembly.GetTypes()
+            IEnumerable<Type> analysisClasses = typeof(StandardAnalyzer).Assembly.GetTypes()
                 .Where(c => {
-                    var typeInfo = c.GetTypeInfo();
+                    var typeInfo = c;
 
                     return !typeInfo.IsAbstract && typeInfo.IsPublic && !typeInfo.IsInterface 
                         && typeInfo.IsClass && (typeInfo.GetCustomAttribute<ObsoleteAttribute>() == null)
@@ -217,7 +217,7 @@ namespace Lucene.Net.Analysis.Core
                         continue;
                     }
 
-                    var typeInfo = c.GetTypeInfo();
+                    var typeInfo = c;
 
                     if (typeInfo.IsSubclassOf(typeof(Tokenizer)))
                     {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilterFactory.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Analysis.Core
 
             // defaults
             factory = (StopFilterFactory)TokenFilterFactory("Stop");
-            assertEquals(StopAnalyzer.ENGLISH_STOP_WORDS_SET, factory.StopWords);
+            assertEquals(StopAnalyzer.ENGLISH_STOP_WORDS_SET, factory.StopWords, aggressive: false);
             assertEquals(false, factory.IgnoreCase);
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestAllDictionaries.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestAllDictionaries.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
         // set this to the location of where you downloaded all the files
         internal static readonly DirectoryInfo DICTIONARY_HOME = new DirectoryInfo(
-            System.IO.Path.Combine(new DirectoryInfo(typeof(TestAllDictionaries2).GetTypeInfo().Assembly.Location).Parent.Parent.Parent.Parent.Parent.FullName,
+            System.IO.Path.Combine(new DirectoryInfo(typeof(TestAllDictionaries2).Assembly.Location).Parent.Parent.Parent.Parent.Parent.FullName,
                 @"test-files\analysis\data\dictionaries"));
 
         internal readonly string[] tests = new string[] 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestAllDictionaries2.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestAllDictionaries2.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
         // set this to the location of where you downloaded all the files
         internal static readonly DirectoryInfo DICTIONARY_HOME = new DirectoryInfo(
-            System.IO.Path.Combine(new DirectoryInfo(typeof(TestAllDictionaries2).GetTypeInfo().Assembly.Location).Parent.Parent.Parent.Parent.Parent.FullName,
+            System.IO.Path.Combine(new DirectoryInfo(typeof(TestAllDictionaries2).Assembly.Location).Parent.Parent.Parent.Parent.Parent.FullName,
                 @"test-files\analysis\data\thunderbirdDicts"));
 
         internal readonly string[] tests = new string[]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymFilterFactory.cs
@@ -187,7 +187,7 @@ namespace Lucene.Net.Analysis.Synonym
             object delegator = synFac.Delegator;
 #pragma warning restore 612, 618
             assertNotNull(delegator);
-            assertTrue("delegator not expected class: " + delegator.GetType(), delegatorClass.GetTypeInfo().IsInstanceOfType(delegator));
+            assertTrue("delegator not expected class: " + delegator.GetType(), delegatorClass.IsInstanceOfType(delegator));
 
         }
     }

--- a/src/Lucene.Net.Tests.Analysis.Morfologik/Morfologik/TestMorfologikAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Morfologik/Morfologik/TestMorfologikAnalyzer.cs
@@ -147,19 +147,20 @@ namespace Lucene.Net.Analysis.Morfologik
             SCG.ISet<String> expected = new JCG.SortedSet<String>(StringComparer.Ordinal);
             foreach (StringBuilder b in ts.GetAttribute<IMorphosyntacticTagsAttribute>().Tags)
             {
-                actual.add(b.toString());
+                actual.Add(b.ToString());
             }
             foreach (String s in tags)
             {
-                expected.add(s);
+                expected.Add(s);
             }
 
-            if (!expected.equals(actual))
-            {
-                Console.WriteLine("Expected:\n" + expected);
-                Console.WriteLine("Actual:\n" + actual);
-                assertEquals(expected, actual);
-            }
+            // LUCENENET: Commented out unnecessary extra check
+            //if (!expected.Equals(actual))
+            //{
+            //    Console.WriteLine("Expected:\n" + expected);
+            //    Console.WriteLine("Actual:\n" + actual);
+                assertEquals(expected, actual, aggressive: false);
+            //}
         }
 
         /** Test morphosyntactic annotations. */

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/Alt/AltPackageTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/Alt/AltPackageTaskTest.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks.Alt
             if (allowAlt)
             {
                 return new String[] {
-                    "alt.tasks.packages = " +this.GetType().GetTypeInfo().Assembly.GetName().Name,
+                    "alt.tasks.packages = " +this.GetType().Assembly.GetName().Name,
                     altTask
                 };
             }

--- a/src/Lucene.Net.Tests.Demo/TestDemo.cs
+++ b/src/Lucene.Net.Tests.Demo/TestDemo.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Demo
             // file location, we first extract the files to the disk
             // from embedded resources. Then we know the exact location
             // where they are and it can't fail.
-            var thisAssembly = this.GetType().GetTypeInfo().Assembly;
+            var thisAssembly = this.GetType().Assembly;
             string embeddedDocsLocation = "Test_Files.Docs.";
             foreach (var file in thisAssembly.GetManifestResourceNames())
             {

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
@@ -883,7 +883,7 @@ namespace Lucene.Net.Facet.Taxonomy
                 // Messy: fixup ties
                 SortTies(actual);
 
-                Assert.AreEqual(expected, actual);
+                Assert.AreEqual(expected, actual, aggressive: false);
             }
 
             IOUtils.Dispose(w, tw, searcher.IndexReader, tr, indexDir, taxoDir);

--- a/src/Lucene.Net.Tests.Grouping/AllGroupHeadsCollectorTest.cs
+++ b/src/Lucene.Net.Tests.Grouping/AllGroupHeadsCollectorTest.cs
@@ -326,7 +326,7 @@ namespace Lucene.Net.Search.Grouping
                 try
                 {
                     IndexSearcher s = NewSearcher(r);
-                    if (typeof(SlowCompositeReaderWrapper).GetTypeInfo().IsAssignableFrom(s.IndexReader.GetType()))
+                    if (typeof(SlowCompositeReaderWrapper).IsAssignableFrom(s.IndexReader.GetType()))
                     {
                         canUseIDV = false;
                     }

--- a/src/Lucene.Net.Tests.Queries/CommonTermsQueryTest.cs
+++ b/src/Lucene.Net.Tests.Queries/CommonTermsQueryTest.cs
@@ -275,7 +275,10 @@ namespace Lucene.Net.Tests.Queries
                 assertEquals(search.TotalHits, 3);
                 assertEquals(search.ScoreDocs[1].Score, search.ScoreDocs[2].Score, 0F);
                 assertEquals(@"0", r.Document(search.ScoreDocs[0].Doc).Get(@"id"));
-                assertEquals(new JCG.HashSet<string> { @"2", @"3" }, new JCG.HashSet<string> { r.Document(search.ScoreDocs[1].Doc).Get(@"id"), r.Document(search.ScoreDocs[2].Doc).Get(@"id") });
+                assertEquals(
+                    new JCG.HashSet<string> { @"2", @"3" },
+                    new JCG.HashSet<string> { r.Document(search.ScoreDocs[1].Doc).Get(@"id"), r.Document(search.ScoreDocs[2].Doc).Get(@"id") },
+                    aggressive: false);
             }
 
             {
@@ -298,7 +301,10 @@ namespace Lucene.Net.Tests.Queries
                 query.HighFreqMinimumNumberShouldMatch = 2F;
                 TopDocs search = s.Search(query, 10);
                 assertEquals(search.TotalHits, 2);
-                assertEquals(new JCG.HashSet<string> { @"0", @"2" }, new JCG.HashSet<string> { r.Document(search.ScoreDocs[0].Doc).Get(@"id"), r.Document(search.ScoreDocs[1].Doc).Get(@"id") });
+                assertEquals(
+                    new JCG.HashSet<string> { @"0", @"2" },
+                    new JCG.HashSet<string> { r.Document(search.ScoreDocs[0].Doc).Get(@"id"), r.Document(search.ScoreDocs[1].Doc).Get(@"id") },
+                    aggressive: false);
             }
 
             r.Dispose();

--- a/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
@@ -145,7 +145,7 @@ namespace Lucene.Net.QueryParsers.Classic
         {
             try
             {
-                typeof(QueryParser).GetTypeInfo().GetConstructor(new Type[] { typeof(ICharStream) });
+                typeof(QueryParser).GetConstructor(new Type[] { typeof(ICharStream) });
                 fail("please switch public QueryParser(CharStream) to be protected");
             }
             catch (Exception /*nsme*/)
@@ -154,7 +154,7 @@ namespace Lucene.Net.QueryParsers.Classic
             }
             try
             {
-                typeof(QueryParser).GetTypeInfo().GetConstructor(new Type[] { typeof(QueryParserTokenManager) });
+                typeof(QueryParser).GetConstructor(new Type[] { typeof(QueryParserTokenManager) });
                 fail("please switch public QueryParser(QueryParserTokenManager) to be protected");
             }
             catch (Exception /*nsme*/)

--- a/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Replicator
             assertEquals(session1.SourceFiles.Keys, session2.SourceFiles.Keys);
             IList<RevisionFile> files1 = session1.SourceFiles.Values.First();
             IList<RevisionFile> files2 = session2.SourceFiles.Values.First();
-            assertEquals(files1, files2);
+            assertEquals(files1, files2, aggressive: false);
 
             IOUtils.Dispose(writer, directory);
         }

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
@@ -704,7 +704,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                         Update update = new Update();
                         update.index = Random.nextInt(inputs.size());
                         update.weight = weight;
-                        Input input = inputs.ElementAt(update.index);
+                        Input input = inputs[update.index];
                         pendingUpdates.Add(update);
                         if (VERBOSE)
                         {
@@ -735,7 +735,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                         visibleUpto = inputs.size();
                         foreach (Update update in pendingUpdates)
                         {
-                            Input oldInput = inputs.ElementAt(update.index);
+                            Input oldInput = inputs[update.index];
                             Input newInput = new Input(oldInput.term, update.weight, oldInput.payload);
                             inputs[update.index] = newInput;
                         }
@@ -760,7 +760,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                         visibleUpto = inputs.size();
                         foreach (Update update in pendingUpdates)
                         {
-                            Input oldInput = inputs.ElementAt(update.index);
+                            Input oldInput = inputs[update.index];
                             Input newInput = new Input(oldInput.term, update.weight, oldInput.payload);
                             inputs[update.index] = newInput;
                         }
@@ -789,7 +789,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                         List<Input> expected = new List<Input>();
                         for (int i = 0; i < visibleUpto; i++)
                         {
-                            Input input = inputs.ElementAt(i);
+                            Input input = inputs[i];
                             string[] inputTerms = Regex.Split(input.term.Utf8ToString(), "\\s", RegexOptions.Compiled).TrimEnd();
                             bool match = false;
                             for (int j = 0; j < queryTerms.Length; j++)
@@ -849,7 +849,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                         expected.Sort(new TestRandomNRTComparer());
 
-                        if (expected.Any())
+                        if (expected.Count > 0)
                         {
 
                             int topN = TestUtil.NextInt32(Random, 1, expected.size());
@@ -863,7 +863,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                                 Console.WriteLine("  expected:");
                                 for (int i = 0; i < expectedCount; i++)
                                 {
-                                    Input x = expected.ElementAt(i);
+                                    Input x = expected[i];
                                     Console.WriteLine("    " + x.term.Utf8ToString() + "/" + x.v);
                                 }
                                 Console.WriteLine("  actual:");
@@ -876,9 +876,9 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                             assertEquals(expectedCount, actual.size());
                             for (int i = 0; i < expectedCount; i++)
                             {
-                                assertEquals(expected.ElementAt(i).term.Utf8ToString(), actual.ElementAt(i).Key.toString());
-                                assertEquals(expected.ElementAt(i).v, actual.ElementAt(i).Value);
-                                assertEquals(expected.ElementAt(i).payload, actual.ElementAt(i).Payload);
+                                assertEquals(expected[i].term.Utf8ToString(), actual[i].Key.toString());
+                                assertEquals(expected[i].v, actual[i].Value);
+                                assertEquals(expected[i].payload, actual[i].Payload);
                             }
                         }
                         else
@@ -966,9 +966,9 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                 IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), 10, true, true);
                 assertEquals(1, results.size());
-                assertEquals("lend me your <b>ear</b>", results.ElementAt(0).Key);
-                assertEquals(8, results.ElementAt(0).Value);
-                assertEquals(new BytesRef("foobar"), results.ElementAt(0).Payload);
+                assertEquals("lend me your <b>ear</b>", results[0].Key);
+                assertEquals(8, results[0].Value);
+                assertEquals(new BytesRef("foobar"), results[0].Payload);
 
                 // Add a new suggestion:
                 suggester.Add(new BytesRef("a penny saved is a penny earned"), null, 10, new BytesRef("foobaz"));
@@ -978,31 +978,31 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                 results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), 10, true, true);
                 assertEquals(2, results.size());
-                assertEquals("a penny saved is a penny <b>ear</b>ned", results.ElementAt(0).Key);
-                assertEquals(10, results.ElementAt(0).Value);
-                assertEquals(new BytesRef("foobaz"), results.ElementAt(0).Payload);
+                assertEquals("a penny saved is a penny <b>ear</b>ned", results[0].Key);
+                assertEquals(10, results[0].Value);
+                assertEquals(new BytesRef("foobaz"), results[0].Payload);
 
-                assertEquals("lend me your <b>ear</b>", results.ElementAt(1).Key);
-                assertEquals(8, results.ElementAt(1).Value);
-                assertEquals(new BytesRef("foobar"), results.ElementAt(1).Payload);
+                assertEquals("lend me your <b>ear</b>", results[1].Key);
+                assertEquals(8, results[1].Value);
+                assertEquals(new BytesRef("foobar"), results[1].Payload);
 
                 results = suggester.DoLookup(TestUtil.StringToCharSequence("ear ", Random).ToString(), 10, true, true);
                 assertEquals(1, results.size());
-                assertEquals("lend me your <b>ear</b>", results.ElementAt(0).Key);
-                assertEquals(8, results.ElementAt(0).Value);
-                assertEquals(new BytesRef("foobar"), results.ElementAt(0).Payload);
+                assertEquals("lend me your <b>ear</b>", results[0].Key);
+                assertEquals(8, results[0].Value);
+                assertEquals(new BytesRef("foobar"), results[0].Payload);
 
                 results = suggester.DoLookup(TestUtil.StringToCharSequence("pen", Random).ToString(), 10, true, true);
                 assertEquals(1, results.size());
-                assertEquals("a <b>pen</b>ny saved is a <b>pen</b>ny earned", results.ElementAt(0).Key);
-                assertEquals(10, results.ElementAt(0).Value);
-                assertEquals(new BytesRef("foobaz"), results.ElementAt(0).Payload);
+                assertEquals("a <b>pen</b>ny saved is a <b>pen</b>ny earned", results[0].Key);
+                assertEquals(10, results[0].Value);
+                assertEquals(new BytesRef("foobaz"), results[0].Payload);
 
                 results = suggester.DoLookup(TestUtil.StringToCharSequence("p", Random).ToString(), 10, true, true);
                 assertEquals(1, results.size());
-                assertEquals("a <b>p</b>enny saved is a <b>p</b>enny earned", results.ElementAt(0).Key);
-                assertEquals(10, results.ElementAt(0).Value);
-                assertEquals(new BytesRef("foobaz"), results.ElementAt(0).Payload);
+                assertEquals("a <b>p</b>enny saved is a <b>p</b>enny earned", results[0].Key);
+                assertEquals(10, results[0].Value);
+                assertEquals(new BytesRef("foobaz"), results[0].Payload);
 
                 // Change the weight:
                 suggester.Update(new BytesRef("lend me your ear"), null, 12, new BytesRef("foobox"));
@@ -1012,12 +1012,12 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                 results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), 10, true, true);
                 assertEquals(2, results.size());
-                assertEquals("lend me your <b>ear</b>", results.ElementAt(0).Key);
-                assertEquals(12, results.ElementAt(0).Value);
-                assertEquals(new BytesRef("foobox"), results.ElementAt(0).Payload);
-                assertEquals("a penny saved is a penny <b>ear</b>ned", results.ElementAt(1).Key);
-                assertEquals(10, results.ElementAt(1).Value);
-                assertEquals(new BytesRef("foobaz"), results.ElementAt(1).Payload);
+                assertEquals("lend me your <b>ear</b>", results[0].Key);
+                assertEquals(12, results[0].Value);
+                assertEquals(new BytesRef("foobox"), results[0].Payload);
+                assertEquals("a penny saved is a penny <b>ear</b>ned", results[1].Key);
+                assertEquals(10, results[1].Value);
+                assertEquals(new BytesRef("foobaz"), results[1].Payload);
             }
         }
 
@@ -1063,7 +1063,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     // No context provided, all results returned
                     IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), 10, true, true);
                     assertEquals(2, results.size());
-                    Lookup.LookupResult result = results.ElementAt(0);
+                    Lookup.LookupResult result = results[0];
                     assertEquals("a penny saved is a penny <b>ear</b>ned", result.Key);
                     assertEquals(10, result.Value);
                     assertEquals(new BytesRef("foobaz"), result.Payload);
@@ -1072,7 +1072,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     assertTrue(result.Contexts.Contains(new BytesRef("foo")));
                     assertTrue(result.Contexts.Contains(new BytesRef("baz")));
 
-                    result = results.ElementAt(1);
+                    result = results[1];
                     assertEquals("lend me your <b>ear</b>", result.Key);
                     assertEquals(8, result.Value);
                     assertEquals(new BytesRef("foobar"), result.Payload);
@@ -1085,7 +1085,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), AsSet("foo"), 10, true, true);
                     assertEquals(2, results.size());
 
-                    result = results.ElementAt(0);
+                    result = results[0];
                     assertEquals("a penny saved is a penny <b>ear</b>ned", result.Key);
                     assertEquals(10, result.Value);
                     assertEquals(new BytesRef("foobaz"), result.Payload);
@@ -1094,7 +1094,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     assertTrue(result.Contexts.Contains(new BytesRef("foo")));
                     assertTrue(result.Contexts.Contains(new BytesRef("baz")));
 
-                    result = results.ElementAt(1);
+                    result = results[1];
                     assertEquals("lend me your <b>ear</b>", result.Key);
                     assertEquals(8, result.Value);
                     assertEquals(new BytesRef("foobar"), result.Payload);
@@ -1107,7 +1107,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), AsSet("bar"), 10, true, true);
                     assertEquals(1, results.size());
 
-                    result = results.ElementAt(0);
+                    result = results[0];
                     assertEquals("lend me your <b>ear</b>", result.Key);
                     assertEquals(8, result.Value);
                     assertEquals(new BytesRef("foobar"), result.Payload);
@@ -1120,7 +1120,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), AsSet("baz"), 10, true, true);
                     assertEquals(1, results.size());
 
-                    result = results.ElementAt(0);
+                    result = results[0];
                     assertEquals("a penny saved is a penny <b>ear</b>ned", result.Key);
                     assertEquals(10, result.Value);
                     assertEquals(new BytesRef("foobaz"), result.Payload);
@@ -1133,7 +1133,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), AsSet("foo", "bar"), 10, true, true);
                     assertEquals(2, results.size());
 
-                    result = results.ElementAt(0);
+                    result = results[0];
                     assertEquals("a penny saved is a penny <b>ear</b>ned", result.Key);
                     assertEquals(10, result.Value);
                     assertEquals(new BytesRef("foobaz"), result.Payload);
@@ -1142,7 +1142,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     assertTrue(result.Contexts.Contains(new BytesRef("foo")));
                     assertTrue(result.Contexts.Contains(new BytesRef("baz")));
 
-                    result = results.ElementAt(1);
+                    result = results[1];
                     assertEquals("lend me your <b>ear</b>", result.Key);
                     assertEquals(8, result.Value);
                     assertEquals(new BytesRef("foobar"), result.Payload);

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingSuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingSuggesterTest.cs
@@ -56,33 +56,33 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             // top N of 2, but only foo is available
             IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("f", Random).ToString(), false, 2);
             assertEquals(1, results.size());
-            assertEquals("foo", results.ElementAt(0).Key.toString());
-            assertEquals(50, results.ElementAt(0).Value, 0.01F);
+            assertEquals("foo", results[0].Key.toString());
+            assertEquals(50, results[0].Value, 0.01F);
 
             // top N of 1 for 'bar': we return this even though
             // barbar is higher because exactFirst is enabled:
             results = suggester.DoLookup(TestUtil.StringToCharSequence("bar", Random).ToString(), false, 1);
             assertEquals(1, results.size());
-            assertEquals("bar", results.ElementAt(0).Key.toString());
-            assertEquals(10, results.ElementAt(0).Value, 0.01F);
+            assertEquals("bar", results[0].Key.toString());
+            assertEquals(10, results[0].Value, 0.01F);
 
             // top N Of 2 for 'b'
             results = suggester.DoLookup(TestUtil.StringToCharSequence("b", Random).ToString(), false, 2);
             assertEquals(2, results.size());
-            assertEquals("barbar", results.ElementAt(0).Key.toString());
-            assertEquals(12, results.ElementAt(0).Value, 0.01F);
-            assertEquals("bar", results.ElementAt(1).Key.toString());
-            assertEquals(10, results.ElementAt(1).Value, 0.01F);
+            assertEquals("barbar", results[0].Key.toString());
+            assertEquals(12, results[0].Value, 0.01F);
+            assertEquals("bar", results[1].Key.toString());
+            assertEquals(10, results[1].Value, 0.01F);
 
             // top N of 3 for 'ba'
             results = suggester.DoLookup(TestUtil.StringToCharSequence("ba", Random).ToString(), false, 3);
             assertEquals(3, results.size());
-            assertEquals("barbar", results.ElementAt(0).Key.toString());
-            assertEquals(12, results.ElementAt(0).Value, 0.01F);
-            assertEquals("bar", results.ElementAt(1).Key.toString());
-            assertEquals(10, results.ElementAt(1).Value, 0.01F);
-            assertEquals("barbara", results.ElementAt(2).Key.toString());
-            assertEquals(6, results.ElementAt(2).Value, 0.01F);
+            assertEquals("barbar", results[0].Key.toString());
+            assertEquals(12, results[0].Value, 0.01F);
+            assertEquals("bar", results[1].Key.toString());
+            assertEquals(10, results[1].Value, 0.01F);
+            assertEquals("barbara", results[2].Key.toString());
+            assertEquals(6, results[2].Value, 0.01F);
         }
 
         [Test]
@@ -103,40 +103,40 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 // top N of 2, but only foo is available
                 IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("f", Random).ToString(), false, 2);
                 assertEquals(1, results.size());
-                assertEquals("foo", results.ElementAt(0).Key.toString());
-                assertEquals(50, results.ElementAt(0).Value, 0.01F);
-                assertEquals(new BytesRef("hello"), results.ElementAt(0).Payload);
+                assertEquals("foo", results[0].Key.toString());
+                assertEquals(50, results[0].Value, 0.01F);
+                assertEquals(new BytesRef("hello"), results[0].Payload);
 
                 // top N of 1 for 'bar': we return this even though
                 // barbar is higher because exactFirst is enabled:
                 results = suggester.DoLookup(TestUtil.StringToCharSequence("bar", Random).ToString(), false, 1);
                 assertEquals(1, results.size());
-                assertEquals("bar", results.ElementAt(0).Key.toString());
-                assertEquals(10, results.ElementAt(0).Value, 0.01F);
-                assertEquals(new BytesRef("goodbye"), results.ElementAt(0).Payload);
+                assertEquals("bar", results[0].Key.toString());
+                assertEquals(10, results[0].Value, 0.01F);
+                assertEquals(new BytesRef("goodbye"), results[0].Payload);
 
                 // top N Of 2 for 'b'
                 results = suggester.DoLookup(TestUtil.StringToCharSequence("b", Random).ToString(), false, 2);
                 assertEquals(2, results.size());
-                assertEquals("barbar", results.ElementAt(0).Key.toString());
-                assertEquals(12, results.ElementAt(0).Value, 0.01F);
-                assertEquals(new BytesRef("thank you"), results.ElementAt(0).Payload);
-                assertEquals("bar", results.ElementAt(1).Key.toString());
-                assertEquals(10, results.ElementAt(1).Value, 0.01F);
-                assertEquals(new BytesRef("goodbye"), results.ElementAt(1).Payload);
+                assertEquals("barbar", results[0].Key.toString());
+                assertEquals(12, results[0].Value, 0.01F);
+                assertEquals(new BytesRef("thank you"), results[0].Payload);
+                assertEquals("bar", results[1].Key.toString());
+                assertEquals(10, results[1].Value, 0.01F);
+                assertEquals(new BytesRef("goodbye"), results[1].Payload);
 
                 // top N of 3 for 'ba'
                 results = suggester.DoLookup(TestUtil.StringToCharSequence("ba", Random).ToString(), false, 3);
                 assertEquals(3, results.size());
-                assertEquals("barbar", results.ElementAt(0).Key.toString());
-                assertEquals(12, results.ElementAt(0).Value, 0.01F);
-                assertEquals(new BytesRef("thank you"), results.ElementAt(0).Payload);
-                assertEquals("bar", results.ElementAt(1).Key.toString());
-                assertEquals(10, results.ElementAt(1).Value, 0.01F);
-                assertEquals(new BytesRef("goodbye"), results.ElementAt(1).Payload);
-                assertEquals("barbara", results.ElementAt(2).Key.toString());
-                assertEquals(6, results.ElementAt(2).Value, 0.01F);
-                assertEquals(new BytesRef("for all the fish"), results.ElementAt(2).Payload);
+                assertEquals("barbar", results[0].Key.toString());
+                assertEquals(12, results[0].Value, 0.01F);
+                assertEquals(new BytesRef("thank you"), results[0].Payload);
+                assertEquals("bar", results[1].Key.toString());
+                assertEquals(10, results[1].Value, 0.01F);
+                assertEquals(new BytesRef("goodbye"), results[1].Payload);
+                assertEquals("barbara", results[2].Key.toString());
+                assertEquals(6, results[2].Value, 0.01F);
+                assertEquals(new BytesRef("for all the fish"), results[2].Payload);
             }
         }
 
@@ -215,20 +215,20 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("the ghost of chris", Random).ToString(), false, 1);
             assertEquals(1, results.size());
-            assertEquals("the ghost of christmas past", results.ElementAt(0).Key.toString());
-            assertEquals(50, results.ElementAt(0).Value, 0.01F);
+            assertEquals("the ghost of christmas past", results[0].Key.toString());
+            assertEquals(50, results[0].Value, 0.01F);
 
             // omit the 'the' since its a stopword, its suggested anyway
             results = suggester.DoLookup(TestUtil.StringToCharSequence("ghost of chris", Random).ToString(), false, 1);
             assertEquals(1, results.size());
-            assertEquals("the ghost of christmas past", results.ElementAt(0).Key.toString());
-            assertEquals(50, results.ElementAt(0).Value, 0.01F);
+            assertEquals("the ghost of christmas past", results[0].Key.toString());
+            assertEquals(50, results[0].Value, 0.01F);
 
             // omit the 'the' and 'of' since they are stopwords, its suggested anyway
             results = suggester.DoLookup(TestUtil.StringToCharSequence("ghost chris", Random).ToString(), false, 1);
             assertEquals(1, results.size());
-            assertEquals("the ghost of christmas past", results.ElementAt(0).Key.toString());
-            assertEquals(50, results.ElementAt(0).Value, 0.01F);
+            assertEquals("the ghost of christmas past", results[0].Key.toString());
+            assertEquals(50, results[0].Value, 0.01F);
         }
 
         [Test]
@@ -266,7 +266,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             // With no PRESERVE_SEPS specified, "ab c" should also
             // complete to "abcd", which has higher weight so should
             // appear first:
-            assertEquals("abcd", r.ElementAt(0).Key.toString());
+            assertEquals("abcd", r[0].Key.toString());
         }
 
         internal class TestGraphDupsTokenStreamComponents : TokenStreamComponents
@@ -353,10 +353,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 Console.WriteLine("Results: " + results);
             }
             assertEquals(2, results.size());
-            assertEquals("wifi network is slow", results.ElementAt(0).Key);
-            assertEquals(50, results.ElementAt(0).Value);
-            assertEquals("wi fi network is fast", results.ElementAt(1).Key);
-            assertEquals(10, results.ElementAt(1).Value);
+            assertEquals("wifi network is slow", results[0].Key);
+            assertEquals(50, results[0].Value);
+            assertEquals("wi fi network is fast", results[1].Key);
+            assertEquals(10, results[1].Value);
         }
 
         internal class TestInputPathRequiredTokenStreamComponents : TokenStreamComponents
@@ -553,23 +553,23 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                 assertEquals(Math.Min(topN, 4), results.size());
 
-                assertEquals("x y", results.ElementAt(0).Key);
-                assertEquals(1, results.ElementAt(0).Value);
+                assertEquals("x y", results[0].Key);
+                assertEquals(1, results[0].Value);
 
                 if (topN > 1)
                 {
-                    assertEquals("z z z", results.ElementAt(1).Key);
-                    assertEquals(20, results.ElementAt(1).Value);
+                    assertEquals("z z z", results[1].Key);
+                    assertEquals(20, results[1].Value);
 
                     if (topN > 2)
                     {
-                        assertEquals("x y z", results.ElementAt(2).Key);
-                        assertEquals(3, results.ElementAt(2).Value);
+                        assertEquals("x y z", results[2].Key);
+                        assertEquals(3, results[2].Value);
 
                         if (topN > 3)
                         {
-                            assertEquals("x", results.ElementAt(3).Key);
-                            assertEquals(2, results.ElementAt(3).Value);
+                            assertEquals("x", results[3].Key);
+                            assertEquals(2, results[3].Value);
                         }
                     }
                 }
@@ -596,23 +596,23 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                 assertEquals(Math.Min(topN, 4), results.size());
 
-                assertEquals("z z z", results.ElementAt(0).Key);
-                assertEquals(20, results.ElementAt(0).Value);
+                assertEquals("z z z", results[0].Key);
+                assertEquals(20, results[0].Value);
 
                 if (topN > 1)
                 {
-                    assertEquals("x y z", results.ElementAt(1).Key);
-                    assertEquals(3, results.ElementAt(1).Value);
+                    assertEquals("x y z", results[1].Key);
+                    assertEquals(3, results[1].Value);
 
                     if (topN > 2)
                     {
-                        assertEquals("x", results.ElementAt(2).Key);
-                        assertEquals(2, results.ElementAt(2).Value);
+                        assertEquals("x", results[2].Key);
+                        assertEquals(2, results[2].Value);
 
                         if (topN > 3)
                         {
-                            assertEquals("x y", results.ElementAt(3).Key);
-                            assertEquals(1, results.ElementAt(3).Value);
+                            assertEquals("x y", results[3].Key);
+                            assertEquals(1, results[3].Value);
                         }
                     }
                 }
@@ -1030,11 +1030,11 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 for (int hit = 0; hit < r.size(); hit++)
                 {
                     //System.out.println("  check hit " + hit);
-                    assertEquals(matches.ElementAt(hit).surfaceForm, r.ElementAt(hit).Key);
-                    assertEquals(matches.ElementAt(hit).weight, r.ElementAt(hit).Value, 0f);
+                    assertEquals(matches[hit].surfaceForm, r[hit].Key);
+                    assertEquals(matches[hit].weight, r[hit].Value, 0f);
                     if (doPayloads)
                     {
-                        assertEquals(matches.ElementAt(hit).payload, r.ElementAt(hit).Payload);
+                        assertEquals(matches[hit].payload, r[hit].Payload);
                     }
                 }
             }
@@ -1073,8 +1073,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             assertEquals(1, r1.size());
 
-            assertEquals("bar foo orange cat", r1.ElementAt(0).Key);
-            assertEquals(654321, r1.ElementAt(0).Value, 0f);
+            assertEquals("bar foo orange cat", r1[0].Key);
+            assertEquals(654321, r1[0].Value, 0f);
 
             // Query 2
             Analyzer a2 = new MockTokenEatingAnalyzer(numStopChars, preserveHoles);
@@ -1088,8 +1088,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             assertEquals(1, r2.size());
 
-            assertEquals("peter piper picked a pack of pickled peppers", r2.ElementAt(0).Key);
-            assertEquals(7654321, r2.ElementAt(0).Value, 0f);
+            assertEquals("peter piper picked a pack of pickled peppers", r2[0].Key);
+            assertEquals(7654321, r2[0].Value, 0f);
         }
 
 
@@ -1103,10 +1103,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             IList<Lookup.LookupResult> results = suggester.DoLookup("a", false, 5);
             assertEquals(2, results.size());
-            assertEquals(" a", results.ElementAt(0).Key);
-            assertEquals(60, results.ElementAt(0).Value);
-            assertEquals("a ", results.ElementAt(1).Key);
-            assertEquals(50, results.ElementAt(1).Value);
+            assertEquals(" a", results[0].Key);
+            assertEquals(60, results[0].Value);
+            assertEquals("a ", results[1].Key);
+            assertEquals(50, results[1].Value);
         }
 
         [Test]
@@ -1142,12 +1142,12 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             assertEquals(3, suggester.Count);
             IList<Lookup.LookupResult> results = suggester.DoLookup("a", false, 3);
             assertEquals(3, results.size());
-            assertEquals("a", results.ElementAt(0).Key);
-            assertEquals(5, results.ElementAt(0).Value);
-            assertEquals("a c", results.ElementAt(1).Key);
-            assertEquals(4, results.ElementAt(1).Value);
-            assertEquals("a b", results.ElementAt(2).Key);
-            assertEquals(3, results.ElementAt(2).Value);
+            assertEquals("a", results[0].Key);
+            assertEquals(5, results[0].Value);
+            assertEquals("a c", results[1].Key);
+            assertEquals(4, results[1].Value);
+            assertEquals("a b", results[2].Key);
+            assertEquals(3, results[2].Value);
 
             // Try again after save/load:
             DirectoryInfo tmpDir = CreateTempDir("AnalyzingSuggesterTest");
@@ -1166,12 +1166,12 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             assertEquals(3, suggester.Count);
             results = suggester.DoLookup("a", false, 3);
             assertEquals(3, results.size());
-            assertEquals("a", results.ElementAt(0).Key);
-            assertEquals(5, results.ElementAt(0).Value);
-            assertEquals("a c", results.ElementAt(1).Key);
-            assertEquals(4, results.ElementAt(1).Value);
-            assertEquals("a b", results.ElementAt(2).Key);
-            assertEquals(3, results.ElementAt(2).Value);
+            assertEquals("a", results[0].Key);
+            assertEquals(5, results[0].Value);
+            assertEquals("a c", results[1].Key);
+            assertEquals(4, results[1].Value);
+            assertEquals("a b", results[2].Key);
+            assertEquals(3, results[2].Value);
         }
 
         internal class TestDupSurfaceFormsMissingResultsTokenStreamComponents : TokenStreamComponents
@@ -1227,10 +1227,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             IList<Lookup.LookupResult> results = suggester.DoLookup("nellie", false, 2);
             assertEquals(2, results.size());
-            assertEquals("hambone", results.ElementAt(0).Key);
-            assertEquals(6, results.ElementAt(0).Value);
-            assertEquals("nellie", results.ElementAt(1).Key);
-            assertEquals(5, results.ElementAt(1).Value);
+            assertEquals("hambone", results[0].Key);
+            assertEquals(6, results[0].Value);
+            assertEquals("nellie", results[1].Key);
+            assertEquals(5, results[1].Value);
 
             // Try again after save/load:
             DirectoryInfo tmpDir = CreateTempDir("AnalyzingSuggesterTest");
@@ -1248,10 +1248,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             results = suggester.DoLookup("nellie", false, 2);
             assertEquals(2, results.size());
-            assertEquals("hambone", results.ElementAt(0).Key);
-            assertEquals(6, results.ElementAt(0).Value);
-            assertEquals("nellie", results.ElementAt(1).Key);
-            assertEquals(5, results.ElementAt(1).Value);
+            assertEquals("hambone", results[0].Key);
+            assertEquals(6, results[0].Value);
+            assertEquals("nellie", results[1].Key);
+            assertEquals(5, results[1].Value);
         }
         internal class TestDupSurfaceFormsMissingResults2TokenStreamComponents : TokenStreamComponents
         {
@@ -1311,10 +1311,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             IList<Lookup.LookupResult> results = suggester.DoLookup("a", false, 2);
             assertEquals(2, results.size());
-            assertEquals("a", results.ElementAt(0).Key);
-            assertEquals(6, results.ElementAt(0).Value);
-            assertEquals("b", results.ElementAt(1).Key);
-            assertEquals(5, results.ElementAt(1).Value);
+            assertEquals("a", results[0].Key);
+            assertEquals(6, results[0].Value);
+            assertEquals("b", results[1].Key);
+            assertEquals(5, results[1].Value);
 
             // Try again after save/load:
             DirectoryInfo tmpDir = CreateTempDir("AnalyzingSuggesterTest");
@@ -1332,10 +1332,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             results = suggester.DoLookup("a", false, 2);
             assertEquals(2, results.size());
-            assertEquals("a", results.ElementAt(0).Key);
-            assertEquals(6, results.ElementAt(0).Value);
-            assertEquals("b", results.ElementAt(1).Key);
-            assertEquals(5, results.ElementAt(1).Value);
+            assertEquals("a", results[0].Key);
+            assertEquals(6, results[0].Value);
+            assertEquals("b", results[1].Key);
+            assertEquals(5, results[1].Value);
         }
 
         internal class Test0ByteKeysTokenStreamComponents : TokenStreamComponents

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/FuzzySuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/FuzzySuggesterTest.cs
@@ -59,8 +59,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 string addRandomEdit = AddRandomEdit("foo bar boo", FuzzySuggester.DEFAULT_NON_FUZZY_PREFIX);
                 IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence(addRandomEdit, Random).ToString(), false, 2);
                 assertEquals(addRandomEdit, 1, results.size());
-                assertEquals("foo bar boo far", results.ElementAt(0).Key.toString());
-                assertEquals(12, results.ElementAt(0).Value, 0.01F);
+                assertEquals("foo bar boo far", results[0].Key.toString());
+                assertEquals(12, results[0].Value, 0.01F);
             }
         }
 
@@ -84,8 +84,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 string addRandomEdit = AddRandomEdit("фуу бар буу", 0);
                 IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence(addRandomEdit, Random).ToString(), false, 2);
                 assertEquals(addRandomEdit, 1, results.size());
-                assertEquals("фуу бар буу фар", results.ElementAt(0).Key.toString());
-                assertEquals(12, results.ElementAt(0).Value, 0.01F);
+                assertEquals("фуу бар буу фар", results[0].Key.toString());
+                assertEquals(12, results[0].Value, 0.01F);
             }
         }
 
@@ -105,63 +105,63 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("bariar", Random).ToString(), false, 2);
             assertEquals(2, results.size());
-            assertEquals("barbar", results.ElementAt(0).Key.toString());
-            assertEquals(12, results.ElementAt(0).Value, 0.01F);
+            assertEquals("barbar", results[0].Key.toString());
+            assertEquals(12, results[0].Value, 0.01F);
 
             results = suggester.DoLookup(TestUtil.StringToCharSequence("barbr", Random).ToString(), false, 2);
             assertEquals(2, results.size());
-            assertEquals("barbar", results.ElementAt(0).Key.toString());
-            assertEquals(12, results.ElementAt(0).Value, 0.01F);
+            assertEquals("barbar", results[0].Key.toString());
+            assertEquals(12, results[0].Value, 0.01F);
 
             results = suggester.DoLookup(TestUtil.StringToCharSequence("barbara", Random).ToString(), false, 2);
             assertEquals(2, results.size());
-            assertEquals("barbara", results.ElementAt(0).Key.toString());
-            assertEquals(6, results.ElementAt(0).Value, 0.01F);
+            assertEquals("barbara", results[0].Key.toString());
+            assertEquals(6, results[0].Value, 0.01F);
 
             results = suggester.DoLookup(TestUtil.StringToCharSequence("barbar", Random).ToString(), false, 2);
             assertEquals(2, results.size());
-            assertEquals("barbar", results.ElementAt(0).Key.toString());
-            assertEquals(12, results.ElementAt(0).Value, 0.01F);
-            assertEquals("barbara", results.ElementAt(1).Key.toString());
-            assertEquals(6, results.ElementAt(1).Value, 0.01F);
+            assertEquals("barbar", results[0].Key.toString());
+            assertEquals(12, results[0].Value, 0.01F);
+            assertEquals("barbara", results[1].Key.toString());
+            assertEquals(6, results[1].Value, 0.01F);
 
             results = suggester.DoLookup(TestUtil.StringToCharSequence("barbaa", Random).ToString(), false, 2);
             assertEquals(2, results.size());
-            assertEquals("barbar", results.ElementAt(0).Key.toString());
-            assertEquals(12, results.ElementAt(0).Value, 0.01F);
-            assertEquals("barbara", results.ElementAt(1).Key.toString());
-            assertEquals(6, results.ElementAt(1).Value, 0.01F);
+            assertEquals("barbar", results[0].Key.toString());
+            assertEquals(12, results[0].Value, 0.01F);
+            assertEquals("barbara", results[1].Key.toString());
+            assertEquals(6, results[1].Value, 0.01F);
 
             // top N of 2, but only foo is available
             results = suggester.DoLookup(TestUtil.StringToCharSequence("f", Random).ToString(), false, 2);
             assertEquals(1, results.size());
-            assertEquals("foo", results.ElementAt(0).Key.toString());
-            assertEquals(50, results.ElementAt(0).Value, 0.01F);
+            assertEquals("foo", results[0].Key.toString());
+            assertEquals(50, results[0].Value, 0.01F);
 
             // top N of 1 for 'bar': we return this even though
             // barbar is higher because exactFirst is enabled:
             results = suggester.DoLookup(TestUtil.StringToCharSequence("bar", Random).ToString(), false, 1);
             assertEquals(1, results.size());
-            assertEquals("bar", results.ElementAt(0).Key.toString());
-            assertEquals(10, results.ElementAt(0).Value, 0.01F);
+            assertEquals("bar", results[0].Key.toString());
+            assertEquals(10, results[0].Value, 0.01F);
 
             // top N Of 2 for 'b'
             results = suggester.DoLookup(TestUtil.StringToCharSequence("b", Random).ToString(), false, 2);
             assertEquals(2, results.size());
-            assertEquals("barbar", results.ElementAt(0).Key.toString());
-            assertEquals(12, results.ElementAt(0).Value, 0.01F);
-            assertEquals("bar", results.ElementAt(1).Key.toString());
-            assertEquals(10, results.ElementAt(1).Value, 0.01F);
+            assertEquals("barbar", results[0].Key.toString());
+            assertEquals(12, results[0].Value, 0.01F);
+            assertEquals("bar", results[1].Key.toString());
+            assertEquals(10, results[1].Value, 0.01F);
 
             // top N of 3 for 'ba'
             results = suggester.DoLookup(TestUtil.StringToCharSequence("ba", Random).ToString(), false, 3);
             assertEquals(3, results.size());
-            assertEquals("barbar", results.ElementAt(0).Key.toString());
-            assertEquals(12, results.ElementAt(0).Value, 0.01F);
-            assertEquals("bar", results.ElementAt(1).Key.toString());
-            assertEquals(10, results.ElementAt(1).Value, 0.01F);
-            assertEquals("barbara", results.ElementAt(2).Key.toString());
-            assertEquals(6, results.ElementAt(2).Value, 0.01F);
+            assertEquals("barbar", results[0].Key.toString());
+            assertEquals(12, results[0].Value, 0.01F);
+            assertEquals("bar", results[1].Key.toString());
+            assertEquals(10, results[1].Value, 0.01F);
+            assertEquals("barbara", results[2].Key.toString());
+            assertEquals(6, results[2].Value, 0.01F);
         }
 
         /**
@@ -181,20 +181,20 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("the ghost of chris", Random).ToString(), false, 1);
             assertEquals(1, results.size());
-            assertEquals("the ghost of christmas past", results.ElementAt(0).Key.toString());
-            assertEquals(50, results.ElementAt(0).Value, 0.01F);
+            assertEquals("the ghost of christmas past", results[0].Key.toString());
+            assertEquals(50, results[0].Value, 0.01F);
 
             // omit the 'the' since its a stopword, its suggested anyway
             results = suggester.DoLookup(TestUtil.StringToCharSequence("ghost of chris", Random).ToString(), false, 1);
             assertEquals(1, results.size());
-            assertEquals("the ghost of christmas past", results.ElementAt(0).Key.toString());
-            assertEquals(50, results.ElementAt(0).Value, 0.01F);
+            assertEquals("the ghost of christmas past", results[0].Key.toString());
+            assertEquals(50, results[0].Value, 0.01F);
 
             // omit the 'the' and 'of' since they are stopwords, its suggested anyway
             results = suggester.DoLookup(TestUtil.StringToCharSequence("ghost chris", Random).ToString(), false, 1);
             assertEquals(1, results.size());
-            assertEquals("the ghost of christmas past", results.ElementAt(0).Key.toString());
-            assertEquals(50, results.ElementAt(0).Value, 0.01F);
+            assertEquals("the ghost of christmas past", results[0].Key.toString());
+            assertEquals(50, results[0].Value, 0.01F);
         }
 
         [Test]
@@ -220,7 +220,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             // With no PRESERVE_SEPS specified, "ab c" should also
             // complete to "abcd", which has higher weight so should
             // appear first:
-            assertEquals("abcd", r.ElementAt(0).Key.toString());
+            assertEquals("abcd", r[0].Key.toString());
         }
         internal class TestGraphDupsTokenStreamComponents : TokenStreamComponents
         {
@@ -304,10 +304,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 Console.WriteLine("Results: " + results);
             }
             assertEquals(2, results.size());
-            assertEquals("wifi network is slow", results.ElementAt(0).Key);
-            assertEquals(50, results.ElementAt(0).Value);
-            assertEquals("wi fi network is fast", results.ElementAt(1).Key);
-            assertEquals(10, results.ElementAt(1).Value);
+            assertEquals("wifi network is slow", results[0].Key);
+            assertEquals(50, results[0].Value);
+            assertEquals("wi fi network is fast", results[1].Key);
+            assertEquals(10, results[1].Value);
         }
 
         [Test]
@@ -508,23 +508,23 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                 assertEquals(Math.Min(topN, 4), results.size());
 
-                assertEquals("x y", results.ElementAt(0).Key);
-                assertEquals(1, results.ElementAt(0).Value);
+                assertEquals("x y", results[0].Key);
+                assertEquals(1, results[0].Value);
 
                 if (topN > 1)
                 {
-                    assertEquals("z z z", results.ElementAt(1).Key);
-                    assertEquals(20, results.ElementAt(1).Value);
+                    assertEquals("z z z", results[1].Key);
+                    assertEquals(20, results[1].Value);
 
                     if (topN > 2)
                     {
-                        assertEquals("x y z", results.ElementAt(2).Key);
-                        assertEquals(3, results.ElementAt(2).Value);
+                        assertEquals("x y z", results[2].Key);
+                        assertEquals(3, results[2].Value);
 
                         if (topN > 3)
                         {
-                            assertEquals("x", results.ElementAt(3).Key);
-                            assertEquals(2, results.ElementAt(3).Value);
+                            assertEquals("x", results[3].Key);
+                            assertEquals(2, results[3].Value);
                         }
                     }
                 }
@@ -551,23 +551,23 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                 assertEquals(Math.Min(topN, 4), results.size());
 
-                assertEquals("z z z", results.ElementAt(0).Key);
-                assertEquals(20, results.ElementAt(0).Value);
+                assertEquals("z z z", results[0].Key);
+                assertEquals(20, results[0].Value);
 
                 if (topN > 1)
                 {
-                    assertEquals("x y z", results.ElementAt(1).Key);
-                    assertEquals(3, results.ElementAt(1).Value);
+                    assertEquals("x y z", results[1].Key);
+                    assertEquals(3, results[1].Value);
 
                     if (topN > 2)
                     {
-                        assertEquals("x", results.ElementAt(2).Key);
-                        assertEquals(2, results.ElementAt(2).Value);
+                        assertEquals("x", results[2].Key);
+                        assertEquals(2, results[2].Value);
 
                         if (topN > 3)
                         {
-                            assertEquals("x y", results.ElementAt(3).Key);
-                            assertEquals(1, results.ElementAt(3).Value);
+                            assertEquals("x y", results[3].Key);
+                            assertEquals(1, results[3].Value);
                         }
                     }
                 }
@@ -977,8 +977,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 for (int hit = 0; hit < r.size(); hit++)
                 {
                     //Console.WriteLine("  check hit " + hit);
-                    assertEquals(prefix + "  " + topN, matches.ElementAt(hit).Key.toString(), r.ElementAt(hit).Key.toString());
-                    assertEquals(matches.ElementAt(hit).Value, r.ElementAt(hit).Value, 0f);
+                    assertEquals(prefix + "  " + topN, matches[hit].Key.toString(), r[hit].Key.toString());
+                    assertEquals(matches[hit].Value, r[hit].Value, 0f);
                 }
             }
         }
@@ -1189,8 +1189,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 int limit = Math.Min(expected.size(), actual.size());
                 for (int ans = 0; ans < limit; ans++)
                 {
-                    Lookup.LookupResult c0 = expected.ElementAt(ans);
-                    Lookup.LookupResult c1 = actual.ElementAt(ans);
+                    Lookup.LookupResult c0 = expected[ans];
+                    Lookup.LookupResult c1 = actual[ans];
                     assertEquals("expected " + c0.Key +
                                  " but got " + c1.Key,
                                  0,

--- a/src/Lucene.Net.Tests.Suggest/Suggest/TestInputIterator.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/TestInputIterator.cs
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search.Suggest
                 BytesRef payload = wrapper.Payload;
                 actual.Put(BytesRef.DeepCopyOf(key), new KeyValuePair<long, BytesRef>(value, BytesRef.DeepCopyOf(payload)));
             }
-            assertEquals(sorted, actual);
+            assertEquals(sorted, actual, aggressive: false);
 
             // test the sorted iterator wrapper without payloads
             IInputIterator wrapperWithoutPayload = new SortedInputIterator(new InputArrayIterator(unsortedWithoutPayload), comparer);
@@ -155,7 +155,7 @@ namespace Lucene.Net.Search.Suggest
                 assertNull(wrapperWithoutPayload.Payload);
                 actualWithoutPayload.Put(BytesRef.DeepCopyOf(key), value);
             }
-            assertEquals(sortedWithoutPayload, actualWithoutPayload);
+            assertEquals(sortedWithoutPayload, actualWithoutPayload, aggressive: false);
         }
 
         public static long AsLong(BytesRef b)

--- a/src/Lucene.Net.Tests/Index/Test2BTerms.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BTerms.cs
@@ -160,7 +160,7 @@ namespace Lucene.Net.Index
                     {
                         return new MyTermAttributeImpl();
                     }
-                    if (attClass.GetTypeInfo().IsSubclassOf(typeof(CharTermAttribute)))
+                    if (attClass.IsSubclassOf(typeof(CharTermAttribute)))
                     {
                         throw new System.ArgumentException("no");
                     }

--- a/src/Lucene.Net.Tests/Index/TestFilterAtomicReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestFilterAtomicReader.cs
@@ -188,7 +188,7 @@ namespace Lucene.Net.Index
 
         private static void CheckOverrideMethods(Type clazz)
         {
-            Type superClazz = clazz.GetTypeInfo().BaseType;
+            Type superClazz = clazz.BaseType;
             foreach (MethodInfo m in superClazz.GetMethods())
             {
                 // LUCENENET specific - since we changed to using a property for Attributes rather than a method,

--- a/src/Lucene.Net.Tests/Index/TestNoDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestNoDeletionPolicy.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestFinalSingleton()
 	    {
-		    assertTrue(typeof(NoDeletionPolicy).GetTypeInfo().IsSealed);
+		    assertTrue(typeof(NoDeletionPolicy).IsSealed);
 		    ConstructorInfo[] ctors = typeof(NoDeletionPolicy).GetConstructors(BindingFlags.Instance |
                     BindingFlags.NonPublic |
                     BindingFlags.Public |

--- a/src/Lucene.Net.Tests/Index/TestNoMergePolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestNoMergePolicy.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestFinalSingleton()
 	    {
-		    assertTrue(typeof(NoMergePolicy).GetTypeInfo().IsSealed);
+		    assertTrue(typeof(NoMergePolicy).IsSealed);
 		    ConstructorInfo[] ctors = typeof(NoMergePolicy).GetConstructors(BindingFlags.Instance |
                     BindingFlags.NonPublic |
                     BindingFlags.Public |

--- a/src/Lucene.Net.Tests/Index/TestNoMergeScheduler.cs
+++ b/src/Lucene.Net.Tests/Index/TestNoMergeScheduler.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestFinalSingleton()
 	    {
-		    assertTrue(typeof(NoMergeScheduler).GetTypeInfo().IsSealed);
+		    assertTrue(typeof(NoMergeScheduler).IsSealed);
 		    ConstructorInfo[] ctors = typeof(NoMergeScheduler).GetConstructors(BindingFlags.Instance |
                     BindingFlags.NonPublic |
                     BindingFlags.Public |

--- a/src/Lucene.Net.Tests/Support/Codecs/TestDefaultCodecFactory.cs
+++ b/src/Lucene.Net.Tests/Support/Codecs/TestDefaultCodecFactory.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Codecs
             protected override void Initialize()
             {
                 base.Initialize();
-                base.ScanForCodecs(this.GetType().GetTypeInfo().Assembly);
+                base.ScanForCodecs(this.GetType().Assembly);
             }
         }
 

--- a/src/Lucene.Net.Tests/Support/Codecs/TestDefaultDocValuesFormatFactory.cs
+++ b/src/Lucene.Net.Tests/Support/Codecs/TestDefaultDocValuesFormatFactory.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Codecs
             protected override void Initialize()
             {
                 base.Initialize();
-                base.ScanForDocValuesFormats(this.GetType().GetTypeInfo().Assembly);
+                base.ScanForDocValuesFormats(this.GetType().Assembly);
             }
         }
 

--- a/src/Lucene.Net.Tests/Support/Codecs/TestDefaultPostingsFormatFactory.cs
+++ b/src/Lucene.Net.Tests/Support/Codecs/TestDefaultPostingsFormatFactory.cs
@@ -52,7 +52,7 @@ namespace Lucene.Net.Codecs
             protected override void Initialize()
             {
                 base.Initialize();
-                base.ScanForPostingsFormats(this.GetType().GetTypeInfo().Assembly);
+                base.ScanForPostingsFormats(this.GetType().Assembly);
             }
         }
 

--- a/src/Lucene.Net.Tests/Util/TestCollectionUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestCollectionUtil.cs
@@ -44,17 +44,17 @@ namespace Lucene.Net.Util
                 IList<int> list1 = CreateRandomList(2000), list2 = new List<int>(list1);
                 CollectionUtil.IntroSort(list1);
                 list2.Sort();
-                assertEquals(list2, list1);
+                assertEquals(list2, list1, aggressive: false);
 
                 list1 = CreateRandomList(2000);
                 list2 = new List<int>(list1);
                 CollectionUtil.IntroSort(list1, Collections.ReverseOrder<int>());
                 list2.Sort(Collections.ReverseOrder<int>());
-                assertEquals(list2, list1);
+                assertEquals(list2, list1, aggressive: false);
                 // reverse back, so we can test that completely backwards sorted array (worst case) is working:
                 CollectionUtil.IntroSort(list1);
                 list2.Sort();
-                assertEquals(list2, list1);
+                assertEquals(list2, list1, aggressive: false);
             }
         }
 
@@ -66,17 +66,17 @@ namespace Lucene.Net.Util
                 IList<int> list1 = CreateRandomList(2000), list2 = new List<int>(list1);
                 CollectionUtil.TimSort(list1);
                 list2.Sort();
-                assertEquals(list2, list1);
+                assertEquals(list2, list1, aggressive: false);
 
                 list1 = CreateRandomList(2000);
                 list2 = new List<int>(list1);
                 CollectionUtil.TimSort(list1, Collections.ReverseOrder<int>());
                 list2.Sort(Collections.ReverseOrder<int>());
-                assertEquals(list2, list1);
+                assertEquals(list2, list1, aggressive: false);
                 // reverse back, so we can test that completely backwards sorted array (worst case) is working:
                 CollectionUtil.TimSort(list1);
                 list2.Sort();
-                assertEquals(list2, list1);
+                assertEquals(list2, list1, aggressive: false);
             }
         }
 

--- a/src/Lucene.Net.Tests/Util/TestIdentityHashSet.cs
+++ b/src/Lucene.Net.Tests/Util/TestIdentityHashSet.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Lucene.Net.Util
 {
@@ -41,7 +42,7 @@ namespace Lucene.Net.Util
             for (int i = 0; i < max; i++)
             {
                 // some of these will be interned and some will not so there will be collisions.
-                int? v = rnd.Next(threshold);
+                int v = rnd.Next(threshold);
 
                 bool e1 = jdk.Contains(v);
                 bool e2 = us.Contains(v);
@@ -53,12 +54,13 @@ namespace Lucene.Net.Util
             }
 
             ISet<object> collected = new JCG.HashSet<object>(IdentityEqualityComparer<object>.Default);
-            foreach (object o in us)
+            foreach (var o in us)
             {
                 collected.Add(o);
             }
 
-            assertEquals(collected, jdk);
+            // LUCENENET: We have 2 J2N hashsets, so no need to use aggressive mode
+            assertEquals(collected, jdk, aggressive: false);
         }
     }
 }

--- a/src/Lucene.Net.Tests/Util/TestVersion.cs
+++ b/src/Lucene.Net.Tests/Util/TestVersion.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Util
                 {
                     Assert.AreEqual(LuceneVersion.LUCENE_CURRENT, values[i], "Last constant must be LUCENE_CURRENT");
                 }
-                bool dep = typeof(LuceneVersion).GetTypeInfo().GetField(values[i].ToString()).GetCustomAttributes(typeof(ObsoleteAttribute), false).Any();
+                bool dep = typeof(LuceneVersion).GetField(values[i].ToString()).GetCustomAttributes(typeof(ObsoleteAttribute), false).Any();
                 if (i + 2 != values.Length)
                 {
                     assertTrue(values[i].ToString() + " should be deprecated", dep);

--- a/src/Lucene.Net/Analysis/Analyzer.cs
+++ b/src/Lucene.Net/Analysis/Analyzer.cs
@@ -632,7 +632,7 @@ namespace Lucene.Net.Analysis
         {
             if (analyzer.storedValue == null)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this Analyzer is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this Analyzer is closed");
             }
             return analyzer.storedValue.Get();
         }

--- a/src/Lucene.Net/Analysis/NumericTokenStream.cs
+++ b/src/Lucene.Net/Analysis/NumericTokenStream.cs
@@ -145,7 +145,7 @@ namespace Lucene.Net.Analysis
             public override Util.Attribute CreateAttributeInstance<T>()
             {
                 var attClass = typeof(T);
-                if (typeof(ICharTermAttribute).GetTypeInfo().IsAssignableFrom(attClass.GetTypeInfo()))
+                if (typeof(ICharTermAttribute).IsAssignableFrom(attClass))
                 {
                     throw new System.ArgumentException("NumericTokenStream does not support CharTermAttribute.");
                 }

--- a/src/Lucene.Net/Analysis/Token.cs
+++ b/src/Lucene.Net/Analysis/Token.cs
@@ -694,7 +694,7 @@ namespace Lucene.Net.Analysis
             public override Attribute CreateAttributeInstance<T>()
             {
                 var attClass = typeof(T);
-                return attClass.GetTypeInfo().IsAssignableFrom(typeof(Token).GetTypeInfo()) ? new Token() : @delegate.CreateAttributeInstance<T>();
+                return attClass.IsAssignableFrom(typeof(Token)) ? new Token() : @delegate.CreateAttributeInstance<T>();
             }
 
             public override bool Equals(object other)

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
@@ -71,9 +71,9 @@ namespace Lucene.Net.Analysis.TokenAttributes
             {
                 // Not big enough; create a new array with slight
                 // over allocation and preserve content
-                char[] newCharBuffer = new char[ArrayUtil.Oversize(newSize, RamUsageEstimator.NUM_BYTES_CHAR)];
-                Array.Copy(termBuffer, 0, newCharBuffer, 0, termBuffer.Length);
-                termBuffer = newCharBuffer;
+                
+                // LUCENENET: Resize rather than copy
+                Array.Resize(ref termBuffer, ArrayUtil.Oversize(newSize, RamUsageEstimator.NUM_BYTES_CHAR));
             }
             return termBuffer;
         }

--- a/src/Lucene.Net/Codecs/Codec.cs
+++ b/src/Lucene.Net/Codecs/Codec.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Codecs
     /// <list type="number">
     ///     <item><description>Subclass this class.</description></item>
     ///     <item><description>Subclass <see cref="DefaultCodecFactory"/>, override the <see cref="DefaultCodecFactory.Initialize()"/> method,
-    ///         and add the line <c>base.ScanForCodecs(typeof(YourCodec).GetTypeInfo().Assembly)</c>. 
+    ///         and add the line <c>base.ScanForCodecs(typeof(YourCodec).Assembly)</c>. 
     ///         If you have any codec classes in your assembly 
     ///         that are not meant for reading, you can add the <see cref="ExcludeCodecFromScanAttribute"/> 
     ///         to them so they are ignored by the scan.</description></item>

--- a/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
@@ -169,7 +169,7 @@ namespace Lucene.Net.Codecs.Compressing
         {
             if (closed)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this FieldsReader is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this FieldsReader is closed");
             }
         }
 

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
@@ -179,7 +179,7 @@ namespace Lucene.Net.Codecs.Compressing
         {
             if (closed)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this FieldsReader is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this FieldsReader is closed");
             }
         }
 

--- a/src/Lucene.Net/Codecs/DocValuesFormat.cs
+++ b/src/Lucene.Net/Codecs/DocValuesFormat.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Codecs
     /// <list type="number">
     ///     <item><description>Subclass this class.</description></item>
     ///     <item><description>Subclass <see cref="DefaultDocValuesFormatFactory"/>, override the <see cref="DefaultDocValuesFormatFactory.Initialize()"/> method,
-    ///         and add the line <c>base.ScanForDocValuesFormats(typeof(YourDocValuesFormat).GetTypeInfo().Assembly)</c>. 
+    ///         and add the line <c>base.ScanForDocValuesFormats(typeof(YourDocValuesFormat).Assembly)</c>. 
     ///         If you have any format classes in your assembly 
     ///         that are not meant for reading, you can add the <see cref="ExcludeDocValuesFormatFromScanAttribute"/> 
     ///         to them so they are ignored by the scan.</description></item>

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xStoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xStoredFieldsReader.cs
@@ -235,7 +235,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         {
             if (closed)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this FieldsReader is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this FieldsReader is closed");
             }
         }
 

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsReader.cs
@@ -128,7 +128,7 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             if (closed)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this FieldsReader is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this FieldsReader is closed");
             }
         }
 

--- a/src/Lucene.Net/Codecs/PostingsFormat.cs
+++ b/src/Lucene.Net/Codecs/PostingsFormat.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Codecs
     /// <list type="number">
     ///     <item><description>Subclass this class.</description></item>
     ///     <item><description>Subclass <see cref="DefaultPostingsFormatFactory"/>, override <see cref="DefaultPostingsFormatFactory.Initialize()"/>,
-    ///         and add the line <c>base.ScanForPostingsFormats(typeof(YourPostingsFormat).GetTypeInfo().Assembly)</c>. 
+    ///         and add the line <c>base.ScanForPostingsFormats(typeof(YourPostingsFormat).Assembly)</c>. 
     ///         If you have any format classes in your assembly 
     ///         that are not meant for reading, you can add the <see cref="ExcludePostingsFormatFromScanAttribute"/> 
     ///         to them so they are ignored by the scan.</description></item>

--- a/src/Lucene.Net/Index/CompositeReader.cs
+++ b/src/Lucene.Net/Index/CompositeReader.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Index
         {
             StringBuilder buffer = new StringBuilder();
             // walk up through class hierarchy to get a non-empty simple name (anonymous classes have no name):
-            for (Type clazz = this.GetType(); clazz != null; clazz = clazz.GetTypeInfo().BaseType)
+            for (Type clazz = this.GetType(); clazz != null; clazz = clazz.BaseType)
             {
                 if (clazz.Name != null)
                 {

--- a/src/Lucene.Net/Index/DocumentsWriter.cs
+++ b/src/Lucene.Net/Index/DocumentsWriter.cs
@@ -233,7 +233,7 @@ namespace Lucene.Net.Index
         {
             if (closed)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this IndexWriter is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this IndexWriter is closed");
             }
         }
 

--- a/src/Lucene.Net/Index/IndexFileDeleter.cs
+++ b/src/Lucene.Net/Index/IndexFileDeleter.cs
@@ -336,7 +336,7 @@ namespace Lucene.Net.Index
         {
             if (writer == null)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this IndexWriter is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this IndexWriter is closed");
             }
             else
             {

--- a/src/Lucene.Net/Index/IndexReader.cs
+++ b/src/Lucene.Net/Index/IndexReader.cs
@@ -270,7 +270,7 @@ namespace Lucene.Net.Index
             // still close the reader if it was made invalid by a child:
             if (refCount <= 0)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this IndexReader is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this IndexReader is closed");
             }
 
             int rc = refCount.DecrementAndGet();
@@ -312,13 +312,13 @@ namespace Lucene.Net.Index
         {
             if (refCount <= 0)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this IndexReader is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this IndexReader is closed");
             }
             // the happens before rule on reading the refCount, which must be after the fake write,
             // ensures that we see the value:
             if (closedByChild)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this IndexReader cannot be used anymore as one of its child readers was closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this IndexReader cannot be used anymore as one of its child readers was closed");
             }
         }
 

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -772,7 +772,7 @@ namespace Lucene.Net.Index
         {
             if (closed || (failIfDisposing && closing))
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this IndexWriter is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this IndexWriter is closed");
             }
         }
 

--- a/src/Lucene.Net/Index/SegmentCoreReaders.cs
+++ b/src/Lucene.Net/Index/SegmentCoreReaders.cs
@@ -198,7 +198,7 @@ namespace Lucene.Net.Index
                     return;
                 }
             }
-            throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "SegmentCoreReaders is already closed");
+            throw new ObjectDisposedException(this.GetType().FullName, "SegmentCoreReaders is already closed");
         }
 
         internal NumericDocValues GetNormValues(FieldInfo fi)

--- a/src/Lucene.Net/Index/Term.cs
+++ b/src/Lucene.Net/Index/Term.cs
@@ -114,8 +114,9 @@ namespace Lucene.Net.Index
 
         public override bool Equals(object obj)
         {
-            Term t = obj as Term;
-            return this.Equals(t);
+            if (obj is Term other)
+                return Equals(other);
+            return false;
         }
 
         public override int GetHashCode()
@@ -162,21 +163,15 @@ namespace Lucene.Net.Index
 
         public bool Equals(Term other)
         {
-            if (object.ReferenceEquals(null, other))
-            {
-                return object.ReferenceEquals(null, this);
-            }
-            if (object.ReferenceEquals(this, other))
-            {
+            if (other is null)
+                return false;
+            if (ReferenceEquals(this, other))
                 return true;
-            }
 
             if (this.GetType() != other.GetType())
-            {
                 return false;
-            }
 
-            if (string.Compare(this.Field, other.Field, StringComparison.Ordinal) != 0)
+            if (!StringComparer.Ordinal.Equals(Field, other.Field))
             {
                 return false;
             }
@@ -188,7 +183,7 @@ namespace Lucene.Net.Index
                     return false;
                 }
             }
-            else if (!Bytes.Equals(other.Bytes))
+            else if (!Bytes.BytesEquals(other.Bytes))
             {
                 return false;
             }

--- a/src/Lucene.Net/Search/ReferenceManager.cs
+++ b/src/Lucene.Net/Search/ReferenceManager.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Search
         {
             if (current == null)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, REFERENCE_MANAGER_IS_CLOSED_MSG);
+                throw new ObjectDisposedException(this.GetType().FullName, REFERENCE_MANAGER_IS_CLOSED_MSG);
             }
         }
 
@@ -110,7 +110,7 @@ namespace Lucene.Net.Search
             {
                 if ((@ref = current) == null)
                 {
-                    throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, REFERENCE_MANAGER_IS_CLOSED_MSG);
+                    throw new ObjectDisposedException(this.GetType().FullName, REFERENCE_MANAGER_IS_CLOSED_MSG);
                 }
                 if (TryIncRef(@ref))
                 {

--- a/src/Lucene.Net/Search/SearcherLifetimeManager.cs
+++ b/src/Lucene.Net/Search/SearcherLifetimeManager.cs
@@ -146,7 +146,7 @@ namespace Lucene.Net.Search
         {
             if (_closed)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this SearcherLifetimeManager instance is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this SearcherLifetimeManager instance is closed");
             }
         }
 

--- a/src/Lucene.Net/Store/BaseDirectory.cs
+++ b/src/Lucene.Net/Store/BaseDirectory.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Store
         {
             if (!IsOpen)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "this Directory is closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "this Directory is closed");
             }
         }
     }

--- a/src/Lucene.Net/Store/ByteBufferIndexInput.cs
+++ b/src/Lucene.Net/Store/ByteBufferIndexInput.cs
@@ -241,7 +241,7 @@ namespace Lucene.Net.Store
             }
             catch (NullReferenceException)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "Already closed: " + this);
+                throw new ObjectDisposedException(this.GetType().FullName, "Already closed: " + this);
             }
         }
 
@@ -292,7 +292,7 @@ namespace Lucene.Net.Store
         {
             if (buffers == null)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "Already closed: " + this);
+                throw new ObjectDisposedException(this.GetType().FullName, "Already closed: " + this);
             }
             if (offset < 0 || length < 0 || offset + length > this.length)
             {
@@ -358,7 +358,7 @@ namespace Lucene.Net.Store
         {
             if (buffers == null || curBuf == null)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "Already closed: " + this);
+                throw new ObjectDisposedException(this.GetType().FullName, "Already closed: " + this);
             }
         }
 

--- a/src/Lucene.Net/Store/CompoundFileWriter.cs
+++ b/src/Lucene.Net/Store/CompoundFileWriter.cs
@@ -203,7 +203,7 @@ namespace Lucene.Net.Store
         {
             if (closed)
             {
-                throw new ObjectDisposedException(this.GetType().GetTypeInfo().FullName, "CFS Directory is already closed");
+                throw new ObjectDisposedException(this.GetType().FullName, "CFS Directory is already closed");
             }
         }
 

--- a/src/Lucene.Net/Support/Codecs/DefaultCodecFactory.cs
+++ b/src/Lucene.Net/Support/Codecs/DefaultCodecFactory.cs
@@ -152,7 +152,7 @@ namespace Lucene.Net.Codecs
         {
             if (codec == null)
                 throw new ArgumentNullException(nameof(codec));
-            if (!typeof(Codec).GetTypeInfo().IsAssignableFrom(codec))
+            if (!typeof(Codec).IsAssignableFrom(codec))
                 throw new ArgumentException($"The supplied type {codec.AssemblyQualifiedName} does not subclass {nameof(Codec)}.");
 
             PutCodecTypeImpl(codec);

--- a/src/Lucene.Net/Support/Codecs/DefaultDocValuesFormatFactory.cs
+++ b/src/Lucene.Net/Support/Codecs/DefaultDocValuesFormatFactory.cs
@@ -149,7 +149,7 @@ namespace Lucene.Net.Codecs
         {
             if (docValuesFormat == null)
                 throw new ArgumentNullException(nameof(docValuesFormat));
-            if (!typeof(DocValuesFormat).GetTypeInfo().IsAssignableFrom(docValuesFormat))
+            if (!typeof(DocValuesFormat).IsAssignableFrom(docValuesFormat))
                 throw new ArgumentException($"The supplied type {docValuesFormat.AssemblyQualifiedName} does not subclass {nameof(DocValuesFormat)}.");
 
             PutDocValuesFormatTypeImpl(docValuesFormat);

--- a/src/Lucene.Net/Support/Codecs/DefaultPostingsFormatFactory.cs
+++ b/src/Lucene.Net/Support/Codecs/DefaultPostingsFormatFactory.cs
@@ -149,7 +149,7 @@ namespace Lucene.Net.Codecs
         {
             if (postingsFormat == null)
                 throw new ArgumentNullException(nameof(postingsFormat));
-            if (!typeof(PostingsFormat).GetTypeInfo().IsAssignableFrom(postingsFormat))
+            if (!typeof(PostingsFormat).IsAssignableFrom(postingsFormat))
                 throw new ArgumentException($"The supplied type {postingsFormat.AssemblyQualifiedName} does not subclass {nameof(PostingsFormat)}.");
 
             PutPostingsFormatTypeImpl(postingsFormat);

--- a/src/Lucene.Net/Support/Collections.cs
+++ b/src/Lucene.Net/Support/Collections.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Support
                 return "[]";
             }
 
-            bool isValueType = typeof(T).GetTypeInfo().IsValueType;
+            bool isValueType = typeof(T).IsValueType;
             using (var it = collection.GetEnumerator())
             {
                 StringBuilder sb = new StringBuilder();
@@ -126,8 +126,8 @@ namespace Lucene.Net.Support
                 return "{}";
             }
 
-            bool keyIsValueType = typeof(TKey).GetTypeInfo().IsValueType;
-            bool valueIsValueType = typeof(TValue).GetTypeInfo().IsValueType;
+            bool keyIsValueType = typeof(TKey).IsValueType;
+            bool valueIsValueType = typeof(TValue).IsValueType;
             using (var i = dictionary.GetEnumerator())
             {
                 StringBuilder sb = new StringBuilder();
@@ -171,7 +171,7 @@ namespace Lucene.Net.Support
         public static string ToString(object obj)
         {
             Type t = obj.GetType();
-            if (t.GetTypeInfo().IsGenericType
+            if (t.IsGenericType
                 && (t.ImplementsGenericInterface(typeof(ICollection<>)))
                 || t.ImplementsGenericInterface(typeof(IDictionary<,>)))
             {

--- a/src/Lucene.Net/Support/Collections.cs
+++ b/src/Lucene.Net/Support/Collections.cs
@@ -77,6 +77,9 @@ namespace Lucene.Net.Support
         /// </summary>
         public static string ToString<T>(ICollection<T> collection)
         {
+            if (collection == null)
+                return "null";
+
             if (collection.Count == 0)
             {
                 return "[]";
@@ -121,6 +124,9 @@ namespace Lucene.Net.Support
         /// </summary>
         public static string ToString<TKey, TValue>(IDictionary<TKey, TValue> dictionary)
         {
+            if (dictionary == null)
+                return "null";
+
             if (dictionary.Count == 0)
             {
                 return "{}";

--- a/src/Lucene.Net/Support/Util/BundleResourceManagerFactory.cs
+++ b/src/Lucene.Net/Support/Util/BundleResourceManagerFactory.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Util
         /// <returns>A new <see cref="ResourceManager"/> instance.</returns>
         public virtual ResourceManager Create(Type resourceSource)
         {
-            return new ResourceManager(GetResourceName(resourceSource), resourceSource.GetTypeInfo().Assembly);
+            return new ResourceManager(GetResourceName(resourceSource), resourceSource.Assembly);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Support/Util/NamedServiceFactory.cs
+++ b/src/Lucene.Net/Support/Util/NamedServiceFactory.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Util
                     Type simpleTextType = Type.GetType("Lucene.Net.Codecs.SimpleText.SimpleTextCodec, Lucene.Net.Codecs");
                     if (simpleTextType != null)
                     {
-                        codecsAssembly = simpleTextType.GetTypeInfo().Assembly;
+                        codecsAssembly = simpleTextType.Assembly;
                     }
                 }
 
@@ -85,10 +85,10 @@ namespace Lucene.Net.Util
         {
             return
                 type != null &&
-                type.GetTypeInfo().IsPublic &&
-                !type.GetTypeInfo().IsAbstract &&
-                typeof(TService).GetTypeInfo().IsAssignableFrom(type) &&
-                type.GetTypeInfo().GetCustomAttribute<ExcludeServiceAttribute>(inherit: true) == null;
+                type.IsPublic &&
+                !type.IsAbstract &&
+                typeof(TService).IsAssignableFrom(type) &&
+                type.GetCustomAttribute<ExcludeServiceAttribute>(inherit: true) == null;
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Lucene.Net.Util
         public static string GetServiceName(Type type)
         {
             // Check for ServiceName attribute
-            var nameAttributes = type.GetTypeInfo().GetCustomAttributes(typeof(ServiceNameAttribute), inherit: true);
+            var nameAttributes = type.GetCustomAttributes(typeof(ServiceNameAttribute), inherit: true);
             if (nameAttributes.Any())
             {
                 ServiceNameAttribute nameAttribute = nameAttributes.FirstOrDefault() as ServiceNameAttribute;
@@ -131,7 +131,7 @@ namespace Lucene.Net.Util
                 genericSuffix = "Generic" + name.Substring(genericIndex + 1);
                 name = name.Substring(0, genericIndex);
             }
-            string serviceName = typeof(TService).GetTypeInfo().Name;
+            string serviceName = typeof(TService).Name;
             if (name.EndsWith(serviceName, StringComparison.Ordinal))
             {
                 name = name.Substring(0, name.Length - serviceName.Length);

--- a/src/Lucene.Net/Util/ArrayUtil.cs
+++ b/src/Lucene.Net/Util/ArrayUtil.cs
@@ -839,7 +839,7 @@ namespace Lucene.Net.Util
             // implements IComparable<T>, otherwise use Comparer<T>.Default.
             // This allows the comparison to be customized, but it is not mandatory
             // to implement IComparable<T>.
-            else if (typeof(IComparable<T>).GetTypeInfo().IsAssignableFrom(genericClosingType))
+            else if (typeof(IComparable<T>).IsAssignableFrom(genericClosingType))
             {
                 return new NaturalComparer<T>();
             }

--- a/src/Lucene.Net/Util/AttributeImpl.cs
+++ b/src/Lucene.Net/Util/AttributeImpl.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 

--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -310,7 +310,7 @@ namespace Lucene.Net.Util
                             foundInterfaces.AddLast(new WeakReference<Type>(curInterface));
                         }
                     }
-                    actClazz = actClazz.GetTypeInfo().BaseType;
+                    actClazz = actClazz.BaseType;
                 } while (actClazz != null);
 
                 return foundInterfaces;
@@ -367,7 +367,7 @@ namespace Lucene.Net.Util
             var attClass = typeof(T);
             if (!attributes.ContainsKey(attClass))
             {
-                if (!(attClass.GetTypeInfo().IsInterface && typeof(IAttribute).IsAssignableFrom(attClass)))
+                if (!(attClass.IsInterface && typeof(IAttribute).IsAssignableFrom(attClass)))
                 {
                     throw new ArgumentException("AddAttribute() only accepts an interface that extends IAttribute, but " + attClass.FullName + " does not fulfil this contract.");
                 }

--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -137,16 +137,34 @@ namespace Lucene.Net.Util
                 }
 
                 // LUCENENET specific - factored this out so we can reuse
-                private static WeakReference<Type> CreateAttributeWeakReference(Type attClass, out Type clazz)
+                private static WeakReference<Type> CreateAttributeWeakReference(Type attributeInterfaceType, out Type clazz)
                 {
                     try
                     {
-                        string name = attClass.FullName.Replace(attClass.Name, attClass.Name.Substring(1)) + ", " + attClass.GetTypeInfo().Assembly.FullName;
-                        return new WeakReference<Type>(clazz = Type.GetType(name, true));
+                        string name = ConvertAttributeInterfaceToClassName(attributeInterfaceType);
+                        return new WeakReference<Type>(clazz = attributeInterfaceType.Assembly.GetType(name, true));
                     }
                     catch (Exception e)
                     {
-                        throw new ArgumentException("Could not find implementing class for " + attClass.Name, e);
+                        throw new ArgumentException("Could not find implementing class for " + attributeInterfaceType.Name, e);
+                    }
+                }
+
+                private static string ConvertAttributeInterfaceToClassName(Type attributeInterfaceType)
+                {
+                    int lastPlus = attributeInterfaceType.FullName.LastIndexOf('+');
+                    if (lastPlus == -1)
+                    {
+                        return string.Concat(
+                            attributeInterfaceType.Namespace,
+                            ".",
+                            attributeInterfaceType.Name.Substring(1));
+                    }
+                    else
+                    {
+                        return string.Concat(
+                            attributeInterfaceType.FullName.Substring(0, lastPlus + 1),
+                            attributeInterfaceType.Name.Substring(1));
                     }
                 }
             }

--- a/src/Lucene.Net/Util/Automaton/Automaton.cs
+++ b/src/Lucene.Net/Util/Automaton/Automaton.cs
@@ -281,9 +281,8 @@ namespace Lucene.Net.Util.Automaton
                             t.to.number = upto;
                             if (upto == states.Length)
                             {
-                                State[] newArray = new State[ArrayUtil.Oversize(1 + upto, RamUsageEstimator.NUM_BYTES_OBJECT_REF)];
-                                Array.Copy(states, 0, newArray, 0, upto);
-                                states = newArray;
+                                // LUCENENET: Resize rather than copy
+                                Array.Resize(ref states, ArrayUtil.Oversize(1 + upto, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
                             }
                             states[upto] = t.to;
                             upto++;
@@ -292,9 +291,8 @@ namespace Lucene.Net.Util.Automaton
                 }
                 if (states.Length != upto)
                 {
-                    State[] newArray = new State[upto];
-                    Array.Copy(states, 0, newArray, 0, upto);
-                    states = newArray;
+                    // LUCENENET: Resize rather than copy
+                    Array.Resize(ref states, upto);
                 }
                 numberedStates = states;
             }

--- a/src/Lucene.Net/Util/Automaton/BasicOperations.cs
+++ b/src/Lucene.Net/Util/Automaton/BasicOperations.cs
@@ -631,9 +631,8 @@ namespace Lucene.Net.Util.Automaton
             {
                 if (transitions.Length == count)
                 {
-                    Transition[] newArray = new Transition[ArrayUtil.Oversize(1 + count, RamUsageEstimator.NUM_BYTES_OBJECT_REF)];
-                    Array.Copy(transitions, 0, newArray, 0, count);
-                    transitions = newArray;
+                    // LUCENENET: Resize rather than copy
+                    Array.Resize(ref transitions, ArrayUtil.Oversize(1 + count, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
                 }
                 transitions[count++] = t;
             }
@@ -684,9 +683,8 @@ namespace Lucene.Net.Util.Automaton
                 // 1st time we are seeing this point
                 if (count == points.Length)
                 {
-                    PointTransitions[] newArray = new PointTransitions[ArrayUtil.Oversize(1 + count, RamUsageEstimator.NUM_BYTES_OBJECT_REF)];
-                    Array.Copy(points, 0, newArray, 0, count);
-                    points = newArray;
+                    // LUCENENET: Resize rather than copy
+                    Array.Resize(ref points, ArrayUtil.Oversize(1 + count, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
                 }
                 PointTransitions points0 = points[count];
                 if (points0 == null)
@@ -703,8 +701,7 @@ namespace Lucene.Net.Util.Automaton
                 if (useHash)
                 {
                     int? pi = point;
-                    PointTransitions p;
-                    if (!map.TryGetValue(pi, out p))
+                    if (!map.TryGetValue(pi, out PointTransitions p))
                     {
                         p = Next(point);
                         map[pi] = p;
@@ -856,8 +853,7 @@ namespace Lucene.Net.Util.Automaton
 
                         statesSet.ComputeHash();
 
-                        State q;
-                        if (!newstate.TryGetValue(statesSet.ToFrozenInt32Set(), out q) || q == null)
+                        if (!newstate.TryGetValue(statesSet.ToFrozenInt32Set(), out State q) || q == null)
                         {
                             q = new State();
 
@@ -865,9 +861,8 @@ namespace Lucene.Net.Util.Automaton
                             worklist.AddLast(p);
                             if (newStateUpto == newStatesArray.Length)
                             {
-                                State[] newArray = new State[ArrayUtil.Oversize(1 + newStateUpto, RamUsageEstimator.NUM_BYTES_OBJECT_REF)];
-                                Array.Copy(newStatesArray, 0, newArray, 0, newStateUpto);
-                                newStatesArray = newArray;
+                                // LUCENENET: Resize rather than copy
+                                Array.Resize(ref newStatesArray, ArrayUtil.Oversize(1 + newStateUpto, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
                             }
                             newStatesArray[newStateUpto] = q;
                             q.number = newStateUpto;

--- a/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
+++ b/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
@@ -42,11 +42,20 @@ namespace Lucene.Net.Util.Automaton
         {
             /// <summary>
             /// An empty set of labels. </summary>
-            private static readonly int[] NO_LABELS = new int[0];
-
+            private static readonly int[] NO_LABELS =
+#if FEATURE_ARRAYEMPTY
+                Array.Empty<int>();
+#else
+                new int[0];
+#endif
             /// <summary>
             /// An empty set of states. </summary>
-            private static readonly State[] NO_STATES = new State[0];
+            private static readonly State[] NO_STATES =
+#if FEATURE_ARRAYEMPTY
+                Array.Empty<State>();
+#else
+                new State[0];
+#endif
 
             /// <summary>
             /// Labels of outgoing transitions. Indexed identically to <see cref="states"/>.

--- a/src/Lucene.Net/Util/Automaton/SortedIntSet.cs
+++ b/src/Lucene.Net/Util/Automaton/SortedIntSet.cs
@@ -59,8 +59,7 @@ namespace Lucene.Net.Util.Automaton
             if (useTreeMap)
             {
                 int key = num;
-                int val;
-                if (!map.TryGetValue(key, out val))
+                if (!map.TryGetValue(key, out int val))
                 {
                     map[key] = 1;
                 }

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -172,9 +172,8 @@ namespace Lucene.Net.Util.Automaton
         {
             if (numTransitions == transitionsArray.Length)
             {
-                Transition[] newArray = new Transition[ArrayUtil.Oversize(1 + numTransitions, RamUsageEstimator.NUM_BYTES_OBJECT_REF)];
-                Array.Copy(transitionsArray, 0, newArray, 0, numTransitions);
-                transitionsArray = newArray;
+                // LUCENENET: Resize rather than copy
+                Array.Resize(ref transitionsArray, ArrayUtil.Oversize(1 + numTransitions, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
             }
             transitionsArray[numTransitions++] = t;
         }

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -48,11 +48,15 @@ namespace Lucene.Net.Util.Automaton
         [SuppressMessage("Microsoft.Performance", "CA1819", Justification = "Lucene's design requires some writable array properties")]
         public Transition[] TransitionsArray
         {
-            get { return transitionsArray; }
+            get => transitionsArray;
             // LUCENENET NOTE: Setter removed because it is apparently not in use outside of this class
         }
-        private Transition[] transitionsArray;
-        internal int numTransitions; // LUCENENET NOTE: Made internal because we already have a public property for access
+#if FEATURE_ARRAYEMPTY
+        private Transition[] transitionsArray = Array.Empty<Transition>();
+#else
+        private Transition[] transitionsArray = new Transition[0];
+#endif
+        internal int numTransitions = 0;// LUCENENET NOTE: Made internal because we already have a public property for access
 
         internal int number;
 
@@ -64,7 +68,7 @@ namespace Lucene.Net.Util.Automaton
         /// </summary>
         public State()
         {
-            ResetTransitions();
+            //ResetTransitions(); // LUCENENET: Let class initializer set these
             id = next_id++;
         }
 
@@ -73,7 +77,11 @@ namespace Lucene.Net.Util.Automaton
         /// </summary>
         internal void ResetTransitions()
         {
+#if FEATURE_ARRAYEMPTY
+            transitionsArray = Array.Empty<Transition>();
+#else
             transitionsArray = new Transition[0];
+#endif
             numTransitions = 0;
         }
 
@@ -242,9 +250,7 @@ namespace Lucene.Net.Util.Automaton
         {
             if (numTransitions < transitionsArray.Length)
             {
-                Transition[] newArray = new Transition[numTransitions];
-                Array.Copy(transitionsArray, 0, newArray, 0, numTransitions);
-                transitionsArray = newArray;
+                Array.Resize(ref transitionsArray, numTransitions); // LUCENENET: Resize rather than copy
             }
         }
 

--- a/src/Lucene.Net/Util/Bits.cs
+++ b/src/Lucene.Net/Util/Bits.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Lucene.Net.Util
 {
     /*
@@ -40,8 +42,12 @@ namespace Lucene.Net.Util
 
     public static class Bits
     {
-        public static readonly IBits[] EMPTY_ARRAY = new IBits[0];
-
+        public static readonly IBits[] EMPTY_ARRAY =
+#if FEATURE_ARRAYEMPTY
+            Array.Empty<IBits>();
+#else
+            new IBits[0];
+#endif
         /// <summary>
         /// Bits impl of the specified length with all bits set.
         /// </summary>

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Util
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
-    public sealed class BytesRef : IComparable<BytesRef>, IComparable // LUCENENET specific - implemented IComparable for FieldComparator
+    public sealed class BytesRef : IComparable<BytesRef>, IComparable, IEquatable<BytesRef> // LUCENENET specific - implemented IComparable for FieldComparator, IEquatable<BytesRef>
 #if FEATURE_CLONEABLE
         , System.ICloneable
 #endif
@@ -210,15 +210,16 @@ namespace Lucene.Net.Util
         public override bool Equals(object other)
         {
             if (other == null)
-            {
                 return false;
-            }
-            if (other is BytesRef)
-            {
-                return this.BytesEquals((BytesRef)other);
-            }
+
+            if (other is BytesRef otherBytes)
+                return this.BytesEquals(otherBytes);
+
             return false;
         }
+
+        bool IEquatable<BytesRef>.Equals(BytesRef other) // LUCENENET specific - implemented IEquatable<BytesRef>
+            => BytesEquals(other);
 
         /// <summary>
         /// Interprets stored bytes as UTF8 bytes, returning the

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -47,7 +47,12 @@ namespace Lucene.Net.Util
     {
         /// <summary>
         /// An empty byte array for convenience </summary>
-        public static readonly byte[] EMPTY_BYTES = new byte[0];
+        public static readonly byte[] EMPTY_BYTES =
+#if FEATURE_ARRAYEMPTY
+            Array.Empty<byte>();
+#else
+            new byte[0];
+#endif
 
         /// <summary>
         /// The contents of the BytesRef. Should never be <c>null</c>.

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Util
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
-    public sealed class CharsRef : IComparable<CharsRef>, ICharSequence
+    public sealed class CharsRef : IComparable<CharsRef>, ICharSequence, IEquatable<CharsRef> // LUCENENET specific - implemented IEquatable<CharsRef>
 #if FEATURE_CLONEABLE
         , System.ICloneable
 #endif
@@ -148,6 +148,9 @@ namespace Lucene.Net.Util
             }
             return false;
         }
+
+        bool IEquatable<CharsRef>.Equals(CharsRef other) // LUCENENET specific - implemented IEquatable<CharsRef>
+            => CharsEquals(other);
 
         public bool CharsEquals(CharsRef other)
         {

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -41,8 +41,12 @@ namespace Lucene.Net.Util
     {
         /// <summary>
         /// An empty character array for convenience </summary>
-        public static readonly char[] EMPTY_CHARS = new char[0];
-
+        public static readonly char[] EMPTY_CHARS =
+#if FEATURE_ARRAYEMPTY
+            Array.Empty<char>();
+#else
+            new char[0];
+#endif
         bool ICharSequence.HasValue => true;
 
         /// <summary>

--- a/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
+++ b/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
@@ -105,7 +105,11 @@ namespace Lucene.Net.Util
         {
             if (null == cacheEntries || 0 == cacheEntries.Length)
             {
+#if FEATURE_ARRAYEMPTY
+                return Array.Empty<Insanity>();
+#else
                 return new Insanity[0];
+#endif
             }
 
             if (estimateRam)

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -105,7 +105,12 @@ namespace Lucene.Net.Util.Fst
         /// <seealso cref= #shouldExpand(UnCompiledNode) </seealso>
         internal const int FIXED_ARRAY_NUM_ARCS_DEEP = 10;*/
 
-        private int[] bytesPerArc = new int[0];
+        private int[] bytesPerArc =
+#if FEATURE_ARRAYEMPTY
+            Array.Empty<int>();
+#else
+            new int[0];
+#endif
 
         /*// Increment version to change it
         private const string FILE_FORMAT_NAME = "FST";

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -452,12 +452,12 @@ namespace Lucene.Net.Util.Fst
                     // LUCENENET NOTE: In .NET, IEnumerable will not equal another identical IEnumerable
                     // because it checks for reference equality, not that the list contents
                     // are the same. StructuralEqualityComparer.Default.Equals() will make that check.
-                    Debug.Assert(typeof(T).GetTypeInfo().IsValueType 
+                    Debug.Assert(typeof(T).IsValueType 
                         ? JCG.EqualityComparer<T>.Default.Equals(root.NextFinalOutput, asserting.NextFinalOutput)
                         : StructuralEqualityComparer.Default.Equals(root.NextFinalOutput, asserting.NextFinalOutput));
                     Debug.Assert(root.Node == asserting.Node);
                     Debug.Assert(root.NumArcs == asserting.NumArcs);
-                    Debug.Assert(typeof(T).GetTypeInfo().IsValueType
+                    Debug.Assert(typeof(T).IsValueType
                         ? JCG.EqualityComparer<T>.Default.Equals(root.Output, asserting.Output)
                         : StructuralEqualityComparer.Default.Equals(root.Output, asserting.Output));
                     Debug.Assert(root.PosArcsStart == asserting.PosArcsStart);

--- a/src/Lucene.Net/Util/Fst/NodeHash.cs
+++ b/src/Lucene.Net/Util/Fst/NodeHash.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Util.Fst
 
         // LUCENENET specific - optimize the Hash methods
         // by only calling StructuralEqualityComparer.GetHashCode() if the value is a reference type
-        private readonly static bool tIsValueType = typeof(T).GetTypeInfo().IsValueType;
+        private readonly static bool tIsValueType = typeof(T).IsValueType;
 
         public NodeHash(FST<T> fst, FST.BytesReader input)
         {

--- a/src/Lucene.Net/Util/IntsRef.cs
+++ b/src/Lucene.Net/Util/IntsRef.cs
@@ -45,7 +45,12 @@ namespace Lucene.Net.Util
         /// <para/>
         /// NOTE: This was EMPTY_INTS in Lucene
         /// </summary>
-        public static readonly int[] EMPTY_INT32S = new int[0];
+        public static readonly int[] EMPTY_INT32S =
+#if FEATURE_ARRAYEMPTY
+            Array.Empty<int>();
+#else
+            new int[0];
+#endif
 
         /// <summary>
         /// The contents of the <see cref="Int32sRef"/>. Should never be <c>null</c>. 

--- a/src/Lucene.Net/Util/LongsRef.cs
+++ b/src/Lucene.Net/Util/LongsRef.cs
@@ -45,7 +45,12 @@ namespace Lucene.Net.Util
         /// <para/>
         /// NOTE: This was EMPTY_LONGS in Lucene
         /// </summary>
-        public static readonly long[] EMPTY_INT64S = new long[0];
+        public static readonly long[] EMPTY_INT64S =
+#if FEATURE_ARRAYEMPTY
+            Array.Empty<long>();
+#else
+            new long[0];
+#endif
 
         /// <summary>
         /// The contents of the <see cref="Int64sRef"/>. Should never be <c>null</c>. 

--- a/src/Lucene.Net/Util/MathUtil.cs
+++ b/src/Lucene.Net/Util/MathUtil.cs
@@ -1,5 +1,6 @@
 using J2N.Numerics;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util
 {
@@ -23,16 +24,12 @@ namespace Lucene.Net.Util
     /// <summary>
     /// Math static utility methods.
     /// </summary>
-    public sealed class MathUtil
+    public static class MathUtil // LUCENENET: Changed to static
     {
-        // No instance:
-        private MathUtil()
-        {
-        }
-
         /// <summary>
         /// Returns <c>x &lt;= 0 ? 0 : Math.Floor(Math.Log(x) / Math.Log(base))</c>. </summary>
         /// <param name="base"> Must be <c>&gt; 1</c>.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Log(long x, int @base)
         {
             if (@base <= 1)
@@ -51,6 +48,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Calculates logarithm in a given <paramref name="base"/> with doubles.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Log(double @base, double x)
         {
             return Math.Log(x) / Math.Log(@base);
@@ -113,6 +111,7 @@ namespace Lucene.Net.Util
         ///    <item><description>If the argument is infinite, then the result is infinity with the same sign as the argument.</description></item>
         /// </list>
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Asinh(double a)
         {
             double sign;
@@ -141,6 +140,7 @@ namespace Lucene.Net.Util
         ///    <item><description>If the argument is less than 1, then the result is NaN.</description></item>
         /// </list>
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Acosh(double a)
         {
             return Math.Log(Math.Sqrt(a * a - 1.0d) + a);
@@ -158,6 +158,7 @@ namespace Lucene.Net.Util
         ///    <item><description>If the argument's absolute value is greater than 1, then the result is NaN.</description></item>
         /// </list>
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Atanh(double a)
         {
             double mult;

--- a/src/Lucene.Net/Util/NamedSPILoader.cs
+++ b/src/Lucene.Net/Util/NamedSPILoader.cs
@@ -66,7 +66,7 @@
 //                SPIClassIterator<S> loader = SPIClassIterator<S>.Get();
 
 //                // Ensure there is a default constructor (the SPIClassIterator contains types that don't)
-//                foreach (Type c in loader.Where(t => t.GetTypeInfo().GetConstructor(Type.EmptyTypes) != null))
+//                foreach (Type c in loader.Where(t => t.GetConstructor(Type.EmptyTypes) != null))
 //                {
 //                    try
 //                    {

--- a/src/Lucene.Net/Util/NumericUtils.cs
+++ b/src/Lucene.Net/Util/NumericUtils.cs
@@ -1,5 +1,6 @@
 using J2N.Numerics;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util
 {
@@ -60,12 +61,8 @@ namespace Lucene.Net.Util
     /// @lucene.internal
     /// @since 2.9, API changed non backwards-compliant in 4.0
     /// </summary>
-    public sealed class NumericUtils
+    public static class NumericUtils // LUCENENET specific - changed to static
     {
-        private NumericUtils() // no instance!
-        {
-        }
-
         /// <summary>
         /// The default precision step used by <see cref="Documents.Int32Field"/>,
         /// <see cref="Documents.SingleField"/>, <see cref="Documents.Int64Field"/>, 
@@ -118,6 +115,7 @@ namespace Lucene.Net.Util
         /// <param name="val"> The numeric value </param>
         /// <param name="shift"> How many bits to strip from the right </param>
         /// <param name="bytes"> Will contain the encoded value </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Int64ToPrefixCoded(long val, int shift, BytesRef bytes)
         {
             Int64ToPrefixCodedBytes(val, shift, bytes);
@@ -133,6 +131,7 @@ namespace Lucene.Net.Util
         /// <param name="val"> The numeric value </param>
         /// <param name="shift"> How many bits to strip from the right </param>
         /// <param name="bytes"> Will contain the encoded value </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Int32ToPrefixCoded(int val, int shift, BytesRef bytes)
         {
             Int32ToPrefixCodedBytes(val, shift, bytes);
@@ -215,6 +214,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <exception cref="FormatException"> if the supplied <see cref="BytesRef"/> is
         /// not correctly prefix encoded. </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetPrefixCodedInt64Shift(BytesRef val)
         {
             int shift = val.Bytes[val.Offset] - SHIFT_START_INT64;
@@ -232,6 +232,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <exception cref="FormatException"> if the supplied <see cref="BytesRef"/> is
         /// not correctly prefix encoded. </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetPrefixCodedInt32Shift(BytesRef val)
         {
             int shift = val.Bytes[val.Offset] - SHIFT_START_INT32;
@@ -305,6 +306,7 @@ namespace Lucene.Net.Util
         /// NOTE: This was doubleToSortableLong() in Lucene
         /// </summary>
         /// <seealso cref="SortableInt64ToDouble(long)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long DoubleToSortableInt64(double val)
         {
             long f = J2N.BitConversion.DoubleToInt64Bits(val);
@@ -321,6 +323,7 @@ namespace Lucene.Net.Util
         /// NOTE: This was sortableLongToDouble() in Lucene
         /// </summary>
         /// <seealso cref="DoubleToSortableInt64(double)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double SortableInt64ToDouble(long val)
         {
             if (val < 0)
@@ -341,6 +344,7 @@ namespace Lucene.Net.Util
         /// NOTE: This was floatToSortableInt() in Lucene
         /// </summary>
         /// <seealso cref="SortableInt32ToSingle(int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int SingleToSortableInt32(float val)
         {
             int f = J2N.BitConversion.SingleToInt32Bits(val);
@@ -357,6 +361,7 @@ namespace Lucene.Net.Util
         /// NOTE: This was sortableIntToFloat() in Lucene
         /// </summary>
         /// <seealso cref="SingleToSortableInt32"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float SortableInt32ToSingle(int val)
         {
             if (val < 0)
@@ -377,6 +382,7 @@ namespace Lucene.Net.Util
         /// <para/>
         /// NOTE: This was splitLongRange() in Lucene
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SplitInt64Range(Int64RangeBuilder builder, int precisionStep, long minBound, long maxBound)
         {
             SplitRange(builder, 64, precisionStep, minBound, maxBound);
@@ -393,6 +399,7 @@ namespace Lucene.Net.Util
         /// <para/>
         /// NOTE: This was splitIntRange() in Lucene
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SplitInt32Range(Int32RangeBuilder builder, int precisionStep, int minBound, int maxBound)
         {
             SplitRange(builder, 32, precisionStep, minBound, maxBound);

--- a/src/Lucene.Net/Util/PagedBytes.cs
+++ b/src/Lucene.Net/Util/PagedBytes.cs
@@ -51,7 +51,12 @@ namespace Lucene.Net.Util
         private byte[] currentBlock;
         private readonly long bytesUsedPerBlock;
 
-        private static readonly byte[] EMPTY_BYTES = new byte[0];
+        private static readonly byte[] EMPTY_BYTES =
+#if FEATURE_ARRAYEMPTY
+            Array.Empty<byte>();
+#else
+            new byte[0];
+#endif
 
         /// <summary>
         /// Provides methods to read <see cref="BytesRef"/>s from a frozen

--- a/src/Lucene.Net/Util/PrintStreamInfoStream.cs
+++ b/src/Lucene.Net/Util/PrintStreamInfoStream.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Util
             // after calling Dispose(), we need to determine whether it is a system stream
             // here instead of on demand.
             this.isSystemStream = stream == Console.Out || stream == Console.Error;
-            this.m_stream = typeof(SafeTextWriterWrapper).GetTypeInfo().IsAssignableFrom(stream.GetType()) ? stream : new SafeTextWriterWrapper(stream);
+            this.m_stream = typeof(SafeTextWriterWrapper).IsAssignableFrom(stream.GetType()) ? stream : new SafeTextWriterWrapper(stream);
             this.m_messageID = messageID;
         }
 

--- a/src/Lucene.Net/Util/RamUsageEstimator.cs
+++ b/src/Lucene.Net/Util/RamUsageEstimator.cs
@@ -427,7 +427,7 @@ namespace Lucene.Net.Util
             {
                 throw new System.ArgumentException("this method does not work with array classes.");
             }
-            if (clazz.GetTypeInfo().IsPrimitive)
+            if (clazz.IsPrimitive)
             {
                 return primitiveSizes[clazz];
             }
@@ -435,7 +435,7 @@ namespace Lucene.Net.Util
             long size = NUM_BYTES_OBJECT_HEADER;
 
             // Walk type hierarchy
-            for (; clazz != null; clazz = clazz.GetTypeInfo().BaseType)
+            for (; clazz != null; clazz = clazz.BaseType)
             {
                 FieldInfo[] fields = clazz.GetFields(
                     BindingFlags.Instance | 
@@ -464,7 +464,7 @@ namespace Lucene.Net.Util
             if (len > 0)
             {
                 Type arrayElementClazz = array.GetType().GetElementType();
-                if (arrayElementClazz.GetTypeInfo().IsPrimitive)
+                if (arrayElementClazz.IsPrimitive)
                 {
                     size += (long)len * primitiveSizes[arrayElementClazz];
                 }
@@ -525,7 +525,7 @@ namespace Lucene.Net.Util
                     if (len > 0)
                     {
                         Type componentClazz = obClazz.GetElementType();
-                        if (componentClazz.GetTypeInfo().IsPrimitive)
+                        if (componentClazz.IsPrimitive)
                         {
                             size += (long)len * primitiveSizes[componentClazz];
                         }
@@ -596,7 +596,7 @@ namespace Lucene.Net.Util
             ClassCache cachedInfo;
             long shallowInstanceSize = NUM_BYTES_OBJECT_HEADER;
             List<FieldInfo> referenceFields = new List<FieldInfo>(32);
-            for (Type c = clazz; c != null; c = c.GetTypeInfo().BaseType)
+            for (Type c = clazz; c != null; c = c.BaseType)
             {
                 FieldInfo[] fields = c.GetFields(
                     BindingFlags.Instance | 
@@ -610,7 +610,7 @@ namespace Lucene.Net.Util
                     {
                         shallowInstanceSize = AdjustForField(shallowInstanceSize, f);
 
-                        if (!f.FieldType.GetTypeInfo().IsPrimitive)
+                        if (!f.FieldType.IsPrimitive)
                         {
                             referenceFields.Add(f);
                         }
@@ -635,7 +635,7 @@ namespace Lucene.Net.Util
             int fsize = 0;
             
             if (!typeof(IntPtr).Equals(type) && !typeof(UIntPtr).Equals(type))
-                fsize = type.GetTypeInfo().IsPrimitive ? primitiveSizes[type] : NUM_BYTES_OBJECT_REF;
+                fsize = type.IsPrimitive ? primitiveSizes[type] : NUM_BYTES_OBJECT_REF;
 
             // LUCENENET NOTE: I dont think this will ever not be null
             //if (ObjectFieldOffsetMethod != null)

--- a/src/Lucene.Net/Util/SPIClassIterator.cs
+++ b/src/Lucene.Net/Util/SPIClassIterator.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Util
             {
                 try
                 {
-                    foreach (var type in assembly.GetTypes().Where(x => x.GetTypeInfo().IsPublic))
+                    foreach (var type in assembly.GetTypes().Where(x => x.IsPublic))
                     {
                         try
                         {
@@ -109,7 +109,7 @@ namespace Lucene.Net.Util
 
         internal static bool IsInvokableSubclassOf<T>(Type type)
         {
-            return typeof(T).IsAssignableFrom(type) && !type.GetTypeInfo().IsAbstract && !type.GetTypeInfo().IsInterface;
+            return typeof(T).IsAssignableFrom(type) && !type.IsAbstract && !type.IsInterface;
         }
 
         public static SPIClassIterator<S> Get()

--- a/src/Lucene.Net/Util/SloppyMath.cs
+++ b/src/Lucene.Net/Util/SloppyMath.cs
@@ -1,5 +1,6 @@
 using J2N;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util
 {
@@ -34,7 +35,7 @@ namespace Lucene.Net.Util
 
     /// <summary>
     /// Math functions that trade off accuracy for speed. </summary>
-    public class SloppyMath
+    public static class SloppyMath // LUCENENET: Changed to static
     {
         /// <summary>
         /// Returns the distance in kilometers between two points
@@ -158,6 +159,7 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Return an approximate value of the diameter of the earth at the given latitude, in kilometers. </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double EarthDiameter(double latitude)
         {
             if(double.IsNaN(latitude)) 

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -2,6 +2,7 @@ using J2N;
 using J2N.Text;
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Lucene.Net.Util
@@ -571,6 +572,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <exception cref="ArgumentException"> If invalid codepoint header byte occurs or the
         ///    content is prematurely truncated. </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CodePointCount(BytesRef utf8)
         {
             int pos = utf8.Offset;
@@ -696,6 +698,7 @@ namespace Lucene.Net.Util
         /// <returns> a String representing the code points between offset and count. </returns>
         /// <exception cref="ArgumentException"> If an invalid code point is encountered. </exception>
         /// <exception cref="IndexOutOfRangeException"> If the offset or count are out of bounds. </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string NewString(int[] codePoints, int offset, int count)
         {
             char[] chars = ToCharArray(codePoints, offset, count);
@@ -862,6 +865,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Utility method for <see cref="UTF8toUTF16(byte[], int, int, CharsRef)"/> </summary>
         /// <seealso cref="UTF8toUTF16(byte[], int, int, CharsRef)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UTF8toUTF16(BytesRef bytesRef, CharsRef chars)
         {
             UTF8toUTF16(bytesRef.Bytes, bytesRef.Offset, bytesRef.Length, chars);

--- a/src/Lucene.Net/Util/VirtualMethod.cs
+++ b/src/Lucene.Net/Util/VirtualMethod.cs
@@ -169,13 +169,13 @@ namespace Lucene.Net.Util
 
         private int ReflectImplementationDistance(Type subclazz)
         {
-            if (!baseClass.GetTypeInfo().IsAssignableFrom(subclazz))
+            if (!baseClass.IsAssignableFrom(subclazz))
             {
                 throw new System.ArgumentException(subclazz.Name + " is not a subclass of " + baseClass.Name);
             }
             bool overridden = false;
             int distance = 0;
-            for (Type clazz = subclazz; clazz != baseClass && clazz != null; clazz = clazz.GetTypeInfo().BaseType)
+            for (Type clazz = subclazz; clazz != baseClass && clazz != null; clazz = clazz.BaseType)
             {
                 // lookup method, if success mark as overridden
                 if (!overridden)

--- a/src/Lucene.Net/Util/WAH8DocIdSet.cs
+++ b/src/Lucene.Net/Util/WAH8DocIdSet.cs
@@ -88,8 +88,11 @@ namespace Lucene.Net.Util
         public const int DEFAULT_INDEX_INTERVAL = 24;
 
         private static readonly MonotonicAppendingInt64Buffer SINGLE_ZERO_BUFFER = LoadSingleZeroBuffer();
-        private static WAH8DocIdSet EMPTY = new WAH8DocIdSet(new byte[0], 0, 1, SINGLE_ZERO_BUFFER, SINGLE_ZERO_BUFFER);
-
+#if FEATURE_ARRAYEMPTY
+        private static WAH8DocIdSet EMPTY = new WAH8DocIdSet(Array.Empty<byte>(), 0, 1, SINGLE_ZERO_BUFFER, SINGLE_ZERO_BUFFER);
+#else
+        private static WAH8DocIdSet EMPTY = new WAH8DocIdSet(new byte[0],         0, 1, SINGLE_ZERO_BUFFER, SINGLE_ZERO_BUFFER);
+#endif
         private static MonotonicAppendingInt64Buffer LoadSingleZeroBuffer() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
             var buffer = new MonotonicAppendingInt64Buffer(1, 64, PackedInt32s.COMPACT);

--- a/src/dotnet/tools/lucene-cli/ConfigurationBase.cs
+++ b/src/dotnet/tools/lucene-cli/ConfigurationBase.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Cli
 
     public abstract class ConfigurationBase : CommandLineApplication
     {
-        private static Assembly thisAssembly = typeof(ConfigurationBase).GetTypeInfo().Assembly;
+        private static Assembly thisAssembly = typeof(ConfigurationBase).Assembly;
         protected static string HELP_VALUE_NAME = "help";
 
         protected ConfigurationBase()


### PR DESCRIPTION
This has several enhancements that improve the performance of tests in the `Lucene.Net.Util` namespace.