### PR TITLE
WIP Benchmarks between nuget versions

### DIFF
--- a/Lucene.Net.sln
+++ b/Lucene.Net.sln
@@ -200,6 +200,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lucene.Net.CodeAnalysis", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lucene.Net.Tests.CodeAnalysis", "src\dotnet\Lucene.Net.Tests.CodeAnalysis\Lucene.Net.Tests.CodeAnalysis.csproj", "{158F5D30-8B96-4C49-9009-0B8ACEDF8546}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lucene.Net.Tests.BenchmarkDotNet", "src\Lucene.Net.Tests.BenchmarkDotNet\Lucene.Net.Tests.BenchmarkDotNet.csproj", "{0C476146-411E-4C94-8A59-726A5F982A89}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -462,6 +464,10 @@ Global
 		{158F5D30-8B96-4C49-9009-0B8ACEDF8546}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{158F5D30-8B96-4C49-9009-0B8ACEDF8546}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{158F5D30-8B96-4C49-9009-0B8ACEDF8546}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C476146-411E-4C94-8A59-726A5F982A89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C476146-411E-4C94-8A59-726A5F982A89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C476146-411E-4C94-8A59-726A5F982A89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C476146-411E-4C94-8A59-726A5F982A89}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Lucene.Net.Tests.BenchmarkDotNet/HomePageScriptBenchmarks.cs
+++ b/src/Lucene.Net.Tests.BenchmarkDotNet/HomePageScriptBenchmarks.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using Lucene.Net.Util;
+using Lucene.Net.Store;
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Index;
+using Lucene.Net.Documents;
+using Lucene.Net.Search;
+using System.Diagnostics;
+
+namespace Lucene.Net.Tests.BenchmarkDotNet
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    [MemoryDiagnoser]
+    [Config(typeof(Config))]
+    public class HomePageScriptBenchmarks
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                var baseJob = Job.MediumRun;
+
+                AddJob(baseJob.WithNuGet("Lucene.Net.Analysis.Common", "4.8.0-beta00009").WithId("4.8.0-beta00009"));
+                AddJob(baseJob.WithNuGet("Lucene.Net.Analysis.Common", "4.8.0-beta00008").WithId("4.8.0-beta00008"));
+                AddJob(baseJob.WithNuGet("Lucene.Net.Analysis.Common", "4.8.0-beta00007").WithId("4.8.0-beta00007"));
+            }
+        }
+
+        private const int _directoryWriterIterations = 10;
+        private const int _indexSearchIterations = 25;
+
+        [Benchmark]
+        public void HomePageScript()
+        {
+            // Ensures index backwards compatibility
+            var AppLuceneVersion = LuceneVersion.LUCENE_48;
+
+            for (int d = 0; d < _directoryWriterIterations; d++)
+            {
+                using var dir = new RAMDirectory();
+
+                //create an analyzer to process the text
+                var analyzer = new StandardAnalyzer(AppLuceneVersion);
+
+                //create an index writer
+                var indexConfig = new IndexWriterConfig(AppLuceneVersion, analyzer);
+                using var writer = new IndexWriter(dir, indexConfig);
+
+                for (int i = 0; i < _indexSearchIterations; i++)
+                {
+                    var source = new
+                    {
+                        Name = $"Kermit{i} the Frog{i}",
+                        FavoritePhrase = $"The quick{i} brown{i} fox{i} jumps{i} over{i} the lazy{i} dog{i} "
+                    };
+                    Document doc = new Document
+                    {
+                        // StringField indexes but doesn't tokenize
+                        new StringField("name", source.Name, Field.Store.YES),
+                        new TextField("favoritePhrase", source.FavoritePhrase, Field.Store.YES)
+                    };
+
+                    writer.AddDocument(doc);
+                    writer.Flush(triggerMerge: false, applyAllDeletes: false);
+                }
+
+                for (int i = 0; i < _indexSearchIterations; i++)
+                {
+                    // search with a phrase
+                    var phrase = new MultiPhraseQuery
+                    {
+                        new Term("favoritePhrase", $"brown{i}"),
+                        new Term("favoritePhrase", $"fox{i}")
+                    };
+
+                    // re-use the writer to get real-time updates
+                    using var reader = writer.GetReader(applyAllDeletes: true);
+                    var searcher = new IndexSearcher(reader);
+                    var hits = searcher.Search(phrase, 20 /* top 20 */).ScoreDocs;
+                    Debug.Assert(hits.Length > 0);
+                    foreach (var hit in hits)
+                    {
+                        var foundDoc = searcher.Doc(hit.Doc);
+                        var score = hit.Score;
+                        var name = foundDoc.Get("name");
+                        var favoritePhrase = foundDoc.Get("favoritePhrase");
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/Lucene.Net.Tests.BenchmarkDotNet/Lucene.Net.Tests.BenchmarkDotNet.csproj
+++ b/src/Lucene.Net.Tests.BenchmarkDotNet/Lucene.Net.Tests.BenchmarkDotNet.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00005" />
+  </ItemGroup>
+
+</Project>

--- a/src/Lucene.Net.Tests.BenchmarkDotNet/Program.cs
+++ b/src/Lucene.Net.Tests.BenchmarkDotNet/Program.cs
@@ -1,0 +1,26 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace Lucene.Net.Tests.BenchmarkDotNet
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    class Program
+    {
+        private static void Main(string[] args) => new BenchmarkSwitcher(typeof(Program).Assembly).Run(args);
+    }
+}


### PR DESCRIPTION
This is a WIP for creating benchmarkdotnet tests to see performance (currently for testing between nuget packages).

I have asked about specifying different nuget package sources here https://github.com/dotnet/BenchmarkDotNet/pull/922#issuecomment-658519567 (I feel like I had done this in some way when implementing that feature but can't remember now) since that will be needed to test the 'current' version. It is not possible to reference the 'current' projects and then also use 'WithNuget' because that results in Nuget errors.

Currently just added a single benchmark as an example, this is just the script from the home page. There's manual iterations specified in there so that we don't get warnings from BenchmarkDotNet about `MultimodalDistribution` or `MinIterationTime` since one less iterations are too fast to measure correctly. 

This example benchmark isn't showing much since the results are nearly identical between versions, for example: 

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.900 (1909/November2018Update/19H2)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.400-preview-015151
  [Host]          : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00007 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00008 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00009 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT

IterationCount=15  LaunchCount=2  WarmupCount=10  

```
|         Method |             Job |                            NuGetReferences |     Mean |   Error |  StdDev |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|--------------- |---------------- |------------------------------------------- |---------:|--------:|--------:|-----------:|----------:|----------:|----------:|
| HomePageScript | 4.8.0-beta00007 | Lucene.Net.Analysis.Common 4.8.0-beta00007 | 207.5 ms | 3.94 ms | 5.65 ms | 63000.0000 | 6000.0000 | 1000.0000 | 249.37 MB |
| HomePageScript | 4.8.0-beta00008 | Lucene.Net.Analysis.Common 4.8.0-beta00008 | 196.8 ms | 6.20 ms | 9.28 ms | 60000.0000 | 9000.0000 | 2000.0000 | 250.74 MB |
| HomePageScript | 4.8.0-beta00009 | Lucene.Net.Analysis.Common 4.8.0-beta00009 | 208.8 ms | 7.15 ms | 9.54 ms | 62000.0000 | 7000.0000 | 2000.0000 | 250.77 MB |


