### PR TITLE
Fixing #308

### DIFF
--- a/src/Lucene.Net.Tests._E-I/FindFirstFailingSeedAttribute.cs
+++ b/src/Lucene.Net.Tests._E-I/FindFirstFailingSeedAttribute.cs
@@ -1,0 +1,97 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+
+namespace Lucene.Net
+{
+    /// <summary>
+    /// Provides a way to keep running the test in NUnit with a different test seed
+    /// </summary>
+    /// <remarks>
+    /// see https://github.com/nunit/nunit/issues/1461#issuecomment-429580661
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class FindFirstFailingSeedAttribute : Attribute, IWrapSetUpTearDown
+    {
+        public int StartingSeed { get; set; }
+        public int TimeoutMilliseconds { get; set; } = Timeout.Infinite;
+
+        public TestCommand Wrap(TestCommand command)
+        {
+            return new FindFirstFailingSeedCommand(command, StartingSeed, TimeoutMilliseconds);
+        }
+
+        private sealed class FindFirstFailingSeedCommand : DelegatingTestCommand
+        {
+            private readonly int startingSeed;
+            private readonly int timeoutMilliseconds;
+
+            public FindFirstFailingSeedCommand(TestCommand innerCommand, int startingSeed, int timeoutMilliseconds) : base(innerCommand)
+            {
+                this.startingSeed = startingSeed;
+                this.timeoutMilliseconds = timeoutMilliseconds;
+            }
+
+            public override TestResult Execute(TestExecutionContext context)
+            {
+                var stopwatch = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.StartNew();
+
+                for (var seed = startingSeed; ;)
+                {
+                    ResetRandomSeed(context, seed);
+                    context.CurrentResult = context.CurrentTest.MakeTestResult();
+
+                    try
+                    {
+                        context.CurrentResult = innerCommand.Execute(context);
+                    }
+                    catch (Exception ex)
+                    {
+                        context.CurrentResult.RecordException(ex);
+                    }
+
+                    if (context.CurrentTest.Seed != seed)
+                        throw new InvalidOperationException($"{nameof(FindFirstFailingSeedAttribute)} cannot be used together with an attribute or test that changes the seed.");
+
+                    TestContext.WriteLine($"Random seed: {seed}");
+
+                    if (context.CurrentResult.ResultState.Status == TestStatus.Failed)
+                    {                        
+                        break;
+                    }
+
+                    seed++;
+                    if (seed == startingSeed)
+                    {
+                        TestContext.WriteLine("Tried every seed without producing a failure.");
+                        break;
+                    }
+
+                    if (stopwatch != null && stopwatch.ElapsedMilliseconds > timeoutMilliseconds)
+                    {
+                        TestContext.WriteLine($"Timed out after seeds {startingSeed}–{seed} did not produce a failure.");
+                        break;
+                    }
+                }
+
+                return context.CurrentResult;
+            }
+
+            private static void ResetRandomSeed(TestExecutionContext context, int seed)
+            {
+                context.CurrentTest.Seed = seed;
+
+                typeof(TestExecutionContext)
+                    .GetField("_randomGenerator", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                    .SetValue(context, null);
+            }
+        }
+    }
+}

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -981,6 +982,19 @@ namespace Lucene.Net.Index
                     }
                 }
             }
+        }
+
+        [Explicit("Used for debugging the long running test")]
+        [FindFirstFailingSeed(TimeoutMilliseconds = 240000)]
+        [Test]
+        public virtual void TestAddIndexesWithCloseNoWait_Repeated()
+        {
+            TestContext.WriteLine("Starting");
+            var watch = Stopwatch.StartNew();
+            TestAddIndexesWithCloseNoWait();
+            if (watch.ElapsedMilliseconds > 60000)
+                throw new InvalidOperationException($"Took too long {watch.ElapsedMilliseconds}");
+            TestContext.WriteLine($"Completed {watch.ElapsedMilliseconds}");
         }
 
         // LUCENE-1335: test simultaneous addIndexes & close


### PR DESCRIPTION
This is a WIP to fix #308 

The first part is that this fixes a deadlock issues with MockDirectoryWrapper. 

* This was locking on `this` which seems common from the java port. This wasn't the problem but lock (this) shouldn't be used since there is no way of knowing if something else is locking on that object which will cause deadlocks. This has been changed to lock on a private field. I have verified that there is no other code that ever locks on a directory object so there was nothing important about locking on `this`.
* Deadlocks are easily produced when there are recursive locks which happened often in MockDirectoryWrapper. Take for example the call to MockDirectoryWrapper.CreateOutput which takes a lock, then it calls into MaybeThrowDeterministicException which takes the same lock and then it calls into MaybeThrowIOExceptionOnOpen which also takes the same lock, then Init with the same lock and then within the same method is taking a recursive lock on the same lock, then in AddFileHandle again the same lock. This all occurs within the same method CreateOutput. Meanwhile, if any other thread calls any other method that uses this lock (which seems like all of them) you'll get a deadlock
* This can be fixed by ensuring there's never recursive locks taken. Currently this means there are private methods suffixed with the term "Locked" which double check they are being called within a lock. The original methods that explicitly create the lock now call into their sister "Locked" methods.

There's currently a temp test in this code which allows to run the slow running test over and over until it runs for longer than the specified time. With the deadlock fixed I think i can now see where the slowness of the method comes from so will now look into profiling this.
