### PR TITLE
Performance Enhancements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,10 @@
 <Project>
   <Import Project="build\Dependencies.props" />
 
+  <PropertyGroup>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+  
   <!-- IMPORTANT: When these values are changed, the CI counter number should also be reset. -->
   <PropertyGroup Label="Version of Builds">
     <!-- IMPORTANT: VersionPrefix must always be the same as the Lucene version this is based on.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -295,17 +295,17 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-2019'
-          maximumParallelJobs: 7
+          maximumParallelJobs: 8
           maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
         Linux:
           osName: 'Linux'
           imageName: 'ubuntu-16.04'
-          maximumParallelJobs: 6
+          maximumParallelJobs: 7
           maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
         macOS:
           osName: 'macOS'
           imageName: 'macOS-10.14'
-          maximumParallelJobs: 6
+          maximumParallelJobs: 7
           maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
     displayName: 'Test netcoreapp3.1 on'
     pool:
@@ -326,17 +326,17 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-2019'
-          maximumParallelJobs: 7
+          maximumParallelJobs: 8
           maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
         Linux:
           osName: 'Linux'
           imageName: 'ubuntu-16.04'
-          maximumParallelJobs: 6
+          maximumParallelJobs: 7
           maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
         macOS:
           osName: 'macOS'
           imageName: 'macOS-10.14'
-          maximumParallelJobs: 6
+          maximumParallelJobs: 7
           maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
     displayName: 'Test netcoreapp2.1 on'
     pool:
@@ -361,7 +361,7 @@ stages:
         osName: 'Windows'
         framework: 'net48'
         testResultsArtifactName: '$(TestResultsArtifactName)'
-        maximumParallelJobs: 7
+        maximumParallelJobs: 8
         maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
 
 - stage: Publish_Stage

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/CompoundWordTokenFilterBase.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/CompoundWordTokenFilterBase.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Analysis.Compound
 
         protected readonly LuceneVersion m_matchVersion;
         protected readonly CharArraySet m_dictionary;
-        protected readonly LinkedList<CompoundToken> m_tokens;
+        protected readonly Queue<CompoundToken> m_tokens;
         protected readonly int m_minWordSize;
         protected readonly int m_minSubwordSize;
         protected readonly int m_maxSubwordSize;
@@ -86,7 +86,7 @@ namespace Lucene.Net.Analysis.Compound
             posIncAtt = AddAttribute<IPositionIncrementAttribute>();
 
             this.m_matchVersion = matchVersion;
-            this.m_tokens = new LinkedList<CompoundToken>();
+            this.m_tokens = new Queue<CompoundToken>();
             if (minWordSize < 0)
             {
                 throw new ArgumentException("minWordSize cannot be negative");
@@ -111,8 +111,7 @@ namespace Lucene.Net.Analysis.Compound
             if (m_tokens.Count > 0)
             {
                 Debug.Assert(current != null);
-                CompoundToken token = m_tokens.First.Value;
-                m_tokens.Remove(token);
+                CompoundToken token = m_tokens.Dequeue();
                 RestoreState(current); // keep all other attributes untouched
                 m_termAtt.SetEmpty().Append(token.Text);
                 m_offsetAtt.SetOffset(token.StartOffset, token.EndOffset);

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/DictionaryCompoundWordTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/DictionaryCompoundWordTokenFilter.cs
@@ -120,13 +120,13 @@ namespace Lucene.Net.Analysis.Compound
                         }
                         else
                         {
-                            m_tokens.AddLast(new CompoundToken(this, i, j));
+                            m_tokens.Enqueue(new CompoundToken(this, i, j));
                         }
                     }
                 }
                 if (this.m_onlyLongestMatch && longestMatchToken != null)
                 {
-                    m_tokens.AddLast(longestMatchToken);
+                    m_tokens.Enqueue(longestMatchToken);
                 }
             }
         }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/HyphenationCompoundWordTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/HyphenationCompoundWordTokenFilter.cs
@@ -250,7 +250,7 @@ namespace Lucene.Net.Analysis.Compound
                         }
                         else
                         {
-                            m_tokens.AddLast(new CompoundToken(this, start, partLength));
+                            m_tokens.Enqueue(new CompoundToken(this, start, partLength));
                         }
                     }
                     else if (m_dictionary.Contains(m_termAtt.Buffer, start, partLength - 1))
@@ -275,13 +275,13 @@ namespace Lucene.Net.Analysis.Compound
                         }
                         else
                         {
-                            m_tokens.AddLast(new CompoundToken(this, start, partLength - 1));
+                            m_tokens.Enqueue(new CompoundToken(this, start, partLength - 1));
                         }
                     }
                 }
                 if (this.m_onlyLongestMatch && longestMatchToken != null)
                 {
-                    m_tokens.AddLast(longestMatchToken);
+                    m_tokens.Enqueue(longestMatchToken);
                 }
             }
         }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -1079,19 +1079,11 @@ namespace Lucene.Net.Analysis.Hunspell
         /// </summary>
         private class DoubleASCIIFlagParsingStrategy : FlagParsingStrategy
         {
-            // LUCENENET specific - optimized empty array creation
-            private static readonly char[] EMPTY_CHARS =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<char>();
-#else
-                new char[0];
-#endif
-
             internal override char[] ParseFlags(string rawFlags)
             {
                 if (rawFlags.Length == 0)
                 {
-                    return EMPTY_CHARS; // LUCENENET: Optimized char[] creation
+                    return Arrays.Empty<char>(); ; // LUCENENET: Optimized char[] creation
                 }
 
                 StringBuilder builder = new StringBuilder();

--- a/src/Lucene.Net.Analysis.Common/Analysis/Query/QueryAutoStopWordAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Query/QueryAutoStopWordAnalyzer.cs
@@ -1,8 +1,8 @@
 ﻿using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Index;
+using Lucene.Net.Support;
 using Lucene.Net.Util;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -171,16 +171,8 @@ namespace Lucene.Net.Analysis.Query
         public string[] GetStopWords(string fieldName)
         {            
             var stopWords = stopWordsPerField[fieldName];
-            return stopWords != null ? stopWords.ToArray() : EMPTY_STRINGS;
+            return stopWords != null ? stopWords.ToArray() : Arrays.Empty<string>();
         }
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly string[] EMPTY_STRINGS =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<string>();
-#else
-                new string[0];
-#endif
 
         /// <summary>
         /// Provides information on which stop words have been identified for all fields

--- a/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Analysis.Shingle
         /// The sequence of input stream tokens (or filler tokens, if necessary)
         /// that will be composed to form output shingles.
         /// </summary>
-        private LinkedList<InputWindowToken> inputWindow = new LinkedList<InputWindowToken>();
+        private readonly Queue<InputWindowToken> inputWindow = new Queue<InputWindowToken>();
 
         /// <summary>
         /// The number of input tokens in the next output token.  This is the "n" in
@@ -80,7 +80,7 @@ namespace Lucene.Net.Analysis.Shingle
         /// <summary>
         /// Shingle and unigram text is composed here.
         /// </summary>
-        private StringBuilder gramBuilder = new StringBuilder();
+        private readonly StringBuilder gramBuilder = new StringBuilder();
 
         /// <summary>
         /// The token type attribute value to use - default is "shingle"
@@ -296,7 +296,7 @@ namespace Lucene.Net.Analysis.Shingle
         /// <param name="tokenSeparator"> used to separate input stream tokens in output shingles </param>
         public void SetTokenSeparator(string tokenSeparator)
         {
-            this.tokenSeparator = null == tokenSeparator ? "" : tokenSeparator;
+            this.tokenSeparator = tokenSeparator ?? string.Empty;
         }
 
         /// <summary>
@@ -363,7 +363,7 @@ namespace Lucene.Net.Analysis.Shingle
                 }
                 if (!isAllFiller && builtGramSize == gramSize.Value)
                 {
-                    inputWindow.First.Value.attSource.CopyTo(this);
+                    inputWindow.Peek().attSource.CopyTo(this);
                     posIncrAtt.PositionIncrement = isOutputHere ? 0 : 1;
                     termAtt.SetEmpty().Append(gramBuilder);
                     if (gramSize.Value > 1)
@@ -401,7 +401,7 @@ namespace Lucene.Net.Analysis.Shingle
             {
                 if (null == target)
                 {
-                    newTarget = new InputWindowToken(this, nextInputStreamToken.CloneAttributes());
+                    newTarget = new InputWindowToken(nextInputStreamToken.CloneAttributes());
                 }
                 else
                 {
@@ -417,7 +417,7 @@ namespace Lucene.Net.Analysis.Shingle
             {
                 if (null == target)
                 {
-                    newTarget = new InputWindowToken(this, nextInputStreamToken.CloneAttributes());
+                    newTarget = new InputWindowToken(nextInputStreamToken.CloneAttributes());
                 }
                 else
                 {
@@ -432,7 +432,7 @@ namespace Lucene.Net.Analysis.Shingle
                 {
                     if (null == target)
                     {
-                        newTarget = new InputWindowToken(this, CloneAttributes());
+                        newTarget = new InputWindowToken(CloneAttributes());
                     }
                     else
                     {
@@ -518,8 +518,7 @@ namespace Lucene.Net.Analysis.Shingle
             InputWindowToken firstToken = null;
             if (inputWindow.Count > 0)
             {
-                firstToken = inputWindow.First.Value;
-                inputWindow.Remove(firstToken);
+                firstToken = inputWindow.Dequeue();
             }
             while (inputWindow.Count < maxShingleSize)
             {
@@ -527,7 +526,7 @@ namespace Lucene.Net.Analysis.Shingle
                 {
                     if (null != GetNextToken(firstToken))
                     {
-                        inputWindow.AddLast(firstToken); // the firstToken becomes the last
+                        inputWindow.Enqueue(firstToken); // the firstToken becomes the last
                         firstToken = null;
                     }
                     else
@@ -540,7 +539,7 @@ namespace Lucene.Net.Analysis.Shingle
                     InputWindowToken nextToken = GetNextToken(null);
                     if (null != nextToken)
                     {
-                        inputWindow.AddLast(nextToken);
+                        inputWindow.Enqueue(nextToken);
                     }
                     else
                     {
@@ -678,16 +677,13 @@ namespace Lucene.Net.Analysis.Shingle
 
         private class InputWindowToken
         {
-            private readonly ShingleFilter outerInstance;
-
             internal readonly AttributeSource attSource;
             internal readonly ICharTermAttribute termAtt;
             internal readonly IOffsetAttribute offsetAtt;
             internal bool isFiller = false;
 
-            public InputWindowToken(ShingleFilter outerInstance, AttributeSource attSource)
+            public InputWindowToken(AttributeSource attSource)
             {
-                this.outerInstance = outerInstance;
                 this.attSource = attSource;
                 this.termAtt = attSource.GetAttribute<ICharTermAttribute>();
                 this.offsetAtt = attSource.GetAttribute<IOffsetAttribute>();

--- a/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
@@ -306,16 +307,8 @@ namespace Lucene.Net.Analysis.Shingle
         /// <param name="fillerToken"> string to insert at each position where there is no token </param>
         public void SetFillerToken(string fillerToken)
         {
-            this.fillerToken = null == fillerToken ? EMPTY_CHARS : fillerToken.ToCharArray();
+            this.fillerToken = null == fillerToken ? Arrays.Empty<char>() : fillerToken.ToCharArray();
         }
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly char[] EMPTY_CHARS =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<char>();
-#else
-                new char[0];
-#endif
 
         public override bool IncrementToken()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Among.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Among.cs
@@ -47,12 +47,7 @@ namespace Lucene.Net.Tartarus.Snowball
     /// </summary>
     public class Among
     {
-        private readonly Type[] EMPTY_PARAMS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<Type>();
-#else
-            new Type[0];
-#endif
+        private readonly Type[] EMPTY_PARAMS = Arrays.Empty<Type>();
 
         public Among(string s, int substring_i, int result,
             string methodname, SnowballProgram methodobject)

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/SnowballProgram.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/SnowballProgram.cs
@@ -49,12 +49,8 @@ namespace Lucene.Net.Tartarus.Snowball
     /// </summary>
     public abstract class SnowballProgram
     {
-        private static readonly object[] EMPTY_ARGS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<object>();
-#else
-            new object[0];
-#endif
+        private static readonly object[] EMPTY_ARGS = Arrays.Empty<object>();
+
         protected SnowballProgram()
         {
             m_current = new char[8];

--- a/src/Lucene.Net.Analysis.Kuromoji/Util/CSVUtil.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Util/CSVUtil.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Lucene.Net.Support;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -34,14 +35,6 @@ namespace Lucene.Net.Analysis.Ja.Util
         private static readonly Regex QUOTE_REPLACE_PATTERN = new Regex("^\"([^\"]+)\"$", RegexOptions.Compiled);
 
         private const string ESCAPED_QUOTE = "\"\"";
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly string[] EMPTY_STRINGS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<string>();
-#else
-            new string[0];
-#endif
 
         private CSVUtil() { } // no instance!!!
 
@@ -83,7 +76,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             // Validate
             if (quoteCount % 2 != 0)
             {
-                return EMPTY_STRINGS;
+                return Arrays.Empty<string>();
             }
 
             return result.ToArray(/*new String[result.size()]*/);

--- a/src/Lucene.Net.Analysis.Phonetic/DoubleMetaphoneFilter.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/DoubleMetaphoneFilter.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Analysis.Phonetic
     {
         //private static readonly string TOKEN_TYPE = "DoubleMetaphone"; // LUCENENET: Not used
 
-        private readonly LinkedList<State> remainingTokens = new LinkedList<State>();
+        private readonly Queue<State> remainingTokens = new Queue<State>();
         private readonly DoubleMetaphone encoder = new DoubleMetaphone();
         private readonly bool inject;
         private readonly ICharTermAttribute termAtt;
@@ -57,9 +57,8 @@ namespace Lucene.Net.Analysis.Phonetic
                 if (!(remainingTokens.Count == 0))
                 {
                     // clearAttributes();  // not currently necessary
-                    var first = remainingTokens.First;
-                    remainingTokens.Remove(first);
-                    RestoreState(first.Value);
+                    var first = remainingTokens.Dequeue();
+                    RestoreState(first);
                     return true;
                 }
 
@@ -82,7 +81,7 @@ namespace Lucene.Net.Analysis.Phonetic
                 {
                     if (saveState)
                     {
-                        remainingTokens.AddLast(CaptureState());
+                        remainingTokens.Enqueue(CaptureState());
                     }
                     posAtt.PositionIncrement = firstAlternativeIncrement;
                     firstAlternativeIncrement = 0;
@@ -96,7 +95,7 @@ namespace Lucene.Net.Analysis.Phonetic
                 {
                     if (saveState)
                     {
-                        remainingTokens.AddLast(CaptureState());
+                        remainingTokens.Enqueue(CaptureState());
                         saveState = false;
                     }
                     posAtt.PositionIncrement = firstAlternativeIncrement;
@@ -113,7 +112,7 @@ namespace Lucene.Net.Analysis.Phonetic
 
                 if (saveState)
                 {
-                    remainingTokens.AddLast(CaptureState());
+                    remainingTokens.Enqueue(CaptureState());
                 }
             }
         }

--- a/src/Lucene.Net.Benchmark/Support/TagSoup/Parser.cs
+++ b/src/Lucene.Net.Benchmark/Support/TagSoup/Parser.cs
@@ -15,6 +15,7 @@
 // The TagSoup parser
 
 using J2N.Text;
+using Lucene.Net.Support;
 using Sax;
 using Sax.Ext;
 using Sax.Helpers;
@@ -1082,14 +1083,6 @@ namespace TagSoup
             return value;
         }
 
-        // LUCENENET: Optimized empty array creation
-        private static readonly string[] EMPTY_STRINGS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<string>();
-#else
-            new string[0];
-#endif
-
         /// <summary>
         ///   Split the supplied string into words or phrases seperated by spaces.
         ///   Recognises quotes around a phrase and doesn't split it.
@@ -1101,7 +1094,7 @@ namespace TagSoup
             val = val.Trim();
             if (val.Length == 0)
             {
-                return EMPTY_STRINGS;
+                return Arrays.Empty<string>();
             }
             var l = new List<string>();
             int s = 0;

--- a/src/Lucene.Net.Codecs/BlockTerms/TermsIndexWriterBase.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/TermsIndexWriterBase.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Index;
+using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
 
@@ -31,20 +32,10 @@ namespace Lucene.Net.Codecs.BlockTerms
     public abstract class TermsIndexWriterBase : IDisposable
     {
         // LUCENENET specific - optimized empty array creation
-        internal static readonly short[] EMPTY_INT16S =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<short>();
-#else
-            new short[0];
-#endif
+        internal static readonly short[] EMPTY_INT16S = Arrays.Empty<short>();
 
         // LUCENENET specific - optimized empty array creation
-        internal static readonly int[] EMPTY_INT32S =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<int>();
-#else
-            new int[0];
-#endif
+        internal static readonly int[] EMPTY_INT32S = Arrays.Empty<int>();
 
         /// <summary>Terms index API for a single field.</summary>
         public abstract class FieldWriter

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
@@ -1,4 +1,5 @@
 ﻿using J2N.Text;
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -495,17 +496,9 @@ namespace Lucene.Net.Codecs.SimpleText
                 _input = input;
                 _scratch = scratch;
                 _decoderFormat = field.Pattern;
-                _currentOrds = EMPTY_STRINGS;
+                _currentOrds = Arrays.Empty<string>();
                 _currentIndex = 0;
             }
-
-            // LUCENENET specific - optimized empty array creation
-            private static readonly string[] EMPTY_STRINGS =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<string>();
-#else
-                new string[0];
-#endif
 
             private string[] _currentOrds;
             private int _currentIndex;
@@ -527,7 +520,7 @@ namespace Lucene.Net.Codecs.SimpleText
                                 docID * (1 + _field.OrdPattern.Length));
                     SimpleTextUtil.ReadLine(_input, _scratch);
                     var ordList = _scratch.Utf8ToString().Trim();
-                    _currentOrds = ordList.Length == 0 ? EMPTY_STRINGS : ordList.Split(',').TrimEnd();
+                    _currentOrds = ordList.Length == 0 ? Arrays.Empty<string>() : ordList.Split(',').TrimEnd();
                     _currentIndex = 0;
                 }
                 catch (IOException ioe)

--- a/src/Lucene.Net.Facet/FacetsConfig.cs
+++ b/src/Lucene.Net.Facet/FacetsConfig.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Lucene.Net.Support;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -602,14 +603,6 @@ namespace Lucene.Net.Facet
         // Escapes any occurrence of the path component inside the label:
         private const char ESCAPE_CHAR = '\u001E';
 
-        // LUCENENET specific - optimized empty array creation
-        private static readonly string[] EMPTY_STRINGS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<string>();
-#else
-            new string[0];
-#endif
-
         /// <summary>
         /// Turns a dim + path into an encoded string.
         /// </summary>
@@ -675,7 +668,7 @@ namespace Lucene.Net.Facet
             int length = s.Length;
             if (length == 0)
             {
-                return EMPTY_STRINGS;
+                return Arrays.Empty<string>();
             }
             char[] buffer = new char[length];
 

--- a/src/Lucene.Net.Facet/SortedSet/SortedSetDocValuesFacetCounts.cs
+++ b/src/Lucene.Net.Facet/SortedSet/SortedSetDocValuesFacetCounts.cs
@@ -1,4 +1,5 @@
 ﻿using J2N.Text;
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 
@@ -56,14 +57,6 @@ namespace Lucene.Net.Facet.SortedSet
         internal readonly SortedSetDocValues dv;
         internal readonly string field;
         internal readonly int[] counts;
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly string[] EMPTY_STRINGS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<string>();
-#else
-            new string[0];
-#endif
 
         /// <summary>
         /// Sparse faceting: returns any dimension that had any
@@ -153,7 +146,7 @@ namespace Lucene.Net.Facet.SortedSet
                 labelValues[i] = new LabelAndValue(parts[1], ordAndValue.Value);
             }
 
-            return new FacetResult(dim, EMPTY_STRINGS, dimCount, labelValues, childCount);
+            return new FacetResult(dim, Arrays.Empty<string>(), dimCount, labelValues, childCount);
         }
 
         /// <summary>

--- a/src/Lucene.Net.Grouping/GroupingSearch.cs
+++ b/src/Lucene.Net.Grouping/GroupingSearch.cs
@@ -58,25 +58,6 @@ namespace Lucene.Net.Search.Grouping
         private ICollection /* Collection<?> */ matchingGroups;
         private IBits matchingGroupHeads;
 
-        // LUCENENET specific - optimized empty array creation
-        private static readonly SortField[] EMPTY_SORTFIELDS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<SortField>();
-#else
-            new SortField[0];
-#endif
-
-        // LUCENENET specific - optimized empty array creation
-        private class EmptyGroupDocsHolder<TGroupValue>
-        {
-            public static readonly GroupDocs<TGroupValue>[] EMPTY_GROUPDOCS =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<GroupDocs<TGroupValue>>();
-#else
-                new GroupDocs<TGroupValue>[0];
-#endif
-        }
-
         /// <summary>
         /// Constructs a <see cref="GroupingSearch"/> instance that groups documents by index terms using the <see cref="FieldCache"/>.
         /// The group field can only have one token per document. This means that the field must not be analysed.
@@ -310,7 +291,7 @@ namespace Lucene.Net.Search.Grouping
             if (topSearchGroups == null)
             {
                 // LUCENENET specific - optimized empty array creation
-                return new TopGroups<TGroupValue>(EMPTY_SORTFIELDS, EMPTY_SORTFIELDS, 0, 0, EmptyGroupDocsHolder<TGroupValue>.EMPTY_GROUPDOCS, float.NaN);
+                return new TopGroups<TGroupValue>(Arrays.Empty<SortField>(), Arrays.Empty<SortField>(), 0, 0, Arrays.Empty<GroupDocs<TGroupValue>>(), float.NaN);
             }
 
             int topNInsideGroup = groupDocsOffset + groupDocsLimit;

--- a/src/Lucene.Net.Queries/CustomScoreQuery.cs
+++ b/src/Lucene.Net.Queries/CustomScoreQuery.cs
@@ -43,27 +43,11 @@ namespace Lucene.Net.Queries
         private Query[] scoringQueries; // never null (empty array if there are no valSrcQueries).
         private bool strict = false; // if true, valueSource part of query does not take part in weights normalization.
 
-        // LUCENENET specific - optimized empty array creation
-        private static readonly FunctionQuery[] EMPTY_FUNCTION_QUERIES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<FunctionQuery>();
-#else
-            new FunctionQuery[0];
-#endif
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly Query[] EMPTY_QUERIES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<Query>();
-#else
-            new Query[0];
-#endif
-
         /// <summary>
         /// Create a <see cref="CustomScoreQuery"/> over input <paramref name="subQuery"/>. </summary>
         /// <param name="subQuery"> the sub query whose scored is being customized. Must not be <c>null</c>.  </param>
         public CustomScoreQuery(Query subQuery)
-            : this(subQuery, EMPTY_FUNCTION_QUERIES)
+            : this(subQuery, Arrays.Empty<FunctionQuery>())
         {
         }
 
@@ -73,7 +57,7 @@ namespace Lucene.Net.Queries
         /// <param name="scoringQuery"> a value source query whose scores are used in the custom score
         /// computation.  This parameter is optional - it can be null. </param>
         public CustomScoreQuery(Query subQuery, FunctionQuery scoringQuery)
-            : this(subQuery, scoringQuery != null ? new FunctionQuery[] { scoringQuery } : EMPTY_FUNCTION_QUERIES)
+            : this(subQuery, scoringQuery != null ? new FunctionQuery[] { scoringQuery } : Arrays.Empty<FunctionQuery>())
         // don't want an array that contains a single null..
         {
         }
@@ -86,7 +70,7 @@ namespace Lucene.Net.Queries
         public CustomScoreQuery(Query subQuery, params FunctionQuery[] scoringQueries)
         {
             this.subQuery = subQuery;
-            this.scoringQueries = scoringQueries != null ? scoringQueries : EMPTY_QUERIES;
+            this.scoringQueries = scoringQueries ?? Arrays.Empty<Query>();
             if (subQuery == null)
             {
                 throw new ArgumentException("<subquery> must not be null!");

--- a/src/Lucene.Net.Queries/TermsFilter.cs
+++ b/src/Lucene.Net.Queries/TermsFilter.cs
@@ -50,14 +50,6 @@ namespace Lucene.Net.Queries
         private readonly int hashCode; // cached hashcode for fast cache lookups
         private const int PRIME = 31;
 
-        // LUCENENET specific - optimized empty array creation
-        private static readonly byte[] EMPTY_BYTES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<byte>();
-#else
-            new byte[0];
-#endif
-
         /// <summary>
         /// Creates a new <see cref="TermsFilter"/> from the given list. The list
         /// can contain duplicate terms and multiple fields.
@@ -168,7 +160,7 @@ namespace Lucene.Net.Queries
             // an automaton an call intersect on the termsenum if the density is high
             
             int hash = 9;
-            var serializedTerms = EMPTY_BYTES;
+            var serializedTerms = Arrays.Empty<byte>();
             this.offsets = new int[length + 1];
             int lastEndOffset = 0;
             int index = 0;

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletionLookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletionLookup.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Store;
+using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
 using Lucene.Net.Util;
 using Lucene.Net.Util.Fst;
@@ -90,14 +91,6 @@ namespace Lucene.Net.Search.Suggest.Fst
         /// Number of entries the lookup was built with </summary>
         private long count = 0;
 
-        // LUCENENET specific - optimized empty array creation
-        private static readonly byte[] EMPTY_BYTES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<byte>();
-#else
-            new byte[0];
-#endif
-
 
         /// <summary>
         /// This constructor prepares for creating a suggested FST using the
@@ -167,7 +160,7 @@ namespace Lucene.Net.Search.Suggest.Fst
             count = 0;
             try
             {
-                byte[] buffer = EMPTY_BYTES;
+                byte[] buffer = Arrays.Empty<byte>();
                 ByteArrayDataOutput output = new ByteArrayDataOutput(buffer);
                 BytesRef spare;
                 while ((spare = iterator.Next()) != null)

--- a/src/Lucene.Net.Suggest/Suggest/SortedInputIterator.cs
+++ b/src/Lucene.Net.Suggest/Suggest/SortedInputIterator.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Store;
+using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
 using Lucene.Net.Util;
 using System;
@@ -46,14 +47,6 @@ namespace Lucene.Net.Search.Suggest
         private readonly BytesRef scratch = new BytesRef();
         private BytesRef payload = new BytesRef();
         private ISet<BytesRef> contexts = null;
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly byte[] EMPTY_BYTES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<byte>();
-#else
-            new byte[0];
-#endif
 
         /// <summary>
         /// Creates a new sorted wrapper, using <see cref="BytesRef.UTF8SortedAsUnicodeComparer"/>
@@ -199,7 +192,7 @@ namespace Lucene.Net.Search.Suggest
             try
             {
                 BytesRef spare;
-                byte[] buffer = EMPTY_BYTES;
+                byte[] buffer = Arrays.Empty<byte>();
                 var output = new ByteArrayDataOutput(buffer);
 
                 while ((spare = source.Next()) != null)

--- a/src/Lucene.Net.Suggest/Suggest/SortedTermFreqIteratorWrapper.cs
+++ b/src/Lucene.Net.Suggest/Suggest/SortedTermFreqIteratorWrapper.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Search.Spell;
 using Lucene.Net.Store;
+using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
 using Lucene.Net.Util;
 using System;
@@ -41,14 +42,6 @@ namespace Lucene.Net.Search.Suggest
 
         private long weight;
         private readonly BytesRef scratch = new BytesRef();
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly byte[] EMPTY_BYTES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<byte>();
-#else
-            new byte[0];
-#endif
 
         /// <summary>
         /// Creates a new sorted wrapper, using <see cref="BytesRef.UTF8SortedAsUnicodeComparer"/>
@@ -144,7 +137,7 @@ namespace Lucene.Net.Search.Suggest
             try
             {
                 BytesRef spare;
-                byte[] buffer = EMPTY_BYTES;
+                byte[] buffer = Arrays.Empty<byte>();
                 ByteArrayDataOutput output = new ByteArrayDataOutput(buffer);
 
                 while ((spare = source.Next()) != null)

--- a/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
@@ -877,6 +877,73 @@ namespace Lucene.Net.TestFramework
         }
 
 
+        //
+        // Summary:
+        //     Verifies that the object that is passed in is not equal to null If the object
+        //     is null then an NUnit.Framework.AssertionException is thrown.
+        //
+        // Parameters:
+        //   anObject:
+        //     The object that is to be tested
+        //
+        //   message:
+        //     The message to display in case of failure
+        //
+        //   args:
+        //     Array of objects to be used in formatting the message
+        public static void IsNotEmpty(string aString, string message, params object[] args)
+        {
+            if (string.Empty.Equals(aString))
+                _NUnit.Assert.IsNotEmpty(aString, message, args);
+        }
+        //
+        // Summary:
+        //     Verifies that the object that is passed in is not equal to null If the object
+        //     is null then an NUnit.Framework.AssertionException is thrown.
+        //
+        // Parameters:
+        //   anObject:
+        //     The object that is to be tested
+        public static void IsNotEmpty(string aString)
+        {
+            if (string.Empty.Equals(aString))
+                _NUnit.Assert.IsNotEmpty(aString);
+        }
+
+
+        //
+        // Summary:
+        //     Verifies that the object that is passed in is not equal to null If the object
+        //     is null then an NUnit.Framework.AssertionException is thrown.
+        //
+        // Parameters:
+        //   anObject:
+        //     The object that is to be tested
+        //
+        //   message:
+        //     The message to display in case of failure
+        //
+        //   args:
+        //     Array of objects to be used in formatting the message
+        public static void IsEmpty(string aString, string message, params object[] args)
+        {
+            if (!string.Empty.Equals(aString))
+                _NUnit.Assert.IsEmpty(aString, message, args);
+        }
+        //
+        // Summary:
+        //     Verifies that the object that is passed in is not equal to null If the object
+        //     is null then an NUnit.Framework.AssertionException is thrown.
+        //
+        // Parameters:
+        //   anObject:
+        //     The object that is to be tested
+        public static void IsEmpty(string aString)
+        {
+            if (!string.Empty.Equals(aString))
+                _NUnit.Assert.IsEmpty(aString);
+        }
+
         public static void LessOrEqual(int arg1, int arg2)
         {
             _NUnit.Assert.LessOrEqual(arg1, arg2);

--- a/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using _NUnit = NUnit.Framework;
 using JCG = J2N.Collections.Generic;
@@ -82,7 +81,7 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual<T>(T expected, T actual, string message, params object[] args)
         {
             if (!JCG.EqualityComparer<T>.Default.Equals(expected, actual))
-                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(expected, actual, message, args));
         }
 
         //
@@ -123,7 +122,7 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual(string expected, string actual, string message, params object[] args)
         {
             if (!StringComparer.Ordinal.Equals(expected, actual))
-                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(expected, actual, message, args));
         }
 
         //
@@ -166,7 +165,7 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual(bool expected, bool actual, string message, params object[] args)
         {
             if (!expected.Equals(actual))
-                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(expected, actual, message, args));
         }
 
         //
@@ -299,7 +298,7 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual(int expected, int actual, string message, params object[] args)
         {
             if (!expected.Equals(actual))
-                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(expected, actual, message, args));
         }
 
         //
@@ -340,7 +339,7 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual(long expected, long actual, string message, params object[] args)
         {
             if (!expected.Equals(actual))
-                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(expected, actual, message, args));
         }
 
         //
@@ -381,7 +380,7 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual(byte expected, byte actual, string message, params object[] args)
         {
             if (!expected.Equals(actual))
-                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(expected, actual, message, args));
         }
 
 
@@ -406,6 +405,13 @@ namespace Lucene.Net.TestFramework
                 : JCG.DictionaryEqualityComparer<TKey, TValue>.Default;
         }
 
+        private static string FormatErrorMessage(object expected, object actual, string message, params object[] args)
+        {
+            string failureHeader = string.Format(FailureFormat, expected, actual);
+            string msg = args == null || args.Length == 0 ? message : string.Format(message, args);
+            return string.Concat(failureHeader, Environment.NewLine, Environment.NewLine, msg);
+        }
+
         public static string FormatCollection(object collection)
         {
             return string.Format(StringFormatter.CurrentCulture, "{0}", collection);
@@ -419,14 +425,15 @@ namespace Lucene.Net.TestFramework
 
         public static void AreEqual<T>(ISet<T> expected, ISet<T> actual, bool aggressive, string message, params object[] args)
         {
+            //Fail(FormatErrorMessage(expected, actual, message, args));
             if (!GetSetComparer<T>(aggressive).Equals(expected, actual))
-                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(FormatCollection(expected), FormatCollection(actual), message, args));
         }
 
         public static void AreEqual<T>(ISet<T> expected, ISet<T> actual, bool aggressive, Func<string> getMessage)
         {
             if (!GetSetComparer<T>(aggressive).Equals(expected, actual))
-                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, getMessage()));
+                Fail(FormatErrorMessage(FormatCollection(expected), FormatCollection(actual), getMessage()));
         }
 
         public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive = true)
@@ -438,13 +445,13 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive, string message, params object[] args)
         {
             if (!GetListComparer<T>(aggressive).Equals(expected, actual))
-                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(FormatCollection(expected), FormatCollection(actual), message, args));
         }
 
         public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive, Func<string> getMessage)
         {
             if (!GetListComparer<T>(aggressive).Equals(expected, actual))
-                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, getMessage()));
+                Fail(FormatErrorMessage(FormatCollection(expected), FormatCollection(actual), getMessage()));
         }
 
         public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive = true)
@@ -456,13 +463,13 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive, string message, params object[] args)
         {
             if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
-                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(FormatCollection(expected), FormatCollection(actual), message, args));
         }
 
         public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive, Func<string> getMessage)
         {
             if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
-                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, getMessage()));
+                Fail(FormatErrorMessage(FormatCollection(expected), FormatCollection(actual), getMessage()));
         }
 
 
@@ -477,7 +484,14 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual<T>(T[] expected, T[] actual, string message, params object[] args)
         {
             if (!J2N.Collections.ArrayEqualityComparer<T>.OneDimensional.Equals(expected, actual))
-                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+                Fail(FormatErrorMessage(FormatCollection(expected), FormatCollection(actual), message, args));
+        }
+
+        // From CollectionAssert
+        public static void AreEqual<T>(T[] expected, T[] actual, Func<string> getMessage)
+        {
+            if (!J2N.Collections.ArrayEqualityComparer<T>.OneDimensional.Equals(expected, actual))
+                Fail(FormatErrorMessage(FormatCollection(expected), FormatCollection(actual), getMessage()));
         }
 
         //
@@ -790,7 +804,8 @@ namespace Lucene.Net.TestFramework
         //     The object that is to be tested
         public static void NotNull(object anObject)
         {
-            _NUnit.Assert.NotNull(anObject);
+            if (!(anObject is null))
+                _NUnit.Assert.NotNull(anObject);
         }
         //
         // Summary:
@@ -808,7 +823,8 @@ namespace Lucene.Net.TestFramework
         //     Array of objects to be used in formatting the message
         public static void NotNull(object anObject, string message, params object[] args)
         {
-            _NUnit.Assert.NotNull(anObject, message, args);
+            if (anObject is null)
+                _NUnit.Assert.NotNull(anObject, message, args);
         }
 
         //
@@ -827,7 +843,8 @@ namespace Lucene.Net.TestFramework
         //     Array of objects to be used in formatting the message
         public static void Null(object anObject, string message, params object[] args)
         {
-            _NUnit.Assert.Null(anObject, message, args);
+            if (!(anObject is null))
+                _NUnit.Assert.Null(anObject, message, args);
         }
         //
         // Summary:
@@ -839,7 +856,8 @@ namespace Lucene.Net.TestFramework
         //     The object that is to be tested
         public static void Null(object anObject)
         {
-            _NUnit.Assert.Null(anObject);
+            if (!(anObject is null))
+                _NUnit.Assert.Null(anObject);
         }
 
         //
@@ -946,12 +964,14 @@ namespace Lucene.Net.TestFramework
 
         public static void LessOrEqual(int arg1, int arg2)
         {
-            _NUnit.Assert.LessOrEqual(arg1, arg2);
+            if (arg1 > arg2)
+                _NUnit.Assert.LessOrEqual(arg1, arg2);
         }
 
         public static void Greater(int arg1, int arg2)
         {
-            _NUnit.Assert.Greater(arg1, arg2);
+            if (arg1 <= arg2)
+                _NUnit.Assert.Greater(arg1, arg2);
         }
 
         public static Exception Throws<TException>(Action action, string message, params object[] args)

--- a/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using _NUnit = NUnit.Framework;
 using JCG = J2N.Collections.Generic;
@@ -31,6 +32,8 @@ namespace Lucene.Net.TestFramework
     /// </summary>
     internal partial class Assert
     {
+        private const string FailureFormat = "Expected: {0}, Actual: {1}";
+
         //
         // Summary:
         //     We don't actually want any instances of this object, but some people like to
@@ -52,9 +55,10 @@ namespace Lucene.Net.TestFramework
         //
         //   actual:
         //     The actual value
-        public static void AreEqual(object expected, object actual)
+        public static void AreEqual<T>(T expected, T actual)
         {
-            _NUnit.Assert.AreEqual(expected, actual);
+            if (!JCG.EqualityComparer<T>.Default.Equals(expected, actual))
+                Fail(FailureFormat, expected, actual);
         }
         //
         // Summary:
@@ -75,10 +79,53 @@ namespace Lucene.Net.TestFramework
         //
         //   args:
         //     Array of objects to be used in formatting the message
-        public static void AreEqual(object expected, object actual, string message, params object[] args)
+        public static void AreEqual<T>(T expected, T actual, string message, params object[] args)
         {
-            _NUnit.Assert.AreEqual(expected, actual, message, args);
+            if (!JCG.EqualityComparer<T>.Default.Equals(expected, actual))
+                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
         }
+
+        //
+        // Summary:
+        //     Verifies that two objects are equal. Two objects are considered equal if both
+        //     are null, or if both have the same value. NUnit has special semantics for some
+        //     object types. If they are not equal an NUnit.Framework.AssertionException is
+        //     thrown.
+        //
+        // Parameters:
+        //   expected:
+        //     The value that is expected
+        //
+        //   actual:
+        //     The actual value
+        public static void AreEqual(string expected, string actual)
+        {
+            if (!StringComparer.Ordinal.Equals(expected, actual))
+                Fail(FailureFormat, expected, actual);
+        }
+
+        //
+        // Summary:
+        //     Verifies that two objects are equal. Two objects are considered equal if both
+        //     are null, or if both have the same value. NUnit has special semantics for some
+        //     object types. If they are not equal an NUnit.Framework.AssertionException is
+        //     thrown.
+        //
+        // Parameters:
+        //   expected:
+        //     The value that is expected
+        //
+        //   message:
+        //     The message to display in case of failure
+        //
+        //   actual:
+        //     The actual value
+        public static void AreEqual(string expected, string actual, string message, params object[] args)
+        {
+            if (!StringComparer.Ordinal.Equals(expected, actual))
+                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
+        }
+
         //
         // Summary:
         //     Verifies that two objects are equal. Two objects are considered equal if both
@@ -94,7 +141,8 @@ namespace Lucene.Net.TestFramework
         //     The actual value
         public static void AreEqual(bool expected, bool actual)
         {
-            _NUnit.Assert.IsTrue(expected.Equals(actual));
+            if (!expected.Equals(actual))
+                Fail(FailureFormat, expected, actual);
         }
         //
         // Summary:
@@ -117,8 +165,10 @@ namespace Lucene.Net.TestFramework
         //     Array of objects to be used in formatting the message
         public static void AreEqual(bool expected, bool actual, string message, params object[] args)
         {
-            _NUnit.Assert.IsTrue(expected.Equals(actual), message, args);
+            if (!expected.Equals(actual))
+                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
         }
+
         //
         // Summary:
         //     Verifies that two doubles are equal considering a delta. If the expected value
@@ -142,7 +192,8 @@ namespace Lucene.Net.TestFramework
         //     Array of objects to be used in formatting the message
         public static void AreEqual(double expected, double actual, double delta, string message, params object[] args)
         {
-            _NUnit.Assert.AreEqual(expected, actual, delta, message, args);
+            if (Math.Abs(expected - actual) > delta)
+                _NUnit.Assert.AreEqual(expected, actual, delta, message, args);
         }
         //
         // Summary:
@@ -161,7 +212,8 @@ namespace Lucene.Net.TestFramework
         //     The maximum acceptable difference between the the expected and the actual
         public static void AreEqual(double expected, double actual, double delta)
         {
-            _NUnit.Assert.AreEqual(expected, actual, delta);
+            if (Math.Abs(expected - actual) > delta)
+                _NUnit.Assert.AreEqual(expected, actual, delta);
         }
         //
         // Summary:
@@ -187,9 +239,7 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual(float expected, float actual, float delta, string message, params object[] args)
         {
             if (Math.Abs(expected - actual) > delta)
-            {
                 _NUnit.Assert.AreEqual(expected, actual, delta, message, args);
-            }
         }
         //
         // Summary:
@@ -209,9 +259,7 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual(float expected, float actual, float delta)
         {
             if (Math.Abs(expected - actual) > delta)
-            {
                 _NUnit.Assert.AreEqual(expected, actual, delta);
-            }
         }
         //
         // Summary:
@@ -228,7 +276,8 @@ namespace Lucene.Net.TestFramework
         //     The actual value
         public static void AreEqual(int expected, int actual)
         {
-            _NUnit.Assert.True(expected.Equals(actual));
+            if (!expected.Equals(actual))
+                Fail(FailureFormat, expected, actual);
         }
 
         //
@@ -247,9 +296,10 @@ namespace Lucene.Net.TestFramework
         //
         //   actual:
         //     The actual value
-        public static void AreEqual(int expected, int actual, string message)
+        public static void AreEqual(int expected, int actual, string message, params object[] args)
         {
-            _NUnit.Assert.True(expected.Equals(actual), message);
+            if (!expected.Equals(actual))
+                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
         }
 
         //
@@ -267,7 +317,8 @@ namespace Lucene.Net.TestFramework
         //     The actual value
         public static void AreEqual(long expected, long actual)
         {
-            _NUnit.Assert.True(expected.Equals(actual));
+            if (!expected.Equals(actual))
+                Fail(FailureFormat, expected, actual);
         }
 
         //
@@ -286,9 +337,10 @@ namespace Lucene.Net.TestFramework
         //
         //   actual:
         //     The actual value
-        public static void AreEqual(long expected, long actual, string message)
+        public static void AreEqual(long expected, long actual, string message, params object[] args)
         {
-            _NUnit.Assert.True(expected.Equals(actual), message);
+            if (!expected.Equals(actual))
+                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
         }
 
         //
@@ -306,7 +358,8 @@ namespace Lucene.Net.TestFramework
         //     The actual value
         public static void AreEqual(byte expected, byte actual)
         {
-            _NUnit.Assert.True(expected.Equals(actual));
+            if (!expected.Equals(actual))
+                Fail(FailureFormat, expected, actual);
         }
 
         //
@@ -325,9 +378,10 @@ namespace Lucene.Net.TestFramework
         //
         //   actual:
         //     The actual value
-        public static void AreEqual(byte expected, byte actual, string message)
+        public static void AreEqual(byte expected, byte actual, string message, params object[] args)
         {
-            _NUnit.Assert.True(expected.Equals(actual), message);
+            if (!expected.Equals(actual))
+                Fail(string.Concat(string.Format(FailureFormat, expected, actual), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
         }
 
 
@@ -360,74 +414,55 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual<T>(ISet<T> expected, ISet<T> actual, bool aggressive = true)
         {
             if (!GetSetComparer<T>(aggressive).Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail("Expected: '{0}', Actual: '{1}'", FormatCollection(expected), FormatCollection(actual));
-            }
+                Fail(FailureFormat, FormatCollection(expected), FormatCollection(actual));
         }
 
         public static void AreEqual<T>(ISet<T> expected, ISet<T> actual, bool aggressive, string message, params object[] args)
         {
             if (!GetSetComparer<T>(aggressive).Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail(message, args);
-            }
+                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
         }
 
         public static void AreEqual<T>(ISet<T> expected, ISet<T> actual, bool aggressive, Func<string> getMessage)
         {
             if (!GetSetComparer<T>(aggressive).Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail(getMessage());
-            }
+                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, getMessage()));
         }
 
         public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive = true)
         {
             if (!GetListComparer<T>(aggressive).Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail("Expected: '{0}', Actual: '{1}'", FormatCollection(expected), FormatCollection(actual));
-            }
-
+                Fail(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)));
         }
 
         public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive, string message, params object[] args)
         {
             if (!GetListComparer<T>(aggressive).Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail(message, args);
-            }
+                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
         }
 
         public static void AreEqual<T>(IList<T> expected, IList<T> actual, bool aggressive, Func<string> getMessage)
         {
             if (!GetListComparer<T>(aggressive).Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail(getMessage());
-            }
+                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, getMessage()));
         }
 
         public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive = true)
         {
             if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail("Expected: '{0}', Actual: '{1}'", FormatCollection(expected), FormatCollection(actual));
-            }
+                Fail(FailureFormat, FormatCollection(expected), FormatCollection(actual));
         } 
 
         public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive, string message, params object[] args)
         {
             if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail(message, args);
-            }
+                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
         }
 
         public static void AreEqual<TKey, TValue>(IDictionary<TKey, TValue> expected, IDictionary<TKey, TValue> actual, bool aggressive, Func<string> getMessage)
         {
             if (!GetDictionaryComparer<TKey, TValue>(aggressive).Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail(getMessage());
-            }
+                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, getMessage()));
         }
 
 
@@ -435,18 +470,14 @@ namespace Lucene.Net.TestFramework
         public static void AreEqual<T>(T[] expected, T[] actual)
         {
             if (!J2N.Collections.ArrayEqualityComparer<T>.OneDimensional.Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail("Expected: '{0}', Actual: '{1}'", FormatCollection(expected), FormatCollection(actual));
-            }
+                Fail(FailureFormat, FormatCollection(expected), FormatCollection(actual));
         }
 
         // From CollectionAssert
         public static void AreEqual<T>(T[] expected, T[] actual, string message, params object[] args)
         {
             if (!J2N.Collections.ArrayEqualityComparer<T>.OneDimensional.Equals(expected, actual))
-            {
-                _NUnit.Assert.Fail(message, args);
-            }
+                Fail(string.Concat(string.Format(FailureFormat, FormatCollection(expected), FormatCollection(actual)), Environment.NewLine, Environment.NewLine, string.Format(message, args)));
         }
 
         //
@@ -603,7 +634,8 @@ namespace Lucene.Net.TestFramework
         //     Array of objects to be used in formatting the message
         public static void False(bool condition, string message, params object[] args)
         {
-            _NUnit.Assert.False(condition, message, args);
+            if (condition)
+                _NUnit.Assert.Fail(message, args);
         }
         //
         // Summary:
@@ -615,7 +647,8 @@ namespace Lucene.Net.TestFramework
         //     The evaluated condition
         public static void False(bool condition)
         {
-            _NUnit.Assert.False(condition);
+            if (condition)
+                _NUnit.Assert.Fail("Expected: False  Actual: True");
         }
 
         //
@@ -628,7 +661,8 @@ namespace Lucene.Net.TestFramework
         //     The evaluated condition
         public static void IsFalse(bool condition)
         {
-            _NUnit.Assert.IsFalse(condition);
+            if (condition)
+                _NUnit.Assert.Fail("Expected: False  Actual: True");
         }
 
         //
@@ -647,7 +681,8 @@ namespace Lucene.Net.TestFramework
         //     Array of objects to be used in formatting the message
         public static void IsFalse(bool condition, string message, params object[] args)
         {
-            _NUnit.Assert.IsFalse(condition, message, args);
+            if (condition)
+                _NUnit.Assert.Fail(message, args);
         }
 
         //
@@ -727,7 +762,8 @@ namespace Lucene.Net.TestFramework
         //     Array of objects to be used in formatting the message
         public static void IsTrue(bool condition, string message, params object[] args)
         {
-            _NUnit.Assert.IsTrue(condition, message, args);
+            if (!condition)
+                _NUnit.Assert.Fail(message, args);
         }
 
         //
@@ -740,7 +776,8 @@ namespace Lucene.Net.TestFramework
         //     The evaluated condition
         public static void IsTrue(bool condition)
         {
-            _NUnit.Assert.IsTrue(condition);
+            if (!condition)
+                _NUnit.Assert.Fail("Expected: True  Actual: False");
         }
 
         //
@@ -821,7 +858,8 @@ namespace Lucene.Net.TestFramework
         //     Array of objects to be used in formatting the message
         public static void True(bool condition, string message, params object[] args)
         {
-            _NUnit.Assert.True(condition, message, args);
+            if (!condition)
+                _NUnit.Assert.Fail(message, args);
         }
 
         //
@@ -834,7 +872,8 @@ namespace Lucene.Net.TestFramework
         //     The evaluated condition
         public static void True(bool condition)
         {
-            _NUnit.Assert.True(condition);
+            if (!condition)
+                _NUnit.Assert.Fail("Expected: True  Actual: False");
         }
 
 
@@ -848,7 +887,7 @@ namespace Lucene.Net.TestFramework
             _NUnit.Assert.Greater(arg1, arg2);
         }
 
-        public static Exception Throws<TException>(Action action, string message, params string[] args)
+        public static Exception Throws<TException>(Action action, string message, params object[] args)
         {
             return Throws(typeof(TException), action, message, args);
         }
@@ -863,7 +902,7 @@ namespace Lucene.Net.TestFramework
             return _NUnit.Assert.Throws(expectedExceptionType, () => action());
         }
 
-        public static Exception Throws(Type expectedExceptionType, Action action, string message, params string[] args)
+        public static Exception Throws(Type expectedExceptionType, Action action, string message, params object[] args)
         {
             return _NUnit.Assert.Throws(expectedExceptionType, () => action(), message, args);
         }

--- a/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
@@ -3496,7 +3496,7 @@ namespace Lucene.Net.Index
                 {
                     Document doc = new Document();
                     Field idField = new StringField("id", "", Field.Store.NO);
-                    Field storedBinField = new StoredField("storedBin", EMPTY_BYTES);
+                    Field storedBinField = new StoredField("storedBin", Arrays.Empty<byte>());
                     Field dvBinField = new BinaryDocValuesField("dvBin", new BytesRef());
                     Field dvSortedField = new SortedDocValuesField("dvSorted", new BytesRef());
                     Field storedNumericField = new StoredField("storedNum", "");
@@ -3621,7 +3621,7 @@ namespace Lucene.Net.Index
                 using (RandomIndexWriter writer = new RandomIndexWriter(Random, dir, conf))
                 {
                     Field idField = new StringField("id", "", Field.Store.NO);
-                    Field storedBinField = new StoredField("storedBin", EMPTY_BYTES);
+                    Field storedBinField = new StoredField("storedBin", Arrays.Empty<byte>());
                     Field dvBinField = new BinaryDocValuesField("dvBin", new BytesRef());
                     Field dvSortedField = new SortedDocValuesField("dvSorted", new BytesRef());
                     Field storedNumericField = new StoredField("storedNum", "");

--- a/src/Lucene.Net.TestFramework/Index/BaseIndexFileFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseIndexFileFormatTestCase.cs
@@ -5,7 +5,6 @@ using Lucene.Net.Index.Extensions;
 using Lucene.Net.Store;
 using Lucene.Net.TestFramework;
 using Lucene.Net.Util;
-using System;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
 
@@ -56,14 +55,6 @@ namespace Lucene.Net.Index
         // because it has public subclasses. So we are creating an internal constructor instead.
         internal BaseIndexFileFormatTestCase() { }
 #endif
-        // LUCENENET specific - optimized empty array creation
-        internal static readonly byte[] EMPTY_BYTES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<byte>();
-#else
-            new byte[0];
-#endif
-
 
         /// <summary>
         /// Returns the codec to run tests against </summary>

--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -763,7 +763,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestLotsOfFields()
         {
-            RandomDocumentFactory docFactory = new RandomDocumentFactory(this, 500, 10);
+            RandomDocumentFactory docFactory = new RandomDocumentFactory(this, 5000, 10);
             foreach (Options options in ValidOptions())
             {
                 using (Directory dir = NewDirectory())

--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -126,6 +126,7 @@
     <InternalsVisibleTo Include="Lucene.Net.Tests.Spatial" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.Suggest" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.TestFramework" />
+    <InternalsVisibleTo Include="Lucene.Net.Tests.TestFramework.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.TestFramework/Support/ApiScanTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Support/ApiScanTestBase.cs
@@ -138,10 +138,15 @@ namespace Lucene.Net.Util
                 "Private field names should be camelCase.");
         }
 
-        //[Test, LuceneNetSpecific]
         public virtual void TestPublicFields(Type typeFromTargetAssembly)
         {
-            var names = GetInvalidPublicFields(typeFromTargetAssembly.Assembly);
+            TestPublicFields(typeFromTargetAssembly, null);
+        }
+
+        //[Test, LuceneNetSpecific]
+        public virtual void TestPublicFields(Type typeFromTargetAssembly, string exceptionRegex)
+        {
+            var names = GetInvalidPublicFields(typeFromTargetAssembly.Assembly, exceptionRegex);
 
             //if (VERBOSE)
             //{
@@ -433,11 +438,6 @@ namespace Lucene.Net.Util
                     if ((field.IsPrivate || field.IsAssembly) && !PrivateFieldName.IsMatch(field.Name) && field.DeclaringType.Equals(c.UnderlyingSystemType))
                     {
                         var name = string.Concat(c.FullName, ".", field.Name);
-                        //bool hasExceptions = !string.IsNullOrWhiteSpace(exceptionRegex);
-                        //if (!hasExceptions || (hasExceptions && !Regex.IsMatch(name, exceptionRegex)))
-                        //{
-                        //    result.Add(name);
-                        //}
                         if (!IsException(name, exceptionRegex))
                         {
                             result.Add(name);
@@ -495,7 +495,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="assembly"></param>
         /// <returns></returns>
-        private static IEnumerable<string> GetInvalidPublicFields(Assembly assembly)
+        private static IEnumerable<string> GetInvalidPublicFields(Assembly assembly, string exceptionRegex)
         {
             var result = new List<string>();
 
@@ -529,7 +529,11 @@ namespace Lucene.Net.Util
 
                     if (field.IsPublic && field.DeclaringType.Equals(c.UnderlyingSystemType))
                     {
-                        result.Add(string.Concat(c.FullName, ".", field.Name));
+                        var name = string.Concat(c.FullName, ".", field.Name);
+                        if (!IsException(name, exceptionRegex))
+                        {
+                            result.Add(name);
+                        }
                     }
                 }
             }

--- a/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
@@ -223,6 +223,16 @@ namespace Lucene.Net.Util
             Assert.AreEqual(a1, a2);
         }
 
+        internal static void assertArrayEquals<T>(string message, T[] a1, T[] a2)
+        {
+            Assert.AreEqual(a1, a2, message);
+        }
+
+        internal static void assertArrayEquals<T>(Func<string> getMessage, T[] a1, T[] a2)
+        {
+            Assert.AreEqual(a1, a2, getMessage());
+        }
+
         internal static void assertSame(object expected, object actual)
         {
             Assert.AreSame(expected, actual);

--- a/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
@@ -68,12 +68,22 @@ namespace Lucene.Net.Util
             Assert.IsFalse(condition, message);
         }
 
-        internal static void assertEquals(object expected, object actual)
+        internal static void assertEquals<T>(T expected, T actual)
         {
             Assert.AreEqual(expected, actual);
         }
 
-        internal static void assertEquals(string message, object expected, object actual)
+        internal static void assertEquals<T>(string message, T expected, T actual)
+        {
+            Assert.AreEqual(expected, actual, message);
+        }
+
+        internal static void assertEquals(string expected, string actual)
+        {
+            Assert.AreEqual(expected, actual);
+        }
+
+        internal static void assertEquals(string message, string expected, string actual)
         {
             Assert.AreEqual(expected, actual, message);
         }
@@ -213,12 +223,12 @@ namespace Lucene.Net.Util
             Assert.AreEqual(a1, a2);
         }
 
-        internal static void assertSame(Object expected, Object actual)
+        internal static void assertSame(object expected, object actual)
         {
             Assert.AreSame(expected, actual);
         }
 
-        internal static void assertSame(string message, Object expected, Object actual)
+        internal static void assertSame(string message, object expected, object actual)
         {
             Assert.AreSame(expected, actual, message);
         }

--- a/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
+++ b/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
@@ -822,7 +822,9 @@ namespace Lucene.Net.Util.Fst
             //System.out.println("TEST: tally prefixes");
 
             // build all prefixes
-            IDictionary<Int32sRef, CountMinOutput<T>> prefixes = new JCG.Dictionary<Int32sRef, CountMinOutput<T>>();
+
+            // LUCENENET: We don't want to use a J2N dictionary here because of performance
+            IDictionary<Int32sRef, CountMinOutput<T>> prefixes = new Dictionary<Int32sRef, CountMinOutput<T>>();
             Int32sRef scratch = new Int32sRef(10);
             foreach (InputOutput<T> pair in pairs)
             {

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -1,3 +1,5 @@
+using J2N;
+using J2N.IO;
 using J2N.Text;
 using Lucene.Net.Codecs;
 using Lucene.Net.Codecs.Lucene46;
@@ -68,11 +70,11 @@ namespace Lucene.Net.Util
                 StringBuilder b = new StringBuilder("Could not remove the following files (in the order of attempts):\n");
                 foreach (var f in unremoved)
                 {
-                    b.append("   ")
-                     .append(f.FullName)
-                     .append("\n");
+                    b.Append("   ")
+                     .Append(f.FullName)
+                     .Append("\n");
                 }
-                throw new IOException(b.toString());
+                throw new IOException(b.ToString());
             }
         }
 
@@ -362,7 +364,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public static string RandomSimpleString(Random r)
         {
-            return RandomSimpleString(r, 0, 20);
+            return RandomSimpleString(r, 0, 10);
         }
 
         /// <summary>
@@ -714,7 +716,7 @@ namespace Lucene.Net.Util
                 string toRecase;
 
                 // check if the next char sequence is a surrogate pair
-                if (pos + 1 < str.Length && char.IsSurrogatePair(str[pos], str[pos+1]))
+                if (pos + 1 < str.Length && char.IsSurrogatePair(str[pos], str[pos + 1]))
                 {
                     toRecase = str.Substring(pos, 2);
                 }
@@ -885,7 +887,7 @@ namespace Lucene.Net.Util
 
         private class Lucene46CodecAnonymousInnerClassHelper : Lucene46Codec
         {
-            private PostingsFormat format;
+            private readonly PostingsFormat format;
 
             public Lucene46CodecAnonymousInnerClassHelper(PostingsFormat format)
             {
@@ -917,7 +919,7 @@ namespace Lucene.Net.Util
 
         private class Lucene46CodecAnonymousInnerClassHelper2 : Lucene46Codec
         {
-            private DocValuesFormat format;
+            private readonly DocValuesFormat format;
 
             public Lucene46CodecAnonymousInnerClassHelper2(DocValuesFormat format)
             {
@@ -1031,15 +1033,12 @@ namespace Lucene.Net.Util
         {
             IDictionary<string, object> map = new JCG.Dictionary<string, object>();
             att.ReflectWith(new AttributeReflectorAnonymousInnerClassHelper(map));
-            IDictionary<string, object> newReflectedObjects = new JCG.Dictionary<string, object>();
-            foreach (KeyValuePair<string, object> de in reflectedValues)
-                newReflectedObjects.Add(de.Key, (object)de.Value);
-            Assert.AreEqual(newReflectedObjects, map, aggressive: false, "Reflection does not produce same map");
+            Assert.AreEqual(reflectedValues, map, aggressive: false, "Reflection does not produce same map");
         }
 
         private class AttributeReflectorAnonymousInnerClassHelper : IAttributeReflector
         {
-            private IDictionary<string, object> map;
+            private readonly IDictionary<string, object> map;
 
             public AttributeReflectorAnonymousInnerClassHelper(IDictionary<string, object> map)
             {
@@ -1222,8 +1221,8 @@ namespace Lucene.Net.Util
                     CharsRef chars = new CharsRef(@ref.Length);
                     UnicodeUtil.UTF8toUTF16(@ref.Bytes, @ref.Offset, @ref.Length, chars);
                     return chars;
-                //case 3: // LUCENENET: Not ported
-                //    return CharBuffer.Wrap(@ref.Utf8ToString());
+                case 3:
+                    return CharBuffer.Wrap(@ref.Utf8ToString());
                 default:
                     return new StringCharSequence(@ref.Utf8ToString());
             }
@@ -1308,10 +1307,6 @@ namespace Lucene.Net.Util
 
         private class RandomAccessFilterStrategyAnonymousInnerClassHelper : FilteredQuery.RandomAccessFilterStrategy
         {
-            public RandomAccessFilterStrategyAnonymousInnerClassHelper()
-            {
-            }
-
             protected override bool UseRandomAccess(IBits bits, int firstFilterDoc)
             {
                 return LuceneTestCase.Random.NextBoolean();

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/StemmerTestBase.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/StemmerTestBase.cs
@@ -83,9 +83,8 @@ namespace Lucene.Net.Analysis.Hunspell
             }
             Array.Sort(actual);
 
-            // LUCENENET: Originally, the code was as follows, but it failed to properly compare the arrays.
-            //assertArrayEquals("expected=" + Arrays.ToString(expected) + ",actual=" + Arrays.ToString(actual), expected, actual);
-            Assert.AreEqual(expected, actual, "expected=" + Arrays.ToString(expected) + ",actual=" + Arrays.ToString(actual));
+            // LUCENENET: Use delegate to build the string so we don't have the expensive operation unless there is a failure
+            assertArrayEquals(() => "expected=" + Arrays.ToString(expected) + ",actual=" + Arrays.ToString(actual), expected, actual);
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Shingle/ShingleFilterTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Shingle/ShingleFilterTest.cs
@@ -510,24 +510,12 @@ namespace Lucene.Net.Analysis.Shingle
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly ShingleFilterTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(ShingleFilterTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new ShingleFilter(tokenizer));
-            }
+            });
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
 
         /// <summary>
@@ -536,47 +524,23 @@ namespace Lucene.Net.Analysis.Shingle
         public virtual void TestRandomHugeStrings()
         {
             Random random = Random;
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckRandomData(random, a, 100 * RandomMultiplier, 8192);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly ShingleFilterTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(ShingleFilterTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new ShingleFilter(tokenizer));
-            }
+            });
+            CheckRandomData(random, a, 100 * RandomMultiplier, 8192);
         }
 
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly ShingleFilterTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(ShingleFilterTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new ShingleFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Collation/TestCollationKeyFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Collation/TestCollationKeyFilterFactory.cs
@@ -8,6 +8,7 @@ using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Collation
 {

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPSentenceBreakIterator.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPSentenceBreakIterator.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Analysis.Util;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
+//using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Analysis.OpenNlp
 {

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/Language/Bm/LanguageGuessingTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/Language/Bm/LanguageGuessingTest.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 {

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/Language/Caverphone1Test.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/Language/Caverphone1Test.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Analysis.Phonetic.Language
 {

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/Language/Caverphone2Test .cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/Language/Caverphone2Test .cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Analysis.Phonetic.Language
 {

--- a/src/Lucene.Net.Tests.Benchmark/Support/TestEnglishNumberFormatExtensions.cs
+++ b/src/Lucene.Net.Tests.Benchmark/Support/TestEnglishNumberFormatExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Attributes;
 using Lucene.Net.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Support
 {

--- a/src/Lucene.Net.Tests.Classification/ClassificationTestBase.cs
+++ b/src/Lucene.Net.Tests.Classification/ClassificationTestBase.cs
@@ -1,34 +1,33 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 using System;
 using System.Diagnostics;
 using System.Text;
 using Lucene.Net.Analysis;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
-using Lucene.Net.Randomized.Generators;
 using Lucene.Net.Search;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Classification
 {
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
 
     /**
      * Base class for testing <see cref="IClassifier{T}"/>s

--- a/src/Lucene.Net.Tests.Classification/Utils/DataSplitterTest.cs
+++ b/src/Lucene.Net.Tests.Classification/Utils/DataSplitterTest.cs
@@ -1,21 +1,3 @@
-
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 using System;
 using System.Text;
 using Lucene.Net.Analysis;
@@ -24,9 +6,27 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Classification
 {
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
     /**
      * Testcase for <see cref="DatasetSplitter"/>
      */

--- a/src/Lucene.Net.Tests.Expressions/JS/TestCustomFunctions.cs
+++ b/src/Lucene.Net.Tests.Expressions/JS/TestCustomFunctions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Expressions.JS
 {

--- a/src/Lucene.Net.Tests.Expressions/JS/TestJavascriptCompiler.cs
+++ b/src/Lucene.Net.Tests.Expressions/JS/TestJavascriptCompiler.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Expressions.JS
 {

--- a/src/Lucene.Net.Tests.Expressions/JS/TestJavascriptFunction.cs
+++ b/src/Lucene.Net.Tests.Expressions/JS/TestJavascriptFunction.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.Globalization;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Expressions.JS
 {

--- a/src/Lucene.Net.Tests.Expressions/JS/TestJavascriptOperations.cs
+++ b/src/Lucene.Net.Tests.Expressions/JS/TestJavascriptOperations.cs
@@ -1,5 +1,6 @@
 using Lucene.Net.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Expressions.JS
 {

--- a/src/Lucene.Net.Tests.Expressions/TestDemoExpressions.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestDemoExpressions.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Expressions
 {

--- a/src/Lucene.Net.Tests.Expressions/TestExpressionRescorer.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestExpressionRescorer.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Search;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Expressions
 {

--- a/src/Lucene.Net.Tests.Expressions/TestExpressionSortField.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestExpressionSortField.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Expressions.JS;
 using Lucene.Net.Search;
 using Lucene.Net.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Expressions
 {

--- a/src/Lucene.Net.Tests.Expressions/TestExpressionValidation.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestExpressionValidation.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Search;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Expressions
 {

--- a/src/Lucene.Net.Tests.Expressions/TestExpressionValueSource.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestExpressionValueSource.cs
@@ -9,6 +9,7 @@ using Lucene.Net.Store;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Expressions
 {
@@ -95,7 +96,7 @@ namespace Lucene.Net.Expressions
             Assert.AreEqual(10, values.Int64Val(0));
             Assert.AreEqual(10, values.Int32Val(0));
             Assert.AreEqual(10, values.Int16Val(0));
-            Assert.AreEqual(10, values.ByteVal(0));
+            Assert.AreEqual((byte)10, values.ByteVal(0));
             Assert.AreEqual("10", values.StrVal(0));
             Assert.AreEqual(System.Convert.ToDouble(10), values.ObjectVal(0));
             Assert.AreEqual(40, values.DoubleVal(1), 0);
@@ -103,7 +104,7 @@ namespace Lucene.Net.Expressions
             Assert.AreEqual(40, values.Int64Val(1));
             Assert.AreEqual(40, values.Int32Val(1));
             Assert.AreEqual(40, values.Int16Val(1));
-            Assert.AreEqual(40, values.ByteVal(1));
+            Assert.AreEqual((byte)40, values.ByteVal(1));
             Assert.AreEqual("40", values.StrVal(1));
             Assert.AreEqual(System.Convert.ToDouble(40), values.ObjectVal(1));
             Assert.AreEqual(4, values.DoubleVal(2), 0);
@@ -111,7 +112,7 @@ namespace Lucene.Net.Expressions
             Assert.AreEqual(4, values.Int64Val(2));
             Assert.AreEqual(4, values.Int32Val(2));
             Assert.AreEqual(4, values.Int16Val(2));
-            Assert.AreEqual(4, values.ByteVal(2));
+            Assert.AreEqual((byte)4, values.ByteVal(2));
             Assert.AreEqual("4", values.StrVal(2));
             Assert.AreEqual(System.Convert.ToDouble(4), values.ObjectVal(2));
         }

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
@@ -683,7 +683,7 @@ namespace Lucene.Net.Facet.Taxonomy
             Facets facets = GetTaxonomyFacetCounts(taxoReader, config, sfc);
             IList<FacetResult> res1 = facets.GetAllDims(10);
             IList<FacetResult> res2 = facets.GetAllDims(10);
-            Assert.AreEqual(res1, res2, "calling getFacetResults twice should return the .equals()=true result");
+            Assert.AreEqual(res1, res2, aggressive: false, "calling getFacetResults twice should return the .equals()=true result");
 
             IOUtils.Dispose(taxoWriter, iw, taxoReader, taxoDir, r, indexDir);
         }

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
@@ -297,13 +297,13 @@ namespace Lucene.Net.Facet.Taxonomy
             Assert.AreEqual(-1, (int)result.Value);
             foreach (LabelAndValue labelValue in result.LabelValues)
             {
-                Assert.AreEqual(termExpectedCounts[CP_A + "/" + labelValue.Label], labelValue.Value);
+                Assert.AreEqual(termExpectedCounts[CP_A + "/" + labelValue.Label].GetValueOrDefault(), labelValue.Value);
             }
             result = facets.GetTopChildren(NUM_CHILDREN_CP_B, CP_B);
-            Assert.AreEqual(termExpectedCounts[CP_B], result.Value);
+            Assert.AreEqual(termExpectedCounts[CP_B].GetValueOrDefault(), result.Value);
             foreach (LabelAndValue labelValue in result.LabelValues)
             {
-                Assert.AreEqual(termExpectedCounts[CP_B + "/" + labelValue.Label], labelValue.Value);
+                Assert.AreEqual(termExpectedCounts[CP_B + "/" + labelValue.Label].GetValueOrDefault(), labelValue.Value);
             }
 
             IOUtils.Dispose(indexReader, taxoReader);
@@ -326,17 +326,17 @@ namespace Lucene.Net.Facet.Taxonomy
             int prevValue = int.MaxValue;
             foreach (LabelAndValue labelValue in result.LabelValues)
             {
-                Assert.AreEqual(allExpectedCounts[CP_A + "/" + labelValue.Label], labelValue.Value);
+                Assert.AreEqual(allExpectedCounts[CP_A + "/" + labelValue.Label].GetValueOrDefault(), labelValue.Value);
                 Assert.True((int)labelValue.Value <= prevValue, "wrong sort order of sub results: labelValue.value=" + labelValue.Value + " prevValue=" + prevValue);
                 prevValue = (int)labelValue.Value;
             }
 
             result = facets.GetTopChildren(NUM_CHILDREN_CP_B, CP_B);
-            Assert.AreEqual(allExpectedCounts[CP_B], result.Value);
+            Assert.AreEqual(allExpectedCounts[CP_B].GetValueOrDefault(), result.Value);
             prevValue = int.MaxValue;
             foreach (LabelAndValue labelValue in result.LabelValues)
             {
-                Assert.AreEqual(allExpectedCounts[CP_B + "/" + labelValue.Label], labelValue.Value);
+                Assert.AreEqual(allExpectedCounts[CP_B + "/" + labelValue.Label].GetValueOrDefault(), labelValue.Value);
                 Assert.True((int)labelValue.Value <= prevValue, "wrong sort order of sub results: labelValue.value=" + labelValue.Value + " prevValue=" + prevValue);
                 prevValue = (int)labelValue.Value;
             }
@@ -360,13 +360,13 @@ namespace Lucene.Net.Facet.Taxonomy
             Assert.AreEqual(-1, (int)result.Value);
             foreach (LabelAndValue labelValue in result.LabelValues)
             {
-                Assert.AreEqual(allExpectedCounts[CP_A + "/" + labelValue.Label], labelValue.Value);
+                Assert.AreEqual(allExpectedCounts[CP_A + "/" + labelValue.Label].GetValueOrDefault(), labelValue.Value);
             }
             result = facets.GetTopChildren(int.MaxValue, CP_B);
-            Assert.AreEqual(allExpectedCounts[CP_B], result.Value);
+            Assert.AreEqual(allExpectedCounts[CP_B].GetValueOrDefault(), result.Value);
             foreach (LabelAndValue labelValue in result.LabelValues)
             {
-                Assert.AreEqual(allExpectedCounts[CP_B + "/" + labelValue.Label], labelValue.Value);
+                Assert.AreEqual(allExpectedCounts[CP_B + "/" + labelValue.Label].GetValueOrDefault(), labelValue.Value);
             }
 
             IOUtils.Dispose(indexReader, taxoReader);
@@ -385,16 +385,16 @@ namespace Lucene.Net.Facet.Taxonomy
             Facets facets = GetTaxonomyFacetCounts(taxoReader, Config, sfc);
 
             FacetResult result = facets.GetTopChildren(NUM_CHILDREN_CP_C, CP_C);
-            Assert.AreEqual(allExpectedCounts[CP_C], result.Value);
+            Assert.AreEqual(allExpectedCounts[CP_C].GetValueOrDefault(), result.Value);
             foreach (LabelAndValue labelValue in result.LabelValues)
             {
-                Assert.AreEqual(allExpectedCounts[CP_C + "/" + labelValue.Label], labelValue.Value);
+                Assert.AreEqual(allExpectedCounts[CP_C + "/" + labelValue.Label].GetValueOrDefault(), labelValue.Value);
             }
             result = facets.GetTopChildren(NUM_CHILDREN_CP_D, CP_D);
-            Assert.AreEqual(allExpectedCounts[CP_C], result.Value);
+            Assert.AreEqual(allExpectedCounts[CP_C].GetValueOrDefault(), result.Value);
             foreach (LabelAndValue labelValue in result.LabelValues)
             {
-                Assert.AreEqual(allExpectedCounts[CP_D + "/" + labelValue.Label], labelValue.Value);
+                Assert.AreEqual(allExpectedCounts[CP_D + "/" + labelValue.Label].GetValueOrDefault(), labelValue.Value);
             }
 
             IOUtils.Dispose(indexReader, taxoReader);

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -8,7 +9,6 @@ using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Facet.Taxonomy
 {
-
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
      * contributor license agreements.  See the NOTICE file distributed with
@@ -27,7 +27,6 @@ namespace Lucene.Net.Facet.Taxonomy
      */
 
 
-    using NUnit.Framework;
     using AtomicReaderContext = Lucene.Net.Index.AtomicReaderContext;
     using ConstantScoreQuery = Lucene.Net.Search.ConstantScoreQuery;
     using DirectoryReader = Lucene.Net.Index.DirectoryReader;
@@ -59,6 +58,7 @@ namespace Lucene.Net.Facet.Taxonomy
     using TestUtil = Lucene.Net.Util.TestUtil;
     using TopDocs = Lucene.Net.Search.TopDocs;
     using ValueSource = Lucene.Net.Queries.Function.ValueSource;
+
     [TestFixture]
     public class TestTaxonomyFacetSumValueSource : FacetTestCase
     {

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
@@ -26,7 +26,6 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
     public class TestCharBlockArray : FacetTestCase
     {
         [Test]
-        [Slow]
         public virtual void TestArray()
         {
             CharBlockArray array = new CharBlockArray();

--- a/src/Lucene.Net.Tests.Grouping/TestGrouping.cs
+++ b/src/Lucene.Net.Tests.Grouping/TestGrouping.cs
@@ -317,13 +317,13 @@ namespace Lucene.Net.Search.Grouping
 
             if (group.GroupValue.GetType().IsAssignableFrom(typeof(BytesRef)))
             {
-                assertEquals(new BytesRef(expected), group.GroupValue);
+                assertEquals<object>(new BytesRef(expected), group.GroupValue);
             }
             else if (group.GroupValue.GetType().IsAssignableFrom(typeof(MutableValueStr)))
             {
                 MutableValueStr v = new MutableValueStr();
                 v.Value = new BytesRef(expected);
-                assertEquals(v, group.GroupValue);
+                assertEquals<object>(v, group.GroupValue);
             }
             else
             {

--- a/src/Lucene.Net.Tests.QueryParser/Surround/Query/BooleanQueryTst.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Surround/Query/BooleanQueryTst.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Search;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.QueryParsers.Surround.Query

--- a/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
@@ -51,7 +51,11 @@ namespace Lucene.Net.Replicator
             assertEquals(session1.Version, session2.Version);
             assertEquals(1, session2.SourceFiles.Count);
             assertEquals(session1.SourceFiles.Count, session2.SourceFiles.Count);
-            assertEquals(session1.SourceFiles.Keys, session2.SourceFiles.Keys);
+
+            // LUCENENET: Collections don't compare automatically in .NET and J2N has no structural equality
+            // checking on Keys, so using CollectionAssert here. This is set
+            // equality (where order doesn't matter) because in Java the keys and values collections are sets.
+            CollectionAssert.AreEquivalent(session1.SourceFiles.Keys, session2.SourceFiles.Keys);
             IList<RevisionFile> files1 = session1.SourceFiles.Values.First();
             IList<RevisionFile> files2 = session2.SourceFiles.Values.First();
             assertEquals(files1, files2, aggressive: false);

--- a/src/Lucene.Net.Tests.TestFramework.DependencyInjection/Codecs/TestCodecServices.cs
+++ b/src/Lucene.Net.Tests.TestFramework.DependencyInjection/Codecs/TestCodecServices.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Codecs.Lucene46;
 using Lucene.Net.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Codecs
 {

--- a/src/Lucene.Net.Tests.TestFramework.DependencyInjection/Configuration/TestConfigurationService.cs
+++ b/src/Lucene.Net.Tests.TestFramework.DependencyInjection/Configuration/TestConfigurationService.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Configuration
 {

--- a/src/Lucene.Net.Tests.TestFramework/Configuration/Custom/TestCustomConfigurationFactory.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Configuration/Custom/TestCustomConfigurationFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Configuration.Custom
 {

--- a/src/Lucene.Net.Tests.TestFramework/Configuration/TestConfigurationSettings.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Configuration/TestConfigurationSettings.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 using System;
 using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Configuration
 {

--- a/src/Lucene.Net.Tests.TestFramework/Configuration/TestSystemProperties.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Configuration/TestSystemProperties.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 using System;
 using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Configuration
 {

--- a/src/Lucene.Net.Tests.TestFramework/Store/TestMockDirectoryWrapper.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Store/TestMockDirectoryWrapper.cs
@@ -14,7 +14,7 @@ using Test = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
 using Assert = Lucene.Net.TestFramework.Assert;
 #elif TESTFRAMEWORK_NUNIT
 using Test = NUnit.Framework.TestAttribute;
-using Assert = NUnit.Framework.Assert;
+using Assert = Lucene.Net.TestFramework.Assert;
 #elif TESTFRAMEWORK_XUNIT
 using Test = Lucene.Net.TestFramework.SkippableFactAttribute;
 using Assert = Lucene.Net.TestFramework.Assert;

--- a/src/Lucene.Net.Tests.TestFramework/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Support/TestApiConsistency.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Tests.TestFramework
         [TestCase(typeof(Lucene.Net.RandomExtensions))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly, @"ApiScanTestBase|TestUtil.MaxRecursionBound");
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"ApiScanTestBase|TestUtil.MaxRecursionBound|Assert.FailureFormat");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests/Analysis/TestGraphTokenizers.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestGraphTokenizers.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Analysis

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -327,9 +327,9 @@ namespace Lucene.Net.Analysis.TokenAttributes
             //              "01234567890123456789012345678901234567890123456789"
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
             t.SetEmpty().Append(/*(ICharSequence)*/ new StringBuilder("01234567890123456789"), 5, 17 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence
-            Assert.AreEqual(new StringCharSequence("567890123456"), t.ToString());
+            Assert.AreEqual((ICharSequence)new StringCharSequence("567890123456"), t /*.ToString()*/);
             t.Append(new StringBuilder(t.ToString()));
-            Assert.AreEqual(new StringCharSequence("567890123456567890123456"), t.ToString());
+            Assert.AreEqual((ICharSequence)new StringCharSequence("567890123456567890123456"), t /*.ToString()*/);
             // very wierd, to test if a subSlice is wrapped correct :)
             //CharBuffer buf = CharBuffer.wrap("012345678901234567890123456789".ToCharArray(), 3, 15); // LUCENENET: No CharBuffer in .NET
             StringBuilder buf = new StringBuilder("012345678901234567890123456789", 3, 15, 16);

--- a/src/Lucene.Net.Tests/Codecs/Compressing/TestFastDecompressionMode.cs
+++ b/src/Lucene.Net.Tests/Codecs/Compressing/TestFastDecompressionMode.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Codecs.Compressing
 {

--- a/src/Lucene.Net.Tests/Codecs/Lucene3x/TestImpersonation.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene3x/TestImpersonation.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Codecs.Lucene3x
 {

--- a/src/Lucene.Net.Tests/Index/Test2BTerms.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BTerms.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Index

--- a/src/Lucene.Net.Tests/Index/TestDocInverterPerFieldErrorInfo.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocInverterPerFieldErrorInfo.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Index
 {

--- a/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Index

--- a/src/Lucene.Net.Tests/Index/TestExceedMaxTermLength.cs
+++ b/src/Lucene.Net.Tests/Index/TestExceedMaxTermLength.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Documents;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Index
 {

--- a/src/Lucene.Net.Tests/Index/TestForTooMuchCloning.cs
+++ b/src/Lucene.Net.Tests/Index/TestForTooMuchCloning.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Index
 {

--- a/src/Lucene.Net.Tests/Index/TestForceMergeForever.cs
+++ b/src/Lucene.Net.Tests/Index/TestForceMergeForever.cs
@@ -3,6 +3,7 @@ using J2N.Threading.Atomic;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Index

--- a/src/Lucene.Net.Tests/Index/TestIndexFileDeleter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexFileDeleter.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterForceMerge.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterForceMerge.cs
@@ -38,6 +38,7 @@ namespace Lucene.Net.Index
         private static readonly FieldType storedTextType = new FieldType(TextField.TYPE_NOT_STORED);
 
         [Test]
+        [Slow] // Occasionally
         public virtual void TestPartialMerge()
         {
             Directory dir = NewDirectory();

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterNRTIsCurrent.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterNRTIsCurrent.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Threading;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Index

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOutOfFileDescriptors.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOutOfFileDescriptors.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using JCG = J2N.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Index

--- a/src/Lucene.Net.Tests/Index/TestNeverDelete.cs
+++ b/src/Lucene.Net.Tests/Index/TestNeverDelete.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using JCG = J2N.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Index

--- a/src/Lucene.Net.Tests/Index/TestNoMergePolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestNoMergePolicy.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
 using System.Reflection;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Index
 {

--- a/src/Lucene.Net.Tests/Index/TestNoMergeScheduler.cs
+++ b/src/Lucene.Net.Tests/Index/TestNoMergeScheduler.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
 using System.Reflection;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Index
 {

--- a/src/Lucene.Net.Tests/Index/TestReaderClosed.cs
+++ b/src/Lucene.Net.Tests/Index/TestReaderClosed.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Index
 {

--- a/src/Lucene.Net.Tests/Index/TestStressIndexing.cs
+++ b/src/Lucene.Net.Tests/Index/TestStressIndexing.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.Threading;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Index

--- a/src/Lucene.Net.Tests/Index/TestTransactions.cs
+++ b/src/Lucene.Net.Tests/Index/TestTransactions.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Threading;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Index

--- a/src/Lucene.Net.Tests/Index/TestTwoPhaseCommitTool.cs
+++ b/src/Lucene.Net.Tests/Index/TestTwoPhaseCommitTool.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Index
 {

--- a/src/Lucene.Net.Tests/Search/MultiCollectorTest.cs
+++ b/src/Lucene.Net.Tests/Search/MultiCollectorTest.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Search
 {

--- a/src/Lucene.Net.Tests/Search/Payloads/TestPayloadTermQuery.cs
+++ b/src/Lucene.Net.Tests/Search/Payloads/TestPayloadTermQuery.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
 using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Search.Payloads
 {

--- a/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
+++ b/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Search

--- a/src/Lucene.Net.Tests/Search/TestDocBoost.cs
+++ b/src/Lucene.Net.Tests/Search/TestDocBoost.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Search

--- a/src/Lucene.Net.Tests/Search/TestEarlyTermination.cs
+++ b/src/Lucene.Net.Tests/Search/TestEarlyTermination.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Search
 {

--- a/src/Lucene.Net.Tests/Search/TestPositionIncrement.cs
+++ b/src/Lucene.Net.Tests/Search/TestPositionIncrement.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Search

--- a/src/Lucene.Net.Tests/Search/TestSearchWithThreads.cs
+++ b/src/Lucene.Net.Tests/Search/TestSearchWithThreads.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Documents;
 using NUnit.Framework;
 using System;
 using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Search

--- a/src/Lucene.Net.Tests/Search/TestSimilarityProvider.cs
+++ b/src/Lucene.Net.Tests/Search/TestSimilarityProvider.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Search
 {

--- a/src/Lucene.Net.Tests/Search/TestTermScorer.cs
+++ b/src/Lucene.Net.Tests/Search/TestTermScorer.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Search
 {

--- a/src/Lucene.Net.Tests/Store/TestFilterDirectory.cs
+++ b/src/Lucene.Net.Tests/Store/TestFilterDirectory.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Assert = Lucene.Net.TestFramework.Assert;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Store

--- a/src/Lucene.Net.Tests/Store/TestMockDirectoryWrapper.cs
+++ b/src/Lucene.Net.Tests/Store/TestMockDirectoryWrapper.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System;
 using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Store
 {

--- a/src/Lucene.Net.Tests/Store/TestRateLimiter.cs
+++ b/src/Lucene.Net.Tests/Store/TestRateLimiter.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Store
 {

--- a/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
@@ -38,14 +38,14 @@ namespace Lucene.Net
         [TestCase(typeof(Lucene.Net.Analysis.Analyzer))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:LurchTable|HashUtilities|ConcurrentHashSet|PlatformHelper)");
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:ConcurrentHashSet|PlatformHelper)");
         }
 
         [Test, LuceneNetSpecific]
         [TestCase(typeof(Lucene.Net.Analysis.Analyzer))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^Lucene\.Net\.Util\.(?:LightWeight|Disposable)ThreadLocal`1\+(?:LocalState|CurrentThreadState)");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests/Support/TestEnumerableExtensions.cs
+++ b/src/Lucene.Net.Tests/Support/TestEnumerableExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Support
 {

--- a/src/Lucene.Net.Tests/Support/TestIDisposable.cs
+++ b/src/Lucene.Net.Tests/Support/TestIDisposable.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Store;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 #pragma warning disable 612, 618
 namespace Lucene.Net.Support

--- a/src/Lucene.Net.Tests/TestMergeSchedulerExternal.cs
+++ b/src/Lucene.Net.Tests/TestMergeSchedulerExternal.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Threading;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net

--- a/src/Lucene.Net.Tests/Util/Automaton/TestBasicOperations.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestBasicOperations.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Randomized.Generators;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Util.Automaton

--- a/src/Lucene.Net.Tests/Util/Automaton/TestCompiledAutomaton.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestCompiledAutomaton.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JCG = J2N.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Util.Automaton

--- a/src/Lucene.Net.Tests/Util/Automaton/TestDeterminism.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestDeterminism.cs
@@ -1,5 +1,5 @@
-using Lucene.Net.Attributes;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util.Automaton
 {

--- a/src/Lucene.Net.Tests/Util/Automaton/TestDeterminizeLexicon.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestDeterminizeLexicon.cs
@@ -3,6 +3,7 @@ using J2N.Text;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util.Automaton
 {

--- a/src/Lucene.Net.Tests/Util/Automaton/TestLevenshteinAutomata.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestLevenshteinAutomata.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util.Automaton
 {

--- a/src/Lucene.Net.Tests/Util/Automaton/TestMinimize.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestMinimize.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Util.Automaton

--- a/src/Lucene.Net.Tests/Util/Automaton/TestSpecialOperations.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestSpecialOperations.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using System.Collections.Generic;
-
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util.Automaton
 {

--- a/src/Lucene.Net.Tests/Util/Automaton/TestUTF32ToUTF8.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestUTF32ToUTF8.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Diagnostics;
 using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Util.Automaton

--- a/src/Lucene.Net.Tests/Util/Fst/Test2BFST.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/Test2BFST.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Util.Fst

--- a/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
@@ -501,7 +501,7 @@ namespace Lucene.Net.Util.Fst
             dir.Dispose();
         }
 
-        private void AssertSame<T1>(TermsEnum termsEnum, BytesRefFSTEnum<T1> fstEnum, bool storeOrd)
+        private void AssertSame(TermsEnum termsEnum, BytesRefFSTEnum<long?> fstEnum, bool storeOrd) // LUCENENET specific - changed to long? so we don't need a cast
         {
             if (termsEnum.Term == null)
             {

--- a/src/Lucene.Net.Tests/Util/Packed/TestPackedInts.cs
+++ b/src/Lucene.Net.Tests/Util/Packed/TestPackedInts.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Util.Packed
@@ -1125,7 +1126,6 @@ namespace Lucene.Net.Util.Packed
 
 
         [Test]
-        [Slow]
         public virtual void TestAppendingLongBuffer()
         {
 

--- a/src/Lucene.Net.Tests/Util/StressRamUsageEstimator.cs
+++ b/src/Lucene.Net.Tests/Util/StressRamUsageEstimator.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
 using System.Globalization;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Util

--- a/src/Lucene.Net.Tests/Util/Test2BPagedBytes.cs
+++ b/src/Lucene.Net.Tests/Util/Test2BPagedBytes.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Store;
 using NUnit.Framework;
 using System;
 using System.Diagnostics;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestArrayUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestArrayUtil.cs
@@ -349,11 +349,8 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestEmptyArraySort()
         {
-#if FEATURE_ARRAYEMPTY
-            int[] a = Array.Empty<int>();
-#else
-            int[] a = new int[0];
-#endif
+            int[] a = Arrays.Empty<int>();
+
             ArrayUtil.IntroSort(a);
             ArrayUtil.TimSort(a);
             ArrayUtil.IntroSort(a, Collections.ReverseOrder<int>());

--- a/src/Lucene.Net.Tests/Util/TestBytesRef.cs
+++ b/src/Lucene.Net.Tests/Util/TestBytesRef.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Util
             for (int i = 0; i < 100; i++)
             {
                 ICharSequence s = new StringCharSequence(TestUtil.RandomUnicodeString(Random));
-                string s2 = (new BytesRef(s)).Utf8ToString();
+                ICharSequence s2 = (new BytesRef(s)).Utf8ToString().AsCharSequence();
                 Assert.AreEqual(s, s2);
             }
 

--- a/src/Lucene.Net.Tests/Util/TestCloseableThreadLocal.cs
+++ b/src/Lucene.Net.Tests/Util/TestCloseableThreadLocal.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestCollectionUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestCollectionUtil.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestConstants.cs
+++ b/src/Lucene.Net.Tests/Util/TestConstants.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System;
 using System.Text.RegularExpressions;
+using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Util

--- a/src/Lucene.Net.Tests/Util/TestDocIdBitSet.cs
+++ b/src/Lucene.Net.Tests/Util/TestDocIdBitSet.cs
@@ -1,3 +1,4 @@
+using Assert = Lucene.Net.TestFramework.Assert;
 using BitSet = J2N.Collections.BitSet;
 
 namespace Lucene.Net.Util

--- a/src/Lucene.Net.Tests/Util/TestDoubleBarrelLRUCache.cs
+++ b/src/Lucene.Net.Tests/Util/TestDoubleBarrelLRUCache.cs
@@ -1,6 +1,7 @@
 using J2N.Threading;
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestIOUtils.cs
+++ b/src/Lucene.Net.Tests/Util/TestIOUtils.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System;
 using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestInPlaceMergeSorter.cs
+++ b/src/Lucene.Net.Tests/Util/TestInPlaceMergeSorter.cs
@@ -1,3 +1,5 @@
+using Assert = Lucene.Net.TestFramework.Assert;
+
 namespace Lucene.Net.Util
 {
     /*

--- a/src/Lucene.Net.Tests/Util/TestIntroSorter.cs
+++ b/src/Lucene.Net.Tests/Util/TestIntroSorter.cs
@@ -1,3 +1,5 @@
+using Assert = Lucene.Net.TestFramework.Assert;
+
 namespace Lucene.Net.Util
 {
     /*

--- a/src/Lucene.Net.Tests/Util/TestNamedSPILoader.cs
+++ b/src/Lucene.Net.Tests/Util/TestNamedSPILoader.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
+++ b/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
@@ -361,7 +361,6 @@ namespace Lucene.Net.Util
         }
 
         [Test]
-        [Slow]
         public virtual void TestRandomSplit()
         {
             long num = (long)AtLeast(10);

--- a/src/Lucene.Net.Tests/Util/TestRamUsageEstimator.cs
+++ b/src/Lucene.Net.Tests/Util/TestRamUsageEstimator.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestRamUsageEstimatorOnWildAnimals.cs
+++ b/src/Lucene.Net.Tests/Util/TestRamUsageEstimatorOnWildAnimals.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestVersionComparator.cs
+++ b/src/Lucene.Net.Tests/Util/TestVersionComparator.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestWeakIdentityMap.cs
+++ b/src/Lucene.Net.Tests/Util/TestWeakIdentityMap.cs
@@ -11,6 +11,7 @@
 //using System.Collections.Generic;
 //using System.Globalization;
 //using System.Threading;
+//using Assert = Lucene.Net.TestFramework.Assert;
 
 //namespace Lucene.Net.Util
 //{

--- a/src/Lucene.Net/Analysis/CachingTokenFilter.cs
+++ b/src/Lucene.Net/Analysis/CachingTokenFilter.cs
@@ -32,7 +32,7 @@ namespace Lucene.Net.Analysis
     /// </summary>
     public sealed class CachingTokenFilter : TokenFilter
     {
-        private LinkedList<AttributeSource.State> cache = null;
+        private IList<AttributeSource.State> cache = null;
         private IEnumerator<AttributeSource.State> iterator = null;
         private AttributeSource.State finalState;
 
@@ -51,7 +51,7 @@ namespace Lucene.Net.Analysis
             if (cache == null)
             {
                 // fill cache lazily
-                cache = new LinkedList<AttributeSource.State>();
+                cache = new List<AttributeSource.State>();
                 FillCache();
                 iterator = cache.GetEnumerator();
             }
@@ -93,7 +93,7 @@ namespace Lucene.Net.Analysis
         {
             while (m_input.IncrementToken())
             {
-                cache.AddLast(CaptureState());
+                cache.Add(CaptureState());
             }
             // capture final state
             m_input.End();

--- a/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
@@ -1501,12 +1501,8 @@ namespace Lucene.Net.Codecs
                 private FST.Arc<BytesRef>[] arcs = new FST.Arc<BytesRef>[1];
 
                 // LUCENENET specific - optimized empty array creation
-                private static readonly Frame[] EMPTY_FRAMES =
-#if FEATURE_ARRAYEMPTY
-                    Array.Empty<Frame>();
-#else
-                    new Frame[0];
-#endif
+                private static readonly Frame[] EMPTY_FRAMES = Arrays.Empty<Frame>();
+
                 public SegmentTermsEnum(BlockTreeTermsReader.FieldReader outerInstance)
                 {
                     this.outerInstance = outerInstance;

--- a/src/Lucene.Net/Codecs/PostingsFormat.cs
+++ b/src/Lucene.Net/Codecs/PostingsFormat.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Index;
+using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
@@ -69,12 +70,7 @@ namespace Lucene.Net.Codecs
 
         /// <summary>
         /// Zero-length <see cref="PostingsFormat"/> array. </summary>
-        public static readonly PostingsFormat[] EMPTY =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<PostingsFormat>();
-#else
-            new PostingsFormat[0];
-#endif
+        public static readonly PostingsFormat[] EMPTY = Arrays.Empty<PostingsFormat>();
 
         /// <summary>
         /// Unique name that's used to retrieve this format when

--- a/src/Lucene.Net/Document/Document.cs
+++ b/src/Lucene.Net/Document/Document.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Index;
+using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
 using System.Collections;
@@ -218,12 +219,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public IList<IIndexableField> Fields => fields;
 
-        private static readonly string[] NO_STRINGS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<string>();
-#else
-            new string[0];
-#endif
+        private static readonly string[] NO_STRINGS = Arrays.Empty<string>();
 
         /// <summary>
         /// Returns an array of values of the field specified as the method parameter.

--- a/src/Lucene.Net/Index/Fields.cs
+++ b/src/Lucene.Net/Index/Fields.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Support;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -97,11 +98,6 @@ namespace Lucene.Net.Index
         /// <summary>
         /// Zero-length <see cref="Fields"/> array.
         /// </summary>
-        public static readonly Fields[] EMPTY_ARRAY =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<Fields>();
-#else
-            new Fields[0];
-#endif
+        public static readonly Fields[] EMPTY_ARRAY = Arrays.Empty<Fields>();
     }
 }

--- a/src/Lucene.Net/Index/IndexFileDeleter.cs
+++ b/src/Lucene.Net/Index/IndexFileDeleter.cs
@@ -122,14 +122,6 @@ namespace Lucene.Net.Index
             //LUCENENET TODO: This always returns true - probably incorrect
             writer == null || true /*Monitor.IsEntered(writer)*/;
 
-        // LUCENENET specific - optimized empty array creation
-        private static readonly string[] EMPTY_STRINGS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<string>();
-#else
-            new string[0];
-#endif
-
         /// <summary>
         /// Initialize the deleter: find all previous commits in
         /// the <see cref="Directory"/>, incref the files they reference, call
@@ -166,7 +158,7 @@ namespace Lucene.Net.Index
 #pragma warning restore 168
             {
                 // it means the directory is empty, so ignore it.
-                files = EMPTY_STRINGS;
+                files = Arrays.Empty<string>();
             }
 
             if (currentSegmentsFile != null)

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -254,7 +254,7 @@ namespace Lucene.Net.Index
 
         private readonly MergePolicy mergePolicy;
         private readonly IMergeScheduler mergeScheduler;
-        private readonly LinkedList<MergePolicy.OneMerge> pendingMerges = new LinkedList<MergePolicy.OneMerge>();
+        private readonly Queue<MergePolicy.OneMerge> pendingMerges = new Queue<MergePolicy.OneMerge>();
         private readonly JCG.HashSet<MergePolicy.OneMerge> runningMerges = new JCG.HashSet<MergePolicy.OneMerge>();
         private IList<MergePolicy.OneMerge> mergeExceptions = new List<MergePolicy.OneMerge>();
         private long mergeGen;
@@ -2467,8 +2467,7 @@ namespace Lucene.Net.Index
                 else
                 {
                     // Advance the merge from pending to running
-                    MergePolicy.OneMerge merge = pendingMerges.First.Value;
-                    pendingMerges.Remove(merge);
+                    MergePolicy.OneMerge merge = pendingMerges.Dequeue();
                     runningMerges.Add(merge);
                     return merge;
                 }
@@ -4665,7 +4664,7 @@ namespace Lucene.Net.Index
 
                 EnsureValidMerge(merge);
 
-                pendingMerges.AddLast(merge);
+                pendingMerges.Enqueue(merge);
 
                 if (infoStream.IsEnabled("IW"))
                 {

--- a/src/Lucene.Net/Index/MultiTermsEnum.cs
+++ b/src/Lucene.Net/Index/MultiTermsEnum.cs
@@ -52,12 +52,7 @@ namespace Lucene.Net.Index
 
         public class TermsEnumIndex
         {
-            public static readonly TermsEnumIndex[] EMPTY_ARRAY =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<TermsEnumIndex>();
-#else
-                new TermsEnumIndex[0];
-#endif
+            public static readonly TermsEnumIndex[] EMPTY_ARRAY = Arrays.Empty<TermsEnumIndex>();
             internal int SubIndex { get; private set; }
             internal TermsEnum TermsEnum { get; private set; }
 

--- a/src/Lucene.Net/Index/ParallelCompositeReader.cs
+++ b/src/Lucene.Net/Index/ParallelCompositeReader.cs
@@ -1,4 +1,5 @@
 using J2N.Runtime.CompilerServices;
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -53,14 +54,6 @@ namespace Lucene.Net.Index
         private readonly bool closeSubReaders;
         private readonly ISet<IndexReader> completeReaderSet = new JCG.HashSet<IndexReader>(IdentityEqualityComparer<IndexReader>.Default);
 
-        // LUCENENET specific - optimized empty array creation
-        private static readonly IndexReader[] EMPTY_INDEXREADERS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<IndexReader>();
-#else
-            new IndexReader[0];
-#endif
-
         /// <summary>
         /// Create a <see cref="ParallelCompositeReader"/> based on the provided
         /// readers; auto-disposes the given <paramref name="readers"/> on <see cref="IndexReader.Dispose()"/>.
@@ -111,7 +104,7 @@ namespace Lucene.Net.Index
                     throw new ArgumentException("There must be at least one main reader if storedFieldsReaders are used.");
                 }
                 // LUCENENET: Optimized empty string array creation
-                return EMPTY_INDEXREADERS;
+                return Arrays.Empty<IndexReader>();
             }
             else
             {

--- a/src/Lucene.Net/Index/ReaderSlice.cs
+++ b/src/Lucene.Net/Index/ReaderSlice.cs
@@ -1,4 +1,4 @@
-using System;
+using Lucene.Net.Support;
 
 namespace Lucene.Net.Index
 {
@@ -28,12 +28,7 @@ namespace Lucene.Net.Index
     {
         /// <summary>
         /// Zero-length <see cref="ReaderSlice"/> array. </summary>
-        public static readonly ReaderSlice[] EMPTY_ARRAY =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<ReaderSlice>();
-#else
-            new ReaderSlice[0];
-#endif
+        public static readonly ReaderSlice[] EMPTY_ARRAY = Arrays.Empty<ReaderSlice>();
 
         /// <summary>
         /// Document ID this slice starts from. </summary>

--- a/src/Lucene.Net/Index/Terms.cs
+++ b/src/Lucene.Net/Index/Terms.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 
@@ -169,11 +170,6 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Zero-length array of <see cref="Terms"/>. </summary>
-        public static readonly Terms[] EMPTY_ARRAY =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<Terms>();
-#else
-            new Terms[0];
-#endif
+        public static readonly Terms[] EMPTY_ARRAY = Arrays.Empty<Terms>();
     }
 }

--- a/src/Lucene.Net/Search/CachingCollector.cs
+++ b/src/Lucene.Net/Search/CachingCollector.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 
@@ -56,12 +57,7 @@ namespace Lucene.Net.Search
         /// <summary>
         /// NOTE: This was EMPTY_INT_ARRAY in Lucene
         /// </summary>
-        private static readonly int[] EMPTY_INT32_ARRAY =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<int>();
-#else
-            new int[0];
-#endif
+        private static readonly int[] EMPTY_INT32_ARRAY = Arrays.Empty<int>();
 
         private class SegStart
         {

--- a/src/Lucene.Net/Search/FieldComparator.cs
+++ b/src/Lucene.Net/Search/FieldComparator.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Support;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -1408,19 +1409,9 @@ namespace Lucene.Net.Search
         public sealed class TermValComparer : FieldComparer<BytesRef>
         {
             // sentinels, just used internally in this comparer
-            private static readonly byte[] MISSING_BYTES =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<byte>();
-#else
-                new byte[0];
-#endif
+            private static readonly byte[] MISSING_BYTES = Arrays.Empty<byte>();
 
-            private static readonly byte[] NON_MISSING_BYTES =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<byte>();
-#else
-                new byte[0];
-#endif
+            private static readonly byte[] NON_MISSING_BYTES = Arrays.Empty<byte>();
 
             private BytesRef[] values;
             private BinaryDocValues docTerms;

--- a/src/Lucene.Net/Search/NumericRangeQuery.cs
+++ b/src/Lucene.Net/Search/NumericRangeQuery.cs
@@ -300,7 +300,7 @@ namespace Lucene.Net.Search
 
             internal BytesRef currentLowerBound, currentUpperBound;
 
-            internal readonly LinkedList<BytesRef> rangeBounds = new LinkedList<BytesRef>();
+            internal readonly Queue<BytesRef> rangeBounds = new Queue<BytesRef>();
             internal readonly IComparer<BytesRef> termComp;
 
             internal NumericRangeTermsEnum(NumericRangeQuery<T> outerInstance, TermsEnum tenum)
@@ -422,8 +422,8 @@ namespace Lucene.Net.Search
 
                 public override sealed void AddRange(BytesRef minPrefixCoded, BytesRef maxPrefixCoded)
                 {
-                    outerInstance.rangeBounds.AddLast(minPrefixCoded);
-                    outerInstance.rangeBounds.AddLast(maxPrefixCoded);
+                    outerInstance.rangeBounds.Enqueue(minPrefixCoded);
+                    outerInstance.rangeBounds.Enqueue(maxPrefixCoded);
                 }
             }
 
@@ -438,8 +438,8 @@ namespace Lucene.Net.Search
 
                 public override sealed void AddRange(BytesRef minPrefixCoded, BytesRef maxPrefixCoded)
                 {
-                    outerInstance.rangeBounds.AddLast(minPrefixCoded);
-                    outerInstance.rangeBounds.AddLast(maxPrefixCoded);
+                    outerInstance.rangeBounds.Enqueue(minPrefixCoded);
+                    outerInstance.rangeBounds.Enqueue(maxPrefixCoded);
                 }
             }
 
@@ -447,12 +447,10 @@ namespace Lucene.Net.Search
             {
                 Debug.Assert(rangeBounds.Count % 2 == 0);
 
-                currentLowerBound = rangeBounds.First.Value;
-                rangeBounds.Remove(currentLowerBound);
+                currentLowerBound = rangeBounds.Dequeue();
                 Debug.Assert(currentUpperBound == null || termComp.Compare(currentUpperBound, currentLowerBound) <= 0, "The current upper bound must be <= the new lower bound");
 
-                currentUpperBound = rangeBounds.First.Value;
-                rangeBounds.Remove(currentUpperBound);
+                currentUpperBound = rangeBounds.Dequeue();
             }
 
             protected override sealed BytesRef NextSeekTerm(BytesRef term)
@@ -485,7 +483,7 @@ namespace Lucene.Net.Search
                         return AcceptStatus.END;
                     }
                     // peek next sub-range, only seek if the current term is smaller than next lower bound
-                    if (termComp.Compare(term, rangeBounds.First.Value) < 0)
+                    if (termComp.Compare(term, rangeBounds.Peek()) < 0)
                     {
                         return AcceptStatus.NO_AND_SEEK;
                     }

--- a/src/Lucene.Net/Search/TopDocs.cs
+++ b/src/Lucene.Net/Search/TopDocs.cs
@@ -295,7 +295,7 @@ namespace Lucene.Net.Search
             ScoreDoc[] hits;
             if (availHitCount <= start)
             {
-                hits = EMPTY_SCOREDOCS;
+                hits = Arrays.Empty<ScoreDoc>();
             }
             else
             {
@@ -336,13 +336,5 @@ namespace Lucene.Net.Search
                 return new TopFieldDocs(totalHitCount, hits, sort.GetSort(), maxScore);
             }
         }
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly ScoreDoc[] EMPTY_SCOREDOCS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<ScoreDoc>();
-#else
-            new ScoreDoc[0];
-#endif
     }
 }

--- a/src/Lucene.Net/Search/TopFieldCollector.cs
+++ b/src/Lucene.Net/Search/TopFieldCollector.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
 using System.IO;
@@ -1128,12 +1129,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private static readonly ScoreDoc[] EMPTY_SCOREDOCS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<ScoreDoc>();
-#else
-            new ScoreDoc[0];
-#endif
+        private static readonly ScoreDoc[] EMPTY_SCOREDOCS = Arrays.Empty<ScoreDoc>();
 
         private readonly bool fillFields;
 

--- a/src/Lucene.Net/Search/TopScoreDocCollector.cs
+++ b/src/Lucene.Net/Search/TopScoreDocCollector.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Support;
 using System;
 using System.Diagnostics;
 
@@ -127,17 +128,9 @@ namespace Lucene.Net.Search
             protected override TopDocs NewTopDocs(ScoreDoc[] results, int start)
             {
                 // LUCENENET specific - optimized empty array creation
-                return results == null ? new TopDocs(m_totalHits, EMPTY_SCOREDOCS, float.NaN) : new TopDocs(m_totalHits, results);
+                return results == null ? new TopDocs(m_totalHits, Arrays.Empty<ScoreDoc>(), float.NaN) : new TopDocs(m_totalHits, results);
             }
         }
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly ScoreDoc[] EMPTY_SCOREDOCS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<ScoreDoc>();
-#else
-            new ScoreDoc[0];
-#endif
 
         // Assumes docs are scored out of order.
         private class OutOfOrderTopScoreDocCollector : TopScoreDocCollector
@@ -233,7 +226,7 @@ namespace Lucene.Net.Search
             protected override TopDocs NewTopDocs(ScoreDoc[] results, int start)
             {
                 // LUCENENET specific - optimized empty array creation
-                return results == null ? new TopDocs(m_totalHits, EMPTY_SCOREDOCS, float.NaN) : new TopDocs(m_totalHits, results);
+                return results == null ? new TopDocs(m_totalHits, Arrays.Empty<ScoreDoc>(), float.NaN) : new TopDocs(m_totalHits, results);
             }
         }
 

--- a/src/Lucene.Net/Support/Arrays.cs
+++ b/src/Lucene.Net/Support/Arrays.cs
@@ -169,5 +169,29 @@ namespace Lucene.Net.Support
             sb.Append(']');
             return sb.ToString();
         }
+
+        /// <summary>
+        /// Returns an empty array.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements of the array.</typeparam>
+        /// <returns>An empty array.</returns>
+        // LUCENENET: Since Array.Empty<T>() doesn't exist in all supported platforms, we
+        // have this wrapper method to add support.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T[] Empty<T>()
+        {
+#if FEATURE_ARRAYEMPTY
+            return Array.Empty<T>();
+#else
+            return EmptyArrayHolder<T>.EMPTY;
+#endif
+        }
+
+        private static class EmptyArrayHolder<T>
+        {
+#pragma warning disable CA1825 // Avoid zero-length array allocations.
+            public static readonly T[] EMPTY = new T[0];
+#pragma warning restore CA1825 // Avoid zero-length array allocations.
+        }
     }
 }

--- a/src/Lucene.Net/Support/Collections.cs
+++ b/src/Lucene.Net/Support/Collections.cs
@@ -248,7 +248,7 @@ namespace Lucene.Net.Support
 
             public int Compare(T x, T y)
             {
-                return (new CaseInsensitiveComparer()).Compare(y, x);
+                return CaseInsensitiveComparer.Default.Compare(y, x);
             }
         }
 

--- a/src/Lucene.Net/Util/Automaton/Automaton.cs
+++ b/src/Lucene.Net/Util/Automaton/Automaton.cs
@@ -252,25 +252,24 @@ namespace Lucene.Net.Util.Automaton
             {
                 ExpandSingleton();
                 JCG.HashSet<State> visited = new JCG.HashSet<State>();
-                LinkedList<State> worklist = new LinkedList<State>();
+                Queue<State> worklist = new Queue<State>(); // LUCENENET specific - Queue is much more performant than LinkedList
                 State[] states = new State[4];
                 int upto = 0;
-                worklist.AddLast(initial);
+                worklist.Enqueue(initial);
                 visited.Add(initial);
                 initial.number = upto;
                 states[upto] = initial;
                 upto++;
                 while (worklist.Count > 0)
                 {
-                    State s = worklist.First.Value;
-                    worklist.Remove(s);
+                    State s = worklist.Dequeue();
                     for (int i = 0; i < s.numTransitions; i++)
                     {
                         Transition t = s.TransitionsArray[i];
                         if (!visited.Contains(t.to))
                         {
                             visited.Add(t.to);
-                            worklist.AddLast(t.to);
+                            worklist.Enqueue(t.to);
                             t.to.number = upto;
                             if (upto == states.Length)
                             {
@@ -328,13 +327,12 @@ namespace Lucene.Net.Util.Automaton
             ExpandSingleton();
             JCG.HashSet<State> accepts = new JCG.HashSet<State>();
             JCG.HashSet<State> visited = new JCG.HashSet<State>();
-            LinkedList<State> worklist = new LinkedList<State>();
-            worklist.AddLast(initial);
+            Queue<State> worklist = new Queue<State>(); // LUCENENET specific - Queue is much more performant than LinkedList
+            worklist.Enqueue(initial);
             visited.Add(initial);
             while (worklist.Count > 0)
             {
-                State s = worklist.First.Value;
-                worklist.Remove(s);
+                State s = worklist.Dequeue();
                 if (s.accept)
                 {
                     accepts.Add(s);
@@ -344,7 +342,7 @@ namespace Lucene.Net.Util.Automaton
                     if (!visited.Contains(t.to))
                     {
                         visited.Add(t.to);
-                        worklist.AddLast(t.to);
+                        worklist.Enqueue(t.to);
                     }
                 }
             }
@@ -468,7 +466,7 @@ namespace Lucene.Net.Util.Automaton
                     map[s.TransitionsArray[i].to.Number].Add(s);
                 }
             }
-            LinkedList<State> worklist = new LinkedList<State>(live);
+            LinkedList<State> worklist = new LinkedList<State>(live); // LUCENENET: Queue would be slower in this case because of the copy constructor
             while (worklist.Count > 0)
             {
                 State s = worklist.First.Value;
@@ -629,16 +627,15 @@ namespace Lucene.Net.Util.Automaton
             this.Determinize(); // LUCENENET: should we do this ?
 
             Transition[][] transitions = this.GetSortedTransitions();
-            LinkedList<State> worklist = new LinkedList<State>();
+            Queue<State> worklist = new Queue<State>(); // LUCENENET specific - Queue is much more performant than LinkedList
             JCG.HashSet<State> visited = new JCG.HashSet<State>();
 
-            State current = this.initial;
-            worklist.AddLast(this.initial);
+            State current;
+            worklist.Enqueue(this.initial);
             visited.Add(this.initial);
             while (worklist.Count > 0)
             {
-                current = worklist.First.Value;
-                worklist.Remove(current);
+                current = worklist.Dequeue();
                 hash = 31 * hash + current.accept.GetHashCode();
 
                 Transition[] t1 = transitions[current.number];
@@ -653,7 +650,7 @@ namespace Lucene.Net.Util.Automaton
                     State next = t1[n1].to;
                     if (!visited.Contains(next))
                     {
-                        worklist.AddLast(next);
+                        worklist.Enqueue(next);
                         visited.Add(next);
                     }
                 }

--- a/src/Lucene.Net/Util/Automaton/BasicOperations.cs
+++ b/src/Lucene.Net/Util/Automaton/BasicOperations.cs
@@ -396,15 +396,14 @@ namespace Lucene.Net.Util.Automaton
             Transition[][] transitions1 = a1.GetSortedTransitions();
             Transition[][] transitions2 = a2.GetSortedTransitions();
             Automaton c = new Automaton();
-            LinkedList<StatePair> worklist = new LinkedList<StatePair>();
+            Queue<StatePair> worklist = new Queue<StatePair>(); // LUCENENET specific - Queue is much more performant than LinkedList
             Dictionary<StatePair, StatePair> newstates = new Dictionary<StatePair, StatePair>();
             StatePair p = new StatePair(c.initial, a1.initial, a2.initial);
-            worklist.AddLast(p);
+            worklist.Enqueue(p);
             newstates[p] = p;
             while (worklist.Count > 0)
             {
-                p = worklist.First.Value;
-                worklist.Remove(p);
+                p = worklist.Dequeue();
                 p.s.accept = p.s1.accept && p.s2.accept;
                 Transition[] t1 = transitions1[p.s1.number];
                 Transition[] t2 = transitions2[p.s2.number];
@@ -419,12 +418,10 @@ namespace Lucene.Net.Util.Automaton
                         if (t2[n2].max >= t1[n1].min)
                         {
                             StatePair q = new StatePair(t1[n1].to, t2[n2].to);
-                            StatePair r;
-                            newstates.TryGetValue(q, out r);
-                            if (r == null)
+                            if (!newstates.TryGetValue(q, out StatePair r) || r is null)
                             {
                                 q.s = new State();
-                                worklist.AddLast(q);
+                                worklist.Enqueue(q);
                                 newstates[q] = q;
                                 r = q;
                             }
@@ -492,15 +489,14 @@ namespace Lucene.Net.Util.Automaton
             a2.Determinize();
             Transition[][] transitions1 = a1.GetSortedTransitions();
             Transition[][] transitions2 = a2.GetSortedTransitions();
-            LinkedList<StatePair> worklist = new LinkedList<StatePair>();
+            Queue<StatePair> worklist = new Queue<StatePair>(); // LUCENENET specific - Queue is much more performant than LinkedList
             JCG.HashSet<StatePair> visited = new JCG.HashSet<StatePair>();
             StatePair p = new StatePair(a1.initial, a2.initial);
-            worklist.AddLast(p);
+            worklist.Enqueue(p);
             visited.Add(p);
             while (worklist.Count > 0)
             {
-                p = worklist.First.Value;
-                worklist.Remove(p);
+                p = worklist.Dequeue();
                 if (p.s1.accept && !p.s2.accept)
                 {
                     return false;
@@ -533,7 +529,7 @@ namespace Lucene.Net.Util.Automaton
                         StatePair q = new StatePair(t1[n1].to, t2[n2].to);
                         if (!visited.Contains(q))
                         {
-                            worklist.AddLast(q);
+                            worklist.Enqueue(q);
                             visited.Add(q);
                         }
                     }
@@ -792,10 +788,10 @@ namespace Lucene.Net.Util.Automaton
             a.initial = new State();
             SortedInt32Set.FrozenInt32Set initialset = new SortedInt32Set.FrozenInt32Set(initNumber, a.initial);
 
-            LinkedList<SortedInt32Set.FrozenInt32Set> worklist = new LinkedList<SortedInt32Set.FrozenInt32Set>();
+            Queue<SortedInt32Set.FrozenInt32Set> worklist = new Queue<SortedInt32Set.FrozenInt32Set>(); // LUCENENET specific - Queue is much more performant than LinkedList
             IDictionary<SortedInt32Set.FrozenInt32Set, State> newstate = new Dictionary<SortedInt32Set.FrozenInt32Set, State>();
 
-            worklist.AddLast(initialset);
+            worklist.Enqueue(initialset);
 
             a.initial.accept = initAccept;
             newstate[initialset] = a.initial;
@@ -812,13 +808,10 @@ namespace Lucene.Net.Util.Automaton
             // like SortedMap<Integer,Integer>
             SortedInt32Set statesSet = new SortedInt32Set(5);
 
-            // LUCENENET NOTE: The problem here is almost certainly 
-            // due to the conversion to FrozenIntSet along with its
-            // differing equality checking.
             while (worklist.Count > 0)
             {
-                SortedInt32Set.FrozenInt32Set s = worklist.First.Value;
-                worklist.Remove(s);
+                SortedInt32Set.FrozenInt32Set s = worklist.Dequeue();
+                //worklist.Remove(s);
 
                 // Collate all outgoing transitions by min/1+max:
                 for (int i = 0; i < s.values.Length; i++)
@@ -857,7 +850,7 @@ namespace Lucene.Net.Util.Automaton
                             q = new State();
 
                             SortedInt32Set.FrozenInt32Set p = statesSet.Freeze(q);
-                            worklist.AddLast(p);
+                            worklist.Enqueue(p);
                             if (newStateUpto == newStatesArray.Length)
                             {
                                 // LUCENENET: Resize rather than copy

--- a/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
+++ b/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
@@ -42,20 +42,11 @@ namespace Lucene.Net.Util.Automaton
         {
             /// <summary>
             /// An empty set of labels. </summary>
-            private static readonly int[] NO_LABELS =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<int>();
-#else
-                new int[0];
-#endif
+            private static readonly int[] NO_LABELS = Arrays.Empty<int>();
+
             /// <summary>
             /// An empty set of states. </summary>
-            private static readonly State[] NO_STATES =
-#if FEATURE_ARRAYEMPTY
-                Array.Empty<State>();
-#else
-                new State[0];
-#endif
+            private static readonly State[] NO_STATES = Arrays.Empty<State>();
 
             /// <summary>
             /// Labels of outgoing transitions. Indexed identically to <see cref="states"/>.

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -43,21 +43,13 @@ namespace Lucene.Net.Util.Automaton
     /// </summary>
     public class State : IComparable<State>, IEquatable<State> // LUCENENET specific: Implemented IEquatable, since this class is used in hashtables
     {
-        // LUCENENET specific - optimized empty array creation
-        private static readonly Transition[] EMPTY_TRANSITIONS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<Transition>();
-#else
-            new Transition[0];
-#endif
-
         internal bool accept;
         [WritableArray]
         [SuppressMessage("Microsoft.Performance", "CA1819", Justification = "Lucene's design requires some writable array properties")]
         public Transition[] TransitionsArray => transitionsArray;
 
         // LUCENENET NOTE: Setter removed because it is apparently not in use outside of this class
-        private Transition[] transitionsArray = EMPTY_TRANSITIONS;
+        private Transition[] transitionsArray = Arrays.Empty<Transition>();
 
         internal int numTransitions = 0;// LUCENENET NOTE: Made internal because we already have a public property for access
 
@@ -80,7 +72,7 @@ namespace Lucene.Net.Util.Automaton
         /// </summary>
         internal void ResetTransitions()
         {
-            transitionsArray = EMPTY_TRANSITIONS;
+            transitionsArray = Arrays.Empty<Transition>();
             numTransitions = 0;
         }
 

--- a/src/Lucene.Net/Util/Bits.cs
+++ b/src/Lucene.Net/Util/Bits.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Support;
 using System;
 
 namespace Lucene.Net.Util
@@ -42,12 +43,8 @@ namespace Lucene.Net.Util
 
     public static class Bits
     {
-        public static readonly IBits[] EMPTY_ARRAY =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<IBits>();
-#else
-            new IBits[0];
-#endif
+        public static readonly IBits[] EMPTY_ARRAY = Arrays.Empty<IBits>();
+
         /// <summary>
         /// Bits impl of the specified length with all bits set.
         /// </summary>

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -1,4 +1,5 @@
 using J2N.Text;
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -47,12 +48,7 @@ namespace Lucene.Net.Util
     {
         /// <summary>
         /// An empty byte array for convenience </summary>
-        public static readonly byte[] EMPTY_BYTES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<byte>();
-#else
-            new byte[0];
-#endif
+        public static readonly byte[] EMPTY_BYTES = Arrays.Empty<byte>();
 
         /// <summary>
         /// The contents of the BytesRef. Should never be <c>null</c>.

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -1,4 +1,5 @@
 using J2N.Text;
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -41,12 +42,8 @@ namespace Lucene.Net.Util
     {
         /// <summary>
         /// An empty character array for convenience </summary>
-        public static readonly char[] EMPTY_CHARS =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<char>();
-#else
-            new char[0];
-#endif
+        public static readonly char[] EMPTY_CHARS = Arrays.Empty<char>();
+
         bool ICharSequence.HasValue => true;
 
         /// <summary>

--- a/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
+++ b/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
@@ -55,14 +55,6 @@ namespace Lucene.Net.Util
     {
         private readonly bool estimateRam;
 
-        // LUCENENET specific - optimized empty array creation
-        private static readonly Insanity[] EMPTY_INSANTITIES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<Insanity>();
-#else
-            new Insanity[0];
-#endif
-
         public FieldCacheSanityChecker()
         {
             /* NOOP */
@@ -113,7 +105,7 @@ namespace Lucene.Net.Util
         {
             if (null == cacheEntries || 0 == cacheEntries.Length)
             {
-                return EMPTY_INSANTITIES;
+                return Arrays.Empty<Insanity>();
             }
 
             if (estimateRam)

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -1,4 +1,5 @@
 using J2N.Collections;
+using Lucene.Net.Support;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -105,12 +106,7 @@ namespace Lucene.Net.Util.Fst
         /// <seealso cref= #shouldExpand(UnCompiledNode) </seealso>
         internal const int FIXED_ARRAY_NUM_ARCS_DEEP = 10;*/
 
-        private int[] bytesPerArc =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<int>();
-#else
-            new int[0];
-#endif
+        private int[] bytesPerArc = Arrays.Empty<int>();
 
         /*// Increment version to change it
         private const string FILE_FORMAT_NAME = "FST";

--- a/src/Lucene.Net/Util/IntsRef.cs
+++ b/src/Lucene.Net/Util/IntsRef.cs
@@ -45,12 +45,7 @@ namespace Lucene.Net.Util
         /// <para/>
         /// NOTE: This was EMPTY_INTS in Lucene
         /// </summary>
-        public static readonly int[] EMPTY_INT32S =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<int>();
-#else
-            new int[0];
-#endif
+        public static readonly int[] EMPTY_INT32S = Arrays.Empty<int>();
 
         /// <summary>
         /// The contents of the <see cref="Int32sRef"/>. Should never be <c>null</c>. 

--- a/src/Lucene.Net/Util/LongsRef.cs
+++ b/src/Lucene.Net/Util/LongsRef.cs
@@ -45,12 +45,7 @@ namespace Lucene.Net.Util
         /// <para/>
         /// NOTE: This was EMPTY_LONGS in Lucene
         /// </summary>
-        public static readonly long[] EMPTY_INT64S =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<long>();
-#else
-            new long[0];
-#endif
+        public static readonly long[] EMPTY_INT64S = Arrays.Empty<long>();
 
         /// <summary>
         /// The contents of the <see cref="Int64sRef"/>. Should never be <c>null</c>. 

--- a/src/Lucene.Net/Util/PagedBytes.cs
+++ b/src/Lucene.Net/Util/PagedBytes.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -51,12 +52,7 @@ namespace Lucene.Net.Util
         private byte[] currentBlock;
         private readonly long bytesUsedPerBlock;
 
-        private static readonly byte[] EMPTY_BYTES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<byte>();
-#else
-            new byte[0];
-#endif
+        private static readonly byte[] EMPTY_BYTES = Arrays.Empty<byte>();
 
         /// <summary>
         /// Provides methods to read <see cref="BytesRef"/>s from a frozen

--- a/src/Lucene.Net/Util/WAH8DocIdSet.cs
+++ b/src/Lucene.Net/Util/WAH8DocIdSet.cs
@@ -87,17 +87,10 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Default index interval. </summary>
         public const int DEFAULT_INDEX_INTERVAL = 24;
-
-        // LUCENENET specific - optimized empty array creation
-        private static readonly byte[] EMPTY_BYTES =
-#if FEATURE_ARRAYEMPTY
-            Array.Empty<byte>();
-#else
-            new byte[0];
-#endif
-
+        
         private static readonly MonotonicAppendingInt64Buffer SINGLE_ZERO_BUFFER = LoadSingleZeroBuffer();
-        private static readonly WAH8DocIdSet EMPTY = new WAH8DocIdSet(EMPTY_BYTES, 0, 1, SINGLE_ZERO_BUFFER, SINGLE_ZERO_BUFFER);
+        // LUCENENET specific - optimized empty array creation
+        private static readonly WAH8DocIdSet EMPTY = new WAH8DocIdSet(Arrays.Empty<byte>(), 0, 1, SINGLE_ZERO_BUFFER, SINGLE_ZERO_BUFFER);
         private static MonotonicAppendingInt64Buffer LoadSingleZeroBuffer() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
             var buffer = new MonotonicAppendingInt64Buffer(1, 64, PackedInt32s.COMPACT);

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Commands/CommandTestCase.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Commands/CommandTestCase.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Cli.Commands
 {
@@ -111,7 +112,7 @@ namespace Lucene.Net.Cli.Commands
             var output = new MockConsoleApp();
             var cmd = CreateConfiguration(output);
             Assert.IsNotNull(cmd.Description);
-            Assert.IsNotEmpty(cmd.Description);
+            NUnit.Framework.Assert.IsNotEmpty(cmd.Description);
         }
 
         [Test]

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Commands/Index/IndexUpgradeCommandTest.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Commands/Index/IndexUpgradeCommandTest.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Index;
 using Lucene.Net.Store;
 using NUnit.Framework;
 using System.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Cli.Commands
 {

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/TestConfigurationSettings.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/TestConfigurationSettings.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 using System;
 using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Cli.Configuration
 {

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/SourceCode/SourceCodeParserTest.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/SourceCode/SourceCodeParserTest.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System.IO;
 using System.Reflection;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Cli.SourceCode
 {


### PR DESCRIPTION
This addresses the following:

- Reverted testing conditions from 2200e79938ac6de7d002fe3ab8944d3c3cdeb211. The maximum random string length set at 20 instead of 10 was slowing down tests.
- Refactored `Assert` class to use custom comparisons on all overloads. NUnit is way too slow, so we need our own conditions.
- Imported our `Assert` class in some tests were it was being bypassed.
- Replaced `LinkedList<T>` with `Queue<T>` in places where a queue provides a performance advantage.
- Refactored `DirectoryTaxonomyReader<T>` to reduce locking and eliminated unnecessary type conversions.
- Updated C# language version to 8.0
- Added support for filtering public field scanning with a regex in `TestApiConsistency`
- Consolidated empty array creation code so it is DRY