### PR TITLE
Fix for NGram TestUTF8FullRange() tests (See #269)

### DIFF
--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/NGramTokenizerTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/NGramTokenizerTest.cs
@@ -1,4 +1,5 @@
 ﻿using J2N;
+using J2N.Text;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Support;
 using Lucene.Net.Util;
@@ -165,11 +166,22 @@ namespace Lucene.Net.Analysis.NGram
             return codePoints;
         }
 
+        internal static int[] toCodePoints(ICharSequence s)
+        {
+            int[] codePoints = new int[Character.CodePointCount(s, 0, s.Length)];
+            for (int i = 0, j = 0; i < s.Length; ++j)
+            {
+                codePoints[j] = Character.CodePointAt(s, i);
+                i += Character.CharCount(codePoints[j]);
+            }
+            return codePoints;
+        }
+
         internal static bool isTokenChar(string nonTokenChars, int codePoint)
         {
             for (int i = 0; i < nonTokenChars.Length;)
             {
-                int cp = char.ConvertToUtf32(nonTokenChars, i);
+                int cp = nonTokenChars.CodePointAt(i);
                 if (cp == codePoint)
                 {
                     return false;
@@ -211,8 +223,7 @@ namespace Lucene.Net.Analysis.NGram
                         }
                     }
                     assertTrue(grams.IncrementToken());
-
-                    assertArrayEquals(Arrays.CopyOfRange(codePoints, start, end), toCodePoints(termAtt.ToString()));
+                    assertArrayEquals(Arrays.CopyOfRange(codePoints, start, end), toCodePoints(termAtt));
                     assertEquals(1, posIncAtt.PositionIncrement);
                     assertEquals(1, posLenAtt.PositionLength);
                     assertEquals(offsets[start], offsetAtt.StartOffset);
@@ -229,7 +240,7 @@ namespace Lucene.Net.Analysis.NGram
 
         private class NGramTokenizerAnonymousInnerClassHelper : NGramTokenizer
         {
-            private string nonTokenChars;
+            private readonly string nonTokenChars;
 
             public NGramTokenizerAnonymousInnerClassHelper(LuceneVersion TEST_VERSION_CURRENT, StringReader java, int minGram, int maxGram, bool edgesOnly, string nonTokenChars)
                   : base(TEST_VERSION_CURRENT, java, minGram, maxGram, edgesOnly)
@@ -239,7 +250,7 @@ namespace Lucene.Net.Analysis.NGram
 
             protected override bool IsTokenChar(int chr)
             {
-                return nonTokenChars.IndexOf((char)chr) < 0;
+                return nonTokenChars.IndexOf(chr) < 0;
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharTokenizers.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharTokenizers.cs
@@ -9,6 +9,7 @@ using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Util;
 using NUnit.Framework;
+using Lucene.Net.Attributes;
 
 namespace Lucene.Net.Analysis.Util
 {
@@ -135,7 +136,7 @@ namespace Lucene.Net.Analysis.Util
                         var highlightedText = s.Substring(offsetAtt.StartOffset, offsetAtt.EndOffset - offsetAtt.StartOffset);
                         for (int j = 0, cp = 0; j < highlightedText.Length; j += Character.CharCount(cp))
                         {
-                            cp = char.ConvertToUtf32(highlightedText, j);
+                            cp = highlightedText.CodePointAt(j);
                             assertTrue("non-letter:" + cp.ToString("x"), Character.IsLetter(cp));
                         }
                     }
@@ -198,7 +199,7 @@ namespace Lucene.Net.Analysis.Util
                         string highlightedText = s.Substring(offsetAtt.StartOffset, offsetAtt.EndOffset - offsetAtt.StartOffset);
                         for (int j = 0, cp = 0; j < highlightedText.Length; j += Character.CharCount(cp))
                         {
-                            cp = char.ConvertToUtf32(highlightedText, j);
+                            cp = highlightedText.CodePointAt(j);
                             assertTrue("non-letter:" + cp.ToString("x"), Character.IsLetter(cp));
                         }
                     }
@@ -248,6 +249,7 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
 
         [Test]
+        [LuceneNetSpecific]
         public virtual void TestSurrogates()
         {
             var analyzer = new AnalyzerAnonymousInnerClassHelper3();


### PR DESCRIPTION
See the known failing tests in #269.

The problem was that the code point was being cast to a `char` before calling the `IndexOf` method, which means that it didn't support surrogate pairs. In rare instances where the cast turned the code point into a valid token character the test failed.

.NET doesn't have a built-in overload of `String.IndexOf()` that accepts a code point, that is an extension method in J2N.