### PR TITLE
Fixed ThaiWordBreaker to account for surrogate pairs

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiWordFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiWordFilter.cs
@@ -3,7 +3,6 @@ using ICU4N.Text;
 using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.Util;
-using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
 using System.Globalization;


### PR DESCRIPTION
The `ThaiWordBreaker` was created to cover the gap between ICU's `BreakIterator` class and the `BreakIterator` class from the JDK which this analyzer was originally based on. However, there was a bug that made it fail when there were surrogate pairs in the input which this patch addresses.

Also, this adds locking which helps (but does not completely fix) a thread safety issue with `ThaiTokenizer`. The prime suspect is the dictionary-based `BreakIterator` for Thai in ICU4N, but we need to investigate further.