### PR TITLE
Fix for LineFileDocs Bottleneck/Performance Improvements

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/CompoundWordTokenFilterBase.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/CompoundWordTokenFilterBase.cs
@@ -170,16 +170,16 @@ namespace Lucene.Net.Analysis.Compound
 
             /// <summary>
             /// Construct the compound token based on a slice of the current <see cref="CompoundWordTokenFilterBase.m_termAtt"/>. </summary>
-            public CompoundToken(CompoundWordTokenFilterBase outerInstance, int offset, int length)
+            public CompoundToken(CompoundWordTokenFilterBase compoundWordTokenFilterBase, int offset, int length)
             {
-                this.txt = outerInstance.m_termAtt.Subsequence(offset, length); // LUCENENET: Corrected 2nd Subsequence parameter
+                this.txt = compoundWordTokenFilterBase.m_termAtt.Subsequence(offset, length); // LUCENENET: Corrected 2nd Subsequence parameter
 
                 // offsets of the original word
-                int startOff = outerInstance.m_offsetAtt.StartOffset;
-                int endOff = outerInstance.m_offsetAtt.EndOffset;
+                int startOff = compoundWordTokenFilterBase.m_offsetAtt.StartOffset;
+                int endOff = compoundWordTokenFilterBase.m_offsetAtt.EndOffset;
 
 #pragma warning disable 612, 618
-                if (outerInstance.m_matchVersion.OnOrAfter(LuceneVersion.LUCENE_44) || endOff - startOff != outerInstance.m_termAtt.Length)
+                if (compoundWordTokenFilterBase.m_matchVersion.OnOrAfter(LuceneVersion.LUCENE_44) || endOff - startOff != compoundWordTokenFilterBase.m_termAtt.Length)
 #pragma warning restore 612, 618
                 {
                     // if length by start + end offsets doesn't match the term text then assume

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/TernaryTree.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/TernaryTree.cs
@@ -580,18 +580,18 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
             /// <summary>
             /// Node stack
             /// </summary>
-            private Stack<Item> ns;
+            private readonly Stack<Item> ns;
 
             /// <summary>
             /// key stack implemented with a <see cref="StringBuilder"/>
             /// </summary>
-            private StringBuilder ks;
+            private readonly StringBuilder ks;
 
             private bool isInitialized = false;
 
-            public Iterator(TernaryTree outerInstance)
+            public Iterator(TernaryTree ternaryTree)
             {
-                this.outerInstance = outerInstance;
+                this.outerInstance = ternaryTree;
                 cur = -1;
                 ns = new Stack<Item>();
                 ks = new StringBuilder();
@@ -743,6 +743,13 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
             object IEnumerator.Current => Current;
 
             public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            // LUCENENET specific - implemented proper dispose pattern
+            protected virtual void Dispose(bool disposing)
             {
                 // nothing to do
             }

--- a/src/Lucene.Net.Analysis.Common/Analysis/De/GermanStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/De/GermanStemmer.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Analysis.De
         /// <summary>
         /// Buffer for the terms while stemming them.
         /// </summary>
-        private StringBuilder sb = new StringBuilder();
+        private readonly StringBuilder sb = new StringBuilder();
 
         /// <summary>
         /// Amount of characters that are removed with <see cref="Substitute"/> while stemming.

--- a/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Analysis.Fr
         /// <summary>
         /// A temporary buffer, used to reconstruct R2
         /// </summary>
-        private StringBuilder tb = new StringBuilder();
+        private readonly StringBuilder tb = new StringBuilder();
 
         /// <summary>
         /// Region R0 is equal to the whole buffer

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/Lucene47WordDelimiterFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/Lucene47WordDelimiterFilter.cs
@@ -57,12 +57,12 @@ namespace Lucene.Net.Analysis.Miscellaneous
         private readonly WordDelimiterIterator iterator;
 
         // used for concatenating runs of similar typed subwords (word,number)
-        private WordDelimiterConcatenation concat;
+        private readonly WordDelimiterConcatenation concat;
         // number of subwords last output by concat.
         private int lastConcatCount = 0;
 
         // used for catenate all
-        private WordDelimiterConcatenation concatAll;
+        private readonly WordDelimiterConcatenation concatAll;
 
         // used for accumulating position increment gaps
         private int accumPosInc = 0;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/WordDelimiterFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/WordDelimiterFilter.cs
@@ -178,12 +178,12 @@ namespace Lucene.Net.Analysis.Miscellaneous
         private readonly WordDelimiterIterator iterator;
 
         // used for concatenating runs of similar typed subwords (word,number)
-        private WordDelimiterConcatenation concat;
+        private readonly WordDelimiterConcatenation concat;
         // number of subwords last output by concat.
         private int lastConcatCount = 0;
 
         // used for catenate all
-        private WordDelimiterConcatenation concatAll;
+        private readonly WordDelimiterConcatenation concatAll;
 
         // used for accumulating position increment gaps
         private int accumPosInc = 0;
@@ -455,9 +455,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
             }
         }
 
-        private OffsetSorter sorter;
-
-        internal OffsetSorter Sorter => this.sorter;
+        private readonly OffsetSorter sorter;
 
         private void Buffer()
         {

--- a/src/Lucene.Net.Analysis.Common/Analysis/NGram/EdgeNGramTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/NGram/EdgeNGramTokenFilter.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Analysis.NGram
         private readonly CharacterUtils charUtils;
         private readonly int minGram;
         private readonly int maxGram;
-        private Side side;
+        private readonly Side side;
         private char[] curTermBuffer;
         private int curTermLength;
         private int curCodePointCount;

--- a/src/Lucene.Net.Analysis.Common/Analysis/NGram/NGramTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/NGram/NGramTokenFilter.cs
@@ -106,8 +106,8 @@ namespace Lucene.Net.Analysis.NGram
             }
             else
             {
-                posIncAtt = new PositionIncrementAttributeAnonymousInnerClassHelper(this);
-                posLenAtt = new PositionLengthAttributeAnonymousInnerClassHelper(this);
+                posIncAtt = new PositionIncrementAttributeAnonymousInnerClassHelper();
+                posLenAtt = new PositionLengthAttributeAnonymousInnerClassHelper();
             }
             termAtt = AddAttribute<ICharTermAttribute>();
             offsetAtt = AddAttribute<IOffsetAttribute>();
@@ -115,13 +115,6 @@ namespace Lucene.Net.Analysis.NGram
 
         private class PositionIncrementAttributeAnonymousInnerClassHelper : PositionIncrementAttribute
         {
-            private readonly NGramTokenFilter outerInstance;
-
-            public PositionIncrementAttributeAnonymousInnerClassHelper(NGramTokenFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
             public override int PositionIncrement
             {
                 get => 0;
@@ -131,13 +124,6 @@ namespace Lucene.Net.Analysis.NGram
 
         private class PositionLengthAttributeAnonymousInnerClassHelper : PositionLengthAttribute
         {
-            private readonly NGramTokenFilter outerInstance;
-
-            public PositionLengthAttributeAnonymousInnerClassHelper(NGramTokenFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
             public override int PositionLength
             {
                 get => 0;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Nl/DutchStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Nl/DutchStemmer.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Analysis.Nl
         /// <summary>
         /// Buffer for the terms while stemming them.
         /// </summary>
-        private StringBuilder sb = new StringBuilder();
+        private readonly StringBuilder sb = new StringBuilder();
         private bool _removedE;
         private IDictionary<string, string> _stemDict;
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
@@ -588,10 +588,10 @@ namespace Lucene.Net.Analysis.Shingle
             private int previousValue;
             private int minValue;
 
-            public CircularSequence(ShingleFilter outerInstance)
+            public CircularSequence(ShingleFilter shingleFilter)
             {
-                this.outerInstance = outerInstance;
-                minValue = outerInstance.outputUnigrams ? 1 : outerInstance.minShingleSize;
+                this.outerInstance = shingleFilter;
+                minValue = shingleFilter.outputUnigrams ? 1 : shingleFilter.minShingleSize;
                 Reset();
             }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/ClassicAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/ClassicAnalyzer.cs
@@ -104,21 +104,19 @@ namespace Lucene.Net.Analysis.Standard
             TokenStream tok = new ClassicFilter(src);
             tok = new LowerCaseFilter(m_matchVersion, tok);
             tok = new StopFilter(m_matchVersion, tok, m_stopwords);
-            return new TokenStreamComponentsAnonymousInnerClassHelper(this, src, tok, reader);
+            return new TokenStreamComponentsAnonymousInnerClassHelper(this, src, tok);
         }
 
         private class TokenStreamComponentsAnonymousInnerClassHelper : TokenStreamComponents
         {
             private readonly ClassicAnalyzer outerInstance;
 
-            private TextReader reader;
-            private ClassicTokenizer src;
+            private readonly ClassicTokenizer src;
 
-            public TokenStreamComponentsAnonymousInnerClassHelper(ClassicAnalyzer outerInstance, ClassicTokenizer src, TokenStream tok, TextReader reader)
+            public TokenStreamComponentsAnonymousInnerClassHelper(ClassicAnalyzer outerInstance, ClassicTokenizer src, TokenStream tok)
                 : base(src, tok)
             {
                 this.outerInstance = outerInstance;
-                this.reader = reader;
                 this.src = src;
             }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/StandardAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/StandardAnalyzer.cs
@@ -105,21 +105,19 @@ namespace Lucene.Net.Analysis.Standard
             TokenStream tok = new StandardFilter(m_matchVersion, src);
             tok = new LowerCaseFilter(m_matchVersion, tok);
             tok = new StopFilter(m_matchVersion, tok, m_stopwords);
-            return new TokenStreamComponentsAnonymousInnerClassHelper(this, src, tok, reader);
+            return new TokenStreamComponentsAnonymousInnerClassHelper(this, src, tok);
         }
 
         private class TokenStreamComponentsAnonymousInnerClassHelper : TokenStreamComponents
         {
             private readonly StandardAnalyzer outerInstance;
 
-            private TextReader reader;
             private readonly StandardTokenizer src;
 
-            public TokenStreamComponentsAnonymousInnerClassHelper(StandardAnalyzer outerInstance, StandardTokenizer src, TokenStream tok, TextReader reader)
+            public TokenStreamComponentsAnonymousInnerClassHelper(StandardAnalyzer outerInstance, StandardTokenizer src, TokenStream tok)
                 : base(src, tok)
             {
                 this.outerInstance = outerInstance;
-                this.reader = reader;
                 this.src = src;
             }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailAnalyzer.cs
@@ -95,21 +95,19 @@ namespace Lucene.Net.Analysis.Standard
             TokenStream tok = new StandardFilter(m_matchVersion, src);
             tok = new LowerCaseFilter(m_matchVersion, tok);
             tok = new StopFilter(m_matchVersion, tok, m_stopwords);
-            return new TokenStreamComponentsAnonymousInnerClassHelper(this, src, tok, reader);
+            return new TokenStreamComponentsAnonymousInnerClassHelper(this, src, tok);
         }
 
         private class TokenStreamComponentsAnonymousInnerClassHelper : TokenStreamComponents
         {
             private readonly UAX29URLEmailAnalyzer outerInstance;
 
-            private TextReader reader;
-            private UAX29URLEmailTokenizer src;
+            private readonly UAX29URLEmailTokenizer src;
 
-            public TokenStreamComponentsAnonymousInnerClassHelper(UAX29URLEmailAnalyzer outerInstance, UAX29URLEmailTokenizer src, TokenStream tok, TextReader reader)
+            public TokenStreamComponentsAnonymousInnerClassHelper(UAX29URLEmailAnalyzer outerInstance, UAX29URLEmailTokenizer src, TokenStream tok)
                 : base(src, tok)
             {
                 this.outerInstance = outerInstance;
-                this.reader = reader;
                 this.src = src;
             }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
@@ -94,11 +94,8 @@ namespace Lucene.Net.Analysis.Util
 
         public virtual string Require(IDictionary<string, string> args, string name)
         {
-            string s;
-            if (!args.TryGetValue(name, out s))
-            {
-                throw new ArgumentException("Configuration Error: missing parameter '" + name + "'");
-            }
+            if (!args.TryGetValue(name, out string s))
+                throw new ArgumentException($"Configuration Error: missing parameter '{name}'");
             args.Remove(name);
             return s;
         }
@@ -110,56 +107,45 @@ namespace Lucene.Net.Analysis.Util
         public virtual string Require(IDictionary<string, string> args, string name, ICollection<string> allowedValues,
             bool caseSensitive)
         {
-            string s;
-            if (!args.TryGetValue(name, out s) || s == null)
-            {
-                throw new ArgumentException("Configuration Error: missing parameter '" + name + "'");
-            }
-
+            if (!args.TryGetValue(name, out string s))
+                throw new ArgumentException($"Configuration Error: missing parameter '{name}'");
             args.Remove(name);
             foreach (var allowedValue in allowedValues)
             {
                 if (caseSensitive)
                 {
                     if (s.Equals(allowedValue, StringComparison.Ordinal))
-                    {
                         return s;
-                    }
                 }
                 else
                 {
                     if (s.Equals(allowedValue, StringComparison.OrdinalIgnoreCase))
-                    {
                         return s;
-                    }
                 }
             }
-            throw new ArgumentException("Configuration Error: '" + name + "' value must be one of " +
-                                               allowedValues);
+            throw new ArgumentException($"Configuration Error: '{name}' value must be one of {Collections.ToString(allowedValues)}");
         }
 
         public virtual string Get(IDictionary<string, string> args, string name, string defaultVal = null)
         {
-            string s;
-            if (args.TryGetValue(name, out s))
+            if (args.TryGetValue(name, out string s))
                 args.Remove(name);
             return s ?? defaultVal;
         }
 
         public virtual string Get(IDictionary<string, string> args, string name, ICollection<string> allowedValues)
         {
-            return Get(args, name, allowedValues, null); // defaultVal = null
+            return Get(args, name, allowedValues, defaultVal: null);
         }
 
         public virtual string Get(IDictionary<string, string> args, string name, ICollection<string> allowedValues, string defaultVal)
         {
-            return Get(args, name, allowedValues, defaultVal, true);
+            return Get(args, name, allowedValues, defaultVal, caseSensitive: true);
         }
 
         public virtual string Get(IDictionary<string, string> args, string name, ICollection<string> allowedValues, string defaultVal, bool caseSensitive)
         {
-            string s = null;
-            if (!args.TryGetValue(name, out s) || s == null)
+            if (!args.TryGetValue(name, out string s) || s is null)
             {
                 return defaultVal;
             }
@@ -183,8 +169,7 @@ namespace Lucene.Net.Analysis.Util
                         }
                     }
                 }
-                throw new ArgumentException("Configuration Error: '" + name + "' value must be one of " +
-                                                   allowedValues);
+                throw new ArgumentException($"Configuration Error: '{name}' value must be one of {Collections.ToString(allowedValues)}");
             }
         }
 
@@ -201,8 +186,7 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         protected int GetInt32(IDictionary<string, string> args, string name, int defaultVal)
         {
-            string s;
-            if (args.TryGetValue(name, out s))
+            if (args.TryGetValue(name, out string s))
             {
                 args.Remove(name);
                 return int.Parse(s, CultureInfo.InvariantCulture);
@@ -217,8 +201,7 @@ namespace Lucene.Net.Analysis.Util
 
         protected bool GetBoolean(IDictionary<string, string> args, string name, bool defaultVal)
         {
-            string s;
-            if (args.TryGetValue(name, out s))
+            if (args.TryGetValue(name, out string s))
             {
                 args.Remove(name);
                 return bool.Parse(s);
@@ -239,8 +222,7 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         protected float GetSingle(IDictionary<string, string> args, string name, float defaultVal)
         {
-            string s;
-            if (args.TryGetValue(name, out s))
+            if (args.TryGetValue(name, out string s))
             {
                 args.Remove(name);
                 return float.Parse(s, CultureInfo.InvariantCulture);
@@ -255,13 +237,12 @@ namespace Lucene.Net.Analysis.Util
 
         public virtual char GetChar(IDictionary<string, string> args, string name, char defaultVal)
         {
-            string s;
-            if (args.TryGetValue(name, out s))
+            if (args.TryGetValue(name, out string s))
             {
                 args.Remove(name);
                 if (s.Length != 1)
                 {
-                    throw new ArgumentException(name + " should be a char. \"" + s + "\" is invalid");
+                    throw new ArgumentException($"{name} should be a char. \"{s}\" is invalid");
                 }
                 else
                 {
@@ -277,8 +258,7 @@ namespace Lucene.Net.Analysis.Util
         /// Returns whitespace- and/or comma-separated set of values, or null if none are found </summary>
         public virtual ISet<string> GetSet(IDictionary<string, string> args, string name)
         {
-            string s;
-            if (args.TryGetValue(name, out s))
+            if (args.TryGetValue(name, out string s))
             {
                 args.Remove(name);
                 ISet<string> set = null;
@@ -325,8 +305,7 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         protected CultureInfo GetCulture(IDictionary<string, string> args, string name, CultureInfo defaultVal)
         {
-            string culture;
-            if (args.TryGetValue(name, out culture))
+            if (args.TryGetValue(name, out string culture))
             {
                 args.Remove(name);
                 try
@@ -393,11 +372,9 @@ namespace Lucene.Net.Analysis.Util
                 foreach (string file in files)
                 {
                     using (Stream stream = loader.OpenResource(file.Trim()))
+                    using (TextReader reader = new StreamReader(stream, Encoding.UTF8))
                     {
-                        using (TextReader reader = new StreamReader(stream, Encoding.UTF8))
-                        {
-                            WordlistLoader.GetSnowballWordSet(reader, words);
-                        }
+                        WordlistLoader.GetSnowballWordSet(reader, words);
                     }
                 }
             }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -1173,12 +1173,10 @@ namespace Lucene.Net.Analysis.Util
             /// </summary>
             private class KeyEnumerator : IEnumerator<string>
             {
-                private readonly CharArrayMap<TValue> outerInstance;
                 private readonly EntryIterator entryIterator;
 
                 public KeyEnumerator(CharArrayMap<TValue> outerInstance)
                 {
-                    this.outerInstance = outerInstance;
                     this.entryIterator = new EntryIterator(outerInstance, !outerInstance.IsReadOnly);
                 }
 
@@ -1288,12 +1286,10 @@ namespace Lucene.Net.Analysis.Util
             /// </summary>
             private class ValueEnumerator : IEnumerator<TValue>
             {
-                private readonly CharArrayMap<TValue> outerInstance;
                 private readonly EntryIterator entryIterator;
 
                 public ValueEnumerator(CharArrayMap<TValue> outerInstance)
                 {
-                    this.outerInstance = outerInstance;
                     this.entryIterator = new EntryIterator(outerInstance, !outerInstance.IsReadOnly);
                 }
 
@@ -1545,7 +1541,13 @@ namespace Lucene.Net.Analysis.Util
             // LUCENENET: Next() and Remove() methods eliminated here
 
             #region Added for better .NET support LUCENENET
-            public virtual void Dispose()
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            protected virtual void Dispose(bool disposing)
             {
                 // nothing to do
             }

--- a/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizer.cs
+++ b/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizer.cs
@@ -1,4 +1,5 @@
 ﻿// Lucene version compatibility level 4.8.1
+using ICU4N;
 using ICU4N.Text;
 using Lucene.Net.Analysis.Icu.TokenAttributes;
 using Lucene.Net.Analysis.TokenAttributes;
@@ -38,7 +39,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
     [ExceptionToClassNameConvention]
     public sealed class ICUTokenizer : Tokenizer
     {
-        private static readonly int IOBUFFER = 4096;
+        private const int IOBUFFER = 4096;
         private readonly char[] buffer = new char[IOBUFFER];
         /// <summary>true length of text in the buffer</summary>
         private int length = 0;
@@ -154,7 +155,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         private int FindSafeEnd()
         {
             for (int i = length - 1; i >= 0; i--)
-                if (char.IsWhiteSpace(buffer[i]))
+                if (UChar.IsWhiteSpace(buffer[i]))
                     return i + 1;
             return -1;
         }

--- a/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ScriptIterator.cs
+++ b/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ScriptIterator.cs
@@ -152,12 +152,14 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         }
 
         /// <summary>Linear fast-path for basic latin case.</summary>
-        private static readonly int[] basicLatin = new int[128];
+        private static readonly int[] basicLatin = LoadBasicLatin();
 
-        static ScriptIterator()
+        private static int[] LoadBasicLatin() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
+            var basicLatin = new int[128];
             for (int i = 0; i < basicLatin.Length; i++)
                 basicLatin[i] = UScript.GetScript(i);
+            return basicLatin;
         }
 
         /// <summary>Fast version of <see cref="UScript.GetScript(int)"/>. Basic Latin is an array lookup.</summary>

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/UnknownDictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/UnknownDictionaryBuilder.cs
@@ -28,9 +28,9 @@ namespace Lucene.Net.Analysis.Ja.Util
 
     public class UnknownDictionaryBuilder
     {
-        private static readonly string NGRAM_DICTIONARY_ENTRY = "NGRAM,5,5,-32768,記号,一般,*,*,*,*,*,*,*";
+        private const string NGRAM_DICTIONARY_ENTRY = "NGRAM,5,5,-32768,記号,一般,*,*,*,*,*,*,*";
 
-        private string encoding = "euc-jp";
+        private readonly string encoding = "euc-jp";
 
         public UnknownDictionaryBuilder(string encoding)
         {

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Lang.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Lang.cs
@@ -86,8 +86,8 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
         // guessing rules, perhaps by marking it protected and allowing sub-classing. However, the vast majority of users
         // should be strongly encouraged to use the static factory <code>instance</code> method to get their Lang instances.
 
-        private static Regex WHITESPACE = new Regex("\\s+", RegexOptions.Compiled);
-        private static Regex TOKEN = new Regex("\\+", RegexOptions.Compiled);
+        private static readonly Regex WHITESPACE = new Regex("\\s+", RegexOptions.Compiled);
+        private static readonly Regex TOKEN = new Regex("\\+", RegexOptions.Compiled);
 
         private sealed class LangRule
         {

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
@@ -204,7 +204,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             private readonly IDictionary<string, IList<Rule>> finalRules;
             private readonly string input;
 
-            private PhonemeBuilder phonemeBuilder;
+            private readonly PhonemeBuilder phonemeBuilder;
             private int i;
             private readonly int maxPhonemes;
             private bool found;

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/DocMaker.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/DocMaker.cs
@@ -1,11 +1,11 @@
 ﻿using J2N.Threading.Atomic;
 using Lucene.Net.Benchmarks.ByTask.Utils;
 using Lucene.Net.Documents;
+using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
-using System.Threading;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -177,8 +177,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         // LUCENENET specific: DateUtil not used
 
         // leftovers are thread local, because it is unsafe to share residues between threads
-        private ThreadLocal<LeftOver> leftovr = new ThreadLocal<LeftOver>();
-        private ThreadLocal<DocState> docState = new ThreadLocal<DocState>();
+        private readonly DisposableThreadLocal<LeftOver> leftovr = new DisposableThreadLocal<LeftOver>();
+        private DisposableThreadLocal<DocState> docState = new DisposableThreadLocal<DocState>();
 
         public static readonly string BODY_FIELD = "body";
         public static readonly string TITLE_FIELD = "doctitle";
@@ -497,7 +497,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             // In a multi-rounds run, it is important to reset DocState since settings
             // of fields may change between rounds, and this is the only way to reset
             // the cache of all threads.
-            docState = new ThreadLocal<DocState>();
+            docState = new DisposableThreadLocal<DocState>();
 
             m_indexProperties = config.Get("doc.index.props", false);
 

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             private bool stopped = false;
             private string[] tuple;
             private NoMoreDataException nmde;
-            private StringBuilder contents = new StringBuilder();
+            private readonly StringBuilder contents = new StringBuilder();
             private string title;
             private string body;
             private string time;
@@ -337,7 +337,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         private FileInfo file;
         private bool keepImages = true;
         private Stream @is;
-        private Parser parser;
+        private readonly Parser parser;
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/TrecContentSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/TrecContentSource.cs
@@ -1,11 +1,11 @@
 ﻿using J2N.Text;
 using Lucene.Net.Benchmarks.ByTask.Utils;
+using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
-using System.Threading;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
@@ -84,9 +84,9 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             "hhmm K.K.K. MMMM dd, yyyy",     // 0901 u.t.c. April 28, 1994
         };
 
-        private ThreadLocal<StringBuilder> trecDocBuffer = new ThreadLocal<StringBuilder>();
+        private readonly DisposableThreadLocal<StringBuilder> trecDocBuffer = new DisposableThreadLocal<StringBuilder>();
         private DirectoryInfo dataDir = null;
-        private List<FileInfo> inputFiles = new List<FileInfo>();
+        private readonly List<FileInfo> inputFiles = new List<FileInfo>();
         private int nextFile = 0;
         // Use to synchronize threads on reading from the TREC documents.
         private object @lock = new object();
@@ -199,8 +199,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         public virtual DateTime? ParseDate(string dateStr)
         {
             dateStr = dateStr.Trim();
-            DateTime d;
-            if (DateTime.TryParseExact(dateStr, DATE_FORMATS, CultureInfo.InvariantCulture, DateTimeStyles.None, out d))
+            if (DateTime.TryParseExact(dateStr, DATE_FORMATS, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime d))
             {
                 return d;
             }

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
@@ -82,9 +82,9 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         string factoryName = null;
         int? positionIncrementGap = null;
         int? offsetGap = null;
-        private IList<CharFilterFactory> charFilterFactories = new List<CharFilterFactory>();
+        private readonly IList<CharFilterFactory> charFilterFactories = new List<CharFilterFactory>();
         private TokenizerFactory tokenizerFactory = null;
-        private IList<TokenFilterFactory> tokenFilterFactories = new List<TokenFilterFactory>();
+        private readonly IList<TokenFilterFactory> tokenFilterFactories = new List<TokenFilterFactory>();
 
         public AnalyzerFactoryTask(PerfRunData runData)
             : base(runData)

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/ConsumeContentSourceTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/ConsumeContentSourceTask.cs
@@ -1,5 +1,5 @@
 ﻿using Lucene.Net.Benchmarks.ByTask.Feeds;
-using System.Threading;
+using Lucene.Net.Util;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
 {
@@ -26,7 +26,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     public class ConsumeContentSourceTask : PerfTask
     {
         private readonly ContentSource source;
-        private ThreadLocal<DocData> dd = new ThreadLocal<DocData>();
+        private readonly DisposableThreadLocal<DocData> dd = new DisposableThreadLocal<DocData>();
 
         public ConsumeContentSourceTask(PerfRunData runData)
             : base(runData)

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/NewAnalyzerTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/NewAnalyzerTask.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     /// </summary>
     public class NewAnalyzerTask : PerfTask
     {
-        private IList<string> analyzerNames;
+        private readonly IList<string> analyzerNames;
         private int current;
 
         public NewAnalyzerTask(PerfRunData runData)

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/TaskSequence.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/TaskSequence.cs
@@ -35,8 +35,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         public static int REPEAT_EXHAUST = -2;
         private IList<PerfTask> tasks;
         private int repetitions = 1;
-        private bool parallel;
-        private TaskSequence parent;
+        private readonly bool parallel;
+        private readonly TaskSequence parent;
         private bool letChildReport = true;
         private int rate = 0;
         private bool perMin = false; // rate, if set, is, by default, be sec.
@@ -45,7 +45,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         private bool resetExhausted = false;
         private PerfTask[] tasksArray;
         private bool anyExhaustibleTasks;
-        private bool collapsable = false; // to not collapse external sequence named in alg.  
+        private readonly bool collapsable = false; // to not collapse external sequence named in alg.  
 
         private bool fixedTime;                      // true if we run for fixed time
         private double runTimeSec;                      // how long to run for

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteLineDocTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteLineDocTask.cs
@@ -3,13 +3,13 @@ using Lucene.Net.Benchmarks.ByTask.Feeds;
 using Lucene.Net.Benchmarks.ByTask.Utils;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
+using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
@@ -61,9 +61,9 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     /// </remarks>
     public class WriteLineDocTask : PerfTask
     {
-        public static readonly string FIELDS_HEADER_INDICATOR = "FIELDS_HEADER_INDICATOR###";
+        public const string FIELDS_HEADER_INDICATOR = "FIELDS_HEADER_INDICATOR###";
 
-        public readonly static char SEP = '\t';
+        public const char SEP = '\t';
 
         /// <summary>
         /// Fields to be written by default
@@ -83,8 +83,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         protected readonly string m_fname;
         private readonly TextWriter lineFileOut;
         private readonly DocMaker docMaker;
-        private readonly ThreadLocal<StringBuilder> threadBuffer = new ThreadLocal<StringBuilder>();
-        private readonly ThreadLocal<Regex> threadNormalizer = new ThreadLocal<Regex>();
+        private readonly DisposableThreadLocal<StringBuilder> threadBuffer = new DisposableThreadLocal<StringBuilder>();
+        private readonly DisposableThreadLocal<Regex> threadNormalizer = new DisposableThreadLocal<Regex>();
         private readonly string[] fieldsToWrite;
         private readonly bool[] sufficientFields;
         private readonly bool checkSufficientFields;

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/AnalyzerFactory.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/AnalyzerFactory.cs
@@ -30,9 +30,9 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
     /// <seealso cref="Tasks.AnalyzerFactoryTask"/>
     public sealed class AnalyzerFactory
     {
-        private IList<CharFilterFactory> charFilterFactories;
-        private TokenizerFactory tokenizerFactory;
-        private IList<TokenFilterFactory> tokenFilterFactories;
+        private readonly IList<CharFilterFactory> charFilterFactories;
+        private readonly TokenizerFactory tokenizerFactory;
+        private readonly IList<TokenFilterFactory> tokenFilterFactories;
         public string Name { get; set; } = null;
         public int? PositionIncrementGap { get; set; } = null;
         public int? OffsetGap { get; set; } = null;
@@ -54,7 +54,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
             return new AnalyzerAnonymousHelper(this);
         }
 
-        private class AnalyzerAnonymousHelper : Analyzer
+        private sealed class AnalyzerAnonymousHelper : Analyzer
         {
             private readonly AnalyzerFactory outerInstance;
 
@@ -90,16 +90,12 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
 
             public override int GetPositionIncrementGap(string fieldName)
             {
-                return outerInstance.PositionIncrementGap.HasValue
-                    ? outerInstance.PositionIncrementGap.Value
-                    : base.GetPositionIncrementGap(fieldName);
+                return outerInstance.PositionIncrementGap ?? base.GetPositionIncrementGap(fieldName);
             }
 
             public override int GetOffsetGap(string fieldName)
             {
-                return outerInstance.OffsetGap.HasValue
-                    ? outerInstance.OffsetGap.Value
-                    : base.GetOffsetGap(fieldName);
+                return outerInstance.OffsetGap ?? base.GetOffsetGap(fieldName);
             }
         }
 

--- a/src/Lucene.Net.Benchmark/Quality/Utils/SimpleQQParser.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Utils/SimpleQQParser.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.QueryParsers.Classic;
 using Lucene.Net.Search;
 using Lucene.Net.Util;
-using System.Threading;
 
 namespace Lucene.Net.Benchmarks.Quality.Utils
 {
@@ -30,9 +29,9 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
     /// </summary>
     public class SimpleQQParser : IQualityQueryParser
     {
-        private string[] qqNames;
-        private string indexField;
-        ThreadLocal<QueryParser> queryParser = new ThreadLocal<QueryParser>();
+        private readonly string[] qqNames;
+        private readonly string indexField;
+        private readonly DisposableThreadLocal<QueryParser> queryParser = new DisposableThreadLocal<QueryParser>();
 
         /// <summary>
         /// Constructor of a simple qq parser.

--- a/src/Lucene.Net.Benchmark/Support/Sax/Helpers/NamespaceSupport.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/Helpers/NamespaceSupport.cs
@@ -540,7 +540,7 @@ namespace Sax.Helpers
             /// <param name="parent">The parent Namespace context object.</param>
             public void SetParent(Context parent)
             {
-                this.parent = parent;
+                //this.parent = parent; // LUCENENET: Not used
                 declarations = null;
                 prefixTable = parent.prefixTable;
                 uriTable = parent.uriTable;
@@ -559,7 +559,7 @@ namespace Sax.Helpers
             /// </summary>
             public void Clear()
             {
-                parent = null;
+                //parent = null; // LUCENENET: Not used
                 prefixTable = null;
                 uriTable = null;
                 elementNameTable = null;
@@ -832,7 +832,7 @@ namespace Sax.Helpers
 
             private IList<string> declarations;
             private bool declSeen;
-            private Context parent;
+            //private Context parent; // LUCENENET: Not used
         }
     }
 }

--- a/src/Lucene.Net.Codecs/BlockTerms/BlockTermsWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/BlockTermsWriter.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Codecs.BlockTerms
 
         protected IndexOutput m_output;
         private readonly PostingsWriterBase postingsWriter;
-        private readonly FieldInfos fieldInfos;
+        //private readonly FieldInfos fieldInfos; // LUCENENET: Not used
         private FieldInfo currentField;
         private readonly TermsIndexWriterBase termsIndexWriter;
 
@@ -95,7 +95,7 @@ namespace Lucene.Net.Codecs.BlockTerms
             bool success = false;
             try
             {
-                fieldInfos = state.FieldInfos;
+                //fieldInfos = state.FieldInfos; // LUCENENET: Not used
                 WriteHeader(m_output);
                 currentField = null;
                 this.postingsWriter = postingsWriter;
@@ -193,10 +193,10 @@ namespace Lucene.Net.Codecs.BlockTerms
             private readonly long termsStartPointer;
             private long numTerms;
             private readonly TermsIndexWriterBase.FieldWriter fieldIndexWriter;
-            long sumTotalTermFreq;
-            long sumDocFreq;
-            int docCount;
-            int longsSize;
+            //long sumTotalTermFreq; // LUCENENET: Not used
+            //long sumDocFreq; // LUCENENET: Not used
+            //int docCount; // LUCENENET: Not used
+            private readonly int longsSize;
 
             private TermEntry[] pendingTerms;
 
@@ -284,9 +284,9 @@ namespace Lucene.Net.Codecs.BlockTerms
                 // EOF marker:
                 outerInstance.m_output.WriteVInt32(0);
 
-                this.sumTotalTermFreq = sumTotalTermFreq;
-                this.sumDocFreq = sumDocFreq;
-                this.docCount = docCount;
+                //this.sumTotalTermFreq = sumTotalTermFreq; // LUCENENET: Not used
+                //this.sumDocFreq = sumDocFreq; // LUCENENET: Not used
+                //this.docCount = docCount; // LUCENENET: Not used
                 fieldIndexWriter.Finish(outerInstance.m_output.GetFilePointer());
                 if (numTerms > 0)
                 {

--- a/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexReader.cs
@@ -40,22 +40,22 @@ namespace Lucene.Net.Codecs.BlockTerms
         // will overflow int during those multiplies.  So to avoid
         // having to upgrade each multiple to long in multiple
         // places (error prone), we use long here:
-        private long totalIndexInterval;
+        private readonly long totalIndexInterval;
 
-        private int indexDivisor;
+        private readonly int indexDivisor;
         private readonly int indexInterval;
 
         // Closed if indexLoaded is true:
-        private IndexInput input;
-        private volatile bool indexLoaded;
+        private readonly IndexInput input;
+        private readonly /*volatile*/ bool indexLoaded;
 
         private readonly IComparer<BytesRef> termComp;
 
-        private readonly static int PAGED_BYTES_BITS = 15;
+        private const int PAGED_BYTES_BITS = 15;
 
         // all fields share this single logical byte[]
         private readonly PagedBytes termBytes = new PagedBytes(PAGED_BYTES_BITS);
-        private PagedBytes.Reader termBytesReader;
+        private readonly PagedBytes.Reader termBytesReader;
 
         readonly IDictionary<FieldInfo, FieldIndexData> fields = new Dictionary<FieldInfo, FieldIndexData>();
 

--- a/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexWriter.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Codecs.BlockTerms
 
         private readonly IList<SimpleFieldWriter> fields = new List<SimpleFieldWriter>();
 
-        private readonly FieldInfos fieldInfos; // unread
+        //private readonly FieldInfos fieldInfos; // unread  // LUCENENET: Not used
 
         public FixedGapTermsIndexWriter(SegmentWriteState state)
         {
@@ -60,7 +60,7 @@ namespace Lucene.Net.Codecs.BlockTerms
             bool success = false;
             try
             {
-                fieldInfos = state.FieldInfos;
+                //fieldInfos = state.FieldInfos; // LUCENENET: Not used
                 WriteHeader(m_output);
                 m_output.WriteInt32(termIndexInterval);
                 success = true;

--- a/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexReader.cs
@@ -34,11 +34,11 @@ namespace Lucene.Net.Codecs.BlockTerms
     public class VariableGapTermsIndexReader : TermsIndexReaderBase
     {
         private readonly PositiveInt32Outputs fstOutputs = PositiveInt32Outputs.Singleton;
-        private int indexDivisor;
+        private readonly int indexDivisor;
 
         // Closed if indexLoaded is true:
-        private IndexInput input;
-        private volatile bool indexLoaded;
+        private readonly IndexInput input;
+        private readonly /*volatile*/ bool indexLoaded;
 
         private readonly IDictionary<FieldInfo, FieldIndexData> fields = new Dictionary<FieldInfo, FieldIndexData>();
 
@@ -47,13 +47,13 @@ namespace Lucene.Net.Codecs.BlockTerms
 
         private readonly int version;
 
-        private readonly string segment;
+        //private readonly string segment; // LUCENENET: Not used
 
         public VariableGapTermsIndexReader(Directory dir, FieldInfos fieldInfos, string segment, int indexDivisor,
             string segmentSuffix, IOContext context)
         {
             input = dir.OpenInput(IndexFileNames.SegmentFileName(segment, segmentSuffix, VariableGapTermsIndexWriter.TERMS_INDEX_EXTENSION), new IOContext(context, true));
-            this.segment = segment;
+            //this.segment = segment; // LUCENENET: Not used
             bool success = false;
             Debug.Assert(indexDivisor == -1 || indexDivisor > 0);
 
@@ -258,8 +258,7 @@ namespace Lucene.Net.Codecs.BlockTerms
 
         public override FieldIndexEnum GetFieldEnum(FieldInfo fieldInfo)
         {
-            FieldIndexData fieldData;
-            if (!fields.TryGetValue(fieldInfo, out fieldData) || fieldData == null || fieldData.fst == null)
+            if (!fields.TryGetValue(fieldInfo, out FieldIndexData fieldData) || fieldData == null || fieldData.fst == null)
             {
                 return null;
             }

--- a/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexWriter.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Codecs.BlockTerms
 
         private readonly IList<FSTFieldWriter> fields = new List<FSTFieldWriter>();
 
-        private readonly FieldInfos fieldInfos; // unread
+        //private readonly FieldInfos fieldInfos; // unread  // LUCENENET: Not used
         private readonly IndexTermSelector policy;
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace Lucene.Net.Codecs.BlockTerms
             bool success = false;
             try
             {
-                fieldInfos = state.FieldInfos;
+                //fieldInfos = state.FieldInfos; // LUCENENET: Not used
                 this.policy = policy;
                 WriteHeader(m_output);
                 success = true;

--- a/src/Lucene.Net.Codecs/Bloom/BloomFilteringPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Bloom/BloomFilteringPostingsFormat.cs
@@ -125,13 +125,11 @@ namespace Lucene.Net.Codecs.Bloom
 
         internal class BloomFilteredFieldsProducer : FieldsProducer
         {
-            private readonly BloomFilteringPostingsFormat outerInstance;
             private readonly FieldsProducer _delegateFieldsProducer;
             private readonly JCG.Dictionary<string, FuzzySet> _bloomsByFieldName = new JCG.Dictionary<string, FuzzySet>();
 
             public BloomFilteredFieldsProducer(BloomFilteringPostingsFormat outerInstance, SegmentReadState state)
             {
-                this.outerInstance = outerInstance;
                 var bloomFileName = IndexFileNames.SegmentFileName(
                     state.SegmentInfo.Name, state.SegmentSuffix, BLOOM_EXTENSION);
                 ChecksumIndexInput bloomIn = null;

--- a/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
@@ -197,7 +197,7 @@ namespace Lucene.Net.Codecs.Memory
             internal readonly long sumTotalTermFreq;
             internal readonly long sumDocFreq;
             internal readonly int docCount;
-            private readonly int longsSize;
+            //private readonly int longsSize; // LUCENENET: Not used
             internal readonly FST<FSTTermOutputs.TermData> dict;
 
             internal TermsReader(FSTTermsReader outerInstance, FieldInfo fieldInfo, IndexInput @in, long numTerms, long sumTotalTermFreq, long sumDocFreq, int docCount, int longsSize)
@@ -208,7 +208,7 @@ namespace Lucene.Net.Codecs.Memory
                 this.sumTotalTermFreq = sumTotalTermFreq;
                 this.sumDocFreq = sumDocFreq;
                 this.docCount = docCount;
-                this.longsSize = longsSize;
+                //this.longsSize = longsSize; // LUCENENET: Not used
                 this.dict = new FST<FSTTermOutputs.TermData>(@in, new FSTTermOutputs(fieldInfo, longsSize));
             }
 
@@ -440,17 +440,14 @@ namespace Lucene.Net.Codecs.Memory
 
                 internal sealed class Frame
                 {
-                    private readonly FSTTermsReader.TermsReader.IntersectTermsEnum outerInstance;
-
                     /// <summary>Fst stats.</summary>
                     internal FST.Arc<FSTTermOutputs.TermData> fstArc;
 
                     /// <summary>Automaton stats.</summary>
                     internal int fsaState;
 
-                    internal Frame(FSTTermsReader.TermsReader.IntersectTermsEnum outerInstance)
+                    internal Frame()
                     {
-                        this.outerInstance = outerInstance;
                         this.fstArc = new FST.Arc<FSTTermOutputs.TermData>();
                         this.fsaState = -1;
                     }
@@ -473,7 +470,7 @@ namespace Lucene.Net.Codecs.Memory
                     this.stack = new Frame[16];
                     for (int i = 0; i < stack.Length; i++)
                     {
-                        this.stack[i] = new Frame(this);
+                        this.stack[i] = new Frame();
                     }
 
                     Frame frame;
@@ -763,7 +760,7 @@ namespace Lucene.Net.Codecs.Memory
                         Array.Copy(stack, 0, temp, 0, stack.Length);
                         for (int i = stack.Length; i < temp.Length; i++)
                         {
-                            temp[i] = new Frame(this);
+                            temp[i] = new Frame();
                         }
                         stack = temp;
                     }

--- a/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
@@ -1,8 +1,6 @@
 ﻿using Lucene.Net.Index;
-using Lucene.Net.Support;
 using Lucene.Net.Util.Fst;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -28,7 +26,6 @@ namespace Lucene.Net.Codecs.Memory
      */
 
     using ArrayUtil = Util.ArrayUtil;
-    using IBits = Util.IBits;
     using ByteArrayDataInput = Store.ByteArrayDataInput;
     using ByteRunAutomaton = Util.Automaton.ByteRunAutomaton;
     using BytesRef = Util.BytesRef;
@@ -38,6 +35,7 @@ namespace Lucene.Net.Codecs.Memory
     using DocsEnum = Index.DocsEnum;
     using FieldInfo = Index.FieldInfo;
     using FieldInfos = Index.FieldInfos;
+    using IBits = Util.IBits;
     using IndexFileNames = Index.IndexFileNames;
     using IndexInput = Store.IndexInput;
     using IndexOptions = Index.IndexOptions;
@@ -809,39 +807,39 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        internal static void Walk<T>(FST<T> fst) // LUCENENET NOTE: Not referenced
-        {
-            List<FST.Arc<T>> queue = new List<FST.Arc<T>>();
-            FST.BytesReader reader = fst.GetBytesReader();
-            FST.Arc<T> startArc = fst.GetFirstArc(new FST.Arc<T>());
-            queue.Add(startArc);
-            BitArray seen = new BitArray(queue.Count);
-            while (queue.Count > 0)
-            {
-                FST.Arc<T> arc = queue[0];
-                queue.RemoveAt(0);
+        //internal static void Walk<T>(FST<T> fst) // LUCENENET NOTE: Not referenced
+        //{
+        //    List<FST.Arc<T>> queue = new List<FST.Arc<T>>();
+        //    FST.BytesReader reader = fst.GetBytesReader();
+        //    FST.Arc<T> startArc = fst.GetFirstArc(new FST.Arc<T>());
+        //    queue.Add(startArc);
+        //    BitSet seen = new BitSet(queue.Count);
+        //    while (queue.Count > 0)
+        //    {
+        //        FST.Arc<T> arc = queue[0];
+        //        queue.RemoveAt(0);
 
-                long node = arc.Target;
-                //System.out.println(arc);
-                if (FST<T>.TargetHasArcs(arc) && !seen.SafeGet((int)node))
-                {
-                    seen.SafeSet((int)node, true);
-                    fst.ReadFirstRealTargetArc(node, arc, reader);
-                    while (true)
-                    {
-                        queue.Add((new FST.Arc<T>()).CopyFrom(arc));
-                        if (arc.IsLast)
-                        {
-                            break;
-                        }
-                        else
-                        {
-                            fst.ReadNextRealArc(arc, reader);
-                        }
-                    }
-                }
-            }
-        }
+        //        long node = arc.Target;
+        //        //System.out.println(arc);
+        //        if (FST<T>.TargetHasArcs(arc) && !seen.Get((int)node))
+        //        {
+        //            seen.Set((int)node);
+        //            fst.ReadFirstRealTargetArc(node, arc, reader);
+        //            while (true)
+        //            {
+        //                queue.Add((new FST.Arc<T>()).CopyFrom(arc));
+        //                if (arc.IsLast)
+        //                {
+        //                    break;
+        //                }
+        //                else
+        //                {
+        //                    fst.ReadNextRealArc(arc, reader);
+        //                }
+        //            }
+        //        }
+        //    }
+        //}
 
         public override long RamBytesUsed()
         {

--- a/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Expressions.JS
 
         private static readonly string COMPILED_EXPRESSION_CLASS = typeof(Expression).Namespace + ".CompiledExpression";
 
-        private static readonly string COMPILED_EXPRESSION_INTERNAL = COMPILED_EXPRESSION_CLASS.Replace('.', '/');
+        //private static readonly string COMPILED_EXPRESSION_INTERNAL = COMPILED_EXPRESSION_CLASS.Replace('.', '/'); // LUCENENET: Not used
 
         private static readonly Type EXPRESSION_TYPE = Type.GetType(typeof(Expression).FullName);
 

--- a/src/Lucene.Net.Highlighter/Highlight/QueryScorer.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/QueryScorer.cs
@@ -36,16 +36,16 @@ namespace Lucene.Net.Search.Highlight
         private float totalScore;
         private ISet<string> foundTerms;
         private IDictionary<string, WeightedSpanTerm> fieldWeightedSpanTerms;
-        private float maxTermWeight;
+        private readonly float maxTermWeight;
         private int position = -1;
-        private string defaultField;
+        private readonly string defaultField;
         private ICharTermAttribute termAtt;
         private IPositionIncrementAttribute posIncAtt;
         private bool expandMultiTermQuery = true;
         private Query query;
         private string field;
         private IndexReader reader;
-        private bool skipInitExtractor;
+        private readonly bool skipInitExtractor;
         private bool wrapToCaching = true;
         private int maxCharsToAnalyze;
 

--- a/src/Lucene.Net.Highlighter/Highlight/QueryTermScorer.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/QueryTermScorer.cs
@@ -33,12 +33,12 @@ namespace Lucene.Net.Search.Highlight
     // based on fragment.getFragNum()
     public class QueryTermScorer : IScorer
     {
-        private TextFragment currentTextFragment = null;
+        //private TextFragment currentTextFragment = null; // LUCENENET: Not used
         private ISet<string> uniqueTermsInFragment;
 
         private float totalScore = 0;
-        private float maxTermWeight = 0;
-        private IDictionary<string, WeightedTerm> termsToFind;
+        private readonly float maxTermWeight = 0;
+        private readonly IDictionary<string, WeightedTerm> termsToFind;
 
         private ICharTermAttribute termAtt;
 
@@ -108,7 +108,7 @@ namespace Lucene.Net.Search.Highlight
         public virtual void StartFragment(TextFragment newFragment)
         {
             uniqueTermsInFragment = new JCG.HashSet<string>();
-            currentTextFragment = newFragment;
+            //currentTextFragment = newFragment; // LUCENENET: Not used
             totalScore = 0;
         }
 
@@ -119,8 +119,7 @@ namespace Lucene.Net.Search.Highlight
         {
             string termText = termAtt.ToString();
 
-            WeightedTerm queryTerm;
-            if (!termsToFind.TryGetValue(termText, out queryTerm) || queryTerm == null)
+            if (!termsToFind.TryGetValue(termText, out WeightedTerm queryTerm) || queryTerm == null)
             {
                 // not a query term - return
                 return 0;

--- a/src/Lucene.Net.Highlighter/Highlight/WeightedSpanTermExtractor.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/WeightedSpanTermExtractor.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Search.Highlight
     {
         private string fieldName;
         private TokenStream tokenStream;
-        private string defaultField;
+        private readonly string defaultField;
         private bool expandMultiTermQuery;
         private bool cachedTokenStream;
         private bool wrapToCaching = true;

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Processors/QueryNodeProcessorPipeline.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Processors/QueryNodeProcessorPipeline.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Processors
     /// </summary>
     public class QueryNodeProcessorPipeline : IQueryNodeProcessor, IList<IQueryNodeProcessor>
     {
-        private List<IQueryNodeProcessor> processors = new List<IQueryNodeProcessor>();
+        private readonly List<IQueryNodeProcessor> processors = new List<IQueryNodeProcessor>();
 
         private QueryConfigHandler queryConfig;
 

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Util/UnescapedCharSequence.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Util/UnescapedCharSequence.cs
@@ -26,9 +26,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Util
     /// </summary>
     public sealed class UnescapedCharSequence : ICharSequence
     {
-        private char[] chars;
+        private readonly char[] chars;
 
-        private bool[] wasEscaped;
+        private readonly bool[] wasEscaped;
 
         /// <summary>
         /// Create a escaped <see cref="ICharSequence"/>

--- a/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
+++ b/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
@@ -50,13 +50,13 @@ namespace Lucene.Net.Sandbox.Queries
         // provided to TermQuery, so that the general idea is agnostic to any scoring system...
         internal static TFIDFSimilarity sim = new DefaultSimilarity();
         private Query rewrittenQuery = null;
-        private IList<FieldVals> fieldVals = new JCG.List<FieldVals>();
-        private Analyzer analyzer;
+        private readonly IList<FieldVals> fieldVals = new JCG.List<FieldVals>();
+        private readonly Analyzer analyzer;
 
-        private ScoreTermQueue q;
-        private int MAX_VARIANTS_PER_TERM = 50;
+        private readonly ScoreTermQueue q;
+        private const int MAX_VARIANTS_PER_TERM = 50;
         private bool ignoreTF = false;
-        private int maxNumTerms;
+        private readonly int maxNumTerms;
 
         public override int GetHashCode()
         {

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -728,18 +728,27 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             return false;
         }
 
-        public virtual void Dispose()
+        public void Dispose()
         {
-            if (m_searcherMgr != null)
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing) // LUCENENET specific - implemented proper dispose pattern
+        {
+            if (disposing)
             {
-                m_searcherMgr.Dispose();
-                m_searcherMgr = null;
-            }
-            if (writer != null)
-            {
-                writer.Dispose();
-                dir.Dispose();
-                writer = null;
+                if (m_searcherMgr != null)
+                {
+                    m_searcherMgr.Dispose();
+                    m_searcherMgr = null;
+                }
+                if (writer != null)
+                {
+                    writer.Dispose();
+                    dir.Dispose();
+                    writer = null;
+                }
             }
         }
 

--- a/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellLookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellLookup.cs
@@ -29,9 +29,9 @@ namespace Lucene.Net.Search.Suggest.Jaspell
     /// <seealso cref="JaspellTernarySearchTrie"/>
     public class JaspellLookup : Lookup
     {
-        internal JaspellTernarySearchTrie trie = new JaspellTernarySearchTrie();
-        private bool usePrefix = true;
-        private int editDistance = 2;
+        private JaspellTernarySearchTrie trie = new JaspellTernarySearchTrie();
+        private readonly bool usePrefix = true;
+        private readonly int editDistance = 2;
 
         /// <summary>
         /// Number of entries the lookup was built with </summary>
@@ -170,19 +170,19 @@ namespace Lucene.Net.Search.Suggest.Jaspell
             }
             if ((mask & LO_KID) != 0)
             {
-                var kid = new JaspellTernarySearchTrie.TSTNode(trie, '\0', node);
+                var kid = new JaspellTernarySearchTrie.TSTNode('\0', node);
                 node.relatives[JaspellTernarySearchTrie.TSTNode.LOKID] = kid;
                 ReadRecursively(@in, kid);
             }
             if ((mask & EQ_KID) != 0)
             {
-                var kid = new JaspellTernarySearchTrie.TSTNode(trie, '\0', node);
+                var kid = new JaspellTernarySearchTrie.TSTNode('\0', node);
                 node.relatives[JaspellTernarySearchTrie.TSTNode.EQKID] = kid;
                 ReadRecursively(@in, kid);
             }
             if ((mask & HI_KID) != 0)
             {
-                var kid = new JaspellTernarySearchTrie.TSTNode(trie, '\0', node);
+                var kid = new JaspellTernarySearchTrie.TSTNode('\0', node);
                 node.relatives[JaspellTernarySearchTrie.TSTNode.HIKID] = kid;
                 ReadRecursively(@in, kid);
             }
@@ -237,7 +237,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         public override bool Load(DataInput input)
         {
             count = input.ReadVInt64();
-            var root = new JaspellTernarySearchTrie.TSTNode(trie, '\0', null);
+            var root = new JaspellTernarySearchTrie.TSTNode('\0', null);
             ReadRecursively(input, root);
             trie.Root = root;
             return true;

--- a/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
@@ -65,9 +65,6 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// </summary>
         public sealed class TSTNode
         {
-            private readonly JaspellTernarySearchTrie outerInstance;
-
-
             /// <summary>
             /// Index values for accessing relatives array. </summary>
             internal const int PARENT = 0, LOKID = 1, EQKID = 2, HIKID = 3;
@@ -87,14 +84,12 @@ namespace Lucene.Net.Search.Suggest.Jaspell
             /// <summary>
             /// Constructor method.
             /// </summary>
-            /// <param name="outerInstance">The containing <see cref="JaspellTernarySearchTrie"/></param>
             /// <param name="splitchar">
             ///          The char used in the split. </param>
             /// <param name="parent">
             ///          The parent node. </param>
-            internal TSTNode(JaspellTernarySearchTrie outerInstance, char splitchar, TSTNode parent)
+            internal TSTNode(char splitchar, TSTNode parent)
             {
-                this.outerInstance = outerInstance;
                 this.splitchar = splitchar;
                 relatives[PARENT] = parent;
             }
@@ -299,7 +294,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
                     string key = culture.TextInfo.ToLower(word);
                     if (rootNode == null)
                     {
-                        rootNode = new TSTNode(this, key[0], null);
+                        rootNode = new TSTNode(key[0], null);
                     }
                     TSTNode node = null;
                     if (key.Length > 0 && rootNode != null)
@@ -629,7 +624,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
             }
             if (rootNode == null)
             {
-                rootNode = new TSTNode(this, key[0], null);
+                rootNode = new TSTNode(key[0], null);
             }
             TSTNode currentNode = rootNode;
             int charIndex = 0;
@@ -645,7 +640,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
                     }
                     if (currentNode.relatives[TSTNode.EQKID] == null)
                     {
-                        currentNode.relatives[TSTNode.EQKID] = new TSTNode(this, key[charIndex], currentNode);
+                        currentNode.relatives[TSTNode.EQKID] = new TSTNode(key[charIndex], currentNode);
                     }
                     currentNode = currentNode.relatives[TSTNode.EQKID];
                 }
@@ -653,7 +648,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
                 {
                     if (currentNode.relatives[TSTNode.LOKID] == null)
                     {
-                        currentNode.relatives[TSTNode.LOKID] = new TSTNode(this, key[charIndex], currentNode);
+                        currentNode.relatives[TSTNode.LOKID] = new TSTNode(key[charIndex], currentNode);
                     }
                     currentNode = currentNode.relatives[TSTNode.LOKID];
                 }
@@ -661,7 +656,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
                 {
                     if (currentNode.relatives[TSTNode.HIKID] == null)
                     {
-                        currentNode.relatives[TSTNode.HIKID] = new TSTNode(this, key[charIndex], currentNode);
+                        currentNode.relatives[TSTNode.HIKID] = new TSTNode(key[charIndex], currentNode);
                     }
                     currentNode = currentNode.relatives[TSTNode.HIKID];
                 }

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -103,25 +103,55 @@ namespace Lucene.Net.Analysis
 #else
     {
 #endif
-//#if TESTFRAMEWORK_MSTEST
-//        [Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute(Microsoft.VisualStudio.TestTools.UnitTesting.InheritanceBehavior.BeforeEachDerivedClass)]
-//        new public static void BeforeClass(Microsoft.VisualStudio.TestTools.UnitTesting.TestContext context)
-//        {
-//            Lucene.Net.Util.LuceneTestCase.BeforeClass(context);
-//        }
+        //#if TESTFRAMEWORK_MSTEST
+        //        [Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute(Microsoft.VisualStudio.TestTools.UnitTesting.InheritanceBehavior.BeforeEachDerivedClass)]
+        //        new public static void BeforeClass(Microsoft.VisualStudio.TestTools.UnitTesting.TestContext context)
+        //        {
+        //            Lucene.Net.Util.LuceneTestCase.BeforeClass(context);
+        //        }
 
-//        [Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute(Microsoft.VisualStudio.TestTools.UnitTesting.InheritanceBehavior.BeforeEachDerivedClass)]
-//        new public static void AfterClass()
-//        {
-//            Lucene.Net.Util.LuceneTestCase.AfterClass();
-//        }
-//#endif
+        //        [Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute(Microsoft.VisualStudio.TestTools.UnitTesting.InheritanceBehavior.BeforeEachDerivedClass)]
+        //        new public static void AfterClass()
+        //        {
+        //            Lucene.Net.Util.LuceneTestCase.AfterClass();
+        //        }
+        //#endif
 
         // some helpers to test Analyzers and TokenStreams:
 
         // LUCENENET specific - de-nested ICheckClearAttributesAttribute
 
         // LUCENENET specific - de-nested CheckClearAttributesAttribute
+
+        private static string tempLineFileDocs;
+
+        // LUCENENET specific - LineFileDocs is extemely slow because GZipStream is not seekable. We can
+        // drastically improve performance by unzipping the file here in the base class and seeking within
+        // that file in each test.
+        public override void BeforeClass()
+        {
+            base.BeforeClass();
+
+            Stream temp = null;
+            if (TestLineDocsFile == DEFAULT_LINE_DOCS_FILE) // Always GZipped
+            {
+                temp = typeof(LineFileDocs).FindAndGetManifestResourceStream(TestLineDocsFile);
+            }
+            else if (TestLineDocsFile.EndsWith(".gz", StringComparison.Ordinal))
+            {
+                temp = new FileStream(TestLineDocsFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+            }
+            if (null != temp)
+            {
+                var file = CreateTempFile("lucene-linefiledocs-", null);
+                tempLineFileDocs = file.FullName;
+                using (var gzs = new GZipStream(temp, CompressionMode.Decompress, leaveOpen: false))
+                using (Stream output = new FileStream(tempLineFileDocs, FileMode.Open, FileAccess.Write, FileShare.Read))
+                {
+                    gzs.CopyTo(output);
+                }
+            }
+        }
 
         // offsetsAreCorrect also validates:
         //   - graph offsets are correct (all tokens leaving from
@@ -828,61 +858,69 @@ namespace Lucene.Net.Analysis
 
         private static void CheckRandomData(Random random, Analyzer a, int iterations, int maxWordLength, bool useCharFilter, bool simple, bool offsetsAreCorrect, RandomIndexWriter iw)
         {
-            LineFileDocs docs = new LineFileDocs(random);
-            Document doc = null;
-            Field field = null, currentField = null;
-            StringReader bogus = new StringReader("");
-            if (iw != null)
-            {
-                doc = new Document();
-                FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
-                if (random.NextBoolean())
-                {
-                    ft.StoreTermVectors = true;
-                    ft.StoreTermVectorOffsets = random.NextBoolean();
-                    ft.StoreTermVectorPositions = random.NextBoolean();
-                    if (ft.StoreTermVectorPositions && !OldFormatImpersonationIsActive)
-                    {
-                        ft.StoreTermVectorPayloads = random.NextBoolean();
-                    }
-                }
-                if (random.NextBoolean())
-                {
-                    ft.OmitNorms = true;
-                }
-                string pf = TestUtil.GetPostingsFormat("dummy");
-                bool supportsOffsets = !DoesntSupportOffsets.Contains(pf);
-                switch (random.Next(4))
-                {
-                    case 0:
-                        ft.IndexOptions = IndexOptions.DOCS_ONLY;
-                        break;
-
-                    case 1:
-                        ft.IndexOptions = IndexOptions.DOCS_AND_FREQS;
-                        break;
-
-                    case 2:
-                        ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS;
-                        break;
-
-                    default:
-                        if (supportsOffsets && offsetsAreCorrect)
-                        {
-                            ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS;
-                        }
-                        else
-                        {
-                            ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS;
-                        }
-                        break;
-                }
-                currentField = field = new Field("dummy", bogus, ft);
-                doc.Add(currentField);
-            }
+            // LUCENENET specific - LineFileDocs is extemely slow because GZipStream is not seekable. We can
+            // drastically improve performance by unzipping the once in the base class and seeking within
+            // that file in each test. If the file wasn't GZipped, we simply use the default behavior.
+            LineFileDocs docs;
+            if (!string.IsNullOrEmpty(tempLineFileDocs))
+                docs = new LineFileDocs(random, tempLineFileDocs, useDocValues: false);
+            else
+                docs = new LineFileDocs(random);
 
             try
             {
+                Document doc = null;
+                Field field = null, currentField = null;
+                StringReader bogus = new StringReader("");
+                if (iw != null)
+                {
+                    doc = new Document();
+                    FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+                    if (random.NextBoolean())
+                    {
+                        ft.StoreTermVectors = true;
+                        ft.StoreTermVectorOffsets = random.NextBoolean();
+                        ft.StoreTermVectorPositions = random.NextBoolean();
+                        if (ft.StoreTermVectorPositions && !OldFormatImpersonationIsActive)
+                        {
+                            ft.StoreTermVectorPayloads = random.NextBoolean();
+                        }
+                    }
+                    if (random.NextBoolean())
+                    {
+                        ft.OmitNorms = true;
+                    }
+                    string pf = TestUtil.GetPostingsFormat("dummy");
+                    bool supportsOffsets = !DoesntSupportOffsets.Contains(pf);
+                    switch (random.Next(4))
+                    {
+                        case 0:
+                            ft.IndexOptions = IndexOptions.DOCS_ONLY;
+                            break;
+
+                        case 1:
+                            ft.IndexOptions = IndexOptions.DOCS_AND_FREQS;
+                            break;
+
+                        case 2:
+                            ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS;
+                            break;
+
+                        default:
+                            if (supportsOffsets && offsetsAreCorrect)
+                            {
+                                ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS;
+                            }
+                            else
+                            {
+                                ft.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS;
+                            }
+                            break;
+                    }
+                    currentField = field = new Field("dummy", bogus, ft);
+                    doc.Add(currentField);
+                }
+
                 for (int i = 0; i < iterations; i++)
                 {
                     string text;

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40DocValuesWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40DocValuesWriter.cs
@@ -171,15 +171,12 @@ namespace Lucene.Net.Codecs.Lucene40
             int minLength = int.MaxValue;
             int maxLength = int.MinValue;
 
-            var vals = values.ToArray();
-
-            for (int i = 0; i < vals.Length; i++)
+            foreach (var value in values)
             {
-                var b = vals[i];
-
+                BytesRef b = value;
                 if (b == null)
                 {
-                    b = vals[i] = new BytesRef(); // 4.0 doesnt distinguish
+                    b = new BytesRef(); // 4.0 doesnt distinguish
                 }
                 if (b.Length > Lucene40DocValuesFormat.MAX_BINARY_FIELD_LENGTH)
                 {

--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -515,10 +515,19 @@ namespace Lucene.Net.Index
         }
 
         // to test reuse
-        private readonly ThreadLocal<TermsEnum> termsEnum = new ThreadLocal<TermsEnum>();
+        private readonly DisposableThreadLocal<TermsEnum> termsEnum = new DisposableThreadLocal<TermsEnum>();
 
-        private readonly ThreadLocal<DocsEnum> docsEnum = new ThreadLocal<DocsEnum>();
-        private readonly ThreadLocal<DocsAndPositionsEnum> docsAndPositionsEnum = new ThreadLocal<DocsAndPositionsEnum>();
+        private readonly DisposableThreadLocal<DocsEnum> docsEnum = new DisposableThreadLocal<DocsEnum>();
+        private readonly DisposableThreadLocal<DocsAndPositionsEnum> docsAndPositionsEnum = new DisposableThreadLocal<DocsAndPositionsEnum>();
+
+        // LUCENENET specific - cleanup DisposableThreadLocal instances after running tests
+        public override void AfterClass()
+        {
+            termsEnum.Dispose();
+            docsEnum.Dispose();
+            docsAndPositionsEnum.Dispose();
+            base.AfterClass();
+        }
 
         protected virtual void AssertEquals(RandomTokenStream tk, FieldType ft, Terms terms)
         {

--- a/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
@@ -432,9 +432,9 @@ namespace Lucene.Net.Index
         {
             private readonly ThreadedIndexingAndSearchingTestCase outerInstance;
 
-            private long stopTimeMS;
-            private AtomicInt32 totHits;
-            private AtomicInt32 totTermCount;
+            private readonly long stopTimeMS;
+            private readonly AtomicInt32 totHits;
+            private readonly AtomicInt32 totTermCount;
 
             public ThreadAnonymousInnerClassHelper2(ThreadedIndexingAndSearchingTestCase outerInstance, long stopTimeMS, AtomicInt32 totHits, AtomicInt32 totTermCount)
             {
@@ -602,7 +602,7 @@ namespace Lucene.Net.Index
 
             if (Verbose)
             {
-                conf.SetInfoStream(new PrintStreamInfoStreamAnonymousInnerClassHelper(this, Console.Out));
+                conf.SetInfoStream(new PrintStreamInfoStreamAnonymousInnerClassHelper(Console.Out));
             }
             m_writer = new IndexWriter(m_dir, conf);
             TestUtil.ReduceOpenFiles(m_writer);
@@ -837,12 +837,9 @@ namespace Lucene.Net.Index
 
         private class PrintStreamInfoStreamAnonymousInnerClassHelper : TextWriterInfoStream
         {
-            private readonly ThreadedIndexingAndSearchingTestCase outerInstance;
-
-            public PrintStreamInfoStreamAnonymousInnerClassHelper(ThreadedIndexingAndSearchingTestCase outerInstance, TextWriter @out)
+            public PrintStreamInfoStreamAnonymousInnerClassHelper(TextWriter @out)
                 : base(@out)
             {
-                this.outerInstance = outerInstance;
             }
 
             public override void Message(string component, string message)
@@ -859,7 +856,7 @@ namespace Lucene.Net.Index
         // Boolean reference type.
         private class BooleanRef : IEquatable<BooleanRef>
         {
-            private bool value;
+            private readonly bool value;
 
             public BooleanRef(bool value)
             {

--- a/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
@@ -78,6 +78,13 @@ namespace Lucene.Net.Index
             }
         }
 
+        // LUCENENET specific - Specify to unzip the line file docs
+        public override void BeforeClass()
+        {
+            UseTempLineDocsFile = true;
+            base.BeforeClass();
+        }
+
         // Called per-search
         protected abstract IndexSearcher GetCurrentSearcher();
 

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -94,9 +94,9 @@ namespace Lucene.Net.Search
 
         internal class FieldAndShardVersion
         {
-            private long version;
-            private int nodeID;
-            private string field;
+            private readonly long version;
+            private readonly int nodeID;
+            private readonly string field;
 
             public FieldAndShardVersion(int nodeID, long version, string field)
             {

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -82,6 +82,14 @@ namespace Lucene.Net.Search
 #else
     {
 #endif
+        // LUCENENET specific - Specify to unzip the line file docs
+        public override void BeforeClass()
+        {
+            UseTempLineDocsFile = true;
+            base.BeforeClass();
+        }
+
+
         // LUCENENET specific - de-nested SearcherExpiredException
 
         internal class FieldAndShardVersion

--- a/src/Lucene.Net.TestFramework/Support/Attributes/DeadlockAttribute.cs
+++ b/src/Lucene.Net.TestFramework/Support/Attributes/DeadlockAttribute.cs
@@ -1,7 +1,10 @@
-﻿using Lucene.Net.Attributes;
-using Lucene.Net.Index;
+﻿#if TESTFRAMEWORK_NUNIT
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using System;
 
-namespace Lucene.Net.Codecs.SimpleText
+namespace Lucene.Net.Attributes
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -20,18 +23,18 @@ namespace Lucene.Net.Codecs.SimpleText
      * limitations under the License.
      */
 
-    public class TestSimpleTextStoredFieldsFormat : BaseStoredFieldsFormatTestCase
+    /// <summary>
+    /// Indicates a test has contention between concurrent processes and may deadlock.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    internal class DeadlockAttribute : TimeoutAttribute, IApplyToTest
     {
+        public DeadlockAttribute() : base(600000) { }
 
-        protected override Codec GetCodec()
+        void IApplyToTest.ApplyToTest(Test test)
         {
-            return new SimpleTextCodec();
-        }
-
-        [Deadlock]
-        public override void TestConcurrentReads()
-        {
-            base.TestConcurrentReads();
+            test.Properties.Add(PropertyNames.Category, "Deadlock");
         }
     }
 }
+#endif

--- a/src/Lucene.Net.TestFramework/Support/Attributes/LuceneNetSpecificAttribute.cs
+++ b/src/Lucene.Net.TestFramework/Support/Attributes/LuceneNetSpecificAttribute.cs
@@ -1,29 +1,25 @@
 #if TESTFRAMEWORK_NUNIT
-/*
- *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *
-*/
-
 using NUnit.Framework;
 
 namespace Lucene.Net.Attributes
 {
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
     /// <summary>
     /// This test was added during the port to .NET to test
     /// additional factors that apply specifically to the port.

--- a/src/Lucene.Net.TestFramework/Support/Attributes/NoOpAttribute.cs
+++ b/src/Lucene.Net.TestFramework/Support/Attributes/NoOpAttribute.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Lucene.Net.Attributes
 {

--- a/src/Lucene.Net.TestFramework/Support/Configuration/TestParameterConfigurationProvider.cs
+++ b/src/Lucene.Net.TestFramework/Support/Configuration/TestParameterConfigurationProvider.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Configuration
      */
     public class TestParameterConfigurationProvider : IConfigurationProvider
     {
-        private CommandLineConfigurationProvider _instance;
+        private readonly CommandLineConfigurationProvider _instance;
 
         /// <summary>
         /// Initializes a new instance.

--- a/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
@@ -1,18 +1,9 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using Lucene.Net.Support;
-using JCG = J2N.Collections.Generic;
-using Debug = Lucene.Net.Diagnostics.Debug; // LUCENENET NOTE: We cannot use System.Diagnostics.Debug because those calls will be optimized out of the release!
+using System;
+using System.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
-
-#if TESTFRAMEWORK_MSTEST
-using CollectionAssert = Lucene.Net.TestFramework.Assert;
-#elif TESTFRAMEWORK_NUNIT
-using CollectionAssert = NUnit.Framework.CollectionAssert;
-#elif TESTFRAMEWORK_XUNIT
-using CollectionAssert = Lucene.Net.TestFramework.Assert;
-#endif
+using Debug = Lucene.Net.Diagnostics.Debug; // LUCENENET NOTE: We cannot use System.Diagnostics.Debug because those calls will be optimized out of the release!
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.TestFramework/Util/LineFileDocs.cs
+++ b/src/Lucene.Net.TestFramework/Util/LineFileDocs.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Console = Lucene.Net.Util.SystemConsole;
 
@@ -296,7 +295,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        private readonly ThreadLocal<DocState> threadDocs = new ThreadLocal<DocState>();
+        private readonly DisposableThreadLocal<DocState> threadDocs = new DisposableThreadLocal<DocState>();
 
         /// <summary>
         /// Note: Document instance is re-used per-thread </summary>

--- a/src/Lucene.Net.TestFramework/Util/LineFileDocs.cs
+++ b/src/Lucene.Net.TestFramework/Util/LineFileDocs.cs
@@ -56,12 +56,12 @@ namespace Lucene.Net.Util
         }
 
         public LineFileDocs(Random random)
-            : this(random, LuceneTestCase.TestLineDocsFile, true)
+            : this(random, LuceneTestCase.TempLineDocsFile ?? LuceneTestCase.TestLineDocsFile, true)
         {
         }
 
         public LineFileDocs(Random random, bool useDocValues)
-            : this(random, LuceneTestCase.TestLineDocsFile, useDocValues)
+            : this(random, LuceneTestCase.TempLineDocsFile ?? LuceneTestCase.TestLineDocsFile, useDocValues)
         {
         }
 
@@ -370,29 +370,29 @@ namespace Lucene.Net.Util
             return docState.Doc;
         }
 
-        //private static string MaybeCreateTempFile()
-        //{
-        //    string result = null;
-        //    Stream temp = null;
-        //    if (LuceneTestCase.TestLineDocsFile == LuceneTestCase.DEFAULT_LINE_DOCS_FILE) // Always GZipped
-        //    {
-        //        temp = typeof(LineFileDocs).FindAndGetManifestResourceStream(LuceneTestCase.TestLineDocsFile);
-        //    }
-        //    else if (LuceneTestCase.TestLineDocsFile.EndsWith(".gz", StringComparison.Ordinal))
-        //    {
-        //        temp = new FileStream(LuceneTestCase.TestLineDocsFile, FileMode.Open, FileAccess.Read, FileShare.Read);
-        //    }
-        //    if (null != temp)
-        //    {
-        //        var file = LuceneTestCase.CreateTempFile("lucene-linefiledocs-", null);
-        //        result = file.FullName;
-        //        using (var gzs = new GZipStream(temp, CompressionMode.Decompress, leaveOpen: false))
-        //        using (Stream output = new FileStream(result, FileMode.Open, FileAccess.Write, FileShare.Read))
-        //        {
-        //            gzs.CopyTo(output);
-        //        }
-        //    }
-        //    return result;
-        //}
+        internal static string MaybeCreateTempFile()
+        {
+            string result = null;
+            Stream temp = null;
+            if (LuceneTestCase.TestLineDocsFile == LuceneTestCase.DEFAULT_LINE_DOCS_FILE) // Always GZipped
+            {
+                temp = typeof(LineFileDocs).FindAndGetManifestResourceStream(LuceneTestCase.TestLineDocsFile);
+            }
+            else if (LuceneTestCase.TestLineDocsFile.EndsWith(".gz", StringComparison.Ordinal))
+            {
+                temp = new FileStream(LuceneTestCase.TestLineDocsFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+            }
+            if (null != temp)
+            {
+                var file = LuceneTestCase.CreateTempFile("lucene-linefiledocs-", null);
+                result = file.FullName;
+                using (var gzs = new GZipStream(temp, CompressionMode.Decompress, leaveOpen: false))
+                using (Stream output = new FileStream(result, FileMode.Open, FileAccess.Write, FileShare.Read))
+                {
+                    gzs.CopyTo(output);
+                }
+            }
+            return result;
+        }
     }
 }

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -565,8 +565,18 @@ namespace Lucene.Net.Util
         public static string TestDirectory => TestProperties.TestDirectory; // LUCENENET specific - changed from field to property, and renamed
 
         /// <summary>
-        /// The line file used by LineFileDocs </summary>
+        /// The line file used by <see cref="LineFileDocs"/> </summary>
         public static string TestLineDocsFile => TestProperties.TestLineDocsFile; // LUCENENET specific - changed from field to property, and renamed
+
+        /// <summary>
+        /// The line file used by <see cref="LineFileDocs"/> to override <see cref="TestLineDocsFile"/> if it exists (points to an unzipped file).</summary>
+        // LUCENENET specific - used to unzip the LineDocsFile at the class level so we don't have to do it in every test.
+        internal static string TempLineDocsFile { get; set; }
+
+        /// <summary>
+        /// Whether to use the temporary line docs file. This should be set to <c>true</c> when a subclass requires <see cref="LineFileDocs"/>.</summary>
+        // LUCENENET specific - used to unzip the LineDocsFile at the class level so we don't have to do it in every test.
+        internal bool UseTempLineDocsFile { get; set; }
 
         /// <summary>
         /// Whether or not <see cref="NightlyAttribute"/> tests should run. </summary>
@@ -945,6 +955,11 @@ namespace Lucene.Net.Util
 
                 // LUCENENET TODO: Scan for a custom attribute and setup ordering to
                 // initialize data from this class to the top class
+
+                if (UseTempLineDocsFile)
+                {
+                    TempLineDocsFile = LineFileDocs.MaybeCreateTempFile();
+                }
             }
             catch (Exception ex)
             {
@@ -977,6 +992,11 @@ namespace Lucene.Net.Util
                 // LUCENENET: Generate the info once so it can be printed out for each test
                 codecType = ClassEnvRule.codec.GetType().Name;
                 similarityName = ClassEnvRule.similarity.ToString();
+
+                if (UseTempLineDocsFile)
+                {
+                    TempLineDocsFile = LineFileDocs.MaybeCreateTempFile();
+                }
             }
             catch (Exception ex)
             {
@@ -997,6 +1017,10 @@ namespace Lucene.Net.Util
             {
                 ClassEnvRule.After(null);
                 CleanupTemporaryFiles();
+                if (UseTempLineDocsFile)
+                {
+                    TempLineDocsFile = null;
+                }
             }
             catch (Exception ex)
             {
@@ -1022,6 +1046,10 @@ namespace Lucene.Net.Util
             {
                 ClassEnvRule.After(this);
                 CleanupTemporaryFiles();
+                if (UseTempLineDocsFile)
+                {
+                    TempLineDocsFile = null;
+                }
             }
             catch (Exception ex)
             {

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -3350,7 +3350,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Retry to create temporary file name this many times.
         /// </summary>
-        private static int TEMP_NAME_RETRY_THRESHOLD = 9999;
+        private const int TEMP_NAME_RETRY_THRESHOLD = 9999;
 
         // LUCENENET: Not Implemented
         /////// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ar/TestArabicNormalizationFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ar/TestArabicNormalizationFilter.cs
@@ -123,24 +123,12 @@ namespace Lucene.Net.Analysis.Ar
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestArabicNormalizationFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestArabicNormalizationFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new ArabicNormalizationFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ar/TestArabicStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ar/TestArabicStemFilter.cs
@@ -181,24 +181,12 @@ namespace Lucene.Net.Analysis.Ar
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestArabicStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestArabicStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new ArabicStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Bg/TestBulgarianStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Bg/TestBulgarianStemmer.cs
@@ -234,24 +234,12 @@ namespace Lucene.Net.Analysis.Bg
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestBulgarianStemmer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestBulgarianStemmer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new BulgarianStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Br/TestBrazilianStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Br/TestBrazilianStemmer.cs
@@ -174,24 +174,12 @@ namespace Lucene.Net.Analysis.Br
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestBrazilianStemmer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestBrazilianStemmer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new BrazilianStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/HTMLStripCharFilterTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/HTMLStripCharFilterTest.cs
@@ -32,25 +32,14 @@ namespace Lucene.Net.Analysis.CharFilters
 
         private static Analyzer NewTestAnalyzer()
         {
-            return new AnalyzerAnonymousInnerClassHelper();
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            return Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
-
-            protected internal override TextReader InitReader(string fieldName, TextReader reader)
+            }, initReader: (fieldName, reader) =>
             {
                 return new HTMLStripCharFilter(reader);
-            }
+            });
         }
 
         //this is some text  here is a  link  and another  link . This is an entity: & plus a <.  Here is an &

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
@@ -211,32 +211,17 @@ namespace Lucene.Net.Analysis.CharFilters
         [Test]
         public virtual void TestRandom()
         {
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper(this);
-
-            int numRounds = RandomMultiplier * 10000;
-            CheckRandomData(Random, analyzer, numRounds);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestMappingCharFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestMappingCharFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
+            }, initReader: (fieldName, reader) =>
+            { 
+                return new MappingCharFilter(normMap, reader);
+            });
 
-            protected internal override TextReader InitReader(string fieldName, TextReader reader)
-            {
-                return new MappingCharFilter(outerInstance.normMap, reader);
-            }
+            int numRounds = RandomMultiplier * 10000;
+            CheckRandomData(Random, analyzer, numRounds);
         }
 
         [Ignore("wrong finalOffset: https://issues.apache.org/jira/browse/LUCENE-3971")]
@@ -250,34 +235,14 @@ namespace Lucene.Net.Analysis.CharFilters
 
             NormalizeCharMap map = builder.Build();
 
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper2(this, map);
-
-            string text = "gzw f quaxot";
-            CheckAnalysisConsistency(Random, analyzer, false, text);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestMappingCharFilter outerInstance;
-
-            private NormalizeCharMap map;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestMappingCharFilter outerInstance, NormalizeCharMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
+            }, initReader: (fieldName, reader) => new MappingCharFilter(map, reader));
 
-            protected internal override TextReader InitReader(string fieldName, TextReader reader)
-            {
-                return new MappingCharFilter(map, reader);
-            }
+            string text = "gzw f quaxot";
+            CheckAnalysisConsistency(Random, analyzer, false, text);
         }
 
         [Ignore("wrong finalOffset: https://issues.apache.org/jira/browse/LUCENE-3971")]
@@ -288,33 +253,13 @@ namespace Lucene.Net.Analysis.CharFilters
             for (int i = 0; i < numIterations; i++)
             {
                 NormalizeCharMap map = RandomMap();
-                Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper3(this, map);
+                Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+                    return new TokenStreamComponents(tokenizer, tokenizer);
+                }, initReader: (fieldName, reader) => new MappingCharFilter(map, reader));
                 int numRounds = 100;
                 CheckRandomData(Random, analyzer, numRounds);
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestMappingCharFilter outerInstance;
-
-            private NormalizeCharMap map;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestMappingCharFilter outerInstance, NormalizeCharMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, tokenizer);
-            }
-
-            protected internal override TextReader InitReader(string fieldName, TextReader reader)
-            {
-                return new MappingCharFilter(map, reader);
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cjk/TestCJKAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cjk/TestCJKAnalyzer.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Analysis.Cjk
     /// </summary>
     public class TestCJKAnalyzer : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new CJKAnalyzer(TEST_VERSION_CURRENT);
+        private static readonly Analyzer analyzer = new CJKAnalyzer(TEST_VERSION_CURRENT);
 
         [Test]
         public virtual void TestJa1()

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cjk/TestCJKBigramFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cjk/TestCJKBigramFilter.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿using Lucene.Net.Analysis.Standard;
 using NUnit.Framework;
-using System.IO;
-using Lucene.Net.Analysis.Standard;
+using System;
 
 namespace Lucene.Net.Analysis.Cjk
 {
@@ -24,35 +23,17 @@ namespace Lucene.Net.Analysis.Cjk
 
     public class TestCJKBigramFilter : BaseTokenStreamTestCase
     {
-        internal Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        internal static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
+            Tokenizer t = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
+            return new TokenStreamComponents(t, new CJKBigramFilter(t));
+        });
 
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer t = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(t, new CJKBigramFilter(t));
-            }
-        }
-
-        internal Analyzer unibiAnalyzer = new AnalyzerAnonymousInnerClassHelper2();
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
+        internal static readonly Analyzer unibiAnalyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper2()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer t = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(t, new CJKBigramFilter(t, (CJKScript)0xff, true));
-            }
-        }
+            Tokenizer t = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
+            return new TokenStreamComponents(t, new CJKBigramFilter(t, (CJKScript)0xff, true));
+        });
 
         [Test]
         public virtual void TestHuge()
@@ -63,47 +44,23 @@ namespace Lucene.Net.Analysis.Cjk
         [Test]
         public virtual void TestHanOnly()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            AssertAnalyzesTo(a, "多くの学生が試験に落ちた。", new string[] { "多", "く", "の", "学生", "が", "試験", "に", "落", "ち", "た" }, new int[] { 0, 1, 2, 3, 5, 6, 8, 9, 10, 11 }, new int[] { 1, 2, 3, 5, 6, 8, 9, 10, 11, 12 }, new string[] { "<SINGLE>", "<HIRAGANA>", "<HIRAGANA>", "<DOUBLE>", "<HIRAGANA>", "<DOUBLE>", "<HIRAGANA>", "<SINGLE>", "<HIRAGANA>", "<HIRAGANA>", "<SINGLE>" }, new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestCJKBigramFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestCJKBigramFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer t = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
                 return new TokenStreamComponents(t, new CJKBigramFilter(t, CJKScript.HAN));
-            }
+            });
+            AssertAnalyzesTo(a, "多くの学生が試験に落ちた。", new string[] { "多", "く", "の", "学生", "が", "試験", "に", "落", "ち", "た" }, new int[] { 0, 1, 2, 3, 5, 6, 8, 9, 10, 11 }, new int[] { 1, 2, 3, 5, 6, 8, 9, 10, 11, 12 }, new string[] { "<SINGLE>", "<HIRAGANA>", "<HIRAGANA>", "<DOUBLE>", "<HIRAGANA>", "<DOUBLE>", "<HIRAGANA>", "<SINGLE>", "<HIRAGANA>", "<HIRAGANA>", "<SINGLE>" }, new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 });
         }
 
         [Test]
         public virtual void TestAllScripts()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper4(this);
-            AssertAnalyzesTo(a, "多くの学生が試験に落ちた。", new string[] { "多く", "くの", "の学", "学生", "生が", "が試", "試験", "験に", "に落", "落ち", "ちた" });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper4 : Analyzer
-        {
-            private readonly TestCJKBigramFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper4(TestCJKBigramFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer t = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
                 return new TokenStreamComponents(t, new CJKBigramFilter(t, (CJKScript)0xff, false));
-            }
+            });
+            AssertAnalyzesTo(a, "多くの学生が試験に落ちた。", new string[] { "多く", "くの", "の学", "学生", "生が", "が試", "試験", "験に", "に落", "落ち", "ちた" });
         }
 
         [Test]
@@ -115,24 +72,12 @@ namespace Lucene.Net.Analysis.Cjk
         [Test]
         public virtual void TestUnigramsAndBigramsHanOnly()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper5(this);
-            AssertAnalyzesTo(a, "多くの学生が試験に落ちた。", new string[] { "多", "く", "の", "学", "学生", "生", "が", "試", "試験", "験", "に", "落", "ち", "た" }, new int[] { 0, 1, 2, 3, 3, 4, 5, 6, 6, 7, 8, 9, 10, 11 }, new int[] { 1, 2, 3, 4, 5, 5, 6, 7, 8, 8, 9, 10, 11, 12 }, new string[] { "<SINGLE>", "<HIRAGANA>", "<HIRAGANA>", "<SINGLE>", "<DOUBLE>", "<SINGLE>", "<HIRAGANA>", "<SINGLE>", "<DOUBLE>", "<SINGLE>", "<HIRAGANA>", "<SINGLE>", "<HIRAGANA>", "<HIRAGANA>", "<SINGLE>" }, new int[] { 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1 }, new int[] { 1, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 1, 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper5 : Analyzer
-        {
-            private readonly TestCJKBigramFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper5(TestCJKBigramFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer t = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
                 return new TokenStreamComponents(t, new CJKBigramFilter(t, CJKScript.HAN, true));
-            }
+            });
+            AssertAnalyzesTo(a, "多くの学生が試験に落ちた。", new string[] { "多", "く", "の", "学", "学生", "生", "が", "試", "試験", "験", "に", "落", "ち", "た" }, new int[] { 0, 1, 2, 3, 3, 4, 5, 6, 6, 7, 8, 9, 10, 11 }, new int[] { 1, 2, 3, 4, 5, 5, 6, 7, 8, 8, 9, 10, 11, 12 }, new string[] { "<SINGLE>", "<HIRAGANA>", "<HIRAGANA>", "<SINGLE>", "<DOUBLE>", "<SINGLE>", "<HIRAGANA>", "<SINGLE>", "<DOUBLE>", "<SINGLE>", "<HIRAGANA>", "<SINGLE>", "<HIRAGANA>", "<HIRAGANA>", "<SINGLE>" }, new int[] { 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1 }, new int[] { 1, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 1, 1 });
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cjk/TestCJKTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cjk/TestCJKTokenizer.cs
@@ -26,15 +26,8 @@ namespace Lucene.Net.Analysis.Cjk
     public class TestCJKTokenizer : BaseTokenStreamTestCase
     {
 
-        internal class TestToken
+        internal sealed class TestToken
         {
-            private readonly TestCJKTokenizer outerInstance;
-
-            public TestToken(TestCJKTokenizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
             internal string termText;
             internal int start;
             internal int end;
@@ -43,7 +36,7 @@ namespace Lucene.Net.Analysis.Cjk
 
         internal virtual TestToken newToken(string termText, int start, int end, int type)
         {
-            TestToken token = new TestToken(this);
+            TestToken token = new TestToken();
             token.termText = termText;
             token.type = CJKTokenizer.TOKEN_TYPE_NAMES[type];
             token.start = start;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cjk/TestCJKWidthFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cjk/TestCJKWidthFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Cjk
 {
@@ -26,20 +25,11 @@ namespace Lucene.Net.Analysis.Cjk
     /// </summary>
     public class TestCJKWidthFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new CJKWidthFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new CJKWidthFilter(source));
+        });
 
         /// <summary>
         /// Full-width ASCII forms normalized to half-width (basic latin)
@@ -72,24 +62,12 @@ namespace Lucene.Net.Analysis.Cjk
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestCJKWidthFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestCJKWidthFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new CJKWidthFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ckb/TestSoraniNormalizationFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ckb/TestSoraniNormalizationFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Ckb
 {
@@ -26,20 +25,11 @@ namespace Lucene.Net.Analysis.Ckb
     /// </summary>
     public class TestSoraniNormalizationFilter : BaseTokenStreamTestCase
     {
-        internal Analyzer a = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        internal static readonly Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new KeywordTokenizer(reader);
-                return new TokenStreamComponents(tokenizer, new SoraniNormalizationFilter(tokenizer));
-            }
-        }
+            Tokenizer tokenizer = new KeywordTokenizer(reader);
+            return new TokenStreamComponents(tokenizer, new SoraniNormalizationFilter(tokenizer));
+        });
 
         [Test]
         public virtual void TestY()

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ckb/TestSoraniStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ckb/TestSoraniStemFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Ckb
 {
@@ -97,24 +96,12 @@ namespace Lucene.Net.Analysis.Ckb
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestSoraniStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestSoraniStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new SoraniStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cn/TestChineseTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cn/TestChineseTokenizer.cs
@@ -61,15 +61,8 @@ namespace Lucene.Net.Analysis.Cn
          * Analyzer that just uses ChineseTokenizer, not ChineseFilter.
          * convenience to show the behavior of the tokenizer
          */
-        private class JustChineseTokenizerAnalyzer : Analyzer
+        private sealed class JustChineseTokenizerAnalyzer : Analyzer
         {
-            private readonly TestChineseTokenizer outerInstance;
-
-            public JustChineseTokenizerAnalyzer(TestChineseTokenizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
             protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
             {
                 return new TokenStreamComponents(new ChineseTokenizer(reader));
@@ -80,15 +73,8 @@ namespace Lucene.Net.Analysis.Cn
          * Analyzer that just uses ChineseFilter, not ChineseTokenizer.
          * convenience to show the behavior of the filter.
          */
-        private class JustChineseFilterAnalyzer : Analyzer
+        private sealed class JustChineseFilterAnalyzer : Analyzer
         {
-            private readonly TestChineseTokenizer outerInstance;
-
-            public JustChineseFilterAnalyzer(TestChineseTokenizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
             protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
             {
                 Tokenizer tokenizer = new WhitespaceTokenizer(LuceneVersion.LUCENE_CURRENT, reader);
@@ -102,7 +88,7 @@ namespace Lucene.Net.Analysis.Cn
         [Test]
         public virtual void TestNumerics()
         {
-            Analyzer justTokenizer = new JustChineseTokenizerAnalyzer(this);
+            Analyzer justTokenizer = new JustChineseTokenizerAnalyzer();
             AssertAnalyzesTo(justTokenizer, "中1234", new string[] { "中", "1234" });
 
             // in this case the ChineseAnalyzer (which applies ChineseFilter) will remove the numeric token.
@@ -123,10 +109,10 @@ namespace Lucene.Net.Analysis.Cn
             Analyzer chinese = new ChineseAnalyzer();
             AssertAnalyzesTo(chinese, "This is a Test. b c d", new string[] { "test" });
 
-            Analyzer justTokenizer = new JustChineseTokenizerAnalyzer(this);
+            Analyzer justTokenizer = new JustChineseTokenizerAnalyzer();
             AssertAnalyzesTo(justTokenizer, "This is a Test. b c d", new string[] { "this", "is", "a", "test", "b", "c", "d" });
 
-            Analyzer justFilter = new JustChineseFilterAnalyzer(this);
+            Analyzer justFilter = new JustChineseFilterAnalyzer();
             AssertAnalyzesTo(justFilter, "This is a Test. b c d", new string[] { "This", "Test." });
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Commongrams/CommonGramsFilterTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Commongrams/CommonGramsFilterTest.cs
@@ -90,7 +90,11 @@ namespace Lucene.Net.Analysis.CommonGrams
         [Test]
         public virtual void TestCommonGramsQueryFilter()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+                return new TokenStreamComponents(tokenizer, new CommonGramsQueryFilter(new CommonGramsFilter(TEST_VERSION_CURRENT, tokenizer, commonWords)));
+            });
 
             // Stop words used below are "of" "the" and "s"
 
@@ -130,26 +134,14 @@ namespace Lucene.Net.Analysis.CommonGrams
             AssertAnalyzesTo(a, "of the of", new string[] { "of_the", "the_of" });
         }
 
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly CommonGramsFilterTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(CommonGramsFilterTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new CommonGramsQueryFilter(new CommonGramsFilter(TEST_VERSION_CURRENT, tokenizer, commonWords)));
-            }
-        }
-
         [Test]
         public virtual void TestCommonGramsFilter()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+                return new TokenStreamComponents(tokenizer, new CommonGramsFilter(TEST_VERSION_CURRENT, tokenizer, commonWords));
+            });
 
             // Stop words used below are "of" "the" and "s"
             // one word queries
@@ -186,22 +178,6 @@ namespace Lucene.Net.Analysis.CommonGrams
 
             AssertAnalyzesTo(a, "s s s", new string[] { "s", "s_s", "s", "s_s", "s" }, new int[] { 1, 0, 1, 0, 1 });
             AssertAnalyzesTo(a, "of the of", new string[] { "of", "of_the", "the", "the_of", "of" }, new int[] { 1, 0, 1, 0, 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly CommonGramsFilterTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(CommonGramsFilterTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new CommonGramsFilter(TEST_VERSION_CURRENT, tokenizer, commonWords));
-            }
         }
 
         /// <summary>
@@ -286,49 +262,23 @@ namespace Lucene.Net.Analysis.CommonGrams
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-
-            Analyzer b = new AnalyzerAnonymousInnerClassHelper4(this);
-
-            CheckRandomData(Random, b, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly CommonGramsFilterTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(CommonGramsFilterTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer t = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 CommonGramsFilter cgf = new CommonGramsFilter(TEST_VERSION_CURRENT, t, commonWords);
                 return new TokenStreamComponents(t, cgf);
-            }
-        }
+            });
 
-        private class AnalyzerAnonymousInnerClassHelper4 : Analyzer
-        {
-            private readonly CommonGramsFilterTest outerInstance;
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
 
-            public AnalyzerAnonymousInnerClassHelper4(CommonGramsFilterTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer b = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer t = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 CommonGramsFilter cgf = new CommonGramsFilter(TEST_VERSION_CURRENT, t, commonWords);
                 return new TokenStreamComponents(t, new CommonGramsQueryFilter(cgf));
-            }
+            });
+
+            CheckRandomData(Random, b, 1000 * RandomMultiplier);
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAnalyzers.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAnalyzers.cs
@@ -111,27 +111,17 @@ namespace Lucene.Net.Analysis.Core
 #pragma warning restore 219, 612, 618
         }
 
-        private class LowerCaseWhitespaceAnalyzer : Analyzer
+        private static readonly Analyzer LOWERCASE_WHITESPACE_ANALYZER = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
+            Tokenizer tokenizer = new WhitespaceTokenizer(TEST_VERSION_CURRENT, reader);
+            return new TokenStreamComponents(tokenizer, new LowerCaseFilter(TEST_VERSION_CURRENT, tokenizer));
+        });
 
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new WhitespaceTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(tokenizer, new LowerCaseFilter(TEST_VERSION_CURRENT, tokenizer));
-            }
-
-        }
-
-        private class UpperCaseWhitespaceAnalyzer : Analyzer
+        private static readonly Analyzer UPPERCASE_WHITESPACE_ANALYZER = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new WhitespaceTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(tokenizer, new UpperCaseFilter(TEST_VERSION_CURRENT, tokenizer));
-            }
-
-        }
+            Tokenizer tokenizer = new WhitespaceTokenizer(TEST_VERSION_CURRENT, reader);
+            return new TokenStreamComponents(tokenizer, new UpperCaseFilter(TEST_VERSION_CURRENT, tokenizer));
+        });
 
 
         /// <summary>
@@ -140,7 +130,7 @@ namespace Lucene.Net.Analysis.Core
         [Test]
         public virtual void TestLowerCaseFilter()
         {
-            Analyzer a = new LowerCaseWhitespaceAnalyzer();
+            Analyzer a = LOWERCASE_WHITESPACE_ANALYZER;
             // BMP
             AssertAnalyzesTo(a, "AbaCaDabA", new string[] { "abacadaba" });
             // supplementary
@@ -158,7 +148,7 @@ namespace Lucene.Net.Analysis.Core
         [Test]
         public virtual void TestUpperCaseFilter()
         {
-            Analyzer a = new UpperCaseWhitespaceAnalyzer();
+            Analyzer a = UPPERCASE_WHITESPACE_ANALYZER;
             // BMP
             AssertAnalyzesTo(a, "AbaCaDabA", new string[] { "ABACADABA" });
             // supplementary

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
@@ -47,42 +47,23 @@ namespace Lucene.Net.Analysis.Core
             builder.Add("tcgyreo", "zpfpajyws");
             NormalizeCharMap map = builder.Build();
 
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this, cas, map);
-            CheckAnalysisConsistency(Random, a, false, "wmgddzunizdomqyj");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestBugInSomething outerInstance;
-
-            private CharArraySet cas;
-            private NormalizeCharMap map;
-
-            public AnalyzerAnonymousInnerClassHelper(TestBugInSomething outerInstance, CharArraySet cas, NormalizeCharMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.cas = cas;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer t = new MockTokenizer(new TestRandomChains.CheckThatYouDidntReadAnythingReaderWrapper(reader), MockTokenFilter.ENGLISH_STOPSET, false, -65);
                 TokenFilter f = new CommonGramsFilter(TEST_VERSION_CURRENT, t, cas);
                 return new TokenStreamComponents(t, f);
-            }
-
-            protected internal override TextReader InitReader(string fieldName, TextReader reader)
+            }, initReader: (fieldName, reader) =>
             {
                 reader = new MockCharFilter(reader, 0);
                 reader = new MappingCharFilter(map, reader);
-                return reader;
-            }
+                return reader;            
+            });
+            CheckAnalysisConsistency(Random, a, false, "wmgddzunizdomqyj");
         }
 
         internal CharFilter wrappedStream = new CharFilterAnonymousInnerClassHelper(new StringReader("bogus"));
 
-        private class CharFilterAnonymousInnerClassHelper : CharFilter
+        private sealed class CharFilterAnonymousInnerClassHelper : CharFilter
         {
             public CharFilterAnonymousInnerClassHelper(StringReader java) : base(java)
             {
@@ -300,20 +281,7 @@ namespace Lucene.Net.Analysis.Core
         [Slow]
         public virtual void TestUnicodeShinglesAndNgrams()
         {
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper100(this);
-            CheckRandomData(Random, analyzer, 2000);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper100 : Analyzer
-        {
-            private readonly TestBugInSomething outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper100(TestBugInSomething outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new EdgeNGramTokenizer(TEST_VERSION_CURRENT, reader, 2, 94);
                 //TokenStream stream = new SopTokenFilter(tokenizer);
@@ -322,7 +290,8 @@ namespace Lucene.Net.Analysis.Core
                 stream = new NGramTokenFilter(TEST_VERSION_CURRENT, stream, 55, 83);
                 //stream = new SopTokenFilter(stream);
                 return new TokenStreamComponents(tokenizer, stream);
-            }
+            });
+            CheckRandomData(Random, analyzer, 2000);
         }
 
         [Test]
@@ -330,32 +299,15 @@ namespace Lucene.Net.Analysis.Core
         {
             CharArraySet protWords = new CharArraySet(TEST_VERSION_CURRENT, new JCG.HashSet<string> { "rrdpafa", "pupmmlu", "xlq", "dyy", "zqrxrrck", "o", "hsrlfvcha" }, false);
             byte[] table = (byte[])(Array)new sbyte[] { -57, 26, 1, 48, 63, -23, 55, -84, 18, 120, -97, 103, 58, 13, 84, 89, 57, -13, -63, 5, 28, 97, -54, -94, 102, -108, -5, 5, 46, 40, 43, 78, 43, -72, 36, 29, 124, -106, -22, -51, 65, 5, 31, -42, 6, -99, 97, 14, 81, -128, 74, 100, 54, -55, -25, 53, -71, -98, 44, 33, 86, 106, -42, 47, 115, -89, -18, -26, 22, -95, -43, 83, -125, 105, -104, -24, 106, -16, 126, 115, -105, 97, 65, -33, 57, 44, -1, 123, -68, 100, 13, -41, -64, -119, 0, 92, 94, -36, 53, -9, -102, -18, 90, 94, -26, 31, 71, -20 };
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, protWords, table);
-            CheckAnalysisConsistency(Random, a, false, "B\u28c3\ue0f8[ \ud800\udfc2 </p> jb");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestBugInSomething outerInstance;
-
-            private CharArraySet protWords;
-            private byte[] table;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestBugInSomething outerInstance, CharArraySet protWords, byte[] table)
-            {
-                this.outerInstance = outerInstance;
-                this.protWords = protWords;
-                this.table = table;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new WikipediaTokenizer(reader);
                 TokenStream stream = new SopTokenFilter(tokenizer);
                 stream = new WordDelimiterFilter(TEST_VERSION_CURRENT, stream, table, (WordDelimiterFlags)(object)-50, protWords);
                 stream = new SopTokenFilter(stream);
                 return new TokenStreamComponents(tokenizer, stream);
-            }
+            });
+            CheckAnalysisConsistency(Random, a, false, "B\u28c3\ue0f8[ \ud800\udfc2 </p> jb");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestDuelingAnalyzers.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestDuelingAnalyzers.cs
@@ -61,27 +61,15 @@ namespace Lucene.Net.Analysis.Core
         {
             Random random = Random;
             Analyzer left = new MockAnalyzer(random, jvmLetter, false);
-            Analyzer right = new AnalyzerAnonymousInnerClassHelper(this);
+            Analyzer right = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
+                return new TokenStreamComponents(tokenizer, tokenizer);
+            });
             for (int i = 0; i < 1000; i++)
             {
                 string s = TestUtil.RandomSimpleString(random);
                 assertEquals(s, left.GetTokenStream("foo", newStringReader(s)), right.GetTokenStream("foo", newStringReader(s)));
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestDuelingAnalyzers outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestDuelingAnalyzers outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(tokenizer, tokenizer);
             }
         }
 
@@ -93,7 +81,11 @@ namespace Lucene.Net.Analysis.Core
             int maxLength = 8192; // CharTokenizer.IO_BUFFER_SIZE*2
             MockAnalyzer left = new MockAnalyzer(random, jvmLetter, false);
             left.MaxTokenLength = 255; // match CharTokenizer's max token length
-            Analyzer right = new AnalyzerAnonymousInnerClassHelper2(this);
+            Analyzer right = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
+                return new TokenStreamComponents(tokenizer, tokenizer);
+            });
             int numIterations = AtLeast(50);
             for (int i = 0; i < numIterations; i++)
             {
@@ -102,48 +94,20 @@ namespace Lucene.Net.Analysis.Core
             }
         }
 
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestDuelingAnalyzers outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestDuelingAnalyzers outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(tokenizer, tokenizer);
-            }
-        }
-
         [Test]
         public virtual void TestLetterHtmlish()
         {
             Random random = Random;
             Analyzer left = new MockAnalyzer(random, jvmLetter, false);
-            Analyzer right = new AnalyzerAnonymousInnerClassHelper3(this);
+            Analyzer right = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
+                return new TokenStreamComponents(tokenizer, tokenizer);
+            });
             for (int i = 0; i < 1000; i++)
             {
                 string s = TestUtil.RandomHtmlishString(random, 20);
                 assertEquals(s, left.GetTokenStream("foo", newStringReader(s)), right.GetTokenStream("foo", newStringReader(s)));
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestDuelingAnalyzers outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestDuelingAnalyzers outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(tokenizer, tokenizer);
             }
         }
 
@@ -154,7 +118,11 @@ namespace Lucene.Net.Analysis.Core
             int maxLength = 1024; // this is number of elements, not chars!
             MockAnalyzer left = new MockAnalyzer(random, jvmLetter, false);
             left.MaxTokenLength = 255; // match CharTokenizer's max token length
-            Analyzer right = new AnalyzerAnonymousInnerClassHelper4(this);
+            Analyzer right = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
+                return new TokenStreamComponents(tokenizer, tokenizer);
+            });
             int numIterations = AtLeast(50);
             for (int i = 0; i < numIterations; i++)
             {
@@ -163,48 +131,20 @@ namespace Lucene.Net.Analysis.Core
             }
         }
 
-        private class AnalyzerAnonymousInnerClassHelper4 : Analyzer
-        {
-            private readonly TestDuelingAnalyzers outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper4(TestDuelingAnalyzers outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(tokenizer, tokenizer);
-            }
-        }
-
         [Test]
         public virtual void TestLetterUnicode()
         {
             Random random = Random;
             Analyzer left = new MockAnalyzer(LuceneTestCase.Random, jvmLetter, false);
-            Analyzer right = new AnalyzerAnonymousInnerClassHelper5(this);
+            Analyzer right = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
+                return new TokenStreamComponents(tokenizer, tokenizer);
+            });
             for (int i = 0; i < 1000; i++)
             {
                 string s = TestUtil.RandomUnicodeString(random);
                 assertEquals(s, left.GetTokenStream("foo", newStringReader(s)), right.GetTokenStream("foo", newStringReader(s)));
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper5 : Analyzer
-        {
-            private readonly TestDuelingAnalyzers outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper5(TestDuelingAnalyzers outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(tokenizer, tokenizer);
             }
         }
 
@@ -215,28 +155,16 @@ namespace Lucene.Net.Analysis.Core
             int maxLength = 4300; // CharTokenizer.IO_BUFFER_SIZE + fudge
             MockAnalyzer left = new MockAnalyzer(random, jvmLetter, false);
             left.MaxTokenLength = 255; // match CharTokenizer's max token length
-            Analyzer right = new AnalyzerAnonymousInnerClassHelper6(this);
+            Analyzer right = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
+                return new TokenStreamComponents(tokenizer, tokenizer);
+            });
             int numIterations = AtLeast(50);
             for (int i = 0; i < numIterations; i++)
             {
                 string s = TestUtil.RandomUnicodeString(random, maxLength);
                 assertEquals(s, left.GetTokenStream("foo", newStringReader(s)), right.GetTokenStream("foo", newStringReader(s)));
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper6 : Analyzer
-        {
-            private readonly TestDuelingAnalyzers outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper6(TestDuelingAnalyzers outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new LetterTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(tokenizer, tokenizer);
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestFactories.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestFactories.cs
@@ -168,12 +168,13 @@ namespace Lucene.Net.Analysis.Core
                 }
             }
 
-            if (factory is IResourceLoaderAware)
+            if (factory is IResourceLoaderAware aware)
             {
                 try
                 {
-                    ((IResourceLoaderAware)factory).Inform(new StringMockResourceLoader(""));
+                    aware.Inform(new StringMockResourceLoader(""));
                 }
+#pragma warning disable CA1031 // Do not catch general exception types
                 catch (IOException)
                 {
                     // its ok if the right files arent available or whatever to throw this
@@ -182,12 +183,13 @@ namespace Lucene.Net.Analysis.Core
                 {
                     // is this ok? I guess so
                 }
+#pragma warning restore CA1031 // Do not catch general exception types
             }
             return factory;
         }
 
         // some silly classes just so we can use checkRandomData
-        private TokenizerFactory assertingTokenizer = new AnonymousInnerClassHelperTokenizerFactory(new Dictionary<string, string>());
+        private readonly TokenizerFactory assertingTokenizer = new AnonymousInnerClassHelperTokenizerFactory(new Dictionary<string, string>());
 
         private sealed class AnonymousInnerClassHelperTokenizerFactory : TokenizerFactory
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestFactories.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestFactories.cs
@@ -126,21 +126,24 @@ namespace Lucene.Net.Analysis.Core
             }
         }
 
+        // LUCENENET specific - remove overhead of converting to a string on each loop
+        private static readonly string TEST_VERSION_CURRENT_STRING = TEST_VERSION_CURRENT.ToString();
+
         /// <summary>
         /// tries to initialize a factory with no arguments </summary>
         private AbstractAnalysisFactory Initialize(Type factoryClazz)
         {
-            IDictionary<string, string> args = new Dictionary<string, string>();
-            args["luceneMatchVersion"] = TEST_VERSION_CURRENT.ToString();
+            IDictionary<string, string> args =
+                new Dictionary<string, string> { ["luceneMatchVersion"] = TEST_VERSION_CURRENT_STRING };
 
             ConstructorInfo ctor;
             try
             {
                 ctor = factoryClazz.GetConstructor(new Type[] { typeof(IDictionary<string, string>) });
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                throw new Exception("factory '" + factoryClazz + "' does not have a proper ctor!");
+                throw new Exception("factory '" + factoryClazz + "' does not have a proper ctor!", e);
             }
 
             AbstractAnalysisFactory factory = null;
@@ -186,7 +189,7 @@ namespace Lucene.Net.Analysis.Core
         // some silly classes just so we can use checkRandomData
         private TokenizerFactory assertingTokenizer = new AnonymousInnerClassHelperTokenizerFactory(new Dictionary<string, string>());
 
-        private class AnonymousInnerClassHelperTokenizerFactory : TokenizerFactory
+        private sealed class AnonymousInnerClassHelperTokenizerFactory : TokenizerFactory
         {
             public AnonymousInnerClassHelperTokenizerFactory(IDictionary<string, string> java) : base(java)
             {
@@ -198,7 +201,7 @@ namespace Lucene.Net.Analysis.Core
             }
         }
 
-        private class FactoryAnalyzer : Analyzer
+        private sealed class FactoryAnalyzer : Analyzer
         {
             internal readonly TokenizerFactory tokenizer;
             internal readonly CharFilterFactory charFilter;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStandardAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStandardAnalyzer.cs
@@ -41,20 +41,11 @@ namespace Lucene.Net.Analysis.Core
             BaseTokenStreamTestCase.AssertTokenStreamContents(tokenizer, new string[] { "testing", "1234" });
         }
 
-        private Analyzer a = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
-                return new TokenStreamComponents(tokenizer);
-            }
-        }
+            Tokenizer tokenizer = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
+            return new TokenStreamComponents(tokenizer);
+        });
 
         [Test]
         public virtual void TestArmenian()
@@ -323,26 +314,14 @@ namespace Lucene.Net.Analysis.Core
         [Obsolete("uses older unicode (6.0). simple test to make sure its basically working")]
         public virtual void TestVersion36()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            AssertAnalyzesTo(a, "this is just a t\u08E6st lucene@apache.org", new string[] { "this", "is", "just", "a", "t", "st", "lucene", "apache.org" }); // new combining mark in 6.1
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestStandardAnalyzer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestStandardAnalyzer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
 #pragma warning disable 612, 618
                 Tokenizer tokenizer = new StandardTokenizer(LuceneVersion.LUCENE_36, reader);
 #pragma warning restore 612, 618
                 return new TokenStreamComponents(tokenizer);
-            }
+            });
+            AssertAnalyzesTo(a, "this is just a t\u08E6st lucene@apache.org", new string[] { "this", "is", "just", "a", "t", "st", "lucene", "apache.org" }); // new combining mark in 6.1
         }
 
         /// @deprecated uses older unicode (6.1). simple test to make sure its basically working 
@@ -350,28 +329,16 @@ namespace Lucene.Net.Analysis.Core
         [Obsolete("uses older unicode (6.1). simple test to make sure its basically working")]
         public virtual void TestVersion40()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            // U+061C is a new combining mark in 6.3, found using "[[\p{WB:Format}\p{WB:Extend}]&[^\p{Age:6.2}]]"
-            // on the online UnicodeSet utility: <http://unicode.org/cldr/utility/list-unicodeset.jsp>
-            AssertAnalyzesTo(a, "this is just a t\u061Cst lucene@apache.org", new string[] { "this", "is", "just", "a", "t", "st", "lucene", "apache.org" });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestStandardAnalyzer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestStandardAnalyzer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
 #pragma warning disable 612, 618
                 Tokenizer tokenizer = new StandardTokenizer(LuceneVersion.LUCENE_40, reader);
 #pragma warning restore 612, 618
                 return new TokenStreamComponents(tokenizer);
-            }
+            });
+            // U+061C is a new combining mark in 6.3, found using "[[\p{WB:Format}\p{WB:Extend}]&[^\p{Age:6.2}]]"
+            // on the online UnicodeSet utility: <http://unicode.org/cldr/utility/list-unicodeset.jsp>
+            AssertAnalyzesTo(a, "this is just a t\u061Cst lucene@apache.org", new string[] { "this", "is", "just", "a", "t", "st", "lucene", "apache.org" });
         }
 
         /// <summary>
@@ -396,24 +363,14 @@ namespace Lucene.Net.Analysis.Core
         public virtual void TestRandomHugeStringsGraphAfter()
         {
             Random random = Random;
-            CheckRandomData(random, new AnalyzerAnonymousInnerClassHelper4(this), 100 * RandomMultiplier, 8192);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper4 : Analyzer
-        {
-            private readonly TestStandardAnalyzer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper4(TestStandardAnalyzer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
-                TokenStream tokenStream = new MockGraphTokenFilter(Random, tokenizer);
-                return new TokenStreamComponents(tokenizer, tokenStream);
-            }
+            CheckRandomData(random,
+                Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
+                    TokenStream tokenStream = new MockGraphTokenFilter(Random, tokenizer);
+                    return new TokenStreamComponents(tokenizer, tokenStream);
+                })
+                , 100 * RandomMultiplier, 8192);
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilter.cs
@@ -212,30 +212,18 @@ namespace Lucene.Net.Analysis.Core
         [Test]
         public virtual void TestFirstPosInc()
         {
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper(this);
-
-            AssertAnalyzesTo(analyzer, "the quick brown fox", new string[] { "hte", "quick", "brown", "fox" }, new int[] { 1, 1, 1, 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestStopFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestStopFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                TokenFilter filter = new MockSynonymFilter(outerInstance, tokenizer);
+                TokenFilter filter = new MockSynonymFilter(this, tokenizer);
 #pragma warning disable 612, 618
                 StopFilter stopfilter = new StopFilter(Version.LUCENE_43, filter, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
                 stopfilter.SetEnablePositionIncrements(false);
 #pragma warning restore 612, 618
                 return new TokenStreamComponents(tokenizer, stopfilter);
-            }
+            });
+
+            AssertAnalyzesTo(analyzer, "the quick brown fox", new string[] { "hte", "quick", "brown", "fox" }, new int[] { 1, 1, 1, 1 });
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilter.cs
@@ -164,16 +164,13 @@ namespace Lucene.Net.Analysis.Core
         // stupid filter that inserts synonym of 'hte' for 'the'
         private sealed class MockSynonymFilter : TokenFilter
         {
-            private readonly TestStopFilter outerInstance;
-
             internal State bufferedState;
             internal ICharTermAttribute termAtt;
             internal IPositionIncrementAttribute posIncAtt;
 
-            internal MockSynonymFilter(TestStopFilter outerInstance, TokenStream input)
+            internal MockSynonymFilter(TokenStream input)
                 : base(input)
             {
-                this.outerInstance = outerInstance;
                 termAtt = AddAttribute<ICharTermAttribute>();
                 posIncAtt = AddAttribute<IPositionIncrementAttribute>();
             }
@@ -215,7 +212,7 @@ namespace Lucene.Net.Analysis.Core
             Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                TokenFilter filter = new MockSynonymFilter(this, tokenizer);
+                TokenFilter filter = new MockSynonymFilter(tokenizer);
 #pragma warning disable 612, 618
                 StopFilter stopfilter = new StopFilter(Version.LUCENE_43, filter, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
                 stopfilter.SetEnablePositionIncrements(false);

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cz/TestCzechStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cz/TestCzechStemmer.cs
@@ -299,24 +299,12 @@ namespace Lucene.Net.Analysis.Cz
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestCzechStemmer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestCzechStemmer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new CzechStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/De/TestGermanLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/De/TestGermanLightStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.De
 {
@@ -28,20 +27,11 @@ namespace Lucene.Net.Analysis.De
     /// </summary>
     public class TestGermanLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new GermanLightStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new GermanLightStemFilter(source));
+        });
 
         /// <summary>
         /// Test against a vocabulary from the reference impl </summary>
@@ -55,28 +45,13 @@ namespace Lucene.Net.Analysis.De
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("sängerinnen"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "sängerinnen", "sängerinnen");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestGermanLightStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestGermanLightStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new GermanLightStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "sängerinnen", "sängerinnen");
         }
 
         /// <summary>
@@ -90,24 +65,12 @@ namespace Lucene.Net.Analysis.De
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestGermanLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestGermanLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new GermanLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/De/TestGermanMinimalStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/De/TestGermanMinimalStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.De
 {
@@ -28,20 +27,11 @@ namespace Lucene.Net.Analysis.De
     /// </summary>
     public class TestGermanMinimalStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new GermanMinimalStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new GermanMinimalStemFilter(source));
+        });
 
         /// <summary>
         /// Test some examples from the paper </summary>
@@ -62,28 +52,13 @@ namespace Lucene.Net.Analysis.De
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("sängerinnen"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "sängerinnen", "sängerinnen");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestGermanMinimalStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestGermanMinimalStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new GermanMinimalStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "sängerinnen", "sängerinnen");
         }
 
         /// <summary>
@@ -105,24 +80,12 @@ namespace Lucene.Net.Analysis.De
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestGermanMinimalStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestGermanMinimalStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new GermanMinimalStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/De/TestGermanNormalizationFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/De/TestGermanNormalizationFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.De
 {
@@ -26,21 +25,12 @@ namespace Lucene.Net.Analysis.De
     /// </summary>
     public class TestGermanNormalizationFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string field, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                TokenStream stream = new GermanNormalizationFilter(tokenizer);
-                return new TokenStreamComponents(tokenizer, stream);
-            }
-        }
+            Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            TokenStream stream = new GermanNormalizationFilter(tokenizer);
+            return new TokenStreamComponents(tokenizer, stream);
+        });
 
         /// <summary>
         /// Tests that a/o/u + e is equivalent to the umlaut form
@@ -81,24 +71,12 @@ namespace Lucene.Net.Analysis.De
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestGermanNormalizationFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestGermanNormalizationFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new GermanNormalizationFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/De/TestGermanStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/De/TestGermanStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.De
 {
@@ -31,20 +30,11 @@ namespace Lucene.Net.Analysis.De
     /// </summary>
     public class TestGermanStemFilter : BaseTokenStreamTestCase
     {
-        internal Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        internal static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer t = new KeywordTokenizer(reader);
-                return new TokenStreamComponents(t, new GermanStemFilter(new LowerCaseFilter(TEST_VERSION_CURRENT, t)));
-            }
-        }
+            Tokenizer t = new KeywordTokenizer(reader);
+            return new TokenStreamComponents(t, new GermanStemFilter(new LowerCaseFilter(TEST_VERSION_CURRENT, t)));
+        });
 
         [Test]
         public virtual void TestStemming()
@@ -66,28 +56,13 @@ namespace Lucene.Net.Analysis.De
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("sängerinnen"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "sängerinnen", "sängerinnen");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestGermanStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestGermanStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new GermanStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "sängerinnen", "sängerinnen");
         }
 
         /// <summary>
@@ -101,24 +76,12 @@ namespace Lucene.Net.Analysis.De
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestGermanStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestGermanStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new GermanStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/El/TestGreekStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/El/TestGreekStemmer.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.El
 {
@@ -23,541 +22,529 @@ namespace Lucene.Net.Analysis.El
 
     public class TestGreekStemmer : BaseTokenStreamTestCase
     {
-      internal Analyzer a = new GreekAnalyzer(TEST_VERSION_CURRENT);
+        internal static readonly Analyzer a = new GreekAnalyzer(TEST_VERSION_CURRENT);
 
         [Test]
         public virtual void TestMasculineNouns()
-      {
-        // -ος
-        CheckOneTerm(a, "άνθρωπος", "ανθρωπ");
-        CheckOneTerm(a, "ανθρώπου", "ανθρωπ");
-        CheckOneTerm(a, "άνθρωπο", "ανθρωπ");
-        CheckOneTerm(a, "άνθρωπε", "ανθρωπ");
-        CheckOneTerm(a, "άνθρωποι", "ανθρωπ");
-        CheckOneTerm(a, "ανθρώπων", "ανθρωπ");
-        CheckOneTerm(a, "ανθρώπους", "ανθρωπ");
-        CheckOneTerm(a, "άνθρωποι", "ανθρωπ");
+        {
+            // -ος
+            CheckOneTerm(a, "άνθρωπος", "ανθρωπ");
+            CheckOneTerm(a, "ανθρώπου", "ανθρωπ");
+            CheckOneTerm(a, "άνθρωπο", "ανθρωπ");
+            CheckOneTerm(a, "άνθρωπε", "ανθρωπ");
+            CheckOneTerm(a, "άνθρωποι", "ανθρωπ");
+            CheckOneTerm(a, "ανθρώπων", "ανθρωπ");
+            CheckOneTerm(a, "ανθρώπους", "ανθρωπ");
+            CheckOneTerm(a, "άνθρωποι", "ανθρωπ");
 
-        // -ης
-        CheckOneTerm(a, "πελάτης", "πελατ");
-        CheckOneTerm(a, "πελάτη", "πελατ");
-        CheckOneTerm(a, "πελάτες", "πελατ");
-        CheckOneTerm(a, "πελατών", "πελατ");
+            // -ης
+            CheckOneTerm(a, "πελάτης", "πελατ");
+            CheckOneTerm(a, "πελάτη", "πελατ");
+            CheckOneTerm(a, "πελάτες", "πελατ");
+            CheckOneTerm(a, "πελατών", "πελατ");
 
-        // -ας/-ες
-        CheckOneTerm(a, "ελέφαντας", "ελεφαντ");
-        CheckOneTerm(a, "ελέφαντα", "ελεφαντ");
-        CheckOneTerm(a, "ελέφαντες", "ελεφαντ");
-        CheckOneTerm(a, "ελεφάντων", "ελεφαντ");
+            // -ας/-ες
+            CheckOneTerm(a, "ελέφαντας", "ελεφαντ");
+            CheckOneTerm(a, "ελέφαντα", "ελεφαντ");
+            CheckOneTerm(a, "ελέφαντες", "ελεφαντ");
+            CheckOneTerm(a, "ελεφάντων", "ελεφαντ");
 
-        // -ας/-αδες
-        CheckOneTerm(a, "μπαμπάς", "μπαμπ");
-        CheckOneTerm(a, "μπαμπά", "μπαμπ");
-        CheckOneTerm(a, "μπαμπάδες", "μπαμπ");
-        CheckOneTerm(a, "μπαμπάδων", "μπαμπ");
+            // -ας/-αδες
+            CheckOneTerm(a, "μπαμπάς", "μπαμπ");
+            CheckOneTerm(a, "μπαμπά", "μπαμπ");
+            CheckOneTerm(a, "μπαμπάδες", "μπαμπ");
+            CheckOneTerm(a, "μπαμπάδων", "μπαμπ");
 
-        // -ης/-ηδες
-        CheckOneTerm(a, "μπακάλης", "μπακαλ");
-        CheckOneTerm(a, "μπακάλη", "μπακαλ");
-        CheckOneTerm(a, "μπακάληδες", "μπακαλ");
-        CheckOneTerm(a, "μπακάληδων", "μπακαλ");
+            // -ης/-ηδες
+            CheckOneTerm(a, "μπακάλης", "μπακαλ");
+            CheckOneTerm(a, "μπακάλη", "μπακαλ");
+            CheckOneTerm(a, "μπακάληδες", "μπακαλ");
+            CheckOneTerm(a, "μπακάληδων", "μπακαλ");
 
-        // -ες
-        CheckOneTerm(a, "καφές", "καφ");
-        CheckOneTerm(a, "καφέ", "καφ");
-        CheckOneTerm(a, "καφέδες", "καφ");
-        CheckOneTerm(a, "καφέδων", "καφ");
+            // -ες
+            CheckOneTerm(a, "καφές", "καφ");
+            CheckOneTerm(a, "καφέ", "καφ");
+            CheckOneTerm(a, "καφέδες", "καφ");
+            CheckOneTerm(a, "καφέδων", "καφ");
 
-        // -έας/είς
-        CheckOneTerm(a, "γραμματέας", "γραμματε");
-        CheckOneTerm(a, "γραμματέα", "γραμματε");
-        // plural forms conflate w/ each other, not w/ the sing forms
-        CheckOneTerm(a, "γραμματείς", "γραμματ");
-        CheckOneTerm(a, "γραμματέων", "γραμματ");
+            // -έας/είς
+            CheckOneTerm(a, "γραμματέας", "γραμματε");
+            CheckOneTerm(a, "γραμματέα", "γραμματε");
+            // plural forms conflate w/ each other, not w/ the sing forms
+            CheckOneTerm(a, "γραμματείς", "γραμματ");
+            CheckOneTerm(a, "γραμματέων", "γραμματ");
 
-        // -ους/οι
-        CheckOneTerm(a, "απόπλους", "αποπλ");
-        CheckOneTerm(a, "απόπλου", "αποπλ");
-        CheckOneTerm(a, "απόπλοι", "αποπλ");
-        CheckOneTerm(a, "απόπλων", "αποπλ");
+            // -ους/οι
+            CheckOneTerm(a, "απόπλους", "αποπλ");
+            CheckOneTerm(a, "απόπλου", "αποπλ");
+            CheckOneTerm(a, "απόπλοι", "αποπλ");
+            CheckOneTerm(a, "απόπλων", "αποπλ");
 
-        // -ους/-ουδες
-        CheckOneTerm(a, "παππούς", "παππ");
-        CheckOneTerm(a, "παππού", "παππ");
-        CheckOneTerm(a, "παππούδες", "παππ");
-        CheckOneTerm(a, "παππούδων", "παππ");
+            // -ους/-ουδες
+            CheckOneTerm(a, "παππούς", "παππ");
+            CheckOneTerm(a, "παππού", "παππ");
+            CheckOneTerm(a, "παππούδες", "παππ");
+            CheckOneTerm(a, "παππούδων", "παππ");
 
-        // -ης/-εις
-        CheckOneTerm(a, "λάτρης", "λατρ");
-        CheckOneTerm(a, "λάτρη", "λατρ");
-        CheckOneTerm(a, "λάτρεις", "λατρ");
-        CheckOneTerm(a, "λάτρεων", "λατρ");
+            // -ης/-εις
+            CheckOneTerm(a, "λάτρης", "λατρ");
+            CheckOneTerm(a, "λάτρη", "λατρ");
+            CheckOneTerm(a, "λάτρεις", "λατρ");
+            CheckOneTerm(a, "λάτρεων", "λατρ");
 
-        // -υς
-        CheckOneTerm(a, "πέλεκυς", "πελεκ");
-        CheckOneTerm(a, "πέλεκυ", "πελεκ");
-        CheckOneTerm(a, "πελέκεις", "πελεκ");
-        CheckOneTerm(a, "πελέκεων", "πελεκ");
+            // -υς
+            CheckOneTerm(a, "πέλεκυς", "πελεκ");
+            CheckOneTerm(a, "πέλεκυ", "πελεκ");
+            CheckOneTerm(a, "πελέκεις", "πελεκ");
+            CheckOneTerm(a, "πελέκεων", "πελεκ");
 
-        // -ωρ
-        // note: nom./voc. doesn't conflate w/ the rest
-        CheckOneTerm(a, "μέντωρ", "μεντωρ");
-        CheckOneTerm(a, "μέντορος", "μεντορ");
-        CheckOneTerm(a, "μέντορα", "μεντορ");
-        CheckOneTerm(a, "μέντορες", "μεντορ");
-        CheckOneTerm(a, "μεντόρων", "μεντορ");
+            // -ωρ
+            // note: nom./voc. doesn't conflate w/ the rest
+            CheckOneTerm(a, "μέντωρ", "μεντωρ");
+            CheckOneTerm(a, "μέντορος", "μεντορ");
+            CheckOneTerm(a, "μέντορα", "μεντορ");
+            CheckOneTerm(a, "μέντορες", "μεντορ");
+            CheckOneTerm(a, "μεντόρων", "μεντορ");
 
-        // -ων
-        CheckOneTerm(a, "αγώνας", "αγων");
-        CheckOneTerm(a, "αγώνος", "αγων");
-        CheckOneTerm(a, "αγώνα", "αγων");
-        CheckOneTerm(a, "αγώνα", "αγων");
-        CheckOneTerm(a, "αγώνες", "αγων");
-        CheckOneTerm(a, "αγώνων", "αγων");
+            // -ων
+            CheckOneTerm(a, "αγώνας", "αγων");
+            CheckOneTerm(a, "αγώνος", "αγων");
+            CheckOneTerm(a, "αγώνα", "αγων");
+            CheckOneTerm(a, "αγώνα", "αγων");
+            CheckOneTerm(a, "αγώνες", "αγων");
+            CheckOneTerm(a, "αγώνων", "αγων");
 
-        // -ας/-ηδες
-        CheckOneTerm(a, "αέρας", "αερ");
-        CheckOneTerm(a, "αέρα", "αερ");
-        CheckOneTerm(a, "αέρηδες", "αερ");
-        CheckOneTerm(a, "αέρηδων", "αερ");
+            // -ας/-ηδες
+            CheckOneTerm(a, "αέρας", "αερ");
+            CheckOneTerm(a, "αέρα", "αερ");
+            CheckOneTerm(a, "αέρηδες", "αερ");
+            CheckOneTerm(a, "αέρηδων", "αερ");
 
-        // -ης/-ητες
-        CheckOneTerm(a, "γόης", "γο");
-        CheckOneTerm(a, "γόη", "γοη"); // too short
-        // the two plural forms conflate
-        CheckOneTerm(a, "γόητες", "γοητ");
-        CheckOneTerm(a, "γοήτων", "γοητ");
-      }
+            // -ης/-ητες
+            CheckOneTerm(a, "γόης", "γο");
+            CheckOneTerm(a, "γόη", "γοη"); // too short
+                                           // the two plural forms conflate
+            CheckOneTerm(a, "γόητες", "γοητ");
+            CheckOneTerm(a, "γοήτων", "γοητ");
+        }
 
         [Test]
         public virtual void TestFeminineNouns()
-      {
-        // -α/-ες,-ών
-        CheckOneTerm(a, "φορά", "φορ");
-        CheckOneTerm(a, "φοράς", "φορ");
-        CheckOneTerm(a, "φορές", "φορ");
-        CheckOneTerm(a, "φορών", "φορ");
+        {
+            // -α/-ες,-ών
+            CheckOneTerm(a, "φορά", "φορ");
+            CheckOneTerm(a, "φοράς", "φορ");
+            CheckOneTerm(a, "φορές", "φορ");
+            CheckOneTerm(a, "φορών", "φορ");
 
-        // -α/-ες,-ων
-        CheckOneTerm(a, "αγελάδα", "αγελαδ");
-        CheckOneTerm(a, "αγελάδας", "αγελαδ");
-        CheckOneTerm(a, "αγελάδες", "αγελαδ");
-        CheckOneTerm(a, "αγελάδων", "αγελαδ");
+            // -α/-ες,-ων
+            CheckOneTerm(a, "αγελάδα", "αγελαδ");
+            CheckOneTerm(a, "αγελάδας", "αγελαδ");
+            CheckOneTerm(a, "αγελάδες", "αγελαδ");
+            CheckOneTerm(a, "αγελάδων", "αγελαδ");
 
-        // -η/-ες
-        CheckOneTerm(a, "ζάχαρη", "ζαχαρ");
-        CheckOneTerm(a, "ζάχαρης", "ζαχαρ");
-        CheckOneTerm(a, "ζάχαρες", "ζαχαρ");
-        CheckOneTerm(a, "ζαχάρεων", "ζαχαρ");
+            // -η/-ες
+            CheckOneTerm(a, "ζάχαρη", "ζαχαρ");
+            CheckOneTerm(a, "ζάχαρης", "ζαχαρ");
+            CheckOneTerm(a, "ζάχαρες", "ζαχαρ");
+            CheckOneTerm(a, "ζαχάρεων", "ζαχαρ");
 
-        // -η/-εις
-        CheckOneTerm(a, "τηλεόραση", "τηλεορασ");
-        CheckOneTerm(a, "τηλεόρασης", "τηλεορασ");
-        CheckOneTerm(a, "τηλεοράσεις", "τηλεορασ");
-        CheckOneTerm(a, "τηλεοράσεων", "τηλεορασ");
+            // -η/-εις
+            CheckOneTerm(a, "τηλεόραση", "τηλεορασ");
+            CheckOneTerm(a, "τηλεόρασης", "τηλεορασ");
+            CheckOneTerm(a, "τηλεοράσεις", "τηλεορασ");
+            CheckOneTerm(a, "τηλεοράσεων", "τηλεορασ");
 
-        // -α/-αδες
-        CheckOneTerm(a, "μαμά", "μαμ");
-        CheckOneTerm(a, "μαμάς", "μαμ");
-        CheckOneTerm(a, "μαμάδες", "μαμ");
-        CheckOneTerm(a, "μαμάδων", "μαμ");
+            // -α/-αδες
+            CheckOneTerm(a, "μαμά", "μαμ");
+            CheckOneTerm(a, "μαμάς", "μαμ");
+            CheckOneTerm(a, "μαμάδες", "μαμ");
+            CheckOneTerm(a, "μαμάδων", "μαμ");
 
-        // -ος
-        CheckOneTerm(a, "λεωφόρος", "λεωφορ");
-        CheckOneTerm(a, "λεωφόρου", "λεωφορ");
-        CheckOneTerm(a, "λεωφόρο", "λεωφορ");
-        CheckOneTerm(a, "λεωφόρε", "λεωφορ");
-        CheckOneTerm(a, "λεωφόροι", "λεωφορ");
-        CheckOneTerm(a, "λεωφόρων", "λεωφορ");
-        CheckOneTerm(a, "λεωφόρους", "λεωφορ");
+            // -ος
+            CheckOneTerm(a, "λεωφόρος", "λεωφορ");
+            CheckOneTerm(a, "λεωφόρου", "λεωφορ");
+            CheckOneTerm(a, "λεωφόρο", "λεωφορ");
+            CheckOneTerm(a, "λεωφόρε", "λεωφορ");
+            CheckOneTerm(a, "λεωφόροι", "λεωφορ");
+            CheckOneTerm(a, "λεωφόρων", "λεωφορ");
+            CheckOneTerm(a, "λεωφόρους", "λεωφορ");
 
-        // -ου
-        CheckOneTerm(a, "αλεπού", "αλεπ");
-        CheckOneTerm(a, "αλεπούς", "αλεπ");
-        CheckOneTerm(a, "αλεπούδες", "αλεπ");
-        CheckOneTerm(a, "αλεπούδων", "αλεπ");
+            // -ου
+            CheckOneTerm(a, "αλεπού", "αλεπ");
+            CheckOneTerm(a, "αλεπούς", "αλεπ");
+            CheckOneTerm(a, "αλεπούδες", "αλεπ");
+            CheckOneTerm(a, "αλεπούδων", "αλεπ");
 
-        // -έας/είς
-        // note: not all forms conflate
-        CheckOneTerm(a, "γραμματέας", "γραμματε");
-        CheckOneTerm(a, "γραμματέως", "γραμματ");
-        CheckOneTerm(a, "γραμματέα", "γραμματε");
-        CheckOneTerm(a, "γραμματείς", "γραμματ");
-        CheckOneTerm(a, "γραμματέων", "γραμματ");
-      }
+            // -έας/είς
+            // note: not all forms conflate
+            CheckOneTerm(a, "γραμματέας", "γραμματε");
+            CheckOneTerm(a, "γραμματέως", "γραμματ");
+            CheckOneTerm(a, "γραμματέα", "γραμματε");
+            CheckOneTerm(a, "γραμματείς", "γραμματ");
+            CheckOneTerm(a, "γραμματέων", "γραμματ");
+        }
 
         [Test]
         public virtual void TestNeuterNouns()
-      {
-        // ending with -ο
-        // note: nom doesnt conflate
-        CheckOneTerm(a, "βιβλίο", "βιβλι");
-        CheckOneTerm(a, "βιβλίου", "βιβλ");
-        CheckOneTerm(a, "βιβλία", "βιβλ");
-        CheckOneTerm(a, "βιβλίων", "βιβλ");
+        {
+            // ending with -ο
+            // note: nom doesnt conflate
+            CheckOneTerm(a, "βιβλίο", "βιβλι");
+            CheckOneTerm(a, "βιβλίου", "βιβλ");
+            CheckOneTerm(a, "βιβλία", "βιβλ");
+            CheckOneTerm(a, "βιβλίων", "βιβλ");
 
-        // ending with -ι
-        CheckOneTerm(a, "πουλί", "πουλ");
-        CheckOneTerm(a, "πουλιού", "πουλ");
-        CheckOneTerm(a, "πουλιά", "πουλ");
-        CheckOneTerm(a, "πουλιών", "πουλ");
+            // ending with -ι
+            CheckOneTerm(a, "πουλί", "πουλ");
+            CheckOneTerm(a, "πουλιού", "πουλ");
+            CheckOneTerm(a, "πουλιά", "πουλ");
+            CheckOneTerm(a, "πουλιών", "πουλ");
 
-        // ending with -α
-        // note: nom. doesnt conflate
-        CheckOneTerm(a, "πρόβλημα", "προβλημ");
-        CheckOneTerm(a, "προβλήματος", "προβλημα");
-        CheckOneTerm(a, "προβλήματα", "προβλημα");
-        CheckOneTerm(a, "προβλημάτων", "προβλημα");
+            // ending with -α
+            // note: nom. doesnt conflate
+            CheckOneTerm(a, "πρόβλημα", "προβλημ");
+            CheckOneTerm(a, "προβλήματος", "προβλημα");
+            CheckOneTerm(a, "προβλήματα", "προβλημα");
+            CheckOneTerm(a, "προβλημάτων", "προβλημα");
 
-        // ending with -ος/-ους
-        CheckOneTerm(a, "πέλαγος", "πελαγ");
-        CheckOneTerm(a, "πελάγους", "πελαγ");
-        CheckOneTerm(a, "πελάγη", "πελαγ");
-        CheckOneTerm(a, "πελάγων", "πελαγ");
+            // ending with -ος/-ους
+            CheckOneTerm(a, "πέλαγος", "πελαγ");
+            CheckOneTerm(a, "πελάγους", "πελαγ");
+            CheckOneTerm(a, "πελάγη", "πελαγ");
+            CheckOneTerm(a, "πελάγων", "πελαγ");
 
-        // ending with -ός/-ότος
-        CheckOneTerm(a, "γεγονός", "γεγον");
-        CheckOneTerm(a, "γεγονότος", "γεγον");
-        CheckOneTerm(a, "γεγονότα", "γεγον");
-        CheckOneTerm(a, "γεγονότων", "γεγον");
+            // ending with -ός/-ότος
+            CheckOneTerm(a, "γεγονός", "γεγον");
+            CheckOneTerm(a, "γεγονότος", "γεγον");
+            CheckOneTerm(a, "γεγονότα", "γεγον");
+            CheckOneTerm(a, "γεγονότων", "γεγον");
 
-        // ending with -υ/-ιου
-        CheckOneTerm(a, "βράδυ", "βραδ");
-        CheckOneTerm(a, "βράδι", "βραδ");
-        CheckOneTerm(a, "βραδιού", "βραδ");
-        CheckOneTerm(a, "βράδια", "βραδ");
-        CheckOneTerm(a, "βραδιών", "βραδ");
+            // ending with -υ/-ιου
+            CheckOneTerm(a, "βράδυ", "βραδ");
+            CheckOneTerm(a, "βράδι", "βραδ");
+            CheckOneTerm(a, "βραδιού", "βραδ");
+            CheckOneTerm(a, "βράδια", "βραδ");
+            CheckOneTerm(a, "βραδιών", "βραδ");
 
-        // ending with -υ/-ατος
-        // note: nom. doesnt conflate
-        CheckOneTerm(a, "δόρυ", "δορ");
-        CheckOneTerm(a, "δόρατος", "δορατ");
-        CheckOneTerm(a, "δόρατα", "δορατ");
-        CheckOneTerm(a, "δοράτων", "δορατ");
+            // ending with -υ/-ατος
+            // note: nom. doesnt conflate
+            CheckOneTerm(a, "δόρυ", "δορ");
+            CheckOneTerm(a, "δόρατος", "δορατ");
+            CheckOneTerm(a, "δόρατα", "δορατ");
+            CheckOneTerm(a, "δοράτων", "δορατ");
 
-        // ending with -ας
-        CheckOneTerm(a, "κρέας", "κρε");
-        CheckOneTerm(a, "κρέατος", "κρε");
-        CheckOneTerm(a, "κρέατα", "κρε");
-        CheckOneTerm(a, "κρεάτων", "κρε");
+            // ending with -ας
+            CheckOneTerm(a, "κρέας", "κρε");
+            CheckOneTerm(a, "κρέατος", "κρε");
+            CheckOneTerm(a, "κρέατα", "κρε");
+            CheckOneTerm(a, "κρεάτων", "κρε");
 
-        // ending with -ως
-        CheckOneTerm(a, "λυκόφως", "λυκοφω");
-        CheckOneTerm(a, "λυκόφωτος", "λυκοφω");
-        CheckOneTerm(a, "λυκόφωτα", "λυκοφω");
-        CheckOneTerm(a, "λυκοφώτων", "λυκοφω");
+            // ending with -ως
+            CheckOneTerm(a, "λυκόφως", "λυκοφω");
+            CheckOneTerm(a, "λυκόφωτος", "λυκοφω");
+            CheckOneTerm(a, "λυκόφωτα", "λυκοφω");
+            CheckOneTerm(a, "λυκοφώτων", "λυκοφω");
 
-        // ending with -ον/-ου
-        // note: nom. doesnt conflate
-        CheckOneTerm(a, "μέσον", "μεσον");
-        CheckOneTerm(a, "μέσου", "μεσ");
-        CheckOneTerm(a, "μέσα", "μεσ");
-        CheckOneTerm(a, "μέσων", "μεσ");
+            // ending with -ον/-ου
+            // note: nom. doesnt conflate
+            CheckOneTerm(a, "μέσον", "μεσον");
+            CheckOneTerm(a, "μέσου", "μεσ");
+            CheckOneTerm(a, "μέσα", "μεσ");
+            CheckOneTerm(a, "μέσων", "μεσ");
 
-        // ending in -ον/-οντος
-        // note: nom. doesnt conflate
-        CheckOneTerm(a, "ενδιαφέρον", "ενδιαφερον");
-        CheckOneTerm(a, "ενδιαφέροντος", "ενδιαφεροντ");
-        CheckOneTerm(a, "ενδιαφέροντα", "ενδιαφεροντ");
-        CheckOneTerm(a, "ενδιαφερόντων", "ενδιαφεροντ");
+            // ending in -ον/-οντος
+            // note: nom. doesnt conflate
+            CheckOneTerm(a, "ενδιαφέρον", "ενδιαφερον");
+            CheckOneTerm(a, "ενδιαφέροντος", "ενδιαφεροντ");
+            CheckOneTerm(a, "ενδιαφέροντα", "ενδιαφεροντ");
+            CheckOneTerm(a, "ενδιαφερόντων", "ενδιαφεροντ");
 
-        // ending with -εν/-εντος
-        CheckOneTerm(a, "ανακοινωθέν", "ανακοινωθεν");
-        CheckOneTerm(a, "ανακοινωθέντος", "ανακοινωθεντ");
-        CheckOneTerm(a, "ανακοινωθέντα", "ανακοινωθεντ");
-        CheckOneTerm(a, "ανακοινωθέντων", "ανακοινωθεντ");
+            // ending with -εν/-εντος
+            CheckOneTerm(a, "ανακοινωθέν", "ανακοινωθεν");
+            CheckOneTerm(a, "ανακοινωθέντος", "ανακοινωθεντ");
+            CheckOneTerm(a, "ανακοινωθέντα", "ανακοινωθεντ");
+            CheckOneTerm(a, "ανακοινωθέντων", "ανακοινωθεντ");
 
-        // ending with -αν/-αντος
-        CheckOneTerm(a, "σύμπαν", "συμπ");
-        CheckOneTerm(a, "σύμπαντος", "συμπαντ");
-        CheckOneTerm(a, "σύμπαντα", "συμπαντ");
-        CheckOneTerm(a, "συμπάντων", "συμπαντ");
+            // ending with -αν/-αντος
+            CheckOneTerm(a, "σύμπαν", "συμπ");
+            CheckOneTerm(a, "σύμπαντος", "συμπαντ");
+            CheckOneTerm(a, "σύμπαντα", "συμπαντ");
+            CheckOneTerm(a, "συμπάντων", "συμπαντ");
 
-        // ending with  -α/-ακτος
-        CheckOneTerm(a, "γάλα", "γαλ");
-        CheckOneTerm(a, "γάλακτος", "γαλακτ");
-        CheckOneTerm(a, "γάλατα", "γαλατ");
-        CheckOneTerm(a, "γαλάκτων", "γαλακτ");
-      }
+            // ending with  -α/-ακτος
+            CheckOneTerm(a, "γάλα", "γαλ");
+            CheckOneTerm(a, "γάλακτος", "γαλακτ");
+            CheckOneTerm(a, "γάλατα", "γαλατ");
+            CheckOneTerm(a, "γαλάκτων", "γαλακτ");
+        }
 
         [Test]
         public virtual void TestAdjectives()
-      {
-        // ending with -ής, -ές/-είς, -ή
-        CheckOneTerm(a, "συνεχής", "συνεχ");
-        CheckOneTerm(a, "συνεχούς", "συνεχ");
-        CheckOneTerm(a, "συνεχή", "συνεχ");
-        CheckOneTerm(a, "συνεχών", "συνεχ");
-        CheckOneTerm(a, "συνεχείς", "συνεχ");
-        CheckOneTerm(a, "συνεχές", "συνεχ");
+        {
+            // ending with -ής, -ές/-είς, -ή
+            CheckOneTerm(a, "συνεχής", "συνεχ");
+            CheckOneTerm(a, "συνεχούς", "συνεχ");
+            CheckOneTerm(a, "συνεχή", "συνεχ");
+            CheckOneTerm(a, "συνεχών", "συνεχ");
+            CheckOneTerm(a, "συνεχείς", "συνεχ");
+            CheckOneTerm(a, "συνεχές", "συνεχ");
 
-        // ending with -ης, -ες/-εις, -η
-        CheckOneTerm(a, "συνήθης", "συνηθ");
-        CheckOneTerm(a, "συνήθους", "συνηθ");
-        CheckOneTerm(a, "συνήθη", "συνηθ");
-        // note: doesn't conflate
-        CheckOneTerm(a, "συνήθεις", "συν");
-        CheckOneTerm(a, "συνήθων", "συνηθ");
-        CheckOneTerm(a, "σύνηθες", "συνηθ");
+            // ending with -ης, -ες/-εις, -η
+            CheckOneTerm(a, "συνήθης", "συνηθ");
+            CheckOneTerm(a, "συνήθους", "συνηθ");
+            CheckOneTerm(a, "συνήθη", "συνηθ");
+            // note: doesn't conflate
+            CheckOneTerm(a, "συνήθεις", "συν");
+            CheckOneTerm(a, "συνήθων", "συνηθ");
+            CheckOneTerm(a, "σύνηθες", "συνηθ");
 
-        // ending with -υς, -υ/-εις, -ια
-        CheckOneTerm(a, "βαθύς", "βαθ");
-        CheckOneTerm(a, "βαθέος", "βαθε");
-        CheckOneTerm(a, "βαθύ", "βαθ");
-        CheckOneTerm(a, "βαθείς", "βαθ");
-        CheckOneTerm(a, "βαθέων", "βαθ");
+            // ending with -υς, -υ/-εις, -ια
+            CheckOneTerm(a, "βαθύς", "βαθ");
+            CheckOneTerm(a, "βαθέος", "βαθε");
+            CheckOneTerm(a, "βαθύ", "βαθ");
+            CheckOneTerm(a, "βαθείς", "βαθ");
+            CheckOneTerm(a, "βαθέων", "βαθ");
 
-        CheckOneTerm(a, "βαθιά", "βαθ");
-        CheckOneTerm(a, "βαθιάς", "βαθι");
-        CheckOneTerm(a, "βαθιές", "βαθι");
-        CheckOneTerm(a, "βαθιών", "βαθ");
+            CheckOneTerm(a, "βαθιά", "βαθ");
+            CheckOneTerm(a, "βαθιάς", "βαθι");
+            CheckOneTerm(a, "βαθιές", "βαθι");
+            CheckOneTerm(a, "βαθιών", "βαθ");
 
-        CheckOneTerm(a, "βαθέα", "βαθε");
+            CheckOneTerm(a, "βαθέα", "βαθε");
 
-        // comparative/superlative
-        CheckOneTerm(a, "ψηλός", "ψηλ");
-        CheckOneTerm(a, "ψηλότερος", "ψηλ");
-        CheckOneTerm(a, "ψηλότατος", "ψηλ");
+            // comparative/superlative
+            CheckOneTerm(a, "ψηλός", "ψηλ");
+            CheckOneTerm(a, "ψηλότερος", "ψηλ");
+            CheckOneTerm(a, "ψηλότατος", "ψηλ");
 
-        CheckOneTerm(a, "ωραίος", "ωραι");
-        CheckOneTerm(a, "ωραιότερος", "ωραι");
-        CheckOneTerm(a, "ωραιότατος", "ωραι");
+            CheckOneTerm(a, "ωραίος", "ωραι");
+            CheckOneTerm(a, "ωραιότερος", "ωραι");
+            CheckOneTerm(a, "ωραιότατος", "ωραι");
 
-        CheckOneTerm(a, "επιεικής", "επιεικ");
-        CheckOneTerm(a, "επιεικέστερος", "επιεικ");
-        CheckOneTerm(a, "επιεικέστατος", "επιεικ");
-      }
+            CheckOneTerm(a, "επιεικής", "επιεικ");
+            CheckOneTerm(a, "επιεικέστερος", "επιεικ");
+            CheckOneTerm(a, "επιεικέστατος", "επιεικ");
+        }
 
 
         [Test]
         public virtual void TestVerbs()
-      {
-        // note, past/present verb stems will not conflate (from the paper)
-        //-ω,-α/-.ω,-.α
-        CheckOneTerm(a, "ορίζω", "οριζ");
-        CheckOneTerm(a, "όριζα", "οριζ");
-        CheckOneTerm(a, "όριζε", "οριζ");
-        CheckOneTerm(a, "ορίζοντας", "οριζ");
-        CheckOneTerm(a, "ορίζομαι", "οριζ");
-        CheckOneTerm(a, "οριζόμουν", "οριζ");
-        CheckOneTerm(a, "ορίζεσαι", "οριζ");
+        {
+            // note, past/present verb stems will not conflate (from the paper)
+            //-ω,-α/-.ω,-.α
+            CheckOneTerm(a, "ορίζω", "οριζ");
+            CheckOneTerm(a, "όριζα", "οριζ");
+            CheckOneTerm(a, "όριζε", "οριζ");
+            CheckOneTerm(a, "ορίζοντας", "οριζ");
+            CheckOneTerm(a, "ορίζομαι", "οριζ");
+            CheckOneTerm(a, "οριζόμουν", "οριζ");
+            CheckOneTerm(a, "ορίζεσαι", "οριζ");
 
-        CheckOneTerm(a, "όρισα", "ορισ");
-        CheckOneTerm(a, "ορίσω", "ορισ");
-        CheckOneTerm(a, "όρισε", "ορισ");
-        CheckOneTerm(a, "ορίσει", "ορισ");
+            CheckOneTerm(a, "όρισα", "ορισ");
+            CheckOneTerm(a, "ορίσω", "ορισ");
+            CheckOneTerm(a, "όρισε", "ορισ");
+            CheckOneTerm(a, "ορίσει", "ορισ");
 
-        CheckOneTerm(a, "ορίστηκα", "οριστ");
-        CheckOneTerm(a, "οριστώ", "οριστ");
-        CheckOneTerm(a, "οριστείς", "οριστ");
-        CheckOneTerm(a, "οριστεί", "οριστ");
+            CheckOneTerm(a, "ορίστηκα", "οριστ");
+            CheckOneTerm(a, "οριστώ", "οριστ");
+            CheckOneTerm(a, "οριστείς", "οριστ");
+            CheckOneTerm(a, "οριστεί", "οριστ");
 
-        CheckOneTerm(a, "ορισμένο", "ορισμεν");
-        CheckOneTerm(a, "ορισμένη", "ορισμεν");
-        CheckOneTerm(a, "ορισμένος", "ορισμεν");
+            CheckOneTerm(a, "ορισμένο", "ορισμεν");
+            CheckOneTerm(a, "ορισμένη", "ορισμεν");
+            CheckOneTerm(a, "ορισμένος", "ορισμεν");
 
-        // -ω,-α/-ξω,-ξα
-        CheckOneTerm(a, "ανοίγω", "ανοιγ");
-        CheckOneTerm(a, "άνοιγα", "ανοιγ");
-        CheckOneTerm(a, "άνοιγε", "ανοιγ");
-        CheckOneTerm(a, "ανοίγοντας", "ανοιγ");
-        CheckOneTerm(a, "ανοίγομαι", "ανοιγ");
-        CheckOneTerm(a, "ανοιγόμουν", "ανοιγ");
+            // -ω,-α/-ξω,-ξα
+            CheckOneTerm(a, "ανοίγω", "ανοιγ");
+            CheckOneTerm(a, "άνοιγα", "ανοιγ");
+            CheckOneTerm(a, "άνοιγε", "ανοιγ");
+            CheckOneTerm(a, "ανοίγοντας", "ανοιγ");
+            CheckOneTerm(a, "ανοίγομαι", "ανοιγ");
+            CheckOneTerm(a, "ανοιγόμουν", "ανοιγ");
 
-        CheckOneTerm(a, "άνοιξα", "ανοιξ");
-        CheckOneTerm(a, "ανοίξω", "ανοιξ");
-        CheckOneTerm(a, "άνοιξε", "ανοιξ");
-        CheckOneTerm(a, "ανοίξει", "ανοιξ");
+            CheckOneTerm(a, "άνοιξα", "ανοιξ");
+            CheckOneTerm(a, "ανοίξω", "ανοιξ");
+            CheckOneTerm(a, "άνοιξε", "ανοιξ");
+            CheckOneTerm(a, "ανοίξει", "ανοιξ");
 
-        CheckOneTerm(a, "ανοίχτηκα", "ανοιχτ");
-        CheckOneTerm(a, "ανοιχτώ", "ανοιχτ");
-        CheckOneTerm(a, "ανοίχτηκα", "ανοιχτ");
-        CheckOneTerm(a, "ανοιχτείς", "ανοιχτ");
-        CheckOneTerm(a, "ανοιχτεί", "ανοιχτ");
+            CheckOneTerm(a, "ανοίχτηκα", "ανοιχτ");
+            CheckOneTerm(a, "ανοιχτώ", "ανοιχτ");
+            CheckOneTerm(a, "ανοίχτηκα", "ανοιχτ");
+            CheckOneTerm(a, "ανοιχτείς", "ανοιχτ");
+            CheckOneTerm(a, "ανοιχτεί", "ανοιχτ");
 
-        CheckOneTerm(a, "ανοίξου", "ανοιξ");
+            CheckOneTerm(a, "ανοίξου", "ανοιξ");
 
-        //-ώ/-άω,-ούσα/-άσω,-ασα
-        CheckOneTerm(a, "περνώ", "περν");
-        CheckOneTerm(a, "περνάω", "περν");
-        CheckOneTerm(a, "περνούσα", "περν");
-        CheckOneTerm(a, "πέρναγα", "περν");
-        CheckOneTerm(a, "πέρνα", "περν");
-        CheckOneTerm(a, "περνώντας", "περν");
+            //-ώ/-άω,-ούσα/-άσω,-ασα
+            CheckOneTerm(a, "περνώ", "περν");
+            CheckOneTerm(a, "περνάω", "περν");
+            CheckOneTerm(a, "περνούσα", "περν");
+            CheckOneTerm(a, "πέρναγα", "περν");
+            CheckOneTerm(a, "πέρνα", "περν");
+            CheckOneTerm(a, "περνώντας", "περν");
 
-        CheckOneTerm(a, "πέρασα", "περασ");
-        CheckOneTerm(a, "περάσω", "περασ");
-        CheckOneTerm(a, "πέρασε", "περασ");
-        CheckOneTerm(a, "περάσει", "περασ");
+            CheckOneTerm(a, "πέρασα", "περασ");
+            CheckOneTerm(a, "περάσω", "περασ");
+            CheckOneTerm(a, "πέρασε", "περασ");
+            CheckOneTerm(a, "περάσει", "περασ");
 
-        CheckOneTerm(a, "περνιέμαι", "περν");
-        CheckOneTerm(a, "περνιόμουν", "περν");
+            CheckOneTerm(a, "περνιέμαι", "περν");
+            CheckOneTerm(a, "περνιόμουν", "περν");
 
-        CheckOneTerm(a, "περάστηκα", "περαστ");
-        CheckOneTerm(a, "περαστώ", "περαστ");
-        CheckOneTerm(a, "περαστείς", "περαστ");
-        CheckOneTerm(a, "περαστεί", "περαστ");
+            CheckOneTerm(a, "περάστηκα", "περαστ");
+            CheckOneTerm(a, "περαστώ", "περαστ");
+            CheckOneTerm(a, "περαστείς", "περαστ");
+            CheckOneTerm(a, "περαστεί", "περαστ");
 
-        CheckOneTerm(a, "περασμένο", "περασμεν");
-        CheckOneTerm(a, "περασμένη", "περασμεν");
-        CheckOneTerm(a, "περασμένος", "περασμεν");
+            CheckOneTerm(a, "περασμένο", "περασμεν");
+            CheckOneTerm(a, "περασμένη", "περασμεν");
+            CheckOneTerm(a, "περασμένος", "περασμεν");
 
-        // -ώ/-άω,-ούσα/-άξω,-αξα
-        CheckOneTerm(a, "πετώ", "πετ");
-        CheckOneTerm(a, "πετάω", "πετ");
-        CheckOneTerm(a, "πετούσα", "πετ");
-        CheckOneTerm(a, "πέταγα", "πετ");
-        CheckOneTerm(a, "πέτα", "πετ");
-        CheckOneTerm(a, "πετώντας", "πετ");
-        CheckOneTerm(a, "πετιέμαι", "πετ");
-        CheckOneTerm(a, "πετιόμουν", "πετ");
+            // -ώ/-άω,-ούσα/-άξω,-αξα
+            CheckOneTerm(a, "πετώ", "πετ");
+            CheckOneTerm(a, "πετάω", "πετ");
+            CheckOneTerm(a, "πετούσα", "πετ");
+            CheckOneTerm(a, "πέταγα", "πετ");
+            CheckOneTerm(a, "πέτα", "πετ");
+            CheckOneTerm(a, "πετώντας", "πετ");
+            CheckOneTerm(a, "πετιέμαι", "πετ");
+            CheckOneTerm(a, "πετιόμουν", "πετ");
 
-        CheckOneTerm(a, "πέταξα", "πεταξ");
-        CheckOneTerm(a, "πετάξω", "πεταξ");
-        CheckOneTerm(a, "πέταξε", "πεταξ");
-        CheckOneTerm(a, "πετάξει", "πεταξ");
+            CheckOneTerm(a, "πέταξα", "πεταξ");
+            CheckOneTerm(a, "πετάξω", "πεταξ");
+            CheckOneTerm(a, "πέταξε", "πεταξ");
+            CheckOneTerm(a, "πετάξει", "πεταξ");
 
-        CheckOneTerm(a, "πετάχτηκα", "πεταχτ");
-        CheckOneTerm(a, "πεταχτώ", "πεταχτ");
-        CheckOneTerm(a, "πεταχτείς", "πεταχτ");
-        CheckOneTerm(a, "πεταχτεί", "πεταχτ");
+            CheckOneTerm(a, "πετάχτηκα", "πεταχτ");
+            CheckOneTerm(a, "πεταχτώ", "πεταχτ");
+            CheckOneTerm(a, "πεταχτείς", "πεταχτ");
+            CheckOneTerm(a, "πεταχτεί", "πεταχτ");
 
-        CheckOneTerm(a, "πεταμένο", "πεταμεν");
-        CheckOneTerm(a, "πεταμένη", "πεταμεν");
-        CheckOneTerm(a, "πεταμένος", "πεταμεν");
+            CheckOneTerm(a, "πεταμένο", "πεταμεν");
+            CheckOneTerm(a, "πεταμένη", "πεταμεν");
+            CheckOneTerm(a, "πεταμένος", "πεταμεν");
 
-        // -ώ/-άω,-ούσα / -έσω,-εσα
-        CheckOneTerm(a, "καλώ", "καλ");
-        CheckOneTerm(a, "καλούσα", "καλ");
-        CheckOneTerm(a, "καλείς", "καλ");
-        CheckOneTerm(a, "καλώντας", "καλ");
+            // -ώ/-άω,-ούσα / -έσω,-εσα
+            CheckOneTerm(a, "καλώ", "καλ");
+            CheckOneTerm(a, "καλούσα", "καλ");
+            CheckOneTerm(a, "καλείς", "καλ");
+            CheckOneTerm(a, "καλώντας", "καλ");
 
-        CheckOneTerm(a, "καλούμαι", "καλ");
-        // pass. imperfect /imp. progressive doesnt conflate
-        CheckOneTerm(a, "καλούμουν", "καλουμ");
-        CheckOneTerm(a, "καλείσαι", "καλεισα");
+            CheckOneTerm(a, "καλούμαι", "καλ");
+            // pass. imperfect /imp. progressive doesnt conflate
+            CheckOneTerm(a, "καλούμουν", "καλουμ");
+            CheckOneTerm(a, "καλείσαι", "καλεισα");
 
-        CheckOneTerm(a, "καλέστηκα", "καλεστ");
-        CheckOneTerm(a, "καλεστώ", "καλεστ");
-        CheckOneTerm(a, "καλεστείς", "καλεστ");
-        CheckOneTerm(a, "καλεστεί", "καλεστ");
+            CheckOneTerm(a, "καλέστηκα", "καλεστ");
+            CheckOneTerm(a, "καλεστώ", "καλεστ");
+            CheckOneTerm(a, "καλεστείς", "καλεστ");
+            CheckOneTerm(a, "καλεστεί", "καλεστ");
 
-        CheckOneTerm(a, "καλεσμένο", "καλεσμεν");
-        CheckOneTerm(a, "καλεσμένη", "καλεσμεν");
-        CheckOneTerm(a, "καλεσμένος", "καλεσμεν");
+            CheckOneTerm(a, "καλεσμένο", "καλεσμεν");
+            CheckOneTerm(a, "καλεσμένη", "καλεσμεν");
+            CheckOneTerm(a, "καλεσμένος", "καλεσμεν");
 
-        CheckOneTerm(a, "φορώ", "φορ");
-        CheckOneTerm(a, "φοράω", "φορ");
-        CheckOneTerm(a, "φορούσα", "φορ");
-        CheckOneTerm(a, "φόραγα", "φορ");
-        CheckOneTerm(a, "φόρα", "φορ");
-        CheckOneTerm(a, "φορώντας", "φορ");
-        CheckOneTerm(a, "φοριέμαι", "φορ");
-        CheckOneTerm(a, "φοριόμουν", "φορ");
-        CheckOneTerm(a, "φοριέσαι", "φορ");
+            CheckOneTerm(a, "φορώ", "φορ");
+            CheckOneTerm(a, "φοράω", "φορ");
+            CheckOneTerm(a, "φορούσα", "φορ");
+            CheckOneTerm(a, "φόραγα", "φορ");
+            CheckOneTerm(a, "φόρα", "φορ");
+            CheckOneTerm(a, "φορώντας", "φορ");
+            CheckOneTerm(a, "φοριέμαι", "φορ");
+            CheckOneTerm(a, "φοριόμουν", "φορ");
+            CheckOneTerm(a, "φοριέσαι", "φορ");
 
-        CheckOneTerm(a, "φόρεσα", "φορεσ");
-        CheckOneTerm(a, "φορέσω", "φορεσ");
-        CheckOneTerm(a, "φόρεσε", "φορεσ");
-        CheckOneTerm(a, "φορέσει", "φορεσ");
+            CheckOneTerm(a, "φόρεσα", "φορεσ");
+            CheckOneTerm(a, "φορέσω", "φορεσ");
+            CheckOneTerm(a, "φόρεσε", "φορεσ");
+            CheckOneTerm(a, "φορέσει", "φορεσ");
 
-        CheckOneTerm(a, "φορέθηκα", "φορεθ");
-        CheckOneTerm(a, "φορεθώ", "φορεθ");
-        CheckOneTerm(a, "φορεθείς", "φορεθ");
-        CheckOneTerm(a, "φορεθεί", "φορεθ");
+            CheckOneTerm(a, "φορέθηκα", "φορεθ");
+            CheckOneTerm(a, "φορεθώ", "φορεθ");
+            CheckOneTerm(a, "φορεθείς", "φορεθ");
+            CheckOneTerm(a, "φορεθεί", "φορεθ");
 
-        CheckOneTerm(a, "φορεμένο", "φορεμεν");
-        CheckOneTerm(a, "φορεμένη", "φορεμεν");
-        CheckOneTerm(a, "φορεμένος", "φορεμεν");
+            CheckOneTerm(a, "φορεμένο", "φορεμεν");
+            CheckOneTerm(a, "φορεμένη", "φορεμεν");
+            CheckOneTerm(a, "φορεμένος", "φορεμεν");
 
-        // -ώ/-άω,-ούσα / -ήσω,-ησα
-        CheckOneTerm(a, "κρατώ", "κρατ");
-        CheckOneTerm(a, "κρατάω", "κρατ");
-        CheckOneTerm(a, "κρατούσα", "κρατ");
-        CheckOneTerm(a, "κράταγα", "κρατ");
-        CheckOneTerm(a, "κράτα", "κρατ");
-        CheckOneTerm(a, "κρατώντας", "κρατ");
+            // -ώ/-άω,-ούσα / -ήσω,-ησα
+            CheckOneTerm(a, "κρατώ", "κρατ");
+            CheckOneTerm(a, "κρατάω", "κρατ");
+            CheckOneTerm(a, "κρατούσα", "κρατ");
+            CheckOneTerm(a, "κράταγα", "κρατ");
+            CheckOneTerm(a, "κράτα", "κρατ");
+            CheckOneTerm(a, "κρατώντας", "κρατ");
 
-        CheckOneTerm(a, "κράτησα", "κρατ");
-        CheckOneTerm(a, "κρατήσω", "κρατ");
-        CheckOneTerm(a, "κράτησε", "κρατ");
-        CheckOneTerm(a, "κρατήσει", "κρατ");
+            CheckOneTerm(a, "κράτησα", "κρατ");
+            CheckOneTerm(a, "κρατήσω", "κρατ");
+            CheckOneTerm(a, "κράτησε", "κρατ");
+            CheckOneTerm(a, "κρατήσει", "κρατ");
 
-        CheckOneTerm(a, "κρατούμαι", "κρατ");
-        CheckOneTerm(a, "κρατιέμαι", "κρατ");
-        // this imperfect form doesnt conflate 
-        CheckOneTerm(a, "κρατούμουν", "κρατουμ");
-        CheckOneTerm(a, "κρατιόμουν", "κρατ");
-        // this imp. prog form doesnt conflate
-        CheckOneTerm(a, "κρατείσαι", "κρατεισα");
+            CheckOneTerm(a, "κρατούμαι", "κρατ");
+            CheckOneTerm(a, "κρατιέμαι", "κρατ");
+            // this imperfect form doesnt conflate 
+            CheckOneTerm(a, "κρατούμουν", "κρατουμ");
+            CheckOneTerm(a, "κρατιόμουν", "κρατ");
+            // this imp. prog form doesnt conflate
+            CheckOneTerm(a, "κρατείσαι", "κρατεισα");
 
-        CheckOneTerm(a, "κρατήθηκα", "κρατ");
-        CheckOneTerm(a, "κρατηθώ", "κρατ");
-        CheckOneTerm(a, "κρατηθείς", "κρατ");
-        CheckOneTerm(a, "κρατηθεί", "κρατ");
-        CheckOneTerm(a, "κρατήσου", "κρατ");
+            CheckOneTerm(a, "κρατήθηκα", "κρατ");
+            CheckOneTerm(a, "κρατηθώ", "κρατ");
+            CheckOneTerm(a, "κρατηθείς", "κρατ");
+            CheckOneTerm(a, "κρατηθεί", "κρατ");
+            CheckOneTerm(a, "κρατήσου", "κρατ");
 
-        CheckOneTerm(a, "κρατημένο", "κρατημεν");
-        CheckOneTerm(a, "κρατημένη", "κρατημεν");
-        CheckOneTerm(a, "κρατημένος", "κρατημεν");
+            CheckOneTerm(a, "κρατημένο", "κρατημεν");
+            CheckOneTerm(a, "κρατημένη", "κρατημεν");
+            CheckOneTerm(a, "κρατημένος", "κρατημεν");
 
-        // -.μαι,-.μουν / -.ώ,-.ηκα
-        CheckOneTerm(a, "κοιμάμαι", "κοιμ");
-        CheckOneTerm(a, "κοιμόμουν", "κοιμ");
-        CheckOneTerm(a, "κοιμάσαι", "κοιμ");
+            // -.μαι,-.μουν / -.ώ,-.ηκα
+            CheckOneTerm(a, "κοιμάμαι", "κοιμ");
+            CheckOneTerm(a, "κοιμόμουν", "κοιμ");
+            CheckOneTerm(a, "κοιμάσαι", "κοιμ");
 
-        CheckOneTerm(a, "κοιμήθηκα", "κοιμ");
-        CheckOneTerm(a, "κοιμηθώ", "κοιμ");
-        CheckOneTerm(a, "κοιμήσου", "κοιμ");
-        CheckOneTerm(a, "κοιμηθεί", "κοιμ");
+            CheckOneTerm(a, "κοιμήθηκα", "κοιμ");
+            CheckOneTerm(a, "κοιμηθώ", "κοιμ");
+            CheckOneTerm(a, "κοιμήσου", "κοιμ");
+            CheckOneTerm(a, "κοιμηθεί", "κοιμ");
 
-        CheckOneTerm(a, "κοιμισμένο", "κοιμισμεν");
-        CheckOneTerm(a, "κοιμισμένη", "κοιμισμεν");
-        CheckOneTerm(a, "κοιμισμένος", "κοιμισμεν");
-      }
+            CheckOneTerm(a, "κοιμισμένο", "κοιμισμεν");
+            CheckOneTerm(a, "κοιμισμένη", "κοιμισμεν");
+            CheckOneTerm(a, "κοιμισμένος", "κοιμισμεν");
+        }
 
         [Test]
         public virtual void TestExceptions()
-      {
-        CheckOneTerm(a, "καθεστώτα", "καθεστ");
-        CheckOneTerm(a, "καθεστώτος", "καθεστ");
-        CheckOneTerm(a, "καθεστώς", "καθεστ");
-        CheckOneTerm(a, "καθεστώτων", "καθεστ");
+        {
+            CheckOneTerm(a, "καθεστώτα", "καθεστ");
+            CheckOneTerm(a, "καθεστώτος", "καθεστ");
+            CheckOneTerm(a, "καθεστώς", "καθεστ");
+            CheckOneTerm(a, "καθεστώτων", "καθεστ");
 
-        CheckOneTerm(a, "χουμε", "χουμ");
-        CheckOneTerm(a, "χουμ", "χουμ");
+            CheckOneTerm(a, "χουμε", "χουμ");
+            CheckOneTerm(a, "χουμ", "χουμ");
 
-        CheckOneTerm(a, "υποταγεσ", "υποταγ");
-        CheckOneTerm(a, "υποταγ", "υποταγ");
+            CheckOneTerm(a, "υποταγεσ", "υποταγ");
+            CheckOneTerm(a, "υποταγ", "υποταγ");
 
-        CheckOneTerm(a, "εμετε", "εμετ");
-        CheckOneTerm(a, "εμετ", "εμετ");
+            CheckOneTerm(a, "εμετε", "εμετ");
+            CheckOneTerm(a, "εμετ", "εμετ");
 
-        CheckOneTerm(a, "αρχοντασ", "αρχοντ");
-        CheckOneTerm(a, "αρχοντων", "αρχοντ");
-      }
+            CheckOneTerm(a, "αρχοντασ", "αρχοντ");
+            CheckOneTerm(a, "αρχοντων", "αρχοντ");
+        }
 
         [Test]
         public virtual void TestEmptyTerm()
-      {
-        Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-        CheckOneTerm(a, "", "");
-      }
-
-      private class AnalyzerAnonymousInnerClassHelper : Analyzer
-      {
-          private readonly TestGreekStemmer outerInstance;
-
-          public AnalyzerAnonymousInnerClassHelper(TestGreekStemmer outerInstance)
-          {
-              this.outerInstance = outerInstance;
-          }
-
-          protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-          {
-            Tokenizer tokenizer = new KeywordTokenizer(reader);
-            return new TokenStreamComponents(tokenizer, new GreekStemFilter(tokenizer));
-          }
-      }
+        {
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new KeywordTokenizer(reader);
+                return new TokenStreamComponents(tokenizer, new GreekStemFilter(tokenizer));
+            });
+            CheckOneTerm(a, "", "");
+        }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/En/TestEnglishMinimalStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/En/TestEnglishMinimalStemFilter.cs
@@ -26,20 +26,11 @@ namespace Lucene.Net.Analysis.En
     /// </summary>
     public class TestEnglishMinimalStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new EnglishMinimalStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new EnglishMinimalStemFilter(source));
+        });
 
         /// <summary>
         /// Test some examples from various papers about this technique </summary>
@@ -68,24 +59,12 @@ namespace Lucene.Net.Analysis.En
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestEnglishMinimalStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestEnglishMinimalStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new EnglishMinimalStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/En/TestKStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/En/TestKStemmer.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.En
 {
@@ -26,20 +25,11 @@ namespace Lucene.Net.Analysis.En
     /// </summary>
     public class TestKStemmer : BaseTokenStreamTestCase
     {
-        internal Analyzer a = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        internal static readonly Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, true);
-                return new TokenStreamComponents(tokenizer, new KStemFilter(tokenizer));
-            }
-        }
+            Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, true);
+            return new TokenStreamComponents(tokenizer, new KStemFilter(tokenizer));
+        });
 
         /// <summary>
         /// blast some random strings through the analyzer </summary>
@@ -63,26 +53,13 @@ namespace Lucene.Net.Analysis.En
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestKStemmer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestKStemmer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new KStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
-
 
         // requires original java kstem source code to create map
         //public void TestCreateMap() throws Exception

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/En/TestPorterStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/En/TestPorterStemFilter.cs
@@ -28,19 +28,11 @@ namespace Lucene.Net.Analysis.En
     /// </summary>
     public class TestPorterStemFilter_ : BaseTokenStreamTestCase
     {
-        internal Analyzer a = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        internal static readonly Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer t = new MockTokenizer(reader, MockTokenizer.KEYWORD, false);
-                return new TokenStreamComponents(t, new PorterStemFilter(t));
-            }
-        }
+            Tokenizer t = new MockTokenizer(reader, MockTokenizer.KEYWORD, false);
+            return new TokenStreamComponents(t, new PorterStemFilter(t));
+        });
 
         /// <summary>
         /// Run the stemmer against all strings in voc.txt
@@ -73,17 +65,12 @@ namespace Lucene.Net.Analysis.En
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2();
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new PorterStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Es/TestSpanishLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Es/TestSpanishLightStemFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Es
 {
@@ -26,20 +25,11 @@ namespace Lucene.Net.Analysis.Es
     /// </summary>
     public class TestSpanishLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new SpanishLightStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new SpanishLightStemFilter(source));
+        });
 
         /// <summary>
         /// Test against a vocabulary from the reference impl </summary>
@@ -60,24 +50,12 @@ namespace Lucene.Net.Analysis.Es
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestSpanishLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestSpanishLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new SpanishLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fa/TestPersianCharFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fa/TestPersianCharFilter.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Fa
 {
@@ -22,24 +21,10 @@ namespace Lucene.Net.Analysis.Fa
 
     public class TestPersianCharFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                return new TokenStreamComponents(new MockTokenizer(reader));
-            }
-
-            protected internal override TextReader InitReader(string fieldName, TextReader reader)
-            {
-                return new PersianCharFilter(reader);
-            }
-        }
+            return new TokenStreamComponents(new MockTokenizer(reader));
+        }, initReader: (fieldName, reader) => new PersianCharFilter(reader));
 
         [Test]
         public virtual void TestBasics()

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fa/TestPersianNormalizationFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fa/TestPersianNormalizationFilter.cs
@@ -77,24 +77,12 @@ namespace Lucene.Net.Analysis.Fa
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestPersianNormalizationFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestPersianNormalizationFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new PersianNormalizationFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fi/TestFinnishLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fi/TestFinnishLightStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Fi
 {
@@ -28,20 +27,11 @@ namespace Lucene.Net.Analysis.Fi
     /// </summary>
     public class TestFinnishLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new FinnishLightStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new FinnishLightStemFilter(source));
+        });
 
         /// <summary>
         /// Test against a vocabulary from the reference impl </summary>
@@ -55,28 +45,13 @@ namespace Lucene.Net.Analysis.Fi
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("edeltäjistään"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "edeltäjistään", "edeltäjistään");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestFinnishLightStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestFinnishLightStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new FinnishLightStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "edeltäjistään", "edeltäjistään");
         }
 
         /// <summary>
@@ -90,24 +65,12 @@ namespace Lucene.Net.Analysis.Fi
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestFinnishLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestFinnishLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new FinnishLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fr/TestFrenchLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fr/TestFrenchLightStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Fr
 {
@@ -28,20 +27,11 @@ namespace Lucene.Net.Analysis.Fr
     /// </summary>
     public class TestFrenchLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new FrenchLightStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new FrenchLightStemFilter(source));
+        });
 
         /// <summary>
         /// Test some examples from the paper </summary>
@@ -188,29 +178,14 @@ namespace Lucene.Net.Analysis.Fr
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("chevaux"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-
-            CheckOneTerm(a, "chevaux", "chevaux");
-        }
-
-        internal class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestFrenchLightStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestFrenchLightStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new FrenchLightStemFilter(sink));
-            }
+            });
+
+            CheckOneTerm(a, "chevaux", "chevaux");
         }
 
         /// <summary>
@@ -224,24 +199,12 @@ namespace Lucene.Net.Analysis.Fr
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        internal class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestFrenchLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestFrenchLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new FrenchLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fr/TestFrenchMinimalStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fr/TestFrenchMinimalStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Fr
 {
@@ -28,20 +27,11 @@ namespace Lucene.Net.Analysis.Fr
     /// </summary>
     public class TestFrenchMinimalStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new FrenchMinimalStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new FrenchMinimalStemFilter(source));
+        });
 
         /// <summary>
         /// Test some examples from the paper </summary>
@@ -64,28 +54,13 @@ namespace Lucene.Net.Analysis.Fr
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("chevaux"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "chevaux", "chevaux");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestFrenchMinimalStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestFrenchMinimalStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new FrenchMinimalStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "chevaux", "chevaux");
         }
 
         /// <summary>
@@ -107,24 +82,12 @@ namespace Lucene.Net.Analysis.Fr
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestFrenchMinimalStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestFrenchMinimalStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new FrenchMinimalStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ga/TestIrishLowerCaseFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ga/TestIrishLowerCaseFilter.cs
@@ -41,24 +41,12 @@ namespace Lucene.Net.Analysis.Ga
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestIrishLowerCaseFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestIrishLowerCaseFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new IrishLowerCaseFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Gl/TestGalicianMinimalStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Gl/TestGalicianMinimalStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Gl
 {
@@ -28,20 +27,11 @@ namespace Lucene.Net.Analysis.Gl
     /// </summary>
     public class TestGalicianMinimalStemFilter : BaseTokenStreamTestCase
     {
-        internal Analyzer a = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        internal static readonly Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new GalicianMinimalStemFilter(tokenizer));
-            }
-        }
+            Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(tokenizer, new GalicianMinimalStemFilter(tokenizer));
+        });
 
         [Test]
         public virtual void TestPlural()
@@ -63,28 +53,13 @@ namespace Lucene.Net.Analysis.Gl
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("elefantes"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "elefantes", "elefantes");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestGalicianMinimalStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestGalicianMinimalStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new GalicianMinimalStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "elefantes", "elefantes");
         }
 
         /// <summary>
@@ -98,24 +73,12 @@ namespace Lucene.Net.Analysis.Gl
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestGalicianMinimalStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestGalicianMinimalStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new GalicianMinimalStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Gl/TestGalicianStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Gl/TestGalicianStemFilter.cs
@@ -1,7 +1,6 @@
 ﻿using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.Standard;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Gl
 {
@@ -27,22 +26,12 @@ namespace Lucene.Net.Analysis.Gl
     /// </summary>
     public class TestGalicianStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
-                TokenStream result = new LowerCaseFilter(TEST_VERSION_CURRENT, source);
-                return new TokenStreamComponents(source, new GalicianStemFilter(result));
-            }
-        }
-
+            Tokenizer source = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
+            TokenStream result = new LowerCaseFilter(TEST_VERSION_CURRENT, source);
+            return new TokenStreamComponents(source, new GalicianStemFilter(result));
+        });
 
         /// <summary>
         /// Test against a vocabulary from the reference impl </summary>
@@ -55,24 +44,12 @@ namespace Lucene.Net.Analysis.Gl
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestGalicianStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestGalicianStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new GalicianStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hi/TestHindiNormalizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hi/TestHindiNormalizer.cs
@@ -70,24 +70,12 @@ namespace Lucene.Net.Analysis.Hi
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestHindiNormalizer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestHindiNormalizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new HindiNormalizationFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hi/TestHindiStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hi/TestHindiStemmer.cs
@@ -95,24 +95,12 @@ namespace Lucene.Net.Analysis.Hi
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestHindiStemmer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestHindiStemmer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new HindiStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hu/TestHungarianLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hu/TestHungarianLightStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Hu
 {
@@ -28,20 +27,11 @@ namespace Lucene.Net.Analysis.Hu
     /// </summary>
     public class TestHungarianLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new HungarianLightStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new HungarianLightStemFilter(source));
+        });
 
         /// <summary>
         /// Test against a vocabulary from the reference impl </summary>
@@ -55,51 +45,24 @@ namespace Lucene.Net.Analysis.Hu
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("babakocsi"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "babakocsi", "babakocsi");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestHungarianLightStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestHungarianLightStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new HungarianLightStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "babakocsi", "babakocsi");
         }
 
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestHungarianLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestHungarianLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new HungarianLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
@@ -84,47 +84,23 @@ namespace Lucene.Net.Analysis.Hunspell
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckRandomData(Random, analyzer, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestHunspellStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestHunspellStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new HunspellStemFilter(tokenizer, dictionary));
-            }
+            });
+            CheckRandomData(Random, analyzer, 1000 * RandomMultiplier);
         }
 
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestHunspellStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestHunspellStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new HunspellStemFilter(tokenizer, dictionary));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
 
         [Test]
@@ -141,27 +117,12 @@ namespace Lucene.Net.Analysis.Hunspell
             {
                 IOUtils.DisposeWhileHandlingException(affixStream, dictStream);
             }
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this, d);
-            CheckOneTerm(a, "NoChAnGy", "NoChAnGy");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestHunspellStemFilter outerInstance;
-
-            private Dictionary d;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestHunspellStemFilter outerInstance, Dictionary d)
-            {
-                this.outerInstance = outerInstance;
-                this.d = d;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new HunspellStemFilter(tokenizer, d));
-            }
+            });
+            CheckOneTerm(a, "NoChAnGy", "NoChAnGy");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Id/TestIndonesianStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Id/TestIndonesianStemmer.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Id
 {
@@ -27,20 +26,11 @@ namespace Lucene.Net.Analysis.Id
     public class TestIndonesianStemmer : BaseTokenStreamTestCase
     {
         /* full stemming, no stopwords */
-        internal Analyzer a = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        internal static readonly Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new KeywordTokenizer(reader);
-                return new TokenStreamComponents(tokenizer, new IndonesianStemFilter(tokenizer));
-            }
-        }
+            Tokenizer tokenizer = new KeywordTokenizer(reader);
+            return new TokenStreamComponents(tokenizer, new IndonesianStemFilter(tokenizer));
+        });
 
         /// <summary>
         /// Some examples from the paper </summary>
@@ -121,20 +111,11 @@ namespace Lucene.Net.Analysis.Id
         }
 
         /* inflectional-only stemming */
-        internal Analyzer b = new AnalyzerAnonymousInnerClassHelper2();
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
+        internal static readonly Analyzer b = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper2()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new KeywordTokenizer(reader);
-                return new TokenStreamComponents(tokenizer, new IndonesianStemFilter(tokenizer, false));
-            }
-        }
+            Tokenizer tokenizer = new KeywordTokenizer(reader);
+            return new TokenStreamComponents(tokenizer, new IndonesianStemFilter(tokenizer, false));
+        });
 
         /// <summary>
         /// Test stemming only inflectional suffixes </summary>
@@ -158,24 +139,12 @@ namespace Lucene.Net.Analysis.Id
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestIndonesianStemmer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestIndonesianStemmer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new IndonesianStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/In/TestIndicNormalizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/In/TestIndicNormalizer.cs
@@ -52,24 +52,12 @@ namespace Lucene.Net.Analysis.In
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestIndicNormalizer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestIndicNormalizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new IndicNormalizationFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/It/TestItalianLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/It/TestItalianLightStemFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.It
 {
@@ -26,20 +25,11 @@ namespace Lucene.Net.Analysis.It
     /// </summary>
     public class TestItalianLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new ItalianLightStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new ItalianLightStemFilter(source));
+        });
 
         /// <summary>
         /// Test against a vocabulary from the reference impl </summary>
@@ -60,24 +50,12 @@ namespace Lucene.Net.Analysis.It
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestItalianLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestItalianLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new ItalianLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Lv/TestLatvianStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Lv/TestLatvianStemmer.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Lv
 {
@@ -26,20 +25,11 @@ namespace Lucene.Net.Analysis.Lv
     /// </summary>
     public class TestLatvianStemmer : BaseTokenStreamTestCase
     {
-        private Analyzer a = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new LatvianStemFilter(tokenizer));
-            }
-        }
+            Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(tokenizer, new LatvianStemFilter(tokenizer));
+        });
 
         [Test]
         public virtual void TestNouns1()
@@ -294,24 +284,12 @@ namespace Lucene.Net.Analysis.Lv
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestLatvianStemmer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestLatvianStemmer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new LatvianStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestASCIIFoldingFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestASCIIFoldingFilter.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
 
         // testLain1Accents() is a copy of TestLatin1AccentFilter.testU().
         [Test]
-        public virtual void testLatin1Accents()
+        public virtual void TestLatin1Accents()
         {
             TokenStream stream = new MockTokenizer(new StringReader("Des mot clés À LA CHAÎNE À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï Ĳ Ð Ñ" + " Ò Ó Ô Õ Ö Ø Œ Þ Ù Ú Û Ü Ý Ÿ à á â ã ä å æ ç è é ê ë ì í î ï ĳ" + " ð ñ ò ó ô õ ö ø œ ß þ ù ú û ü ý ÿ ﬁ ﬂ"), MockTokenizer.WHITESPACE, false);
             ASCIIFoldingFilter filter = new ASCIIFoldingFilter(stream, Random.nextBoolean());
@@ -177,7 +177,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
         //    ============== end get.test.cases.pl ==============
         //
         [Test]
-        public virtual void testAllFoldings()
+        public virtual void TestAllFoldings()
         {
             // Alternating strings of:
             //   1. All non-ASCII characters to be folded, concatenated together as a
@@ -212,7 +212,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
             }
 
             TokenStream stream = new MockTokenizer(new StringReader(inputText.ToString()), MockTokenizer.WHITESPACE, false);
-            ASCIIFoldingFilter filter = new ASCIIFoldingFilter(stream, Random.nextBoolean());
+            ASCIIFoldingFilter filter = new ASCIIFoldingFilter(stream, Random.NextBoolean());
             ICharTermAttribute termAtt = filter.GetAttribute<ICharTermAttribute>();
             IEnumerator<string> unfoldedIter = expectedUnfoldedTokens.GetEnumerator();
             IEnumerator<string> foldedIter = expectedFoldedTokens.GetEnumerator();
@@ -228,49 +228,25 @@ namespace Lucene.Net.Analysis.Miscellaneous
         /// <summary>
         /// blast some random strings through the analyzer </summary>
         [Test]
-        public virtual void testRandomStrings()
+        public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+                return new TokenStreamComponents(tokenizer, new ASCIIFoldingFilter(tokenizer, Random.NextBoolean()));
+            });
             CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
 
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestASCIIFoldingFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestASCIIFoldingFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new ASCIIFoldingFilter(tokenizer, Random.nextBoolean()));
-            }
-        }
-
         [Test]
-        public virtual void testEmptyTerm()
+        public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestASCIIFoldingFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestASCIIFoldingFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
-                return new TokenStreamComponents(tokenizer, new ASCIIFoldingFilter(tokenizer, Random.nextBoolean()));
-            }
+                return new TokenStreamComponents(tokenizer, new ASCIIFoldingFilter(tokenizer, Random.NextBoolean()));
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCapitalizationFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCapitalizationFilter.cs
@@ -94,48 +94,24 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestRandomString()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestCapitalizationFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestCapitalizationFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new CapitalizationFilter(tokenizer));
-            }
+            });
+
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
 
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestCapitalizationFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestCapitalizationFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new CapitalizationFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCodepointCountFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCodepointCountFilter.cs
@@ -37,24 +37,12 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestCodepointCountFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestCodepointCountFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new CodepointCountFilter(TEST_VERSION_CURRENT, tokenizer, 0, 5));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestHyphenatedWordsFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestHyphenatedWordsFilter.cs
@@ -63,48 +63,24 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestRandomString()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestHyphenatedWordsFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestHyphenatedWordsFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new HyphenatedWordsFilter(tokenizer));
-            }
+            });
+
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
 
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestHyphenatedWordsFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestHyphenatedWordsFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new HyphenatedWordsFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestKeepWordFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestKeepWordFilter.cs
@@ -70,29 +70,14 @@ namespace Lucene.Net.Analysis.Miscellaneous
             words.Add("a");
             words.Add("b");
 
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this, words);
-
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestKeepWordFilter outerInstance;
-
-            private ISet<string> words;
-
-            public AnalyzerAnonymousInnerClassHelper(TestKeepWordFilter outerInstance, ISet<string> words)
-            {
-                this.outerInstance = outerInstance;
-                this.words = words;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream stream = new KeepWordFilter(TEST_VERSION_CURRENT, tokenizer, new CharArraySet(TEST_VERSION_CURRENT, words, true));
                 return new TokenStreamComponents(tokenizer, stream);
-            }
+            });
+
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLengthFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLengthFilter.cs
@@ -47,24 +47,12 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestLengthFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestLengthFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new LengthFilter(TEST_VERSION_CURRENT, tokenizer, 0, 5));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLucene47WordDelimiterFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestLucene47WordDelimiterFilter.cs
@@ -206,14 +206,11 @@ namespace Lucene.Net.Analysis.Miscellaneous
          */
         private sealed class LargePosIncTokenFilter : TokenFilter
         {
-            private readonly TestLucene47WordDelimiterFilter outerInstance;
-
             internal ICharTermAttribute termAtt;
             internal IPositionIncrementAttribute posIncAtt;
 
-            public LargePosIncTokenFilter(TestLucene47WordDelimiterFilter outerInstance, TokenStream input) : base(input)
+            public LargePosIncTokenFilter(TokenStream input) : base(input)
             {
-                this.outerInstance = outerInstance;
                 this.termAtt = AddAttribute<ICharTermAttribute>();
                 this.posIncAtt = AddAttribute<IPositionIncrementAttribute>();
             }
@@ -265,7 +262,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
             Analyzer a2 = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new Lucene47WordDelimiterFilter(new LargePosIncTokenFilter(this, tokenizer), flags, protWords));
+                return new TokenStreamComponents(tokenizer, new Lucene47WordDelimiterFilter(new LargePosIncTokenFilter(tokenizer), flags, protWords));
             });
 
             /* increment of "largegap" is preserved */

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestPerFieldAnalyzerWrapper.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestPerFieldAnalyzerWrapper.cs
@@ -6,7 +6,6 @@ using Lucene.Net.Support;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System.Collections.Generic;
-using System.IO;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Miscellaneous
@@ -92,33 +91,16 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestCharFilters()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                return new TokenStreamComponents(new MockTokenizer(reader));
+            }, initReader: (fieldName, reader) => new MockCharFilter(reader, 7));
             AssertAnalyzesTo(a, "ab", new string[] { "aab" }, new int[] { 0 }, new int[] { 2 });
 
             // now wrap in PFAW
             PerFieldAnalyzerWrapper p = new PerFieldAnalyzerWrapper(a, Collections.EmptyMap<string, Analyzer>());
 
             AssertAnalyzesTo(p, "ab", new string[] { "aab" }, new int[] { 0 }, new int[] { 2 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestPerFieldAnalyzerWrapper outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestPerFieldAnalyzerWrapper outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                return new TokenStreamComponents(new MockTokenizer(reader));
-            }
-
-            protected internal override TextReader InitReader(string fieldName, TextReader reader)
-            {
-                return new MockCharFilter(reader, 7);
-            }
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestRemoveDuplicatesTokenFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestRemoveDuplicatesTokenFilter.cs
@@ -45,20 +45,17 @@ namespace Lucene.Net.Analysis.Miscellaneous
         public virtual void TestDups(string expected, params Token[] tokens)
         {
             IEnumerator<Token> toks = ((IEnumerable<Token>)tokens).GetEnumerator();
-            TokenStream ts = new RemoveDuplicatesTokenFilter((new TokenStreamAnonymousInnerClassHelper(this, toks)));
+            TokenStream ts = new RemoveDuplicatesTokenFilter((new TokenStreamAnonymousInnerClassHelper(toks)));
 
             AssertTokenStreamContents(ts, Regex.Split(expected, "\\s").TrimEnd());
         }
 
         private sealed class TokenStreamAnonymousInnerClassHelper : TokenStream
         {
-            private readonly TestRemoveDuplicatesTokenFilter outerInstance;
+            private readonly IEnumerator<Token> toks;
 
-            private IEnumerator<Token> toks;
-
-            public TokenStreamAnonymousInnerClassHelper(TestRemoveDuplicatesTokenFilter outerInstance, IEnumerator<Token> toks)
+            public TokenStreamAnonymousInnerClassHelper(IEnumerator<Token> toks)
             {
-                this.outerInstance = outerInstance;
                 this.toks = toks;
                 termAtt = AddAttribute<ICharTermAttribute>();
                 offsetAtt = AddAttribute<IOffsetAttribute>();

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestScandinavianFoldingFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestScandinavianFoldingFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Miscellaneous
 {
@@ -23,21 +22,12 @@ namespace Lucene.Net.Analysis.Miscellaneous
 
     public class TestScandinavianFoldingFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                TokenStream stream = new ScandinavianFoldingFilter(tokenizer);
-                return new TokenStreamComponents(tokenizer, stream);
-            }
-        }
+            Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            TokenStream stream = new ScandinavianFoldingFilter(tokenizer);
+            return new TokenStreamComponents(tokenizer, stream);
+        });
 
         [Test]
         public virtual void Test()
@@ -115,24 +105,12 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestScandinavianFoldingFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestScandinavianFoldingFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new ScandinavianFoldingFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestScandinavianNormalizationFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestScandinavianNormalizationFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.Core;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Miscellaneous
 {
@@ -23,23 +22,12 @@ namespace Lucene.Net.Analysis.Miscellaneous
 
     public class TestScandinavianNormalizationFilter : BaseTokenStreamTestCase
     {
-
-
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                TokenStream stream = new ScandinavianNormalizationFilter(tokenizer);
-                return new TokenStreamComponents(tokenizer, stream);
-            }
-        }
+            Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            TokenStream stream = new ScandinavianNormalizationFilter(tokenizer);
+            return new TokenStreamComponents(tokenizer, stream);
+        });
 
         [Test]
         public virtual void Test()
@@ -115,24 +103,12 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestScandinavianNormalizationFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestScandinavianNormalizationFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new ScandinavianNormalizationFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestTrimFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestTrimFilter.cs
@@ -5,7 +5,6 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace Lucene.Net.Analysis.Miscellaneous
@@ -56,7 +55,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
 
         /// @deprecated (3.0) does not support custom attributes 
         [Obsolete("(3.0) does not support custom attributes")]
-        private class IterTokenStream : TokenStream
+        private sealed class IterTokenStream : TokenStream
         {
             internal readonly Token[] tokens;
             internal int index = 0;
@@ -110,68 +109,32 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-
-            Analyzer b = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckRandomData(Random, b, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestTrimFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestTrimFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.KEYWORD, false);
                 return new TokenStreamComponents(tokenizer, new TrimFilter(LuceneVersion.LUCENE_43, tokenizer, true));
-            }
-        }
+            });
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
 
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestTrimFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestTrimFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer b = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.KEYWORD, false);
                 return new TokenStreamComponents(tokenizer, new TrimFilter(TEST_VERSION_CURRENT, tokenizer, false));
-            }
+            });
+            CheckRandomData(Random, b, 1000 * RandomMultiplier);
         }
 
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestTrimFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestTrimFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 bool updateOffsets = Random.nextBoolean();
                 LuceneVersion version = updateOffsets ? LuceneVersion.LUCENE_43 : TEST_VERSION_CURRENT;
                 return new TokenStreamComponents(tokenizer, new TrimFilter(version, tokenizer, updateOffsets));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 #pragma warning restore 612, 618

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/EdgeNGramTokenizerTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/EdgeNGramTokenizerTest.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.IO;
-using Reader = System.IO.TextReader;
 using Version = Lucene.Net.Util.LuceneVersion;
 
 namespace Lucene.Net.Analysis.NGram
@@ -142,53 +141,24 @@ namespace Lucene.Net.Analysis.NGram
                 int min = TestUtil.NextInt32(Random, 2, 10);
                 int max = TestUtil.NextInt32(Random, min, 20);
 
-                Analyzer a = new AnalyzerAnonymousInnerClassHelper(this, min, max);
+                Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new EdgeNGramTokenizer(TEST_VERSION_CURRENT, reader, min, max);
+                    return new TokenStreamComponents(tokenizer, tokenizer);
+                });
                 CheckRandomData(Random, a, 100 * RandomMultiplier, 20);
                 CheckRandomData(Random, a, 10 * RandomMultiplier, 8192);
             }
 
-            Analyzer b = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckRandomData(Random, b, 1000 * RandomMultiplier, 20, false, false);
-            CheckRandomData(Random, b, 100 * RandomMultiplier, 8192, false, false);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly EdgeNGramTokenizerTest outerInstance;
-
-            private int min;
-            private int max;
-
-            public AnalyzerAnonymousInnerClassHelper(EdgeNGramTokenizerTest outerInstance, int min, int max)
-            {
-                this.outerInstance = outerInstance;
-                this.min = min;
-                this.max = max;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, Reader reader)
-            {
-                Tokenizer tokenizer = new EdgeNGramTokenizer(TEST_VERSION_CURRENT, reader, min, max);
-                return new TokenStreamComponents(tokenizer, tokenizer);
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly EdgeNGramTokenizerTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(EdgeNGramTokenizerTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, Reader reader)
+            Analyzer b = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
 #pragma warning disable 612, 618
                 Tokenizer tokenizer = new Lucene43EdgeNGramTokenizer(Version.LUCENE_43, reader, Lucene43EdgeNGramTokenizer.Side.BACK, 2, 4);
 #pragma warning restore 612, 618
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
+            });
+            CheckRandomData(Random, b, 1000 * RandomMultiplier, 20, false, false);
+            CheckRandomData(Random, b, 100 * RandomMultiplier, 8192, false, false);
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/NGramTokenFilterTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/NGramTokenFilterTest.cs
@@ -129,26 +129,14 @@ namespace Lucene.Net.Analysis.NGram
         [Test]
         public virtual void TestInvalidOffsets()
         {
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper(this);
-            AssertAnalyzesTo(analyzer, "mosfellsbær", new string[] { "mo", "os", "sf", "fe", "el", "ll", "ls", "sb", "ba", "ae", "er" }, new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, new int[] { 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11 }, new int[] { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly NGramTokenFilterTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(NGramTokenFilterTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenFilter filters = new ASCIIFoldingFilter(tokenizer);
                 filters = new NGramTokenFilter(TEST_VERSION_CURRENT, filters, 2, 2);
                 return new TokenStreamComponents(tokenizer, filters);
-            }
+            });
+            AssertAnalyzesTo(analyzer, "mosfellsbær", new string[] { "mo", "os", "sf", "fe", "el", "ll", "ls", "sb", "ba", "ae", "er" }, new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, new int[] { 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11 }, new int[] { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
         }
 
         /// <summary>
@@ -160,29 +148,12 @@ namespace Lucene.Net.Analysis.NGram
             {
                 int min = TestUtil.NextInt32(Random, 2, 10);
                 int max = TestUtil.NextInt32(Random, min, 20);
-                Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, min, max);
+                Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+                    return new TokenStreamComponents(tokenizer, new NGramTokenFilter(TEST_VERSION_CURRENT, tokenizer, min, max));
+                });
                 CheckRandomData(Random, a, 200 * RandomMultiplier, 20);
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly NGramTokenFilterTest outerInstance;
-
-            private int min;
-            private int max;
-
-            public AnalyzerAnonymousInnerClassHelper2(NGramTokenFilterTest outerInstance, int min, int max)
-            {
-                this.outerInstance = outerInstance;
-                this.min = min;
-                this.max = max;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new NGramTokenFilter(TEST_VERSION_CURRENT, tokenizer, min, max));
             }
         }
 
@@ -190,24 +161,12 @@ namespace Lucene.Net.Analysis.NGram
         public virtual void TestEmptyTerm()
         {
             Random random = Random;
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckAnalysisConsistency(random, a, random.nextBoolean(), "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly NGramTokenFilterTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(NGramTokenFilterTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new NGramTokenFilter(TEST_VERSION_CURRENT, tokenizer, 2, 15));
-            }
+            });
+            CheckAnalysisConsistency(random, a, random.nextBoolean(), "");
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/NGramTokenizerTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/NGramTokenizerTest.cs
@@ -116,30 +116,13 @@ namespace Lucene.Net.Analysis.NGram
             {
                 int min = TestUtil.NextInt32(Random, 2, 10);
                 int max = TestUtil.NextInt32(Random, min, 20);
-                Analyzer a = new AnalyzerAnonymousInnerClassHelper(this, min, max);
+                Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new NGramTokenizer(TEST_VERSION_CURRENT, reader, min, max);
+                    return new TokenStreamComponents(tokenizer, tokenizer);
+                });
                 CheckRandomData(Random, a, 200 * RandomMultiplier, 20);
                 CheckRandomData(Random, a, 10 * RandomMultiplier, 1027);
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly NGramTokenizerTest outerInstance;
-
-            private int min;
-            private int max;
-
-            public AnalyzerAnonymousInnerClassHelper(NGramTokenizerTest outerInstance, int min, int max)
-            {
-                this.outerInstance = outerInstance;
-                this.min = min;
-                this.max = max;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new NGramTokenizer(TEST_VERSION_CURRENT, reader, min, max);
-                return new TokenStreamComponents(tokenizer, tokenizer);
             }
         }
 
@@ -238,7 +221,7 @@ namespace Lucene.Net.Analysis.NGram
             assertEquals(s.Length, offsetAtt.EndOffset);
         }
 
-        private class NGramTokenizerAnonymousInnerClassHelper : NGramTokenizer
+        private sealed class NGramTokenizerAnonymousInnerClassHelper : NGramTokenizer
         {
             private readonly string nonTokenChars;
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/No/TestNorwegianLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/No/TestNorwegianLightStemFilter.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
 using System;
-using System.IO;
 
 namespace Lucene.Net.Analysis.No
 {
@@ -29,20 +28,11 @@ namespace Lucene.Net.Analysis.No
     /// </summary>
     public class TestNorwegianLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new NorwegianLightStemFilter(source, NorwegianStandard.BOKMAAL));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new NorwegianLightStemFilter(source, NorwegianStandard.BOKMAAL));
+        });
 
         /// <summary>
         /// Test against a vocabulary file </summary>
@@ -57,52 +47,25 @@ namespace Lucene.Net.Analysis.No
         [Test]
         public virtual void TestNynorskVocabulary()
         {
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper2(this);
-            VocabularyAssert.AssertVocabulary(analyzer, GetDataFile("nn_light.txt"));
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestNorwegianLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestNorwegianLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(source, new NorwegianLightStemFilter(source, NorwegianStandard.NYNORSK));
-            }
+            });
+            VocabularyAssert.AssertVocabulary(analyzer, GetDataFile("nn_light.txt"));
         }
 
         [Test]
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("sekretæren"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this, exclusionSet);
-            CheckOneTerm(a, "sekretæren", "sekretæren");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestNorwegianLightStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestNorwegianLightStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new NorwegianLightStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "sekretæren", "sekretæren");
         }
 
         /// <summary>
@@ -117,24 +80,12 @@ namespace Lucene.Net.Analysis.No
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper4(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper4 : Analyzer
-        {
-            private readonly TestNorwegianLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper4(TestNorwegianLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new NorwegianLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/No/TestNorwegianMinimalStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/No/TestNorwegianMinimalStemFilter.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
 using System;
-using System.IO;
 
 namespace Lucene.Net.Analysis.No
 {
@@ -29,20 +28,11 @@ namespace Lucene.Net.Analysis.No
     /// </summary>
     public class TestNorwegianMinimalStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new NorwegianMinimalStemFilter(source, NorwegianStandard.BOKMAAL));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new NorwegianMinimalStemFilter(source, NorwegianStandard.BOKMAAL));
+        });
 
         /// <summary>
         /// Test against a Bokmål vocabulary file </summary>
@@ -57,52 +47,25 @@ namespace Lucene.Net.Analysis.No
         [Test]
         public virtual void TestNynorskVocabulary()
         {
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper2(this);
-            VocabularyAssert.AssertVocabulary(analyzer, GetDataFile("nn_minimal.txt"));
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestNorwegianMinimalStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestNorwegianMinimalStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(source, new NorwegianMinimalStemFilter(source, NorwegianStandard.NYNORSK));
-            }
+            });
+            VocabularyAssert.AssertVocabulary(analyzer, GetDataFile("nn_minimal.txt"));
         }
 
         [Test]
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("sekretæren"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this, exclusionSet);
-            CheckOneTerm(a, "sekretæren", "sekretæren");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestNorwegianMinimalStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestNorwegianMinimalStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new NorwegianMinimalStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "sekretæren", "sekretæren");
         }
 
         /// <summary>
@@ -117,24 +80,12 @@ namespace Lucene.Net.Analysis.No
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper4(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper4 : Analyzer
-        {
-            private readonly TestNorwegianMinimalStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper4(TestNorwegianMinimalStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new NorwegianMinimalStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Path/TestPathHierarchyTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Path/TestPathHierarchyTokenizer.cs
@@ -155,24 +155,12 @@ namespace Lucene.Net.Analysis.Path
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestPathHierarchyTokenizer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestPathHierarchyTokenizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new PathHierarchyTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
+            });
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
 
         /// <summary>
@@ -181,24 +169,12 @@ namespace Lucene.Net.Analysis.Path
         public virtual void TestRandomHugeStrings()
         {
             Random random = Random;
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckRandomData(random, a, 100 * RandomMultiplier, 1027);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestPathHierarchyTokenizer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestPathHierarchyTokenizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new PathHierarchyTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
+            });
+            CheckRandomData(random, a, 100 * RandomMultiplier, 1027);
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Path/TestReversePathHierarchyTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Path/TestReversePathHierarchyTokenizer.cs
@@ -124,24 +124,12 @@ namespace Lucene.Net.Analysis.Path
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestReversePathHierarchyTokenizer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestReversePathHierarchyTokenizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new ReversePathHierarchyTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
+            });
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
 
         /// <summary>
@@ -150,24 +138,12 @@ namespace Lucene.Net.Analysis.Path
         public virtual void TestRandomHugeStrings()
         {
             Random random = Random;
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckRandomData(random, a, 100 * RandomMultiplier, 1027);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestReversePathHierarchyTokenizer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestReversePathHierarchyTokenizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new ReversePathHierarchyTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
+            });
+            CheckRandomData(random, a, 100 * RandomMultiplier, 1027);
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternCaptureGroupTokenFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternCaptureGroupTokenFilter.cs
@@ -178,25 +178,13 @@ namespace Lucene.Net.Analysis.Pattern
         [Test]
         public virtual void TestRandomString()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestPatternCaptureGroupTokenFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestPatternCaptureGroupTokenFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new PatternCaptureGroupTokenFilter(tokenizer, false, new Regex("((..)(..))", RegexOptions.Compiled)));
-            }
+            });
+
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
 
         private void TestPatterns(string input, string[] regexes, string[] tokens, int[] startOffsets, int[] endOffsets, int[] positions, bool preserveOriginal)

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternReplaceCharFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternReplaceCharFilter.cs
@@ -257,7 +257,11 @@ namespace Lucene.Net.Analysis.Pattern
                 Regex p = TestUtil.RandomRegex(LuceneTestCase.Random);
 
                 string replacement = TestUtil.RandomSimpleString(random);
-                Analyzer a = new AnalyzerAnonymousInnerClassHelper(this, p, replacement);
+                Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+                    return new TokenStreamComponents(tokenizer, tokenizer);
+                }, initReader: (fieldName, reader) => new PatternReplaceCharFilter(p, replacement, reader));
 
                 /* max input length. don't make it longer -- exponential processing
                  * time for certain patterns. */
@@ -265,31 +269,6 @@ namespace Lucene.Net.Analysis.Pattern
                 /* ASCII only input?: */
                 const bool asciiOnly = true;
                 CheckRandomData(random, a, 250 * RandomMultiplier, maxInputLength, asciiOnly);
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestPatternReplaceCharFilter outerInstance;
-
-            private Regex p;
-            private string replacement;
-
-            public AnalyzerAnonymousInnerClassHelper(TestPatternReplaceCharFilter outerInstance, Regex p, string replacement)
-            {
-                this.outerInstance = outerInstance;
-                this.p = p;
-                this.replacement = replacement;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, tokenizer);
-            }
-            protected internal override TextReader InitReader(string fieldName, TextReader reader)
-            {
-                return new PatternReplaceCharFilter(p, replacement, reader);
             }
         }
     }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternReplaceFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternReplaceFilter.cs
@@ -71,68 +71,32 @@ namespace Lucene.Net.Analysis.Pattern
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-
-            Analyzer b = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckRandomData(Random, b, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestPatternReplaceFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestPatternReplaceFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream filter = new PatternReplaceFilter(tokenizer, new Regex("a", RegexOptions.Compiled), "b", false);
                 return new TokenStreamComponents(tokenizer, filter);
-            }
-        }
+            });
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
 
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestPatternReplaceFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestPatternReplaceFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer b = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream filter = new PatternReplaceFilter(tokenizer, new Regex("a", RegexOptions.Compiled), "b", true);
                 return new TokenStreamComponents(tokenizer, filter);
-            }
+            });
+            CheckRandomData(Random, b, 1000 * RandomMultiplier);
         }
 
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestPatternReplaceFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestPatternReplaceFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new PatternReplaceFilter(tokenizer, new Regex("a", RegexOptions.Compiled), "b", true));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternTokenizer.cs
@@ -120,43 +120,19 @@ namespace Lucene.Net.Analysis.Pattern
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-
-            Analyzer b = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckRandomData(Random, b, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestPatternTokenizer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestPatternTokenizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new PatternTokenizer(reader, new Regex("a", RegexOptions.Compiled), -1);
                 return new TokenStreamComponents(tokenizer);
-            }
-        }
+            });
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
 
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestPatternTokenizer outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestPatternTokenizer outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer b = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new PatternTokenizer(reader, new Regex("a", RegexOptions.Compiled), 0);
                 return new TokenStreamComponents(tokenizer);
-            }
+            });
+            CheckRandomData(Random, b, 1000 * RandomMultiplier);
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Payloads/TypeAsPayloadTokenFilterTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Payloads/TypeAsPayloadTokenFilterTest.cs
@@ -32,7 +32,7 @@ namespace Lucene.Net.Analysis.Payloads
         {
             string test = "The quick red fox jumped over the lazy brown dogs";
 
-            TypeAsPayloadTokenFilter nptf = new TypeAsPayloadTokenFilter(new WordTokenFilter(this, new MockTokenizer(new StringReader(test), MockTokenizer.WHITESPACE, false)));
+            TypeAsPayloadTokenFilter nptf = new TypeAsPayloadTokenFilter(new WordTokenFilter(new MockTokenizer(new StringReader(test), MockTokenizer.WHITESPACE, false)));
             int count = 0;
             ICharTermAttribute termAtt = nptf.GetAttribute<ICharTermAttribute>();
             ITypeAttribute typeAtt = nptf.GetAttribute<ITypeAttribute>();
@@ -52,14 +52,11 @@ namespace Lucene.Net.Analysis.Payloads
 
         private sealed class WordTokenFilter : TokenFilter
         {
-            private readonly TypeAsPayloadTokenFilterTest outerInstance;
-
             internal readonly ICharTermAttribute termAtt;
             internal readonly ITypeAttribute typeAtt;
 
-            internal WordTokenFilter(TypeAsPayloadTokenFilterTest outerInstance, TokenStream input) : base(input)
+            internal WordTokenFilter(TokenStream input) : base(input)
             {
-                this.outerInstance = outerInstance;
                 termAtt = AddAttribute<ICharTermAttribute>();
                 typeAtt = AddAttribute<ITypeAttribute>();
             }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pt/TestPortugueseLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pt/TestPortugueseLightStemFilter.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Pt
 {
@@ -29,21 +28,12 @@ namespace Lucene.Net.Analysis.Pt
     /// </summary>
     public class TestPortugueseLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
-                TokenStream result = new LowerCaseFilter(TEST_VERSION_CURRENT, source);
-                return new TokenStreamComponents(source, new PortugueseLightStemFilter(result));
-            }
-        }
+            Tokenizer source = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
+            TokenStream result = new LowerCaseFilter(TEST_VERSION_CURRENT, source);
+            return new TokenStreamComponents(source, new PortugueseLightStemFilter(result));
+        });
 
         /// <summary>
         /// Test the example from the paper "Assessing the impact of stemming accuracy
@@ -95,28 +85,13 @@ namespace Lucene.Net.Analysis.Pt
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("quilométricas"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "quilométricas", "quilométricas");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestPortugueseLightStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestPortugueseLightStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new PortugueseLightStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "quilométricas", "quilométricas");
         }
 
         /// <summary>
@@ -130,24 +105,12 @@ namespace Lucene.Net.Analysis.Pt
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestPortugueseLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestPortugueseLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new PortugueseLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pt/TestPortugueseMinimalStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pt/TestPortugueseMinimalStemFilter.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Pt
 {
@@ -29,21 +28,12 @@ namespace Lucene.Net.Analysis.Pt
     /// </summary>
     public class TestPortugueseMinimalStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
-                TokenStream result = new LowerCaseFilter(TEST_VERSION_CURRENT, source);
-                return new TokenStreamComponents(source, new PortugueseMinimalStemFilter(result));
-            }
-        }
+            Tokenizer source = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
+            TokenStream result = new LowerCaseFilter(TEST_VERSION_CURRENT, source);
+            return new TokenStreamComponents(source, new PortugueseMinimalStemFilter(result));
+        });
 
         /// <summary>
         /// Test the example from the paper "Assessing the impact of stemming accuracy
@@ -67,28 +57,13 @@ namespace Lucene.Net.Analysis.Pt
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("quilométricas"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "quilométricas", "quilométricas");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestPortugueseMinimalStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestPortugueseMinimalStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new PortugueseMinimalStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "quilométricas", "quilométricas");
         }
 
         /// <summary>
@@ -102,24 +77,12 @@ namespace Lucene.Net.Analysis.Pt
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestPortugueseMinimalStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestPortugueseMinimalStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new PortugueseMinimalStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pt/TestPortugueseStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pt/TestPortugueseStemFilter.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Pt
 {
@@ -29,21 +28,12 @@ namespace Lucene.Net.Analysis.Pt
     /// </summary>
     public class TestPortugueseStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
-                TokenStream result = new LowerCaseFilter(TEST_VERSION_CURRENT, source);
-                return new TokenStreamComponents(source, new PortugueseStemFilter(result));
-            }
-        }
+            Tokenizer source = new StandardTokenizer(TEST_VERSION_CURRENT, reader);
+            TokenStream result = new LowerCaseFilter(TEST_VERSION_CURRENT, source);
+            return new TokenStreamComponents(source, new PortugueseStemFilter(result));
+        });
 
         /// <summary>
         /// Test the example from the paper "Assessing the impact of stemming accuracy
@@ -67,28 +57,13 @@ namespace Lucene.Net.Analysis.Pt
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("quilométricas"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "quilométricas", "quilométricas");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestPortugueseStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestPortugueseStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new PortugueseStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "quilométricas", "quilométricas");
         }
 
         /// <summary>
@@ -102,24 +77,12 @@ namespace Lucene.Net.Analysis.Pt
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestPortugueseStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestPortugueseStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new PortugueseStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Reverse/TestReverseStringFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Reverse/TestReverseStringFilter.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.IO;
-using NUnit.Framework;
-using Lucene.Net.Analysis.Core;
+﻿using Lucene.Net.Analysis.Core;
 using Lucene.Net.Util;
+using NUnit.Framework;
+using System;
+using System.IO;
 
 namespace Lucene.Net.Analysis.Reverse
 {
@@ -112,47 +112,23 @@ namespace Lucene.Net.Analysis.Reverse
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestReverseStringFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestReverseStringFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new ReverseStringFilter(TEST_VERSION_CURRENT, tokenizer));
-            }
+            });
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
 
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestReverseStringFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestReverseStringFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new ReverseStringFilter(TEST_VERSION_CURRENT, tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ru/TestRussianLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ru/TestRussianLightStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Ru
 {
@@ -28,20 +27,11 @@ namespace Lucene.Net.Analysis.Ru
     /// </summary>
     public class TestRussianLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new RussianLightStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new RussianLightStemFilter(source));
+        });
 
         /// <summary>
         /// Test against a vocabulary from the reference impl </summary>
@@ -55,28 +45,13 @@ namespace Lucene.Net.Analysis.Ru
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("энергии"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "энергии", "энергии");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestRussianLightStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestRussianLightStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new RussianLightStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "энергии", "энергии");
         }
 
         /// <summary>
@@ -90,24 +65,12 @@ namespace Lucene.Net.Analysis.Ru
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestRussianLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestRussianLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new RussianLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TestTeeSinkTokenFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TestTeeSinkTokenFilter.cs
@@ -61,12 +61,8 @@ namespace Lucene.Net.Analysis.Sinks
 
         internal static readonly TeeSinkTokenFilter.SinkFilter theFilter = new SinkFilterAnonymousInnerClassHelper();
 
-        private class SinkFilterAnonymousInnerClassHelper : TeeSinkTokenFilter.SinkFilter
+        private sealed class SinkFilterAnonymousInnerClassHelper : TeeSinkTokenFilter.SinkFilter
         {
-            public SinkFilterAnonymousInnerClassHelper()
-            {
-            }
-
             public override bool Accept(AttributeSource a)
             {
                 ICharTermAttribute termAtt = a.GetAttribute<ICharTermAttribute>();
@@ -76,12 +72,8 @@ namespace Lucene.Net.Analysis.Sinks
 
         internal static readonly TeeSinkTokenFilter.SinkFilter dogFilter = new SinkFilterAnonymousInnerClassHelper2();
 
-        private class SinkFilterAnonymousInnerClassHelper2 : TeeSinkTokenFilter.SinkFilter
+        private sealed class SinkFilterAnonymousInnerClassHelper2 : TeeSinkTokenFilter.SinkFilter
         {
-            public SinkFilterAnonymousInnerClassHelper2()
-            {
-            }
-
             public override bool Accept(AttributeSource a)
             {
                 ICharTermAttribute termAtt = a.GetAttribute<ICharTermAttribute>();
@@ -268,7 +260,7 @@ namespace Lucene.Net.Analysis.Sinks
         }
 
 
-        internal class ModuloTokenFilter : TokenFilter
+        internal sealed class ModuloTokenFilter : TokenFilter
         {
             private readonly TestTeeSinkTokenFilter outerInstance;
 
@@ -296,7 +288,7 @@ namespace Lucene.Net.Analysis.Sinks
             }
         }
 
-        internal class ModuloSinkFilter : TeeSinkTokenFilter.SinkFilter
+        internal sealed class ModuloSinkFilter : TeeSinkTokenFilter.SinkFilter
         {
             private readonly TestTeeSinkTokenFilter outerInstance;
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TestTeeSinkTokenFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TestTeeSinkTokenFilter.cs
@@ -193,9 +193,9 @@ namespace Lucene.Net.Analysis.Sinks
                 }
                 //make sure we produce the same tokens
                 TeeSinkTokenFilter teeStream = new TeeSinkTokenFilter(new StandardFilter(TEST_VERSION_CURRENT, new StandardTokenizer(TEST_VERSION_CURRENT, new StringReader(buffer.ToString()))));
-                TokenStream sink = teeStream.NewSinkTokenStream(new ModuloSinkFilter(this, 100));
+                TokenStream sink = teeStream.NewSinkTokenStream(new ModuloSinkFilter(100));
                 teeStream.ConsumeAllTokens();
-                TokenStream stream = new ModuloTokenFilter(this, new StandardFilter(TEST_VERSION_CURRENT, new StandardTokenizer(TEST_VERSION_CURRENT, new StringReader(buffer.ToString()))), 100);
+                TokenStream stream = new ModuloTokenFilter(new StandardFilter(TEST_VERSION_CURRENT, new StandardTokenizer(TEST_VERSION_CURRENT, new StringReader(buffer.ToString()))), 100);
                 ICharTermAttribute tfTok = stream.AddAttribute<ICharTermAttribute>();
                 ICharTermAttribute sinkTok = sink.AddAttribute<ICharTermAttribute>();
                 for (int i = 0; stream.IncrementToken(); i++)
@@ -218,7 +218,7 @@ namespace Lucene.Net.Analysis.Sinks
                         {
                             tfPos += posIncrAtt.PositionIncrement;
                         }
-                        stream = new ModuloTokenFilter(this, new StandardFilter(TEST_VERSION_CURRENT, new StandardTokenizer(TEST_VERSION_CURRENT, new StringReader(buffer.ToString()))), modCounts[j]);
+                        stream = new ModuloTokenFilter(new StandardFilter(TEST_VERSION_CURRENT, new StandardTokenizer(TEST_VERSION_CURRENT, new StringReader(buffer.ToString()))), modCounts[j]);
                         posIncrAtt = stream.GetAttribute<IPositionIncrementAttribute>();
                         while (stream.IncrementToken())
                         {
@@ -235,7 +235,7 @@ namespace Lucene.Net.Analysis.Sinks
                     for (int i = 0; i < 20; i++)
                     {
                         teeStream = new TeeSinkTokenFilter(new StandardFilter(TEST_VERSION_CURRENT, new StandardTokenizer(TEST_VERSION_CURRENT, new StringReader(buffer.ToString()))));
-                        sink = teeStream.NewSinkTokenStream(new ModuloSinkFilter(this, modCounts[j]));
+                        sink = teeStream.NewSinkTokenStream(new ModuloSinkFilter(modCounts[j]));
                         IPositionIncrementAttribute posIncrAtt = teeStream.GetAttribute<IPositionIncrementAttribute>();
                         while (teeStream.IncrementToken())
                         {
@@ -262,14 +262,10 @@ namespace Lucene.Net.Analysis.Sinks
 
         internal sealed class ModuloTokenFilter : TokenFilter
         {
-            private readonly TestTeeSinkTokenFilter outerInstance;
-
-
             internal int modCount;
 
-            internal ModuloTokenFilter(TestTeeSinkTokenFilter outerInstance, TokenStream input, int mc) : base(input)
+            internal ModuloTokenFilter(TokenStream input, int mc) : base(input)
             {
-                this.outerInstance = outerInstance;
                 modCount = mc;
             }
 
@@ -290,14 +286,11 @@ namespace Lucene.Net.Analysis.Sinks
 
         internal sealed class ModuloSinkFilter : TeeSinkTokenFilter.SinkFilter
         {
-            private readonly TestTeeSinkTokenFilter outerInstance;
-
             internal int count = 0;
             internal int modCount;
 
-            internal ModuloSinkFilter(TestTeeSinkTokenFilter outerInstance, int mc)
+            internal ModuloSinkFilter(int mc)
             {
-                this.outerInstance = outerInstance;
                 modCount = mc;
             }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TokenTypeSinkTokenizerTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TokenTypeSinkTokenizerTest.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Analysis.Sinks
             TokenTypeSinkFilter sinkFilter = new TokenTypeSinkFilter("D");
             string test = "The quick red fox jumped over the lazy brown dogs";
 
-            TeeSinkTokenFilter ttf = new TeeSinkTokenFilter(new WordTokenFilter(this, new MockTokenizer(new StringReader(test), MockTokenizer.WHITESPACE, false)));
+            TeeSinkTokenFilter ttf = new TeeSinkTokenFilter(new WordTokenFilter(new MockTokenizer(new StringReader(test), MockTokenizer.WHITESPACE, false)));
             TeeSinkTokenFilter.SinkTokenStream sink = ttf.NewSinkTokenStream(sinkFilter);
 
             bool seenDogs = false;
@@ -65,14 +65,11 @@ namespace Lucene.Net.Analysis.Sinks
 
         private sealed class WordTokenFilter : TokenFilter
         {
-            private readonly TokenTypeSinkTokenizerTest outerInstance;
-
             internal readonly ICharTermAttribute termAtt;
             internal readonly ITypeAttribute typeAtt;
 
-            internal WordTokenFilter(TokenTypeSinkTokenizerTest outerInstance, TokenStream input) : base(input)
+            internal WordTokenFilter(TokenStream input) : base(input)
             {
-                this.outerInstance = outerInstance;
                 termAtt = AddAttribute<ICharTermAttribute>();
                 typeAtt = AddAttribute<ITypeAttribute>();
             }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TokenTypeSinkTokenizerTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sinks/TokenTypeSinkTokenizerTest.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Analysis.Sinks
             assertTrue("sink Size: " + sinkCount + " is not: " + 1, sinkCount == 1);
         }
 
-        private class WordTokenFilter : TokenFilter
+        private sealed class WordTokenFilter : TokenFilter
         {
             private readonly TokenTypeSinkTokenizerTest outerInstance;
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Snowball/TestSnowball.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Snowball/TestSnowball.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Analysis.Snowball
         [Test]
         public virtual void TestFilterTokens()
         {
-            SnowballFilter filter = new SnowballFilter(new TestTokenStream(this), "English");
+            SnowballFilter filter = new SnowballFilter(new TestTokenStream(), "English");
             ICharTermAttribute termAtt = filter.GetAttribute<ICharTermAttribute>();
             IOffsetAttribute offsetAtt = filter.GetAttribute<IOffsetAttribute>();
             ITypeAttribute typeAtt = filter.GetAttribute<ITypeAttribute>();
@@ -127,8 +127,6 @@ namespace Lucene.Net.Analysis.Snowball
 
         private sealed class TestTokenStream : TokenStream
         {
-            private readonly TestSnowball outerInstance;
-
             internal readonly ICharTermAttribute termAtt;
             internal readonly IOffsetAttribute offsetAtt;
             internal readonly ITypeAttribute typeAtt;
@@ -136,9 +134,8 @@ namespace Lucene.Net.Analysis.Snowball
             internal readonly IPositionIncrementAttribute posIncAtt;
             internal readonly IFlagsAttribute flagsAtt;
 
-            internal TestTokenStream(TestSnowball outerInstance) : base()
+            internal TestTokenStream() : base()
             {
-                this.outerInstance = outerInstance;
                 this.termAtt = AddAttribute<ICharTermAttribute>();
                 this.offsetAtt = AddAttribute<IOffsetAttribute>();
                 this.typeAtt = AddAttribute<ITypeAttribute>();

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Snowball/TestSnowball.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Snowball/TestSnowball.cs
@@ -6,7 +6,6 @@ using Lucene.Net.Tartarus.Snowball.Ext;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Snowball
 {
@@ -170,26 +169,12 @@ namespace Lucene.Net.Analysis.Snowball
         {
             foreach (String lang in SNOWBALL_LANGS)
             {
-                Analyzer a = new AnalyzerAnonymousInnerClassHelper(this, lang);
+                Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new KeywordTokenizer(reader);
+                    return new TokenStreamComponents(tokenizer, new SnowballFilter(tokenizer, lang));
+                });
                 CheckOneTerm(a, "", "");
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestSnowball outerInstance;
-            private readonly string lang;
-
-            public AnalyzerAnonymousInnerClassHelper(TestSnowball outerInstance, string lang)
-            {
-                this.outerInstance = outerInstance;
-                this.lang = lang;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new KeywordTokenizer(reader);
-                return new TokenStreamComponents(tokenizer, new SnowballFilter(tokenizer, lang));
             }
         }
 
@@ -205,27 +190,12 @@ namespace Lucene.Net.Analysis.Snowball
 
         public virtual void CheckRandomStrings(string snowballLanguage)
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, snowballLanguage);
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestSnowball outerInstance;
-
-            private string snowballLanguage;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestSnowball outerInstance, string snowballLanguage)
-            {
-                this.outerInstance = outerInstance;
-                this.snowballLanguage = snowballLanguage;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer t = new MockTokenizer(reader);
                 return new TokenStreamComponents(t, new SnowballFilter(t, snowballLanguage));
-            }
+            });
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
     }
 #pragma warning restore 612, 618

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Snowball/TestSnowballVocab.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Snowball/TestSnowballVocab.cs
@@ -1,7 +1,6 @@
 ﻿using Lucene.Net.Analysis.Core;
 using Lucene.Net.Util;
 using NUnit.Framework;
-using System.IO;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Analysis.Snowball
@@ -71,28 +70,13 @@ namespace Lucene.Net.Analysis.Snowball
                 Console.WriteLine("checking snowball language: " + snowballLanguage);
             }
 
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this, snowballLanguage);
-
-            VocabularyAssert.AssertVocabulary(a, GetDataFile("TestSnowballVocabData.zip"), dataDirectory + "/voc.txt", dataDirectory + "/output.txt");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestSnowballVocab outerInstance;
-
-            private string snowballLanguage;
-
-            public AnalyzerAnonymousInnerClassHelper(TestSnowballVocab outerInstance, string snowballLanguage)
-            {
-                this.outerInstance = outerInstance;
-                this.snowballLanguage = snowballLanguage;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer t = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(t, new SnowballFilter(t, snowballLanguage));
-            }
+            });
+
+            VocabularyAssert.AssertVocabulary(a, GetDataFile("TestSnowballVocabData.zip"), dataDirectory + "/voc.txt", dataDirectory + "/output.txt");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sv/TestSwedishLightStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Sv/TestSwedishLightStemFilter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
-using System.IO;
 
 namespace Lucene.Net.Analysis.Sv
 {
@@ -28,20 +27,11 @@ namespace Lucene.Net.Analysis.Sv
     /// </summary>
     public class TestSwedishLightStemFilter : BaseTokenStreamTestCase
     {
-        private Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            public AnalyzerAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(source, new SwedishLightStemFilter(source));
-            }
-        }
+            Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+            return new TokenStreamComponents(source, new SwedishLightStemFilter(source));
+        });
 
         /// <summary>
         /// Test against a vocabulary from the reference impl </summary>
@@ -55,28 +45,13 @@ namespace Lucene.Net.Analysis.Sv
         public virtual void TestKeyword()
         {
             CharArraySet exclusionSet = new CharArraySet(TEST_VERSION_CURRENT, AsSet("jaktkarlens"), false);
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this, exclusionSet);
-            CheckOneTerm(a, "jaktkarlens", "jaktkarlens");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestSwedishLightStemFilter outerInstance;
-
-            private CharArraySet exclusionSet;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestSwedishLightStemFilter outerInstance, CharArraySet exclusionSet)
-            {
-                this.outerInstance = outerInstance;
-                this.exclusionSet = exclusionSet;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer source = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 TokenStream sink = new SetKeywordMarkerFilter(source, exclusionSet);
                 return new TokenStreamComponents(source, new SwedishLightStemFilter(sink));
-            }
+            });
+            CheckOneTerm(a, "jaktkarlens", "jaktkarlens");
         }
 
         /// <summary>
@@ -90,24 +65,12 @@ namespace Lucene.Net.Analysis.Sv
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper3(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestSwedishLightStemFilter outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestSwedishLightStemFilter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new SwedishLightStemFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSlowSynonymFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSlowSynonymFilter.cs
@@ -330,7 +330,7 @@ namespace Lucene.Net.Analysis.Synonym
 
         /// @deprecated (3.0) does not support custom attributes 
         [Obsolete("(3.0) does not support custom attributes")]
-        private class IterTokenStream : TokenStream
+        private sealed class IterTokenStream : TokenStream
         {
             internal readonly Token[] tokens;
             internal int index = 0;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSolrSynonymParser.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSolrSynonymParser.cs
@@ -40,7 +40,11 @@ namespace Lucene.Net.Analysis.Synonym
             parser.Parse(new StringReader(testFile));
             SynonymMap map = parser.Build();
 
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper(this, map);
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, true);
+                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
+            });
 
             AssertAnalyzesTo(analyzer, "ball", new string[] { "ball" }, new int[] { 1 });
 
@@ -49,25 +53,6 @@ namespace Lucene.Net.Analysis.Synonym
             AssertAnalyzesTo(analyzer, "foo", new string[] { "foo", "baz", "bar" }, new int[] { 1, 0, 1 });
 
             AssertAnalyzesTo(analyzer, "this test", new string[] { "this", "that", "test", "testing" }, new int[] { 1, 0, 1, 0 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestSolrSynonymParser outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper(TestSolrSynonymParser outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, true);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
         }
 
         /// <summary>
@@ -129,32 +114,17 @@ namespace Lucene.Net.Analysis.Synonym
             SolrSynonymParser parser = new SolrSynonymParser(true, true, new MockAnalyzer(Random, MockTokenizer.KEYWORD, false));
             parser.Parse(new StringReader(testFile));
             SynonymMap map = parser.Build();
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper2(this, map);
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.KEYWORD, false);
+                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, false));
+            });
 
             AssertAnalyzesTo(analyzer, "ball", new string[] { "ball" }, new int[] { 1 });
 
             AssertAnalyzesTo(analyzer, "a=>a", new string[] { "b=>b" }, new int[] { 1 });
 
             AssertAnalyzesTo(analyzer, "a,a", new string[] { "b,b" }, new int[] { 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestSolrSynonymParser outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestSolrSynonymParser outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.KEYWORD, false);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, false));
-            }
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Analysis.Synonym
         private IPositionLengthAttribute posLenAtt;
         private IOffsetAttribute offsetAtt;
 
-        private static Regex space = new Regex(" +", RegexOptions.Compiled);
+        private static readonly Regex space = new Regex(" +", RegexOptions.Compiled);
 
         private void Add(string input, string output, bool keepOrig)
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
@@ -163,7 +163,11 @@ namespace Lucene.Net.Analysis.Synonym
             Add("a b", "foo", false);
 
             SynonymMap map = b.Build();
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper(this, map);
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
+                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, false));
+            });
 
             AssertAnalyzesTo(analyzer, "a b c", 
                             new string[] { "foo", "c" }, 
@@ -176,25 +180,6 @@ namespace Lucene.Net.Analysis.Synonym
             CheckAnalysisConsistency(Random, analyzer, false, "a b c");
         }
 
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, false));
-            }
-        }
-
         [Test]
         public virtual void TestDoKeepOrig()
         {
@@ -203,7 +188,11 @@ namespace Lucene.Net.Analysis.Synonym
 
             SynonymMap map = b.Build();
 
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper2(this, map);
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
+                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, false));
+            });
 
             AssertAnalyzesTo(analyzer, "a b c", 
                             new string[] { "a", "foo", "b", "c" }, 
@@ -214,25 +203,6 @@ namespace Lucene.Net.Analysis.Synonym
                             new int[] { 1, 2, 1, 1 }, 
                             true);
             CheckAnalysisConsistency(Random, analyzer, false, "a b c");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper2(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, false));
-            }
         }
 
         [Test]
@@ -587,30 +557,13 @@ namespace Lucene.Net.Analysis.Synonym
                 SynonymMap map = b.Build();
                 bool ignoreCase = Random.nextBoolean();
 
-                Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper100(this, map, ignoreCase);
+                Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
+                    return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, ignoreCase));
+                });
 
                 CheckRandomData(Random, analyzer, 100);
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper100 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-            private bool ignoreCase;
-
-            public AnalyzerAnonymousInnerClassHelper100(TestSynonymMapFilter outerInstance, SynonymMap map, bool ignoreCase)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-                this.ignoreCase = ignoreCase;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, ignoreCase));
             }
         }
 
@@ -662,32 +615,15 @@ namespace Lucene.Net.Analysis.Synonym
                 SynonymMap map = b.Build();
                 bool ignoreCase = random.nextBoolean();
 
-                Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper101(this, map, ignoreCase);
+                Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
+                    TokenStream syns = new SynonymFilter(tokenizer, map, ignoreCase);
+                    TokenStream graph = new MockGraphTokenFilter(Random, syns);
+                    return new TokenStreamComponents(tokenizer, graph);
+                });
 
                 CheckRandomData(random, analyzer, 100);
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper101 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-            private bool ignoreCase;
-
-            public AnalyzerAnonymousInnerClassHelper101(TestSynonymMapFilter outerInstance, SynonymMap map, bool ignoreCase)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-                this.ignoreCase = ignoreCase;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
-                TokenStream syns = new SynonymFilter(tokenizer, map, ignoreCase);
-                TokenStream graph = new MockGraphTokenFilter(Random, syns);
-                return new TokenStreamComponents(tokenizer, graph);
             }
         }
 
@@ -702,35 +638,18 @@ namespace Lucene.Net.Analysis.Synonym
                 int numEntries = AtLeast(10);
                 for (int j = 0; j < numEntries; j++)
                 {
-                    Add(RandomNonEmptyString(), RandomNonEmptyString(), random.nextBoolean());
+                    Add(RandomNonEmptyString(), RandomNonEmptyString(), random.NextBoolean());
                 }
                 SynonymMap map = b.Build();
                 bool ignoreCase = random.nextBoolean();
 
-                Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper3(this, map, ignoreCase);
+                Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new KeywordTokenizer(reader);
+                    return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, ignoreCase));
+                });
 
-                CheckAnalysisConsistency(random, analyzer, random.nextBoolean(), "");
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper3 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-            private bool ignoreCase;
-
-            public AnalyzerAnonymousInnerClassHelper3(TestSynonymMapFilter outerInstance, SynonymMap map, bool ignoreCase)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-                this.ignoreCase = ignoreCase;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new KeywordTokenizer(reader);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, ignoreCase));
+                CheckAnalysisConsistency(random, analyzer, random.NextBoolean(), "");
             }
         }
 
@@ -744,7 +663,7 @@ namespace Lucene.Net.Analysis.Synonym
             int numIters = AtLeast(3);
             for (int i = 0; i < numIters; i++)
             {
-                b = new SynonymMap.Builder(random.nextBoolean());
+                b = new SynonymMap.Builder(random.NextBoolean());
                 int numEntries = AtLeast(10);
                 if (Verbose)
                 {
@@ -752,35 +671,18 @@ namespace Lucene.Net.Analysis.Synonym
                 }
                 for (int j = 0; j < numEntries; j++)
                 {
-                    Add(RandomNonEmptyString(), RandomNonEmptyString(), random.nextBoolean());
+                    Add(RandomNonEmptyString(), RandomNonEmptyString(), random.NextBoolean());
                 }
                 SynonymMap map = b.Build();
-                bool ignoreCase = random.nextBoolean();
+                bool ignoreCase = random.NextBoolean();
 
-                Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper4(this, map, ignoreCase);
+                Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+                {
+                    Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
+                    return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, ignoreCase));
+                });
 
                 CheckRandomData(random, analyzer, 100, 1024);
-            }
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper4 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-            private bool ignoreCase;
-
-            public AnalyzerAnonymousInnerClassHelper4(TestSynonymMapFilter outerInstance, SynonymMap map, bool ignoreCase)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-                this.ignoreCase = ignoreCase;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.SIMPLE, true);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, ignoreCase));
             }
         }
 
@@ -794,7 +696,11 @@ namespace Lucene.Net.Analysis.Synonym
             parser.Parse(new StringReader(testFile));
             SynonymMap map = parser.Build();
 
-            Analyzer analyzer = new AnalyzerAnonymousInnerClassHelper5(this, map);
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, true);
+                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
+            });
 
             // where did my pot go?!
             AssertAnalyzesTo(analyzer, "xyzzy bbb pot of gold", new string[] { "xyzzy", "bbbb1", "pot", "bbbb2", "of", "gold" });
@@ -802,25 +708,6 @@ namespace Lucene.Net.Analysis.Synonym
             // this one nukes 'pot' and 'of'
             // xyzzy aaa pot of gold -> xyzzy aaaa1 aaaa2 aaaa3 gold
             AssertAnalyzesTo(analyzer, "xyzzy aaa pot of gold", new string[] { "xyzzy", "aaaa1", "pot", "aaaa2", "of", "aaaa3", "gold" });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper5 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper5(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, true);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
         }
 
         [Test]
@@ -869,7 +756,11 @@ namespace Lucene.Net.Analysis.Synonym
             Add("z x c v", "zxcv", keepOrig);
             Add("x c", "xc", keepOrig);
             SynonymMap map = b.Build();
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper6(this, map);
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
+            });
 
             CheckOneTerm(a, "$", "$");
             CheckOneTerm(a, "a", "aa");
@@ -886,25 +777,6 @@ namespace Lucene.Net.Analysis.Synonym
             AssertAnalyzesTo(a, "z x c $", new string[] { "z", "xc", "$" }, new int[] { 1, 1, 1 });
         }
 
-        private class AnalyzerAnonymousInnerClassHelper6 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper6(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
-        }
-
         [Test]
         public virtual void TestRepeatsOff()
         {
@@ -914,28 +786,13 @@ namespace Lucene.Net.Analysis.Synonym
             Add("a b", "ab", keepOrig);
             Add("a b", "ab", keepOrig);
             SynonymMap map = b.Build();
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper7(this, map);
-
-            AssertAnalyzesTo(a, "a b", new string[] { "ab" }, new int[] { 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper7 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper7(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
+            });
+
+            AssertAnalyzesTo(a, "a b", new string[] { "ab" }, new int[] { 1 });
         }
 
         [Test]
@@ -947,28 +804,13 @@ namespace Lucene.Net.Analysis.Synonym
             Add("a b", "ab", keepOrig);
             Add("a b", "ab", keepOrig);
             SynonymMap map = b.Build();
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper8(this, map);
-
-            AssertAnalyzesTo(a, "a b", new string[] { "ab", "ab", "ab" }, new int[] { 1, 0, 0 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper8 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper8(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
+            });
+
+            AssertAnalyzesTo(a, "a b", new string[] { "ab", "ab", "ab" }, new int[] { 1, 0, 0 });
         }
 
         [Test]
@@ -978,28 +820,13 @@ namespace Lucene.Net.Analysis.Synonym
             const bool keepOrig = false;
             Add("zoo", "zoo", keepOrig);
             SynonymMap map = b.Build();
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper9(this, map);
-
-            AssertAnalyzesTo(a, "zoo zoo $ zoo", new string[] { "zoo", "zoo", "$", "zoo" }, new int[] { 1, 1, 1, 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper9 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper9(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
+            });
+
+            AssertAnalyzesTo(a, "zoo zoo $ zoo", new string[] { "zoo", "zoo", "$", "zoo" }, new int[] { 1, 1, 1, 1 });
         }
 
         [Test]
@@ -1010,29 +837,14 @@ namespace Lucene.Net.Analysis.Synonym
             Add("zoo", "zoo", keepOrig);
             Add("zoo", "zoo zoo", keepOrig);
             SynonymMap map = b.Build();
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper10(this, map);
-
-            // verify("zoo zoo $ zoo", "zoo/zoo zoo/zoo/zoo $/zoo zoo/zoo zoo");
-            AssertAnalyzesTo(a, "zoo zoo $ zoo", new string[] { "zoo", "zoo", "zoo", "zoo", "zoo", "$", "zoo", "zoo", "zoo", "zoo" }, new int[] { 1, 0, 1, 0, 0, 1, 0, 1, 0, 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper10 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper10(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
+            });
+
+            // verify("zoo zoo $ zoo", "zoo/zoo zoo/zoo/zoo $/zoo zoo/zoo zoo");
+            AssertAnalyzesTo(a, "zoo zoo $ zoo", new string[] { "zoo", "zoo", "zoo", "zoo", "zoo", "$", "zoo", "zoo", "zoo", "zoo" }, new int[] { 1, 0, 1, 0, 0, 1, 0, 1, 0, 1 });
         }
 
         [Test]
@@ -1071,7 +883,11 @@ namespace Lucene.Net.Analysis.Synonym
             Add("z x c v", "zxcv", keepOrig);
             Add("x c", "xc", keepOrig);
             SynonymMap map = b.Build();
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper11(this, map);
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
+                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
+            });
 
             AssertAnalyzesTo(a, "$", new string[] { "$" }, new int[] { 1 });
             AssertAnalyzesTo(a, "a", new string[] { "a", "aa" }, new int[] { 1, 0 });
@@ -1085,25 +901,6 @@ namespace Lucene.Net.Analysis.Synonym
             AssertAnalyzesTo(a, "z x c $", new string[] { "z", "x", "xc", "c", "$" }, new int[] { 1, 1, 0, 1, 1 });
         }
 
-        private class AnalyzerAnonymousInnerClassHelper11 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper11(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
-        }
-
         [Test]
         public virtual void TestRecursion3()
         {
@@ -1111,28 +908,13 @@ namespace Lucene.Net.Analysis.Synonym
             const bool keepOrig = true;
             Add("zoo zoo", "zoo", keepOrig);
             SynonymMap map = b.Build();
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper12(this, map);
-
-            AssertAnalyzesTo(a, "zoo zoo $ zoo", new string[] { "zoo", "zoo", "zoo", "$", "zoo" }, new int[] { 1, 0, 1, 1, 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper12 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper12(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
+            });
+
+            AssertAnalyzesTo(a, "zoo zoo $ zoo", new string[] { "zoo", "zoo", "zoo", "$", "zoo" }, new int[] { 1, 0, 1, 1, 1 });
         }
 
         [Test]
@@ -1143,28 +925,13 @@ namespace Lucene.Net.Analysis.Synonym
             Add("zoo zoo", "zoo", keepOrig);
             Add("zoo", "zoo zoo", keepOrig);
             SynonymMap map = b.Build();
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper13(this, map);
-
-            AssertAnalyzesTo(a, "zoo zoo $ zoo", new string[] { "zoo", "zoo", "zoo", "$", "zoo", "zoo", "zoo" }, new int[] { 1, 0, 1, 1, 1, 0, 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper13 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper13(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
+            });
+
+            AssertAnalyzesTo(a, "zoo zoo $ zoo", new string[] { "zoo", "zoo", "zoo", "$", "zoo", "zoo", "zoo" }, new int[] { 1, 0, 1, 1, 1, 0, 1 });
         }
 
         [Test]
@@ -1174,28 +941,13 @@ namespace Lucene.Net.Analysis.Synonym
             const bool keepOrig = true;
             Add("national hockey league", "nhl", keepOrig);
             SynonymMap map = b.Build();
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper14(this, map);
-
-            AssertAnalyzesTo(a, "national hockey league", new string[] { "national", "nhl", "hockey", "league" }, new int[] { 0, 0, 9, 16 }, new int[] { 8, 22, 15, 22 }, new int[] { 1, 0, 1, 1 });
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper14 : Analyzer
-        {
-            private readonly TestSynonymMapFilter outerInstance;
-
-            private SynonymMap map;
-
-            public AnalyzerAnonymousInnerClassHelper14(TestSynonymMapFilter outerInstance, SynonymMap map)
-            {
-                this.outerInstance = outerInstance;
-                this.map = map;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
                 return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, true));
-            }
+            });
+
+            AssertAnalyzesTo(a, "national hockey league", new string[] { "national", "nhl", "hockey", "league" }, new int[] { 0, 0, 9, 16 }, new int[] { 8, 22, 15, 22 }, new int[] { 1, 0, 1, 1 });
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Tr/TestTurkishLowerCaseFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Tr/TestTurkishLowerCaseFilter.cs
@@ -73,24 +73,12 @@ namespace Lucene.Net.Analysis.Tr
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestTurkishLowerCaseFilter_ outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestTurkishLowerCaseFilter_ outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new TurkishLowerCaseFilter(tokenizer));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestAnalysisSPILoader.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestAnalysisSPILoader.cs
@@ -30,17 +30,13 @@ namespace Lucene.Net.Analysis.Util
 
         private IDictionary<string, string> VersionArgOnly()
         {
-            return new HashMapAnonymousInnerClassHelper(this);
+            return new HashMapAnonymousInnerClassHelper();
         }
 
-        private class HashMapAnonymousInnerClassHelper : Dictionary<string, string>
+        private sealed class HashMapAnonymousInnerClassHelper : Dictionary<string, string>
         {
-            private readonly TestAnalysisSPILoader outerInstance;
-
-            public HashMapAnonymousInnerClassHelper(TestAnalysisSPILoader outerInstance)
+            public HashMapAnonymousInnerClassHelper()
             {
-                this.outerInstance = outerInstance;
-
                 this["luceneMatchVersion"] = TEST_VERSION_CURRENT.ToString();
             }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestBufferedCharFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestBufferedCharFilter.cs
@@ -261,7 +261,7 @@ namespace Lucene.Net.Analysis.Util
             assertTrue(new BufferedCharFilter(new StringReader(new string(new char[5], 1, 0)), 2).Read() == -1);
         }
 
-        private class ReaderAnonymousInnerClassHelper : CharFilter
+        private sealed class ReaderAnonymousInnerClassHelper : CharFilter
         {
             private const int SIZE = 2;
             private int size = SIZE, pos = 0;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestBufferedCharFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestBufferedCharFilter.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Analysis.Util
     {
         BufferedCharFilter br;
 
-        String testString = "Test_All_Tests\nTest_java_io_BufferedInputStream\nTest_java_io_BufferedOutputStream\nTest_java_io_ByteArrayInputStream\nTest_java_io_ByteArrayOutputStream\nTest_java_io_DataInputStream\nTest_java_io_File\nTest_java_io_FileDescriptor\nTest_java_io_FileInputStream\nTest_java_io_FileNotFoundException\nTest_java_io_FileOutputStream\nTest_java_io_FilterInputStream\nTest_java_io_FilterOutputStream\nTest_java_io_InputStream\nTest_java_io_IOException\nTest_java_io_OutputStream\nTest_java_io_PrintStream\nTest_java_io_RandomAccessFile\nTest_java_io_SyncFailedException\nTest_java_lang_AbstractMethodError\nTest_java_lang_ArithmeticException\nTest_java_lang_ArrayIndexOutOfBoundsException\nTest_java_lang_ArrayStoreException\nTest_java_lang_Boolean\nTest_java_lang_Byte\nTest_java_lang_Character\nTest_java_lang_Class\nTest_java_lang_ClassCastException\nTest_java_lang_ClassCircularityError\nTest_java_lang_ClassFormatError\nTest_java_lang_ClassLoader\nTest_java_lang_ClassNotFoundException\nTest_java_lang_CloneNotSupportedException\nTest_java_lang_Double\nTest_java_lang_Error\nTest_java_lang_Exception\nTest_java_lang_ExceptionInInitializerError\nTest_java_lang_Float\nTest_java_lang_IllegalAccessError\nTest_java_lang_IllegalAccessException\nTest_java_lang_IllegalArgumentException\nTest_java_lang_IllegalMonitorStateException\nTest_java_lang_IllegalThreadStateException\nTest_java_lang_IncompatibleClassChangeError\nTest_java_lang_IndexOutOfBoundsException\nTest_java_lang_InstantiationError\nTest_java_lang_InstantiationException\nTest_java_lang_Integer\nTest_java_lang_InternalError\nTest_java_lang_InterruptedException\nTest_java_lang_LinkageError\nTest_java_lang_Long\nTest_java_lang_Math\nTest_java_lang_NegativeArraySizeException\nTest_java_lang_NoClassDefFoundError\nTest_java_lang_NoSuchFieldError\nTest_java_lang_NoSuchMethodError\nTest_java_lang_NullPointerException\nTest_java_lang_Number\nTest_java_lang_NumberFormatException\nTest_java_lang_Object\nTest_java_lang_OutOfMemoryError\nTest_java_lang_RuntimeException\nTest_java_lang_SecurityManager\nTest_java_lang_Short\nTest_java_lang_StackOverflowError\nTest_java_lang_String\nTest_java_lang_StringBuffer\nTest_java_lang_StringIndexOutOfBoundsException\nTest_java_lang_System\nTest_java_lang_Thread\nTest_java_lang_ThreadDeath\nTest_java_lang_ThreadGroup\nTest_java_lang_Throwable\nTest_java_lang_UnknownError\nTest_java_lang_UnsatisfiedLinkError\nTest_java_lang_VerifyError\nTest_java_lang_VirtualMachineError\nTest_java_lang_vm_Image\nTest_java_lang_vm_MemorySegment\nTest_java_lang_vm_ROMStoreException\nTest_java_lang_vm_VM\nTest_java_lang_Void\nTest_java_net_BindException\nTest_java_net_ConnectException\nTest_java_net_DatagramPacket\nTest_java_net_DatagramSocket\nTest_java_net_DatagramSocketImpl\nTest_java_net_InetAddress\nTest_java_net_NoRouteToHostException\nTest_java_net_PlainDatagramSocketImpl\nTest_java_net_PlainSocketImpl\nTest_java_net_Socket\nTest_java_net_SocketException\nTest_java_net_SocketImpl\nTest_java_net_SocketInputStream\nTest_java_net_SocketOutputStream\nTest_java_net_UnknownHostException\nTest_java_util_ArrayEnumerator\nTest_java_util_Date\nTest_java_util_EventObject\nTest_java_util_HashEnumerator\nTest_java_util_Hashtable\nTest_java_util_Properties\nTest_java_util_ResourceBundle\nTest_java_util_tm\nTest_java_util_Vector\n";
+        readonly String testString = "Test_All_Tests\nTest_java_io_BufferedInputStream\nTest_java_io_BufferedOutputStream\nTest_java_io_ByteArrayInputStream\nTest_java_io_ByteArrayOutputStream\nTest_java_io_DataInputStream\nTest_java_io_File\nTest_java_io_FileDescriptor\nTest_java_io_FileInputStream\nTest_java_io_FileNotFoundException\nTest_java_io_FileOutputStream\nTest_java_io_FilterInputStream\nTest_java_io_FilterOutputStream\nTest_java_io_InputStream\nTest_java_io_IOException\nTest_java_io_OutputStream\nTest_java_io_PrintStream\nTest_java_io_RandomAccessFile\nTest_java_io_SyncFailedException\nTest_java_lang_AbstractMethodError\nTest_java_lang_ArithmeticException\nTest_java_lang_ArrayIndexOutOfBoundsException\nTest_java_lang_ArrayStoreException\nTest_java_lang_Boolean\nTest_java_lang_Byte\nTest_java_lang_Character\nTest_java_lang_Class\nTest_java_lang_ClassCastException\nTest_java_lang_ClassCircularityError\nTest_java_lang_ClassFormatError\nTest_java_lang_ClassLoader\nTest_java_lang_ClassNotFoundException\nTest_java_lang_CloneNotSupportedException\nTest_java_lang_Double\nTest_java_lang_Error\nTest_java_lang_Exception\nTest_java_lang_ExceptionInInitializerError\nTest_java_lang_Float\nTest_java_lang_IllegalAccessError\nTest_java_lang_IllegalAccessException\nTest_java_lang_IllegalArgumentException\nTest_java_lang_IllegalMonitorStateException\nTest_java_lang_IllegalThreadStateException\nTest_java_lang_IncompatibleClassChangeError\nTest_java_lang_IndexOutOfBoundsException\nTest_java_lang_InstantiationError\nTest_java_lang_InstantiationException\nTest_java_lang_Integer\nTest_java_lang_InternalError\nTest_java_lang_InterruptedException\nTest_java_lang_LinkageError\nTest_java_lang_Long\nTest_java_lang_Math\nTest_java_lang_NegativeArraySizeException\nTest_java_lang_NoClassDefFoundError\nTest_java_lang_NoSuchFieldError\nTest_java_lang_NoSuchMethodError\nTest_java_lang_NullPointerException\nTest_java_lang_Number\nTest_java_lang_NumberFormatException\nTest_java_lang_Object\nTest_java_lang_OutOfMemoryError\nTest_java_lang_RuntimeException\nTest_java_lang_SecurityManager\nTest_java_lang_Short\nTest_java_lang_StackOverflowError\nTest_java_lang_String\nTest_java_lang_StringBuffer\nTest_java_lang_StringIndexOutOfBoundsException\nTest_java_lang_System\nTest_java_lang_Thread\nTest_java_lang_ThreadDeath\nTest_java_lang_ThreadGroup\nTest_java_lang_Throwable\nTest_java_lang_UnknownError\nTest_java_lang_UnsatisfiedLinkError\nTest_java_lang_VerifyError\nTest_java_lang_VirtualMachineError\nTest_java_lang_vm_Image\nTest_java_lang_vm_MemorySegment\nTest_java_lang_vm_ROMStoreException\nTest_java_lang_vm_VM\nTest_java_lang_Void\nTest_java_net_BindException\nTest_java_net_ConnectException\nTest_java_net_DatagramPacket\nTest_java_net_DatagramSocket\nTest_java_net_DatagramSocketImpl\nTest_java_net_InetAddress\nTest_java_net_NoRouteToHostException\nTest_java_net_PlainDatagramSocketImpl\nTest_java_net_PlainSocketImpl\nTest_java_net_Socket\nTest_java_net_SocketException\nTest_java_net_SocketImpl\nTest_java_net_SocketInputStream\nTest_java_net_SocketOutputStream\nTest_java_net_UnknownHostException\nTest_java_util_ArrayEnumerator\nTest_java_util_Date\nTest_java_util_EventObject\nTest_java_util_HashEnumerator\nTest_java_util_Hashtable\nTest_java_util_Properties\nTest_java_util_ResourceBundle\nTest_java_util_tm\nTest_java_util_Vector\n";
 
         /**
          * The spec says that BufferedReader.readLine() considers only "\r", "\n"
@@ -264,7 +264,7 @@ namespace Lucene.Net.Analysis.Util
         private sealed class ReaderAnonymousInnerClassHelper : CharFilter
         {
             private const int SIZE = 2;
-            private int size = SIZE, pos = 0;
+            private int pos = 0;
 
             private readonly char[] contents = new char[SIZE];
 
@@ -274,18 +274,18 @@ namespace Lucene.Net.Analysis.Util
 
             public override int Read()
             {
-                if (pos >= size)
+                if (pos >= SIZE)
                     throw new IOException("Read past end of data");
                 return contents[pos++];
             }
 
             public override int Read(char[] buf, int off, int len)
             {
-                if (pos >= size)
+                if (pos >= SIZE)
                     throw new IOException("Read past end of data");
                 int toRead = len;
-                if (toRead > (size - pos))
-                    toRead = size - pos;
+                if (toRead > (SIZE - pos))
+                    toRead = SIZE - pos;
                 System.Array.Copy(contents, pos, buf, off, toRead);
                 pos += toRead;
                 return toRead;
@@ -293,7 +293,7 @@ namespace Lucene.Net.Analysis.Util
 
             public bool Ready()
             {
-                return size - pos > 0;
+                return SIZE - pos > 0;
             }
 
 //#if !NETSTANDARD

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestElision.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestElision.cs
@@ -58,24 +58,12 @@ namespace Lucene.Net.Analysis.Util
         [Test]
         public virtual void TestEmptyTerm()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckOneTerm(a, "", "");
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly TestElision outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(TestElision outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new ElisionFilter(tokenizer, FrenchAnalyzer.DEFAULT_ARTICLES));
-            }
+            });
+            CheckOneTerm(a, "", "");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestSegmentingTokenizerBase.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestSegmentingTokenizerBase.cs
@@ -37,25 +37,15 @@ namespace Lucene.Net.Analysis.Util
             base.SetUp();
         }
 
-        private Analyzer sentence = new AnalyzerAnonymousInnerClassHelper();
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
+        private static readonly Analyzer sentence = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                return new TokenStreamComponents(new WholeSentenceTokenizer(reader));
-            }
-        }
+            return new TokenStreamComponents(new WholeSentenceTokenizer(reader));
+        });
 
-        private Analyzer sentenceAndWord = new AnalyzerAnonymousInnerClassHelper2();
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
+        private static readonly Analyzer sentenceAndWord = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         {
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                return new TokenStreamComponents(new SentenceAndWordTokenizer(reader));
-            }
-        }
+            return new TokenStreamComponents(new SentenceAndWordTokenizer(reader));
+        });
 
         [Test]
         public virtual void TestBasics()

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizerTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizerTest.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using Lucene.Net.Analysis.TokenAttributes;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Framework;
-using Lucene.Net.Analysis.TokenAttributes;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Wikipedia
@@ -114,24 +114,12 @@ namespace Lucene.Net.Analysis.Wikipedia
         [Test]
         public virtual void TestRandomStrings()
         {
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper(this);
-            CheckRandomData(Random, a, 1000 * RandomMultiplier);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper : Analyzer
-        {
-            private readonly WikipediaTokenizerTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper(WikipediaTokenizerTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new WikipediaTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
+            });
+            CheckRandomData(Random, a, 1000 * RandomMultiplier);
         }
 
         /// <summary>
@@ -140,24 +128,12 @@ namespace Lucene.Net.Analysis.Wikipedia
         public virtual void TestRandomHugeStrings()
         {
             Random random = Random;
-            Analyzer a = new AnalyzerAnonymousInnerClassHelper2(this);
-            CheckRandomData(random, a, 100 * RandomMultiplier, 8192);
-        }
-
-        private class AnalyzerAnonymousInnerClassHelper2 : Analyzer
-        {
-            private readonly WikipediaTokenizerTest outerInstance;
-
-            public AnalyzerAnonymousInnerClassHelper2(WikipediaTokenizerTest outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
             {
                 Tokenizer tokenizer = new WikipediaTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, tokenizer);
-            }
+            });
+            CheckRandomData(random, a, 100 * RandomMultiplier, 8192);
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Startup.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests.Analysis.ICU/Startup.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/Startup.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests.Analysis.Morfologik/Startup.cs
+++ b/src/Lucene.Net.Tests.Analysis.Morfologik/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/Startup.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/Startup.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/Startup.cs
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests.Analysis.Stempel/Startup.cs
+++ b/src/Lucene.Net.Tests.Analysis.Stempel/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
@@ -1,5 +1,6 @@
 ﻿using J2N.Threading;
 using J2N.Threading.Atomic;
+using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System;
 using System.Collections.Concurrent;
@@ -259,6 +260,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
         [Test]
         [Slow]
+        [Deadlock]
         public virtual void TestConcurrency()
         {
             int ncats = AtLeast(100000); // add many categories

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
         // A No-Op ITaxonomyWriterCache which always discards all given categories, and
         // always returns true in put(), to indicate some cache entries were cleared.
-        private static ITaxonomyWriterCache NO_OP_CACHE = new TaxonomyWriterCacheAnonymousInnerClassHelper();
+        private static readonly ITaxonomyWriterCache NO_OP_CACHE = new TaxonomyWriterCacheAnonymousInnerClassHelper();
 
         private class TaxonomyWriterCacheAnonymousInnerClassHelper : ITaxonomyWriterCache
         {
@@ -294,7 +294,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             ThreadJob[] addThreads = new ThreadJob[AtLeast(4)];
             for (int z = 0; z < addThreads.Length; z++)
             {
-                addThreads[z] = new ThreadAnonymousInnerClassHelper(this, range, numCats, values, tw);
+                addThreads[z] = new ThreadAnonymousInnerClassHelper(range, numCats, values, tw);
             }
 
             foreach (var t in addThreads)
@@ -344,16 +344,13 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
         private class ThreadAnonymousInnerClassHelper : ThreadJob
         {
-            private readonly TestDirectoryTaxonomyWriter outerInstance;
+            private readonly int range;
+            private readonly AtomicInt32 numCats;
+            private readonly ConcurrentDictionary<string, string> values;
+            private readonly DirectoryTaxonomyWriter tw;
 
-            private int range;
-            private AtomicInt32 numCats;
-            private ConcurrentDictionary<string, string> values;
-            private Lucene.Net.Facet.Taxonomy.Directory.DirectoryTaxonomyWriter tw;
-
-            public ThreadAnonymousInnerClassHelper(TestDirectoryTaxonomyWriter outerInstance, int range, AtomicInt32 numCats, ConcurrentDictionary<string, string> values, Lucene.Net.Facet.Taxonomy.Directory.DirectoryTaxonomyWriter tw)
+            public ThreadAnonymousInnerClassHelper(int range, AtomicInt32 numCats, ConcurrentDictionary<string, string> values, DirectoryTaxonomyWriter tw)
             {
-                this.outerInstance = outerInstance;
                 this.range = range;
                 this.numCats = numCats;
                 this.values = values;

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
@@ -1,5 +1,6 @@
 ﻿using J2N.Threading;
 using J2N.Threading.Atomic;
+using Lucene.Net.Attributes;
 using Lucene.Net.Index.Extensions;
 using Lucene.Net.Search;
 using NUnit.Framework;
@@ -258,6 +259,7 @@ namespace Lucene.Net.Facet.Taxonomy
         
         [Test]
         [Slow]
+        [Deadlock]
         public virtual void Test_Directory() // LUCENENET specific - name collides with property of LuceneTestCase
         {
             Store.Directory indexDir = NewDirectory();

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
@@ -162,7 +162,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
             var mgr = new SearcherTaxonomyManager(w, true, null, tw);
 
-            var reopener = new ThreadAnonymousInnerClassHelper(this, stop, mgr);
+            var reopener = new ThreadAnonymousInnerClassHelper(stop, mgr);
 
             reopener.Name = "reopener";
             reopener.Start();
@@ -215,14 +215,11 @@ namespace Lucene.Net.Facet.Taxonomy
 
         private class ThreadAnonymousInnerClassHelper : ThreadJob
         {
-            private readonly TestSearcherTaxonomyManager outerInstance;
+            private readonly AtomicBoolean stop;
+            private readonly SearcherTaxonomyManager mgr;
 
-            private AtomicBoolean stop;
-            private Lucene.Net.Facet.Taxonomy.SearcherTaxonomyManager mgr;
-
-            public ThreadAnonymousInnerClassHelper(TestSearcherTaxonomyManager outerInstance, AtomicBoolean stop, Lucene.Net.Facet.Taxonomy.SearcherTaxonomyManager mgr)
+            public ThreadAnonymousInnerClassHelper(AtomicBoolean stop, SearcherTaxonomyManager mgr)
             {
-                this.outerInstance = outerInstance;
                 this.stop = stop;
                 this.mgr = mgr;
             }

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -1,4 +1,5 @@
 ﻿using J2N.Threading.Atomic;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Facet;
 using Lucene.Net.Facet.Taxonomy;
@@ -288,6 +289,7 @@ namespace Lucene.Net.Replicator
         // handler copies them to the index directory.
         [Test]
         [Slow]
+        [Deadlock]
         public void TestConsistencyOnExceptions()
         {
             // so the handler's index isn't empty

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -42,10 +42,11 @@ namespace Lucene.Net.Replicator
     {
         private class IndexAndTaxonomyReadyCallback : IDisposable
         {
-            private Directory indexDir, taxoDir;
+            private readonly Directory indexDir;
+            private readonly Directory taxoDir;
             private DirectoryReader indexReader;
             private DirectoryTaxonomyReader taxoReader;
-            private FacetsConfig config;
+            private readonly FacetsConfig config;
             private long lastIndexGeneration = -1;
 
             public IndexAndTaxonomyReadyCallback(MockDirectoryWrapper indexDir, MockDirectoryWrapper taxoDir)

--- a/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
@@ -1,4 +1,5 @@
 using J2N.Threading.Atomic;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
@@ -219,6 +220,7 @@ namespace Lucene.Net.Replicator
         // a client copies files from the server to the temporary space, or when the
         // handler copies them to the index directory.
         [Test]
+        [Deadlock]
         public void TestConsistencyOnExceptions()
         {
             // so the handler's index isn't empty

--- a/src/Lucene.Net.Tests.TestFramework/Startup.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Startup.cs
@@ -46,7 +46,7 @@ public class Startup : LuceneTestFrameworkInitializer
         ConfigurationFactory = new MockConfigurationFactory(ConfigurationFactory);
     }
 
-    internal override void IncrementInitalizationCount()
+    internal override void AfterInitialization()
     {
         initializationCount.IncrementAndGet();
     }

--- a/src/Lucene.Net.Tests._A-D/Startup.cs
+++ b/src/Lucene.Net.Tests._A-D/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests._I-J/Startup.cs
+++ b/src/Lucene.Net.Tests._I-J/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests._J-S/Startup.cs
+++ b/src/Lucene.Net.Tests._J-S/Startup.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.Util;
+
+// LUCENENET: With this class in place, the LineDocsFile is exported to a temp file 1 time per test run,
+// which makes the tests run faster. This class is simply here to facilitate the call from NUnit which
+// would not occur if it were not here.
+public class Startup : LuceneTestFrameworkInitializer
+{
+}

--- a/src/Lucene.Net.Tests/Codecs/Lucene40/TestReuseDocsEnum.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene40/TestReuseDocsEnum.cs
@@ -51,6 +51,7 @@ namespace Lucene.Net.Codecs.Lucene40
         [OneTimeSetUp]
         public override void BeforeClass()
         {
+            UseTempLineDocsFile = true;
             base.BeforeClass();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -1,4 +1,5 @@
 using J2N.Threading;
+using Lucene.Net.Attributes;
 using Lucene.Net.Codecs;
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
@@ -986,6 +987,7 @@ namespace Lucene.Net.Index
         // LUCENE-1335: test simultaneous addIndexes & close
         [Test]
         [Slow]
+        [Deadlock]
         public virtual void TestAddIndexesWithCloseNoWait()
         {
             const int NUM_COPY = 50;

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -635,8 +635,6 @@ namespace Lucene.Net.Index
 
         private abstract class RunAddIndexesThreads
         {
-            private readonly TestAddIndexes outerInstance;
-
             internal Directory dir, dir2;
             internal const int NUM_INIT_DOCS = 17;
             internal IndexWriter writer2;
@@ -649,7 +647,6 @@ namespace Lucene.Net.Index
 
             public RunAddIndexesThreads(TestAddIndexes outerInstance, int numCopy)
             {
-                this.outerInstance = outerInstance;
                 NUM_COPY = numCopy;
                 dir = new MockDirectoryWrapper(Random, new RAMDirectory());
                 IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2));
@@ -753,12 +750,9 @@ namespace Lucene.Net.Index
 
         private class CommitAndAddIndexes : RunAddIndexesThreads
         {
-            private readonly TestAddIndexes outerInstance;
-
             public CommitAndAddIndexes(TestAddIndexes outerInstance, int numCopy)
                 : base(outerInstance, numCopy)
             {
-                this.outerInstance = outerInstance;
             }
 
             internal override void Handle(Exception t)
@@ -853,12 +847,9 @@ namespace Lucene.Net.Index
 
         private class CommitAndAddIndexes2 : CommitAndAddIndexes
         {
-            private readonly TestAddIndexes outerInstance;
-
             public CommitAndAddIndexes2(TestAddIndexes outerInstance, int numCopy)
                 : base(outerInstance, numCopy)
             {
-                this.outerInstance = outerInstance;
             }
 
             internal override void Handle(Exception t)
@@ -896,12 +887,9 @@ namespace Lucene.Net.Index
 
         private class CommitAndAddIndexes3 : RunAddIndexesThreads
         {
-            private readonly TestAddIndexes outerInstance;
-
             public CommitAndAddIndexes3(TestAddIndexes outerInstance, int numCopy)
                 : base(outerInstance, numCopy)
             {
-                this.outerInstance = outerInstance;
             }
 
             internal override void DoBody(int j, Directory[] dirs)

--- a/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
@@ -46,6 +46,7 @@ namespace Lucene.Net.Index
         [OneTimeSetUp]
         public override void BeforeClass()
         {
+            UseTempLineDocsFile = true; // LUCENENET specific - Specify to unzip the line file docs
             base.BeforeClass();
             lineDocFile = new LineFileDocs(Random, DefaultCodecSupportsDocValues);
         }

--- a/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Index
             IndexThread[] threads = new IndexThread[numThreads];
             for (int x = 0; x < threads.Length; x++)
             {
-                threads[x] = new IndexThread(this, numDocs, numThreads, writer, lineDocFile, false);
+                threads[x] = new IndexThread(numDocs, writer, lineDocFile, false);
                 threads[x].Start();
             }
 
@@ -161,7 +161,7 @@ namespace Lucene.Net.Index
                 IndexThread[] threads = new IndexThread[numThreads[i]];
                 for (int x = 0; x < threads.Length; x++)
                 {
-                    threads[x] = new IndexThread(this, numDocs, numThreads[i], writer, lineDocFile, false);
+                    threads[x] = new IndexThread(numDocs, writer, lineDocFile, false);
                     threads[x].Start();
                 }
 
@@ -207,7 +207,7 @@ namespace Lucene.Net.Index
             IndexThread[] threads = new IndexThread[numThreads];
             for (int x = 0; x < threads.Length; x++)
             {
-                threads[x] = new IndexThread(this, numDocs, numThreads, writer, lineDocFile, true);
+                threads[x] = new IndexThread(numDocs, writer, lineDocFile, true);
                 threads[x].Start();
             }
 
@@ -270,7 +270,7 @@ namespace Lucene.Net.Index
                 IndexThread[] threads = new IndexThread[numThreads[i]];
                 for (int x = 0; x < threads.Length; x++)
                 {
-                    threads[x] = new IndexThread(this, numDocs, numThreads[i], writer, lineDocFile, false);
+                    threads[x] = new IndexThread(numDocs, writer, lineDocFile, false);
                     threads[x].Start();
                 }
 
@@ -315,17 +315,14 @@ namespace Lucene.Net.Index
 
         public class IndexThread : ThreadJob
         {
-            private readonly TestFlushByRamOrCountsPolicy outerInstance;
-
             internal IndexWriter writer;
             internal LiveIndexWriterConfig iwc;
             internal LineFileDocs docs;
             internal AtomicInt32 pendingDocs;
             internal readonly bool doRandomCommit;
 
-            public IndexThread(TestFlushByRamOrCountsPolicy outerInstance, AtomicInt32 pendingDocs, int numThreads, IndexWriter writer, LineFileDocs docs, bool doRandomCommit)
+            public IndexThread(AtomicInt32 pendingDocs, IndexWriter writer, LineFileDocs docs, bool doRandomCommit)
             {
-                this.outerInstance = outerInstance;
                 this.pendingDocs = pendingDocs;
                 this.writer = writer;
                 iwc = writer.Config;

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -1,6 +1,7 @@
 using J2N.Threading;
 using J2N.Threading.Atomic;
 using Lucene.Net.Analysis;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using Lucene.Net.Store;
@@ -66,6 +67,7 @@ namespace Lucene.Net.Index
     using TokenStream = Lucene.Net.Analysis.TokenStream;
 
     [TestFixture]
+    [Deadlock]
     public class TestIndexWriterExceptions : LuceneTestCase
     {
         private class DocCopyIterator : IEnumerable<Document>

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -275,7 +275,14 @@ namespace Lucene.Net.Index
             }
         }
 
-        internal ThreadLocal<Thread> doFail = new ThreadLocal<Thread>();
+        internal DisposableThreadLocal<Thread> doFail = new DisposableThreadLocal<Thread>();
+
+        // LUCENENET specific - cleanup DisposableThreadLocal instances after running tests
+        public override void AfterClass()
+        {
+            doFail.Dispose();
+            base.AfterClass();
+        }
 
         private class TestPoint1 : ITestPoint
         {

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
@@ -463,11 +463,6 @@ namespace Lucene.Net.Index
 
         private class AddDirectoriesThreads
         {
-            internal virtual void InitializeInstanceFields()
-            {
-                threads = new ThreadJob[outerInstance.numThreads];
-            }
-
             private readonly TestIndexWriterReader outerInstance;
 
             internal Directory addDir;
@@ -484,8 +479,7 @@ namespace Lucene.Net.Index
             public AddDirectoriesThreads(TestIndexWriterReader outerInstance, int numDirs, IndexWriter mainWriter)
             {
                 this.outerInstance = outerInstance;
-
-                InitializeInstanceFields();
+                threads = new ThreadJob[outerInstance.numThreads];
                 this.numDirs = numDirs;
                 this.mainWriter = mainWriter;
                 addDir = NewDirectory();
@@ -573,7 +567,7 @@ namespace Lucene.Net.Index
             {
                 private readonly AddDirectoriesThreads outerInstance;
 
-                private int numIter;
+                private readonly int numIter;
 
                 public ThreadAnonymousInnerClassHelper(AddDirectoriesThreads outerInstance, int numIter)
                 {
@@ -953,10 +947,10 @@ namespace Lucene.Net.Index
 
         private class ThreadAnonymousInnerClassHelper : ThreadJob
         {
-            private IndexWriter writer;
-            private Directory[] dirs;
-            private long endTime;
-            private ConcurrentQueue<Exception> excs;
+            private readonly IndexWriter writer;
+            private readonly Directory[] dirs;
+            private readonly long endTime;
+            private readonly ConcurrentQueue<Exception> excs;
 
             public ThreadAnonymousInnerClassHelper(IndexWriter writer, Directory[] dirs, long endTime, ConcurrentQueue<Exception> excs)
             {
@@ -1015,7 +1009,7 @@ namespace Lucene.Net.Index
             var threads = new ThreadJob[numThreads];
             for (int i = 0; i < numThreads; i++)
             {
-                threads[i] = new ThreadAnonymousInnerClassHelper2(writer, r, endTime, excs);
+                threads[i] = new ThreadAnonymousInnerClassHelper2(writer, endTime, excs);
                 threads[i].IsBackground = (true);
                 threads[i].Start();
             }
@@ -1059,15 +1053,13 @@ namespace Lucene.Net.Index
 
         private class ThreadAnonymousInnerClassHelper2 : ThreadJob
         {
-            private IndexWriter writer;
-            private DirectoryReader r;
-            private long endTime;
-            private ConcurrentQueue<Exception> excs;
+            private readonly IndexWriter writer;
+            private readonly long endTime;
+            private readonly ConcurrentQueue<Exception> excs;
 
-            public ThreadAnonymousInnerClassHelper2(IndexWriter writer, DirectoryReader r, long endTime, ConcurrentQueue<Exception> excs)
+            public ThreadAnonymousInnerClassHelper2(IndexWriter writer, long endTime, ConcurrentQueue<Exception> excs)
             {
                 this.writer = writer;
-                this.r = r;
                 this.endTime = endTime;
                 this.excs = excs;
                 rand = new Random(Random.Next());
@@ -1178,7 +1170,7 @@ namespace Lucene.Net.Index
         {
             Directory dir = NewDirectory();
             AtomicBoolean didWarm = new AtomicBoolean();
-            IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2).SetReaderPooling(true).SetMergedSegmentWarmer(new IndexReaderWarmerAnonymousInnerClassHelper(this, didWarm)).
+            IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2).SetReaderPooling(true).SetMergedSegmentWarmer(new IndexReaderWarmerAnonymousInnerClassHelper(didWarm)).
                     SetMergePolicy(NewLogMergePolicy(10)));
 
             Document doc = new Document();
@@ -1195,13 +1187,10 @@ namespace Lucene.Net.Index
 
         private class IndexReaderWarmerAnonymousInnerClassHelper : IndexWriter.IndexReaderWarmer
         {
-            private readonly TestIndexWriterReader outerInstance;
+            private readonly AtomicBoolean didWarm;
 
-            private AtomicBoolean didWarm;
-
-            public IndexReaderWarmerAnonymousInnerClassHelper(TestIndexWriterReader outerInstance, AtomicBoolean didWarm)
+            public IndexReaderWarmerAnonymousInnerClassHelper(AtomicBoolean didWarm)
             {
-                this.outerInstance = outerInstance;
                 this.didWarm = didWarm;
             }
 
@@ -1223,7 +1212,7 @@ namespace Lucene.Net.Index
         {
             Directory dir = NewDirectory();
             AtomicBoolean didWarm = new AtomicBoolean();
-            InfoStream infoStream = new InfoStreamAnonymousInnerClassHelper(this, didWarm);
+            InfoStream infoStream = new InfoStreamAnonymousInnerClassHelper(didWarm);
             IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2).SetReaderPooling(true).SetInfoStream(infoStream).SetMergedSegmentWarmer(new SimpleMergedSegmentWarmer(infoStream)).SetMergePolicy(NewLogMergePolicy(10)));
 
             Document doc = new Document();
@@ -1240,13 +1229,10 @@ namespace Lucene.Net.Index
 
         private class InfoStreamAnonymousInnerClassHelper : InfoStream
         {
-            private readonly TestIndexWriterReader outerInstance;
+            private readonly AtomicBoolean didWarm;
 
-            private AtomicBoolean didWarm;
-
-            public InfoStreamAnonymousInnerClassHelper(TestIndexWriterReader outerInstance, AtomicBoolean didWarm)
+            public InfoStreamAnonymousInnerClassHelper(AtomicBoolean didWarm)
             {
-                this.outerInstance = outerInstance;
                 this.didWarm = didWarm;
             }
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
@@ -1,5 +1,6 @@
 using J2N.Threading;
 using J2N.Threading.Atomic;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using Lucene.Net.Store;
@@ -50,6 +51,7 @@ namespace Lucene.Net.Index
     using TopDocs = Lucene.Net.Search.TopDocs;
 
     [TestFixture]
+    [Deadlock]
     public class TestIndexWriterReader : LuceneTestCase
     {
         private readonly int numThreads = TestNightly ? 5 : 3;

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
@@ -1,5 +1,6 @@
 using J2N.Threading;
 using J2N.Threading.Atomic;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using Lucene.Net.Store;
@@ -53,6 +54,7 @@ namespace Lucene.Net.Index
     /// </summary>
     [SuppressCodecs("Lucene3x")]
     [Slow]
+    [Deadlock]
     [TestFixture]
     public class TestIndexWriterWithThreads : LuceneTestCase
     {

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
@@ -571,8 +571,10 @@ namespace Lucene.Net.Index
         {
             Directory dir = NewDirectory();
             CountdownEvent oneIWConstructed = new CountdownEvent(1);
-            DelayedIndexAndCloseRunnable thread1 = new DelayedIndexAndCloseRunnable(dir, oneIWConstructed, this);
-            DelayedIndexAndCloseRunnable thread2 = new DelayedIndexAndCloseRunnable(dir, oneIWConstructed, this);
+
+            DelayedIndexAndCloseRunnable thread1 = new DelayedIndexAndCloseRunnable(this, dir, oneIWConstructed);
+            DelayedIndexAndCloseRunnable thread2 = new DelayedIndexAndCloseRunnable(this, dir, oneIWConstructed);
+
 
             thread1.Start();
             thread2.Start();
@@ -612,18 +614,22 @@ namespace Lucene.Net.Index
             internal Exception failure = null;
             internal readonly CountdownEvent startIndexing = new CountdownEvent(1);
             internal CountdownEvent iwConstructed;
+#if FEATURE_INSTANCE_TESTDATA_INITIALIZATION
             private readonly LuceneTestCase outerInstance;
+#endif
 
             /// <param name="outerInstance">
             /// LUCENENET specific
             /// Passed in because this class acceses non-static methods,
             /// NewTextField and NewIndexWriterConfig
             /// </param>
-            public DelayedIndexAndCloseRunnable(Directory dir, CountdownEvent iwConstructed, LuceneTestCase outerInstance)
+            public DelayedIndexAndCloseRunnable(LuceneTestCase outerInstance, Directory dir, CountdownEvent iwConstructed)
             {
+#if FEATURE_INSTANCE_TESTDATA_INITIALIZATION
+                this.outerInstance = outerInstance;
+#endif
                 this.dir = dir;
                 this.iwConstructed = iwConstructed;
-                this.outerInstance = outerInstance;
             }
 
             public virtual void StartIndexing()
@@ -710,19 +716,23 @@ namespace Lucene.Net.Index
 
         private class ThreadAnonymousInnerClassHelper : ThreadJob
         {
+#if FEATURE_INSTANCE_TESTDATA_INITIALIZATION
             private readonly TestIndexWriterWithThreads outerInstance;
+#endif
 
-            private BaseDirectoryWrapper d;
-            private AtomicReference<IndexWriter> writerRef;
-            private LineFileDocs docs;
-            private int iters;
-            private AtomicBoolean failed;
-            private ReentrantLock rollbackLock;
-            private ReentrantLock commitLock;
+            private readonly BaseDirectoryWrapper d;
+            private readonly AtomicReference<IndexWriter> writerRef;
+            private readonly LineFileDocs docs;
+            private readonly int iters;
+            private readonly AtomicBoolean failed;
+            private readonly ReentrantLock rollbackLock;
+            private readonly ReentrantLock commitLock;
 
             public ThreadAnonymousInnerClassHelper(TestIndexWriterWithThreads outerInstance, BaseDirectoryWrapper d, AtomicReference<IndexWriter> writerRef, LineFileDocs docs, int iters, AtomicBoolean failed, ReentrantLock rollbackLock, ReentrantLock commitLock)
             {
+#if FEATURE_INSTANCE_TESTDATA_INITIALIZATION
                 this.outerInstance = outerInstance;
+#endif
                 this.d = d;
                 this.writerRef = writerRef;
                 this.docs = docs;

--- a/src/Lucene.Net.Tests/Index/TestNRTReaderWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestNRTReaderWithThreads.cs
@@ -1,5 +1,6 @@
 using J2N.Threading;
 using J2N.Threading.Atomic;
+using Lucene.Net.Attributes;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
@@ -38,6 +39,7 @@ namespace Lucene.Net.Index
 
         [Test]
         [Slow] // (occasionally)
+        [Deadlock]
         public virtual void TestIndexing()
         {
             Directory mainDir = NewDirectory();

--- a/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
+++ b/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
@@ -1,6 +1,7 @@
 using J2N.Threading;
 using J2N.Threading.Atomic;
 using Lucene.Net.Index.Extensions;
+using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -72,8 +73,15 @@ namespace Lucene.Net.Search
         private ControlledRealTimeReopenThread<IndexSearcher> nrtDeletesThread;
         private ControlledRealTimeReopenThread<IndexSearcher> nrtNoDeletesThread;
 
-        private readonly ThreadLocal<long?> lastGens = new ThreadLocal<long?>();
+        private readonly DisposableThreadLocal<long?> lastGens = new DisposableThreadLocal<long?>();
         private bool warmCalled;
+
+        // LUCENENET specific - cleanup DisposableThreadLocal instances
+        public override void AfterClass()
+        {
+            lastGens.Dispose();
+            base.AfterClass();
+        }
 
         [Test]
         [Slow]

--- a/src/Lucene.Net.Tests/Search/TestScorerPerf.cs
+++ b/src/Lucene.Net.Tests/Search/TestScorerPerf.cs
@@ -166,7 +166,7 @@ namespace Lucene.Net.Search
         internal virtual BitSet AddClause(BooleanQuery bq, BitSet result)
         {
             BitSet rnd = sets[Random.Next(sets.Length)];
-            Query q = new ConstantScoreQuery(new FilterAnonymousInnerClassHelper(this, rnd));
+            Query q = new ConstantScoreQuery(new FilterAnonymousInnerClassHelper(rnd));
             bq.Add(q, Occur.MUST);
             if (validate)
             {
@@ -184,13 +184,10 @@ namespace Lucene.Net.Search
 
         private class FilterAnonymousInnerClassHelper : Filter
         {
-            private readonly TestScorerPerf outerInstance;
-
             private readonly BitSet rnd;
 
-            public FilterAnonymousInnerClassHelper(TestScorerPerf outerInstance, BitSet rnd)
+            public FilterAnonymousInnerClassHelper(BitSet rnd)
             {
-                this.outerInstance = outerInstance;
                 this.rnd = rnd;
             }
 

--- a/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
@@ -253,8 +253,10 @@ namespace Lucene.Net.Util.Fst
                 for (int idx = 0; idx < terms.Length; idx++)
                 {
                     string s = Convert.ToString(idx);
-                    Int32sRef output = new Int32sRef(s.Length);
-                    output.Length = s.Length;
+                    Int32sRef output = new Int32sRef(s.Length)
+                    {
+                        Length = s.Length
+                    };
                     for (int idx2 = 0; idx2 < output.Length; idx2++)
                     {
                         output.Int32s[idx2] = s[idx2];
@@ -299,7 +301,7 @@ namespace Lucene.Net.Util.Fst
                 {
                     int numWords = random.Next(maxNumWords + 1);
                     ISet<Int32sRef> termsSet = new JCG.HashSet<Int32sRef>();
-                    Int32sRef[] terms = new Int32sRef[numWords];
+                    //Int32sRef[] terms = new Int32sRef[numWords]; // LUCENENET: Not Used
                     while (termsSet.Count < numWords)
                     {
                         string term = FSTTester<object>.GetRandomString(random);
@@ -389,9 +391,9 @@ namespace Lucene.Net.Util.Fst
                         {
                             var _ = termsEnum.Ord;
                         }
-#pragma warning disable 168
+#pragma warning disable 168, IDE0059
                         catch (NotSupportedException uoe)
-#pragma warning restore 168
+#pragma warning restore 168, IDE0059
                         {
                             if (Verbose)
                             {
@@ -522,7 +524,7 @@ namespace Lucene.Net.Util.Fst
             private readonly int inputMode;
             private readonly Outputs<T> outputs;
             private readonly Builder<T> builder;
-            private readonly bool doPack;
+            //private readonly bool doPack; // LUCENENET: Not used
 
             public VisitTerms(string dirOut, string wordsFileIn, int inputMode, int prune, Outputs<T> outputs, bool doPack, bool noArcArrays)
             {
@@ -530,7 +532,7 @@ namespace Lucene.Net.Util.Fst
                 this.wordsFileIn = wordsFileIn;
                 this.inputMode = inputMode;
                 this.outputs = outputs;
-                this.doPack = doPack;
+                //this.doPack = doPack; // LUCENENET: Not used
 
                 builder = new Builder<T>(inputMode == 0 ? FST.INPUT_TYPE.BYTE1 : FST.INPUT_TYPE.BYTE4, 0, prune, prune == 0, true, int.MaxValue, outputs, null, doPack, PackedInt32s.DEFAULT, !noArcArrays, 15);
             }
@@ -813,7 +815,7 @@ namespace Lucene.Net.Util.Fst
 
         private class VisitTermsAnonymousInnerClassHelper : VisitTerms<Pair>
         {
-            private PairOutputs<long?, long?> outputs;
+            private readonly PairOutputs<long?, long?> outputs;
 
             public VisitTermsAnonymousInnerClassHelper(string dirOut, string wordsFileIn, int inputMode, int prune, PairOutputs<long?, long?> outputs, bool doPack, bool noArcArrays)
                 : base(dirOut, wordsFileIn, inputMode, prune, outputs, doPack, noArcArrays)
@@ -865,7 +867,7 @@ namespace Lucene.Net.Util.Fst
 
         private class VisitTermsAnonymousInnerClassHelper4 : VisitTerms<object>
         {
-            private object NO_OUTPUT;
+            private readonly object NO_OUTPUT;
 
             public VisitTermsAnonymousInnerClassHelper4(string dirOut, string wordsFileIn, int inputMode, int prune, NoOutputs outputs, bool doPack, bool noArcArrays, object NO_OUTPUT)
                 : base(dirOut, wordsFileIn, inputMode, prune, outputs, doPack, noArcArrays)
@@ -1491,7 +1493,7 @@ namespace Lucene.Net.Util.Fst
             builder.Add(Util.ToInt32sRef(new BytesRef("ax"), scratch), 17L);
             FST<long?> fst = builder.Finish();
             AtomicInt32 rejectCount = new AtomicInt32();
-            Util.TopNSearcher<long?> searcher = new TopNSearcherAnonymousInnerClassHelper(this, fst, minLongComparer, rejectCount);
+            Util.TopNSearcher<long?> searcher = new TopNSearcherAnonymousInnerClassHelper(fst, minLongComparer, rejectCount);
 
             searcher.AddStartPaths(fst.GetFirstArc(new FST.Arc<long?>()), outputs.NoOutput, true, new Int32sRef());
             Util.TopResults<long?> res = searcher.Search();
@@ -1502,7 +1504,7 @@ namespace Lucene.Net.Util.Fst
             Assert.AreEqual(Util.ToInt32sRef(new BytesRef("aac"), scratch), res.TopN[0].Input);
             Assert.AreEqual(7L, res.TopN[0].Output);
             rejectCount.Value = (0);
-            searcher = new TopNSearcherAnonymousInnerClassHelper2(this, fst, minLongComparer, rejectCount);
+            searcher = new TopNSearcherAnonymousInnerClassHelper2(fst, minLongComparer, rejectCount);
 
             searcher.AddStartPaths(fst.GetFirstArc(new FST.Arc<long?>()), outputs.NoOutput, true, new Int32sRef());
             res = searcher.Search();
@@ -1512,14 +1514,11 @@ namespace Lucene.Net.Util.Fst
 
         private class TopNSearcherAnonymousInnerClassHelper : Util.TopNSearcher<long?>
         {
-            private readonly TestFSTs outerInstance;
-
             private readonly AtomicInt32 rejectCount;
 
-            public TopNSearcherAnonymousInnerClassHelper(TestFSTs outerInstance, FST<long?> fst, IComparer<long?> minLongComparer, AtomicInt32 rejectCount)
+            public TopNSearcherAnonymousInnerClassHelper(FST<long?> fst, IComparer<long?> minLongComparer, AtomicInt32 rejectCount)
                 : base(fst, 2, 6, minLongComparer)
             {
-                this.outerInstance = outerInstance;
                 this.rejectCount = rejectCount;
             }
 
@@ -1536,14 +1535,11 @@ namespace Lucene.Net.Util.Fst
 
         private class TopNSearcherAnonymousInnerClassHelper2 : Util.TopNSearcher<long?>
         {
-            private readonly TestFSTs outerInstance;
-
             private readonly AtomicInt32 rejectCount;
 
-            public TopNSearcherAnonymousInnerClassHelper2(TestFSTs outerInstance, FST<long?> fst, IComparer<long?> minLongComparer, AtomicInt32 rejectCount)
+            public TopNSearcherAnonymousInnerClassHelper2(FST<long?> fst, IComparer<long?> minLongComparer, AtomicInt32 rejectCount)
                 : base(fst, 2, 5, minLongComparer)
             {
-                this.outerInstance = outerInstance;
                 this.rejectCount = rejectCount;
             }
 
@@ -1722,14 +1718,11 @@ namespace Lucene.Net.Util.Fst
         // used by slowcompletor
         internal class TwoLongs
         {
-            private readonly TestFSTs outerInstance;
-
             internal long a;
             internal long b;
 
-            internal TwoLongs(TestFSTs outerInstance, long a, long b)
+            internal TwoLongs(long a, long b)
             {
-                this.outerInstance = outerInstance;
                 this.a = a;
                 this.b = b;
             }
@@ -1768,7 +1761,7 @@ namespace Lucene.Net.Util.Fst
                 }
                 int weight = TestUtil.NextInt32(random, 1, 100); // weights 1..100
                 int output = TestUtil.NextInt32(random, 0, 500); // outputs 0..500
-                slowCompletor[s] = new TwoLongs(this, weight, output);
+                slowCompletor[s] = new TwoLongs(weight, output);
             }
 
             foreach (KeyValuePair<string, TwoLongs> e in slowCompletor)

--- a/src/Lucene.Net.Tests/Util/Packed/TestEliasFanoDocIdSet.cs
+++ b/src/Lucene.Net.Tests/Util/Packed/TestEliasFanoDocIdSet.cs
@@ -27,20 +27,17 @@ namespace Lucene.Net.Util.Packed
         public override EliasFanoDocIdSet CopyOf(BitSet bs, int numBits)
         {
             EliasFanoDocIdSet set = new EliasFanoDocIdSet((int)bs.Cardinality, numBits - 1);
-            set.EncodeFromDisi(new DocIdSetIteratorAnonymousInnerClassHelper(this, bs, numBits));
+            set.EncodeFromDisi(new DocIdSetIteratorAnonymousInnerClassHelper(bs, numBits));
             return set;
         }
 
         private class DocIdSetIteratorAnonymousInnerClassHelper : DocIdSetIterator
         {
-            private readonly TestEliasFanoDocIdSet outerInstance;
-
             private readonly BitSet bs;
             private readonly int numBits;
 
-            public DocIdSetIteratorAnonymousInnerClassHelper(TestEliasFanoDocIdSet outerInstance, BitSet bs, int numBits)
+            public DocIdSetIteratorAnonymousInnerClassHelper(BitSet bs, int numBits)
             {
-                this.outerInstance = outerInstance;
                 this.bs = bs;
                 this.numBits = numBits;
                 doc = -1;

--- a/src/Lucene.Net.Tests/Util/TestCloseableThreadLocal.cs
+++ b/src/Lucene.Net.Tests/Util/TestCloseableThreadLocal.cs
@@ -28,8 +28,8 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestInitValue()
         {
-            InitValueThreadLocal tl = new InitValueThreadLocal(this);
-            string str = (string)tl.Get();
+            DisposableThreadLocal<object> tl = new DisposableThreadLocal<object>(() => TEST_VALUE);
+            string str = (string)tl.Value;
             Assert.AreEqual(TEST_VALUE, str);
         }
 
@@ -39,8 +39,8 @@ namespace Lucene.Net.Util
             // Tests that null can be set as a valid value (LUCENE-1805). this
             // previously failed in get().
             DisposableThreadLocal<object> ctl = new DisposableThreadLocal<object>();
-            ctl.Set(null);
-            Assert.IsNull(ctl.Get());
+            ctl.Value = (null);
+            Assert.IsNull(ctl.Value);
         }
 
         [Test]
@@ -49,22 +49,7 @@ namespace Lucene.Net.Util
             // LUCENE-1805: make sure default get returns null,
             // twice in a row
             DisposableThreadLocal<object> ctl = new DisposableThreadLocal<object>();
-            Assert.IsNull(ctl.Get());
-        }
-
-        public class InitValueThreadLocal : DisposableThreadLocal<object>
-        {
-            private readonly TestIDisposableThreadLocal outerInstance;
-
-            public InitValueThreadLocal(TestIDisposableThreadLocal outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected internal override object InitialValue()
-            {
-                return TEST_VALUE;
-            }
+            Assert.IsNull(ctl.Value);
         }
     }
 }

--- a/src/Lucene.Net.Tests/Util/TestCollectionUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestCollectionUtil.cs
@@ -2,6 +2,8 @@ using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
@@ -26,13 +28,14 @@ namespace Lucene.Net.Util
     [TestFixture]
     public class TestCollectionUtil : LuceneTestCase
     {
-        private IList<int> CreateRandomList(int maxSize)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int[] CreateRandomList(int maxSize)
         {
             Random rnd = Random;
             int[] a = new int[rnd.Next(maxSize) + 1];
             for (int i = 0; i < a.Length; i++)
             {
-                a[i] = Convert.ToInt32(rnd.Next(a.Length));
+                a[i] = rnd.Next(a.Length);
             }
             return a;
         }
@@ -40,21 +43,26 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestIntroSort()
         {
+            // LUCENENET: Use array for comparison rather than list for better performance
             for (int i = 0, c = AtLeast(500); i < c; i++)
             {
-                IList<int> list1 = CreateRandomList(2000), list2 = new List<int>(list1);
+                IList<int> list1 = CreateRandomList(2000);
+                int[] list2 = new int[list1.Count];
+                list1.CopyTo(list2, 0);
                 CollectionUtil.IntroSort(list1);
-                list2.Sort();
+                Array.Sort(list2);
                 assertEquals(list2, list1, aggressive: false);
 
                 list1 = CreateRandomList(2000);
-                list2 = new List<int>(list1);
+                list2 = new int[list1.Count];
+                list1.CopyTo(list2, 0);
+
                 CollectionUtil.IntroSort(list1, Collections.ReverseOrder<int>());
-                list2.Sort(Collections.ReverseOrder<int>());
+                Array.Sort(list2, Collections.ReverseOrder<int>());
                 assertEquals(list2, list1, aggressive: false);
                 // reverse back, so we can test that completely backwards sorted array (worst case) is working:
                 CollectionUtil.IntroSort(list1);
-                list2.Sort();
+                Array.Sort(list2);
                 assertEquals(list2, list1, aggressive: false);
             }
         }
@@ -62,21 +70,26 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestTimSort()
         {
+            // LUCENENET: Use array for comparison rather than list for better performance
             for (int i = 0, c = AtLeast(500); i < c; i++)
             {
-                IList<int> list1 = CreateRandomList(2000), list2 = new List<int>(list1);
+                IList<int> list1 = CreateRandomList(2000);
+                int[] list2 = new int[list1.Count];
+                list1.CopyTo(list2, 0);
+
                 CollectionUtil.TimSort(list1);
-                list2.Sort();
+                Array.Sort(list2);
                 assertEquals(list2, list1, aggressive: false);
 
                 list1 = CreateRandomList(2000);
-                list2 = new List<int>(list1);
+                list2 = new int[list1.Count];
+                list1.CopyTo(list2, 0);
                 CollectionUtil.TimSort(list1, Collections.ReverseOrder<int>());
-                list2.Sort(Collections.ReverseOrder<int>());
+                Array.Sort(list2, Collections.ReverseOrder<int>());
                 assertEquals(list2, list1, aggressive: false);
                 // reverse back, so we can test that completely backwards sorted array (worst case) is working:
                 CollectionUtil.TimSort(list1);
-                list2.Sort();
+                Array.Sort(list2);
                 assertEquals(list2, list1, aggressive: false);
             }
         }

--- a/src/Lucene.Net.Tests/Util/TestFilterIterator.cs
+++ b/src/Lucene.Net.Tests/Util/TestFilterIterator.cs
@@ -37,18 +37,15 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestEmpty()
         {
-            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper(this, set.GetEnumerator());
+            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper(set.GetEnumerator());
             AssertNoMore(it);
         }
 
         private class FilterIteratorAnonymousInnerClassHelper : FilterIterator<string>
         {
-            private readonly TestFilterIterator outerInstance;
-
-            public FilterIteratorAnonymousInnerClassHelper(TestFilterIterator outerInstance, IEnumerator<string> iterator)
+            public FilterIteratorAnonymousInnerClassHelper(IEnumerator<string> iterator)
                 : base(iterator)
             {
-                this.outerInstance = outerInstance;
             }
 
             protected override bool PredicateFunction(string s)
@@ -60,7 +57,7 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestA1()
         {
-            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper2(this, set.GetEnumerator());
+            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper2(set.GetEnumerator());
             Assert.IsTrue(it.MoveNext());
             Assert.AreEqual("a", it.Current);
             AssertNoMore(it);
@@ -68,12 +65,9 @@ namespace Lucene.Net.Util
 
         private class FilterIteratorAnonymousInnerClassHelper2 : FilterIterator<string>
         {
-            private readonly TestFilterIterator outerInstance;
-
-            public FilterIteratorAnonymousInnerClassHelper2(TestFilterIterator outerInstance, IEnumerator<string> iterator)
+            public FilterIteratorAnonymousInnerClassHelper2(IEnumerator<string> iterator)
                 : base(iterator)
             {
-                this.outerInstance = outerInstance;
             }
 
             protected override bool PredicateFunction(string s)
@@ -85,7 +79,7 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestA2()
         {
-            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper3(this, set.GetEnumerator());
+            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper3(set.GetEnumerator());
             // this time without check: Assert.IsTrue(it.hasNext());
             it.MoveNext();
             Assert.AreEqual("a", it.Current);
@@ -94,12 +88,9 @@ namespace Lucene.Net.Util
 
         private class FilterIteratorAnonymousInnerClassHelper3 : FilterIterator<string>
         {
-            private readonly TestFilterIterator outerInstance;
-
-            public FilterIteratorAnonymousInnerClassHelper3(TestFilterIterator outerInstance, IEnumerator<string> iterator)
+            public FilterIteratorAnonymousInnerClassHelper3(IEnumerator<string> iterator)
                 : base(iterator)
             {
-                this.outerInstance = outerInstance;
             }
 
             protected override bool PredicateFunction(string s)
@@ -111,7 +102,7 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestB1()
         {
-            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper4(this, set.GetEnumerator());
+            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper4(set.GetEnumerator());
             Assert.IsTrue(it.MoveNext());
             Assert.AreEqual("b", it.Current);
             AssertNoMore(it);
@@ -119,12 +110,9 @@ namespace Lucene.Net.Util
 
         private class FilterIteratorAnonymousInnerClassHelper4 : FilterIterator<string>
         {
-            private readonly TestFilterIterator outerInstance;
-
-            public FilterIteratorAnonymousInnerClassHelper4(TestFilterIterator outerInstance, IEnumerator<string> iterator)
+            public FilterIteratorAnonymousInnerClassHelper4(IEnumerator<string> iterator)
                 : base(iterator)
             {
-                this.outerInstance = outerInstance;
             }
 
             protected override bool PredicateFunction(string s)
@@ -136,7 +124,7 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestB2()
         {
-            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper5(this, set.GetEnumerator());
+            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper5(set.GetEnumerator());
             // this time without check: Assert.IsTrue(it.hasNext());
             it.MoveNext();
             Assert.AreEqual("b", it.Current);
@@ -145,12 +133,9 @@ namespace Lucene.Net.Util
 
         private class FilterIteratorAnonymousInnerClassHelper5 : FilterIterator<string>
         {
-            private readonly TestFilterIterator outerInstance;
-
-            public FilterIteratorAnonymousInnerClassHelper5(TestFilterIterator outerInstance, IEnumerator<string> iterator)
+            public FilterIteratorAnonymousInnerClassHelper5(IEnumerator<string> iterator)
                 : base(iterator)
             {
-                this.outerInstance = outerInstance;
             }
 
             protected override bool PredicateFunction(string s)
@@ -162,7 +147,7 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestAll1()
         {
-            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper6(this, set.GetEnumerator());
+            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper6(set.GetEnumerator());
             Assert.IsTrue(it.MoveNext());
             Assert.AreEqual("a", it.Current);
             Assert.IsTrue(it.MoveNext());
@@ -174,12 +159,9 @@ namespace Lucene.Net.Util
 
         private class FilterIteratorAnonymousInnerClassHelper6 : FilterIterator<string>
         {
-            private readonly TestFilterIterator outerInstance;
-
-            public FilterIteratorAnonymousInnerClassHelper6(TestFilterIterator outerInstance, IEnumerator<string> iterator)
+            public FilterIteratorAnonymousInnerClassHelper6(IEnumerator<string> iterator)
                 : base(iterator)
             {
-                this.outerInstance = outerInstance;
             }
 
             protected override bool PredicateFunction(string s)
@@ -191,7 +173,7 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestAll2()
         {
-            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper7(this, set.GetEnumerator());
+            IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper7(set.GetEnumerator());
             it.MoveNext();
             Assert.AreEqual("a", it.Current);
             it.MoveNext();
@@ -203,12 +185,9 @@ namespace Lucene.Net.Util
 
         private class FilterIteratorAnonymousInnerClassHelper7 : FilterIterator<string>
         {
-            private readonly TestFilterIterator outerInstance;
-
-            public FilterIteratorAnonymousInnerClassHelper7(TestFilterIterator outerInstance, IEnumerator<string> iterator)
+            public FilterIteratorAnonymousInnerClassHelper7(IEnumerator<string> iterator)
                 : base(iterator)
             {
-                this.outerInstance = outerInstance;
             }
 
             protected override bool PredicateFunction(string s)
@@ -221,7 +200,7 @@ namespace Lucene.Net.Util
         //[Test]
         //public virtual void TestUnmodifiable()
         //{
-        //    IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper8(this, Set.GetEnumerator());
+        //    IEnumerator<string> it = new FilterIteratorAnonymousInnerClassHelper8(Set.GetEnumerator());
         //    it.MoveNext();
         //    Assert.AreEqual("a", it.Current);
         //    try
@@ -236,20 +215,17 @@ namespace Lucene.Net.Util
         //    }
         //}
 
-        private class FilterIteratorAnonymousInnerClassHelper8 : FilterIterator<string>
-        {
-            private readonly TestFilterIterator outerInstance;
+        //private class FilterIteratorAnonymousInnerClassHelper8 : FilterIterator<string>
+        //{
+        //    public FilterIteratorAnonymousInnerClassHelper8(IEnumerator<string> iterator)
+        //        : base(iterator)
+        //    {
+        //    }
 
-            public FilterIteratorAnonymousInnerClassHelper8(TestFilterIterator outerInstance, IEnumerator<string> iterator)
-                : base(iterator)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected override bool PredicateFunction(string s)
-            {
-                return true;
-            }
-        }
+        //    protected override bool PredicateFunction(string s)
+        //    {
+        //        return true;
+        //    }
+        //}
     }
 }

--- a/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
+++ b/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
@@ -268,7 +268,7 @@ namespace Lucene.Net.Util
             IEnumerator<long> neededBounds = (expectedBounds == null) ? null : expectedBounds.GetEnumerator();
             IEnumerator<int> neededShifts = (expectedShifts == null) ? null : expectedShifts.GetEnumerator();
 
-            NumericUtils.SplitInt64Range(new LongRangeBuilderAnonymousInnerClassHelper(this, lower, upper, useBitSet, bits, neededBounds, neededShifts), precisionStep, lower, upper);
+            NumericUtils.SplitInt64Range(new LongRangeBuilderAnonymousInnerClassHelper(lower, upper, useBitSet, bits, neededBounds, neededShifts), precisionStep, lower, upper);
 
             if (useBitSet)
             {
@@ -280,8 +280,6 @@ namespace Lucene.Net.Util
 
         private class LongRangeBuilderAnonymousInnerClassHelper : NumericUtils.Int64RangeBuilder
         {
-            private readonly TestNumericUtils outerInstance;
-
             private readonly long lower;
             private readonly long upper;
             private readonly bool useBitSet;
@@ -289,9 +287,8 @@ namespace Lucene.Net.Util
             private readonly IEnumerator<long> neededBounds;
             private readonly IEnumerator<int> neededShifts;
 
-            public LongRangeBuilderAnonymousInnerClassHelper(TestNumericUtils outerInstance, long lower, long upper, bool useBitSet, Int64BitSet bits, IEnumerator<long> neededBounds, IEnumerator<int> neededShifts)
+            public LongRangeBuilderAnonymousInnerClassHelper(long lower, long upper, bool useBitSet, Int64BitSet bits, IEnumerator<long> neededBounds, IEnumerator<int> neededShifts)
             {
-                this.outerInstance = outerInstance;
                 this.lower = lower;
                 this.upper = upper;
                 this.useBitSet = useBitSet;
@@ -464,7 +461,7 @@ namespace Lucene.Net.Util
             IEnumerator<int> neededBounds = (expectedBounds == null) ? null : expectedBounds.GetEnumerator();
             IEnumerator<int> neededShifts = (expectedShifts == null) ? null : expectedShifts.GetEnumerator();
 
-            NumericUtils.SplitInt32Range(new IntRangeBuilderAnonymousInnerClassHelper(this, lower, upper, useBitSet, bits, neededBounds, neededShifts), precisionStep, lower, upper);
+            NumericUtils.SplitInt32Range(new IntRangeBuilderAnonymousInnerClassHelper(lower, upper, useBitSet, bits, neededBounds, neededShifts), precisionStep, lower, upper);
 
             if (useBitSet)
             {
@@ -476,8 +473,6 @@ namespace Lucene.Net.Util
 
         private class IntRangeBuilderAnonymousInnerClassHelper : NumericUtils.Int32RangeBuilder
         {
-            private readonly TestNumericUtils outerInstance;
-
             private readonly int lower;
             private readonly int upper;
             private readonly bool useBitSet;
@@ -485,9 +480,8 @@ namespace Lucene.Net.Util
             private readonly IEnumerator<int> neededBounds;
             private readonly IEnumerator<int> neededShifts;
 
-            public IntRangeBuilderAnonymousInnerClassHelper(TestNumericUtils outerInstance, int lower, int upper, bool useBitSet, FixedBitSet bits, IEnumerator<int> neededBounds, IEnumerator<int> neededShifts)
+            public IntRangeBuilderAnonymousInnerClassHelper(int lower, int upper, bool useBitSet, FixedBitSet bits, IEnumerator<int> neededBounds, IEnumerator<int> neededShifts)
             {
-                this.outerInstance = outerInstance;
                 this.lower = lower;
                 this.upper = upper;
                 this.useBitSet = useBitSet;

--- a/src/Lucene.Net.Tests/Util/TestOfflineSorter.cs
+++ b/src/Lucene.Net.Tests/Util/TestOfflineSorter.cs
@@ -66,7 +66,9 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void TestEmpty()
         {
+#pragma warning disable CA1825 // Avoid zero-length array allocations.
             CheckSort(new OfflineSorter(), new byte[][] { });
+#pragma warning restore CA1825 // Avoid zero-length array allocations.
         }
 
         [Test]
@@ -163,12 +165,10 @@ namespace Lucene.Net.Util
                 while ((len = is1.Read(buf1, 0, buf1.Length)) > 0)
                 {
                     is2.Read(buf2, 0, len);
-                    // LUCENENET: Refactored test to let J2N test the byte array rather than iterate each byte
-                    //for (int i = 0; i < len; i++)
-                    //{
-                    //    Assert.AreEqual(buf1[i], buf2[i]);
-                    //}
-                    Assert.IsTrue(J2N.Collections.ArrayEqualityComparer<byte>.OneDimensional.Equals(buf1, buf2));
+                    for (int i = 0; i < len; i++)
+                    {
+                        Assert.AreEqual(buf1[i], buf2[i]);
+                    }
                 }
             }
         }
@@ -197,38 +197,9 @@ namespace Lucene.Net.Util
             OfflineSorter.BufferSize.Megabytes(2047);
             OfflineSorter.BufferSize.Megabytes(1);
 
-            try
-            {
-                OfflineSorter.BufferSize.Megabytes(2048);
-                Assert.Fail("max mb is 2047");
-            }
-#pragma warning disable 168
-            catch (ArgumentException e)
-#pragma warning restore 168
-            {
-            }
-
-            try
-            {
-                OfflineSorter.BufferSize.Megabytes(0);
-                Assert.Fail("min mb is 0.5");
-            }
-#pragma warning disable 168
-            catch (ArgumentException e)
-#pragma warning restore 168
-            {
-            }
-
-            try
-            {
-                OfflineSorter.BufferSize.Megabytes(-1);
-                Assert.Fail("min mb is 0.5");
-            }
-#pragma warning disable 168
-            catch (ArgumentException e)
-#pragma warning restore 168
-            {
-            }
+            Assert.Throws<ArgumentException>(() => OfflineSorter.BufferSize.Megabytes(2048), "max mb is 2047");
+            Assert.Throws<ArgumentException>(() => OfflineSorter.BufferSize.Megabytes(0), "min mb is 0.5");
+            Assert.Throws<ArgumentException>(() => OfflineSorter.BufferSize.Megabytes(-1), "min mb is 0.5");
         }
     }
 }

--- a/src/Lucene.Net.Tests/Util/TestRamUsageEstimator.cs
+++ b/src/Lucene.Net.Tests/Util/TestRamUsageEstimator.cs
@@ -118,8 +118,10 @@ namespace Lucene.Net.Util
 
         private class Holder
         {
+#pragma warning disable IDE0052, IDE0044 // Remove unread private members
             private long field1 = 5000L;
             private string name = "name";
+#pragma warning restore IDE0052, IDE0044 // Remove unread private members
             internal Holder holder;
 
             public long Field2 { get; set; }

--- a/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
+++ b/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Util
         [Test]
         public virtual void Test()
         {
-            RollingBuffer<Position> buffer = new RollingBufferAnonymousInnerClassHelper(this);
+            RollingBuffer<Position> buffer = new RollingBufferAnonymousInnerClassHelper();
 
             for (int iter = 0; iter < 100 * RandomMultiplier; iter++)
             {
@@ -90,12 +90,9 @@ namespace Lucene.Net.Util
 
         private class RollingBufferAnonymousInnerClassHelper : RollingBuffer<Position>
         {
-            private readonly TestRollingBuffer outerInstance;
-
-            public RollingBufferAnonymousInnerClassHelper(TestRollingBuffer outerInstance)
+            public RollingBufferAnonymousInnerClassHelper()
                 : base(NewInstanceFunc)
             {
-                this.outerInstance = outerInstance;
             }
 
             public static Position NewInstanceFunc()

--- a/src/Lucene.Net/Analysis/Analyzer.cs
+++ b/src/Lucene.Net/Analysis/Analyzer.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis
@@ -615,7 +616,7 @@ namespace Lucene.Net.Analysis
             {
                 throw new ObjectDisposedException(this.GetType().FullName, "this Analyzer is closed");
             }
-            return analyzer.storedValue.Get();
+            return analyzer.storedValue.Value;
         }
 
         /// <summary>
@@ -630,7 +631,7 @@ namespace Lucene.Net.Analysis
             {
                 throw new ObjectDisposedException("this Analyzer is closed");
             }
-            analyzer.storedValue.Set(storedValue);
+            analyzer.storedValue.Value = storedValue;
         }
     }
 }

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
         , System.ICloneable
 #endif
     {
-        private static int MIN_BUFFER_SIZE = 10;
+        private const int MIN_BUFFER_SIZE = 10;
 
         private char[] termBuffer = CreateBuffer(MIN_BUFFER_SIZE);
         private int termLength = 0;

--- a/src/Lucene.Net/Codecs/Lucene3x/TermInfosReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/TermInfosReader.cs
@@ -182,12 +182,12 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         private ThreadResources GetThreadResources()
         {
-            ThreadResources resources = threadResources.Get();
+            ThreadResources resources = threadResources.Value;
             if (resources == null)
             {
                 resources = new ThreadResources();
                 resources.termEnum = Terms();
-                threadResources.Set(resources);
+                threadResources.Value = resources;
             }
             return resources;
         }

--- a/src/Lucene.Net/Index/SegmentReader.cs
+++ b/src/Lucene.Net/Index/SegmentReader.cs
@@ -58,33 +58,11 @@ namespace Lucene.Net.Index
         internal readonly SegmentCoreReaders core;
         internal readonly SegmentDocValues segDocValues;
 
-        internal readonly DisposableThreadLocal<IDictionary<string, object>> docValuesLocal = new DisposableThreadLocalAnonymousInnerClassHelper();
+        internal readonly DisposableThreadLocal<IDictionary<string, object>> docValuesLocal =
+            new DisposableThreadLocal<IDictionary<string, object>>(() => new Dictionary<string, object>());
 
-        private class DisposableThreadLocalAnonymousInnerClassHelper : DisposableThreadLocal<IDictionary<string, object>>
-        {
-            public DisposableThreadLocalAnonymousInnerClassHelper()
-            {
-            }
-
-            protected internal override IDictionary<string, object> InitialValue()
-            {
-                return new Dictionary<string, object>();
-            }
-        }
-
-        internal readonly DisposableThreadLocal<IDictionary<string, IBits>> docsWithFieldLocal = new DisposableThreadLocalAnonymousInnerClassHelper2();
-
-        private class DisposableThreadLocalAnonymousInnerClassHelper2 : DisposableThreadLocal<IDictionary<string, IBits>>
-        {
-            public DisposableThreadLocalAnonymousInnerClassHelper2()
-            {
-            }
-
-            protected internal override IDictionary<string, IBits> InitialValue()
-            {
-                return new Dictionary<string, IBits>();
-            }
-        }
+        internal readonly DisposableThreadLocal<IDictionary<string, IBits>> docsWithFieldLocal =
+            new DisposableThreadLocal<IDictionary<string, IBits>>(() => new Dictionary<string, IBits>());
 
         internal readonly IDictionary<string, DocValuesProducer> dvProducersByField = new Dictionary<string, DocValuesProducer>();
         internal readonly ISet<DocValuesProducer> dvProducers = new JCG.HashSet<DocValuesProducer>(IdentityEqualityComparer<DocValuesProducer>.Default);
@@ -339,7 +317,7 @@ namespace Lucene.Net.Index
             get
             {
                 EnsureOpen();
-                return core.fieldsReaderLocal.Get();
+                return core.fieldsReaderLocal.Value;
             }
         }
 
@@ -377,7 +355,7 @@ namespace Lucene.Net.Index
             get
             {
                 EnsureOpen();
-                return core.termVectorsLocal.Get();
+                return core.termVectorsLocal.Value;
             }
         }
 
@@ -476,7 +454,7 @@ namespace Lucene.Net.Index
                 return null;
             }
 
-            IDictionary<string, object> dvFields = docValuesLocal.Get();
+            IDictionary<string, object> dvFields = docValuesLocal.Value;
 
             NumericDocValues dvs;
             object dvsDummy;
@@ -509,10 +487,9 @@ namespace Lucene.Net.Index
                 return null;
             }
 
-            IDictionary<string, IBits> dvFields = docsWithFieldLocal.Get();
+            IDictionary<string, IBits> dvFields = docsWithFieldLocal.Value;
 
-            IBits dvs;
-            dvFields.TryGetValue(field, out dvs);
+            dvFields.TryGetValue(field, out IBits dvs);
             if (dvs == null)
             {
                 DocValuesProducer dvProducer;
@@ -534,7 +511,7 @@ namespace Lucene.Net.Index
                 return null;
             }
 
-            IDictionary<string, object> dvFields = docValuesLocal.Get();
+            IDictionary<string, object> dvFields = docValuesLocal.Value;
 
             object ret;
             BinaryDocValues dvs;
@@ -542,8 +519,7 @@ namespace Lucene.Net.Index
             dvs = (BinaryDocValues)ret;
             if (dvs == null)
             {
-                DocValuesProducer dvProducer;
-                dvProducersByField.TryGetValue(field, out dvProducer);
+                dvProducersByField.TryGetValue(field, out DocValuesProducer dvProducer);
                 Debug.Assert(dvProducer != null);
                 dvs = dvProducer.GetBinary(fi);
                 dvFields[field] = dvs;
@@ -561,7 +537,7 @@ namespace Lucene.Net.Index
                 return null;
             }
 
-            IDictionary<string, object> dvFields = docValuesLocal.Get();
+            IDictionary<string, object> dvFields = docValuesLocal.Value;
 
             SortedDocValues dvs;
             object ret;
@@ -569,8 +545,7 @@ namespace Lucene.Net.Index
             dvs = (SortedDocValues)ret;
             if (dvs == null)
             {
-                DocValuesProducer dvProducer;
-                dvProducersByField.TryGetValue(field, out dvProducer);
+                dvProducersByField.TryGetValue(field, out DocValuesProducer dvProducer);
                 Debug.Assert(dvProducer != null);
                 dvs = dvProducer.GetSorted(fi);
                 dvFields[field] = dvs;
@@ -588,7 +563,7 @@ namespace Lucene.Net.Index
                 return null;
             }
 
-            IDictionary<string, object> dvFields = docValuesLocal.Get();
+            IDictionary<string, object> dvFields = docValuesLocal.Value;
 
             object ret;
             SortedSetDocValues dvs;
@@ -596,8 +571,7 @@ namespace Lucene.Net.Index
             dvs = (SortedSetDocValues)ret;
             if (dvs == null)
             {
-                DocValuesProducer dvProducer;
-                dvProducersByField.TryGetValue(field, out dvProducer);
+                dvProducersByField.TryGetValue(field, out DocValuesProducer dvProducer);
                 Debug.Assert(dvProducer != null);
                 dvs = dvProducer.GetSortedSet(fi);
                 dvFields[field] = dvs;

--- a/src/Lucene.Net/Store/NRTCachingDirectory.cs
+++ b/src/Lucene.Net/Store/NRTCachingDirectory.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Store
         private readonly long maxMergeSizeBytes;
         private readonly long maxCachedBytes;
 
-        private static bool VERBOSE = false;
+        private static readonly bool VERBOSE = false;
 
         /// <summary>
         /// We will cache a newly created output if 1) it's a

--- a/src/Lucene.Net/Store/NativeFSLockFactory.cs
+++ b/src/Lucene.Net/Store/NativeFSLockFactory.cs
@@ -88,7 +88,7 @@ namespace Lucene.Net.Store
         // we are interested in.
         //
         // Reference: https://stackoverflow.com/q/46380483
-        private static bool IS_FILESTREAM_LOCKING_PLATFORM = LoadIsFileStreamLockingPlatform();
+        private static readonly bool IS_FILESTREAM_LOCKING_PLATFORM = LoadIsFileStreamLockingPlatform();
 
         private const int WIN_HRESULT_FILE_LOCK_VIOLATION = unchecked((int)0x80070021);
         private const int WIN_HRESULT_FILE_SHARE_VIOLATION = unchecked((int)0x80070020);

--- a/src/Lucene.Net/Util/ArrayUtil.cs
+++ b/src/Lucene.Net/Util/ArrayUtil.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Util
     /// <para/>
     /// @lucene.internal
     /// </summary>
-    public sealed class ArrayUtil
+    public static class ArrayUtil // LUCENENET specific - made static
     {
         /// <summary>
         /// Maximum length for an array; we set this to "a
@@ -38,10 +38,6 @@ namespace Lucene.Net.Util
         /// different JVM.
         /// </summary>
         public static readonly int MAX_ARRAY_LENGTH = int.MaxValue - 256;
-
-        private ArrayUtil() // no instance
-        {
-        }
 
         /*
            Begin Apache Harmony code

--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -267,7 +267,7 @@ namespace Lucene.Net.Util
             State initState = GetCurrentState();
             if (initState != null)
             {
-                return new IteratorAnonymousInnerClassHelper(this, initState);
+                return new IteratorAnonymousInnerClassHelper(initState);
             }
             else
             {
@@ -277,24 +277,18 @@ namespace Lucene.Net.Util
 
         private class IteratorAnonymousInnerClassHelper : IEnumerator<Attribute>
         {
-            private readonly AttributeSource outerInstance;
-
-            private AttributeSource.State initState;
-            private Attribute current;
-
-            public IteratorAnonymousInnerClassHelper(AttributeSource outerInstance, AttributeSource.State initState)
+            public IteratorAnonymousInnerClassHelper(AttributeSource.State initState)
             {
-                this.outerInstance = outerInstance;
-                this.initState = initState;
                 state = initState;
             }
 
+            private Attribute current;
             private State state;
 
-            public virtual void Remove()
-            {
-                throw new NotSupportedException();
-            }
+            //public virtual void Remove() // LUCENENET specific - not used
+            //{
+            //    throw new NotSupportedException();
+            //}
 
             public void Dispose()
             {
@@ -318,13 +312,9 @@ namespace Lucene.Net.Util
                 throw new NotSupportedException();
             }
 
-            public Attribute Current
-            {
-                get => current;
-                set => current = value;
-            }
+            public Attribute Current => current;
 
-            object IEnumerator.Current => Current;
+            object IEnumerator.Current => current;
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/Automaton/Automaton.cs
+++ b/src/Lucene.Net/Util/Automaton/Automaton.cs
@@ -414,8 +414,10 @@ namespace Lucene.Net.Util.Automaton
         public virtual int[] GetStartPoints()
         {
             State[] states = GetNumberedStates();
-            JCG.HashSet<int> pointset = new JCG.HashSet<int>();
-            pointset.Add(Character.MinCodePoint);
+            JCG.HashSet<int> pointset = new JCG.HashSet<int>
+            {
+                Character.MinCodePoint
+            };
             foreach (State s in states)
             {
                 foreach (Transition t in s.GetTransitions())
@@ -563,7 +565,8 @@ namespace Lucene.Net.Util.Automaton
             {
                 State p = new State();
                 initial = p;
-                for (int i = 0, cp = 0; i < singleton.Length; i += Character.CharCount(cp))
+                int cp; // LUCENENET: Removed unnecessary assignment
+                for (int i = 0; i < singleton.Length; i += Character.CharCount(cp))
                 {
                     State q = new State();
                     p.AddTransition(new Transition(cp = Character.CodePointAt(singleton, i), q));
@@ -680,7 +683,8 @@ namespace Lucene.Net.Util.Automaton
                 b.Append("singleton: ");
                 int length = singleton.CodePointCount(0, singleton.Length);
                 int[] codepoints = new int[length];
-                for (int i = 0, j = 0, cp = 0; i < singleton.Length; i += Character.CharCount(cp))
+                int cp; // LUCENENET: Removed unnecessary assignment
+                for (int i = 0, j = 0; i < singleton.Length; i += Character.CharCount(cp))
                 {
                     codepoints[j++] = cp = singleton.CodePointAt(i);
                 }

--- a/src/Lucene.Net/Util/Automaton/BasicAutomata.cs
+++ b/src/Lucene.Net/Util/Automaton/BasicAutomata.cs
@@ -40,12 +40,8 @@ namespace Lucene.Net.Util.Automaton
     /// <para/>
     /// @lucene.experimental
     /// </summary>
-    public sealed class BasicAutomata
+    public static class BasicAutomata // LUCENENET specific - made static
     {
-        private BasicAutomata()
-        {
-        }
-
         /// <summary>
         /// Returns a new (deterministic) automaton with the empty language.
         /// </summary>
@@ -63,10 +59,11 @@ namespace Lucene.Net.Util.Automaton
         /// </summary>
         public static Automaton MakeEmptyString()
         {
-            Automaton a = new Automaton();
-            a.singleton = "";
-            a.deterministic = true;
-            return a;
+            return new Automaton
+            {
+                singleton = string.Empty,
+                deterministic = true
+            };
         }
 
         /// <summary>
@@ -97,10 +94,11 @@ namespace Lucene.Net.Util.Automaton
         /// </summary>
         public static Automaton MakeChar(int c)
         {
-            Automaton a = new Automaton();
-            a.singleton = new string(Character.ToChars(c));
-            a.deterministic = true;
-            return a;
+            return new Automaton
+            {
+                singleton = new string(Character.ToChars(c)),
+                deterministic = true
+            };
         }
 
         /// <summary>
@@ -306,16 +304,19 @@ namespace Lucene.Net.Util.Automaton
         /// </summary>
         public static Automaton MakeString(string s)
         {
-            Automaton a = new Automaton();
-            a.singleton = s;
-            a.deterministic = true;
-            return a;
+            return new Automaton
+            {
+                singleton = s,
+                deterministic = true
+            };
         }
 
         public static Automaton MakeString(int[] word, int offset, int length)
         {
-            Automaton a = new Automaton();
-            a.IsDeterministic = true;
+            Automaton a = new Automaton
+            {
+                deterministic = true
+            };
             State s = new State();
             a.initial = s;
             for (int i = offset; i < offset + length; i++)

--- a/src/Lucene.Net/Util/Automaton/BasicOperations.cs
+++ b/src/Lucene.Net/Util/Automaton/BasicOperations.cs
@@ -214,8 +214,10 @@ namespace Lucene.Net.Util.Automaton
         public static Automaton Repeat(Automaton a)
         {
             a = a.CloneExpanded();
-            State s = new State();
-            s.accept = true;
+            State s = new State
+            {
+                accept = true
+            };
             s.AddEpsilon(a.initial);
             foreach (State p in a.GetAcceptStates())
             {
@@ -607,9 +609,11 @@ namespace Lucene.Net.Util.Automaton
                 }
                 s.AddEpsilon(bb.initial);
             }
-            Automaton a_ = new Automaton();
-            a_.initial = s;
-            a_.deterministic = false;
+            Automaton a_ = new Automaton
+            {
+                initial = s,
+                deterministic = false
+            };
             //a.clearHashCode();
             a_.ClearNumberedStates();
             a_.CheckMinimizeAlways();
@@ -926,8 +930,7 @@ namespace Lucene.Net.Util.Automaton
                     forward[p.s1] = to;
                 }
                 to.Add(p.s2);
-                JCG.HashSet<State> from;
-                if (!back.TryGetValue(p.s2, out from))
+                if (!back.TryGetValue(p.s2, out JCG.HashSet<State> from))
                 {
                     from = new JCG.HashSet<State>();
                     back[p.s2] = from;
@@ -942,9 +945,10 @@ namespace Lucene.Net.Util.Automaton
                 StatePair p = worklist.First.Value;
                 worklist.Remove(p);
                 workset.Remove(p);
-                JCG.HashSet<State> to;
+#pragma warning disable IDE0018 // Inline variable declaration
                 JCG.HashSet<State> from;
-                if (forward.TryGetValue(p.s2, out to))
+#pragma warning restore IDE0018 // Inline variable declaration
+                if (forward.TryGetValue(p.s2, out JCG.HashSet<State> to))
                 {
                     foreach (State s in to)
                     {
@@ -1044,7 +1048,8 @@ namespace Lucene.Net.Util.Automaton
             if (a.deterministic)
             {
                 State p = a.initial;
-                for (int i = 0, cp = 0; i < s.Length; i += Character.CharCount(cp))
+                int cp; // LUCENENET: Removed unnecessary assignment
+                for (int i = 0; i < s.Length; i += Character.CharCount(cp))
                 {
                     State q = p.Step(cp = Character.CodePointAt(s, i));
                     if (q == null)
@@ -1065,7 +1070,8 @@ namespace Lucene.Net.Util.Automaton
                 pp.AddLast(a.initial);
                 List<State> dest = new List<State>();
                 bool accept = a.initial.accept;
-                for (int i = 0, c = 0; i < s.Length; i += Character.CharCount(c))
+                int c; // LUCENENET: Removed unnecessary assignment
+                for (int i = 0; i < s.Length; i += Character.CharCount(c))
                 {
                     c = Character.CodePointAt(s, i);
                     accept = false;

--- a/src/Lucene.Net/Util/Automaton/CharacterRunAutomaton.cs
+++ b/src/Lucene.Net/Util/Automaton/CharacterRunAutomaton.cs
@@ -36,7 +36,8 @@ namespace Lucene.Net.Util.Automaton
         {
             int p = m_initial;
             int l = s.Length;
-            for (int i = 0, cp = 0; i < l; i += Character.CharCount(cp))
+            int cp; // LUCENENET: Removed unnecessary assignment
+            for (int i = 0; i < l; i += Character.CharCount(cp))
             {
                 p = Step(p, cp = Character.CodePointAt(s, i));
                 if (p == -1) return false;
@@ -51,8 +52,8 @@ namespace Lucene.Net.Util.Automaton
         {
             int p = m_initial;
             int l = offset + length;
-            
-            for (int i = offset, cp = 0; i < l; i += Character.CharCount(cp))
+            int cp; // LUCENENET: Removed unnecessary assignment
+            for (int i = offset; i < l; i += Character.CharCount(cp))
             {
                 p = Step(p, cp = Character.CodePointAt(s, i, l));
                 if (p == -1) return false;

--- a/src/Lucene.Net/Util/Automaton/CompiledAutomaton.cs
+++ b/src/Lucene.Net/Util/Automaton/CompiledAutomaton.cs
@@ -284,29 +284,16 @@ namespace Lucene.Net.Util.Automaton
         // NORMAL:
         public virtual TermsEnum GetTermsEnum(Terms terms)
         {
-            switch (Type)
+            return Type switch
             {
-                case Lucene.Net.Util.Automaton.CompiledAutomaton.AUTOMATON_TYPE.NONE:
-                    return TermsEnum.EMPTY;
-
-                case Lucene.Net.Util.Automaton.CompiledAutomaton.AUTOMATON_TYPE.ALL:
-                    return terms.GetIterator(null);
-
-                case Lucene.Net.Util.Automaton.CompiledAutomaton.AUTOMATON_TYPE.SINGLE:
-                    return new SingleTermsEnum(terms.GetIterator(null), Term);
-
-                case Lucene.Net.Util.Automaton.CompiledAutomaton.AUTOMATON_TYPE.PREFIX:
-                    // TODO: this is very likely faster than .intersect,
-                    // but we should test and maybe cutover
-                    return new PrefixTermsEnum(terms.GetIterator(null), Term);
-
-                case Lucene.Net.Util.Automaton.CompiledAutomaton.AUTOMATON_TYPE.NORMAL:
-                    return terms.Intersect(this, null);
-
-                default:
-                    // unreachable
-                    throw new Exception("unhandled case");
-            }
+                AUTOMATON_TYPE.NONE => TermsEnum.EMPTY,
+                AUTOMATON_TYPE.ALL => terms.GetIterator(null),
+                AUTOMATON_TYPE.SINGLE => new SingleTermsEnum(terms.GetIterator(null), Term),
+                AUTOMATON_TYPE.PREFIX => new PrefixTermsEnum(terms.GetIterator(null), Term),// TODO: this is very likely faster than .intersect,
+                                                                                            // but we should test and maybe cutover
+                AUTOMATON_TYPE.NORMAL => terms.Intersect(this, null),
+                _ => throw new Exception("unhandled case"),// unreachable
+            };
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
+++ b/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
@@ -205,7 +205,7 @@ namespace Lucene.Net.Util.Automaton
         /// <summary>
         /// Root automaton state.
         /// </summary>
-        private State root = new State();
+        private readonly State root = new State();
 
         /// <summary>
         /// Previous sequence added to the automaton in <see cref="Add(CharsRef)"/>.
@@ -275,15 +275,17 @@ namespace Lucene.Net.Util.Automaton
         /// </summary>
         /// <param name="s"></param>
         /// <param name="visited">Must use a dictionary with <see cref="IdentityEqualityComparer{State}.Default"/> passed into its constructor.</param>
-        private static Util.Automaton.State Convert(State s, IDictionary<State, Lucene.Net.Util.Automaton.State> visited)
+        private static Util.Automaton.State Convert(State s, IDictionary<State, Util.Automaton.State> visited)
         {
             if (visited.TryGetValue(s, out Util.Automaton.State converted) && converted != null)
             {
                 return converted;
             }
 
-            converted = new Util.Automaton.State();
-            converted.Accept = s.is_final;
+            converted = new Util.Automaton.State
+            {
+                Accept = s.is_final
+            };
 
             visited[s] = converted;
             int i = 0;
@@ -342,8 +344,7 @@ namespace Lucene.Net.Util.Automaton
                 ReplaceOrRegister(child);
             }
 
-            State registered;
-            if (stateRegistry.TryGetValue(child, out registered))
+            if (stateRegistry.TryGetValue(child, out State registered))
             {
                 state.ReplaceLastChild(registered);
             }

--- a/src/Lucene.Net/Util/Automaton/LevenshteinAutomata.cs
+++ b/src/Lucene.Net/Util/Automaton/LevenshteinAutomata.cs
@@ -125,7 +125,8 @@ namespace Lucene.Net.Util.Automaton
         {
             int length = Character.CodePointCount(input, 0, input.Length);
             int[] word = new int[length];
-            for (int i = 0, j = 0, cp = 0; i < input.Length; i += Character.CharCount(cp))
+            int cp; // LUCENENET: Removed unnecessary assignment
+            for (int i = 0, j = 0; i < input.Length; i += Character.CharCount(cp))
             {
                 word[j++] = cp = Character.CodePointAt(input, i);
             }
@@ -162,9 +163,11 @@ namespace Lucene.Net.Util.Automaton
             // create all states, and mark as accept states if appropriate
             for (int i = 0; i < states.Length; i++)
             {
-                states[i] = new State();
-                states[i].number = i;
-                states[i].Accept = description.IsAccept(i);
+                states[i] = new State
+                {
+                    number = i,
+                    accept = description.IsAccept(i)
+                };
             }
             // create transitions from state to state
             for (int k = 0; k < states.Length; k++)
@@ -200,8 +203,10 @@ namespace Lucene.Net.Util.Automaton
                 }
             }
 
-            Automaton a = new Automaton(states[0]);
-            a.IsDeterministic = true;
+            Automaton a = new Automaton(states[0])
+            {
+                deterministic = true
+            };
             // we create some useless unconnected states, and its a net-win overall to remove these,
             // as well as to combine any adjacent transitions (it makes later algorithms more efficient).
             // so, while we could set our numberedStates here, its actually best not to, and instead to

--- a/src/Lucene.Net/Util/Automaton/RegExp.cs
+++ b/src/Lucene.Net/Util/Automaton/RegExp.cs
@@ -799,11 +799,12 @@ namespace Lucene.Net.Util.Automaton
 
         internal static RegExp MakeUnion(RegExp exp1, RegExp exp2)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_UNION;
-            r.exp1 = exp1;
-            r.exp2 = exp2;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_UNION,
+                exp1 = exp1,
+                exp2 = exp2
+            };
         }
 
         internal static RegExp MakeConcatenation(RegExp exp1, RegExp exp2)
@@ -812,8 +813,10 @@ namespace Lucene.Net.Util.Automaton
             {
                 return MakeString(exp1, exp2);
             }
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_CONCATENATION;
+            RegExp r = new RegExp
+            {
+                kind = Kind.REGEXP_CONCATENATION
+            };
             if (exp1.kind == Kind.REGEXP_CONCATENATION && (exp1.exp2.kind == Kind.REGEXP_CHAR || exp1.exp2.kind == Kind.REGEXP_STRING) && (exp2.kind == Kind.REGEXP_CHAR || exp2.kind == Kind.REGEXP_STRING))
             {
                 r.exp1 = exp1.exp1;
@@ -856,122 +859,136 @@ namespace Lucene.Net.Util.Automaton
 
         internal static RegExp MakeIntersection(RegExp exp1, RegExp exp2)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_INTERSECTION;
-            r.exp1 = exp1;
-            r.exp2 = exp2;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_INTERSECTION,
+                exp1 = exp1,
+                exp2 = exp2
+            };
         }
 
         internal static RegExp MakeOptional(RegExp exp)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_OPTIONAL;
-            r.exp1 = exp;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_OPTIONAL,
+                exp1 = exp
+            };
         }
 
         internal static RegExp MakeRepeat(RegExp exp)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_REPEAT;
-            r.exp1 = exp;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_REPEAT,
+                exp1 = exp
+            };
         }
 
         internal static RegExp MakeRepeat(RegExp exp, int min)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_REPEAT_MIN;
-            r.exp1 = exp;
-            r.min = min;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_REPEAT_MIN,
+                exp1 = exp,
+                min = min
+            };
         }
 
         internal static RegExp MakeRepeat(RegExp exp, int min, int max)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_REPEAT_MINMAX;
-            r.exp1 = exp;
-            r.min = min;
-            r.max = max;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_REPEAT_MINMAX,
+                exp1 = exp,
+                min = min,
+                max = max
+            };
         }
 
         internal static RegExp MakeComplement(RegExp exp)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_COMPLEMENT;
-            r.exp1 = exp;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_COMPLEMENT,
+                exp1 = exp
+            };
         }
 
         internal static RegExp MakeChar(int c)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_CHAR;
-            r.c = c;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_CHAR,
+                c = c
+            };
         }
 
         internal static RegExp MakeCharRange(int from, int to)
         {
             if (from > to)
             {
-                throw new ArgumentException("invalid range: from (" + from + ") cannot be > to (" + to + ")");
+                throw new ArgumentException($"invalid range: from ({from}) cannot be > to ({to})");
             }
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_CHAR_RANGE;
-            r.from = from;
-            r.to = to;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_CHAR_RANGE,
+                from = from,
+                to = to
+            };
         }
 
         internal static RegExp MakeAnyChar()
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_ANYCHAR;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_ANYCHAR
+            };
         }
 
         internal static RegExp MakeEmpty()
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_EMPTY;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_EMPTY
+            };
         }
 
         internal static RegExp MakeString(string s)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_STRING;
-            r.s = s;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_STRING,
+                s = s
+            };
         }
 
         internal static RegExp MakeAnyString()
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_ANYSTRING;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_ANYSTRING
+            };
         }
 
         internal static RegExp MakeAutomaton(string s)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_AUTOMATON;
-            r.s = s;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_AUTOMATON,
+                s = s
+            };
         }
 
         internal static RegExp MakeInterval(int min, int max, int digits)
         {
-            RegExp r = new RegExp();
-            r.kind = Kind.REGEXP_INTERVAL;
-            r.min = min;
-            r.max = max;
-            r.digits = digits;
-            return r;
+            return new RegExp
+            {
+                kind = Kind.REGEXP_INTERVAL,
+                min = min,
+                max = max,
+                digits = digits
+            };
         }
 
         private bool Peek(string s)

--- a/src/Lucene.Net/Util/Automaton/RunAutomaton.cs
+++ b/src/Lucene.Net/Util/Automaton/RunAutomaton.cs
@@ -142,7 +142,7 @@ namespace Lucene.Net.Util.Automaton
         /// <param name="a"> An automaton. </param>
         /// <param name="maxInterval"></param>
         /// <param name="tableize"></param>
-        public RunAutomaton(Automaton a, int maxInterval, bool tableize)
+        protected RunAutomaton(Automaton a, int maxInterval, bool tableize) // LUCENENET specific - marked protected instead of public
         {
             this._maxInterval = maxInterval;
             a.Determinize();

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -99,7 +99,8 @@ namespace Lucene.Net.Util.Automaton
             {
                 private readonly TransitionsEnumerable outerInstance;
                 private Transition current;
-                private int i, upTo;
+                private int i;
+                private readonly int upTo;
 
                 public TransitionsEnumerator(TransitionsEnumerable outerInstance)
                 {
@@ -354,7 +355,8 @@ namespace Lucene.Net.Util.Automaton
             return s.id - id;
         }
 
-        // LUCENENET specific - implemented IEquatable and changed to a struct.
+        #region Equality
+        // LUCENENET specific - implemented IEquatable.
         public bool Equals(State other)
         {
             if (other == null)
@@ -366,5 +368,47 @@ namespace Lucene.Net.Util.Automaton
         {
             return id;
         }
+
+        public override bool Equals(object obj)
+        {
+            return ReferenceEquals(this, obj) || obj is State other && Equals(other);
+        }
+
+        public static bool operator ==(State left, State right)
+        {
+            if (left is null)
+            {
+                return right is null;
+            }
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(State left, State right)
+        {
+            return !(left == right);
+        }
+
+        public static bool operator <(State left, State right)
+        {
+            return left is null ? !(right is null) : left.CompareTo(right) < 0;
+        }
+
+        public static bool operator <=(State left, State right)
+        {
+            return left is null || left.CompareTo(right) <= 0;
+        }
+
+        public static bool operator >(State left, State right)
+        {
+            return !(left is null) && left.CompareTo(right) > 0;
+        }
+
+        public static bool operator >=(State left, State right)
+        {
+            return left is null ? right is null : left.CompareTo(right) >= 0;
+        }
+
+        #endregion
     }
 }

--- a/src/Lucene.Net/Util/Automaton/StatePair.cs
+++ b/src/Lucene.Net/Util/Automaton/StatePair.cs
@@ -78,9 +78,8 @@ namespace Lucene.Net.Util.Automaton
         ///         pair. </returns>
         public override bool Equals(object obj)
         {
-            if (obj is StatePair)
+            if (obj is StatePair p)
             {
-                StatePair p = (StatePair)obj;
                 return p.s1 == s1 && p.s2 == s2;
             }
             else

--- a/src/Lucene.Net/Util/Automaton/Transition.cs
+++ b/src/Lucene.Net/Util/Automaton/Transition.cs
@@ -110,9 +110,8 @@ namespace Lucene.Net.Util.Automaton
         ///         and destination state as this transition. </returns>
         public override bool Equals(object obj)
         {
-            if (obj is Transition)
+            if (obj is Transition t)
             {
-                Transition t = (Transition)obj;
                 return t.min == min && t.max == max && t.to == to;
             }
             else

--- a/src/Lucene.Net/Util/Automaton/UTF32ToUTF8.cs
+++ b/src/Lucene.Net/Util/Automaton/UTF32ToUTF8.cs
@@ -128,7 +128,7 @@ namespace Lucene.Net.Util.Automaton
                 {
                     bytes[numBytes - i].Value = 128 | (code & MASKS[5]);
                     bytes[numBytes - i].Bits = 6;
-                    code = code >> 6;
+                    code >>= 6;
                 }
             }
 

--- a/src/Lucene.Net/Util/BitUtil.cs
+++ b/src/Lucene.Net/Util/BitUtil.cs
@@ -24,7 +24,7 @@ namespace Lucene.Net.Util // from org.apache.solr.util rev 555343
     /// <para/>
     /// @lucene.internal
     /// </summary>
-    public sealed class BitUtil
+    public static class BitUtil // LUCENENET specific - made static
     {
         private static readonly sbyte[] BYTE_COUNTS = new sbyte[] {
             0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
@@ -96,10 +96,6 @@ namespace Lucene.Net.Util // from org.apache.solr.util rev 555343
             0x87653, 0x876531, 0x876532, 0x8765321, 0x87654, 0x876541, 0x876542,
             0x8765421, 0x876543, 0x8765431, 0x8765432, unchecked((int)0x87654321)
         };
-
-        private BitUtil() // no instance
-        {
-        }
 
         /// <summary>
         /// Return the number of bits sets in <paramref name="b"/>. </summary>

--- a/src/Lucene.Net/Util/BroadWord.cs
+++ b/src/Lucene.Net/Util/BroadWord.cs
@@ -33,12 +33,9 @@ namespace Lucene.Net.Util
     /// </list>
     /// @lucene.internal
     /// </summary>
-    public sealed class BroadWord
+    public static class BroadWord // LUCENENET specific - made static
     {
         // TBD: test smaller8 and smaller16 separately.
-        private BroadWord() // no instance
-        {
-        }
 
         /// <summary>
         /// Bit count of a <see cref="long"/>.

--- a/src/Lucene.Net/Util/BytesRefIterator.cs
+++ b/src/Lucene.Net/Util/BytesRefIterator.cs
@@ -53,10 +53,8 @@ namespace Lucene.Net.Util
     /// var iter = BytesRefIterator.Empty;
     /// </code>
     /// </summary>
-    public class BytesRefIterator
+    public static class BytesRefIterator
     {
-        private BytesRefIterator() { } // Disallow creation
-
         /// <summary>
         /// Singleton <see cref="BytesRefIterator"/> that iterates over 0 BytesRefs.
         /// </summary>

--- a/src/Lucene.Net/Util/CollectionUtil.cs
+++ b/src/Lucene.Net/Util/CollectionUtil.cs
@@ -29,12 +29,8 @@ namespace Lucene.Net.Util
     /// <para/>
     /// @lucene.internal
     /// </summary>
-    public sealed class CollectionUtil
+    public static class CollectionUtil // LUCENENET specific - made static
     {
-        private CollectionUtil() // no instance
-        {
-        }
-
         private sealed class ListIntroSorter<T> : IntroSorter
         {
             internal T pivot;
@@ -56,7 +52,7 @@ namespace Lucene.Net.Util
 
             protected override void SetPivot(int i)
             {
-                pivot = (i < list.Count) ? list[i] : default(T);
+                pivot = (i < list.Count) ? list[i] : default;
             }
 
             protected override void Swap(int i, int j)

--- a/src/Lucene.Net/Util/CommandLineUtil.cs
+++ b/src/Lucene.Net/Util/CommandLineUtil.cs
@@ -27,12 +27,8 @@ namespace Lucene.Net.Util
     /// <summary>
     /// Class containing some useful methods used by command line tools
     /// </summary>
-    public sealed class CommandLineUtil
+    public static class CommandLineUtil // LUCENENET specific - made static
     {
-        private CommandLineUtil()
-        {
-        }
-
         /// <summary>
         /// Creates a specific <see cref="FSDirectory"/> instance starting from its class name. </summary>
         /// <param name="clazzName"> The name of the <see cref="FSDirectory"/> class to load. </param>

--- a/src/Lucene.Net/Util/FilterIterator.cs
+++ b/src/Lucene.Net/Util/FilterIterator.cs
@@ -87,6 +87,12 @@ namespace Lucene.Net.Util
 
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
         }
     }
 }

--- a/src/Lucene.Net/Util/Fst/Builder.cs
+++ b/src/Lucene.Net/Util/Fst/Builder.cs
@@ -99,7 +99,6 @@ namespace Lucene.Net.Util.Fst
         public Builder(FST.INPUT_TYPE inputType, Outputs<T> outputs)
             : this(inputType, 0, 0, true, true, int.MaxValue, outputs, null, false, PackedInt32s.COMPACT, true, 15)
         {
-            var x = new System.Text.StringBuilder();
         }
 
         /// <summary>
@@ -211,9 +210,7 @@ namespace Lucene.Net.Util.Fst
 
             nodeIn.Clear();
 
-            CompiledNode fn = new CompiledNode();
-            fn.Node = node;
-            return fn;
+            return new CompiledNode { Node = node };
         }
 
         private void DoFreezeTail(int prefixLenPlus1)
@@ -230,7 +227,7 @@ namespace Lucene.Net.Util.Fst
                 for (int idx = lastInput.Length; idx >= downTo; idx--)
                 {
                     bool doPrune = false;
-                    bool doCompile = false;
+                    bool doCompile /*= false*/; // LUCENENET: Removed unnecessary assignment
 
                     UnCompiledNode<T> node = frontier[idx];
                     UnCompiledNode<T> parent = frontier[idx - 1];
@@ -460,7 +457,7 @@ namespace Lucene.Net.Util.Fst
                 }
                 else
                 {
-                    commonOutputPrefix = wordSuffix = NO_OUTPUT;
+                    commonOutputPrefix = /*wordSuffix =*/ NO_OUTPUT; // LUCENENET: Removed unnecessary assignment
                 }
 
                 output = fst.Outputs.Subtract(output, commonOutputPrefix);

--- a/src/Lucene.Net/Util/Fst/BytesStore.cs
+++ b/src/Lucene.Net/Util/Fst/BytesStore.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using JCG = J2N.Collections.Generic;
 
@@ -433,7 +432,7 @@ namespace Lucene.Net.Util.Fst
 
             public override void SkipBytes(int count)
             {
-                Position = Position + count;
+                Position += count;
             }
 
             public override void ReadBytes(byte[] b, int offset, int len)
@@ -519,7 +518,7 @@ namespace Lucene.Net.Util.Fst
 
             public override void SkipBytes(int count)
             {
-                Position = Position - count;
+                Position -= count;
             }
 
             public override void ReadBytes(byte[] b, int offset, int len)

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -218,7 +218,7 @@ namespace Lucene.Net.Util.Fst
                 inCounts = null;
             }
 
-            emptyOutput = default(T);
+            emptyOutput = default;
             packed = false;
             nodeRefToAddress = null;
         }
@@ -278,26 +278,16 @@ namespace Lucene.Net.Util.Fst
             }
             else
             {
-                emptyOutput = default(T);
+                emptyOutput = default;
             }
             var t = @in.ReadByte();
-            switch (t)
+            inputType = t switch
             {
-                case 0:
-                    inputType = FST.INPUT_TYPE.BYTE1;
-                    break;
-
-                case 1:
-                    inputType = FST.INPUT_TYPE.BYTE2;
-                    break;
-
-                case 2:
-                    inputType = FST.INPUT_TYPE.BYTE4;
-                    break;
-
-                default:
-                    throw new InvalidOperationException("invalid input type " + t);
-            }
+                0 => FST.INPUT_TYPE.BYTE1,
+                1 => FST.INPUT_TYPE.BYTE2,
+                2 => FST.INPUT_TYPE.BYTE4,
+                _ => throw new InvalidOperationException("invalid input type " + t),
+            };
             if (packed)
             {
                 nodeRefToAddress = PackedInt32s.GetReader(@in);
@@ -358,7 +348,7 @@ namespace Lucene.Net.Util.Fst
             {
                 throw new InvalidOperationException("already finished");
             }
-            if (newStartNode == FST.FINAL_END_NODE && !EqualityComparer<T>.Default.Equals(emptyOutput, default(T)))
+            if (newStartNode == FST.FINAL_END_NODE && !EqualityComparer<T>.Default.Equals(emptyOutput, default))
             {
                 newStartNode = 0;
             }
@@ -507,7 +497,7 @@ namespace Lucene.Net.Util.Fst
             }
             // TODO: really we should encode this as an arc, arriving
             // to the root node, instead of special casing here:
-            if (!EqualityComparer<T>.Default.Equals(emptyOutput, default(T)))
+            if (!EqualityComparer<T>.Default.Equals(emptyOutput, default))
             {
                 // Accepts empty string
                 @out.WriteByte(1);
@@ -868,7 +858,7 @@ namespace Lucene.Net.Util.Fst
         /// </summary>
         public FST.Arc<T> GetFirstArc(FST.Arc<T> arc)
         {
-            if (!EqualityComparer<T>.Default.Equals(emptyOutput, default(T)))
+            if (!EqualityComparer<T>.Default.Equals(emptyOutput, default))
             {
                 arc.Flags = FST.BIT_FINAL_ARC | FST.BIT_LAST_ARC;
                 arc.NextFinalOutput = emptyOutput;
@@ -1855,8 +1845,7 @@ namespace Lucene.Net.Util.Fst
                             bool doWriteTarget = TargetHasArcs(arc) && (flags & FST.BIT_TARGET_NEXT) == 0;
                             if (doWriteTarget)
                             {
-                                int ptr;
-                                if (topNodeMap.TryGetValue((int)arc.Target, out ptr))
+                                if (topNodeMap.TryGetValue((int)arc.Target, out int ptr))
                                 {
                                     absPtr = ptr;
                                 }
@@ -2029,7 +2018,7 @@ namespace Lucene.Net.Util.Fst
             fst.startNode = newNodeAddress.Get((int)startNode);
             //System.out.println("new startNode=" + fst.startNode + " old startNode=" + startNode);
 
-            if (!EqualityComparer<T>.Default.Equals(emptyOutput, default(T)))
+            if (!JCG.EqualityComparer<T>.Default.Equals(emptyOutput, default))
             {
                 fst.EmptyOutput = emptyOutput;
             }

--- a/src/Lucene.Net/Util/Fst/PairOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/PairOutputs.cs
@@ -49,19 +49,8 @@ namespace Lucene.Net.Util.Fst
 
             public override bool Equals(object other)
             {
-                if (other == this)
-                {
-                    return true;
-                }
-                else if (other is Pair)
-                {
-                    var pair = (Pair)other;
-                    return Output1.Equals(pair.Output1) && Output2.Equals(pair.Output2);
-                }
-                else
-                {
-                    return false;
-                }
+                // LUCENENET specific - simplified expression
+                return ReferenceEquals(other, this) || (other is Pair pair && Output1.Equals(pair.Output1) && Output2.Equals(pair.Output2));
             }
 
             public override int GetHashCode()

--- a/src/Lucene.Net/Util/Fst/PositiveIntOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/PositiveIntOutputs.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Util.Fst
     /// </summary>
     public sealed class PositiveInt32Outputs : Outputs<long?>
     {
-        private static readonly long NO_OUTPUT = new long();
+        private const long NO_OUTPUT = new long();
 
         private static readonly PositiveInt32Outputs singleton = new PositiveInt32Outputs();
 

--- a/src/Lucene.Net/Util/Fst/Util.cs
+++ b/src/Lucene.Net/Util/Fst/Util.cs
@@ -32,12 +32,8 @@ namespace Lucene.Net.Util.Fst
     /// <para/>
     /// @lucene.experimental
     /// </summary>
-    public sealed class Util // LUCENENET TODO: Fix naming conflict with containing namespace
+    public static class Util // LUCENENET specific - made static // LUCENENET TODO: Fix naming conflict with containing namespace
     {
-        private Util()
-        {
-        }
-
         /// <summary>
         /// Looks up the output for this input, or <c>null</c> if the
         /// input is not accepted.
@@ -55,7 +51,7 @@ namespace Lucene.Net.Util.Fst
             {
                 if (fst.FindTargetArc(input.Int32s[input.Offset + i], arc, arc, fstReader) == null)
                 {
-                    return default(T);
+                    return default;
                 }
                 output = fst.Outputs.Add(output, arc.Output);
             }
@@ -66,7 +62,7 @@ namespace Lucene.Net.Util.Fst
             }
             else
             {
-                return default(T);
+                return default;
             }
         }
 
@@ -91,7 +87,7 @@ namespace Lucene.Net.Util.Fst
             {
                 if (fst.FindTargetArc(input.Bytes[i + input.Offset] & 0xFF, arc, arc, fstReader) == null)
                 {
-                    return default(T);
+                    return default;
                 }
                 output = fst.Outputs.Add(output, arc.Output);
             }
@@ -102,7 +98,7 @@ namespace Lucene.Net.Util.Fst
             }
             else
             {
-                return default(T);
+                return default;
             }
         }
 
@@ -365,7 +361,7 @@ namespace Lucene.Net.Util.Fst
 
             internal JCG.SortedSet<FSTPath<T>> queue = null;
 
-            private object syncLock = new object();
+            private readonly object syncLock = new object();
 
             /// <summary>
             /// Creates an unbounded TopNSearcher </summary>
@@ -756,8 +752,10 @@ namespace Lucene.Net.Util.Fst
             IList<FST.Arc<T>> thisLevelQueue = new JCG.List<FST.Arc<T>>();
 
             // A queue of transitions to consider when processing the next level.
-            IList<FST.Arc<T>> nextLevelQueue = new JCG.List<FST.Arc<T>>();
-            nextLevelQueue.Add(startArc);
+            IList<FST.Arc<T>> nextLevelQueue = new JCG.List<FST.Arc<T>>
+            {
+                startArc
+            };
             //System.out.println("toDot: startArc: " + startArc);
 
             // A list of states on the same level (for ranking).
@@ -803,12 +801,12 @@ namespace Lucene.Net.Util.Fst
                 if (startArc.IsFinal)
                 {
                     isFinal = true;
-                    finalOutput = startArc.NextFinalOutput.Equals(NO_OUTPUT) ? default(T) : startArc.NextFinalOutput;
+                    finalOutput = startArc.NextFinalOutput.Equals(NO_OUTPUT) ? default : startArc.NextFinalOutput;
                 }
                 else
                 {
                     isFinal = false;
-                    finalOutput = default(T);
+                    finalOutput = default;
                 }
 
                 EmitDotState(@out, Convert.ToString(startArc.Target), isFinal ? finalStateShape : stateShape, stateColor, finalOutput == null ? "" : fst.Outputs.OutputToString(finalOutput));
@@ -1136,7 +1134,7 @@ namespace Lucene.Net.Util.Fst
 
                 int low = arc.ArcIdx;
                 int high = arc.NumArcs - 1;
-                int mid = 0;
+                int mid /*= 0*/; // LUCENENET: Removed unnecessary assignment
                 // System.out.println("do arc array low=" + low + " high=" + high +
                 // " targetLabel=" + targetLabel);
                 while (low <= high)

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Util
     /// @lucene.internal
     /// </summary>
     [ExceptionToClassNameConvention]
-    public sealed class IOUtils
+    public static class IOUtils // LUCENENET specific - made static
     {
         /// <summary>
         /// UTF-8 <see cref="Encoding"/> instance to prevent repeated
@@ -47,10 +47,6 @@ namespace Lucene.Net.Util
         /// as using the <see cref="string"/> constant may slow things down. </summary>
         /// <seealso cref="Encoding.UTF8"/>
         public static readonly string UTF_8 = "UTF-8";
-
-        private IOUtils() // no instance
-        {
-        }
 
         /// <summary>
         /// <para>Disposes all given <c>IDisposable</c>s, suppressing all thrown exceptions. Some of the <c>IDisposable</c>s

--- a/src/Lucene.Net/Util/IndexableBinaryStringTools.cs
+++ b/src/Lucene.Net/Util/IndexableBinaryStringTools.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Util
     /// @lucene.experimental 
     /// </summary>
     [Obsolete("Implement Analysis.TokenAttributes.ITermToBytesRefAttribute and store bytes directly instead. this class will be removed in Lucene 5.0")]
-    public sealed class IndexableBinaryStringTools
+    public static class IndexableBinaryStringTools // LUCENENET specific - made static
     {
         private static readonly CodingCase[] CODING_CASES = new CodingCase[] {
             // CodingCase(int initialShift, int finalShift)
@@ -54,11 +54,6 @@ namespace Lucene.Net.Util
             new CodingCase(9, 1, 7),
             new CodingCase(8, 0)
         };
-
-        // Export only static methods
-        private IndexableBinaryStringTools()
-        {
-        }
 
         /// <summary>
         /// Returns the number of chars required to encode the given <see cref="byte"/>s.

--- a/src/Lucene.Net/Util/Mutable/MutableValueBool.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValueBool.cs
@@ -39,10 +39,11 @@ namespace Lucene.Net.Util.Mutable
 
         public override MutableValue Duplicate()
         {
-            MutableValueBool v = new MutableValueBool();
-            v.Value = this.Value;
-            v.Exists = this.Exists;
-            return v;
+            return new MutableValueBool
+            {
+                Value = this.Value,
+                Exists = this.Exists
+            };
         }
 
         public override bool EqualsSameType(object other)

--- a/src/Lucene.Net/Util/Mutable/MutableValueDate.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValueDate.cs
@@ -32,10 +32,11 @@ namespace Lucene.Net.Util.Mutable
 
         public override MutableValue Duplicate()
         {
-            MutableValueDate v = new MutableValueDate();
-            v.Value = this.Value;
-            v.Exists = this.Exists;
-            return v;
+            return new MutableValueDate
+            {
+                Value = this.Value,
+                Exists = this.Exists
+            };
         }
     }
 }

--- a/src/Lucene.Net/Util/Mutable/MutableValueDouble.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValueDouble.cs
@@ -41,10 +41,11 @@ namespace Lucene.Net.Util.Mutable
 
         public override MutableValue Duplicate()
         {
-            MutableValueDouble v = new MutableValueDouble();
-            v.Value = this.Value;
-            v.Exists = this.Exists;
-            return v;
+            return new MutableValueDouble
+            {
+                Value = this.Value,
+                Exists = this.Exists
+            };
         }
 
         public override bool EqualsSameType(object other)

--- a/src/Lucene.Net/Util/Mutable/MutableValueFloat.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValueFloat.cs
@@ -40,10 +40,11 @@ namespace Lucene.Net.Util.Mutable
 
         public override MutableValue Duplicate()
         {
-            MutableValueSingle v = new MutableValueSingle();
-            v.Value = this.Value;
-            v.Exists = this.Exists;
-            return v;
+            return new MutableValueSingle
+            {
+                Value = this.Value,
+                Exists = this.Exists
+            };
         }
 
         public override bool EqualsSameType(object other)

--- a/src/Lucene.Net/Util/Mutable/MutableValueInt.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValueInt.cs
@@ -40,10 +40,11 @@ namespace Lucene.Net.Util.Mutable
 
         public override MutableValue Duplicate()
         {
-            MutableValueInt32 v = new MutableValueInt32();
-            v.Value = this.Value;
-            v.Exists = this.Exists;
-            return v;
+            return new MutableValueInt32
+            {
+                Value = this.Value,
+                Exists = this.Exists
+            };
         }
 
         public override bool EqualsSameType(object other)

--- a/src/Lucene.Net/Util/Mutable/MutableValueLong.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValueLong.cs
@@ -40,10 +40,11 @@ namespace Lucene.Net.Util.Mutable
 
         public override MutableValue Duplicate()
         {
-            MutableValueInt64 v = new MutableValueInt64();
-            v.Value = this.Value;
-            v.Exists = this.Exists;
-            return v;
+            return new MutableValueInt64
+            {
+                Value = this.Value,
+                Exists = this.Exists
+            };
         }
 
         public override bool EqualsSameType(object other)

--- a/src/Lucene.Net/Util/PForDeltaDocIdSet.cs
+++ b/src/Lucene.Net/Util/PForDeltaDocIdSet.cs
@@ -43,16 +43,22 @@ namespace Lucene.Net.Util
         internal static readonly int[] ITERATIONS = new int[32];
         internal static readonly int[] BYTE_BLOCK_COUNTS = new int[32];
         internal static readonly int MAX_BYTE_BLOCK_COUNT;
-        internal static readonly MonotonicAppendingInt64Buffer SINGLE_ZERO_BUFFER = new MonotonicAppendingInt64Buffer(0, 64, PackedInt32s.COMPACT);
+        internal static readonly MonotonicAppendingInt64Buffer SINGLE_ZERO_BUFFER = LoadSingleZeroBuffer();
         internal static readonly PForDeltaDocIdSet EMPTY = new PForDeltaDocIdSet(null, 0, int.MaxValue, SINGLE_ZERO_BUFFER, SINGLE_ZERO_BUFFER);
-        internal static readonly int LAST_BLOCK = 1 << 5; // flag to indicate the last block
-        internal static readonly int HAS_EXCEPTIONS = 1 << 6;
-        internal static readonly int UNARY = 1 << 7;
+        internal const int LAST_BLOCK = 1 << 5; // flag to indicate the last block
+        internal const int HAS_EXCEPTIONS = 1 << 6;
+        internal const int UNARY = 1 << 7;
+
+        private static MonotonicAppendingInt64Buffer LoadSingleZeroBuffer()
+        {
+            var buffer = new MonotonicAppendingInt64Buffer(0, 64, PackedInt32s.COMPACT);
+            buffer.Add(0);
+            buffer.Freeze();
+            return buffer;
+        }
 
         static PForDeltaDocIdSet()
         {
-            SINGLE_ZERO_BUFFER.Add(0);
-            SINGLE_ZERO_BUFFER.Freeze();
             int maxByteBLockCount = 0;
             for (int i = 1; i < ITERATIONS.Length; ++i)
             {

--- a/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Util.Packed
 
         // More than 1M doesn't really makes sense with these appending buffers
         // since their goal is to try to have small numbers of bits per value
-        internal static readonly int MAX_PAGE_SIZE = 1 << 20;
+        internal const int MAX_PAGE_SIZE = 1 << 20;
 
         internal readonly int pageShift, pageMask;
         internal PackedInt32s.Reader[] values;

--- a/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
@@ -27,8 +27,8 @@ namespace Lucene.Net.Util.Packed
     public abstract class AbstractBlockPackedWriter // LUCENENET NOTE: made public rather than internal because has public subclasses
     {
         internal const int MIN_BLOCK_SIZE = 64;
-        internal static readonly int MAX_BLOCK_SIZE = 1 << (30 - 3);
-        internal static readonly int MIN_VALUE_EQUALS_0 = 1 << 0;
+        internal const int MAX_BLOCK_SIZE = 1 << (30 - 3);
+        internal const int MIN_VALUE_EQUALS_0 = 1 << 0;
         internal const int BPV_SHIFT = 1;
 
         internal static long ZigZagEncode(long n)
@@ -61,7 +61,7 @@ namespace Lucene.Net.Util.Packed
         /// <summary>
         /// Sole constructor. </summary>
         /// <param name="blockSize"> the number of values of a single block, must be a multiple of <c>64</c>. </param>
-        public AbstractBlockPackedWriter(DataOutput @out, int blockSize)
+        protected AbstractBlockPackedWriter(DataOutput @out, int blockSize) // LUCENENET specific - marked protected instead of public
         {
             PackedInt32s.CheckBlockSize(blockSize, MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
             Reset(@out);

--- a/src/Lucene.Net/Util/Packed/AbstractPagedMutable.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractPagedMutable.cs
@@ -27,8 +27,8 @@ namespace Lucene.Net.Util.Packed
     /// </summary>
     public abstract class AbstractPagedMutable<T> : Int64Values where T : AbstractPagedMutable<T> // LUCENENET NOTE: made public rather than internal because has public subclasses
     {
-        internal static readonly int MIN_BLOCK_SIZE = 1 << 6;
-        internal static readonly int MAX_BLOCK_SIZE = 1 << 30;
+        internal const int MIN_BLOCK_SIZE = 1 << 6;
+        internal const int MAX_BLOCK_SIZE = 1 << 30;
 
         internal readonly long size;
         internal readonly int pageShift;

--- a/src/Lucene.Net/Util/Packed/BlockPackedReaderIterator.cs
+++ b/src/Lucene.Net/Util/Packed/BlockPackedReaderIterator.cs
@@ -188,10 +188,9 @@ namespace Lucene.Net.Util.Packed
 
         private void SkipBytes(long count)
         {
-            if (@in is IndexInput)
+            if (@in is IndexInput input)
             {
-                IndexInput iin = (IndexInput)@in;
-                iin.Seek(iin.GetFilePointer() + count);
+                input.Seek(input.GetFilePointer() + count);
             }
             else
             {

--- a/src/Lucene.Net/Util/Packed/Direct64.cs
+++ b/src/Lucene.Net/Util/Packed/Direct64.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Util.Packed
             values = new long[valueCount];
         }
 
-        internal Direct64(int packedIntsVersion, DataInput @in, int valueCount)
+        internal Direct64(/*int packedIntsVersion,*/ DataInput @in, int valueCount) // LUCENENET specific - removed unused parameter
             : this(valueCount)
         {
             for (int i = 0; i < valueCount; ++i)

--- a/src/Lucene.Net/Util/Packed/EliasFanoDecoder.cs
+++ b/src/Lucene.Net/Util/Packed/EliasFanoDecoder.cs
@@ -1,6 +1,7 @@
 using J2N.Numerics;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Lucene.Net.Util.Packed
 {
@@ -125,7 +126,7 @@ namespace Lucene.Net.Util.Packed
         ///  <returns> The low value for the current decoding index. </returns>
         private long CurrentLowValue()
         {
-            Debug.Assert(((efIndex >= 0) && (efIndex < numEncoded)), $"efIndex {efIndex.ToString()}");
+            Debug.Assert(((efIndex >= 0) && (efIndex < numEncoded)), $"efIndex {efIndex.ToString(CultureInfo.InvariantCulture)}");
             return UnPackValue(efEncoder.lowerLongs, efEncoder.numLowBits, efIndex, efEncoder.lowerBitsMask);
         }
 

--- a/src/Lucene.Net/Util/Packed/EliasFanoDocIdSet.cs
+++ b/src/Lucene.Net/Util/Packed/EliasFanoDocIdSet.cs
@@ -82,11 +82,8 @@ namespace Lucene.Net.Util.Packed
 
         private class DocIdSetIteratorAnonymousInnerClassHelper : DocIdSetIterator
         {
-            private readonly EliasFanoDocIdSet outerInstance;
-
             public DocIdSetIteratorAnonymousInnerClassHelper(EliasFanoDocIdSet outerInstance)
             {
-                this.outerInstance = outerInstance;
                 curDocId = -1;
                 efDecoder = outerInstance.efEncoder.GetDecoder();
             }
@@ -125,7 +122,7 @@ namespace Lucene.Net.Util.Packed
 
         public override bool Equals(object other)
         {
-            return ((other is EliasFanoDocIdSet)) && efEncoder.Equals(((EliasFanoDocIdSet)other).efEncoder);
+            return (other is EliasFanoDocIdSet otherEncoder) && efEncoder.Equals(otherEncoder.efEncoder);
         }
 
         public override int GetHashCode()

--- a/src/Lucene.Net/Util/Packed/Packed16ThreeBlocks.cs
+++ b/src/Lucene.Net/Util/Packed/Packed16ThreeBlocks.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Util.Packed
     {
         internal readonly short[] blocks;
 
-        public static readonly int MAX_SIZE = int.MaxValue / 3;
+        public const int MAX_SIZE = int.MaxValue / 3;
 
         internal Packed16ThreeBlocks(int valueCount)
             : base(valueCount, 48)

--- a/src/Lucene.Net/Util/Packed/Packed64.cs
+++ b/src/Lucene.Net/Util/Packed/Packed64.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Util.Packed
     {
         internal const int BLOCK_SIZE = 64; // 32 = int, 64 = long
         internal const int BLOCK_BITS = 6; // The #bits representing BLOCK_SIZE
-        internal static readonly int MOD_MASK = BLOCK_SIZE - 1; // x % BLOCK_SIZE
+        internal const int MOD_MASK = BLOCK_SIZE - 1; // x % BLOCK_SIZE
 
         /// <summary>
         /// Values are stores contiguously in the blocks array.

--- a/src/Lucene.Net/Util/Packed/Packed64SingleBlock.cs
+++ b/src/Lucene.Net/Util/Packed/Packed64SingleBlock.cs
@@ -205,7 +205,7 @@ namespace Lucene.Net.Util.Packed
             long blockValue = 0L;
             for (int i = 0; i < valuesPerBlock; ++i)
             {
-                blockValue = blockValue | (val << (i * m_bitsPerValue));
+                blockValue |= (val << (i * m_bitsPerValue));
             }
             Arrays.Fill(blocks, fromBlock, toBlock, blockValue);
 

--- a/src/Lucene.Net/Util/Packed/Packed8ThreeBlocks.cs
+++ b/src/Lucene.Net/Util/Packed/Packed8ThreeBlocks.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Util.Packed
     {
         readonly byte[] blocks;
 
-        public static readonly int MAX_SIZE = int.MaxValue / 3;
+        public const int MAX_SIZE = int.MaxValue / 3;
 
         internal Packed8ThreeBlocks(int valueCount)
             : base(valueCount, 24)

--- a/src/Lucene.Net/Util/Packed/PackedInts.cs
+++ b/src/Lucene.Net/Util/Packed/PackedInts.cs
@@ -190,15 +190,13 @@ namespace Lucene.Net.Util.Packed
 
             internal Format(int id)
             {
-                this.id = id;
+                this.Id = id;
             }
-
-            private int id; // LUCENENET specific - made private, since it is already exposed through public property
 
             /// <summary>
             /// Returns the ID of the format.
             /// </summary>
-            public int Id => id;
+            public int Id { get; private set; }
 
             /// <summary>
             /// Computes how many <see cref="byte"/> blocks are needed to store <paramref name="valueCount"/>
@@ -921,7 +919,7 @@ namespace Lucene.Net.Util.Packed
                         return new Direct32(version, @in, valueCount);
 
                     case 64:
-                        return new Direct64(version, @in, valueCount);
+                        return new Direct64(/*version,*/ @in, valueCount); // LUCENENET specific - removed unused parameter
 
                     case 24:
                         if (valueCount <= Packed8ThreeBlocks.MAX_SIZE)
@@ -1074,9 +1072,9 @@ namespace Lucene.Net.Util.Packed
 
         private class DirectPackedReaderAnonymousInnerClassHelper : DirectPackedReader
         {
-            private IndexInput @in;
-            private int valueCount;
-            private long endPointer;
+            private readonly IndexInput @in;
+            private readonly int valueCount;
+            private readonly long endPointer;
 
             public DirectPackedReaderAnonymousInnerClassHelper(int bitsPerValue, int valueCount, IndexInput @in, long endPointer)
                 : base(bitsPerValue, valueCount, @in)

--- a/src/Lucene.Net/Util/PagedBytes.cs
+++ b/src/Lucene.Net/Util/PagedBytes.cs
@@ -221,7 +221,7 @@ namespace Lucene.Net.Util
                 }
                 currentBlock = new byte[blockSize];
                 upto = 0;
-                left = blockSize;
+                //left = blockSize; // LUCENENET: Unnecessary assignment
                 Debug.Assert(bytes.Length <= blockSize);
                 // TODO: we could also support variable block sizes
             }
@@ -410,9 +410,9 @@ namespace Lucene.Net.Util
         {
             private readonly PagedBytes outerInstance;
 
-            public PagedBytesDataOutput(PagedBytes outerInstance)
+            public PagedBytesDataOutput(PagedBytes pagedBytes)
             {
-                this.outerInstance = outerInstance;
+                this.outerInstance = pagedBytes;
             }
 
             public override void WriteByte(byte b)

--- a/src/Lucene.Net/Util/PriorityQueue.cs
+++ b/src/Lucene.Net/Util/PriorityQueue.cs
@@ -41,15 +41,15 @@ namespace Lucene.Net.Util
     public abstract class PriorityQueue<T>
     {
         private int size = 0;
-        private int maxSize;
-        private T[] heap;
+        private readonly int maxSize;
+        private readonly T[] heap;
 
-        public PriorityQueue(int maxSize)
+        protected PriorityQueue(int maxSize) // LUCENENET specific - made protected instead of public
             : this(maxSize, true)
         {
         }
 
-        public PriorityQueue(int maxSize, bool prepopulate)
+        protected PriorityQueue(int maxSize, bool prepopulate) // LUCENENET specific - made protected instead of public
         {
             int heapSize;
             if (0 == maxSize)
@@ -88,7 +88,7 @@ namespace Lucene.Net.Util
             {
                 // If sentinel objects are supported, populate the queue with them
                 T sentinel = GetSentinelObject();
-                if (!EqualityComparer<T>.Default.Equals(sentinel, default(T)))
+                if (!EqualityComparer<T>.Default.Equals(sentinel, default))
                 {
                     heap[1] = sentinel;
                     for (int i = 2; i < heap.Length; i++)
@@ -147,7 +147,7 @@ namespace Lucene.Net.Util
         ///         sentinel objects are not supported. </returns>
         protected virtual T GetSentinelObject()
         {
-            return default(T);
+            return default;
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Lucene.Net.Util
             if (size < maxSize)
             {
                 Add(element);
-                return default(T);
+                return default;
             }
             else if (size > 0 && !LessThan(element, heap[1]))
             {
@@ -213,14 +213,14 @@ namespace Lucene.Net.Util
             {
                 T result = heap[1]; // save first value
                 heap[1] = heap[size]; // move last to first
-                heap[size] = default(T); // permit GC of objects
+                heap[size] = default; // permit GC of objects
                 size--;
                 DownHeap(); // adjust heap
                 return result;
             }
             else
             {
-                return default(T);
+                return default;
             }
         }
 
@@ -260,7 +260,7 @@ namespace Lucene.Net.Util
         {
             for (int i = 0; i <= size; i++)
             {
-                heap[i] = default(T);
+                heap[i] = default;
             }
             size = 0;
         }

--- a/src/Lucene.Net/Util/QueryBuilder.cs
+++ b/src/Lucene.Net/Util/QueryBuilder.cs
@@ -252,7 +252,7 @@ namespace Lucene.Net.Util
             // rewind the buffer stream
             buffer.Reset();
 
-            BytesRef bytes = termAtt == null ? null : termAtt.BytesRef;
+            BytesRef bytes = termAtt?.BytesRef;
 
             if (numTokens == 0)
             {

--- a/src/Lucene.Net/Util/SPIClassIterator.cs
+++ b/src/Lucene.Net/Util/SPIClassIterator.cs
@@ -92,6 +92,7 @@ namespace Lucene.Net.Util
                                 types.Add(type);
                             }
                         }
+#pragma warning disable CA1031 // Do not catch general exception types
                         catch
                         {
                             // swallow
@@ -102,6 +103,7 @@ namespace Lucene.Net.Util
                 {
                     // swallow
                 }
+#pragma warning restore CA1031 // Do not catch general exception types
             }
             return types;
         }

--- a/src/Lucene.Net/Util/SetOnce.cs
+++ b/src/Lucene.Net/Util/SetOnce.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Util
 #endif
         where T : class // LUCENENET specific - added class constraint so we don't accept value types (which cannot be volatile)
     {
-        private volatile T obj = default(T);
+        private volatile T obj = default;
         private readonly AtomicBoolean set;
 
         /// <summary>

--- a/src/Lucene.Net/Util/SloppyMath.cs
+++ b/src/Lucene.Net/Util/SloppyMath.cs
@@ -169,7 +169,7 @@ namespace Lucene.Net.Util
         }
 
         // haversin
-        private static readonly double TO_RADIANS = Math.PI / 180D;
+        private const double TO_RADIANS = Math.PI / 180D;
 
         // cos/asin
         private const double ONE_DIV_F2 = 1 / 2.0;
@@ -181,7 +181,7 @@ namespace Lucene.Net.Util
         private static readonly double PIO2_LO = J2N.BitConversion.Int64BitsToDouble(0x3DD0B4611A626331L); // 6.07710050650619224932e-11 pi/2 - PIO2_HI
         private static readonly double TWOPI_HI = 4 * PIO2_HI;
         private static readonly double TWOPI_LO = 4 * PIO2_LO;
-        private static readonly int SIN_COS_TABS_SIZE = (1 << 11) + 1;
+        private const int SIN_COS_TABS_SIZE = (1 << 11) + 1;
         private static readonly double SIN_COS_DELTA_HI = TWOPI_HI / (SIN_COS_TABS_SIZE - 1);
         private static readonly double SIN_COS_DELTA_LO = TWOPI_LO / (SIN_COS_TABS_SIZE - 1);
         private static readonly double SIN_COS_INDEXER = 1 / (SIN_COS_DELTA_HI + SIN_COS_DELTA_LO);
@@ -198,7 +198,7 @@ namespace Lucene.Net.Util
         // but seems to work well enough as long as value >= sin(25deg).
         private static readonly double ASIN_MAX_VALUE_FOR_TABS = Math.Sin(73.0.ToRadians());
 
-        private static readonly int ASIN_TABS_SIZE = (1 << 13) + 1;
+        private const int ASIN_TABS_SIZE = (1 << 13) + 1;
         private static readonly double ASIN_DELTA = ASIN_MAX_VALUE_FOR_TABS / (ASIN_TABS_SIZE - 1);
         private static readonly double ASIN_INDEXER = 1 / ASIN_DELTA;
         private static readonly double[] asinTab = new double[ASIN_TABS_SIZE];
@@ -220,9 +220,9 @@ namespace Lucene.Net.Util
         private static readonly double ASIN_QS3 = J2N.BitConversion.Int64BitsToDouble(unchecked((long)0xbfe6066c1b8d0159L)); // -6.88283971605453293030e-01
         private static readonly double ASIN_QS4 = J2N.BitConversion.Int64BitsToDouble(0x3fb3b8c5b12e9282L); //  7.70381505559019352791e-02
 
-        private static readonly int RADIUS_TABS_SIZE = (1 << 10) + 1;
-        private static readonly double RADIUS_DELTA = (Math.PI / 2d) / (RADIUS_TABS_SIZE - 1);
-        private static readonly double RADIUS_INDEXER = 1d / RADIUS_DELTA;
+        private const int RADIUS_TABS_SIZE = (1 << 10) + 1;
+        private const double RADIUS_DELTA = (Math.PI / 2d) / (RADIUS_TABS_SIZE - 1);
+        private const double RADIUS_INDEXER = 1d / RADIUS_DELTA;
         private static readonly double[] earthDiameterPerLatitude = new double[RADIUS_TABS_SIZE];
 
         /// <summary>

--- a/src/Lucene.Net/Util/SmallFloat.cs
+++ b/src/Lucene.Net/Util/SmallFloat.cs
@@ -26,14 +26,8 @@ namespace Lucene.Net.Util
     /// <para/>
     /// @lucene.internal
     /// </summary>
-    public class SmallSingle
+    public static class SmallSingle // LUCENENET specific - made static
     {
-        /// <summary>
-        /// No instance </summary>
-        private SmallSingle()
-        {
-        }
-
         /// <summary>
         /// Converts a 32 bit <see cref="float"/> to an 8 bit <see cref="float"/>.
         /// <para/>Values less than zero are all mapped to zero.

--- a/src/Lucene.Net/Util/Sorter.cs
+++ b/src/Lucene.Net/Util/Sorter.cs
@@ -93,7 +93,7 @@ namespace Lucene.Net.Util
                 len22 = (int)((uint)(to - mid) >> 1);
                 second_cut = mid + len22;
                 first_cut = Upper(from, mid, second_cut);
-                len11 = first_cut - from;
+                //len11 = first_cut - from; // LUCENENET: Unnecessary assignment
             }
             Rotate(first_cut, mid, second_cut);
             int new_mid = first_cut + len22;

--- a/src/Lucene.Net/Util/StringHelper.cs
+++ b/src/Lucene.Net/Util/StringHelper.cs
@@ -1,6 +1,5 @@
 using J2N.Numerics;
 using J2N.Text;
-using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -95,45 +94,43 @@ namespace Lucene.Net.Util
         /// <para/>
         /// @lucene.internal
         /// </summary>
-        public static IComparer<string> VersionComparer => versionComparer;
-
-        private static readonly IComparer<string> versionComparer = Comparer<string>.Create((a, b) =>
-        {
-            var aTokens = new StringTokenizer(a, ".");
-            var bTokens = new StringTokenizer(b, ".");
-
-            while (aTokens.MoveNext())
+        public static IComparer<string> VersionComparer { get; } = Comparer<string>.Create((a, b) =>
             {
-                int aToken = Convert.ToInt32(aTokens.Current, CultureInfo.InvariantCulture);
-                if (bTokens.MoveNext())
+                var aTokens = new StringTokenizer(a, ".");
+                var bTokens = new StringTokenizer(b, ".");
+
+                while (aTokens.MoveNext())
                 {
-                    int bToken = Convert.ToInt32(bTokens.Current, CultureInfo.InvariantCulture);
-                    if (aToken != bToken)
+                    int aToken = Convert.ToInt32(aTokens.Current, CultureInfo.InvariantCulture);
+                    if (bTokens.MoveNext())
                     {
-                        return aToken < bToken ? -1 : 1;
+                        int bToken = Convert.ToInt32(bTokens.Current, CultureInfo.InvariantCulture);
+                        if (aToken != bToken)
+                        {
+                            return aToken < bToken ? -1 : 1;
+                        }
+                    }
+                    else
+                    {
+                        // a has some extra trailing tokens. if these are all zeroes, thats ok.
+                        if (aToken != 0)
+                        {
+                            return 1;
+                        }
                     }
                 }
-                else
+
+                // b has some extra trailing tokens. if these are all zeroes, thats ok.
+                while (bTokens.MoveNext())
                 {
-                    // a has some extra trailing tokens. if these are all zeroes, thats ok.
-                    if (aToken != 0)
+                    if (Convert.ToInt32(bTokens.Current, CultureInfo.InvariantCulture) != 0)
                     {
-                        return 1;
+                        return -1;
                     }
                 }
-            }
 
-            // b has some extra trailing tokens. if these are all zeroes, thats ok.
-            while (bTokens.MoveNext())
-            {
-                if (Convert.ToInt32(bTokens.Current, CultureInfo.InvariantCulture) != 0)
-                {
-                    return -1;
-                }
-            }
-
-            return 0;
-        });
+                return 0;
+            });
 
         public static bool Equals(string s1, string s2)
         {

--- a/src/Lucene.Net/Util/ToStringUtils.cs
+++ b/src/Lucene.Net/Util/ToStringUtils.cs
@@ -23,12 +23,8 @@ namespace Lucene.Net.Util
     /// <summary>
     /// Helper methods to ease implementing <see cref="object.ToString()"/>.
     /// </summary>
-    public sealed class ToStringUtils
+    public static class ToStringUtils // LUCENENET specific - made static
     {
-        private ToStringUtils() // no instance
-        {
-        }
-
         /// <summary>
         /// For printing boost only if not 1.0.
         /// </summary>

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -627,7 +627,7 @@ namespace Lucene.Net.Util
             while (utf8Upto < utf8Limit)
             {
                 int numBytes = utf8CodeLength[bytes[utf8Upto] & 0xFF];
-                int v = 0;
+                int v /*= 0*/;
                 switch (numBytes)
                 {
                     case 1:
@@ -687,7 +687,7 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Value that all lead surrogate starts with. </summary>
-        private static readonly int LEAD_SURROGATE_OFFSET_ = LEAD_SURROGATE_MIN_VALUE - (SUPPLEMENTARY_MIN_VALUE >> LEAD_SURROGATE_SHIFT_);
+        private const int LEAD_SURROGATE_OFFSET_ = LEAD_SURROGATE_MIN_VALUE - (SUPPLEMENTARY_MIN_VALUE >> LEAD_SURROGATE_SHIFT_);
 
         /// <summary>
         /// Cover JDK 1.5 API. Create a String from an array of <paramref name="codePoints"/>.

--- a/src/Lucene.Net/Util/Version.cs
+++ b/src/Lucene.Net/Util/Version.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Lucene.Net.Util
@@ -162,13 +161,12 @@ namespace Lucene.Net.Util
             return other <= instance;
         }
 
-        private static Regex NUMERIC_VERSION = new Regex("^(\\d)\\.(\\d)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex NUMERIC_VERSION = new Regex("^(\\d)\\.(\\d)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         public static LuceneVersion ParseLeniently(string version)
         {
             string parsedMatchVersion = version.ToUpperInvariant();
-            LuceneVersion result;
-            Enum.TryParse(NUMERIC_VERSION.Replace(parsedMatchVersion, "LUCENE_$1$2", 1), out result);
+            Enum.TryParse(NUMERIC_VERSION.Replace(parsedMatchVersion, "LUCENE_$1$2", 1), out LuceneVersion result);
             return result;
         }
     }

--- a/src/Lucene.Net/Util/VirtualMethod.cs
+++ b/src/Lucene.Net/Util/VirtualMethod.cs
@@ -78,7 +78,7 @@ namespace Lucene.Net.Util
         // LUCENENET specific wrapper needed because ConditionalWeakTable requires a reference type.
         private class Int32Ref : IEquatable<Int32Ref>
         {
-            private int value;
+            private readonly int value;
 
             public Int32Ref(int value)
             {
@@ -106,15 +106,9 @@ namespace Lucene.Net.Util
                 return value.GetHashCode();
             }
 
-            public static implicit operator int(Int32Ref value)
-            {
-                return value.value;
-            }
+            public static implicit operator int(Int32Ref value) => value.value;
 
-            public static implicit operator Int32Ref(int value)
-            {
-                return new Int32Ref(value);
-            }
+            public static implicit operator Int32Ref(int value) => new Int32Ref(value);
         }
 
 

--- a/src/Lucene.Net/Util/WAH8DocIdSet.cs
+++ b/src/Lucene.Net/Util/WAH8DocIdSet.cs
@@ -621,7 +621,7 @@ namespace Lucene.Net.Util
         {
             /* Using the index can be costly for close targets. */
 
-            internal static int IndexThreshold(int cardinality, int indexInterval)
+            internal static int IndexThreshold(/*int cardinality, */int indexInterval) // LUCENENET specific - removed unused parameter
             {
                 // Short sequences encode for 3 words (2 clean words and 1 dirty byte),
                 // don't advance if we are going to read less than 3 x indexInterval
@@ -657,7 +657,7 @@ namespace Lucene.Net.Util
                 bitList = 0;
                 sequenceNum = -1;
                 docID = -1;
-                indexThreshold = IndexThreshold(cardinality, indexInterval);
+                indexThreshold = IndexThreshold(/*cardinality,*/ indexInterval); // LUCENENET specific - removed unused parameter
             }
 
             internal virtual bool ReadSequence()


### PR DESCRIPTION
This fixes a bottleneck (see #261) caused by unzipping the line docs file in RAM (~15MB) and then selecting a random line in the file. The .NET `GZipStream` is not seekable, so this was done by copying the entire contents into a `MemoryStream` first. This happened during a significant number of the tests (~20%), and happened in each one of those tests.

The fix was to set up the test framework to unzip the file to a temp file on the test machine. This happens in 1 of 3 different ways:

1. If `LineFileDocs` is used directly in a class that does not specify `LuceneTestCase.UseTempLineDocsFile = true`, `LineFileDocs` will unzip the file before it is used (per instance of the class) and deleted when it is disposed.
2. If `LuceneTestCase.UseTempLineDocsFile = true` is specified in the test fixture, the file will be unzipped in the `BeforeClass()` method and deleted in the `AfterClass()` method.
3. If the test project makes heavy use of this file, adding a subclass of `LuceneTestFrameworkInitializer` to the test project (outside of all namespaces) will cause the file to be unzipped only once for all of the tests in that project and deleted after the last test is finished.

There are also several other patches in this PR:

- The seek behavior of `LineFileDocs` was reverted back to Lucene's original implementation, which has revealed some (potential) false positives in some of the ICU tests. A `BufferedStream` was added to improve performance.
- Removed unnecessary variable allocations.
- Fixed a bug with the `Nightly`, `Weekly`, `Slow`, and `AwaitsFix` attributes so they will wait until NUnit runs the initialization code before running.
- Added a `DeadlockAttribute` to time out tests that we are now seeing threading contention issues with after improving raw speed. This is to ensure that they will fail in the CI environment if they actually deadlock and also can be used to filter out these tests during runs.
- Simplified some expressions to make them simpler to maintain.
- Commented out dead code and unnecessary variable declarations that were carried over from Java.
- Fixed a bug in the `ICUTokenizer` where it was calling `System.Char.IsWhiteSpace()` when it should have been calling `ICU4N.UChar.IsWhiteSpace()` to ensure it is reading the correct version of ICU.
- Changed implementation of `DisposableThreadLocal` to that of RavenDB, [with permission from its maintainers](https://issues.apache.org/jira/browse/LUCENENET-640?focusedCommentId=17033146&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17033146). (closes #251)