### PR TITLE
Fixes #323 - Allow .NET Framework users to upgrade Microsoft.Extensions.Configuration without requiring an IConfigurationFactory

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -90,6 +90,13 @@
     
   </PropertyGroup>
 
+  <!-- Features in .NET Framework 4.6.1+ only -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or $(TargetFramework.StartsWith('net47')) Or $(TargetFramework.StartsWith('net48'))">
+    
+    <DefineConstants>$(DefineConstants);FEATURE_ICONFIGURATIONROOT_PROVIDERS</DefineConstants>
+    
+  </PropertyGroup>
+
   <!-- Features in .NET Framework 4.6+ only -->
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net46')) Or $(TargetFramework.StartsWith('net47')) Or $(TargetFramework.StartsWith('net48'))">
     

--- a/src/Lucene.Net.Tests.TestFramework/Configuration/Custom/MockConfigurationFactory.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Configuration/Custom/MockConfigurationFactory.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Configuration.Custom
                 });
         }
 
-        private class MockConfiguration : IConfigurationRoot
+        private class MockConfiguration : IConfiguration
         {
             private readonly IConfiguration wrapped;
             private readonly IDictionary<string, string> settings;
@@ -68,10 +68,6 @@ namespace Lucene.Net.Configuration.Custom
                     wrapped[key] = value;
                 }
             }
-
-#if FEATURE_ICONFIGURATIONROOT_PROVIDERS
-            public IEnumerable<IConfigurationProvider> Providers => (wrapped as IConfigurationRoot)?.Providers;
-#endif
 
             public IEnumerable<IConfigurationSection> GetChildren()
             {

--- a/src/Lucene.Net/Support/Configuration/Base/ConfigurationRoot.cs
+++ b/src/Lucene.Net/Support/Configuration/Base/ConfigurationRoot.cs
@@ -13,7 +13,12 @@ namespace Lucene.Net.Configuration
     /// <summary>
     /// The root node for a configuration.
     /// </summary>
-    internal class ConfigurationRoot : IConfigurationRoot
+    internal class ConfigurationRoot : IConfiguration
+#if FEATURE_ICONFIGURATIONROOT_PROVIDERS
+        // LUCENENET: Since the IConfigurationRoot interface changed after version 1.1.2, we cannot implement it here
+        // or upgrading the version of Microsoft.Extensions.Configuration will fail.
+        , IConfigurationRoot
+#endif
     {
         private IList<IConfigurationProvider> _providers;
         private ConfigurationReloadToken _changeToken = new ConfigurationReloadToken();
@@ -24,12 +29,7 @@ namespace Lucene.Net.Configuration
         /// <param name="providers">The <see cref="IConfigurationProvider"/>s for this configuration.</param>
         public ConfigurationRoot(IList<IConfigurationProvider> providers)
         {
-            if (providers == null)
-            {
-                throw new ArgumentNullException(nameof(providers));
-            }
-
-            _providers = providers;
+            _providers = providers ?? throw new ArgumentNullException(nameof(providers));
             foreach (var p in providers)
             {
                 p.Load();
@@ -53,12 +53,8 @@ namespace Lucene.Net.Configuration
             {
                 foreach (var provider in _providers.Reverse())
                 {
-                    string value;
-
-                    if (provider.TryGet(key, out value))
-                    {
+                    if (provider.TryGet(key, out string value))
                         return value;
-                    }
                 }
 
                 return null;


### PR DESCRIPTION
Since the `IConfigurationRoot` interface is different between `Microsoft.Extensions.Configuration.Extensions` 1.x and 2.x+, this patch removes the interface from .NET Framework targets and replaces it with `IConfiguration`.