### PR TITLE
Lucene.Net.CodeAnalysis: Separated CSharp and VisualBasic providers (fixes #286)

### DIFF
--- a/Lucene.Net.sln
+++ b/Lucene.Net.sln
@@ -197,9 +197,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lucene.Net.Analysis.Morfolo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lucene.Net.Tests.Analysis.Morfologik", "src\Lucene.Net.Tests.Analysis.Morfologik\Lucene.Net.Tests.Analysis.Morfologik.csproj", "{435F91AD-8BA4-4376-904C-385A165C1AF0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lucene.Net.CodeAnalysis", "src\dotnet\Lucene.Net.CodeAnalysis\Lucene.Net.CodeAnalysis.csproj", "{A9A5C2DC-C4EA-49B4-805A-6CEB5D246D2F}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lucene.Net.Tests.CodeAnalysis", "src\dotnet\Lucene.Net.Tests.CodeAnalysis\Lucene.Net.Tests.CodeAnalysis.csproj", "{158F5D30-8B96-4C49-9009-0B8ACEDF8546}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lucene.Net.CodeAnalysis.CSharp", "src\dotnet\Lucene.Net.CodeAnalysis.CSharp\Lucene.Net.CodeAnalysis.CSharp.csproj", "{441876AF-F691-408C-85EC-6A934E60F627}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lucene.Net.CodeAnalysis.VisualBasic", "src\dotnet\Lucene.Net.CodeAnalysis.VisualBasic\Lucene.Net.CodeAnalysis.VisualBasic.csproj", "{5CD4D4E8-6132-4384-98FC-6AB1C97E0B80}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Lucene.Net.CodeAnalysis", "Lucene.Net.CodeAnalysis", "{E5E8C5DC-7048-4818-B884-FB2D037D2EF2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{4D0ED7D9-ABEE-4890-B06C-477E3A32B9A0}"
+	ProjectSection(SolutionItems) = preProject
+		src\dotnet\Lucene.Net.CodeAnalysis\tools\install.ps1 = src\dotnet\Lucene.Net.CodeAnalysis\tools\install.ps1
+		src\dotnet\Lucene.Net.CodeAnalysis\tools\uninstall.ps1 = src\dotnet\Lucene.Net.CodeAnalysis\tools\uninstall.ps1
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -455,14 +465,18 @@ Global
 		{435F91AD-8BA4-4376-904C-385A165C1AF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{435F91AD-8BA4-4376-904C-385A165C1AF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{435F91AD-8BA4-4376-904C-385A165C1AF0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A9A5C2DC-C4EA-49B4-805A-6CEB5D246D2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A9A5C2DC-C4EA-49B4-805A-6CEB5D246D2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A9A5C2DC-C4EA-49B4-805A-6CEB5D246D2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A9A5C2DC-C4EA-49B4-805A-6CEB5D246D2F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{158F5D30-8B96-4C49-9009-0B8ACEDF8546}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{158F5D30-8B96-4C49-9009-0B8ACEDF8546}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{158F5D30-8B96-4C49-9009-0B8ACEDF8546}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{158F5D30-8B96-4C49-9009-0B8ACEDF8546}.Release|Any CPU.Build.0 = Release|Any CPU
+		{441876AF-F691-408C-85EC-6A934E60F627}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{441876AF-F691-408C-85EC-6A934E60F627}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{441876AF-F691-408C-85EC-6A934E60F627}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{441876AF-F691-408C-85EC-6A934E60F627}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CD4D4E8-6132-4384-98FC-6AB1C97E0B80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CD4D4E8-6132-4384-98FC-6AB1C97E0B80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CD4D4E8-6132-4384-98FC-6AB1C97E0B80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CD4D4E8-6132-4384-98FC-6AB1C97E0B80}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -475,8 +489,11 @@ Global
 		{CF3A74CA-FEFD-4F41-961B-CC8CF8D96286} = {8CA61D33-3590-4024-A304-7B1F75B50653}
 		{4B054831-5275-44E2-A4D4-CA0B19BEE19A} = {8CA61D33-3590-4024-A304-7B1F75B50653}
 		{1F5574FE-19F7-4F10-9B88-76A938621F5B} = {4DF7EACE-2B25-43F6-B558-8520BF20BD76}
-		{A9A5C2DC-C4EA-49B4-805A-6CEB5D246D2F} = {8CA61D33-3590-4024-A304-7B1F75B50653}
 		{158F5D30-8B96-4C49-9009-0B8ACEDF8546} = {8CA61D33-3590-4024-A304-7B1F75B50653}
+		{441876AF-F691-408C-85EC-6A934E60F627} = {8CA61D33-3590-4024-A304-7B1F75B50653}
+		{5CD4D4E8-6132-4384-98FC-6AB1C97E0B80} = {8CA61D33-3590-4024-A304-7B1F75B50653}
+		{E5E8C5DC-7048-4818-B884-FB2D037D2EF2} = {8CA61D33-3590-4024-A304-7B1F75B50653}
+		{4D0ED7D9-ABEE-4890-B06C-477E3A32B9A0} = {E5E8C5DC-7048-4818-B884-FB2D037D2EF2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9F2179CC-CFD2-4419-AB74-D72856931F36}

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -34,14 +34,16 @@
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet Package File Paths">
-    <LuceneNetCodeAnalysisDir>$(SolutionDir)src\dotnet\Lucene.Net.CodeAnalysis\</LuceneNetCodeAnalysisDir>
-    <LuceneNetCodeAnalysisAssemblyFile>$(LuceneNetCodeAnalysisDir)bin\$(Configuration)\netstandard2.0\*.dll</LuceneNetCodeAnalysisAssemblyFile>
+    <LuceneNetDotNetDir>$(SolutionDir)src\dotnet\</LuceneNetDotNetDir>
+    <LuceneNetCodeAnalysisToolsDir>$(LuceneNetDotNetDir)Lucene.Net.CodeAnalysis\tools\</LuceneNetCodeAnalysisToolsDir>
+    <LuceneNetCodeAnalysisCSAssemblyFile>$(LuceneNetDotNetDir)\Lucene.Net.CodeAnalysis.CSharp\bin\$(Configuration)\netstandard2.0\*.dll</LuceneNetCodeAnalysisCSAssemblyFile>
+    <LuceneNetCodeAnalysisVBAssemblyFile>$(LuceneNetDotNetDir)\Lucene.Net.CodeAnalysis.VisualBasic\bin\$(Configuration)\netstandard2.0\*.dll</LuceneNetCodeAnalysisVBAssemblyFile>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Package Files">
-    <None Include="$(LuceneNetCodeAnalysisDir)tools\*.ps1" Pack="true" PackagePath="tools" />
-    <None Include="$(LuceneNetCodeAnalysisAssemblyFile)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="$(LuceneNetCodeAnalysisAssemblyFile)" Pack="true" PackagePath="analyzers/dotnet/vb" Visible="false" />
+    <None Include="$(LuceneNetCodeAnalysisToolsDir)*.ps1" Pack="true" PackagePath="tools" />
+    <None Include="$(LuceneNetCodeAnalysisCSAssemblyFile)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(LuceneNetCodeAnalysisVBAssemblyFile)" Pack="true" PackagePath="analyzers/dotnet/vb" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene.Net.CodeAnalysis.CSharp.csproj
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene.Net.CodeAnalysis.CSharp.csproj
@@ -22,22 +22,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RootNamespace>Lucene.Net.CodeAnalysis</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
-  <Import Project="$(SolutionDir)build/TestReferences.Common.targets" />
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Lucene.Net\Lucene.Net.csproj" />
-    <ProjectReference Include="..\Lucene.Net.CodeAnalysis.CSharp\Lucene.Net.CodeAnalysis.CSharp.csproj" />
-    <ProjectReference Include="..\Lucene.Net.CodeAnalysis.VisualBasic\Lucene.Net.CodeAnalysis.VisualBasic.csproj" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" PrivateAssets="all" />
+    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene1000_SealTokenStreamClassCSCodeFixProvider.cs
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene1000_SealTokenStreamClassCSCodeFixProvider.cs
@@ -29,12 +29,12 @@ namespace Lucene.Net.CodeAnalysis
      * limitations under the License.
      */
 
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(Lucene1000_SealIncrementTokenMethodCSCodeFixProvider)), Shared]
-    public class Lucene1000_SealIncrementTokenMethodCSCodeFixProvider : CodeFixProvider
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(Lucene1000_SealTokenStreamClassCSCodeFixProvider)), Shared]
+    public class Lucene1000_SealTokenStreamClassCSCodeFixProvider : CodeFixProvider
     {
-        private const string Title = "Add sealed keyword to IncrementToken() method";
+        private const string Title = "Add sealed keyword to class definition";
 
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedAnalyzer.DiagnosticId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedCSAnalyzer.DiagnosticId);
 
         public sealed override FixAllProvider GetFixAllProvider()
         {
@@ -53,61 +53,33 @@ namespace Lucene.Net.CodeAnalysis
             // Find the type declaration identified by the diagnostic.
             var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<ClassDeclarationSyntax>().First();
 
-            var incrementTokenMethodDeclaration = GetIncrementTokenMethodDeclaration(declaration);
-
-            // If we can't find the method, we skip registration for this fix
-            if (incrementTokenMethodDeclaration != null)
-            {
-                // Register a code action that will invoke the fix.
-                context.RegisterCodeFix(
-                    CodeAction.Create(
-                        title: Title,
-                        createChangedDocument: c => AddSealedKeywordAsync(context.Document, incrementTokenMethodDeclaration, c),
-                        equivalenceKey: Title),
-                    diagnostic);
-            }
+            // Register a code action that will invoke the fix.
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: Title,
+                    createChangedDocument: c => AddSealedKeywordAsync(context.Document, declaration, c),
+                    equivalenceKey: Title),
+                diagnostic);
         }
 
-        private async Task<Document> AddSealedKeywordAsync(Document document, MethodDeclarationSyntax methodDeclaration, CancellationToken cancellationToken)
+        private async Task<Document> AddSealedKeywordAsync(Document document, ClassDeclarationSyntax classDeclaration, CancellationToken cancellationToken)
         {
             var generator = SyntaxGenerator.GetGenerator(document);
 
             DeclarationModifiers modifiers = DeclarationModifiers.None;
-            if (methodDeclaration.Modifiers.Any(SyntaxKind.NewKeyword))
+            if (classDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
             {
-                modifiers |= DeclarationModifiers.New;
-            }
-            if (methodDeclaration.Modifiers.Any(SyntaxKind.OverrideKeyword))
-            {
-                modifiers |= DeclarationModifiers.Override;
-            }
-            if (methodDeclaration.Modifiers.Any(SyntaxKind.UnsafeKeyword))
-            {
-                modifiers |= DeclarationModifiers.Unsafe;
+                modifiers |= DeclarationModifiers.Partial;
             }
             modifiers |= DeclarationModifiers.Sealed;
 
-            var newMethodDeclaration = generator.WithModifiers(methodDeclaration, modifiers);
+            var newClassDeclaration = generator.WithModifiers(classDeclaration, modifiers);
 
             var oldRoot = await document.GetSyntaxRootAsync(cancellationToken);
-            var newRoot = oldRoot.ReplaceNode(methodDeclaration, newMethodDeclaration);
+            var newRoot = oldRoot.ReplaceNode(classDeclaration, newClassDeclaration);
 
             // Return document with transformed tree.
             return document.WithSyntaxRoot(newRoot);
-        }
-
-        private MethodDeclarationSyntax GetIncrementTokenMethodDeclaration(ClassDeclarationSyntax classDeclaration)
-        {
-            foreach (var member in classDeclaration.Members.Where(m => m.Kind() == SyntaxKind.MethodDeclaration))
-            {
-                var methodDeclaration = (MethodDeclarationSyntax)member;
-
-                if (methodDeclaration.Identifier.ValueText == "IncrementToken")
-                {
-                    return methodDeclaration;
-                }
-            }
-            return null;
         }
     }
 }

--- a/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedCSAnalyzer.cs
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedCSAnalyzer.cs
@@ -1,0 +1,100 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Lucene.Net.CodeAnalysis
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    // LUCENENET: In Lucene, the TokenStream class had an AssertFinal() method with Reflection code to determine
+    // whether subclasses or their IncrementToken() method were marked sealed. This code was not intended to be
+    // used at runtime. In .NET, debug code is compiled out, and running Reflection code conditionally is not
+    // practical. Instead, this analyzer is installed into the IDE and used at design/build time.
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedCSAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "Lucene1000";
+        private const string Category = "Design";
+
+        private const string Title = "TokenStream derived type or its IncrementToken() method must be marked sealed.";
+        private const string MessageFormat = "Type name '{0}' or its IncrementToken() method must be marked sealed.";
+        private const string Description = "TokenStream derived types or their IncrementToken() method must be marked sealed.";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeNodeCS, Microsoft.CodeAnalysis.CSharp.SyntaxKind.ClassDeclaration);
+        }
+
+        private static void AnalyzeNodeCS(SyntaxNodeAnalysisContext context)
+        {
+            var classDeclaration = (Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax)context.Node;
+
+            var classTypeSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclaration) as ITypeSymbol;
+
+            if (!InheritsFrom(classTypeSymbol, "Lucene.Net.Analysis.TokenStream"))
+            {
+                return;
+            }
+            if (classDeclaration.Modifiers.Any(Microsoft.CodeAnalysis.CSharp.SyntaxKind.SealedKeyword) || classDeclaration.Modifiers.Any(Microsoft.CodeAnalysis.CSharp.SyntaxKind.AbstractKeyword))
+            {
+                return;
+            }
+            foreach (var member in classDeclaration.Members.Where(m => m.Kind() == Microsoft.CodeAnalysis.CSharp.SyntaxKind.MethodDeclaration))
+            {
+                var methodDeclaration = (Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax)member;
+
+                if (methodDeclaration.Identifier.ValueText == "IncrementToken")
+                {
+                    if (methodDeclaration.Modifiers.Any(Microsoft.CodeAnalysis.CSharp.SyntaxKind.SealedKeyword))
+                        return; // The method is marked sealed, check passed
+                    else
+                        break; // The method is not marked sealed, exit the loop and report
+                }
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation(), classDeclaration.Identifier));
+        }
+
+        private static bool InheritsFrom(ITypeSymbol symbol, string expectedParentTypeName)
+        {
+            while (true)
+            {
+                if (symbol.ToString().Equals(expectedParentTypeName))
+                {
+                    return true;
+                }
+
+                if (symbol.BaseType != null)
+                {
+                    symbol = symbol.BaseType;
+                    continue;
+                }
+                break;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene.Net.CodeAnalysis.VisualBasic.csproj
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene.Net.CodeAnalysis.VisualBasic.csproj
@@ -28,7 +28,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPackageVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion)" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>

--- a/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene1000_SealIncrementTokenMethodVBCodeFixProvider.cs
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene1000_SealIncrementTokenMethodVBCodeFixProvider.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.CodeAnalysis
     {
         private const string Title = "Add NotOverridable keyword to IncrementToken() method";
 
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedAnalyzer.DiagnosticId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedVBAnalyzer.DiagnosticId);
 
         public sealed override FixAllProvider GetFixAllProvider()
         {

--- a/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedVBAnalyzer.cs
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedVBAnalyzer.cs
@@ -26,65 +26,28 @@ namespace Lucene.Net.CodeAnalysis
     // whether subclasses or their IncrementToken() method were marked sealed. This code was not intended to be
     // used at runtime. In .NET, debug code is compiled out, and running Reflection code conditionally is not
     // practical. Instead, this analyzer is installed into the IDE and used at design/build time.
-    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public class Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedAnalyzer : DiagnosticAnalyzer
+    [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+    public class Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedVBAnalyzer : DiagnosticAnalyzer
     {
         public const string DiagnosticId = "Lucene1000";
         private const string Category = "Design";
 
-        private const string TitleCS = "TokenStream derived type or its IncrementToken() method must be marked sealed.";
-        private const string MessageFormatCS = "Type name '{0}' or its IncrementToken() method must be marked sealed.";
-        private const string DescriptionCS = "TokenStream derived types or their IncrementToken() method must be marked sealed.";
+        private const string Title = "TokenStream derived type must be marked NotInheritable or its IncrementToken() method must be marked NotOverridable.";
+        private const string MessageFormat = "Type name '{0}' must be marked NotInheritable or its IncrementToken() method must be marked NotOverridable.";
+        private const string Description = "TokenStream derived types must be marked NotInheritable or their IncrementToken() method must be marked NotOverridable.";
 
-        private const string TitleVB = "TokenStream derived type must be marked NotInheritable or its IncrementToken() method must be marked NotOverridable.";
-        private const string MessageFormatVB = "Type name '{0}' must be marked NotInheritable or its IncrementToken() method must be marked NotOverridable.";
-        private const string DescriptionVB = "TokenStream derived types must be marked NotInheritable or their IncrementToken() method must be marked NotOverridable.";
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
 
-        private static readonly DiagnosticDescriptor RuleCS = new DiagnosticDescriptor(DiagnosticId, TitleCS, MessageFormatCS, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: DescriptionCS);
-
-        private static readonly DiagnosticDescriptor RuleVB = new DiagnosticDescriptor(DiagnosticId, TitleVB, MessageFormatVB, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: DescriptionVB);
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RuleCS, RuleVB);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
             context.EnableConcurrentExecution();
-            context.RegisterSyntaxNodeAction(AnalyzeNodeCS, Microsoft.CodeAnalysis.CSharp.SyntaxKind.ClassDeclaration);
-            context.RegisterSyntaxNodeAction(AnalyzeNodeVB, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.ClassBlock);
+            context.RegisterSyntaxNodeAction(AnalyzeNode, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.ClassBlock);
         }
 
-        private static void AnalyzeNodeCS(SyntaxNodeAnalysisContext context)
-        {
-            var classDeclaration = (Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax)context.Node;
-
-            var classTypeSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclaration) as ITypeSymbol;
-
-            if (!InheritsFrom(classTypeSymbol, "Lucene.Net.Analysis.TokenStream"))
-            {
-                return;
-            }
-            if (classDeclaration.Modifiers.Any(Microsoft.CodeAnalysis.CSharp.SyntaxKind.SealedKeyword) || classDeclaration.Modifiers.Any(Microsoft.CodeAnalysis.CSharp.SyntaxKind.AbstractKeyword))
-            {
-                return;
-            }
-            foreach (var member in classDeclaration.Members.Where(m => m.Kind() == Microsoft.CodeAnalysis.CSharp.SyntaxKind.MethodDeclaration))
-            {
-                var methodDeclaration = (Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax)member;
-
-                if (methodDeclaration.Identifier.ValueText == "IncrementToken")
-                {
-                    if (methodDeclaration.Modifiers.Any(Microsoft.CodeAnalysis.CSharp.SyntaxKind.SealedKeyword))
-                        return; // The method is marked sealed, check passed
-                    else
-                        break; // The method is not marked sealed, exit the loop and report
-                }
-            }
-
-            context.ReportDiagnostic(Diagnostic.Create(RuleCS, context.Node.GetLocation(), classDeclaration.Identifier));
-        }
-
-        private static void AnalyzeNodeVB(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var classBlock = (Microsoft.CodeAnalysis.VisualBasic.Syntax.ClassBlockSyntax)context.Node;
 
@@ -115,7 +78,7 @@ namespace Lucene.Net.CodeAnalysis
                 }
             }
 
-            context.ReportDiagnostic(Diagnostic.Create(RuleVB, context.Node.GetLocation(), classDeclaration.Identifier));
+            context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation(), classDeclaration.Identifier));
         }
 
         private static bool InheritsFrom(ITypeSymbol symbol, string expectedParentTypeName)

--- a/src/dotnet/Lucene.Net.Tests.CodeAnalysis/TestLucene1000_SealIncrementTokenMethodCSCodeFixProvider.cs
+++ b/src/dotnet/Lucene.Net.Tests.CodeAnalysis/TestLucene1000_SealIncrementTokenMethodCSCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.CodeAnalysis
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return new Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedAnalyzer();
+            return new Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedCSAnalyzer();
         }
 
 
@@ -72,7 +72,7 @@ namespace MyNamespace
 }";
             var expected = new DiagnosticResult
             {
-                Id = Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedAnalyzer.DiagnosticId,
+                Id = Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedCSAnalyzer.DiagnosticId,
                 Message = String.Format("Type name '{0}' or its IncrementToken() method must be marked sealed.", "TypeName"),
                 Severity = DiagnosticSeverity.Error,
                 Locations =

--- a/src/dotnet/Lucene.Net.Tests.CodeAnalysis/TestLucene1000_SealIncrementTokenMethodVBCodeFixProvider.cs
+++ b/src/dotnet/Lucene.Net.Tests.CodeAnalysis/TestLucene1000_SealIncrementTokenMethodVBCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.CodeAnalysis
 
         protected override DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
         {
-            return new Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedAnalyzer();
+            return new Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedVBAnalyzer();
         }
 
 
@@ -72,7 +72,7 @@ Namespace MyNamespace
 End Namespace";
             var expected = new DiagnosticResult
             {
-                Id = Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedAnalyzer.DiagnosticId,
+                Id = Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedVBAnalyzer.DiagnosticId,
                 Message = String.Format("Type name '{0}' must be marked NotInheritable or its IncrementToken() method must be marked NotOverridable.", "TypeName"),
                 Severity = DiagnosticSeverity.Error,
                 Locations =

--- a/src/dotnet/Lucene.Net.Tests.CodeAnalysis/TestLucene1000_SealTokenStreamClassCSCodeFixProvider.cs
+++ b/src/dotnet/Lucene.Net.Tests.CodeAnalysis/TestLucene1000_SealTokenStreamClassCSCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.CodeAnalysis
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return new Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedAnalyzer();
+            return new Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedCSAnalyzer();
         }
 
 
@@ -72,7 +72,7 @@ namespace MyNamespace
 }";
             var expected = new DiagnosticResult
             {
-                Id = Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedAnalyzer.DiagnosticId,
+                Id = Lucene1000_TokenStreamOrItsIncrementTokenMethodMustBeSealedCSAnalyzer.DiagnosticId,
                 Message = String.Format("Type name '{0}' or its IncrementToken() method must be marked sealed.", "TypeName"),
                 Severity = DiagnosticSeverity.Error,
                 Locations =


### PR DESCRIPTION
This works around the problem by creating separate assemblies for CSharp and VisualBasic that only depend on dependencies for the specific language (fixes #286)