### PR TITLE
Lucene.Net.Replicator: Fixed an issue in IndexInputStream.Read(...)

### DIFF
--- a/src/Lucene.Net.Replicator/IndexInputInputStream.cs
+++ b/src/Lucene.Net.Replicator/IndexInputInputStream.cs
@@ -30,12 +30,10 @@ namespace Lucene.Net.Replicator
     public class IndexInputStream : Stream
     {
         private readonly IndexInput input;
-        private long remaining;
 
         public IndexInputStream(IndexInput input)
         {
             this.input = input;
-            remaining = input.Length;
         }
 
         public override void Flush()
@@ -68,8 +66,9 @@ namespace Lucene.Net.Replicator
         public override int Read(byte[] buffer, int offset, int count)
         {
             int remaining = (int) (input.Length - input.GetFilePointer());
-            input.ReadBytes(buffer, offset, Math.Min(remaining, count));
-            return remaining;
+            int readCount = Math.Min(remaining, count);
+            input.ReadBytes(buffer, offset, readCount);
+            return readCount;
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Lucene.Net.Index;
+using Lucene.Net.Replicator;
+using Lucene.Net.Store;
+using NUnit.Framework;
+
+namespace Lucene.Net.Tests.Replicator
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    //Note: LUCENENET specific
+    public class IndexInputStreamTest
+    {
+        
+        [Test]
+        public void Read_RemainingIndexInputLargerThanReadCount_ReturnsReadCount()
+        {
+            byte[] buffer = new byte[8.KiloBytes()];
+            new Random().NextBytes(buffer);
+            IndexInputStream stream = new IndexInputStream(new MockIndexInput(buffer));
+
+            int readBytes = 2.KiloBytes();
+            byte[] readBuffer = new byte[readBytes];
+            Assert.That(stream.Read(readBuffer, 0, readBytes), Is.EqualTo(readBytes));
+        }
+
+        [Test]
+        public void Read_RemainingIndexInputLargerThanReadCount_ReturnsExpectedSection([Range(1,8)]int section)
+        {
+            byte[] buffer = new byte[8.KiloBytes()];
+            new Random().NextBytes(buffer);
+            IndexInputStream stream = new IndexInputStream(new MockIndexInput(buffer));
+
+            int readBytes = 1.KiloBytes();
+            byte[] readBuffer = new byte[readBytes];
+            for (int i = section; i > 0; i--)
+                stream.Read(readBuffer, 0, readBytes);
+
+            Assert.That(readBuffer, Is.EqualTo(buffer.Skip((section-1) * readBytes).Take(readBytes).ToArray()));
+        }
+
+    }
+
+    //Note: LUCENENET specific
+    internal static class ByteHelperExtensions
+    {
+        public static int KiloBytes(this int value)
+        {
+            return value * 1024;
+        }
+    }
+}

--- a/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Lucene.Net.Attributes;
 using Lucene.Net.Index;
 using Lucene.Net.Replicator;
 using Lucene.Net.Store;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Tests.Replicator
 {
@@ -31,6 +33,7 @@ namespace Lucene.Net.Tests.Replicator
     {
         
         [Test]
+        [LuceneNetSpecific]
         public void Read_RemainingIndexInputLargerThanReadCount_ReturnsReadCount()
         {
             byte[] buffer = new byte[8.KiloBytes()];
@@ -39,10 +42,11 @@ namespace Lucene.Net.Tests.Replicator
 
             int readBytes = 2.KiloBytes();
             byte[] readBuffer = new byte[readBytes];
-            Assert.That(stream.Read(readBuffer, 0, readBytes), Is.EqualTo(readBytes));
+            Assert.AreEqual(stream.Read(readBuffer, 0, readBytes), readBytes);
         }
 
         [Test]
+        [LuceneNetSpecific]
         public void Read_RemainingIndexInputLargerThanReadCount_ReturnsExpectedSection([Range(1,8)]int section)
         {
             byte[] buffer = new byte[8.KiloBytes()];
@@ -53,8 +57,7 @@ namespace Lucene.Net.Tests.Replicator
             byte[] readBuffer = new byte[readBytes];
             for (int i = section; i > 0; i--)
                 stream.Read(readBuffer, 0, readBytes);
-
-            Assert.That(readBuffer, Is.EqualTo(buffer.Skip((section-1) * readBytes).Take(readBytes).ToArray()));
+            Assert.AreEqual(readBuffer, buffer.Skip((section - 1) * readBytes).Take(readBytes).ToArray());
         }
 
     }

--- a/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
@@ -29,6 +29,7 @@ namespace Lucene.Net.Tests.Replicator
      */
 
     //Note: LUCENENET specific
+    [LuceneNetSpecific]
     public class IndexInputStreamTest
     {
         


### PR DESCRIPTION
Lucene.Net.Replicator: Fixed an issue in IndexInputStream.Read(...) that meant the method could return a number larger than what was passed in for read count or what the buffer could hold.

It should instead return the total number of bytes that was read into the buffer, which logically can't be bigger than the buffer it self.

This would make implementations like [Stream.CopyTo](https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.copyto?view=netcore-3.1) fail as it relies on the returned number to tell how much to write into the target stream. 
