### PR TITLE
Fixes 4 failing tests in .NET Framework/x86

### DIFF
--- a/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
+++ b/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Search.Similarities;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Sandbox.Queries
@@ -363,6 +364,9 @@ namespace Lucene.Net.Sandbox.Queries
             /// (non-Javadoc)
             /// <see cref="Util.PriorityQueue{T}.LessThan(T, T)"/>
             /// </summary>
+#if NETFRAMEWORK
+            [MethodImpl(MethodImplOptions.NoOptimization)] // LUCENENET specific: comparing score equality fails in x86 on .NET Framework with optimizations enabled
+#endif
             protected internal override bool LessThan(ScoreTerm termA, ScoreTerm termB)
             {
                 if (termA.Score == termB.Score)

--- a/src/Lucene.Net.Sandbox/Queries/SlowFuzzyTermsEnum.cs
+++ b/src/Lucene.Net.Sandbox/Queries/SlowFuzzyTermsEnum.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Search;
 using Lucene.Net.Util;
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Sandbox.Queries
 {
@@ -120,6 +121,9 @@ namespace Lucene.Net.Sandbox.Queries
             /// where distance is the Levenshtein distance for the two words.
             /// </para>
             /// </summary>
+#if NETFRAMEWORK
+            [MethodImpl(MethodImplOptions.NoOptimization)] // LUCENENET specific: comparing float equality fails in x86 on .NET Framework with optimizations enabled. Fixes TestTokenLengthOpt.
+#endif
             protected override sealed AcceptStatus Accept(BytesRef term)
             {
                 if (StringHelper.StartsWith(term, prefixBytesRef))

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1269,8 +1269,7 @@ namespace Lucene.Net.Util
                 return testClass;
 
             // 2nd attempt - try scanning the referenced assemblies to see if we can find the class by fullname
-            var referencedAssemblies = AssemblyUtils.GetReferencedAssemblies();
-            testClass = referencedAssemblies.SelectMany(a => a.GetTypes().Where(t => t.FullName == testClassName)).FirstOrDefault();
+            testClass = AssemblyUtils.GetReferencedAssemblies().SelectMany(a => a.GetTypes().Where(t => t.FullName == testClassName)).FirstOrDefault();
             if (testClass != null)
                 return testClass;
 #endif

--- a/src/Lucene.Net/Search/FuzzyTermsEnum.cs
+++ b/src/Lucene.Net/Search/FuzzyTermsEnum.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search
@@ -381,6 +382,9 @@ namespace Lucene.Net.Search
 
             /// <summary>
             /// Finds the smallest Lev(n) DFA that accepts the term. </summary>
+#if NETFRAMEWORK
+            [MethodImpl(MethodImplOptions.NoOptimization)] // LUCENENET specific: comparing float equality fails in x86 on .NET Framework with optimizations enabled, and is causing the TestTokenLengthOpt test to fail
+#endif
             protected override AcceptStatus Accept(BytesRef term)
             {
                 //System.out.println("AFTE.accept term=" + term);

--- a/src/Lucene.Net/Search/TopScoreDocCollector.cs
+++ b/src/Lucene.Net/Search/TopScoreDocCollector.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Search
 {
@@ -46,6 +47,9 @@ namespace Lucene.Net.Search
             {
             }
 
+#if NETFRAMEWORK
+            [MethodImpl(MethodImplOptions.NoOptimization)] // LUCENENET specific: comparing float equality fails in x86 on .NET Framework with optimizations enabled
+#endif
             public override void Collect(int doc)
             {
                 float score = scorer.GetScore();
@@ -89,6 +93,9 @@ namespace Lucene.Net.Search
                 this.after = after;
             }
 
+#if NETFRAMEWORK
+            [MethodImpl(MethodImplOptions.NoOptimization)] // LUCENENET specific: comparing float equality fails in x86 on .NET Framework with optimizations enabled
+#endif
             public override void Collect(int doc)
             {
                 float score = scorer.GetScore();
@@ -146,6 +153,9 @@ namespace Lucene.Net.Search
             {
             }
 
+#if NETFRAMEWORK
+            [MethodImpl(MethodImplOptions.NoOptimization)] // LUCENENET specific: comparing float equality fails in x86 on .NET Framework with optimizations enabled
+#endif
             public override void Collect(int doc)
             {
                 float score = scorer.GetScore();
@@ -189,6 +199,9 @@ namespace Lucene.Net.Search
                 this.after = after;
             }
 
+#if NETFRAMEWORK
+            [MethodImpl(MethodImplOptions.NoOptimization)] // LUCENENET specific: comparing float equality fails in x86 on .NET Framework with optimizations enabled
+#endif
             public override void Collect(int doc)
             {
                 float score = scorer.GetScore();
@@ -302,7 +315,7 @@ namespace Lucene.Net.Search
             // it means the largest element is already in results, use its score as
             // maxScore. Otherwise pop everything else, until the largest element is
             // extracted and use its score as maxScore.
-            float maxScore = float.NaN;
+            float maxScore/* = float.NaN*/; // LUCENENET: Removed unnecessary assignment
             if (start == 0)
             {
                 maxScore = results[0].Score;

--- a/src/Lucene.Net/Support/AssemblyUtils.cs
+++ b/src/Lucene.Net/Support/AssemblyUtils.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Support
         /// Microsoft assemblies here.
         /// </summary>
         /// <returns></returns>
-        public static IList<Assembly> GetReferencedAssemblies()
+        public static IEnumerable<Assembly> GetReferencedAssemblies()
         {
             // .NET Port Hack: We do a 2-level deep check here because if the assembly you're
             // hoping would be loaded hasn't been loaded yet into the app domain,
@@ -55,9 +55,9 @@ namespace Lucene.Net.Support
                 .Distinct();
             var assembliesLoaded = LoadAssemblyFromName(assemblyNames);
 #endif
-            assembliesLoaded = assembliesLoaded.Where(x => !DotNetFrameworkFilter.IsFrameworkAssembly(x)).ToArray();
+            var nonFrameworkAssembliesLoaded = assembliesLoaded.Where(x => !DotNetFrameworkFilter.IsFrameworkAssembly(x));
 
-            var referencedAssemblies = assembliesLoaded
+            var referencedAssemblies = nonFrameworkAssembliesLoaded
                 .SelectMany(assembly =>
                 {
                     return assembly
@@ -68,7 +68,7 @@ namespace Lucene.Net.Support
                 .Where(x => x != null)
                 .Distinct();
 
-            return assembliesLoaded.Concat(referencedAssemblies).Distinct().ToList();
+            return nonFrameworkAssembliesLoaded.Concat(referencedAssemblies).Distinct();
         }
 
 #if !FEATURE_APPDOMAIN_GETASSEMBLIES


### PR DESCRIPTION
This fixes tests that are failing due to floating point precision issues on x86 when optimized. Disabling optimizations on specific methods fixes the following tests:

- `Lucene.Net.Sandbox.TestSlowFuzzyQuery::TestTokenLengthOpt()`
- `Lucene.Net.Search.TestSearchAfter::TestQueries()`
- `Lucene.Net.Search.TestTopDocsMerge::TestSort_1()`
- `Lucene.Net.Search.TestTopDocsMerge::TestSort_2()`

as recorded in #269.