### PR TITLE
Fixed several references to J2N.BitConversion

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
@@ -161,7 +161,7 @@ namespace Lucene.Net.Index
                         Assert.AreEqual(text, hitDoc.Get("fieldname"));
                         if (Debugging.AssertsEnabled) Debugging.Assert(ireader.Leaves.Count == 1);
                         NumericDocValues dv = ((AtomicReader)((AtomicReader)ireader.Leaves[0].Reader)).GetNumericDocValues("dv");
-                        Assert.AreEqual((long)J2N.BitConversion.SingleToInt32Bits(5.7f), dv.Get(hits.ScoreDocs[i].Doc)); // LUCENENET specific - cast required because types don't match (xUnit checks this)
+                        Assert.AreEqual((long)J2N.BitConversion.SingleToRawInt32Bits(5.7f), dv.Get(hits.ScoreDocs[i].Doc)); // LUCENENET specific - cast required because types don't match (xUnit checks this)
                     }
                 } // ireader.Dispose();
             } // directory.Dispose();

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
@@ -708,7 +708,7 @@ namespace Lucene.Net.Codecs.Compressing
             // start offsets
             for (int i = 0; i < fieldNums.Length; ++i)
             {
-                vectorsStream.WriteInt32(J2N.BitConversion.SingleToInt32Bits(charsPerTerm[i]));
+                vectorsStream.WriteInt32(J2N.BitConversion.SingleToRawInt32Bits(charsPerTerm[i]));
             }
 
             writer.Reset(vectorsStream);

--- a/src/Lucene.Net/Document/FloatDocValuesField.cs
+++ b/src/Lucene.Net/Document/FloatDocValuesField.cs
@@ -43,13 +43,13 @@ namespace Lucene.Net.Documents
         /// <param name="value"> 32-bit <see cref="float"/> value </param>
         /// <exception cref="ArgumentNullException"> if the field name is <c>null</c> </exception>
         public SingleDocValuesField(string name, float value)
-            : base(name, BitConversion.SingleToInt32Bits(value))
+            : base(name, BitConversion.SingleToRawInt32Bits(value))
         {
         }
 
         public override void SetSingleValue(float value)
         {
-            base.SetInt64Value(BitConversion.SingleToInt32Bits(value));
+            base.SetInt64Value(BitConversion.SingleToRawInt32Bits(value));
         }
 
         public override void SetInt64Value(long value)

--- a/src/Lucene.Net/Search/Spans/FieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net/Search/Spans/FieldMaskingSpanQuery.cs
@@ -149,7 +149,7 @@ namespace Lucene.Net.Search.Spans
 
         public override int GetHashCode()
         {
-            return MaskedQuery.GetHashCode() ^ Field.GetHashCode() ^ J2N.BitConversion.SingleToInt32Bits(Boost);
+            return MaskedQuery.GetHashCode() ^ Field.GetHashCode() ^ J2N.BitConversion.SingleToRawInt32Bits(Boost);
         }
     }
 }


### PR DESCRIPTION
Fixed several references to `J2N.BitConversion` that were calling the overload that normalizes NaN when they should have been calling the raw bit conversion instead. This is to match Lucene's behavior, but only affects those who are storing NaN in the index.