### PR TITLE
BREAKING: Changed CaptializationFilter default culture to invariant to match Lucene

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/CapitalizationFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/CapitalizationFilterFactory.cs
@@ -38,6 +38,8 @@ namespace Lucene.Net.Analysis.Miscellaneous
     /// minWordLength is 3, "and" > "And" but "or" stays "or"<para/>
     /// "maxWordCount" - if the token contains more then maxWordCount words, the capitalization is
     /// assumed to be correct.<para/>
+    /// "culture" - the culture to use to apply the capitalization rules. If not supplied or the string
+    /// "invariant" is supplied, the invariant culture is used.<para/>
     /// 
     /// <code>
     /// &lt;fieldType name="text_cptlztn" class="solr.TextField" positionIncrementGap="100"&gt;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCapitalizationFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCapitalizationFilter.cs
@@ -73,8 +73,8 @@ namespace Lucene.Net.Analysis.Miscellaneous
         internal static void AssertCapitalizesTo(Tokenizer tokenizer, string[] expected, bool onlyFirstWord, CharArraySet keep, bool forceFirstLetter, ICollection<char[]> okPrefix, int minWordLength, int maxWordCount, int maxTokenLength)
         {
             CapitalizationFilter filter = new CapitalizationFilter(tokenizer, onlyFirstWord, keep, forceFirstLetter, okPrefix, minWordLength, maxWordCount, maxTokenLength,
-                // LUCENENET specific - pass in the invariant culture to get the same behavior as Lucene,
-                // otherwise the filter is culture-sensitive.
+                // LUCENENET specific - pass in the invariant culture to get the same behavior as Lucene.
+                // This is the default, but it makes the test more readable.
                 CultureInfo.InvariantCulture);
             AssertTokenStreamContents(filter, expected);
         }


### PR DESCRIPTION
Changed default behavior to use invariant culture instead of the current thread's culture to match Lucene, which seems more natural when using filters inside of analyzers.