### PR TITLE
Reduced FieldCacheImpl casting/boxing

### DIFF
--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -363,25 +363,36 @@ namespace Lucene.Net.Search
         /// <summary>
         /// Field values as 8-bit signed bytes
         /// </summary>
-        public abstract class Bytes
+        public class Bytes // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
+            private readonly Func<int, byte> get;
+            private readonly bool hasGet;
+
             /// <summary>
-            /// Return a single Byte representation of this field's value.
+            /// Initialize an instance of <see cref="Bytes"/>.
             /// </summary>
-            public abstract byte Get(int docID);
+            protected Bytes() { } // LUCENENET specific - Added default constructor for subclasses
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Bytes"/> with the specified
+            /// <paramref name="get"/> delegate method.
+            /// </summary>
+            /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
+            public Bytes(Func<int, byte> get) 
+            {
+                this.get = get ?? throw new ArgumentNullException(nameof(get));
+                this.hasGet = true;
+            }
+
+            /// <summary>
+            /// Return a single <see cref="byte"/> representation of this field's value.
+            /// </summary>
+            public virtual byte Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Bytes EMPTY = new EmptyBytes();
-
-            private sealed class EmptyBytes : Bytes
-            {
-                public override byte Get(int docID)
-                {
-                    return 0;
-                }
-            }
+            public static readonly Bytes EMPTY = new Bytes((docID) => 0);
         }
 
         /// <summary>
@@ -389,25 +400,36 @@ namespace Lucene.Net.Search
         /// <para/>
         /// NOTE: This was Shorts in Lucene
         /// </summary>
-        public abstract class Int16s
+        public class Int16s // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
+            private readonly Func<int, short> get;
+            private readonly bool hasGet;
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Int16s"/>.
+            /// </summary>
+            protected Int16s() { } // LUCENENET specific - Added default constructor for subclasses
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Int16s"/> with the specified
+            /// <paramref name="get"/> delegate method.
+            /// </summary>
+            /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
+            public Int16s(Func<int, short> get)
+            {
+                this.get = get ?? throw new ArgumentNullException(nameof(get));
+                this.hasGet = true;
+            }
+
             /// <summary>
             /// Return a <see cref="short"/> representation of this field's value.
             /// </summary>
-            public abstract short Get(int docID);
+            public virtual short Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Int16s EMPTY = new EmptyInt16s();
-
-            private sealed class EmptyInt16s : Int16s
-            {
-                public override short Get(int docID)
-                {
-                    return 0;
-                }
-            }
+            public static readonly Int16s EMPTY = new Int16s((docID) => 0);
         }
 
         /// <summary>
@@ -415,25 +437,36 @@ namespace Lucene.Net.Search
         /// <para/>
         /// NOTE: This was Ints in Lucene
         /// </summary>
-        public abstract class Int32s
+        public class Int32s // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
+            private readonly Func<int, int> get;
+            private readonly bool hasGet;
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Int32s"/>.
+            /// </summary>
+            protected Int32s() { } // LUCENENET specific - Added default constructor for subclasses
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Int32s"/> with the specified
+            /// <paramref name="get"/> delegate method.
+            /// </summary>
+            /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
+            public Int32s(Func<int, int> get)
+            {
+                this.get = get ?? throw new ArgumentNullException(nameof(get));
+                this.hasGet = true;
+            }
+
             /// <summary>
             /// Return an <see cref="int"/> representation of this field's value.
             /// </summary>
-            public abstract int Get(int docID);
+            public virtual int Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Int32s EMPTY = new EmptyInt32s();
-
-            private sealed class EmptyInt32s : Int32s
-            {
-                public override int Get(int docID)
-                {
-                    return 0;
-                }
-            }
+            public static readonly Int32s EMPTY = new Int32s((docID) => 0);
         }
 
         /// <summary>
@@ -441,25 +474,36 @@ namespace Lucene.Net.Search
         /// <para/>
         /// NOTE: This was Longs in Lucene
         /// </summary>
-        public abstract class Int64s
+        public class Int64s // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
+            private readonly Func<int, long> get;
+            private readonly bool hasGet;
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Int64s"/>.
+            /// </summary>
+            protected Int64s() { } // LUCENENET specific - Added default constructor for subclasses
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Int64s"/> with the specified
+            /// <paramref name="get"/> delegate method.
+            /// </summary>
+            /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
+            public Int64s(Func<int, long> get)
+            {
+                this.get = get ?? throw new ArgumentNullException(nameof(get));
+                this.hasGet = true;
+            }
+
             /// <summary>
             /// Return an <see cref="long"/> representation of this field's value.
             /// </summary>
-            public abstract long Get(int docID);
+            public virtual long Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Int64s EMPTY = new EmptyInt64s();
-
-            private sealed class EmptyInt64s : Int64s
-            {
-                public override long Get(int docID)
-                {
-                    return 0;
-                }
-            }
+            public static readonly Int64s EMPTY = new Int64s((docID) => 0);
         }
 
         /// <summary>
@@ -467,50 +511,71 @@ namespace Lucene.Net.Search
         /// <para/>
         /// NOTE: This was Floats in Lucene
         /// </summary>
-        public abstract class Singles
+        public class Singles // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
+            private readonly Func<int, float> get;
+            private readonly bool hasGet;
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Singles"/>.
+            /// </summary>
+            protected Singles() { } // LUCENENET specific - Added default constructor for subclasses
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Singles"/> with the specified
+            /// <paramref name="get"/> delegate method.
+            /// </summary>
+            /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
+            public Singles(Func<int, float> get)
+            {
+                this.get = get ?? throw new ArgumentNullException(nameof(get));
+                this.hasGet = true;
+            }
+
             /// <summary>
             /// Return an <see cref="float"/> representation of this field's value.
             /// </summary>
-            public abstract float Get(int docID);
+            public virtual float Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Singles EMPTY = new EmptySingles();
-
-            private sealed class EmptySingles : Singles
-            {
-                public override float Get(int docID)
-                {
-                    return 0;
-                }
-            }
+            public static readonly Singles EMPTY = new Singles((docID) => 0);
         }
 
         /// <summary>
         /// Field values as 64-bit doubles
         /// </summary>
-        public abstract class Doubles
+        public class Doubles // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
+            private readonly Func<int, double> get;
+            private readonly bool hasGet;
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Doubles"/>.
+            /// </summary>
+            protected Doubles() { } // LUCENENET specific - Added default constructor for subclasses
+
+            /// <summary>
+            /// Initialize an instance of <see cref="Doubles"/> with the specified
+            /// <paramref name="get"/> delegate method.
+            /// </summary>
+            /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
+            public Doubles(Func<int, double> get)
+            {
+                this.get = get ?? throw new ArgumentNullException(nameof(get));
+                this.hasGet = true;
+            }
+
             /// <summary>
             /// Return a <see cref="double"/> representation of this field's value.
             /// </summary>
-            /// <param name="docID"></param>
-            public abstract double Get(int docID);
+            public virtual double Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Doubles EMPTY = new EmptyDoubles();
-
-            private sealed class EmptyDoubles : Doubles
-            {
-                public override double Get(int docID)
-                {
-                    return 0;
-                }
-            }
+            public static readonly Doubles EMPTY = new Doubles((docID) => 0);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -579,11 +579,17 @@ namespace Lucene.Net.Search
         }
 
         /// <summary>
+        /// Interface used to identify a <see cref="CreationPlaceholder{TValue}"/> without
+        /// referencing its generic closing type.
+        /// </summary>
+        public interface ICreationPlaceholder { }
+
+        /// <summary>
         /// Placeholder indicating creation of this cache is currently in-progress.
         /// </summary>
-        public sealed class CreationPlaceholder
+        public sealed class CreationPlaceholder<TValue> : ICreationPlaceholder
         {
-            internal object Value { get; set; }
+            internal TValue Value { get; set; }
         }
 
         /// <summary>

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -59,16 +59,16 @@ namespace Lucene.Net.Search
     internal class FieldCacheImpl : IFieldCache
     {
         // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-        private Cache caches_typeof_sbyte;
-        private Cache caches_typeof_short;
-        private Cache caches_typeof_int;
-        private Cache caches_typeof_float;
-        private Cache caches_typeof_long;
-        private Cache caches_typeof_double;
-        private Cache caches_typeof_BinaryDocValues;
-        private Cache caches_typeof_SortedDocValues;
-        private Cache caches_typeof_DocTermOrds;
-        private Cache caches_typeof_DocsWithFieldCache;
+        private ByteCache caches_typeof_sbyte;
+        private Int16Cache caches_typeof_short;
+        private Int32Cache caches_typeof_int;
+        private SingleCache caches_typeof_float;
+        private Int64Cache caches_typeof_long;
+        private DoubleCache caches_typeof_double;
+        private BinaryDocValuesCache caches_typeof_BinaryDocValues;
+        private SortedDocValuesCache caches_typeof_SortedDocValues;
+        private DocTermOrdsCache caches_typeof_DocTermOrds;
+        private DocsWithFieldCache caches_typeof_DocsWithFieldCache;
         internal FieldCacheImpl()
         {
             Init();
@@ -80,20 +80,19 @@ namespace Lucene.Net.Search
 
         private void Init()
         {
-            lock (this)
-            {
-                // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-                caches_typeof_sbyte              = new ByteCache(this);
-                caches_typeof_short              = new Int16Cache(this);
-                caches_typeof_int                = new Int32Cache(this);
-                caches_typeof_float              = new SingleCache(this);
-                caches_typeof_long               = new Int64Cache(this);
-                caches_typeof_double             = new DoubleCache(this);
-                caches_typeof_BinaryDocValues    = new BinaryDocValuesCache(this);
-                caches_typeof_SortedDocValues    = new SortedDocValuesCache(this);
-                caches_typeof_DocTermOrds        = new DocTermOrdsCache(this);
-                caches_typeof_DocsWithFieldCache = new DocsWithFieldCache(this);
-            }
+            // LUCENENET specific - removed unnecessary lock during construction
+
+            // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
+            caches_typeof_sbyte              = new ByteCache(this);
+            caches_typeof_short              = new Int16Cache(this);
+            caches_typeof_int                = new Int32Cache(this);
+            caches_typeof_float              = new SingleCache(this);
+            caches_typeof_long               = new Int64Cache(this);
+            caches_typeof_double             = new DoubleCache(this);
+            caches_typeof_BinaryDocValues    = new BinaryDocValuesCache(this);
+            caches_typeof_SortedDocValues    = new SortedDocValuesCache(this);
+            caches_typeof_DocTermOrds        = new DocTermOrdsCache(this);
+            caches_typeof_DocsWithFieldCache = new DocsWithFieldCache(this);
         }
 
         public virtual void PurgeAllCaches()
@@ -104,66 +103,65 @@ namespace Lucene.Net.Search
             }
         }
 
-        // LUCENENET specific - added GetCaches() to allow looping over the caches even though they are no longer in a collection
-        private IEnumerable<KeyValuePair<Type, Cache>> GetCaches()
-        {
-            yield return new KeyValuePair<Type, Cache>(typeof(sbyte), caches_typeof_sbyte);
-            yield return new KeyValuePair<Type, Cache>(typeof(short), caches_typeof_short);
-            yield return new KeyValuePair<Type, Cache>(typeof(int), caches_typeof_int);
-            yield return new KeyValuePair<Type, Cache>(typeof(float), caches_typeof_float);
-            yield return new KeyValuePair<Type, Cache>(typeof(long), caches_typeof_long);
-            yield return new KeyValuePair<Type, Cache>(typeof(double), caches_typeof_double);
-            yield return new KeyValuePair<Type, Cache>(typeof(BinaryDocValues), caches_typeof_BinaryDocValues);
-            yield return new KeyValuePair<Type, Cache>(typeof(SortedDocValues), caches_typeof_SortedDocValues);
-            yield return new KeyValuePair<Type, Cache>(typeof(DocTermOrds), caches_typeof_DocTermOrds);
-            yield return new KeyValuePair<Type, Cache>(typeof(DocsWithFieldCache), caches_typeof_DocsWithFieldCache);
-        }
-
         public virtual void PurgeByCacheKey(object coreCacheKey)
         {
             lock (this)
             {
-                // LUCENENET specific - added GetCaches() to allow looping over the caches even though they are no longer in a collection
-                foreach (var kv in GetCaches())
-                {
-                    kv.Value.PurgeByCacheKey(coreCacheKey);
-                }
+                // LUCENENET specific - removed unnecessary Dictionary and loop
+                caches_typeof_sbyte.PurgeByCacheKey(coreCacheKey);
+                caches_typeof_short.PurgeByCacheKey(coreCacheKey);
+                caches_typeof_int.PurgeByCacheKey(coreCacheKey);
+                caches_typeof_float.PurgeByCacheKey(coreCacheKey);
+                caches_typeof_long.PurgeByCacheKey(coreCacheKey);
+                caches_typeof_double.PurgeByCacheKey(coreCacheKey);
+                caches_typeof_BinaryDocValues.PurgeByCacheKey(coreCacheKey);
+                caches_typeof_SortedDocValues.PurgeByCacheKey(coreCacheKey);
+                caches_typeof_DocTermOrds.PurgeByCacheKey(coreCacheKey);
+                caches_typeof_DocsWithFieldCache.PurgeByCacheKey(coreCacheKey);
             }
         }
 
         public virtual FieldCache.CacheEntry[] GetCacheEntries()
         {
+            // LUCENENET specific - instantiate/ToArray() outside of lock to improve performance
+            IList<FieldCache.CacheEntry> result = new List<FieldCache.CacheEntry>(17);
             lock (this)
             {
-                IList<FieldCache.CacheEntry> result = new List<FieldCache.CacheEntry>(17);
-                // LUCENENET specific - added GetCaches() to allow looping over the caches even though they are no longer in a collection
-                foreach (var cacheEntry in GetCaches())
+                // LUCENENET specific - refactored to use generic CacheKey to reduce casting and removed unnecessary Dictionary/loop
+                AddCacheEntries(result, typeof(sbyte), caches_typeof_sbyte);
+                AddCacheEntries(result, typeof(short), caches_typeof_short);
+                AddCacheEntries(result, typeof(int), caches_typeof_int);
+                AddCacheEntries(result, typeof(float), caches_typeof_float);
+                AddCacheEntries(result, typeof(long), caches_typeof_long);
+                AddCacheEntries(result, typeof(double), caches_typeof_double);
+                AddCacheEntries(result, typeof(BinaryDocValues), caches_typeof_BinaryDocValues);
+                AddCacheEntries(result, typeof(SortedDocValues), caches_typeof_SortedDocValues);
+                AddCacheEntries(result, typeof(DocTermOrds), caches_typeof_DocTermOrds);
+                AddCacheEntries(result, typeof(DocsWithFieldCache), caches_typeof_DocsWithFieldCache);
+            }
+            return result.ToArray();
+        }
+
+        private void AddCacheEntries<TCacheKey>(IList<FieldCache.CacheEntry> result, Type cacheType, Cache<TCacheKey> cache) where TCacheKey : CacheKey
+        {
+#if !FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR
+            lock (cache.readerCache)
+#endif
+            {
+                foreach (var readerCacheEntry in cache.readerCache)
                 {
-                    Cache cache = cacheEntry.Value;
-                    Type cacheType = cacheEntry.Key;
-#if !FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR
-                    lock (cache.readerCache)
+                    object readerKey = readerCacheEntry.Key;
+                    if (readerKey is null)
                     {
-#endif
-                        foreach (var readerCacheEntry in cache.readerCache)
-                        {
-                            object readerKey = readerCacheEntry.Key;
-                            if (readerKey == null)
-                            {
-                                continue;
-                            }
-                            IDictionary<CacheKey, object> innerCache = readerCacheEntry.Value;
-                            foreach (KeyValuePair<CacheKey, object> mapEntry in innerCache)
-                            {
-                                CacheKey entry = mapEntry.Key;
-                                result.Add(new FieldCache.CacheEntry(readerKey, entry.field, cacheType, entry.custom, mapEntry.Value));
-                            }
-                        }
-#if !FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR
+                        continue;
                     }
-#endif
+                    IDictionary<TCacheKey, object> innerCache = readerCacheEntry.Value;
+                    foreach (KeyValuePair<TCacheKey, object> mapEntry in innerCache)
+                    {
+                        TCacheKey entry = mapEntry.Key;
+                        result.Add(new FieldCache.CacheEntry(readerKey, entry.field, cacheType, entry.Custom, mapEntry.Value));
+                    }
                 }
-                return result.ToArray();
             }
         }
 
@@ -229,7 +227,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Expert: Internal cache. </summary>
-        internal abstract class Cache
+        internal abstract class Cache<TCacheKey> where TCacheKey : CacheKey
         {
             internal Cache(FieldCacheImpl wrapper)
             {
@@ -239,12 +237,12 @@ namespace Lucene.Net.Search
             internal readonly FieldCacheImpl wrapper;
 
 #if FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR
-            internal ConditionalWeakTable<object, ConcurrentDictionary<CacheKey, object>> readerCache = new ConditionalWeakTable<object, ConcurrentDictionary<CacheKey, object>>();
+            internal ConditionalWeakTable<object, ConcurrentDictionary<TCacheKey, object>> readerCache = new ConditionalWeakTable<object, ConcurrentDictionary<TCacheKey, object>>();
 #else
-            internal WeakDictionary<object, ConcurrentDictionary<CacheKey, object>> readerCache = new WeakDictionary<object, ConcurrentDictionary<CacheKey, object>>();
+            internal WeakDictionary<object, ConcurrentDictionary<TCacheKey, object>> readerCache = new WeakDictionary<object, ConcurrentDictionary<TCacheKey, object>>();
 #endif
 
-            protected abstract object CreateValue(AtomicReader reader, CacheKey key, bool setDocsWithField);
+            protected abstract object CreateValue(AtomicReader reader, TCacheKey key, bool setDocsWithField);
 
             /// <summary>
             /// Remove this reader from the cache, if present. </summary>
@@ -260,16 +258,16 @@ namespace Lucene.Net.Search
             /// Sets the key to the value for the provided reader;
             /// if the key is already set then this doesn't change it.
             /// </summary>
-            public virtual void Put(AtomicReader reader, CacheKey key, object value)
+            public virtual void Put(AtomicReader reader, TCacheKey key, object value)
             {
-                ConcurrentDictionary<CacheKey, object> innerCache;
+                ConcurrentDictionary<TCacheKey, object> innerCache;
                 object readerKey = reader.CoreCacheKey;
 #if FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR
                 innerCache = readerCache.GetValue(readerKey, (readerKey) =>
                 {
                     // First time this reader is using FieldCache
                     wrapper.InitReader(reader);
-                    return new ConcurrentDictionary<CacheKey, object>
+                    return new ConcurrentDictionary<TCacheKey, object>
                     {
                         [key] = value
                     };
@@ -280,7 +278,7 @@ namespace Lucene.Net.Search
                     if (!readerCache.TryGetValue(readerKey, out innerCache) || innerCache == null)
                     {
                         // First time this reader is using FieldCache
-                        innerCache = new ConcurrentDictionary<CacheKey, object>
+                        innerCache = new ConcurrentDictionary<TCacheKey, object>
                         {
                             [key] = value
                         };
@@ -293,16 +291,16 @@ namespace Lucene.Net.Search
                 innerCache.TryAdd(key, value);
             }
 
-            public virtual object Get(AtomicReader reader, CacheKey key, bool setDocsWithField)
+            public virtual object Get(AtomicReader reader, TCacheKey key, bool setDocsWithField)
             {
-                ConcurrentDictionary<CacheKey, object> innerCache;
+                ConcurrentDictionary<TCacheKey, object> innerCache;
                 object readerKey = reader.CoreCacheKey;
 #if FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR
                 innerCache = readerCache.GetValue(readerKey, (readerKey) =>
                 {
                     // First time this reader is using FieldCache
                     wrapper.InitReader(reader);
-                    return new ConcurrentDictionary<CacheKey, object>
+                    return new ConcurrentDictionary<TCacheKey, object>
                     {
                         [key] = new FieldCache.CreationPlaceholder()
                     };
@@ -314,7 +312,7 @@ namespace Lucene.Net.Search
                     if (!readerCache.TryGetValue(readerKey, out innerCache) || innerCache == null)
                     {
                         // First time this reader is using FieldCache
-                        innerCache = new ConcurrentDictionary<CacheKey, object>
+                        innerCache = new ConcurrentDictionary<TCacheKey, object>
                         {
                             [key] = new FieldCache.CreationPlaceholder()
                         };
@@ -336,7 +334,7 @@ namespace Lucene.Net.Search
                                 // Only check if key.custom (the parser) is
                                 // non-null; else, we check twice for a single
                                 // call to FieldCache.getXXX
-                                if (key.custom != null && wrapper != null)
+                                if (!(key.Custom is null) && wrapper != null)
                                 {
                                     TextWriter infoStream = wrapper.InfoStream;
                                     if (infoStream != null)
@@ -378,16 +376,19 @@ namespace Lucene.Net.Search
         /// Expert: Every composite-key in the internal cache is of this type. </summary>
         internal class CacheKey
         {
-            internal readonly string field; // which Field 
-            internal readonly object custom; // which custom comparer or parser 
+            internal readonly string field; // which Field
+            // LUCENENET specific - moved 'custom' to generic class so we don't have to deal with casting/boxing
 
             /// <summary>
             /// Creates one of these objects for a custom comparer/parser. </summary>
-            internal CacheKey(string field, object custom)
+            internal CacheKey(string field)
             {
                 this.field = field;
-                this.custom = custom;
             }
+
+            // LUCENENET specific - Added this property to add this value to a FieldCache.CacheEntry without
+            // knowing its generic closing type.
+            public virtual object Custom => null;
 
             /// <summary>
             /// Two of these are equal if they reference the same field and type. </summary>
@@ -395,15 +396,65 @@ namespace Lucene.Net.Search
             {
                 if (o is CacheKey)
                 {
+#pragma warning disable IDE0020 // Use pattern matching
                     CacheKey other = (CacheKey)o;
+#pragma warning restore IDE0020 // Use pattern matching
                     if (other.field.Equals(field, StringComparison.Ordinal))
                     {
-                        if (other.custom == null)
+                        if (other.Custom is null)
                         {
-                            if (custom == null)
-                            {
-                                return true;
-                            }
+                            return Custom is null;
+                        }
+                        else if (other.Custom.Equals(Custom))
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Composes a hashcode based on the field and type. </summary>
+#pragma warning disable IDE0070 // Use 'System.HashCode'
+            public override int GetHashCode()
+#pragma warning restore IDE0070 // Use 'System.HashCode'
+            {
+                return field.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        /// Expert: Every composite-key in the internal cache is of this type. </summary>
+        // LUCENENET specific - Added generic parameter to eliminate casting/boxing
+        internal class CacheKey<TCustom> : CacheKey
+        {
+            internal readonly TCustom custom; // which custom comparer or parser 
+
+            /// <summary>
+            /// Creates one of these objects for a custom comparer/parser. </summary>
+            internal CacheKey(string field, TCustom custom)
+                : base(field)
+            {
+                this.custom = custom;
+            }
+
+            public override object Custom => custom;
+
+            /// <summary>
+            /// Two of these are equal if they reference the same field and type. </summary>
+            public override bool Equals(object o)
+            {
+                if (o is CacheKey<TCustom>)
+                {
+#pragma warning disable IDE0020 // Use pattern matching
+                    CacheKey<TCustom> other = (CacheKey<TCustom>)o;
+#pragma warning restore IDE0020 // Use pattern matching
+                    if (other.field.Equals(field, StringComparison.Ordinal))
+                    {
+                        if (other.custom is null)
+                        {
+                            return custom is null;
                         }
                         else if (other.custom.Equals(custom))
                         {
@@ -509,7 +560,7 @@ namespace Lucene.Net.Search
                 bits = docsWithField;
             }
             // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-            caches_typeof_DocsWithFieldCache.Put(reader, new CacheKey(field, null), bits);
+            caches_typeof_DocsWithFieldCache.Put(reader, new CacheKey(field), bits);
         }
 
         /// <summary>
@@ -556,7 +607,9 @@ namespace Lucene.Net.Search
                     return FieldCache.Bytes.EMPTY;
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-                return (FieldCache.Bytes)caches_typeof_sbyte.Get(reader, new CacheKey(field, parser), setDocsWithField);
+#pragma warning disable CS0612 // Type or member is obsolete
+                return (FieldCache.Bytes)caches_typeof_sbyte.Get(reader, new CacheKey<FieldCache.IByteParser>(field, parser), setDocsWithField);
+#pragma warning restore CS0612 // Type or member is obsolete
             }
         }
 
@@ -593,19 +646,23 @@ namespace Lucene.Net.Search
             }
         }
 
-        internal sealed class ByteCache : Cache
+#pragma warning disable CS0612 // Type or member is obsolete
+        internal sealed class ByteCache : Cache<CacheKey<FieldCache.IByteParser>>
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             internal ByteCache(FieldCacheImpl wrapper)
                 : base(wrapper)
             {
             }
 
-            protected override object CreateValue(AtomicReader reader, CacheKey key, bool setDocsWithField)
+#pragma warning disable CS0612 // Type or member is obsolete
+            protected override object CreateValue(AtomicReader reader, CacheKey<FieldCache.IByteParser> key, bool setDocsWithField)
+#pragma warning restore CS0612 // Type or member is obsolete
             {
                 int maxDoc = reader.MaxDoc;
                 sbyte[] values;
 #pragma warning disable 612, 618
-                FieldCache.IByteParser parser = (FieldCache.IByteParser)key.custom;
+                FieldCache.IByteParser parser = key.custom;
 #pragma warning restore 612, 618
                 if (parser == null)
                 {
@@ -726,7 +783,7 @@ namespace Lucene.Net.Search
                     return FieldCache.Int16s.EMPTY;
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-                return (FieldCache.Int16s)caches_typeof_short.Get(reader, new CacheKey(field, parser), setDocsWithField);
+                return (FieldCache.Int16s)caches_typeof_short.Get(reader, new CacheKey<FieldCache.IInt16Parser>(field, parser), setDocsWithField);
             }
         }
 
@@ -769,19 +826,23 @@ namespace Lucene.Net.Search
         /// <summary>
         /// NOTE: This was ShortCache in Lucene
         /// </summary>
-        internal sealed class Int16Cache : Cache
+#pragma warning disable CS0612 // Type or member is obsolete
+        internal sealed class Int16Cache : Cache<CacheKey<FieldCache.IInt16Parser>>
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             internal Int16Cache(FieldCacheImpl wrapper)
                 : base(wrapper)
             {
             }
 
-            protected override object CreateValue(AtomicReader reader, CacheKey key, bool setDocsWithField)
+#pragma warning disable CS0612 // Type or member is obsolete
+            protected override object CreateValue(AtomicReader reader, CacheKey<FieldCache.IInt16Parser> key, bool setDocsWithField)
+#pragma warning restore CS0612 // Type or member is obsolete
             {
                 int maxDoc = reader.MaxDoc;
                 short[] values;
 #pragma warning disable 612, 618
-                FieldCache.IInt16Parser parser = (FieldCache.IInt16Parser)key.custom;
+                FieldCache.IInt16Parser parser = key.custom;
                 if (parser == null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
@@ -900,7 +961,7 @@ namespace Lucene.Net.Search
                     return FieldCache.Int32s.EMPTY;
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-                return (FieldCache.Int32s)caches_typeof_int.Get(reader, new CacheKey(field, parser), setDocsWithField);
+                return (FieldCache.Int32s)caches_typeof_int.Get(reader, new CacheKey<FieldCache.IInt32Parser>(field, parser), setDocsWithField);
             }
         }
 
@@ -974,16 +1035,16 @@ namespace Lucene.Net.Search
         /// <summary>
         /// NOTE: This was IntCache in Lucene
         /// </summary>
-        internal sealed class Int32Cache : Cache
+        internal sealed class Int32Cache : Cache<CacheKey<FieldCache.IInt32Parser>>
         {
             internal Int32Cache(FieldCacheImpl wrapper)
                 : base(wrapper)
             {
             }
 
-            protected override object CreateValue(AtomicReader reader, CacheKey key, bool setDocsWithField)
+            protected override object CreateValue(AtomicReader reader, CacheKey<FieldCache.IInt32Parser> key, bool setDocsWithField)
             {
-                FieldCache.IInt32Parser parser = (FieldCache.IInt32Parser)key.custom;
+                FieldCache.IInt32Parser parser = key.custom;
                 if (parser == null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
@@ -1100,10 +1161,10 @@ namespace Lucene.Net.Search
                 return new Lucene.Net.Util.Bits.MatchNoBits(reader.MaxDoc);
             }
             // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-            return (IBits)caches_typeof_DocsWithFieldCache.Get(reader, new CacheKey(field, null), false);
+            return (IBits)caches_typeof_DocsWithFieldCache.Get(reader, new CacheKey(field), false);
         }
 
-        internal sealed class DocsWithFieldCache : Cache
+        internal sealed class DocsWithFieldCache : Cache<CacheKey>
         {
             internal DocsWithFieldCache(FieldCacheImpl wrapper)
                 : base(wrapper)
@@ -1201,7 +1262,7 @@ namespace Lucene.Net.Search
                     return FieldCache.Singles.EMPTY;
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-                return (FieldCache.Singles)caches_typeof_float.Get(reader, new CacheKey(field, parser), setDocsWithField);
+                return (FieldCache.Singles)caches_typeof_float.Get(reader, new CacheKey<FieldCache.ISingleParser>(field, parser), setDocsWithField);
             }
         }
 
@@ -1244,16 +1305,16 @@ namespace Lucene.Net.Search
         /// <summary>
         /// NOTE: This was FloatCache in Lucene
         /// </summary>
-        internal sealed class SingleCache : Cache
+        internal sealed class SingleCache : Cache<CacheKey<FieldCache.ISingleParser>>
         {
             internal SingleCache(FieldCacheImpl wrapper)
                 : base(wrapper)
             {
             }
 
-            protected override object CreateValue(AtomicReader reader, CacheKey key, bool setDocsWithField)
+            protected override object CreateValue(AtomicReader reader, CacheKey<FieldCache.ISingleParser> key, bool setDocsWithField)
             {
-                FieldCache.ISingleParser parser = (FieldCache.ISingleParser)key.custom;
+                FieldCache.ISingleParser parser = key.custom;
                 if (parser == null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
@@ -1373,7 +1434,7 @@ namespace Lucene.Net.Search
                     return FieldCache.Int64s.EMPTY;
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-                return (FieldCache.Int64s)caches_typeof_long.Get(reader, new CacheKey(field, parser), setDocsWithField);
+                return (FieldCache.Int64s)caches_typeof_long.Get(reader, new CacheKey<FieldCache.IInt64Parser>(field, parser), setDocsWithField);
             }
         }
 
@@ -1418,16 +1479,16 @@ namespace Lucene.Net.Search
         /// <summary>
         /// NOTE: This was LongCache in Lucene
         /// </summary>
-        internal sealed class Int64Cache : Cache
+        internal sealed class Int64Cache : Cache<CacheKey<FieldCache.IInt64Parser>>
         {
             internal Int64Cache(FieldCacheImpl wrapper)
                 : base(wrapper)
             {
             }
 
-            protected override object CreateValue(AtomicReader reader, CacheKey key, bool setDocsWithField)
+            protected override object CreateValue(AtomicReader reader, CacheKey<FieldCache.IInt64Parser> key, bool setDocsWithField)
             {
-                FieldCache.IInt64Parser parser = (FieldCache.IInt64Parser)key.custom;
+                FieldCache.IInt64Parser parser = key.custom;
                 if (parser == null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
@@ -1557,7 +1618,7 @@ namespace Lucene.Net.Search
                     return FieldCache.Doubles.EMPTY;
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-                return (FieldCache.Doubles)caches_typeof_double.Get(reader, new CacheKey(field, parser), setDocsWithField);
+                return (FieldCache.Doubles)caches_typeof_double.Get(reader, new CacheKey<FieldCache.IDoubleParser>(field, parser), setDocsWithField);
             }
         }
 
@@ -1594,16 +1655,16 @@ namespace Lucene.Net.Search
             }
         }
 
-        internal sealed class DoubleCache : Cache
+        internal sealed class DoubleCache : Cache<CacheKey<FieldCache.IDoubleParser>>
         {
             internal DoubleCache(FieldCacheImpl wrapper)
                 : base(wrapper)
             {
             }
 
-            protected override object CreateValue(AtomicReader reader, CacheKey key, bool setDocsWithField)
+            protected override object CreateValue(AtomicReader reader, CacheKey<FieldCache.IDoubleParser> key, bool setDocsWithField)
             {
-                FieldCache.IDoubleParser parser = (FieldCache.IDoubleParser)key.custom;
+                FieldCache.IDoubleParser parser = key.custom;
                 if (parser == null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
@@ -1753,24 +1814,24 @@ namespace Lucene.Net.Search
                     return DocValues.EMPTY_SORTED;
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-                return (SortedDocValues)caches_typeof_SortedDocValues.Get(reader, new CacheKey(field, acceptableOverheadRatio), false);
+                return (SortedDocValues)caches_typeof_SortedDocValues.Get(reader, new CacheKey<FieldCache.AcceptableOverheadRatio>(field, new FieldCache.AcceptableOverheadRatio(acceptableOverheadRatio)), false);
             }
         }
 
-        internal class SortedDocValuesCache : Cache
+        internal class SortedDocValuesCache : Cache<CacheKey<FieldCache.AcceptableOverheadRatio>>
         {
             internal SortedDocValuesCache(FieldCacheImpl wrapper)
                 : base(wrapper)
             {
             }
 
-            protected override object CreateValue(AtomicReader reader, CacheKey key, bool setDocsWithField) // ignored
+            protected override object CreateValue(AtomicReader reader, CacheKey<FieldCache.AcceptableOverheadRatio> key, bool setDocsWithField) // ignored
             {
                 int maxDoc = reader.MaxDoc;
 
                 Terms terms = reader.GetTerms(key.field);
 
-                float acceptableOverheadRatio = (float)((float?)key.custom);
+                float acceptableOverheadRatio = key.custom.Value;
 
                 PagedBytes bytes = new PagedBytes(15);
 
@@ -1920,17 +1981,17 @@ namespace Lucene.Net.Search
             }
 
             // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-            return (BinaryDocValues)caches_typeof_BinaryDocValues.Get(reader, new CacheKey(field, acceptableOverheadRatio), setDocsWithField);
+            return (BinaryDocValues)caches_typeof_BinaryDocValues.Get(reader, new CacheKey<FieldCache.AcceptableOverheadRatio>(field, new FieldCache.AcceptableOverheadRatio(acceptableOverheadRatio)), setDocsWithField);
         }
 
-        internal sealed class BinaryDocValuesCache : Cache
+        internal sealed class BinaryDocValuesCache : Cache<CacheKey<FieldCache.AcceptableOverheadRatio>>
         {
             internal BinaryDocValuesCache(FieldCacheImpl wrapper)
                 : base(wrapper)
             {
             }
 
-            protected override object CreateValue(AtomicReader reader, CacheKey key, bool setDocsWithField)
+            protected override object CreateValue(AtomicReader reader, CacheKey<FieldCache.AcceptableOverheadRatio> key, bool setDocsWithField)
             {
                 // TODO: would be nice to first check if DocTermsIndex
                 // was already cached for this field and then return
@@ -1939,7 +2000,7 @@ namespace Lucene.Net.Search
                 int maxDoc = reader.MaxDoc;
                 Terms terms = reader.GetTerms(key.field);
 
-                float acceptableOverheadRatio = (float)((float?)key.custom);
+                float acceptableOverheadRatio = key.custom.Value;
 
                 int termCountHardLimit = maxDoc;
 
@@ -2073,11 +2134,11 @@ namespace Lucene.Net.Search
             }
 
             // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
-            DocTermOrds dto = (DocTermOrds)caches_typeof_DocTermOrds.Get(reader, new CacheKey(field, null), false);
+            DocTermOrds dto = (DocTermOrds)caches_typeof_DocTermOrds.Get(reader, new CacheKey(field), false);
             return dto.GetIterator(reader);
         }
 
-        internal sealed class DocTermOrdsCache : Cache
+        internal sealed class DocTermOrdsCache : Cache<CacheKey>
         {
             internal DocTermOrdsCache(FieldCacheImpl wrapper)
                 : base(wrapper)

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -589,7 +589,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_BytesAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache.Bytes(get: (docID) => (byte)valuesIn.Get(docID));
             }
             else
             {
@@ -610,24 +610,6 @@ namespace Lucene.Net.Search
 #pragma warning disable CS0612 // Type or member is obsolete
                 return (FieldCache.Bytes)caches_typeof_sbyte.Get(reader, new CacheKey<FieldCache.IByteParser>(field, parser), setDocsWithField);
 #pragma warning restore CS0612 // Type or member is obsolete
-            }
-        }
-
-        private class FieldCache_BytesAnonymousInnerClassHelper : FieldCache.Bytes
-        {
-            private readonly FieldCacheImpl outerInstance;
-
-            private NumericDocValues valuesIn;
-
-            public FieldCache_BytesAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
-            {
-                this.outerInstance = outerInstance;
-                this.valuesIn = valuesIn;
-            }
-
-            public override byte Get(int docID)
-            {
-                return (byte)valuesIn.Get(docID);
             }
         }
 
@@ -765,7 +747,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_Int16sAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache.Int16s(get: (docID) => (short)valuesIn.Get(docID));
             }
             else
             {
@@ -784,24 +766,6 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return (FieldCache.Int16s)caches_typeof_short.Get(reader, new CacheKey<FieldCache.IInt16Parser>(field, parser), setDocsWithField);
-            }
-        }
-
-        private class FieldCache_Int16sAnonymousInnerClassHelper : FieldCache.Int16s
-        {
-            private readonly FieldCacheImpl outerInstance;
-
-            private NumericDocValues valuesIn;
-
-            public FieldCache_Int16sAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
-            {
-                this.outerInstance = outerInstance;
-                this.valuesIn = valuesIn;
-            }
-
-            public override short Get(int docID)
-            {
-                return (short)valuesIn.Get(docID);
             }
         }
 
@@ -943,7 +907,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_Int32sAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache.Int32s(get: (docID) => (int)valuesIn.Get(docID));
             }
             else
             {
@@ -962,24 +926,6 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return (FieldCache.Int32s)caches_typeof_int.Get(reader, new CacheKey<FieldCache.IInt32Parser>(field, parser), setDocsWithField);
-            }
-        }
-
-        private class FieldCache_Int32sAnonymousInnerClassHelper : FieldCache.Int32s
-        {
-            private readonly FieldCacheImpl outerInstance;
-
-            private NumericDocValues valuesIn;
-
-            public FieldCache_Int32sAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
-            {
-                this.outerInstance = outerInstance;
-                this.valuesIn = valuesIn;
-            }
-
-            public override int Get(int docID)
-            {
-                return (int)valuesIn.Get(docID);
             }
         }
 
@@ -1244,7 +1190,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_SinglesAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache.Singles(get: (docID) => J2N.BitConversion.Int32BitsToSingle((int)valuesIn.Get(docID)));
             }
             else
             {
@@ -1263,24 +1209,6 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return (FieldCache.Singles)caches_typeof_float.Get(reader, new CacheKey<FieldCache.ISingleParser>(field, parser), setDocsWithField);
-            }
-        }
-
-        private class FieldCache_SinglesAnonymousInnerClassHelper : FieldCache.Singles
-        {
-            private readonly FieldCacheImpl outerInstance;
-
-            private NumericDocValues valuesIn;
-
-            public FieldCache_SinglesAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
-            {
-                this.outerInstance = outerInstance;
-                this.valuesIn = valuesIn;
-            }
-
-            public override float Get(int docID)
-            {
-                return J2N.BitConversion.Int32BitsToSingle((int)valuesIn.Get(docID));
             }
         }
 
@@ -1416,7 +1344,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_Int64sAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache.Int64s(get: (docID) => valuesIn.Get(docID));
             }
             else
             {
@@ -1435,24 +1363,6 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return (FieldCache.Int64s)caches_typeof_long.Get(reader, new CacheKey<FieldCache.IInt64Parser>(field, parser), setDocsWithField);
-            }
-        }
-
-        private class FieldCache_Int64sAnonymousInnerClassHelper : FieldCache.Int64s
-        {
-            private readonly FieldCacheImpl outerInstance;
-
-            private NumericDocValues valuesIn;
-
-            public FieldCache_Int64sAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
-            {
-                this.outerInstance = outerInstance;
-                this.valuesIn = valuesIn;
-            }
-
-            public override long Get(int docID)
-            {
-                return valuesIn.Get(docID);
             }
         }
 
@@ -1600,7 +1510,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_DoublesAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache.Doubles(get: (docID) => J2N.BitConversion.Int64BitsToDouble(valuesIn.Get(docID)));
             }
             else
             {
@@ -1619,24 +1529,6 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return (FieldCache.Doubles)caches_typeof_double.Get(reader, new CacheKey<FieldCache.IDoubleParser>(field, parser), setDocsWithField);
-            }
-        }
-
-        private class FieldCache_DoublesAnonymousInnerClassHelper : FieldCache.Doubles
-        {
-            private readonly FieldCacheImpl outerInstance;
-
-            private NumericDocValues valuesIn;
-
-            public FieldCache_DoublesAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
-            {
-                this.outerInstance = outerInstance;
-                this.valuesIn = valuesIn;
-            }
-
-            public override double Get(int docID)
-            {
-                return J2N.BitConversion.Int64BitsToDouble(valuesIn.Get(docID));
             }
         }
 

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -824,7 +824,7 @@ namespace Lucene.Net.Search
 #pragma warning restore 612, 618
 
                 values = new short[maxDoc];
-                Uninvert u = new UninvertAnonymousInnerClassHelper(this, values, parser);
+                Uninvert u = new UninvertAnonymousInnerClassHelper(values, parser);
 
                 u.DoUninvert(reader, key.field, setDocsWithField);
 
@@ -837,16 +837,13 @@ namespace Lucene.Net.Search
 
             private class UninvertAnonymousInnerClassHelper : Uninvert
             {
-                private readonly Int16Cache outerInstance;
-
-                private short[] values;
+                private readonly short[] values;
 #pragma warning disable 612, 618
-                private FieldCache.IInt16Parser parser;
+                private readonly FieldCache.IInt16Parser parser;
 
-                public UninvertAnonymousInnerClassHelper(Int16Cache outerInstance, short[] values, FieldCache.IInt16Parser parser)
+                public UninvertAnonymousInnerClassHelper(short[] values, FieldCache.IInt16Parser parser)
 #pragma warning restore 612, 618
                 {
-                    this.outerInstance = outerInstance;
                     this.values = values;
                     this.parser = parser;
                 }
@@ -1019,7 +1016,7 @@ namespace Lucene.Net.Search
 
                 HoldsOneThing<GrowableWriterAndMinValue> valuesRef = new HoldsOneThing<GrowableWriterAndMinValue>();
 
-                Uninvert u = new UninvertAnonymousInnerClassHelper(this, reader, parser, valuesRef);
+                Uninvert u = new UninvertAnonymousInnerClassHelper(reader, parser, valuesRef);
 
                 u.DoUninvert(reader, key.field, setDocsWithField);
 
@@ -1037,15 +1034,12 @@ namespace Lucene.Net.Search
 
             private class UninvertAnonymousInnerClassHelper : Uninvert
             {
-                private readonly Int32Cache outerInstance;
+                private readonly AtomicReader reader;
+                private readonly FieldCache.IInt32Parser parser;
+                private readonly FieldCacheImpl.HoldsOneThing<GrowableWriterAndMinValue> valuesRef;
 
-                private AtomicReader reader;
-                private FieldCache.IInt32Parser parser;
-                private FieldCacheImpl.HoldsOneThing<GrowableWriterAndMinValue> valuesRef;
-
-                public UninvertAnonymousInnerClassHelper(Int32Cache outerInstance, AtomicReader reader, FieldCache.IInt32Parser parser, FieldCacheImpl.HoldsOneThing<GrowableWriterAndMinValue> valuesRef)
+                public UninvertAnonymousInnerClassHelper(AtomicReader reader, FieldCache.IInt32Parser parser, FieldCacheImpl.HoldsOneThing<GrowableWriterAndMinValue> valuesRef)
                 {
-                    this.outerInstance = outerInstance;
                     this.reader = reader;
                     this.parser = parser;
                     this.valuesRef = valuesRef;
@@ -1271,7 +1265,7 @@ namespace Lucene.Net.Search
 
                 HoldsOneThing<float[]> valuesRef = new HoldsOneThing<float[]>();
 
-                Uninvert u = new UninvertAnonymousInnerClassHelper(this, reader, parser, valuesRef);
+                Uninvert u = new UninvertAnonymousInnerClassHelper(reader, parser, valuesRef);
 
                 u.DoUninvert(reader, key.field, setDocsWithField);
 
@@ -1290,15 +1284,12 @@ namespace Lucene.Net.Search
 
             private class UninvertAnonymousInnerClassHelper : Uninvert
             {
-                private readonly SingleCache outerInstance;
+                private readonly AtomicReader reader;
+                private readonly FieldCache.ISingleParser parser;
+                private readonly FieldCacheImpl.HoldsOneThing<float[]> valuesRef;
 
-                private AtomicReader reader;
-                private FieldCache.ISingleParser parser;
-                private FieldCacheImpl.HoldsOneThing<float[]> valuesRef;
-
-                public UninvertAnonymousInnerClassHelper(SingleCache outerInstance, AtomicReader reader, FieldCache.ISingleParser parser, FieldCacheImpl.HoldsOneThing<float[]> valuesRef)
+                public UninvertAnonymousInnerClassHelper(AtomicReader reader, FieldCache.ISingleParser parser, FieldCacheImpl.HoldsOneThing<float[]> valuesRef)
                 {
-                    this.outerInstance = outerInstance;
                     this.reader = reader;
                     this.parser = parser;
                     this.valuesRef = valuesRef;
@@ -1427,7 +1418,7 @@ namespace Lucene.Net.Search
 
                 HoldsOneThing<GrowableWriterAndMinValue> valuesRef = new HoldsOneThing<GrowableWriterAndMinValue>();
 
-                Uninvert u = new UninvertAnonymousInnerClassHelper(this, reader, parser, valuesRef);
+                Uninvert u = new UninvertAnonymousInnerClassHelper(reader, parser, valuesRef);
 
                 u.DoUninvert(reader, key.field, setDocsWithField);
 
@@ -1445,15 +1436,12 @@ namespace Lucene.Net.Search
 
             private class UninvertAnonymousInnerClassHelper : Uninvert
             {
-                private readonly Int64Cache outerInstance;
+                private readonly AtomicReader reader;
+                private readonly FieldCache.IInt64Parser parser;
+                private readonly FieldCacheImpl.HoldsOneThing<GrowableWriterAndMinValue> valuesRef;
 
-                private AtomicReader reader;
-                private FieldCache.IInt64Parser parser;
-                private FieldCacheImpl.HoldsOneThing<GrowableWriterAndMinValue> valuesRef;
-
-                public UninvertAnonymousInnerClassHelper(Int64Cache outerInstance, AtomicReader reader, FieldCache.IInt64Parser parser, FieldCacheImpl.HoldsOneThing<GrowableWriterAndMinValue> valuesRef)
+                public UninvertAnonymousInnerClassHelper(AtomicReader reader, FieldCache.IInt64Parser parser, FieldCacheImpl.HoldsOneThing<GrowableWriterAndMinValue> valuesRef)
                 {
-                    this.outerInstance = outerInstance;
                     this.reader = reader;
                     this.parser = parser;
                     this.valuesRef = valuesRef;
@@ -1585,7 +1573,7 @@ namespace Lucene.Net.Search
 
                 HoldsOneThing<double[]> valuesRef = new HoldsOneThing<double[]>();
 
-                Uninvert u = new UninvertAnonymousInnerClassHelper(this, reader, parser, valuesRef);
+                Uninvert u = new UninvertAnonymousInnerClassHelper(reader, parser, valuesRef);
 
                 u.DoUninvert(reader, key.field, setDocsWithField);
 
@@ -1603,15 +1591,12 @@ namespace Lucene.Net.Search
 
             private class UninvertAnonymousInnerClassHelper : Uninvert
             {
-                private readonly DoubleCache outerInstance;
+                private readonly AtomicReader reader;
+                private readonly FieldCache.IDoubleParser parser;
+                private readonly FieldCacheImpl.HoldsOneThing<double[]> valuesRef;
 
-                private AtomicReader reader;
-                private FieldCache.IDoubleParser parser;
-                private FieldCacheImpl.HoldsOneThing<double[]> valuesRef;
-
-                public UninvertAnonymousInnerClassHelper(DoubleCache outerInstance, AtomicReader reader, FieldCache.IDoubleParser parser, FieldCacheImpl.HoldsOneThing<double[]> valuesRef)
+                public UninvertAnonymousInnerClassHelper(AtomicReader reader, FieldCache.IDoubleParser parser, FieldCacheImpl.HoldsOneThing<double[]> valuesRef)
                 {
-                    this.outerInstance = outerInstance;
                     this.reader = reader;
                     this.parser = parser;
                     this.valuesRef = valuesRef;
@@ -1973,7 +1958,7 @@ namespace Lucene.Net.Search
                 PackedInt32s.Reader offsetReader = docToOffset.Mutable;
                 if (setDocsWithField)
                 {
-                    wrapper.SetDocsWithField(reader, key.field, new BitsAnonymousInnerClassHelper(this, maxDoc, offsetReader));
+                    wrapper.SetDocsWithField(reader, key.field, new BitsAnonymousInnerClassHelper(maxDoc, offsetReader));
                 }
                 // maybe an int-only impl?
                 return new BinaryDocValuesImpl(bytes.Freeze(true), offsetReader);
@@ -1981,14 +1966,11 @@ namespace Lucene.Net.Search
 
             private class BitsAnonymousInnerClassHelper : IBits
             {
-                private readonly BinaryDocValuesCache outerInstance;
+                private readonly int maxDoc;
+                private readonly PackedInt32s.Reader offsetReader;
 
-                private int maxDoc;
-                private PackedInt32s.Reader offsetReader;
-
-                public BitsAnonymousInnerClassHelper(BinaryDocValuesCache outerInstance, int maxDoc, PackedInt32s.Reader offsetReader)
+                public BitsAnonymousInnerClassHelper(int maxDoc, PackedInt32s.Reader offsetReader)
                 {
-                    this.outerInstance = outerInstance;
                     this.maxDoc = maxDoc;
                     this.offsetReader = offsetReader;
                 }

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -279,7 +279,7 @@ namespace Lucene.Net.Search
 #else
                 lock (readerCache)
                 {
-                    if (!readerCache.TryGetValue(readerKey, out innerCache) || innerCache == null)
+                    if (!readerCache.TryGetValue(readerKey, out innerCache) || innerCache is null)
                     {
                         // First time this reader is using FieldCache
                         innerCache = new ConcurrentDictionary<TKey, object>
@@ -313,7 +313,7 @@ namespace Lucene.Net.Search
 #else
                 lock (readerCache)
                 {
-                    if (!readerCache.TryGetValue(readerKey, out innerCache) || innerCache == null)
+                    if (!readerCache.TryGetValue(readerKey, out innerCache) || innerCache is null)
                     {
                         // First time this reader is using FieldCache
                         innerCache = new ConcurrentDictionary<TKey, object>
@@ -357,7 +357,7 @@ namespace Lucene.Net.Search
                 return (TValue)value;
             }
 
-            private void PrintNewInsanity(TextWriter infoStream, object value)
+            private void PrintNewInsanity(TextWriter infoStream, TValue value)
             {
                 FieldCacheSanityChecker.Insanity[] insanities = FieldCacheSanityChecker.CheckSanity(wrapper);
                 for (int i = 0; i < insanities.Length; i++)
@@ -366,7 +366,7 @@ namespace Lucene.Net.Search
                     FieldCache.CacheEntry[] entries = insanity.CacheEntries;
                     for (int j = 0; j < entries.Length; j++)
                     {
-                        if (entries[j].Value == value)
+                        if (ReferenceEquals(entries[j].Value, value))
                         {
                             // OK this insanity involves our entry
                             infoStream.WriteLine("WARNING: new FieldCache insanity created\nDetails: " + insanity.ToString());
@@ -476,7 +476,7 @@ namespace Lucene.Net.Search
             /// Composes a hashcode based on the field and type. </summary>
             public override int GetHashCode()
             {
-                return field.GetHashCode() ^ (custom == null ? 0 : custom.GetHashCode());
+                return field.GetHashCode() ^ (custom is null ? 0 : custom.GetHashCode());
             }
         }
 
@@ -520,7 +520,7 @@ namespace Lucene.Net.Search
                             VisitDoc(docID);
                             if (setDocsWithField)
                             {
-                                if (docsWithField == null)
+                                if (docsWithField is null)
                                 {
                                     // Lazy init
                                     this.docsWithField = docsWithField = new FixedBitSet(maxDoc);
@@ -544,11 +544,13 @@ namespace Lucene.Net.Search
         {
             int maxDoc = reader.MaxDoc;
             IBits bits;
-            if (docsWithField == null)
+            if (docsWithField is null)
             {
                 bits = new Lucene.Net.Util.Bits.MatchNoBits(maxDoc);
             }
+#pragma warning disable IDE0038 // Use pattern matching
             else if (docsWithField is FixedBitSet)
+#pragma warning restore IDE0038 // Use pattern matching
             {
                 int numSet = ((FixedBitSet)docsWithField).Cardinality();
                 if (numSet >= maxDoc)
@@ -601,7 +603,7 @@ namespace Lucene.Net.Search
             else
             {
                 FieldInfo info = reader.FieldInfos.FieldInfo(field);
-                if (info == null)
+                if (info is null)
                 {
                     return FieldCache.Bytes.EMPTY;
                 }
@@ -653,7 +655,7 @@ namespace Lucene.Net.Search
 #pragma warning disable 612, 618
                 FieldCache.IByteParser parser = key.custom;
 #pragma warning restore 612, 618
-                if (parser == null)
+                if (parser is null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
                     // setting parser = DEFAULT_INT16_PARSER) so cache
@@ -759,7 +761,7 @@ namespace Lucene.Net.Search
             else
             {
                 FieldInfo info = reader.FieldInfos.FieldInfo(field);
-                if (info == null)
+                if (info is null)
                 {
                     return FieldCache.Int16s.EMPTY;
                 }
@@ -814,7 +816,7 @@ namespace Lucene.Net.Search
                 short[] values;
 #pragma warning disable 612, 618
                 FieldCache.IInt16Parser parser = key.custom;
-                if (parser == null)
+                if (parser is null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
                     // setting parser = DEFAULT_INT16_PARSER) so cache
@@ -916,7 +918,7 @@ namespace Lucene.Net.Search
             else
             {
                 FieldInfo info = reader.FieldInfos.FieldInfo(field);
-                if (info == null)
+                if (info is null)
                 {
                     return FieldCache.Int32s.EMPTY;
                 }
@@ -995,7 +997,7 @@ namespace Lucene.Net.Search
             protected override FieldCache.Int32s CreateValue(AtomicReader reader, CacheKey<FieldCache.IInt32Parser> key, bool setDocsWithField)
             {
                 FieldCache.IInt32Parser parser = key.custom;
-                if (parser == null)
+                if (parser is null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
                     // setting parser =
@@ -1025,7 +1027,7 @@ namespace Lucene.Net.Search
                     wrapper.SetDocsWithField(reader, key.field, u.docsWithField);
                 }
                 GrowableWriterAndMinValue values = valuesRef.Get();
-                if (values == null)
+                if (values is null)
                 {
                     return new Int32sFromArray(new PackedInt32s.NullReader(reader.MaxDoc), 0);
                 }
@@ -1052,7 +1054,7 @@ namespace Lucene.Net.Search
                 protected override void VisitTerm(BytesRef term)
                 {
                     currentValue = parser.ParseInt32(term);
-                    if (values == null)
+                    if (values is null)
                     {
                         // Lazy alloc so for the numeric field case
                         // (which will hit a FormatException
@@ -1094,7 +1096,7 @@ namespace Lucene.Net.Search
         public virtual IBits GetDocsWithField(AtomicReader reader, string field)
         {
             FieldInfo fieldInfo = reader.FieldInfos.FieldInfo(field);
-            if (fieldInfo == null)
+            if (fieldInfo is null)
             {
                 // field does not exist or has no value
                 return new Lucene.Net.Util.Bits.MatchNoBits(reader.MaxDoc);
@@ -1139,7 +1141,7 @@ namespace Lucene.Net.Search
                     DocsEnum docs = null;
                     while (termsEnum.MoveNext())
                     {
-                        if (res == null)
+                        if (res is null)
                         {
                             // lazy init
                             res = new FixedBitSet(maxDoc);
@@ -1158,7 +1160,7 @@ namespace Lucene.Net.Search
                         }
                     }
                 }
-                if (res == null)
+                if (res is null)
                 {
                     return new Lucene.Net.Util.Bits.MatchNoBits(maxDoc);
                 }
@@ -1196,7 +1198,7 @@ namespace Lucene.Net.Search
             else
             {
                 FieldInfo info = reader.FieldInfos.FieldInfo(field);
-                if (info == null)
+                if (info is null)
                 {
                     return FieldCache.Singles.EMPTY;
                 }
@@ -1244,7 +1246,7 @@ namespace Lucene.Net.Search
             protected override FieldCache.Singles CreateValue(AtomicReader reader, CacheKey<FieldCache.ISingleParser> key, bool setDocsWithField)
             {
                 FieldCache.ISingleParser parser = key.custom;
-                if (parser == null)
+                if (parser is null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
                     // setting parser =
@@ -1275,7 +1277,7 @@ namespace Lucene.Net.Search
                 }
 
                 float[] values = valuesRef.Get();
-                if (values == null)
+                if (values is null)
                 {
                     values = new float[reader.MaxDoc];
                 }
@@ -1301,7 +1303,7 @@ namespace Lucene.Net.Search
                 protected override void VisitTerm(BytesRef term)
                 {
                     currentValue = parser.ParseSingle(term);
-                    if (values == null)
+                    if (values is null)
                     {
                         // Lazy alloc so for the numeric field case
                         // (which will hit a FormatException
@@ -1347,7 +1349,7 @@ namespace Lucene.Net.Search
             else
             {
                 FieldInfo info = reader.FieldInfos.FieldInfo(field);
-                if (info == null)
+                if (info is null)
                 {
                     return FieldCache.Int64s.EMPTY;
                 }
@@ -1397,7 +1399,7 @@ namespace Lucene.Net.Search
             protected override FieldCache.Int64s CreateValue(AtomicReader reader, CacheKey<FieldCache.IInt64Parser> key, bool setDocsWithField)
             {
                 FieldCache.IInt64Parser parser = key.custom;
-                if (parser == null)
+                if (parser is null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
                     // setting parser =
@@ -1427,7 +1429,7 @@ namespace Lucene.Net.Search
                     wrapper.SetDocsWithField(reader, key.field, u.docsWithField);
                 }
                 GrowableWriterAndMinValue values = valuesRef.Get();
-                if (values == null)
+                if (values is null)
                 {
                     return new Int64sFromArray(new PackedInt32s.NullReader(reader.MaxDoc), 0L);
                 }
@@ -1454,7 +1456,7 @@ namespace Lucene.Net.Search
                 protected override void VisitTerm(BytesRef term)
                 {
                     currentValue = parser.ParseInt64(term);
-                    if (values == null)
+                    if (values is null)
                     {
                         // Lazy alloc so for the numeric field case
                         // (which will hit a FormatException
@@ -1510,7 +1512,7 @@ namespace Lucene.Net.Search
             else
             {
                 FieldInfo info = reader.FieldInfos.FieldInfo(field);
-                if (info == null)
+                if (info is null)
                 {
                     return FieldCache.Doubles.EMPTY;
                 }
@@ -1552,7 +1554,7 @@ namespace Lucene.Net.Search
             protected override FieldCache.Doubles CreateValue(AtomicReader reader, CacheKey<FieldCache.IDoubleParser> key, bool setDocsWithField)
             {
                 FieldCache.IDoubleParser parser = key.custom;
-                if (parser == null)
+                if (parser is null)
                 {
                     // Confusing: must delegate to wrapper (vs simply
                     // setting parser =
@@ -1582,7 +1584,7 @@ namespace Lucene.Net.Search
                     wrapper.SetDocsWithField(reader, key.field, u.docsWithField);
                 }
                 double[] values = valuesRef.Get();
-                if (values == null)
+                if (values is null)
                 {
                     values = new double[reader.MaxDoc];
                 }
@@ -1608,7 +1610,7 @@ namespace Lucene.Net.Search
                 protected override void VisitTerm(BytesRef term)
                 {
                     currentValue = parser.ParseDouble(term);
-                    if (values == null)
+                    if (values is null)
                     {
                         // Lazy alloc so for the numeric field case
                         // (which will hit a FormatException
@@ -1683,7 +1685,7 @@ namespace Lucene.Net.Search
             else
             {
                 FieldInfo info = reader.FieldInfos.FieldInfo(field);
-                if (info == null)
+                if (info is null)
                 {
                     return DocValues.EMPTY_SORTED;
                 }
@@ -1838,7 +1840,7 @@ namespace Lucene.Net.Search
         public virtual BinaryDocValues GetTerms(AtomicReader reader, string field, bool setDocsWithField, float acceptableOverheadRatio)
         {
             BinaryDocValues valuesIn = reader.GetBinaryDocValues(field);
-            if (valuesIn == null)
+            if (valuesIn is null)
             {
                 valuesIn = reader.GetSortedDocValues(field);
             }
@@ -1851,7 +1853,7 @@ namespace Lucene.Net.Search
             }
 
             FieldInfo info = reader.FieldInfos.FieldInfo(field);
-            if (info == null)
+            if (info is null)
             {
                 return DocValues.EMPTY_BINARY;
             }
@@ -2001,7 +2003,7 @@ namespace Lucene.Net.Search
             }
 
             FieldInfo info = reader.FieldInfos.FieldInfo(field);
-            if (info == null)
+            if (info is null)
             {
                 return DocValues.EMPTY_SORTED_SET;
             }
@@ -2040,7 +2042,7 @@ namespace Lucene.Net.Search
             set =>
                 // LUCENENET specific - use a SafeTextWriterWrapper to ensure that if the TextWriter
                 // is disposed by the caller (using block) we don't get any exceptions if we keep using it.
-                infoStream = value == null
+                infoStream = value is null
                     ? null
                     : (value is SafeTextWriterWrapper ? value : new SafeTextWriterWrapper(value));
         }

--- a/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
+++ b/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
@@ -140,7 +140,7 @@ namespace Lucene.Net.Util
                     continue;
                 }
 
-                if (val is FieldCache.CreationPlaceholder)
+                if (val is FieldCache.ICreationPlaceholder)
                 {
                     continue;
                 }


### PR DESCRIPTION
This refactors `FieldCacheImpl` and `FieldCache` to take advantage of generics to reduce casting and also eliminates a particular boxing issue with the `acceptableOverheadRatio` value of `BinaryDocValuesImpl` and `SortedDocValuesImpl`.

The impact seems negligible on the simple case benchmarks we are using. However, we are now seeing the test times on Windows dip to lower levels than seen before.

## FacetsSimple

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1016 (1909/November2018Update/19H2)
Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.301
  [Host]                      : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00005             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00006             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00007             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00008             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00009             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00010             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00011             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00012             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-ci0000002161-w-GH-344 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-ci0000002035-w-GH-348 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT

IterationCount=15  LaunchCount=2  WarmupCount=10  

```
|           Method |                         Job |                                                                   NuGetReferences |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |---------------------------- |---------------------------------------------------------------------------------- |---------:|----------:|----------:|------:|------:|------:|----------:|
|     RunFacetOnly |             4.8.0-beta00005 |       Lucene.Net.Analysis.Common 4.8.0-beta00005,Lucene.Net.Facet 4.8.0-beta00005 | 5.409 ms | 0.6411 ms | 0.8987 ms |     - |     - |     - |   2.15 MB |
|        RunSearch |             4.8.0-beta00005 |       Lucene.Net.Analysis.Common 4.8.0-beta00005,Lucene.Net.Facet 4.8.0-beta00005 | 5.240 ms | 0.6124 ms | 0.8783 ms |     - |     - |     - |   2.15 MB |
|     RunDrillDown |             4.8.0-beta00005 |       Lucene.Net.Analysis.Common 4.8.0-beta00005,Lucene.Net.Facet 4.8.0-beta00005 | 7.973 ms | 2.2700 ms | 3.2556 ms |     - |     - |     - |   2.25 MB |
| RunDrillSideways |             4.8.0-beta00005 |       Lucene.Net.Analysis.Common 4.8.0-beta00005,Lucene.Net.Facet 4.8.0-beta00005 | 3.217 ms | 0.4605 ms | 0.6604 ms |     - |     - |     - |   2.62 MB |
|     RunFacetOnly |             4.8.0-beta00006 |       Lucene.Net.Analysis.Common 4.8.0-beta00006,Lucene.Net.Facet 4.8.0-beta00006 | 2.944 ms | 0.2626 ms | 0.3766 ms |     - |     - |     - |   2.15 MB |
|        RunSearch |             4.8.0-beta00006 |       Lucene.Net.Analysis.Common 4.8.0-beta00006,Lucene.Net.Facet 4.8.0-beta00006 | 2.820 ms | 0.2576 ms | 0.3694 ms |     - |     - |     - |   2.15 MB |
|     RunDrillDown |             4.8.0-beta00006 |       Lucene.Net.Analysis.Common 4.8.0-beta00006,Lucene.Net.Facet 4.8.0-beta00006 | 2.408 ms | 0.2459 ms | 0.3604 ms |     - |     - |     - |   2.25 MB |
| RunDrillSideways |             4.8.0-beta00006 |       Lucene.Net.Analysis.Common 4.8.0-beta00006,Lucene.Net.Facet 4.8.0-beta00006 | 2.478 ms | 0.2063 ms | 0.2959 ms |     - |     - |     - |   2.62 MB |
|     RunFacetOnly |             4.8.0-beta00007 |       Lucene.Net.Analysis.Common 4.8.0-beta00007,Lucene.Net.Facet 4.8.0-beta00007 | 2.463 ms | 0.3290 ms | 0.4719 ms |     - |     - |     - |   2.13 MB |
|        RunSearch |             4.8.0-beta00007 |       Lucene.Net.Analysis.Common 4.8.0-beta00007,Lucene.Net.Facet 4.8.0-beta00007 | 3.086 ms | 0.5328 ms | 0.7810 ms |     - |     - |     - |   2.13 MB |
|     RunDrillDown |             4.8.0-beta00007 |       Lucene.Net.Analysis.Common 4.8.0-beta00007,Lucene.Net.Facet 4.8.0-beta00007 | 2.762 ms | 0.3603 ms | 0.5168 ms |     - |     - |     - |   2.23 MB |
| RunDrillSideways |             4.8.0-beta00007 |       Lucene.Net.Analysis.Common 4.8.0-beta00007,Lucene.Net.Facet 4.8.0-beta00007 | 2.301 ms | 0.2218 ms | 0.3181 ms |     - |     - |     - |    2.6 MB |
|     RunFacetOnly |             4.8.0-beta00008 |       Lucene.Net.Analysis.Common 4.8.0-beta00008,Lucene.Net.Facet 4.8.0-beta00008 | 2.580 ms | 0.2657 ms | 0.3811 ms |     - |     - |     - |   2.17 MB |
|        RunSearch |             4.8.0-beta00008 |       Lucene.Net.Analysis.Common 4.8.0-beta00008,Lucene.Net.Facet 4.8.0-beta00008 | 2.237 ms | 0.2688 ms | 0.3768 ms |     - |     - |     - |   2.17 MB |
|     RunDrillDown |             4.8.0-beta00008 |       Lucene.Net.Analysis.Common 4.8.0-beta00008,Lucene.Net.Facet 4.8.0-beta00008 | 2.148 ms | 0.2199 ms | 0.3154 ms |     - |     - |     - |   2.27 MB |
| RunDrillSideways |             4.8.0-beta00008 |       Lucene.Net.Analysis.Common 4.8.0-beta00008,Lucene.Net.Facet 4.8.0-beta00008 | 2.343 ms | 0.2433 ms | 0.3489 ms |     - |     - |     - |   2.64 MB |
|     RunFacetOnly |             4.8.0-beta00009 |       Lucene.Net.Analysis.Common 4.8.0-beta00009,Lucene.Net.Facet 4.8.0-beta00009 | 3.205 ms | 0.4344 ms | 0.6503 ms |     - |     - |     - |   2.17 MB |
|        RunSearch |             4.8.0-beta00009 |       Lucene.Net.Analysis.Common 4.8.0-beta00009,Lucene.Net.Facet 4.8.0-beta00009 | 2.736 ms | 0.2491 ms | 0.3572 ms |     - |     - |     - |   2.17 MB |
|     RunDrillDown |             4.8.0-beta00009 |       Lucene.Net.Analysis.Common 4.8.0-beta00009,Lucene.Net.Facet 4.8.0-beta00009 | 2.510 ms | 0.3505 ms | 0.5138 ms |     - |     - |     - |   2.27 MB |
| RunDrillSideways |             4.8.0-beta00009 |       Lucene.Net.Analysis.Common 4.8.0-beta00009,Lucene.Net.Facet 4.8.0-beta00009 | 2.188 ms | 0.2712 ms | 0.3975 ms |     - |     - |     - |   2.64 MB |
|     RunFacetOnly |             4.8.0-beta00010 |       Lucene.Net.Analysis.Common 4.8.0-beta00010,Lucene.Net.Facet 4.8.0-beta00010 | 2.380 ms | 0.3773 ms | 0.5411 ms |     - |     - |     - |   2.16 MB |
|        RunSearch |             4.8.0-beta00010 |       Lucene.Net.Analysis.Common 4.8.0-beta00010,Lucene.Net.Facet 4.8.0-beta00010 | 2.603 ms | 0.2714 ms | 0.3893 ms |     - |     - |     - |   2.16 MB |
|     RunDrillDown |             4.8.0-beta00010 |       Lucene.Net.Analysis.Common 4.8.0-beta00010,Lucene.Net.Facet 4.8.0-beta00010 | 2.213 ms | 0.2396 ms | 0.3279 ms |     - |     - |     - |   2.26 MB |
| RunDrillSideways |             4.8.0-beta00010 |       Lucene.Net.Analysis.Common 4.8.0-beta00010,Lucene.Net.Facet 4.8.0-beta00010 | 2.162 ms | 0.2293 ms | 0.3288 ms |     - |     - |     - |   2.63 MB |
|     RunFacetOnly |             4.8.0-beta00011 |       Lucene.Net.Analysis.Common 4.8.0-beta00011,Lucene.Net.Facet 4.8.0-beta00011 | 2.570 ms | 0.2390 ms | 0.3427 ms |     - |     - |     - |   2.16 MB |
|        RunSearch |             4.8.0-beta00011 |       Lucene.Net.Analysis.Common 4.8.0-beta00011,Lucene.Net.Facet 4.8.0-beta00011 | 2.574 ms | 0.2493 ms | 0.3576 ms |     - |     - |     - |   2.16 MB |
|     RunDrillDown |             4.8.0-beta00011 |       Lucene.Net.Analysis.Common 4.8.0-beta00011,Lucene.Net.Facet 4.8.0-beta00011 | 2.168 ms | 0.2882 ms | 0.4134 ms |     - |     - |     - |   2.26 MB |
| RunDrillSideways |             4.8.0-beta00011 |       Lucene.Net.Analysis.Common 4.8.0-beta00011,Lucene.Net.Facet 4.8.0-beta00011 | 2.143 ms | 0.2106 ms | 0.3020 ms |     - |     - |     - |   2.63 MB |
|     RunFacetOnly |             4.8.0-beta00012 |       Lucene.Net.Analysis.Common 4.8.0-beta00012,Lucene.Net.Facet 4.8.0-beta00012 | 2.579 ms | 0.3045 ms | 0.4367 ms |     - |     - |     - |   2.19 MB |
|        RunSearch |             4.8.0-beta00012 |       Lucene.Net.Analysis.Common 4.8.0-beta00012,Lucene.Net.Facet 4.8.0-beta00012 | 2.748 ms | 0.2675 ms | 0.3837 ms |     - |     - |     - |    2.2 MB |
|     RunDrillDown |             4.8.0-beta00012 |       Lucene.Net.Analysis.Common 4.8.0-beta00012,Lucene.Net.Facet 4.8.0-beta00012 | 2.539 ms | 0.2266 ms | 0.3250 ms |     - |     - |     - |   2.29 MB |
| RunDrillSideways |             4.8.0-beta00012 |       Lucene.Net.Analysis.Common 4.8.0-beta00012,Lucene.Net.Facet 4.8.0-beta00012 | 2.607 ms | 0.2412 ms | 0.3381 ms |     - |     - |     - |   2.67 MB |
|     RunFacetOnly | 4.8.0-ci0000002161-w-GH-344 | Lucene.Net.Analysis.Common 4.8.0-ci0000002161,Lucene.Net.Facet 4.8.0-ci0000002161 | 1.955 ms | 0.1874 ms | 0.2687 ms |     - |     - |     - |    2.2 MB |
|        RunSearch | 4.8.0-ci0000002161-w-GH-344 | Lucene.Net.Analysis.Common 4.8.0-ci0000002161,Lucene.Net.Facet 4.8.0-ci0000002161 | 2.080 ms | 0.2780 ms | 0.4075 ms |     - |     - |     - |    2.2 MB |
|     RunDrillDown | 4.8.0-ci0000002161-w-GH-344 | Lucene.Net.Analysis.Common 4.8.0-ci0000002161,Lucene.Net.Facet 4.8.0-ci0000002161 | 2.094 ms | 0.2216 ms | 0.3178 ms |     - |     - |     - |   2.29 MB |
| RunDrillSideways | 4.8.0-ci0000002161-w-GH-344 | Lucene.Net.Analysis.Common 4.8.0-ci0000002161,Lucene.Net.Facet 4.8.0-ci0000002161 | 2.267 ms | 0.2729 ms | 0.3914 ms |     - |     - |     - |   2.67 MB |
|     RunFacetOnly | 4.8.0-ci0000002035-w-GH-348 | Lucene.Net.Analysis.Common 4.8.0-ci0000002035,Lucene.Net.Facet 4.8.0-ci0000002035 | 2.011 ms | 0.1991 ms | 0.2855 ms |     - |     - |     - |    2.2 MB |
|        RunSearch | 4.8.0-ci0000002035-w-GH-348 | Lucene.Net.Analysis.Common 4.8.0-ci0000002035,Lucene.Net.Facet 4.8.0-ci0000002035 | 2.067 ms | 0.2341 ms | 0.3282 ms |     - |     - |     - |    2.2 MB |
|     RunDrillDown | 4.8.0-ci0000002035-w-GH-348 | Lucene.Net.Analysis.Common 4.8.0-ci0000002035,Lucene.Net.Facet 4.8.0-ci0000002035 | 2.260 ms | 0.2747 ms | 0.3940 ms |     - |     - |     - |   2.29 MB |
| RunDrillSideways | 4.8.0-ci0000002035-w-GH-348 | Lucene.Net.Analysis.Common 4.8.0-ci0000002035,Lucene.Net.Facet 4.8.0-ci0000002035 | 2.438 ms | 0.2855 ms | 0.4095 ms |     - |     - |     - |   2.67 MB |

## IndexFiles

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1016 (1909/November2018Update/19H2)
Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.301
  [Host]                      : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00005             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00006             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00007             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00008             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00009             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00010             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00011             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00012             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-ci0000002161-w-GH-344 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-ci0000002035-w-GH-348 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT

InvocationCount=1  IterationCount=15  LaunchCount=2  
UnrollFactor=1  WarmupCount=10  

```
|     Method |                         Job |                               NuGetReferences |     Mean |    Error |   StdDev |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|----------- |---------------------------- |---------------------------------------------- |---------:|---------:|---------:|-----------:|----------:|----------:|----------:|
| IndexFiles |             4.8.0-beta00005 |    Lucene.Net.Analysis.Common 4.8.0-beta00005 | 697.2 ms | 13.89 ms | 19.92 ms | 44000.0000 | 8000.0000 | 7000.0000 | 220.95 MB |
| IndexFiles |             4.8.0-beta00006 |    Lucene.Net.Analysis.Common 4.8.0-beta00006 | 698.9 ms | 20.54 ms | 30.11 ms | 44000.0000 | 8000.0000 | 7000.0000 | 221.01 MB |
| IndexFiles |             4.8.0-beta00007 |    Lucene.Net.Analysis.Common 4.8.0-beta00007 | 693.7 ms | 16.44 ms | 22.51 ms | 44000.0000 | 8000.0000 | 7000.0000 |  220.8 MB |
| IndexFiles |             4.8.0-beta00008 |    Lucene.Net.Analysis.Common 4.8.0-beta00008 | 695.1 ms | 16.57 ms | 24.29 ms | 44000.0000 | 8000.0000 | 7000.0000 | 221.12 MB |
| IndexFiles |             4.8.0-beta00009 |    Lucene.Net.Analysis.Common 4.8.0-beta00009 | 712.7 ms | 16.01 ms | 23.47 ms | 44000.0000 | 8000.0000 | 7000.0000 |  221.2 MB |
| IndexFiles |             4.8.0-beta00010 |    Lucene.Net.Analysis.Common 4.8.0-beta00010 | 704.8 ms | 14.72 ms | 22.03 ms | 44000.0000 | 8000.0000 | 7000.0000 | 221.32 MB |
| IndexFiles |             4.8.0-beta00011 |    Lucene.Net.Analysis.Common 4.8.0-beta00011 | 705.1 ms | 15.98 ms | 22.40 ms | 44000.0000 | 8000.0000 | 7000.0000 | 221.17 MB |
| IndexFiles |             4.8.0-beta00012 |    Lucene.Net.Analysis.Common 4.8.0-beta00012 | 735.9 ms | 12.89 ms | 18.07 ms | 56000.0000 | 7000.0000 | 6000.0000 | 286.82 MB |
| IndexFiles | 4.8.0-ci0000002161-w-GH-344 | Lucene.Net.Analysis.Common 4.8.0-ci0000002161 | 732.3 ms | 16.84 ms | 23.06 ms | 56000.0000 | 7000.0000 | 6000.0000 | 286.76 MB |
| IndexFiles | 4.8.0-ci0000002035-w-GH-348 | Lucene.Net.Analysis.Common 4.8.0-ci0000002035 | 728.2 ms | 12.59 ms | 18.05 ms | 56000.0000 | 7000.0000 | 6000.0000 | 286.78 MB |

## SearchFiles

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1016 (1909/November2018Update/19H2)
Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.301
  [Host]                      : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00005             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00006             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00007             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00008             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00009             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00010             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00011             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-beta00012             : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-ci0000002161-w-GH-344 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  4.8.0-ci0000002035-w-GH-348 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT

IterationCount=15  LaunchCount=2  WarmupCount=10  

```
|      Method |                         Job |                                                                         NuGetReferences |      Mean |    Error |   StdDev |     Gen 0 |     Gen 1 | Gen 2 | Allocated |
|------------ |---------------------------- |---------------------------------------------------------------------------------------- |----------:|---------:|---------:|----------:|----------:|------:|----------:|
| SearchFiles |             4.8.0-beta00005 |       Lucene.Net.Analysis.Common 4.8.0-beta00005,Lucene.Net.QueryParser 4.8.0-beta00005 | 152.65 ms | 3.971 ms | 5.944 ms | 8750.0000 |  250.0000 |     - |  41.39 MB |
| SearchFiles |             4.8.0-beta00006 |       Lucene.Net.Analysis.Common 4.8.0-beta00006,Lucene.Net.QueryParser 4.8.0-beta00006 | 152.97 ms | 6.662 ms | 9.766 ms | 8750.0000 |  500.0000 |     - |  41.37 MB |
| SearchFiles |             4.8.0-beta00007 |       Lucene.Net.Analysis.Common 4.8.0-beta00007,Lucene.Net.QueryParser 4.8.0-beta00007 | 149.74 ms | 4.525 ms | 6.489 ms | 8000.0000 | 1000.0000 |     - |  41.27 MB |
| SearchFiles |             4.8.0-beta00008 |       Lucene.Net.Analysis.Common 4.8.0-beta00008,Lucene.Net.QueryParser 4.8.0-beta00008 |  88.69 ms | 1.628 ms | 2.387 ms | 8666.6667 |  500.0000 |     - |  40.33 MB |
| SearchFiles |             4.8.0-beta00009 |       Lucene.Net.Analysis.Common 4.8.0-beta00009,Lucene.Net.QueryParser 4.8.0-beta00009 |  86.05 ms | 0.987 ms | 1.478 ms | 8666.6667 |  500.0000 |     - |  40.33 MB |
| SearchFiles |             4.8.0-beta00010 |       Lucene.Net.Analysis.Common 4.8.0-beta00010,Lucene.Net.QueryParser 4.8.0-beta00010 |  87.25 ms | 1.140 ms | 1.522 ms | 8666.6667 |  500.0000 |     - |  40.19 MB |
| SearchFiles |             4.8.0-beta00011 |       Lucene.Net.Analysis.Common 4.8.0-beta00011,Lucene.Net.QueryParser 4.8.0-beta00011 |  85.76 ms | 1.277 ms | 1.872 ms | 8666.6667 |  500.0000 |     - |  40.19 MB |
| SearchFiles |             4.8.0-beta00012 |       Lucene.Net.Analysis.Common 4.8.0-beta00012,Lucene.Net.QueryParser 4.8.0-beta00012 |  86.86 ms | 0.862 ms | 1.236 ms | 8833.3333 |  333.3333 |     - |  40.81 MB |
| SearchFiles | 4.8.0-ci0000002161-w-GH-344 | Lucene.Net.Analysis.Common 4.8.0-ci0000002161,Lucene.Net.QueryParser 4.8.0-ci0000002161 |  86.55 ms | 0.442 ms | 0.619 ms | 8833.3333 |  333.3333 |     - |  40.81 MB |
| SearchFiles | 4.8.0-ci0000002035-w-GH-348 | Lucene.Net.Analysis.Common 4.8.0-ci0000002035,Lucene.Net.QueryParser 4.8.0-ci0000002035 |  87.11 ms | 1.224 ms | 1.715 ms | 8833.3333 |  333.3333 |     - |  40.81 MB |
