### PR TITLE
Adjustments for enabling nightly builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -293,7 +293,7 @@ stages:
 - stage: Test_Stage
   displayName: 'Test Stage:'
   jobs:
-  - job: Test_netcoreapp3_1
+  - job: Test_netcoreapp3_1_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))
     strategy:
       matrix:
@@ -325,7 +325,39 @@ stages:
         maximumParallelJobs: $(maximumParallelJobs)
         maximumAllowedFailures: $(maximumAllowedFailures)
 
-  - job: Test_netcoreapp2_2
+  - job: Test_netcoreapp3_1_x86 # Only run Nightly
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['IsNightly'], 'true'))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-2019'
+          maximumParallelJobs: 8
+          maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
+        Linux:
+          osName: 'Linux'
+          imageName: 'ubuntu-16.04'
+          maximumParallelJobs: 7
+          maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
+        macOS:
+          osName: 'macOS'
+          imageName: 'macOS-10.14'
+          maximumParallelJobs: 7
+          maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
+    displayName: 'Test netcoreapp3.1,x86 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+    - template: 'build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: $(osName)
+        framework: 'netcoreapp3.1'
+        vsTestPlatform: 'x86'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumParallelJobs: $(maximumParallelJobs)
+        maximumAllowedFailures: $(maximumAllowedFailures)
+
+  - job: Test_netcoreapp2_2_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))
     strategy:
       matrix:
@@ -353,6 +385,38 @@ stages:
         osName: $(osName)
         framework: 'netcoreapp2.1'
         vsTestPlatform: 'x64'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumParallelJobs: $(maximumParallelJobs)
+        maximumAllowedFailures: $(maximumAllowedFailures)
+
+  - job: Test_netcoreapp2_2_x86 # Only run Nightly
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['IsNightly'], 'true'))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-2019'
+          maximumParallelJobs: 8
+          maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
+        Linux:
+          osName: 'Linux'
+          imageName: 'ubuntu-16.04'
+          maximumParallelJobs: 7
+          maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
+        macOS:
+          osName: 'macOS'
+          imageName: 'macOS-10.14'
+          maximumParallelJobs: 7
+          maximumAllowedFailures: 4 # Maximum allowed failures for a successful build
+    displayName: 'Test netcoreapp2.1,x86 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+    - template: 'build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: $(osName)
+        framework: 'netcoreapp2.1'
+        vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumParallelJobs: $(maximumParallelJobs)
         maximumAllowedFailures: $(maximumAllowedFailures)

--- a/build/azure-templates/publish-test-results.yml
+++ b/build/azure-templates/publish-test-results.yml
@@ -43,7 +43,7 @@ steps:
 #    EnsureNotNullOrEmpty('${{ parameters.testResultsFileName }}', 'testResultsFileName')
 #  displayName: 'Validate Template Parameters'
 
-- template: 'show-all-files.yml' # Uncomment for debugging
+#- template: 'show-all-files.yml' # Uncomment for debugging
 
 - powershell: |
     $testResultsFileName = "$(Build.ArtifactStagingDirectory)/${{ parameters.testResultsArtifactName }}/${{ parameters.osName }}/${{ parameters.framework }}/${{ parameters.vsTestPlatform }}/${{ parameters.testProjectName }}/${{ parameters.testResultsFileName }}"

--- a/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
@@ -745,7 +745,10 @@ namespace Lucene.Net.Index
             using (Directory dir = new MockDirectoryWrapper(Random, new MMapDirectory(CreateTempDir("testBigDocuments"))))
             {
                 IndexWriterConfig iwConf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));
-                iwConf.SetMaxBufferedDocs(RandomInts.RandomInt32Between(Random, 2, 30));
+                //iwConf.SetMaxBufferedDocs(RandomInts.RandomInt32Between(Random, 2, 30));
+                // LUCENENET specific - Reduced amount to keep the total
+                // Nightly test time under 1 hour
+                iwConf.SetMaxBufferedDocs(RandomInts.RandomInt32Between(Random, 2, 15));
                 using (RandomIndexWriter iw = new RandomIndexWriter(Random, dir, iwConf))
                 {
 
@@ -767,13 +770,19 @@ namespace Lucene.Net.Index
                     onlyStored.IsIndexed = false;
 
                     Field smallField = new Field("fld", RandomByteArray(Random.Next(10), 256), onlyStored);
-                    int numFields = RandomInts.RandomInt32Between(Random, 500000, 1000000);
+                    //int numFields = RandomInts.RandomInt32Between(Random, 500000, 1000000);
+                    // LUCENENET specific - Reduced amount to keep the total
+                    // Nightly test time under 1 hour
+                    int numFields = RandomInts.RandomInt32Between(Random, 250000, 500000);
                     for (int i = 0; i < numFields; ++i)
                     {
                         bigDoc1.Add(smallField);
                     }
 
-                    Field bigField = new Field("fld", RandomByteArray(RandomInts.RandomInt32Between(Random, 1000000, 5000000), 2), onlyStored);
+                    //Field bigField = new Field("fld", RandomByteArray(RandomInts.RandomInt32Between(Random, 1000000, 5000000), 2), onlyStored);
+                    // LUCENENET specific - Reduced amount to keep the total
+                    // Nightly test time under 1 hour
+                    Field bigField = new Field("fld", RandomByteArray(RandomInts.RandomInt32Between(Random, 500000, 2500000), 2), onlyStored);
                     bigDoc2.Add(bigField);
 
                     int numDocs = AtLeast(5);

--- a/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
@@ -186,7 +186,10 @@ namespace Lucene.Net.Index
                             {
                                 Console.WriteLine(Thread.CurrentThread.Name + ": now long sleep");
                             }
-                            Thread.Sleep(TestUtil.NextInt32(Random, 50, 500));
+                            //Thread.Sleep(TestUtil.NextInt32(Random, 50, 500));
+                            // LUCENENET specific - Reduced amount of pause to keep the total
+                            // Nightly test time under 1 hour
+                            Thread.Sleep(TestUtil.NextInt32(Random, 50, 250));
                         }
 
                         // Rate limit ingest rate:
@@ -585,15 +588,18 @@ namespace Lucene.Net.Index
                 MergePolicy mp = conf.MergePolicy;
                 if (mp is TieredMergePolicy)
                 {
-                    ((TieredMergePolicy)mp).MaxMergedSegmentMB = 5000.0;
+                    //((TieredMergePolicy)mp).MaxMergedSegmentMB = 5000.0;
+                    ((TieredMergePolicy)mp).MaxMergedSegmentMB = 2500.0; // LUCENENET specific - reduced each number by 50% to keep testing time under 1 hour
                 }
                 else if (mp is LogByteSizeMergePolicy)
                 {
-                    ((LogByteSizeMergePolicy)mp).MaxMergeMB = 1000.0;
+                    //((LogByteSizeMergePolicy)mp).MaxMergeMB = 1000.0;
+                    ((LogByteSizeMergePolicy)mp).MaxMergeMB = 500.0; // LUCENENET specific - reduced each number by 50% to keep testing time under 1 hour
                 }
                 else if (mp is LogMergePolicy)
                 {
-                    ((LogMergePolicy)mp).MaxMergeDocs = 100000;
+                    //((LogMergePolicy)mp).MaxMergeDocs = 100000;
+                    ((LogMergePolicy)mp).MaxMergeDocs = 50000; // LUCENENET specific - reduced each number by 50% to keep testing time under 1 hour
                 }
             }
 
@@ -612,7 +618,10 @@ namespace Lucene.Net.Index
 
             int NUM_INDEX_THREADS = TestUtil.NextInt32(LuceneTestCase.Random, 2, 4);
 
-            int RUN_TIME_SEC = LuceneTestCase.TestNightly ? 300 : RandomMultiplier;
+            //int RUN_TIME_SEC = LuceneTestCase.TestNightly ? 300 : RandomMultiplier;
+            // LUCENENET specific - lowered from 300 to 150 to reduce total time on Nightly
+            // build to less than 1 hour.
+            int RUN_TIME_SEC = LuceneTestCase.TestNightly ? 150 : RandomMultiplier;
 
             ISet<string> delIDs = new ConcurrentHashSet<string>();
             ISet<string> delPackIDs = new ConcurrentHashSet<string>();

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1396,7 +1396,10 @@ namespace Lucene.Net.Util
         /// </summary>
         public static bool Rarely(Random random)
         {
-            int p = TestNightly ? 10 : 1;
+            //int p = TestNightly ? 10 : 1;
+            // LUCENENET specific - reduced nightly instance by 1/2 to lower the
+            // total test time in Nightly builds to get under the 1 hour time limit of Azure DevOps
+            int p = TestNightly ? 5 : 1;
             p += (int)(p * Math.Log(RandomMultiplier));
             int min = 100 - Math.Min(p, 50); // never more than 50
             return random.Next(100) >= min;

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1378,7 +1378,10 @@ namespace Lucene.Net.Util
         /// </summary>
         public static int AtLeast(Random random, int i)
         {
-            int min = (TestNightly ? 2 * i : i) * RandomMultiplier;
+            //int min = (TestNightly ? 2 * i : i) * RandomMultiplier;
+            // LUCENENET specific - reduced nightly factor to lower the
+            // total test time in Nightly builds to get under the 1 hour time limit of Azure DevOps
+            int min = (TestNightly ? (int)(1.5 * i) : i) * RandomMultiplier;
             int max = min + (min / 2);
             return TestUtil.NextInt32(random, min, max);
         }

--- a/src/Lucene.Net.Tests.Analysis.Common/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -36,3 +37,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("fd602350-abed-4d1e-ad7b-709d18b0b464")]
 
 
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/Properties/AssemblyInfo.cs
@@ -15,6 +15,7 @@
 * limitations under the License.
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -31,4 +32,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("34a2bce8-1351-43bd-a365-f50e7c0b2c49")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -35,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a2867797-0a5d-4878-8f59-58c399c9a4e4")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/Properties/AssemblyInfo.cs
@@ -15,6 +15,7 @@
 * limitations under the License.
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -31,4 +32,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8c8d78d3-bffd-4301-953b-fe5350b2aeeb")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Analysis.Stempel/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Analysis.Stempel/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -35,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("940a6ab1-f00a-40e2-bc1a-2898efa8c48f")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Benchmark/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Benchmark/Properties/AssemblyInfo.cs
@@ -16,6 +16,7 @@
  */
 
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -32,4 +33,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9257f543-44e2-4db6-8b27-a8a354c13e5b")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Classification/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Classification/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -35,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("253246a8-7b09-4251-ab4c-7971d3b2be4a")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Codecs/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Codecs/Properties/AssemblyInfo.cs
@@ -42,3 +42,7 @@ using System.Runtime.InteropServices;
 // LUCENENET specific - only allow tests in this assembly to run one at a time
 // to prevent polluting shared state.
 [assembly: LevelOfParallelism(1)]
+
+// LUCENENET specific - time out this test project at 50 minutes to allow for time before this
+// test runs and the results to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3000000)]

--- a/src/Lucene.Net.Tests.Codecs/SimpleText/TestSimpleTextStoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests.Codecs/SimpleText/TestSimpleTextStoredFieldsFormat.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Attributes;
 using Lucene.Net.Index;
+using NUnit.Framework;
 
 namespace Lucene.Net.Codecs.SimpleText
 {
@@ -28,7 +29,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return new SimpleTextCodec();
         }
 
-        [Deadlock]
+        [Deadlock][Timeout(600000)]
         public override void TestConcurrentReads()
         {
             base.TestConcurrentReads();

--- a/src/Lucene.Net.Tests.Expressions/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Expressions/Properties/AssemblyInfo.cs
@@ -19,8 +19,8 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -36,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("0c789606-781d-47dc-b391-5ac367fce258")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Facet/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Facet/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -36,3 +37,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("253246a8-7b09-4251-ab4c-7971d3b2be4a")]
 
 
+// LUCENENET specific - time out this test project at 50 minutes to allow for time before this
+// test runs and the results to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3000000)]

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestConcurrentFacetedIndexing.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestConcurrentFacetedIndexing.cs
@@ -85,12 +85,13 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                 // this is the fastest, yet most memory consuming
                 return new Cl2oTaxonomyWriterCache(1024, 0.15f, 3);
             }
-            else if (TestNightly && d > 0.98)
-            {
-                // this is the slowest, but tests the writer concurrency when no caching is done.
-                // only pick it during NIGHTLY tests, and even then, with very low chances.
-                return NO_OP_CACHE;
-            }
+            // LUCENENET specific - this option takes too long to get under the 1 hour job limit in Azure DevOps
+            //else if (TestNightly && d > 0.98)
+            //{
+            //    // this is the slowest, but tests the writer concurrency when no caching is done.
+            //    // only pick it during NIGHTLY tests, and even then, with very low chances.
+            //    return NO_OP_CACHE;
+            //}
             else
             {
                 // this is slower than CL2O, but less memory consuming, and exercises finding categories on disk too.

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
@@ -261,7 +261,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
         [Test]
         [Slow]
-        [Deadlock]
+        [Deadlock][Timeout(1200000)]
         public virtual void TestConcurrency()
         {
             int ncats = AtLeast(100000); // add many categories

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
@@ -276,12 +276,13 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                 // this is the fastest, yet most memory consuming
                 cache = new Cl2oTaxonomyWriterCache(1024, 0.15f, 3);
             }
-            else if (TestNightly && d > 0.98)
-            {
-                // this is the slowest, but tests the writer concurrency when no caching is done.
-                // only pick it during NIGHTLY tests, and even then, with very low chances.
-                cache = NO_OP_CACHE;
-            }
+            // LUCENENET specific - this option takes too long to get under the 1 hour job limit in Azure DevOps
+            //else if (TestNightly && d > 0.98)
+            //{
+            //    // this is the slowest, but tests the writer concurrency when no caching is done.
+            //    // only pick it during NIGHTLY tests, and even then, with very low chances.
+            //    cache = NO_OP_CACHE;
+            //}
             else
             {
                 // this is slower than CL2O, but less memory consuming, and exercises finding categories on disk too.

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
@@ -259,7 +259,7 @@ namespace Lucene.Net.Facet.Taxonomy
         
         [Test]
         [Slow]
-        [Deadlock]
+        [Deadlock][Timeout(1200000)]
         public virtual void Test_Directory() // LUCENENET specific - name collides with property of LuceneTestCase
         {
             Store.Directory indexDir = NewDirectory();

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
@@ -259,7 +259,7 @@ namespace Lucene.Net.Facet.Taxonomy
         
         [Test]
         [Slow]
-        [Deadlock][Timeout(1200000)]
+        [Deadlock][Timeout(1800000)]
         public virtual void Test_Directory() // LUCENENET specific - name collides with property of LuceneTestCase
         {
             Store.Directory indexDir = NewDirectory();

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
@@ -156,7 +156,10 @@ namespace Lucene.Net.Facet.Taxonomy
             AtomicBoolean stop = new AtomicBoolean();
 
             // How many unique facets to index before stopping:
-            int ordLimit = TestNightly ? 100000 : 6000;
+            //int ordLimit = TestNightly ? 100000 : 6000;
+            // LUCENENET specific: 100000 facets takes about 2-3 hours. To keep it under
+            // the 1 hour free limit of Azure DevOps, this was reduced to 30000.
+            int ordLimit = TestNightly ? 30000 : 6000;
 
             var indexer = new IndexerThread(w, config, tw, null, ordLimit, stop);
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
@@ -272,7 +272,10 @@ namespace Lucene.Net.Facet.Taxonomy
             AtomicBoolean stop = new AtomicBoolean();
 
             // How many unique facets to index before stopping:
-            int ordLimit = TestNightly ? 100000 : 6000;
+            //int ordLimit = TestNightly ? 100000 : 6000;
+            // LUCENENET specific: 100000 facets takes about 2-3 hours. To keep it under
+            // the 1 hour free limit of Azure DevOps, this was reduced to 30000.
+            int ordLimit = TestNightly ? 30000 : 6000;
 
             var indexer = new IndexerThread(w, config, tw, mgr, ordLimit, stop);
             indexer.Start();

--- a/src/Lucene.Net.Tests.Grouping/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Grouping/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -35,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c2349f0d-fb66-4544-9c33-4d87f73c6004")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Highlighter/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -35,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("fbcd6afe-0a5c-4399-8044-99c58d2912d1")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Join/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Join/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -35,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4c1b794f-8158-45e6-85b3-2c46569bebc2")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Memory/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Memory/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -35,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7f9378bf-c88d-46ff-9ae8-5e7d8c0225d3")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Misc/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Misc/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -35,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7895e023-eb91-401c-b2b3-754eec42134b")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Queries/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Queries/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -36,3 +37,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("ab4a0a26-30fc-4180-ade0-7409b0214107")]
 
 
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.QueryParser/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -36,3 +37,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("27d0ae76-3e51-454c-9c4a-f913fde0ed0a")]
 
 
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -290,7 +290,7 @@ namespace Lucene.Net.Replicator
         // handler copies them to the index directory.
         [Test]
         [Slow]
-        [Deadlock]
+        [Deadlock][Timeout(600000)]
         public void TestConsistencyOnExceptions()
         {
             // so the handler's index isn't empty

--- a/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
@@ -220,7 +220,7 @@ namespace Lucene.Net.Replicator
         // a client copies files from the server to the temporary space, or when the
         // handler copies them to the index directory.
         [Test]
-        [Deadlock]
+        [Deadlock][Timeout(600000)]
         public void TestConsistencyOnExceptions()
         {
             // so the handler's index isn't empty

--- a/src/Lucene.Net.Tests.Replicator/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Replicator/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -34,3 +35,8 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("418e9d8e-2369-4b52-8d2f-5a987213999b")]
+
+
+// LUCENENET specific - time out this test project at 47 minutes to allow for time before this
+// test runs and the results to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(2820000)]

--- a/src/Lucene.Net.Tests.Sandbox/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Sandbox/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -36,3 +37,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("7865cbc8-2c6b-462c-acf5-b2c4d60d93c9")]
 
 
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Spatial/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Spatial/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -35,4 +36,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("31f52f5c-a08f-4363-8003-23d6f7d6eb3a")]
 
-
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net.Tests.Suggest/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Suggest/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@
  *
 */
 
+using NUnit.Framework;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -36,3 +37,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("a6511598-3008-4a3b-ae68-2d1da792ca8a")]
 
 
+// LUCENENET specific - time out this test project at 47 minutes to allow for time before this
+// test runs and the results to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(2820000)]

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TestLookaheadTokenFilter.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TestLookaheadTokenFilter.cs
@@ -56,7 +56,10 @@ namespace Lucene.Net.Analysis
                 TokenStream output = new MockRandomLookaheadTokenFilter(random, tokenizer);
                 return new TokenStreamComponents(tokenizer, output);
             });
-            int maxLength = TestNightly ? 8192 : 1024;
+            //int maxLength = TestNightly ? 8192 : 1024;
+            // LUCENENET specific - reduced Nightly iterations from 8192 to 4096
+            // to keep it under the 1 hour free limit of Azure DevOps
+            int maxLength = TestNightly ? 4096 : 1024;
             CheckRandomData(Random, a, 50 * RandomMultiplier, maxLength);
         }
 
@@ -87,7 +90,10 @@ namespace Lucene.Net.Analysis
                 TokenStream output = new NeverPeeksLookaheadTokenFilter(tokenizer);
                 return new TokenStreamComponents(tokenizer, output);
             });
-            int maxLength = TestNightly ? 8192 : 1024;
+            //int maxLength = TestNightly ? 8192 : 1024;
+            // LUCENENET specific - reduced Nightly iterations from 8192 to 4096
+            // to keep it under the 1 hour free limit of Azure DevOps
+            int maxLength = TestNightly ? 4096 : 1024;
             CheckRandomData(Random, a, 50 * RandomMultiplier, maxLength);
         }
 

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TestMockAnalyzer.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TestMockAnalyzer.cs
@@ -265,7 +265,10 @@ namespace Lucene.Net.Analysis
         [Test]
         public void TestRandomRegexps()
         {
-            int iters = TestNightly ? AtLeast(30) : AtLeast(1);
+            //int iters = TestNightly ? AtLeast(30) : AtLeast(1);
+            // LUCENENET specific - reduced Nightly iterations from 30 to 15
+            // to keep it under the 1 hour free limit of Azure DevOps
+            int iters = TestNightly ? AtLeast(15) : AtLeast(1);
             for (int i = 0; i < iters; i++)
             {
                 CharacterRunAutomaton dfa = new CharacterRunAutomaton(AutomatonTestUtil.RandomAutomaton(Random) /*, int.MaxValue*/);

--- a/src/Lucene.Net.Tests._A-D/Lucene.Net.Tests._A-D.csproj
+++ b/src/Lucene.Net.Tests._A-D/Lucene.Net.Tests._A-D.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <Compile Include="..\Lucene.Net.Tests\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Lucene.Net.Tests\*.cs" />
     <Compile Include="..\Lucene.Net.Tests\Analysis\**\*.cs" LinkBase="Analysis" />
     <Compile Include="..\Lucene.Net.Tests\Codecs\**\*.cs" LinkBase="Codecs" />

--- a/src/Lucene.Net.Tests._E-I/Lucene.Net.Tests._E-I.csproj
+++ b/src/Lucene.Net.Tests._E-I/Lucene.Net.Tests._E-I.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Lucene.Net.Tests\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Lucene.Net.Tests\Index\BinaryTokenStream.cs" />
     <Compile Include="..\Lucene.Net.Tests\Index\Test2*.cs" LinkBase="Index" />
     <Compile Include="..\Lucene.Net.Tests\Index\Test4*.cs" LinkBase="Index" />

--- a/src/Lucene.Net.Tests._I-J/Lucene.Net.Tests._I-J.csproj
+++ b/src/Lucene.Net.Tests._I-J/Lucene.Net.Tests._I-J.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Lucene.Net.Tests\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Lucene.Net.Tests\Index\TestBinaryDocValuesUpdates.cs" LinkBase="Index" />
     <Compile Include="..\Lucene.Net.Tests\Index\TestIndexWriterReader.cs" LinkBase="Index" />
     <Compile Include="..\Lucene.Net.Tests\Index\TestIndexWriter.cs" LinkBase="Index" />

--- a/src/Lucene.Net.Tests._J-S/Lucene.Net.Tests._J-S.csproj
+++ b/src/Lucene.Net.Tests._J-S/Lucene.Net.Tests._J-S.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <Compile Include="..\Lucene.Net.Tests\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Lucene.Net.Tests\Index\TestIndexWriterReader.cs" Link="Index\TestIndexWriterReader.cs" />
     <Compile Include="..\Lucene.Net.Tests\Search\**\*.cs" LinkBase="Search" />
     <Compile Include="..\Lucene.Net.Tests\Store\**\*.cs" LinkBase="Store" />

--- a/src/Lucene.Net.Tests._T-Z/Lucene.Net.Tests._T-Z.csproj
+++ b/src/Lucene.Net.Tests._T-Z/Lucene.Net.Tests._T-Z.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <Compile Include="..\Lucene.Net.Tests\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Lucene.Net.Tests\Util\**\*.cs" LinkBase="Util" />
     <Compile Remove="..\Lucene.Net.Tests\Util\JunitCompat\**\*;..\Lucene.Net.Tests\Util\TestMaxFailuresRule.cs" />
   </ItemGroup>

--- a/src/Lucene.Net.Tests/Index/Test2BPostings.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BPostings.cs
@@ -45,6 +45,7 @@ namespace Lucene.Net.Index
     {
         [Test]
         [Nightly]
+        [Ignore("LUCENENET specific - takes too long to run on Azure DevOps")]
         public virtual void Test([ValueSource(typeof(ConcurrentMergeSchedulerFactories), "Values")]Func<IConcurrentMergeScheduler> newScheduler)
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BPostings"));

--- a/src/Lucene.Net.Tests/Index/Test4GBStoredFields.cs
+++ b/src/Lucene.Net.Tests/Index/Test4GBStoredFields.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using Lucene.Net.Randomized.Generators;
 using Lucene.Net.Store;
+using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using Assert = Lucene.Net.TestFramework.Assert;
@@ -47,6 +48,9 @@ namespace Lucene.Net.Index
         [Nightly]
         public virtual void Test([ValueSource(typeof(ConcurrentMergeSchedulerFactories), "Values")]Func<IConcurrentMergeScheduler> newScheduler)
         {
+            // LUCENENET specific - disable the test if not 64 bit
+            AssumeTrue("This test consumes too much RAM be run on x86.", Constants.RUNTIME_IS_64BIT);
+
             MockDirectoryWrapper dir = new MockDirectoryWrapper(Random, new MMapDirectory(CreateTempDir("4GBStoredFields")));
             dir.Throttling = Throttling.NEVER;
 

--- a/src/Lucene.Net.Tests/Index/Test4GBStoredFields.cs
+++ b/src/Lucene.Net.Tests/Index/Test4GBStoredFields.cs
@@ -46,6 +46,7 @@ namespace Lucene.Net.Index
     {
         [Test]
         [Nightly]
+        [Timeout(1200000)]
         public virtual void Test([ValueSource(typeof(ConcurrentMergeSchedulerFactories), "Values")]Func<IConcurrentMergeScheduler> newScheduler)
         {
             // LUCENENET specific - disable the test if not 64 bit

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -816,6 +816,7 @@ namespace Lucene.Net.Index
         // LUCENE-1335: test simultaneous addIndexes & commits
         // from multiple threads
         [Test]
+        [Timeout(300000)]
         public virtual void TestAddIndexesWithThreads()
         {
             int NUM_ITER = TestNightly ? 15 : 5;
@@ -1004,6 +1005,7 @@ namespace Lucene.Net.Index
 
         // LUCENE-1335: test simultaneous addIndexes & close
         [Test]
+        [Timeout(300000)]
         public virtual void TestAddIndexesWithRollback()
         {
             int NUM_COPY = TestNightly ? 50 : 5;

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -975,7 +975,7 @@ namespace Lucene.Net.Index
         // LUCENE-1335: test simultaneous addIndexes & close
         [Test]
         [Slow]
-        [Deadlock]
+        [Deadlock][Timeout(600000)]
         public virtual void TestAddIndexesWithCloseNoWait()
         {
             const int NUM_COPY = 50;

--- a/src/Lucene.Net.Tests/Index/TestBagOfPositions.cs
+++ b/src/Lucene.Net.Tests/Index/TestBagOfPositions.cs
@@ -64,7 +64,10 @@ namespace Lucene.Net.Index
             if ((isSimpleText || iwc.MergePolicy is MockRandomMergePolicy) && (TestNightly || RandomMultiplier > 1))
             {
                 // Otherwise test can take way too long (> 2 hours)
-                numTerms /= 2;
+                //numTerms /= 2;
+                // LUCENENET specific - To keep this under the 1 hour free limit
+                // of Azure DevOps, this was reduced from /2 to /6.
+                numTerms /= 6;
             }
             if (Verbose)
             {

--- a/src/Lucene.Net.Tests/Index/TestBagOfPostings.cs
+++ b/src/Lucene.Net.Tests/Index/TestBagOfPostings.cs
@@ -62,7 +62,10 @@ namespace Lucene.Net.Index
             if ((isSimpleText || iwc.MergePolicy is MockRandomMergePolicy) && (TestNightly || RandomMultiplier > 1))
             {
                 // Otherwise test can take way too long (> 2 hours)
-                numTerms /= 2;
+                //numTerms /= 2;
+                // LUCENENET specific - To keep this under the 1 hour free limit
+                // of Azure DevOps, this was reduced from /2 to /6.
+                numTerms /= 6;
             }
 
             if (Verbose)

--- a/src/Lucene.Net.Tests/Index/TestDocValuesWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocValuesWithThreads.cs
@@ -181,6 +181,7 @@ namespace Lucene.Net.Index
         }
 
         [Test]
+        [Timeout(600000)]
         public virtual void Test2()
         {
             Random random = Random;

--- a/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
@@ -146,12 +146,14 @@ namespace Lucene.Net.Index
 
             Start(threads);
             int iters = AtLeast(10000);
-            float checkPointProbability = TestNightly ? 0.5f : 0.1f;
+            //float checkPointProbability = TestNightly ? 0.5f : 0.1f;
+            // LUCENENET specific - reduced probabliltiy on x86 to prevent it from timing out.
+            float checkPointProbability = TestNightly ? (Lucene.Net.Util.Constants.RUNTIME_IS_64BIT ? 0.5f : 0.25f) : 0.1f;
             for (int i = 0; i < iters; i++)
             {
                 if (checkPoint)
                 {
-                    Assert.IsTrue(sync.updateJoin.Wait(new TimeSpan(0, 0, 0, 10)), "timed out waiting for update threads - deadlock?");
+                    Assert.IsTrue(sync.updateJoin.Wait(TimeSpan.FromSeconds(10)), "timed out waiting for update threads - deadlock?");
                     if (exceptions.Count > 0)
                     {
                         foreach (Exception throwable in exceptions)

--- a/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
@@ -32,6 +32,7 @@ namespace Lucene.Net.Index
     /// Tests for <seealso cref="DocumentsWriterStallControl"/>
     /// </summary>
     [TestFixture]
+    [Timeout(900000)]
     public class TestDocumentsWriterStallControl : LuceneTestCase
     {
         [Test]

--- a/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
@@ -39,6 +39,7 @@ namespace Lucene.Net.Index
     
 
     [TestFixture]
+    [Timeout(900000)]
     public class TestFlushByRamOrCountsPolicy : LuceneTestCase 
     {
 

--- a/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
@@ -66,7 +66,10 @@ namespace Lucene.Net.Index
             // LUCENENET specific - disable the test if asserts are not enabled
             AssumeTrue("This test requires asserts to be enabled.", Debugging.AssertsEnabled);
 
-            double ramBuffer = (TestNightly ? 1 : 10) + AtLeast(2) + Random.NextDouble();
+            //double ramBuffer = (TestNightly ? 1 : 10) + AtLeast(2) + Random.NextDouble();
+            // LUCENENET specific - increased size of ramBuffer to reduce the amount of
+            // time required and offset AtLeast(2).
+            double ramBuffer = (TestNightly ? 2 : 10) + AtLeast(2) + Random.NextDouble();
             RunFlushByRam(1 + Random.Next(TestNightly ? 5 : 1), ramBuffer, false);
         }
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterDelete.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterDelete.cs
@@ -1305,6 +1305,7 @@ namespace Lucene.Net.Index
         // much RAM that it forces long tail of tiny segments:
         [Test]
         [Nightly]
+        [Timeout(600000)]
         public virtual void TestApplyDeletesOnFlush()
         {
             Directory dir = NewDirectory();

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Index
     using TokenStream = Lucene.Net.Analysis.TokenStream;
 
     [TestFixture]
-    [Deadlock]
+    [Deadlock][Timeout(600000)]
     public class TestIndexWriterExceptions : LuceneTestCase
     {
         private class DocCopyIterator : IEnumerable<Document>

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterForceMerge.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterForceMerge.cs
@@ -39,6 +39,7 @@ namespace Lucene.Net.Index
 
         [Test]
         [Slow] // Occasionally
+        [Timeout(600000)]
         public virtual void TestPartialMerge()
         {
             Directory dir = NewDirectory();

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnDiskFull.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnDiskFull.cs
@@ -47,6 +47,7 @@ namespace Lucene.Net.Index
     /// Tests for IndexWriter when the disk runs out of space
     /// </summary>
     [TestFixture]
+    [Timeout(900000)]
     public class TestIndexWriterOnDiskFull : LuceneTestCase
     {
         /*

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
@@ -867,6 +867,10 @@ namespace Lucene.Net.Index
         [Slow]
         public virtual void TestDuringAddIndexes()
         {
+            // LUCENENET specific - log the current locking strategy used and HResult values
+            // for assistance troubleshooting problems on Linux/macOS
+            LogNativeFSFactoryDebugInfo();
+
             Directory dir1 = GetAssertNoDeletesDirectory(NewDirectory());
             IndexWriter writer = new IndexWriter(
                 dir1, 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Index
     using TopDocs = Lucene.Net.Search.TopDocs;
 
     [TestFixture]
-    [Deadlock]
+    [Deadlock][Timeout(600000)]
     public class TestIndexWriterReader : LuceneTestCase
     {
         private readonly int numThreads = TestNightly ? 5 : 3;

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Index
     /// </summary>
     [SuppressCodecs("Lucene3x")]
     [Slow]
-    [Deadlock]
+    [Deadlock][Timeout(1200000)]
     [TestFixture]
     public class TestIndexWriterWithThreads : LuceneTestCase
     {

--- a/src/Lucene.Net.Tests/Index/TestNRTReaderWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestNRTReaderWithThreads.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Index
 
         [Test]
         [Slow] // (occasionally)
-        [Deadlock]
+        [Deadlock][Timeout(600000)]
         public virtual void TestIndexing()
         {
             Directory mainDir = NewDirectory();

--- a/src/Lucene.Net.Tests/Index/TestTermVectorsWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestTermVectorsWriter.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
+using System;
 using System.IO;
 using Assert = Lucene.Net.TestFramework.Assert;
 
@@ -407,6 +408,10 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestTermVectorCorruption()
         {
+            // LUCENENET specific - log the current locking strategy used and HResult values
+            // for assistance troubleshooting problems on Linux/macOS
+            LogNativeFSFactoryDebugInfo();
+
             Directory dir = NewDirectory();
             for (int iter = 0; iter < 2; iter++)
             {

--- a/src/Lucene.Net.Tests/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests/Properties/AssemblyInfo.cs
@@ -21,7 +21,6 @@
 
 using NUnit.Framework;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -34,3 +33,7 @@ using System.Runtime.CompilerServices;
 // LUCENENET specific - only allow tests in this assembly to run one at a time
 // to prevent polluting shared state.
 [assembly: LevelOfParallelism(1)]
+
+// LUCENENET specific - time out test projects at 55 minutes to allow the results
+// to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
+[assembly: Timeout(3300000)]

--- a/src/Lucene.Net/Store/NativeFSLockFactory.cs
+++ b/src/Lucene.Net/Store/NativeFSLockFactory.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Store
     // to take advantage of .NET FileShare locking in the Windows and Linux environments.
     public class NativeFSLockFactory : FSLockFactory
     {
-        private enum FSLockingStrategy
+        internal enum FSLockingStrategy
         {
             FileStreamLockViolation,
             FileSharingViolation,
@@ -66,7 +66,7 @@ namespace Lucene.Net.Store
         }
 
         // LUCENENET: This controls the locking strategy used for the current operating system and framework
-        private static FSLockingStrategy LockingStrategy
+        internal static FSLockingStrategy LockingStrategy
         {
             get
             {


### PR DESCRIPTION
This PR primarily focuses on reducing the nightly limits of the test framework and tests to prevent them from exceeding the 1 hour job limit of the free Azure DevOps account. Timeouts were set up so if a run goes over the limit there will still be time to upload the results in order to identify the offending test(s).

Also, tests were setup for .NET Core 3.1 x86 and .NET Core 2.1 x86 that only run nightly. Logging was also added to assist with debugging issues we are having with file lock failures on Linux and macOS.