### PR TITLE
Lucene.Net.Tests: Removed calls to obsolete Counter.Get() method

### DIFF
--- a/src/Lucene.Net.Tests/Index/TestIntBlockPool.cs
+++ b/src/Lucene.Net.Tests/Index/TestIntBlockPool.cs
@@ -59,12 +59,12 @@ namespace Lucene.Net.Index
                 if (Random.NextBoolean())
                 {
                     pool.Reset(true, false);
-                    Assert.AreEqual(0, bytesUsed.Get());
+                    Assert.AreEqual(0, bytesUsed);
                 }
                 else
                 {
                     pool.Reset(true, true);
-                    Assert.AreEqual(Int32BlockPool.INT32_BLOCK_SIZE * RamUsageEstimator.NUM_BYTES_INT32, bytesUsed.Get());
+                    Assert.AreEqual(Int32BlockPool.INT32_BLOCK_SIZE * RamUsageEstimator.NUM_BYTES_INT32, bytesUsed);
                 }
             }
         }
@@ -116,12 +116,12 @@ namespace Lucene.Net.Index
                 if (Random.NextBoolean())
                 {
                     pool.Reset(true, false);
-                    Assert.AreEqual(0, bytesUsed.Get());
+                    Assert.AreEqual(0, bytesUsed);
                 }
                 else
                 {
                     pool.Reset(true, true);
-                    Assert.AreEqual(Int32BlockPool.INT32_BLOCK_SIZE * RamUsageEstimator.NUM_BYTES_INT32, bytesUsed.Get());
+                    Assert.AreEqual(Int32BlockPool.INT32_BLOCK_SIZE * RamUsageEstimator.NUM_BYTES_INT32, bytesUsed);
                 }
             }
         }

--- a/src/Lucene.Net.Tests/Util/TestByteBlockPool.cs
+++ b/src/Lucene.Net.Tests/Util/TestByteBlockPool.cs
@@ -57,11 +57,11 @@ namespace Lucene.Net.Util
                 pool.Reset(Random.NextBoolean(), reuseFirst);
                 if (reuseFirst)
                 {
-                    Assert.AreEqual(ByteBlockPool.BYTE_BLOCK_SIZE, bytesUsed.Get());
+                    Assert.AreEqual(ByteBlockPool.BYTE_BLOCK_SIZE, bytesUsed);
                 }
                 else
                 {
-                    Assert.AreEqual(0, bytesUsed.Get());
+                    Assert.AreEqual(0, bytesUsed);
                     pool.NextBuffer(); // prepare for next iter
                 }
             }


### PR DESCRIPTION
Build warnings removed