### PR TITLE
Add new interface to NumericDocValues to close #370

### DIFF
--- a/src/Lucene.Net/Index/NumericDocValues.cs
+++ b/src/Lucene.Net/Index/NumericDocValues.cs
@@ -72,5 +72,67 @@ namespace Lucene.Net.Index
         {
             return J2N.BitConversion.Int64BitsToDouble(Get(docID));
         }
+
+
+        private FieldCache.Bytes   _asBytes;
+        private FieldCache.Int16s  _asInt16s;
+        private FieldCache.Int32s  _asInt32s;
+        private FieldCache.Int64s  _asInt64s;
+        private FieldCache.Singles _asSingles;
+        private FieldCache.Doubles _asDoubles;
+
+        internal FieldCache.Bytes AsBytes() // LUCENENET specific - Avoid allocation of a new FieldCache.Bytes on every Get call
+        {
+            if (_asBytes is null) //No need to lock, as we don't care if this is replaced
+            {
+                _asBytes = new FieldCache.Bytes(this);
+            }
+            return _asBytes;
+        }
+
+        internal FieldCache.Int16s AsInt16s() // LUCENENET specific - Avoid allocation of a new FieldCache.Int16s on every Get call
+        {
+            if (_asInt16s is null) //No need to lock, as we don't care if this is replaced
+            {
+                _asInt16s = new FieldCache.Int16s(this);
+            }
+            return _asInt16s;
+        }
+
+        internal FieldCache.Int32s AsInt32s() // LUCENENET specific - Avoid allocation of a new FieldCache.Int32s on every Get call
+        {
+            if (_asInt32s is null) //No need to lock, as we don't care if this is replaced
+            {
+                _asInt32s = new FieldCache.Int32s(this);
+            }
+            return _asInt32s;
+        }
+
+        internal FieldCache.Int64s AsInt64s() // LUCENENET specific - Avoid allocation of a new FieldCache.Int64s on every Get call
+        {
+            if (_asInt64s is null) //No need to lock, as we don't care if this is replaced
+            {
+                _asInt64s = new FieldCache.Int64s(this);
+            }
+            return _asInt64s;
+        }
+
+        internal FieldCache.Singles AsSingles() // LUCENENET specific - Avoid allocation of a new FieldCache.Singles on every Get call
+        {
+            if (_asSingles is null) //No need to lock, as we don't care if this is replaced
+            {
+                _asSingles = new FieldCache.Singles(this);
+            }
+            return _asSingles;
+        }
+
+        internal FieldCache.Doubles AsDoubles() // LUCENENET specific - Avoid allocation of a new FieldCache.Doubles on every Get call
+        {
+            if(_asDoubles is null) //No need to lock, as we don't care if this is replaced
+            {
+                _asDoubles = new FieldCache.Doubles(this);
+            }
+            return _asDoubles;
+        }
     }
 }

--- a/src/Lucene.Net/Index/NumericDocValues.cs
+++ b/src/Lucene.Net/Index/NumericDocValues.cs
@@ -1,3 +1,5 @@
+using Lucene.Net.Search;
+
 namespace Lucene.Net.Index
 {
     /*
@@ -20,7 +22,12 @@ namespace Lucene.Net.Index
     /// <summary>
     /// A per-document numeric value.
     /// </summary>
-    public abstract class NumericDocValues
+    public abstract class NumericDocValues : IFieldCacheGetter<byte>,  // LUCENENET specific - Add interfaces per type to reduce previous Func<int,T> allocations on reading from cache
+                                             IFieldCacheGetter<short>, 
+                                             IFieldCacheGetter<int>,
+                                             IFieldCacheGetter<long>, 
+                                             IFieldCacheGetter<float>, 
+                                             IFieldCacheGetter<double>
     {
         /// <summary>
         /// Sole constructor. (For invocation by subclass
@@ -35,5 +42,35 @@ namespace Lucene.Net.Index
         /// <param name="docID"> document ID to lookup </param>
         /// <returns> numeric value </returns>
         public abstract long Get(int docID);
+
+        byte IFieldCacheGetter<byte>.GetCached(int docID) // LUCENENET specific - moved read logic from FieldCacheImpl to here
+        {
+            return (byte)Get(docID);
+        }
+
+        short IFieldCacheGetter<short>.GetCached(int docID) // LUCENENET specific - moved read logic from FieldCacheImpl to here
+        {
+            return (short)Get(docID);
+        }
+
+        int IFieldCacheGetter<int>.GetCached(int docID) // LUCENENET specific - moved read logic from FieldCacheImpl to here
+        {
+            return (int)Get(docID);
+        }
+
+        long IFieldCacheGetter<long>.GetCached(int docID) // LUCENENET specific - moved read logic from FieldCacheImpl to here
+        {
+            return Get(docID);
+        }
+
+        float IFieldCacheGetter<float>.GetCached(int docID) // LUCENENET specific - moved read logic from FieldCacheImpl to here
+        {
+            return J2N.BitConversion.Int32BitsToSingle((int)Get(docID));
+        }
+
+        double IFieldCacheGetter<double>.GetCached(int docID) // LUCENENET specific - moved read logic from FieldCacheImpl to here
+        {
+            return J2N.BitConversion.Int64BitsToDouble(Get(docID));
+        }
     }
 }

--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -358,6 +358,17 @@ namespace Lucene.Net.Search
         TextWriter InfoStream { set; get; }
     }
 
+    public interface IFieldCacheGetter<T> // LUCENENET specific - interface to replace passing a Func<int,T> to the FieldCache methods
+    {
+        T GetCached(int docID);
+    }
+
+    public class EmptyGetter<T> : IFieldCacheGetter<T> // LUCENENET specific - Replaces (docID) => 0 
+    {
+        public static readonly EmptyGetter<T> Default = new EmptyGetter<T>();
+        public T GetCached(int docID) => default(T);
+    }
+
     public static class FieldCache 
     {
         /// <summary>
@@ -365,7 +376,7 @@ namespace Lucene.Net.Search
         /// </summary>
         public class Bytes // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
-            private readonly Func<int, byte> get;
+            private readonly IFieldCacheGetter<byte> get;
             private readonly bool hasGet;
 
             /// <summary>
@@ -378,7 +389,7 @@ namespace Lucene.Net.Search
             /// <paramref name="get"/> delegate method.
             /// </summary>
             /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
-            public Bytes(Func<int, byte> get) 
+            public Bytes(IFieldCacheGetter<byte> get) 
             {
                 this.get = get ?? throw new ArgumentNullException(nameof(get));
                 this.hasGet = true;
@@ -387,12 +398,12 @@ namespace Lucene.Net.Search
             /// <summary>
             /// Return a single <see cref="byte"/> representation of this field's value.
             /// </summary>
-            public virtual byte Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
+            public virtual byte Get(int docID) => hasGet ? get.GetCached(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Bytes EMPTY = new Bytes((docID) => 0);
+            public static readonly Bytes EMPTY = new Bytes(EmptyGetter<byte>.Default);
         }
 
         /// <summary>
@@ -402,7 +413,7 @@ namespace Lucene.Net.Search
         /// </summary>
         public class Int16s // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
-            private readonly Func<int, short> get;
+            private readonly IFieldCacheGetter<short> get;
             private readonly bool hasGet;
 
             /// <summary>
@@ -415,7 +426,7 @@ namespace Lucene.Net.Search
             /// <paramref name="get"/> delegate method.
             /// </summary>
             /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
-            public Int16s(Func<int, short> get)
+            public Int16s(IFieldCacheGetter<short> get)
             {
                 this.get = get ?? throw new ArgumentNullException(nameof(get));
                 this.hasGet = true;
@@ -424,12 +435,12 @@ namespace Lucene.Net.Search
             /// <summary>
             /// Return a <see cref="short"/> representation of this field's value.
             /// </summary>
-            public virtual short Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
+            public virtual short Get(int docID) => hasGet ? get.GetCached(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Int16s EMPTY = new Int16s((docID) => 0);
+            public static readonly Int16s EMPTY = new Int16s(EmptyGetter<short>.Default);
         }
 
         /// <summary>
@@ -439,7 +450,7 @@ namespace Lucene.Net.Search
         /// </summary>
         public class Int32s // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
-            private readonly Func<int, int> get;
+            private readonly IFieldCacheGetter<int> get;
             private readonly bool hasGet;
 
             /// <summary>
@@ -452,7 +463,7 @@ namespace Lucene.Net.Search
             /// <paramref name="get"/> delegate method.
             /// </summary>
             /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
-            public Int32s(Func<int, int> get)
+            public Int32s(IFieldCacheGetter<int> get)
             {
                 this.get = get ?? throw new ArgumentNullException(nameof(get));
                 this.hasGet = true;
@@ -461,12 +472,12 @@ namespace Lucene.Net.Search
             /// <summary>
             /// Return an <see cref="int"/> representation of this field's value.
             /// </summary>
-            public virtual int Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
+            public virtual int Get(int docID) => hasGet ? get.GetCached(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Int32s EMPTY = new Int32s((docID) => 0);
+            public static readonly Int32s EMPTY = new Int32s(EmptyGetter<int>.Default);
         }
 
         /// <summary>
@@ -476,7 +487,7 @@ namespace Lucene.Net.Search
         /// </summary>
         public class Int64s // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
-            private readonly Func<int, long> get;
+            private readonly IFieldCacheGetter<long> get;
             private readonly bool hasGet;
 
             /// <summary>
@@ -489,7 +500,7 @@ namespace Lucene.Net.Search
             /// <paramref name="get"/> delegate method.
             /// </summary>
             /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
-            public Int64s(Func<int, long> get)
+            public Int64s(IFieldCacheGetter<long> get)
             {
                 this.get = get ?? throw new ArgumentNullException(nameof(get));
                 this.hasGet = true;
@@ -498,12 +509,12 @@ namespace Lucene.Net.Search
             /// <summary>
             /// Return an <see cref="long"/> representation of this field's value.
             /// </summary>
-            public virtual long Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
+            public virtual long Get(int docID) => hasGet ? get.GetCached(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Int64s EMPTY = new Int64s((docID) => 0);
+            public static readonly Int64s EMPTY = new Int64s(EmptyGetter<long>.Default);
         }
 
         /// <summary>
@@ -513,7 +524,7 @@ namespace Lucene.Net.Search
         /// </summary>
         public class Singles // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
-            private readonly Func<int, float> get;
+            private readonly IFieldCacheGetter<float> get;
             private readonly bool hasGet;
 
             /// <summary>
@@ -526,7 +537,7 @@ namespace Lucene.Net.Search
             /// <paramref name="get"/> delegate method.
             /// </summary>
             /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
-            public Singles(Func<int, float> get)
+            public Singles(IFieldCacheGetter<float> get)
             {
                 this.get = get ?? throw new ArgumentNullException(nameof(get));
                 this.hasGet = true;
@@ -535,12 +546,12 @@ namespace Lucene.Net.Search
             /// <summary>
             /// Return an <see cref="float"/> representation of this field's value.
             /// </summary>
-            public virtual float Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
+            public virtual float Get(int docID) => hasGet ? get.GetCached(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Singles EMPTY = new Singles((docID) => 0);
+            public static readonly Singles EMPTY = new Singles(EmptyGetter<float>.Default);
         }
 
         /// <summary>
@@ -548,7 +559,7 @@ namespace Lucene.Net.Search
         /// </summary>
         public class Doubles // LUCENENET specific - removed abstract so we can pass a delegate to the constructor
         {
-            private readonly Func<int, double> get;
+            private readonly IFieldCacheGetter<double> get;
             private readonly bool hasGet;
 
             /// <summary>
@@ -561,7 +572,7 @@ namespace Lucene.Net.Search
             /// <paramref name="get"/> delegate method.
             /// </summary>
             /// <param name="get">A <see cref="Func{T, TResult}"/> that implements the <see cref="Get(int)"/> method body.</param>
-            public Doubles(Func<int, double> get)
+            public Doubles(IFieldCacheGetter<double> get)
             {
                 this.get = get ?? throw new ArgumentNullException(nameof(get));
                 this.hasGet = true;
@@ -570,12 +581,12 @@ namespace Lucene.Net.Search
             /// <summary>
             /// Return a <see cref="double"/> representation of this field's value.
             /// </summary>
-            public virtual double Get(int docID) => hasGet ? get(docID) : default; // LUCENENET specific - implemented with delegate by default
+            public virtual double Get(int docID) => hasGet ? get.GetCached(docID) : default; // LUCENENET specific - implemented with delegate by default
 
             /// <summary>
             /// Zero value for every document
             /// </summary>
-            public static readonly Doubles EMPTY = new Doubles((docID) => 0);
+            public static readonly Doubles EMPTY = new Doubles(EmptyGetter<double>.Default);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -598,7 +598,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Bytes(valuesIn);
+                return valuesIn.AsBytes();
             }
             else
             {
@@ -756,7 +756,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Int16s(valuesIn);
+                return valuesIn.AsInt16s();
             }
             else
             {
@@ -913,7 +913,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Int32s(valuesIn);
+                return valuesIn.AsInt32s();
             }
             else
             {
@@ -1193,7 +1193,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Singles(valuesIn);
+                return valuesIn.AsSingles();
             }
             else
             {
@@ -1344,7 +1344,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Int64s(valuesIn);
+                return valuesIn.AsInt64s();
             }
             else
             {
@@ -1507,7 +1507,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Doubles(valuesIn);
+                return valuesIn.AsDoubles();
             }
             else
             {

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -598,7 +598,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Bytes(get: (docID) => (byte)valuesIn.Get(docID));
+                return new FieldCache.Bytes(valuesIn);
             }
             else
             {
@@ -756,7 +756,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Int16s(get: (docID) => (short)valuesIn.Get(docID));
+                return new FieldCache.Int16s(valuesIn);
             }
             else
             {
@@ -913,7 +913,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Int32s(get: (docID) => (int)valuesIn.Get(docID));
+                return new FieldCache.Int32s(valuesIn);
             }
             else
             {
@@ -1193,7 +1193,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Singles(get: (docID) => J2N.BitConversion.Int32BitsToSingle((int)valuesIn.Get(docID)));
+                return new FieldCache.Singles(valuesIn);
             }
             else
             {
@@ -1344,7 +1344,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Int64s(get: (docID) => valuesIn.Get(docID));
+                return new FieldCache.Int64s(valuesIn);
             }
             else
             {
@@ -1507,7 +1507,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Doubles(get: (docID) => J2N.BitConversion.Int64BitsToDouble(valuesIn.Get(docID)));
+                return new FieldCache.Doubles(valuesIn);
             }
             else
             {


### PR DESCRIPTION
As mentioned in #370, we measured a significant number of allocations when reading values from the cache, due to a variable capture inside a lambda and a new FieldCache.T instance being created.

Adding an interface to the class NumericDocValues for each of the supported types instead of using the lambda, and adding a cached FieldCache.T for each type on the NumericDocValues class that is created only on first use.

