### PR TITLE
Add fork me on GitHub to API docs

### DIFF
--- a/websites/apidocs/Templates/LuceneApiDocs/layout/_master.tmpl
+++ b/websites/apidocs/Templates/LuceneApiDocs/layout/_master.tmpl
@@ -1,0 +1,56 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+{{!include(/^styles/.*/)}}
+{{!include(/^fonts/.*/)}}
+{{!include(favicon.ico)}}
+{{!include(logo.svg)}}
+{{!include(search-stopwords.json)}}
+<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  {{>partials/head}}
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <span id="forkongithub"><a href="https://github.com/apache/lucenenet">Fork me on GitHub</a></span>
+    <div id="wrapper">
+      <header>
+        {{^_disableNavbar}}
+        {{>partials/navbar}}
+        {{/_disableNavbar}}
+        {{^_disableBreadcrumb}}
+        {{>partials/breadcrumb}}
+        {{/_disableBreadcrumb}}
+      </header>
+      {{#_enableSearch}}
+      <div class="container body-content">
+        {{>partials/searchResults}}
+      </div>
+      {{/_enableSearch}}
+      <div role="main" class="container body-content hide-when-search">
+      {{^_disableToc}}
+        {{>partials/toc}}
+        <div class="article row grid-right">
+      {{/_disableToc}}
+      {{#_disableToc}}
+        <div class="article row grid">
+        {{/_disableToc}}
+          {{#_disableAffix}}
+          <div class="col-md-12">
+          {{/_disableAffix}}
+          {{^_disableAffix}}
+          <div class="col-md-10">
+          {{/_disableAffix}}
+            <article class="content wrap" id="_content" data-uid="{{uid}}">
+                {{!body}}
+            </article>
+          </div>
+          {{^_disableAffix}}
+          {{>partials/affix}}
+          {{/_disableAffix}}
+        </div>
+      </div>
+      {{^_disableFooter}}
+      {{>partials/footer}}
+      {{/_disableFooter}}
+    </div>
+    {{>partials/scripts}}
+  </body>
+</html>

--- a/websites/apidocs/Templates/LuceneApiDocs/layout/_master.tmpl
+++ b/websites/apidocs/Templates/LuceneApiDocs/layout/_master.tmpl
@@ -9,7 +9,7 @@
 <html>
   {{>partials/head}}
   <body data-spy="scroll" data-target="#affix" data-offset="120">
-    <span id="forkongithub"><a href="https://github.com/apache/lucenenet">Fork me on GitHub</a></span>
+    <span id="forkongithub"><a href="https://github.com/apache/lucenenet" target="_blank">Fork me on GitHub</a></span>
     <div id="wrapper">
       <header>
         {{^_disableNavbar}}

--- a/websites/apidocs/Templates/LuceneTemplate/layout/_master.tmpl
+++ b/websites/apidocs/Templates/LuceneTemplate/layout/_master.tmpl
@@ -1,0 +1,56 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+{{!include(/^styles/.*/)}}
+{{!include(/^fonts/.*/)}}
+{{!include(favicon.ico)}}
+{{!include(logo.svg)}}
+{{!include(search-stopwords.json)}}
+<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  {{>partials/head}}
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <span id="forkongithub"><a href="https://github.com/apache/lucenenet">Fork me on GitHub</a></span>
+    <div id="wrapper">
+      <header>
+        {{^_disableNavbar}}
+        {{>partials/navbar}}
+        {{/_disableNavbar}}
+        {{^_disableBreadcrumb}}
+        {{>partials/breadcrumb}}
+        {{/_disableBreadcrumb}}
+      </header>
+      {{#_enableSearch}}
+      <div class="container body-content">
+        {{>partials/searchResults}}
+      </div>
+      {{/_enableSearch}}
+      <div role="main" class="container body-content hide-when-search">
+      {{^_disableToc}}
+        {{>partials/toc}}
+        <div class="article row grid-right">
+      {{/_disableToc}}
+      {{#_disableToc}}
+        <div class="article row grid">
+        {{/_disableToc}}
+          {{#_disableAffix}}
+          <div class="col-md-12">
+          {{/_disableAffix}}
+          {{^_disableAffix}}
+          <div class="col-md-10">
+          {{/_disableAffix}}
+            <article class="content wrap" id="_content" data-uid="{{uid}}">
+                {{!body}}
+            </article>
+          </div>
+          {{^_disableAffix}}
+          {{>partials/affix}}
+          {{/_disableAffix}}
+        </div>
+      </div>
+      {{^_disableFooter}}
+      {{>partials/footer}}
+      {{/_disableFooter}}
+    </div>
+    {{>partials/scripts}}
+  </body>
+</html>

--- a/websites/apidocs/Templates/LuceneTemplate/layout/_master.tmpl
+++ b/websites/apidocs/Templates/LuceneTemplate/layout/_master.tmpl
@@ -9,7 +9,7 @@
 <html>
   {{>partials/head}}
   <body data-spy="scroll" data-target="#affix" data-offset="120">
-    <span id="forkongithub"><a href="https://github.com/apache/lucenenet">Fork me on GitHub</a></span>
+    <span id="forkongithub"><a href="https://github.com/apache/lucenenet" target="_blank">Fork me on GitHub</a></span>
     <div id="wrapper">
       <header>
         {{^_disableNavbar}}

--- a/websites/apidocs/Templates/LuceneTemplateAssets/styles/main.css
+++ b/websites/apidocs/Templates/LuceneTemplateAssets/styles/main.css
@@ -136,7 +136,7 @@ body .toc {
   bottom: 1px;
   top: auto;
 }
-@media screen and (min-width: 800px) {
+@media screen and (min-width: 768px) {
   #forkongithub {
     position: fixed;
     display: block;


### PR DESCRIPTION
This PR addresses issue #365 which adds the 'Fork me on GitHub' ribbon to the API docs. I added the `_master.tmpl` files to both `/websites/apidocs/Templates/LuceneApiDocs/layout/_master.tmpl` and `/websites/apidocs/Templates/LuceneTemplate/layout/_master.tmpl`. However, I was not able to test. For some reason I could not run the `docs.ps1` file. I wanted to go ahead and get the PR in, in case this fix works. If not please let me know and I will try to figure out why I can't get the `docs.ps1` file to run.