### PR TITLE
Fix for Delegate-based Asserts

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/BaseCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/BaseCharFilter.cs
@@ -114,8 +114,7 @@ namespace Lucene.Net.Analysis.CharFilters
             }
 
             int offset = offsets[(size == 0) ? 0 : size - 1];
-            if (Debugging.AssertsEnabled) Debugging.Assert(size == 0 || off >= offset,
-                () => "Offset #" + size + "(" + off + ") is less than the last recorded offset " + offset + "\n" + Arrays.ToString(offsets) + "\n" + Arrays.ToString(diffs));
+            if (Debugging.AssertsEnabled) Debugging.Assert(size == 0 || off >= offset, "Offset #{0}({1}) is less than the last recorded offset {2}\n{3}\n{4}", size, off, offset, Arrays.ToString(offsets), Arrays.ToString(diffs));
 
             if (size == 0 || off != offsets[size - 1])
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/BaseCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/BaseCharFilter.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Analysis.CharFilters
             }
 
             int offset = offsets[(size == 0) ? 0 : size - 1];
-            if (Debugging.AssertsEnabled) Debugging.Assert(size == 0 || off >= offset, "Offset #{0}({1}) is less than the last recorded offset {2}\n{3}\n{4}", size, off, offset, Arrays.ToString(offsets), Arrays.ToString(diffs));
+            if (Debugging.AssertsEnabled) Debugging.Assert(size == 0 || off >= offset, "Offset #{0}({1}) is less than the last recorded offset {2}\n{3}\n{4}", size, off, offset, offsets, diffs);
 
             if (size == 0 || off != offsets[size - 1])
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
@@ -31636,9 +31636,9 @@ namespace Lucene.Net.Analysis.CharFilters
                                 {
                                     codePoint = int.Parse(hexCharRef, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
                                 }
-                                catch (Exception /*e*/)
+                                catch (Exception e)
                                 {
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing hex code point '{0}'");
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing hex code point '{0}'", e);
                                 }
                                 if (codePoint <= 0x10FFFF)
                                 {

--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
@@ -31378,7 +31378,7 @@ namespace Lucene.Net.Analysis.CharFilters
                                 }
                                 catch (Exception /*e*/)
                                 {
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing code point '" + decimalCharRef + "'");
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing code point '{0}'", decimalCharRef);
                                 }
                                 if (codePoint <= 0x10FFFF)
                                 {
@@ -31638,7 +31638,7 @@ namespace Lucene.Net.Analysis.CharFilters
                                 }
                                 catch (Exception /*e*/)
                                 {
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing hex code point '" + hexCharRef + "'");
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing hex code point '{0}'");
                                 }
                                 if (codePoint <= 0x10FFFF)
                                 {
@@ -31901,8 +31901,7 @@ namespace Lucene.Net.Analysis.CharFilters
                             }
                             catch (Exception /*e*/)
                             { // should never happen
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing high surrogate '"
-                                            + surrogatePair.Substring(2, 6 - 2) + "'");
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", surrogatePair.Substring(2, 6 - 2));
                             }
                             try
                             {
@@ -31910,7 +31909,7 @@ namespace Lucene.Net.Analysis.CharFilters
                             }
                             catch (Exception /*e*/)
                             { // should never happen
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing low surrogate '" + surrogatePair.Substring(10, 14 - 10) + "'");
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", surrogatePair.Substring(10, 14 - 10));
                             }
                             // add (previously matched input length) + (this match length) - (substitution length)
                             cumulativeDiff += inputSegment.Length + YyLength - 2;
@@ -31932,8 +31931,7 @@ namespace Lucene.Net.Analysis.CharFilters
                             }
                             catch (Exception /*e*/)
                             { // should never happen
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing high surrogate '"
-                                            + surrogatePair.Substring(2, 6 - 2) + "'");
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", surrogatePair.Substring(2, 6 - 2));
                             }
                             try
                             { // Low surrogates are in decimal range [56320, 57343]
@@ -31941,8 +31939,7 @@ namespace Lucene.Net.Analysis.CharFilters
                             }
                             catch (Exception /*e*/)
                             { // should never happen
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing low surrogate '"
-                                            + surrogatePair.Substring(9, 14 - 9) + "'");
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", surrogatePair.Substring(9, 14 - 9));
                             }
                             if (char.IsLowSurrogate(lowSurrogate))
                             {
@@ -31973,8 +31970,7 @@ namespace Lucene.Net.Analysis.CharFilters
                             }
                             catch (Exception /*e*/)
                             { // should never happen
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing high surrogate '"
-                                            + surrogatePair.Substring(1, 6 - 1) + "'");
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", surrogatePair.Substring(1, 6 - 1));
                             }
                             if (char.IsHighSurrogate(highSurrogate))
                             {
@@ -31986,8 +31982,7 @@ namespace Lucene.Net.Analysis.CharFilters
                                 }
                                 catch (Exception /*e*/)
                                 { // should never happen
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing low surrogate '"
-                                                + surrogatePair.Substring(10, 14 - 10) + "'");
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", surrogatePair.Substring(10, 14 - 10));
                                 }
                                 // add (previously matched input length) + (this match length) - (substitution length)
                                 cumulativeDiff += inputSegment.Length + YyLength - 2;
@@ -32013,8 +32008,7 @@ namespace Lucene.Net.Analysis.CharFilters
                             }
                             catch (Exception /*e*/)
                             { // should never happen
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing high surrogate '"
-                                            + surrogatePair.Substring(1, 6 - 1) + "'");
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", surrogatePair.Substring(1, 6 - 1));
                             }
                             if (char.IsHighSurrogate(highSurrogate))
                             {
@@ -32025,8 +32019,7 @@ namespace Lucene.Net.Analysis.CharFilters
                                 }
                                 catch (Exception /*e*/)
                                 { // should never happen
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "Exception parsing low surrogate '"
-                                                + surrogatePair.Substring(9, 14 - 9) + "'");
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", surrogatePair.Substring(9, 14 - 9));
                                 }
                                 if (char.IsLowSurrogate(lowSurrogate))
                                 {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymFilter.cs
@@ -510,7 +510,7 @@ namespace Lucene.Net.Analysis.Synonym
                         int outputLen = chIDX - lastStart;
                         // Caller is not allowed to have empty string in
                         // the output:
-                        if (Debugging.AssertsEnabled) Debugging.Assert(outputLen > 0, () => "output contains empty string: " + scratchChars);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(outputLen > 0, "output contains empty string: {0}", scratchChars);
                         int endOffset;
                         int posLen;
                         if (chIDX == chEnd && lastStart == scratchChars.Offset)
@@ -536,7 +536,7 @@ namespace Lucene.Net.Analysis.Synonym
                         lastStart = 1 + chIDX;
                         //System.out.println("  slot=" + outputUpto + " keepOrig=" + keepOrig);
                         outputUpto = RollIncr(outputUpto);
-                        if (Debugging.AssertsEnabled) Debugging.Assert(futureOutputs[outputUpto].posIncr == 1, () => "outputUpto=" + outputUpto + " vs nextWrite=" + nextWrite);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(futureOutputs[outputUpto].posIncr == 1, "outputUpto={0} vs nextWrite={1}", outputUpto, nextWrite);
                     }
                 }
             }
@@ -602,7 +602,7 @@ namespace Lucene.Net.Analysis.Synonym
                         {
                             // Pass-through case: return token we just pulled
                             // but didn't capture:
-                            if (Debugging.AssertsEnabled) Debugging.Assert(inputSkipCount == 1, () => "inputSkipCount=" + inputSkipCount + " nextRead=" + nextRead);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(inputSkipCount == 1, "inputSkipCount={0} nextRead={1}", inputSkipCount, nextRead);
                         }
                         input.Reset();
                         if (outputs.count > 0)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymMap.cs
@@ -175,8 +175,8 @@ namespace Lucene.Net.Analysis.Synonym
 
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(!HasHoles(input), () => "input has holes: " + input);
-                    Debugging.Assert(!HasHoles(output), () => "output has holes: " + output);
+                    Debugging.Assert(!HasHoles(input), "input has holes: {0}", input);
+                    Debugging.Assert(!HasHoles(output), "output has holes: {0}", output);
                 }
 
                 //System.out.println("fmap.add input=" + input + " numInputWords=" + numInputWords + " output=" + output + " numOutputWords=" + numOutputWords);

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/RollingCharBuffer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/RollingCharBuffer.cs
@@ -107,11 +107,14 @@ namespace Lucene.Net.Analysis.Util
             }
             else
             {
-                // Cannot read from future (except by 1):
-                if (Debugging.AssertsEnabled) Debugging.Assert(pos < nextPos);
+                if (Debugging.AssertsEnabled)
+                {
+                    // Cannot read from future (except by 1):
+                    Debugging.Assert(pos < nextPos);
 
-                // Cannot read from already freed past:
-                if (Debugging.AssertsEnabled) Debugging.Assert(nextPos - pos <= count, "nextPos={0} pos={1} count={2}", nextPos, pos, count);
+                    // Cannot read from already freed past:
+                    Debugging.Assert(nextPos - pos <= count, "nextPos={0} pos={1} count={2}", nextPos, pos, count);
+                }
 
                 return buffer[GetIndex(pos)];
             }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/RollingCharBuffer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/RollingCharBuffer.cs
@@ -111,7 +111,7 @@ namespace Lucene.Net.Analysis.Util
                 if (Debugging.AssertsEnabled) Debugging.Assert(pos < nextPos);
 
                 // Cannot read from already freed past:
-                if (Debugging.AssertsEnabled) Debugging.Assert(nextPos - pos <= count, () => "nextPos=" + nextPos + " pos=" + pos + " count=" + count);
+                if (Debugging.AssertsEnabled) Debugging.Assert(nextPos - pos <= count, "nextPos={0} pos={1} count={2}", nextPos, pos, count);
 
                 return buffer[GetIndex(pos)];
             }
@@ -140,7 +140,7 @@ namespace Lucene.Net.Analysis.Util
             if (Debugging.AssertsEnabled)
             {
                 Debugging.Assert(length > 0);
-                Debugging.Assert(InBounds(posStart), () => "posStart=" + posStart + " length=" + length);
+                Debugging.Assert(InBounds(posStart), "posStart={0} length={1}", posStart, length);
             }
             //System.out.println("    buffer.Get posStart=" + posStart + " len=" + length);
 
@@ -177,8 +177,8 @@ namespace Lucene.Net.Analysis.Util
             int newCount = nextPos - pos;
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(newCount <= count, () => "newCount=" + newCount + " count=" + count);
-                Debugging.Assert(newCount <= buffer.Length, () => "newCount=" + newCount + " buf.length=" + buffer.Length);
+                Debugging.Assert(newCount <= count, "newCount={0} count={1}", newCount, count);
+                Debugging.Assert(newCount <= buffer.Length, "newCount={0} buf.length={1}", newCount, buffer.Length);
             }
             count = newCount;
         }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/SegmentingTokenizerBase.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/SegmentingTokenizerBase.cs
@@ -184,7 +184,7 @@ namespace Lucene.Net.Analysis.Util
         /// commons-io's readFully, but without bugs if offset != 0 </summary>
         private static int Read(TextReader input, char[] buffer, int offset, int length)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0, () => "length must not be negative: " + length);
+            if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0,"length must not be negative: {0}", length);
 
             int remaining = length;
             while (remaining > 0)

--- a/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizer.cs
+++ b/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizer.cs
@@ -202,7 +202,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         /// <summary>commons-io's readFully, but without bugs if offset != 0</summary>
         private static int Read(TextReader input, char[] buffer, int offset, int length)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0, () => "length must not be negative: " + length);
+            if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0, "length must not be negative: {0}", length);
 
             int remaining = length;
             while (remaining > 0)

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
@@ -916,7 +916,7 @@ namespace Lucene.Net.Analysis.Ja
                 if (Debugging.AssertsEnabled) Debugging.Assert(bestIDX < posData.count);
 
                 int backPos = posData.backPos[bestIDX];
-                if (Debugging.AssertsEnabled) Debugging.Assert(backPos >= lastBackTracePos, () => "backPos=" + backPos + " vs lastBackTracePos=" + lastBackTracePos);
+                if (Debugging.AssertsEnabled) Debugging.Assert(backPos >= lastBackTracePos,"backPos={0} vs lastBackTracePos={1}", backPos, lastBackTracePos);
                 int length = pos - backPos;
                 JapaneseTokenizerType backType = posData.backType[bestIDX];
                 int backID = posData.backID[bestIDX];
@@ -1035,7 +1035,7 @@ namespace Lucene.Net.Analysis.Ja
                     // The pruning we did when we created the altToken
                     // ensures that the back trace will align back with
                     // the start of the altToken:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(altToken.Position == backPos, () => altToken.Position + " vs " + backPos);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(altToken.Position == backPos, "{0} vs {1}", altToken.Position, backPos);
 
                     // NOTE: not quite right: the compound token may
                     // have had all punctuation back traced so far, but
@@ -1355,7 +1355,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             count = 0;
             // forwardCount naturally resets after it runs:
-            if (Debugging.AssertsEnabled) Debugging.Assert(forwardCount == 0, () => "pos=" + pos + " forwardCount=" + forwardCount);
+            if (Debugging.AssertsEnabled) Debugging.Assert(forwardCount == 0,"pos={0} forwardCount={1}", pos, forwardCount);
         }
     }
 

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/BinaryDictionaryWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/BinaryDictionaryWriter.cs
@@ -240,11 +240,11 @@ namespace Lucene.Net.Analysis.Ja.Util
 
         public virtual void AddMapping(int sourceId, int wordId)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(wordId > lastWordId, () => "words out of order: " + wordId + " vs lastID: " + lastWordId);
+            if (Debugging.AssertsEnabled) Debugging.Assert(wordId > lastWordId,"words out of order: {0} vs lastID: {1}", wordId, lastWordId);
 
             if (sourceId > lastSourceId)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(sourceId > lastSourceId, () => "source ids out of order: lastSourceId=" + lastSourceId + " vs sourceId=" + sourceId);
+                if (Debugging.AssertsEnabled) Debugging.Assert(sourceId > lastSourceId,"source ids out of order: lastSourceId={0} vs sourceId={1}", lastSourceId, sourceId);
                 targetMapOffsets = ArrayUtil.Grow(targetMapOffsets, sourceId + 1);
                 for (int i = lastSourceId + 1; i <= sourceId; i++)
                 {
@@ -320,7 +320,7 @@ namespace Lucene.Net.Analysis.Ja.Util
                     }
                     prev += delta;
                 }
-                if (Debugging.AssertsEnabled) Debugging.Assert(sourceId == numSourceIds, () => "sourceId:" + sourceId + " != numSourceIds:" + numSourceIds);
+                if (Debugging.AssertsEnabled) Debugging.Assert(sourceId == numSourceIds,"sourceId:{0} != numSourceIds:{1}", sourceId, numSourceIds);
             }
         }
 
@@ -344,7 +344,7 @@ namespace Lucene.Net.Analysis.Ja.Util
                     else
                     {
                         string[] data = CSVUtil.Parse(s);
-                        if (Debugging.AssertsEnabled) Debugging.Assert(data.Length == 3, () => "malformed pos/inflection: " + s);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(data.Length == 3,"malformed pos/inflection: {0}", s);
                         @out.WriteString(data[0]);
                         @out.WriteString(data[1]);
                         @out.WriteString(data[2]);

--- a/src/Lucene.Net.Benchmark/Quality/QualityStats.cs
+++ b/src/Lucene.Net.Benchmark/Quality/QualityStats.cs
@@ -242,7 +242,7 @@ namespace Lucene.Net.Benchmarks.Quality
                     }
                 }
             }
-            if (Debugging.AssertsEnabled) Debugging.Assert(m > 0, () => "Fishy: no \"good\" queries!");
+            if (Debugging.AssertsEnabled) Debugging.Assert(m > 0, "Fishy: no \"good\" queries!");
             // take average: times go by all queries, other measures go by "good" queries only.
             avg.searchTime /= stats.Length;
             avg.docNamesExtractTime /= stats.Length;

--- a/src/Lucene.Net.Benchmark/Quality/Trec/TrecJudge.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/TrecJudge.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
                     st.MoveNext();
                     bool relevant = !zero.Equals(st.Current, StringComparison.Ordinal);
                     // LUCENENET: don't call st.NextToken() unless the condition fails.
-                    if (Debugging.AssertsEnabled) Debugging.Assert(st.RemainingTokens == 0, () => "wrong format: " + line + "  next: " + (st.MoveNext() ? st.Current : ""));
+                    if (Debugging.AssertsEnabled) Debugging.Assert(st.RemainingTokens == 0,"wrong format: {0}  next: {1}", line, (st.MoveNext() ? st.Current : ""));
                     if (relevant)
                     { // only keep relevant docs
                         if (curr == null || !curr.queryID.Equals(queryID, StringComparison.Ordinal))

--- a/src/Lucene.Net.Codecs/BlockTerms/BlockTermsReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/BlockTermsReader.cs
@@ -844,7 +844,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                     seekPending = false;
 
                     state.Ord = indexEnum.Ord - 1;
-                    if (Debugging.AssertsEnabled) Debugging.Assert(state.Ord >= -1, () => "Ord=" + state.Ord);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(state.Ord >= -1, "Ord={0}", state.Ord);
                     term.CopyBytes(indexEnum.Term);
 
                     // Now, scan:

--- a/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexReader.cs
@@ -190,7 +190,7 @@ namespace Lucene.Net.Codecs.BlockTerms
             {
                 int lo = 0;          // binary search
                 int hi = fieldIndex.numIndexTerms - 1;
-                if (Debugging.AssertsEnabled) Debugging.Assert(outerInstance.totalIndexInterval > 0, () => "totalIndexInterval=" + outerInstance.totalIndexInterval);
+                if (Debugging.AssertsEnabled) Debugging.Assert(outerInstance.totalIndexInterval > 0, "totalIndexInterval={0}", outerInstance.totalIndexInterval);
 
                 while (hi >= lo)
                 {
@@ -332,7 +332,7 @@ namespace Lucene.Net.Codecs.BlockTerms
 
                     this.numIndexTerms = 1 + (numIndexTerms - 1) / outerInstance.outerInstance.indexDivisor;
 
-                    if (Debugging.AssertsEnabled) Debugging.Assert(this.numIndexTerms > 0, () => "numIndexTerms=" + numIndexTerms + " indexDivisor=" + outerInstance.outerInstance.indexDivisor);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(this.numIndexTerms > 0, "numIndexTerms={0} indexDivisor={1}", numIndexTerms, outerInstance.outerInstance.indexDivisor);
 
                     if (outerInstance.outerInstance.indexDivisor == 1)
                     {
@@ -400,7 +400,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                                 clone.Seek(indexStart + termOffset);
                                 if (Debugging.AssertsEnabled)
                                 {
-                                    Debugging.Assert(indexStart + termOffset < clone.Length, () => "indexStart=" + indexStart + " termOffset=" + termOffset + " len=" + clone.Length);
+                                    Debugging.Assert(indexStart + termOffset < clone.Length, "indexStart={0} termOffset={1} len={2}", indexStart, termOffset, clone.Length);
                                     Debugging.Assert(indexStart + termOffset + numTermBytes < clone.Length);
                                 }
 

--- a/src/Lucene.Net.Codecs/IntBlock/VariableIntBlockIndexInput.cs
+++ b/src/Lucene.Net.Codecs/IntBlock/VariableIntBlockIndexInput.cs
@@ -118,7 +118,7 @@ namespace Lucene.Net.Codecs.IntBlock
                 // TODO: should we do this in real-time, not lazy?
                 pendingFP = fp;
                 pendingUpto = upto;
-                if (Debugging.AssertsEnabled) Debugging.Assert(pendingUpto >= 0, () => "pendingUpto=" + pendingUpto);
+                if (Debugging.AssertsEnabled) Debugging.Assert(pendingUpto >= 0, "pendingUpto={0}", pendingUpto);
                 seekPending = true;
             }
 

--- a/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
@@ -1447,7 +1447,7 @@ namespace Lucene.Net.Codecs.Memory
 
                         if (Debugging.AssertsEnabled) Debugging.Assert(termOrd < state.changeOrd);
 
-                        if (Debugging.AssertsEnabled) Debugging.Assert(stateUpto <= termLength, () => "term.length=" + termLength + "; stateUpto=" + stateUpto);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(stateUpto <= termLength, "term.length={0}; stateUpto={1}", termLength, stateUpto);
                         int label = outerInstance.termBytes[termOffset + stateUpto] & 0xFF;
 
                         while (label > state.transitionMax)
@@ -1478,7 +1478,7 @@ namespace Lucene.Net.Codecs.Memory
                                 goto nextTermContinue;
                             }
                             if (Debugging.AssertsEnabled) Debugging.Assert(state.transitionUpto < state.transitions.Length,
-                                () => " state.transitionUpto=" + state.transitionUpto + " vs " + state.transitions.Length);
+                                " state.transitionUpto={0} vs {1}", state.transitionUpto, state.transitions.Length);
                             state.transitionMin = state.transitions[state.transitionUpto].Min;
                             state.transitionMax = state.transitions[state.transitionUpto].Max;
                             if (Debugging.AssertsEnabled)

--- a/src/Lucene.Net.Codecs/Pulsing/PulsingPostingsWriter.cs
+++ b/src/Lucene.Net.Codecs/Pulsing/PulsingPostingsWriter.cs
@@ -175,7 +175,7 @@ namespace Lucene.Net.Codecs.Pulsing
 
         public override void StartDoc(int docId, int termDocFreq)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(docId >= 0, () => "Got DocID=" + docId);
+            if (Debugging.AssertsEnabled) Debugging.Assert(docId >= 0, "Got DocID={0}", docId);
 
             if (_pendingCount == _pending.Length)
             {

--- a/src/Lucene.Net.Codecs/Sep/SepPostingsWriter.cs
+++ b/src/Lucene.Net.Codecs/Sep/SepPostingsWriter.cs
@@ -265,7 +265,7 @@ namespace Lucene.Net.Codecs.Sep
             if (Debugging.AssertsEnabled) Debugging.Assert(indexOptions == IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
 
             int delta = position - lastPosition;
-            if (Debugging.AssertsEnabled) Debugging.Assert(delta >= 0, () => "position=" + position + " lastPosition=" + lastPosition);            // not quite right (if pos=0 is repeated twice we don't catch it)
+            if (Debugging.AssertsEnabled) Debugging.Assert(delta >= 0, "position={0} lastPosition={1}", position, lastPosition);            // not quite right (if pos=0 is repeated twice we don't catch it)
             lastPosition = position;
 
             if (storePayloads)

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
@@ -147,7 +147,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 Debugging.Assert(field != null);
 
                 // SegmentCoreReaders already verifies this field is valid:
-                Debugging.Assert(field != null, () => "field=" + fieldInfo.Name + " fields=" + fields);
+                Debugging.Assert(field != null, "field={0} fields={1}", fieldInfo.Name, fields);
             }
 
             var @in = (IndexInput)data.Clone();

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
@@ -1,6 +1,7 @@
 ﻿using J2N.Text;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
+using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -76,21 +77,24 @@ namespace Lucene.Net.Codecs.SimpleText
                 {
                     break;
                 }
-                if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.FIELD), scratch.Utf8ToString());
+                // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.FIELD), "{0}", new BytesRefFormatter(scratch, BytesRefFormat.UTF8));
                 var fieldName = StripPrefix(SimpleTextDocValuesWriter.FIELD);
                 var field = new OneField();
                 
                 fields[fieldName] = field;
 
                 ReadLine();
-                if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.TYPE), scratch.Utf8ToString());
+                // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.TYPE), "{0}", new BytesRefFormatter(scratch, BytesRefFormat.UTF8));
 
                 var dvType = (DocValuesType)Enum.Parse(typeof(DocValuesType), StripPrefix(SimpleTextDocValuesWriter.TYPE));
                 // if (Debugging.AssertsEnabled) Debugging.Assert(dvType != null); // LUCENENET: Not possible for an enum to be null in .NET
                 if (dvType == DocValuesType.NUMERIC)
                 {
                     ReadLine();
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.MINVALUE), "got {0} field={1} ext={2}", scratch.Utf8ToString(), fieldName, ext);
+                    // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.MINVALUE), "got {0} field={1} ext={2}", new BytesRefFormatter(scratch, BytesRefFormat.UTF8), fieldName, ext);
                     field.MinValue = Convert.ToInt64(StripPrefix(SimpleTextDocValuesWriter.MINVALUE), CultureInfo.InvariantCulture);
                     ReadLine();
                     if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.PATTERN));
@@ -435,7 +439,8 @@ namespace Lucene.Net.Codecs.SimpleText
                     }
                     _input.Seek(_field.DataStartFilePointer + ord * (9 + _field.Pattern.Length + _field.MaxLength));
                     SimpleTextUtil.ReadLine(_input, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextDocValuesWriter.LENGTH), "got {0} in={1}", _scratch.Utf8ToString(), _input.ToString());
+                    // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextDocValuesWriter.LENGTH), "got {0} in={1}", new BytesRefFormatter(_scratch, BytesRefFormat.UTF8), _input);
                     int len;
                     try
                     {
@@ -539,7 +544,8 @@ namespace Lucene.Net.Codecs.SimpleText
 
                     _input.Seek(_field.DataStartFilePointer + ord * (9 + _field.Pattern.Length + _field.MaxLength));
                     SimpleTextUtil.ReadLine(_input, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextDocValuesWriter.LENGTH), "got {0} in={1}", _scratch.Utf8ToString(), _input.ToString());
+                    // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextDocValuesWriter.LENGTH), "got {0} in={1}", new BytesRefFormatter(_scratch, BytesRefFormat.UTF8), _input);
                     int len;
                     try
                     {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
@@ -76,22 +76,21 @@ namespace Lucene.Net.Codecs.SimpleText
                 {
                     break;
                 }
-                if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.FIELD), () => scratch.Utf8ToString());
+                if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.FIELD), scratch.Utf8ToString());
                 var fieldName = StripPrefix(SimpleTextDocValuesWriter.FIELD);
                 var field = new OneField();
                 
                 fields[fieldName] = field;
 
                 ReadLine();
-                if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.TYPE), () => scratch.Utf8ToString());
+                if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.TYPE), scratch.Utf8ToString());
 
                 var dvType = (DocValuesType)Enum.Parse(typeof(DocValuesType), StripPrefix(SimpleTextDocValuesWriter.TYPE));
                 // if (Debugging.AssertsEnabled) Debugging.Assert(dvType != null); // LUCENENET: Not possible for an enum to be null in .NET
                 if (dvType == DocValuesType.NUMERIC)
                 {
                     ReadLine();
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.MINVALUE),
-                        () => "got " + scratch.Utf8ToString() + " field=" + fieldName + " ext=" + ext);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.MINVALUE), "got {0} field={1} ext={2}", scratch.Utf8ToString(), fieldName, ext);
                     field.MinValue = Convert.ToInt64(StripPrefix(SimpleTextDocValuesWriter.MINVALUE), CultureInfo.InvariantCulture);
                     ReadLine();
                     if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.PATTERN));
@@ -416,7 +415,7 @@ namespace Lucene.Net.Codecs.SimpleText
                     }
                     catch (Exception pe)
                     {
-                        var e = new CorruptIndexException("failed to parse ord (resource=" + _input + ")", pe);
+                        var e = new CorruptIndexException($"failed to parse ord (resource={_input})", pe);
                         throw e;
                     }
                 }
@@ -432,13 +431,11 @@ namespace Lucene.Net.Codecs.SimpleText
                 {
                     if (ord < 0 || ord >= _field.NumValues)
                     {
-                        throw new IndexOutOfRangeException("ord must be 0 .. " + (_field.NumValues - 1) + "; got " +
-                                                                  ord);
+                        throw new IndexOutOfRangeException($"ord must be 0 .. {(_field.NumValues - 1)}; got {ord}");
                     }
                     _input.Seek(_field.DataStartFilePointer + ord * (9 + _field.Pattern.Length + _field.MaxLength));
                     SimpleTextUtil.ReadLine(_input, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextDocValuesWriter.LENGTH),
-                        () => "got " + _scratch.Utf8ToString() + " in=" + _input);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextDocValuesWriter.LENGTH), "got {0} in={1}", _scratch.Utf8ToString(), _input.ToString());
                     int len;
                     try
                     {
@@ -449,7 +446,7 @@ namespace Lucene.Net.Codecs.SimpleText
                     }
                     catch (Exception pe)
                     {
-                        var e = new CorruptIndexException("failed to parse int length (resource=" + _input + ")", pe);
+                        var e = new CorruptIndexException($"failed to parse int length (resource={_input})", pe);
                         throw e;
                     }
 
@@ -542,8 +539,7 @@ namespace Lucene.Net.Codecs.SimpleText
 
                     _input.Seek(_field.DataStartFilePointer + ord * (9 + _field.Pattern.Length + _field.MaxLength));
                     SimpleTextUtil.ReadLine(_input, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextDocValuesWriter.LENGTH),
-                        () => "got " + _scratch.Utf8ToString() + " in=" + _input);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextDocValuesWriter.LENGTH), "got {0} in={1}", _scratch.Utf8ToString(), _input.ToString());
                     int len;
                     try
                     {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesWriter.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesWriter.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Codecs.SimpleText
         /// </summary>
         private bool FieldSeen(string field)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(!_fieldsSeen.Contains(field), () => "field \"" + field + "\" was added more than once during flush");
+            if (Debugging.AssertsEnabled) Debugging.Assert(!_fieldsSeen.Contains(field), "field \"{0}\" was added more than once during flush", field);
             _fieldsSeen.Add(field);
             return true;
         }
@@ -134,7 +134,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 if (Debugging.AssertsEnabled) Debugging.Assert(numDocsWritten <= numDocs);
             }
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(numDocs == numDocsWritten, () => "numDocs=" + numDocs + " numDocsWritten=" + numDocsWritten);
+            if (Debugging.AssertsEnabled) Debugging.Assert(numDocs == numDocsWritten, "numDocs={0} numDocsWritten={1}", numDocs, numDocsWritten);
         }
 
         public override void AddBinaryField(FieldInfo field, IEnumerable<BytesRef> values)

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
+using Lucene.Net.Util;
 using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
@@ -477,7 +478,8 @@ namespace Lucene.Net.Codecs.SimpleText
                 if (_readPositions)
                 {
                     SimpleTextUtil.ReadLine(_in, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.POS), "got line={0}", _scratch.Utf8ToString());
+                    // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.POS), "got line={0}", new BytesRefFormatter(_scratch, BytesRefFormat.UTF8));
                     UnicodeUtil.UTF8toUTF16(_scratch.Bytes, _scratch.Offset + SimpleTextFieldsWriter.POS.Length, _scratch.Length - SimpleTextFieldsWriter.POS.Length,
                         _scratchUtf162);
                     pos = ArrayUtil.ParseInt32(_scratchUtf162.Chars, 0, _scratchUtf162.Length);
@@ -490,12 +492,14 @@ namespace Lucene.Net.Codecs.SimpleText
                 if (_readOffsets)
                 {
                     SimpleTextUtil.ReadLine(_in, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.START_OFFSET), "got line={0}", _scratch.Utf8ToString());
+                    // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.START_OFFSET), "got line={0}", new BytesRefFormatter(_scratch, BytesRefFormat.UTF8));
                     UnicodeUtil.UTF8toUTF16(_scratch.Bytes, _scratch.Offset + SimpleTextFieldsWriter.START_OFFSET.Length,
                         _scratch.Length - SimpleTextFieldsWriter.START_OFFSET.Length, _scratchUtf162);
                     _startOffset = ArrayUtil.ParseInt32(_scratchUtf162.Chars, 0, _scratchUtf162.Length);
                     SimpleTextUtil.ReadLine(_in, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.END_OFFSET), "got line={0}", _scratch.Utf8ToString());
+                    // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.END_OFFSET), "got line={0}", new BytesRefFormatter(_scratch, BytesRefFormat.UTF8));
                     UnicodeUtil.UTF8toUTF16(_scratch.Bytes, _scratch.Offset + SimpleTextFieldsWriter.END_OFFSET.Length,
                         _scratch.Length - SimpleTextFieldsWriter.END_OFFSET.Length, _scratchUtf162);
                     _endOffset = ArrayUtil.ParseInt32(_scratchUtf162.Chars, 0, _scratchUtf162.Length);

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
@@ -323,7 +323,7 @@ namespace Lucene.Net.Codecs.SimpleText
                     {
                         if (Debugging.AssertsEnabled) Debugging.Assert(
                             StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.TERM) || StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.FIELD) ||
-                            StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.END), () => "scratch=" + _scratch.Utf8ToString());
+                            StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.END), "scratch={0}", _scratch.Utf8ToString());
 
                         if (!first && (_liveDocs == null || _liveDocs.Get(_docId)))
                         {
@@ -477,7 +477,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 if (_readPositions)
                 {
                     SimpleTextUtil.ReadLine(_in, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.POS), () => "got line=" + _scratch.Utf8ToString());
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.POS), "got line={0}", _scratch.Utf8ToString());
                     UnicodeUtil.UTF8toUTF16(_scratch.Bytes, _scratch.Offset + SimpleTextFieldsWriter.POS.Length, _scratch.Length - SimpleTextFieldsWriter.POS.Length,
                         _scratchUtf162);
                     pos = ArrayUtil.ParseInt32(_scratchUtf162.Chars, 0, _scratchUtf162.Length);
@@ -490,12 +490,12 @@ namespace Lucene.Net.Codecs.SimpleText
                 if (_readOffsets)
                 {
                     SimpleTextUtil.ReadLine(_in, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.START_OFFSET), () => "got line=" + _scratch.Utf8ToString());
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.START_OFFSET), "got line={0}", _scratch.Utf8ToString());
                     UnicodeUtil.UTF8toUTF16(_scratch.Bytes, _scratch.Offset + SimpleTextFieldsWriter.START_OFFSET.Length,
                         _scratch.Length - SimpleTextFieldsWriter.START_OFFSET.Length, _scratchUtf162);
                     _startOffset = ArrayUtil.ParseInt32(_scratchUtf162.Chars, 0, _scratchUtf162.Length);
                     SimpleTextUtil.ReadLine(_in, _scratch);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.END_OFFSET), () => "got line=" + _scratch.Utf8ToString());
+                    if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.END_OFFSET), "got line={0}", _scratch.Utf8ToString());
                     UnicodeUtil.UTF8toUTF16(_scratch.Bytes, _scratch.Offset + SimpleTextFieldsWriter.END_OFFSET.Length,
                         _scratch.Length - SimpleTextFieldsWriter.END_OFFSET.Length, _scratchUtf162);
                     _endOffset = ArrayUtil.ParseInt32(_scratchUtf162.Chars, 0, _scratchUtf162.Length);

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsWriter.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsWriter.cs
@@ -167,7 +167,7 @@ namespace Lucene.Net.Codecs.SimpleText
                     {
                         Debugging.Assert(endOffset >= startOffset);
                         Debugging.Assert(startOffset >= _lastStartOffset,
-                            () => "startOffset=" + startOffset + " lastStartOffset=" + _lastStartOffset);
+                            "startOffset={0} lastStartOffset={1}", startOffset, _lastStartOffset);
                     }
                     _lastStartOffset = startOffset;
                     _outerInstance.Write(START_OFFSET);

--- a/src/Lucene.Net.Facet/DrillDownQuery.cs
+++ b/src/Lucene.Net.Facet/DrillDownQuery.cs
@@ -86,7 +86,7 @@ namespace Lucene.Net.Facet
             {
                 throw new ArgumentException("cannot apply filter unless baseQuery isn't null; pass ConstantScoreQuery instead");
             }
-            if (Debugging.AssertsEnabled) Debugging.Assert(clauses.Length == 1 + other.drillDownDims.Count, () => clauses.Length + " vs " + (1 + other.drillDownDims.Count));
+            if (Debugging.AssertsEnabled) Debugging.Assert(clauses.Length == 1 + other.drillDownDims.Count, "{0} vs {1}", clauses.Length, (1 + other.drillDownDims.Count));
             drillDownDims.PutAll(other.drillDownDims);
             query.Add(new FilteredQuery(clauses[0].Query, filter), Occur.MUST);
             for (int i = 1; i < clauses.Length; i++)

--- a/src/Lucene.Net.Facet/DrillSidewaysScorer.cs
+++ b/src/Lucene.Net.Facet/DrillSidewaysScorer.cs
@@ -550,7 +550,7 @@ namespace Lucene.Net.Facet
                     //}
 
                     // Mark slot as valid:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(docIDs[slot] != docID, () => "slot=" + slot + " docID=" + docID);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(docIDs[slot] != docID, "slot={0} docID={1}", slot, docID);
                     docIDs[slot] = docID;
                     scores[slot] = baseScorer.GetScore();
                     filledSlots[filledCount++] = slot;

--- a/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
@@ -65,7 +65,8 @@ namespace Lucene.Net.Facet.Taxonomy
             // while the code which calls this method is safe, at some point a test
             // tripped on AIOOBE in toString, but we failed to reproduce. adding the
             // assert as a safety check.
-            if (Debugging.AssertsEnabled) Debugging.Assert(prefixLen > 0 && prefixLen <= copyFrom.Components.Length, () => "prefixLen cannot be negative nor larger than the given components' length: prefixLen=" + prefixLen + " components.length=" + copyFrom.Components.Length);
+            if (Debugging.AssertsEnabled) Debugging.Assert(prefixLen > 0 && prefixLen <= copyFrom.Components.Length,
+                "prefixLen cannot be negative nor larger than the given components' length: prefixLen={0} components.length={1}", prefixLen, copyFrom.Components.Length);
             this.Components = copyFrom.Components;
             Length = prefixLen;
         }

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -907,7 +907,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             }
 
             int[] parents = GetTaxoArrays().Parents;
-            if (Debugging.AssertsEnabled) Debugging.Assert(ordinal < parents.Length, () => "requested ordinal (" + ordinal + "); parents.length (" + parents.Length + ") !");
+            if (Debugging.AssertsEnabled) Debugging.Assert(ordinal < parents.Length, "requested ordinal ({0}); parents.length ({1}) !", ordinal, parents.Length);
             return parents[ordinal];
         }
 

--- a/src/Lucene.Net.Facet/Taxonomy/FacetLabel.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/FacetLabel.cs
@@ -68,7 +68,8 @@ namespace Lucene.Net.Facet.Taxonomy
             // while the code which calls this method is safe, at some point a test
             // tripped on AIOOBE in toString, but we failed to reproduce. adding the
             // assert as a safety check.
-            if (Debugging.AssertsEnabled) Debugging.Assert(prefixLen >= 0 && prefixLen <= copyFrom.Components.Length, () => "prefixLen cannot be negative nor larger than the given components' length: prefixLen=" + prefixLen + " components.length=" + copyFrom.Components.Length);
+            if (Debugging.AssertsEnabled) Debugging.Assert(prefixLen >= 0 && prefixLen <= copyFrom.Components.Length,
+                "prefixLen cannot be negative nor larger than the given components' length: prefixLen={0} components.length={1}", prefixLen, copyFrom.Components.Length);
             this.Components = copyFrom.Components;
             Length = prefixLen;
         }

--- a/src/Lucene.Net.Join/ToChildBlockJoinQuery.cs
+++ b/src/Lucene.Net.Join/ToChildBlockJoinQuery.cs
@@ -246,7 +246,7 @@ namespace Lucene.Net.Join
                         }
                     }
 
-                    if (Debugging.AssertsEnabled) Debugging.Assert(_childDoc < _parentDoc, () => "childDoc=" + _childDoc + " parentDoc=" + _parentDoc);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(_childDoc < _parentDoc, "childDoc={0} parentDoc={1}", _childDoc, _parentDoc);
                     _childDoc++;
                     if (_acceptDocs != null && !_acceptDocs.Get(_childDoc))
                     {
@@ -289,7 +289,7 @@ namespace Lucene.Net.Join
                     return _childDoc = _parentDoc = NO_MORE_DOCS;
                 }
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(_childDoc == -1 || childTarget != _parentDoc, () => "childTarget=" + childTarget);
+                if (Debugging.AssertsEnabled) Debugging.Assert(_childDoc == -1 || childTarget != _parentDoc, "childTarget={0}", childTarget);
                 if (_childDoc == -1 || childTarget > _parentDoc)
                 {
                     // Advance to new parent:

--- a/src/Lucene.Net.Join/ToParentBlockJoinCollector.cs
+++ b/src/Lucene.Net.Join/ToParentBlockJoinCollector.cs
@@ -284,7 +284,7 @@ namespace Lucene.Net.Join
                     og.counts[scorerIDX] = joinScorer.ChildCount;
                     //System.out.println("    count=" + og.counts[scorerIDX]);
                     og.docs[scorerIDX] = joinScorer.SwapChildDocs(og.docs[scorerIDX]);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(og.docs[scorerIDX].Length >= og.counts[scorerIDX], () => "length=" + og.docs[scorerIDX].Length + " vs count=" + og.counts[scorerIDX]);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(og.docs[scorerIDX].Length >= og.counts[scorerIDX], "length={0} vs count={1}", og.docs[scorerIDX].Length, og.counts[scorerIDX]);
                     //System.out.println("    len=" + og.docs[scorerIDX].length);
                     /*
                       for(int idx=0;idx<og.counts[scorerIDX];idx++) {
@@ -295,7 +295,7 @@ namespace Lucene.Net.Join
                     {
                         //System.out.println("    copy scores");
                         og.scores[scorerIDX] = joinScorer.SwapChildScores(og.scores[scorerIDX]);
-                        if (Debugging.AssertsEnabled) Debugging.Assert(og.scores[scorerIDX].Length >= og.counts[scorerIDX], () => "length=" + og.scores[scorerIDX].Length + " vs count=" + og.counts[scorerIDX]);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(og.scores[scorerIDX].Length >= og.counts[scorerIDX], "length={0} vs count={1}", og.scores[scorerIDX].Length, og.counts[scorerIDX]);
                     }
                 }
                 else

--- a/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
@@ -461,7 +461,7 @@ namespace Lucene.Net.Index.Memory
                     if (Debugging.AssertsEnabled)
                     {
                         Debugging.Assert(posUpto++ < freq);
-                        Debugging.Assert(!sliceReader.IsEndOfSlice, () => " stores offsets : " + startOffset);
+                        Debugging.Assert(!sliceReader.IsEndOfSlice, " stores offsets : {0}", startOffset);
                     }
                     if (outerInstance.outerInstance.storeOffsets)
                     {

--- a/src/Lucene.Net.Misc/Document/LazyDocument.cs
+++ b/src/Lucene.Net.Misc/Document/LazyDocument.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Documents
             IIndexableField[] realValues = d.GetFields(name);
 
             if (Debugging.AssertsEnabled) Debugging.Assert(realValues.Length <= lazyValues.Count,
-                () => "More lazy values then real values for field: " + name);
+                "More lazy values then real values for field: {0}", name);
 
             for (int i = 0; i < lazyValues.Count; i++)
             {
@@ -166,8 +166,8 @@ namespace Lucene.Net.Documents
                 }
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(HasBeenLoaded, () => "field value was not lazy loaded");
-                    Debugging.Assert(realValue.Name.Equals(Name, StringComparison.Ordinal), () => "realvalue name != name: " + realValue.Name + " != " + Name);
+                    Debugging.Assert(HasBeenLoaded, "field value was not lazy loaded");
+                    Debugging.Assert(realValue.Name.Equals(Name, StringComparison.Ordinal), "realvalue name != name: {0} != {1}", realValue.Name, Name);
                 }
 
                 return realValue;

--- a/src/Lucene.Net.Misc/Index/Sorter/Sorter.cs
+++ b/src/Lucene.Net.Misc/Index/Sorter/Sorter.cs
@@ -85,8 +85,8 @@ namespace Lucene.Net.Index.Sorter
                 int oldID = docMap.NewToOld(newID);
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(newID >= 0 && newID < maxDoc, () => "doc IDs must be in [0-" + maxDoc + "[, got " + newID);
-                    Debugging.Assert(i == oldID, () => "mapping is inconsistent: " + i + " --oldToNew--> " + newID + " --newToOld--> " + oldID);
+                    Debugging.Assert(newID >= 0 && newID < maxDoc, "doc IDs must be in [0-{0}[, got {1}", maxDoc, newID);
+                    Debugging.Assert(i == oldID, "mapping is inconsistent: {0} --oldToNew--> {1} --newToOld--> {2}", i, newID, oldID);
                 }
                 if (i != oldID || newID < 0 || newID >= maxDoc)
                 {

--- a/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
+++ b/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
@@ -187,7 +187,7 @@ namespace Lucene.Net.Replicator
         /// <exception cref="IOException"></exception>
         public virtual Stream Open(string source, string fileName)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(source.Equals(INDEX_SOURCE, StringComparison.Ordinal) || source.Equals(TAXONOMY_SOURCE, StringComparison.Ordinal), () => string.Format("invalid source; expected=({0} or {1}) got={2}", INDEX_SOURCE, TAXONOMY_SOURCE, source));
+            if (Debugging.AssertsEnabled) Debugging.Assert(source.Equals(INDEX_SOURCE, StringComparison.Ordinal) || source.Equals(TAXONOMY_SOURCE, StringComparison.Ordinal), "invalid source; expected=({0} or {1}) got={2}", INDEX_SOURCE, TAXONOMY_SOURCE, source);
             IndexCommit commit = source.Equals(INDEX_SOURCE, StringComparison.Ordinal) ? indexCommit : taxonomyCommit;
             return new IndexInputStream(commit.Directory.OpenInput(fileName, IOContext.READ_ONCE));
         }

--- a/src/Lucene.Net.Replicator/IndexRevision.cs
+++ b/src/Lucene.Net.Replicator/IndexRevision.cs
@@ -134,7 +134,7 @@ namespace Lucene.Net.Replicator
 
         public virtual Stream Open(string source, string fileName)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(source.Equals(SOURCE, StringComparison.Ordinal), () => string.Format("invalid source; expected={0} got={1}", SOURCE, source));
+            if (Debugging.AssertsEnabled) Debugging.Assert(source.Equals(SOURCE, StringComparison.Ordinal), "invalid source; expected={0} got={1}", SOURCE, source);
             return new IndexInputStream(commit.Directory.OpenInput(fileName, IOContext.READ_ONCE));
         }
 

--- a/src/Lucene.Net.Replicator/ReplicationClient.cs
+++ b/src/Lucene.Net.Replicator/ReplicationClient.cs
@@ -370,7 +370,7 @@ namespace Lucene.Net.Replicator
                 // make sure to preserve revisionFiles order
                 List<RevisionFile> res = new List<RevisionFile>();
                 string source = e.Key;
-                if (Debugging.AssertsEnabled) Debugging.Assert(newRevisionFiles.ContainsKey(source), () => string.Format("source not found in newRevisionFiles: {0}", newRevisionFiles));
+                if (Debugging.AssertsEnabled) Debugging.Assert(newRevisionFiles.ContainsKey(source), "source not found in newRevisionFiles: {0}", newRevisionFiles);
                 foreach (RevisionFile file in newRevisionFiles[source])
                 {
                     if (!handlerFiles.Contains(file.FileName))

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
@@ -491,7 +491,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                             output.WriteBytes(surfaceForm.Bytes, surfaceForm.Offset, surfaceForm.Length);
                         }
 
-                        if (Debugging.AssertsEnabled) Debugging.Assert(output.Position == requiredLength, () => output.Position + " vs " + requiredLength);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(output.Position == requiredLength, "{0} vs {1}", output.Position, requiredLength);
 
                         writer.Write(buffer, 0, output.Position);
                     }

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FSTUtil.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FSTUtil.cs
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                               .CopyFrom(nextArc), fst.Outputs.Add(path.Output, nextArc.Output), newInput));
                             int label = nextArc.Label; // used in assert
                             nextArc = nextArc.IsLast ? null : fst.ReadNextRealArc(nextArc, fstReader);
-                            if (Debugging.AssertsEnabled) Debugging.Assert(nextArc == null || label < nextArc.Label, "last: {0} next: {1}", label, (nextArc == null ? "" : nextArc.Label.ToString()));
+                            if (Debugging.AssertsEnabled) Debugging.Assert(nextArc == null || label < nextArc.Label, "last: {0} next: {1}", label, nextArc?.Label);
                         }
                     }
                 }

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FSTUtil.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FSTUtil.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                         while (nextArc != null && nextArc.Label <= max)
                         {
                             if (Debugging.AssertsEnabled) Debugging.Assert(nextArc.Label <= max);
-                            if (Debugging.AssertsEnabled) Debugging.Assert(nextArc.Label >= min, () => nextArc.Label + " " + min);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(nextArc.Label >= min, "{0} {1}", nextArc.Label, min);
                             Int32sRef newInput = new Int32sRef(currentInput.Length + 1);
                             newInput.CopyInt32s(currentInput);
                             newInput.Int32s[currentInput.Length] = nextArc.Label;
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                               .CopyFrom(nextArc), fst.Outputs.Add(path.Output, nextArc.Output), newInput));
                             int label = nextArc.Label; // used in assert
                             nextArc = nextArc.IsLast ? null : fst.ReadNextRealArc(nextArc, fstReader);
-                            if (Debugging.AssertsEnabled) Debugging.Assert(nextArc == null || label < nextArc.Label, () => "last: " + label + " next: " + (nextArc == null ? "" : nextArc.Label.ToString()));
+                            if (Debugging.AssertsEnabled) Debugging.Assert(nextArc == null || label < nextArc.Label, "last: {0} next: {1}", label, (nextArc == null ? "" : nextArc.Label.ToString()));
                         }
                     }
                 }

--- a/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework.NUnit/Support/TestFramework/Assert.cs
@@ -974,6 +974,16 @@ namespace Lucene.Net.TestFramework
                 _NUnit.Assert.Greater(arg1, arg2);
         }
 
+        public static void DoesNotThrow(Action action, string message, params object[] args)
+        {
+            _NUnit.Assert.DoesNotThrow(() => action(), message, args);
+        }
+
+        public static void DoesNotThrow(Action action)
+        {
+            _NUnit.Assert.DoesNotThrow(() => action());
+        }
+
         public static Exception Throws<TException>(Action action, string message, params object[] args)
         {
             return Throws(typeof(TException), action, message, args);

--- a/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
@@ -216,7 +216,7 @@ namespace Lucene.Net.Analysis
                 else
                 {
                     // Make sure our input isn't messing up offsets:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(startPosData.StartOffset == startOffset, () => "prev startOffset=" + startPosData.StartOffset + " vs new startOffset=" + startOffset + " inputPos=" + m_inputPos);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(startPosData.StartOffset == startOffset,"prev startOffset={0} vs new startOffset={1}", startPosData.StartOffset, startOffset + " inputPos=" + m_inputPos);
                 }
 
                 int endOffset = m_offsetAtt.EndOffset;
@@ -227,7 +227,7 @@ namespace Lucene.Net.Analysis
                 else
                 {
                     // Make sure our input isn't messing up offsets:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(endPosData.EndOffset == endOffset, () => "prev endOffset=" + endPosData.EndOffset + " vs new endOffset=" + endOffset + " inputPos=" + m_inputPos);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(endPosData.EndOffset == endOffset,"prev endOffset={0} vs new endOffset={1}", endPosData.EndOffset, endOffset + " inputPos=" + m_inputPos);
                 }
 
                 tokenPending = true;
@@ -365,7 +365,7 @@ namespace Lucene.Net.Analysis
             int posLen = m_posLenAtt.PositionLength;
             Position endPosData = m_positions.Get(m_outputPos + posLen);
             if (Debugging.AssertsEnabled) Debugging.Assert(endPosData.EndOffset != -1);
-            if (Debugging.AssertsEnabled) Debugging.Assert(m_offsetAtt.EndOffset == endPosData.EndOffset, () => "offsetAtt.endOffset=" + m_offsetAtt.EndOffset + " vs expected=" + endPosData.EndOffset);
+            if (Debugging.AssertsEnabled) Debugging.Assert(m_offsetAtt.EndOffset == endPosData.EndOffset,"offsetAtt.endOffset={0} vs expected={1}", m_offsetAtt.EndOffset, endPosData.EndOffset);
             return true;
         }
 

--- a/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
@@ -216,7 +216,7 @@ namespace Lucene.Net.Analysis
                 else
                 {
                     // Make sure our input isn't messing up offsets:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(startPosData.StartOffset == startOffset,"prev startOffset={0} vs new startOffset={1}", startPosData.StartOffset, startOffset + " inputPos=" + m_inputPos);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(startPosData.StartOffset == startOffset, "prev startOffset={0} vs new startOffset={1} inputPos={2}", startPosData.StartOffset, startOffset, m_inputPos);
                 }
 
                 int endOffset = m_offsetAtt.EndOffset;
@@ -227,7 +227,7 @@ namespace Lucene.Net.Analysis
                 else
                 {
                     // Make sure our input isn't messing up offsets:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(endPosData.EndOffset == endOffset,"prev endOffset={0} vs new endOffset={1}", endPosData.EndOffset, endOffset + " inputPos=" + m_inputPos);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(endPosData.EndOffset == endOffset, "prev endOffset={0} vs new endOffset={1} inputPos={2}", endPosData.EndOffset, endOffset, m_inputPos);
                 }
 
                 tokenPending = true;

--- a/src/Lucene.Net.TestFramework/Analysis/MockCharFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockCharFilter.cs
@@ -112,7 +112,7 @@ namespace Lucene.Net.Analysis
                 ret = currentOff;
             }
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(ret >= 0, () => "currentOff=" + currentOff + ",diff=" + (ret - currentOff));
+            if (Debugging.AssertsEnabled) Debugging.Assert(ret >= 0,"currentOff={0},diff={1}", currentOff, (ret - currentOff));
             return ret;
         }
 

--- a/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
@@ -219,7 +219,7 @@ namespace Lucene.Net.Analysis
             }
             else
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(!char.IsLowSurrogate((char)ch),"unpaired low surrogate: {0}", ch.ToString("x"));
+                if (Debugging.AssertsEnabled) Debugging.Assert(!char.IsLowSurrogate((char)ch),"unpaired low surrogate: {0:x}", ch);
                 off++;
                 if (char.IsHighSurrogate((char)ch))
                 {
@@ -227,12 +227,12 @@ namespace Lucene.Net.Analysis
                     if (ch2 >= 0)
                     {
                         off++;
-                        if (Debugging.AssertsEnabled) Debugging.Assert(char.IsLowSurrogate((char)ch2),"unpaired high surrogate: {0}, followed by: {1}", ch.ToString("x"), ch2.ToString("x"));
+                        if (Debugging.AssertsEnabled) Debugging.Assert(char.IsLowSurrogate((char)ch2),"unpaired high surrogate: {0:x}, followed by: {1:x}", ch, ch2);
                         return Character.ToCodePoint((char)ch, (char)ch2);
                     }
                     else
                     {
-                        if (Debugging.AssertsEnabled) Debugging.Assert(false,"stream ends with unpaired high surrogate: {0}", ch.ToString("x"));
+                        if (Debugging.AssertsEnabled) Debugging.Assert(false,"stream ends with unpaired high surrogate: {0:x}", ch);
                     }
                 }
                 return ch;

--- a/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
@@ -140,7 +140,7 @@ namespace Lucene.Net.Analysis
 
         public sealed override bool IncrementToken()
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || (streamState == State.RESET || streamState == State.INCREMENT), () => "IncrementToken() called while in wrong state: " + streamState);
+            if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || (streamState == State.RESET || streamState == State.INCREMENT),"IncrementToken() called while in wrong state: {0}", streamState);
             ClearAttributes();
             for (; ; )
             {
@@ -219,7 +219,7 @@ namespace Lucene.Net.Analysis
             }
             else
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(!char.IsLowSurrogate((char)ch), () => "unpaired low surrogate: " + ch.ToString("x"));
+                if (Debugging.AssertsEnabled) Debugging.Assert(!char.IsLowSurrogate((char)ch),"unpaired low surrogate: {0}", ch.ToString("x"));
                 off++;
                 if (char.IsHighSurrogate((char)ch))
                 {
@@ -227,12 +227,12 @@ namespace Lucene.Net.Analysis
                     if (ch2 >= 0)
                     {
                         off++;
-                        if (Debugging.AssertsEnabled) Debugging.Assert(char.IsLowSurrogate((char)ch2), () => "unpaired high surrogate: " + ch.ToString("x") + ", followed by: " + ch2.ToString("x"));
+                        if (Debugging.AssertsEnabled) Debugging.Assert(char.IsLowSurrogate((char)ch2),"unpaired high surrogate: {0}, followed by: {1}", ch.ToString("x"), ch2.ToString("x"));
                         return Character.ToCodePoint((char)ch, (char)ch2);
                     }
                     else
                     {
-                        if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "stream ends with unpaired high surrogate: " + ch.ToString("x"));
+                        if (Debugging.AssertsEnabled) Debugging.Assert(false,"stream ends with unpaired high surrogate: {0}", ch.ToString("x"));
                     }
                 }
                 return ch;
@@ -312,14 +312,14 @@ namespace Lucene.Net.Analysis
                 // in some exceptional cases (e.g. TestIndexWriterExceptions) a test can prematurely close()
                 // these tests should disable this check, by default we check the normal workflow.
                 // TODO: investigate the CachingTokenFilter "double-close"... for now we ignore this
-                if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.END || streamState == State.CLOSE, () => "Dispose() called in wrong state: " + streamState);
+                if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.END || streamState == State.CLOSE,"Dispose() called in wrong state: {0}", streamState);
                 streamState = State.CLOSE;
             }
         }
 
         internal override bool SetReaderTestPoint()
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.CLOSE, () => "SetReader() called in wrong state: " + streamState);
+            if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.CLOSE,"SetReader() called in wrong state: {0}", streamState);
             streamState = State.SETREADER;
             return true;
         }

--- a/src/Lucene.Net.TestFramework/Codecs/Asserting/AssertingDocValuesFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Asserting/AssertingDocValuesFormat.cs
@@ -164,7 +164,7 @@ namespace Lucene.Net.Codecs.Asserting
                             if (Debugging.AssertsEnabled) Debugging.Assert(o != null);
                             long ord = o.Value;
                             if (Debugging.AssertsEnabled) Debugging.Assert(ord >= 0 && ord < valueCount);
-                            if (Debugging.AssertsEnabled) Debugging.Assert(ord > lastOrd, () => "ord=" + ord + ",lastOrd=" + lastOrd);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(ord > lastOrd,"ord={0},lastOrd={1}", ord, lastOrd);
                             seenOrds.Set(ord);
                             lastOrd = ord;
                         }

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWFieldsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWFieldsWriter.cs
@@ -164,7 +164,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                     lastDocID = docID;
 
-                    if (Debugging.AssertsEnabled) Debugging.Assert(docID < outerInstance.outerInstance.totalNumDocs, () => "docID=" + docID + " totalNumDocs=" + outerInstance.outerInstance.totalNumDocs);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(docID < outerInstance.outerInstance.totalNumDocs,"docID={0} totalNumDocs={1}", docID, outerInstance.outerInstance.totalNumDocs);
 
                     if (outerInstance.omitTF)
                     {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWNormsConsumer.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWNormsConsumer.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override void AddNumericField(FieldInfo field, IEnumerable<long?> values)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(field.Number > lastFieldNumber,"writing norms fields out of order{0} -> {1}", lastFieldNumber, field.Number);
+            if (Debugging.AssertsEnabled) Debugging.Assert(field.Number > lastFieldNumber,"writing norms fields out of order {0} -> {1}", lastFieldNumber, field.Number);
             foreach (var n in values)
             {
                 if (((sbyte)(byte)(long)n) < sbyte.MinValue || ((sbyte)(byte)(long)n) > sbyte.MaxValue)

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWNormsConsumer.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWNormsConsumer.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override void AddNumericField(FieldInfo field, IEnumerable<long?> values)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(field.Number > lastFieldNumber, () => "writing norms fields out of order" + lastFieldNumber + " -> " + field.Number);
+            if (Debugging.AssertsEnabled) Debugging.Assert(field.Number > lastFieldNumber,"writing norms fields out of order{0} -> {1}", lastFieldNumber, field.Number);
             foreach (var n in values)
             {
                 if (((sbyte)(byte)(long)n) < sbyte.MinValue || ((sbyte)(byte)(long)n) > sbyte.MaxValue)

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsWriter.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override void StartField(FieldInfo info, int numTerms, bool positions, bool offsets, bool payloads)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || info.Name.CompareToOrdinal(lastFieldName) > 0, () => "fieldName=" + info.Name + " lastFieldName=" + lastFieldName);
+            if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || info.Name.CompareToOrdinal(lastFieldName) > 0,"fieldName={0} lastFieldName={1}", info.Name, lastFieldName);
             lastFieldName = info.Name;
             if (payloads)
             {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/TermInfosWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/TermInfosWriter.cs
@@ -243,10 +243,17 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// </summary>
         public void Add(int fieldNumber, BytesRef term, TermInfo ti)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(CompareToLastTerm(fieldNumber, term) < 0 || (isIndex && term.Length == 0 && lastTerm.Length == 0), "Terms are out of order: field={0} (number {1}) lastField={2} (number {3}) text={4} lastText={5}", FieldName(fieldInfos, fieldNumber), fieldNumber, FieldName(fieldInfos, lastFieldNumber), lastFieldNumber, term.Utf8ToString(), lastTerm.Utf8ToString());
+            if (Debugging.AssertsEnabled)
+            {
+                Debugging.Assert(CompareToLastTerm(fieldNumber, term) < 0 || (isIndex && term.Length == 0 && lastTerm.Length == 0),
+                    "Terms are out of order: field={0} (number {1}) lastField={2} (number {3}) text={4} lastText={5}",
+                    FieldName(fieldInfos, fieldNumber), fieldNumber, FieldName(fieldInfos, lastFieldNumber), lastFieldNumber,
+                    // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                    new BytesRefFormatter(term, BytesRefFormat.UTF8), new BytesRefFormatter(lastTerm, BytesRefFormat.UTF8));
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(ti.FreqPointer >= lastTi.FreqPointer,"freqPointer out of order ({0} < {1})", ti.FreqPointer, lastTi.FreqPointer);
-            if (Debugging.AssertsEnabled) Debugging.Assert(ti.ProxPointer >= lastTi.ProxPointer,"proxPointer out of order ({0} < {1})", ti.ProxPointer, lastTi.ProxPointer);
+                Debugging.Assert(ti.FreqPointer >= lastTi.FreqPointer, "freqPointer out of order ({0} < {1})", ti.FreqPointer, lastTi.FreqPointer);
+                Debugging.Assert(ti.ProxPointer >= lastTi.ProxPointer, "proxPointer out of order ({0} < {1})", ti.ProxPointer, lastTi.ProxPointer);
+            }
 
             if (!isIndex && size % indexInterval == 0)
             {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/TermInfosWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/TermInfosWriter.cs
@@ -243,10 +243,10 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// </summary>
         public void Add(int fieldNumber, BytesRef term, TermInfo ti)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(CompareToLastTerm(fieldNumber, term) < 0 || (isIndex && term.Length == 0 && lastTerm.Length == 0), () => "Terms are out of order: field=" + FieldName(fieldInfos, fieldNumber) + " (number " + fieldNumber + ")" + " lastField=" + FieldName(fieldInfos, lastFieldNumber) + " (number " + lastFieldNumber + ")" + " text=" + term.Utf8ToString() + " lastText=" + lastTerm.Utf8ToString());
+            if (Debugging.AssertsEnabled) Debugging.Assert(CompareToLastTerm(fieldNumber, term) < 0 || (isIndex && term.Length == 0 && lastTerm.Length == 0), "Terms are out of order: field={0} (number {1}) lastField={2} (number {3}) text={4} lastText={5}", FieldName(fieldInfos, fieldNumber), fieldNumber, FieldName(fieldInfos, lastFieldNumber), lastFieldNumber, term.Utf8ToString(), lastTerm.Utf8ToString());
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(ti.FreqPointer >= lastTi.FreqPointer, () => "freqPointer out of order (" + ti.FreqPointer + " < " + lastTi.FreqPointer + ")");
-            if (Debugging.AssertsEnabled) Debugging.Assert(ti.ProxPointer >= lastTi.ProxPointer, () => "proxPointer out of order (" + ti.ProxPointer + " < " + lastTi.ProxPointer + ")");
+            if (Debugging.AssertsEnabled) Debugging.Assert(ti.FreqPointer >= lastTi.FreqPointer,"freqPointer out of order ({0} < {1})", ti.FreqPointer, lastTi.FreqPointer);
+            if (Debugging.AssertsEnabled) Debugging.Assert(ti.ProxPointer >= lastTi.ProxPointer,"proxPointer out of order ({0} < {1})", ti.ProxPointer, lastTi.ProxPointer);
 
             if (!isIndex && size % indexInterval == 0)
             {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40PostingsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40PostingsWriter.cs
@@ -271,7 +271,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 // and the numbers aren't that much smaller anyways.
                 int offsetDelta = startOffset - lastOffset;
                 int offsetLength = endOffset - startOffset;
-                if (Debugging.AssertsEnabled) Debugging.Assert(offsetDelta >= 0 && offsetLength >= 0,"startOffset={0},lastOffset={1}", startOffset, lastOffset + ",endOffset=" + endOffset);
+                if (Debugging.AssertsEnabled) Debugging.Assert(offsetDelta >= 0 && offsetLength >= 0, "startOffset={0},lastOffset={1},endOffset={2}", startOffset, lastOffset, endOffset);
                 if (offsetLength != lastOffsetLength)
                 {
                     proxOut.WriteVInt32(offsetDelta << 1 | 1);

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40PostingsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40PostingsWriter.cs
@@ -208,7 +208,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 skipListWriter.BufferSkip(df);
             }
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(docID < totalNumDocs, () => "docID=" + docID + " totalNumDocs=" + totalNumDocs);
+            if (Debugging.AssertsEnabled) Debugging.Assert(docID < totalNumDocs,"docID={0} totalNumDocs={1}", docID, totalNumDocs);
 
             lastDocID = docID;
             if (indexOptions == IndexOptions.DOCS_ONLY)
@@ -234,12 +234,12 @@ namespace Lucene.Net.Codecs.Lucene40
         public override void AddPosition(int position, BytesRef payload, int startOffset, int endOffset)
         {
             //if (DEBUG) System.out.println("SPW:     addPos pos=" + position + " payload=" + (payload == null ? "null" : (payload.Length + " bytes")) + " proxFP=" + proxOut.getFilePointer());
-            if (Debugging.AssertsEnabled) Debugging.Assert(indexOptions.CompareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0, () => "invalid indexOptions: " + indexOptions);
+            if (Debugging.AssertsEnabled) Debugging.Assert(indexOptions.CompareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0,"invalid indexOptions: {0}", indexOptions);
             if (Debugging.AssertsEnabled) Debugging.Assert(proxOut != null);
 
             int delta = position - lastPosition;
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(delta >= 0, () => "position=" + position + " lastPosition=" + lastPosition); // not quite right (if pos=0 is repeated twice we don't catch it)
+            if (Debugging.AssertsEnabled) Debugging.Assert(delta >= 0,"position={0} lastPosition={1}", position, lastPosition); // not quite right (if pos=0 is repeated twice we don't catch it)
 
             lastPosition = position;
 
@@ -271,7 +271,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 // and the numbers aren't that much smaller anyways.
                 int offsetDelta = startOffset - lastOffset;
                 int offsetLength = endOffset - startOffset;
-                if (Debugging.AssertsEnabled) Debugging.Assert(offsetDelta >= 0 && offsetLength >= 0, () => "startOffset=" + startOffset + ",lastOffset=" + lastOffset + ",endOffset=" + endOffset);
+                if (Debugging.AssertsEnabled) Debugging.Assert(offsetDelta >= 0 && offsetLength >= 0,"startOffset={0},lastOffset={1}", startOffset, lastOffset + ",endOffset=" + endOffset);
                 if (offsetLength != lastOffsetLength)
                 {
                     proxOut.WriteVInt32(offsetDelta << 1 | 1);

--- a/src/Lucene.Net.TestFramework/Codecs/MockIntBlock/MockVariableIntBlockPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MockIntBlock/MockVariableIntBlockPostingsFormat.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Codecs.MockIntBlock
                     {
                         buffer[0] = input.ReadVInt32();
                         int count = buffer[0] <= 3 ? baseBlockSize - 1 : 2 * baseBlockSize - 1;
-                        if (Debugging.AssertsEnabled) Debugging.Assert(buffer.Length >= count, () => "buffer.length=" + buffer.Length + " count=" + count);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(buffer.Length >= count,"buffer.length={0} count={1}", buffer.Length, count);
                         for (int i = 0; i < count; i++)
                         {
                             buffer[i + 1] = input.ReadVInt32();

--- a/src/Lucene.Net.TestFramework/Index/AssertingAtomicReader.cs
+++ b/src/Lucene.Net.TestFramework/Index/AssertingAtomicReader.cs
@@ -109,7 +109,7 @@ namespace Lucene.Net.Index
             try
             {
                 int docid = @in.DocID;
-                if (Debugging.AssertsEnabled) Debugging.Assert(docid == -1, () => @in.GetType() + ": invalid initial doc id: " + docid);
+                if (Debugging.AssertsEnabled) Debugging.Assert(docid == -1, "{0}: invalid initial doc id: {1}", @in.GetType(), docid);
             }
             catch (NotSupportedException /*e*/)
             {
@@ -125,7 +125,7 @@ namespace Lucene.Net.Index
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(state != DocsEnumState.FINISHED, "NextDoc() called after NO_MORE_DOCS");
             int nextDoc = base.NextDoc();
-            if (Debugging.AssertsEnabled) Debugging.Assert(nextDoc > doc, () => "backwards NextDoc from " + doc + " to " + nextDoc + " " + m_input);
+            if (Debugging.AssertsEnabled) Debugging.Assert(nextDoc > doc, "backwards NextDoc from {0} to {1} {2}", doc, nextDoc, m_input);
             if (nextDoc == DocIdSetIterator.NO_MORE_DOCS)
             {
                 state = DocsEnumState.FINISHED;
@@ -141,9 +141,9 @@ namespace Lucene.Net.Index
         public override int Advance(int target)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(state != DocsEnumState.FINISHED, "Advance() called after NO_MORE_DOCS");
-            if (Debugging.AssertsEnabled) Debugging.Assert(target > doc, () => "target must be > DocID, got " + target + " <= " + doc);
+            if (Debugging.AssertsEnabled) Debugging.Assert(target > doc,"target must be > DocID, got {0} <= {1}", target, doc);
             int advanced = base.Advance(target);
-            if (Debugging.AssertsEnabled) Debugging.Assert(advanced >= target, () => "backwards advance from: " + target + " to: " + advanced);
+            if (Debugging.AssertsEnabled) Debugging.Assert(advanced >= target,"backwards advance from: {0} to: {1}", target, advanced);
             if (advanced == DocIdSetIterator.NO_MORE_DOCS)
             {
                 state = DocsEnumState.FINISHED;
@@ -160,7 +160,7 @@ namespace Lucene.Net.Index
         {
             get
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(doc == base.DocID, () => " invalid DocID in " + m_input.GetType() + " " + base.DocID + " instead of " + doc);
+                if (Debugging.AssertsEnabled) Debugging.Assert(doc == base.DocID," invalid DocID in {0} {1}", m_input.GetType(), base.DocID + " instead of " + doc);
                 return doc;
             }
         }
@@ -309,7 +309,7 @@ namespace Lucene.Net.Index
 
         public override void SetDocument(int docID)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(docID >= 0 && docID < maxDoc, () => "docid=" + docID + ",maxDoc=" + maxDoc);
+            if (Debugging.AssertsEnabled) Debugging.Assert(docID >= 0 && docID < maxDoc,"docid={0},maxDoc={1}", docID, maxDoc);
             @in.SetDocument(docID);
             lastOrd = -2;
         }
@@ -572,7 +572,7 @@ namespace Lucene.Net.Index
                 : base(@in)
             {
                 int docid = @in.DocID;
-                if (Debugging.AssertsEnabled) Debugging.Assert(docid == -1, () => "invalid initial doc id: " + docid);
+                if (Debugging.AssertsEnabled) Debugging.Assert(docid == -1,"invalid initial doc id: {0}", docid);
                 doc = -1;
             }
 
@@ -580,7 +580,7 @@ namespace Lucene.Net.Index
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(state != DocsEnumState.FINISHED, "NextDoc() called after NO_MORE_DOCS");
                 int nextDoc = base.NextDoc();
-                if (Debugging.AssertsEnabled) Debugging.Assert(nextDoc > doc, () => "backwards nextDoc from " + doc + " to " + nextDoc);
+                if (Debugging.AssertsEnabled) Debugging.Assert(nextDoc > doc,"backwards nextDoc from {0} to {1}", doc, nextDoc);
                 positionCount = 0;
                 if (nextDoc == DocIdSetIterator.NO_MORE_DOCS)
                 {
@@ -599,9 +599,9 @@ namespace Lucene.Net.Index
             public override int Advance(int target)
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(state != DocsEnumState.FINISHED, "Advance() called after NO_MORE_DOCS");
-                if (Debugging.AssertsEnabled) Debugging.Assert(target > doc, () => "target must be > DocID, got " + target + " <= " + doc);
+                if (Debugging.AssertsEnabled) Debugging.Assert(target > doc,"target must be > DocID, got {0} <= {1}", target, doc);
                 int advanced = base.Advance(target);
-                if (Debugging.AssertsEnabled) Debugging.Assert(advanced >= target, () => "backwards advance from: " + target + " to: " + advanced);
+                if (Debugging.AssertsEnabled) Debugging.Assert(advanced >= target,"backwards advance from: {0} to: {1}", target, advanced);
                 positionCount = 0;
                 if (advanced == DocIdSetIterator.NO_MORE_DOCS)
                 {
@@ -621,7 +621,7 @@ namespace Lucene.Net.Index
             {
                 get
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(doc == base.DocID, () => " invalid DocID in " + m_input.GetType() + " " + base.DocID + " instead of " + doc);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(doc == base.DocID," invalid DocID in {0} {1}", m_input.GetType(), base.DocID + " instead of " + doc);
                     return doc;
                 }
             }
@@ -644,7 +644,7 @@ namespace Lucene.Net.Index
                 if (Debugging.AssertsEnabled) Debugging.Assert(state != DocsEnumState.FINISHED, "NextPosition() called after NO_MORE_DOCS");
                 if (Debugging.AssertsEnabled) Debugging.Assert(positionCount < positionMax, "NextPosition() called more than Freq times!");
                 int position = base.NextPosition();
-                if (Debugging.AssertsEnabled) Debugging.Assert(position >= 0 || position == -1, () => "invalid position: " + position);
+                if (Debugging.AssertsEnabled) Debugging.Assert(position >= 0 || position == -1,"invalid position: {0}", position);
                 positionCount++;
                 return position;
             }

--- a/src/Lucene.Net.TestFramework/Index/AssertingAtomicReader.cs
+++ b/src/Lucene.Net.TestFramework/Index/AssertingAtomicReader.cs
@@ -160,7 +160,7 @@ namespace Lucene.Net.Index
         {
             get
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(doc == base.DocID," invalid DocID in {0} {1}", m_input.GetType(), base.DocID + " instead of " + doc);
+                if (Debugging.AssertsEnabled) Debugging.Assert(doc == base.DocID, " invalid DocID in {0} {1} instead of {2}", m_input.GetType(), base.DocID, doc);
                 return doc;
             }
         }
@@ -621,7 +621,7 @@ namespace Lucene.Net.Index
             {
                 get
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(doc == base.DocID," invalid DocID in {0} {1}", m_input.GetType(), base.DocID + " instead of " + doc);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(doc == base.DocID, " invalid DocID in {0} {1} instead of {2}", m_input.GetType(), base.DocID, doc);
                     return doc;
                 }
             }

--- a/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
@@ -440,7 +440,7 @@ namespace Lucene.Net.Index
                         Console.WriteLine("RIW: doRandomForceMerge(" + limit + ")");
                     }
                     IndexWriter.ForceMerge(limit);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(!doRandomForceMergeAssert || IndexWriter.SegmentCount <= limit, () => "limit=" + limit + " actual=" + IndexWriter.SegmentCount);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(!doRandomForceMergeAssert || IndexWriter.SegmentCount <= limit,"limit={0} actual={1}", limit, IndexWriter.SegmentCount);
                 }
             }
         }

--- a/src/Lucene.Net.TestFramework/Search/AssertingCollector.cs
+++ b/src/Lucene.Net.TestFramework/Search/AssertingCollector.cs
@@ -52,7 +52,7 @@ namespace Lucene.Net.Search
         {
             if (inOrder || !AcceptsDocsOutOfOrder)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(doc > lastCollected, () => "Out of order : " + lastCollected + " " + doc);
+                if (Debugging.AssertsEnabled) Debugging.Assert(doc > lastCollected,"Out of order : {0} {1}", lastCollected, doc);
             }
             @in.Collect(doc);
             lastCollected = doc;

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -306,7 +306,7 @@ namespace Lucene.Net.Search
                     this.outerInstance = nodeState;
                     this.nodeVersions = nodeVersions;
                     MyNodeID = nodeID;
-                    if (Debugging.AssertsEnabled) Debugging.Assert(MyNodeID == nodeState.MyNodeID,"myNodeID={0} NodeState.this.myNodeID={1}", nodeID, nodeState.MyNodeID);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(MyNodeID == nodeState.MyNodeID,"myNodeID={0} nodeState.MyNodeID={1}", nodeID, nodeState.MyNodeID);
                 }
 
                 public override Query Rewrite(Query original)
@@ -419,7 +419,7 @@ namespace Lucene.Net.Search
                         }
                         // Collection stats are pre-shared on reopen, so,
                         // we better not have a cache miss:
-                        if (Debugging.AssertsEnabled) Debugging.Assert(nodeStats != null,"myNodeID={0} nodeID={1}", MyNodeID, nodeID + " version=" + nodeVersions[nodeID] + " field=" + field);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(nodeStats != null, "myNodeID={0} nodeID={1} version={2} field={3}", MyNodeID, nodeID, nodeVersions[nodeID], field);
 
                         long nodeDocCount = nodeStats.DocCount;
                         if (docCount >= 0 && nodeDocCount >= 0)

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -306,7 +306,7 @@ namespace Lucene.Net.Search
                     this.outerInstance = nodeState;
                     this.nodeVersions = nodeVersions;
                     MyNodeID = nodeID;
-                    if (Debugging.AssertsEnabled) Debugging.Assert(MyNodeID == nodeState.MyNodeID, () => "myNodeID=" + nodeID + " NodeState.this.myNodeID=" + nodeState.MyNodeID);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(MyNodeID == nodeState.MyNodeID,"myNodeID={0} NodeState.this.myNodeID={1}", nodeID, nodeState.MyNodeID);
                 }
 
                 public override Query Rewrite(Query original)
@@ -419,7 +419,7 @@ namespace Lucene.Net.Search
                         }
                         // Collection stats are pre-shared on reopen, so,
                         // we better not have a cache miss:
-                        if (Debugging.AssertsEnabled) Debugging.Assert(nodeStats != null, () => "myNodeID=" + MyNodeID + " nodeID=" + nodeID + " version=" + nodeVersions[nodeID] + " field=" + field);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(nodeStats != null,"myNodeID={0} nodeID={1}", MyNodeID, nodeID + " version=" + nodeVersions[nodeID] + " field=" + field);
 
                         long nodeDocCount = nodeStats.DocCount;
                         if (docCount >= 0 && nodeDocCount >= 0)

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -1024,7 +1024,7 @@ namespace Lucene.Net.Store
                                         extras += "\n\nThese files we had previously tried to delete, but couldn't: " + pendingDeletions;
                                     }
 
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "unreferenced files: before delete:\n    " + Arrays.ToString(startFiles) + "\n  after delete:\n    " + Arrays.ToString(endFiles) + extras);
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false,"unreferenced files: before delete:\n    {0}\n  after delete:\n    {1}", Arrays.ToString(startFiles), Arrays.ToString(endFiles) + extras);
                                 }
 
                                 DirectoryReader ir1 = DirectoryReader.Open(this);
@@ -1034,7 +1034,7 @@ namespace Lucene.Net.Store
                                 DirectoryReader ir2 = DirectoryReader.Open(this);
                                 int numDocs2 = ir2.NumDocs;
                                 ir2.Dispose();
-                                if (Debugging.AssertsEnabled) Debugging.Assert(numDocs1 == numDocs2, () => "numDocs changed after opening/closing IW: before=" + numDocs1 + " after=" + numDocs2);
+                                if (Debugging.AssertsEnabled) Debugging.Assert(numDocs1 == numDocs2,"numDocs changed after opening/closing IW: before={0} after={1}", numDocs1, numDocs2);
                             }
                         }
                     }

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -1024,7 +1024,7 @@ namespace Lucene.Net.Store
                                         extras += "\n\nThese files we had previously tried to delete, but couldn't: " + pendingDeletions;
                                     }
 
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false,"unreferenced files: before delete:\n    {0}\n  after delete:\n    {1}", Arrays.ToString(startFiles), Arrays.ToString(endFiles) + extras);
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "unreferenced files: before delete:\n    {0}\n  after delete:\n    {1}{2}", startFiles, endFiles, extras);
                                 }
 
                                 DirectoryReader ir1 = DirectoryReader.Open(this);

--- a/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
@@ -399,7 +399,7 @@ namespace Lucene.Net.Util.Automaton
         {
             int numStates = a.GetNumberOfStates();
             a.ClearNumberedStates(); // force recomputation of cached numbered states
-            if (Debugging.AssertsEnabled) Debugging.Assert(numStates == a.GetNumberOfStates(),"automaton has {0}", (numStates - a.GetNumberOfStates()) + " detached states");
+            if (Debugging.AssertsEnabled) Debugging.Assert(numStates == a.GetNumberOfStates(), "automaton has {0} detached states", numStates - a.GetNumberOfStates());
         }
     }
 

--- a/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
@@ -191,7 +191,7 @@ namespace Lucene.Net.Util.Automaton
                 }
             }
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(code >= t.Min && code <= t.Max && (code < UnicodeUtil.UNI_SUR_HIGH_START || code > UnicodeUtil.UNI_SUR_LOW_END), () => "code=" + code + " min=" + t.Min + " max=" + t.Max);
+            if (Debugging.AssertsEnabled) Debugging.Assert(code >= t.Min && code <= t.Max && (code < UnicodeUtil.UNI_SUR_HIGH_START || code > UnicodeUtil.UNI_SUR_LOW_END), "code={0} min={1} max={2}", code, t.Min, t.Max);
             return code;
         }
 
@@ -399,7 +399,7 @@ namespace Lucene.Net.Util.Automaton
         {
             int numStates = a.GetNumberOfStates();
             a.ClearNumberedStates(); // force recomputation of cached numbered states
-            if (Debugging.AssertsEnabled) Debugging.Assert(numStates == a.GetNumberOfStates(), () => "automaton has " + (numStates - a.GetNumberOfStates()) + " detached states");
+            if (Debugging.AssertsEnabled) Debugging.Assert(numStates == a.GetNumberOfStates(),"automaton has {0}", (numStates - a.GetNumberOfStates()) + " detached states");
         }
     }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
@@ -422,7 +422,7 @@ namespace Lucene.Net.Analysis.CharFilters
                                 // Same length: no change to offset
                             }
 
-                            if (Debugging.AssertsEnabled) Debugging.Assert(inputOffsets.Count == output.Length,"inputOffsets.size()={0} vs output.length()={1}", inputOffsets.Count, output.Length);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(inputOffsets.Count == output.Length,"inputOffsets.Count={0} vs output.Length={1}", inputOffsets.Count, output.Length);
                         }
                         else
                         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
@@ -422,7 +422,7 @@ namespace Lucene.Net.Analysis.CharFilters
                                 // Same length: no change to offset
                             }
 
-                            if (Debugging.AssertsEnabled) Debugging.Assert(inputOffsets.Count == output.Length, () => "inputOffsets.size()=" + inputOffsets.Count + " vs output.length()=" + output.Length);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(inputOffsets.Count == output.Length,"inputOffsets.size()={0} vs output.length()={1}", inputOffsets.Count, output.Length);
                         }
                         else
                         {

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -461,7 +461,7 @@ namespace Lucene.Net.Replicator
                     {
                         // count-down number of failures
                         failures.DecrementAndGet();
-                        if (Debugging.AssertsEnabled) Debugging.Assert(failures >= 0, () => "handler failed too many times: " + failures);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(failures >= 0,"handler failed too many times: {0}", failures);
                         if (Verbose)
                         {
                             if (failures == 0)

--- a/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
@@ -367,7 +367,7 @@ namespace Lucene.Net.Replicator
                     {
                         // count-down number of failures
                         failures.DecrementAndGet();
-                        if (Debugging.AssertsEnabled) Debugging.Assert(failures >= 0, () => "handler failed too many times: " + failures);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(failures >= 0,"handler failed too many times: {0}", failures);
                         if (Verbose)
                         {
                             if (failures == 0)

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/FuzzySuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/FuzzySuggesterTest.cs
@@ -1314,7 +1314,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 else
                 {
                     int c = CHARSEQUENCE_COMPARER.Compare(a.Key, b.Key);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(c != 0, () => "term=" + a.Key);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(c != 0,"term={0}", a.Key);
                     return c;
                 }
             }

--- a/src/Lucene.Net.Tests/Index/TestStressIndexing2.cs
+++ b/src/Lucene.Net.Tests/Index/TestStressIndexing2.cs
@@ -347,7 +347,7 @@ namespace Lucene.Net.Index
             }
             if (r1.NumDocs != r2.NumDocs)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "r1.NumDocs=" + r1.NumDocs + " vs r2.NumDocs=" + r2.NumDocs);
+                if (Debugging.AssertsEnabled) Debugging.Assert(false,"r1.NumDocs={0} vs r2.NumDocs={1}", r1.NumDocs, r2.NumDocs);
             }
             bool hasDeletes = !(r1.MaxDoc == r2.MaxDoc && r1.NumDocs == r1.MaxDoc);
 

--- a/src/Lucene.Net.Tests/Search/TestMinShouldMatch2.cs
+++ b/src/Lucene.Net.Tests/Search/TestMinShouldMatch2.cs
@@ -384,7 +384,7 @@ namespace Lucene.Net.Search
 
             public override float GetScore()
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(score != 0, currentMatched.ToString);
+                if (Debugging.AssertsEnabled) Debugging.Assert(score != 0, currentMatched.ToString());
                 return (float)score * ((BooleanWeight)m_weight).Coord(currentMatched, ((BooleanWeight)m_weight).MaxCoord);
             }
 

--- a/src/Lucene.Net.Tests/Search/TestTimeLimitingCollector.cs
+++ b/src/Lucene.Net.Tests/Search/TestTimeLimitingCollector.cs
@@ -418,7 +418,7 @@ namespace Lucene.Net.Search
 //#endif
                 }
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(docId >= 0, () => " base=" + docBase + " doc=" + doc);
+                if (Debugging.AssertsEnabled) Debugging.Assert(docId >= 0," base={0} doc={1}", docBase, doc);
                 bits.Set(docId);
                 lastDocCollected = docId;
             }

--- a/src/Lucene.Net.Tests/Support/Diagnostics/TestDebugging.cs
+++ b/src/Lucene.Net.Tests/Support/Diagnostics/TestDebugging.cs
@@ -1,0 +1,258 @@
+using Lucene.Net.Attributes;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
+
+namespace Lucene.Net.Diagnostics
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// LUCENENET specific tests for <see cref="Debugging"/> class
+    /// </summary>
+    public class TestDebugging
+    {
+        [Test, LuceneNetSpecific]
+        public void TestConditionTrue()
+        {
+            TestWithAsserts(enabled: true, () =>
+            {
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message"));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object(), new object(), new object(), new object(), new object()));
+            });
+
+            TestWithAsserts(enabled: false, () =>
+            {
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message"));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: true, "test message", new object(), new object(), new object(), new object(), new object(), new object(), new object(), new object()));
+            });
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestConditionFalse()
+        {
+            TestWithAsserts(enabled: true, () =>
+            {
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false));
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, "test message"));
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, "test message", new object()));
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, "test message", new object(), new object()));
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object()));
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object()));
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object(), new object()));
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object(), new object(), new object()));
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object(), new object(), new object(), new object()));
+                Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object(), new object(), new object(), new object(), new object()));
+            });
+
+            TestWithAsserts(enabled: false, () =>
+            {
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false, "test message"));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false, "test message", new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false, "test message", new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object(), new object(), new object(), new object()));
+                Assert.DoesNotThrow(() => Debugging.Assert(condition: false, "test message", new object(), new object(), new object(), new object(), new object(), new object(), new object(), new object()));
+            });
+        }
+
+        [Test, LuceneNetSpecific]
+        [TestCaseSource(typeof(TestDebugging), "GetMessageFormatCases", new object[] { 1 })]
+        public void TestMessageFormatting_1Parameter(string expectedMessage, string messageFormat, object p0)
+        {
+            TestWithAsserts(enabled: true, () =>
+            {
+                var e = Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, messageFormat, p0));
+                Assert.AreEqual(expectedMessage, e.Message);
+            });
+        }
+
+        [Test, LuceneNetSpecific]
+        [TestCaseSource(typeof(TestDebugging), "GetMessageFormatCases", new object[] { 2 })]
+        public void TestMessageFormatting_2Parameters(string expectedMessage, string messageFormat, object p0, object p1)
+        {
+            TestWithAsserts(enabled: true, () =>
+            {
+                var e = Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, messageFormat, p0, p1));
+                Assert.AreEqual(expectedMessage, e.Message);
+            });
+        }
+
+        [Test, LuceneNetSpecific]
+        [TestCaseSource(typeof(TestDebugging), "GetMessageFormatCases", new object[] { 3 })]
+        public void TestMessageFormatting_3Parameters(string expectedMessage, string messageFormat, object p0, object p1, object p2)
+        {
+            TestWithAsserts(enabled: true, () =>
+            {
+                var e = Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, messageFormat, p0, p1, p2));
+                Assert.AreEqual(expectedMessage, e.Message);
+            });
+        }
+
+        [Test, LuceneNetSpecific]
+        [TestCaseSource(typeof(TestDebugging), "GetMessageFormatCases", new object[] { 4 })]
+        public void TestMessageFormatting_4Parameters(string expectedMessage, string messageFormat, object p0, object p1, object p2, object p3)
+        {
+            TestWithAsserts(enabled: true, () =>
+            {
+                var e = Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, messageFormat, p0, p1, p2, p3));
+                Assert.AreEqual(expectedMessage, e.Message);
+            });
+        }
+
+        [Test, LuceneNetSpecific]
+        [TestCaseSource(typeof(TestDebugging), "GetMessageFormatCases", new object[] { 5 })]
+        public void TestMessageFormatting_5Parameters(string expectedMessage, string messageFormat, object p0, object p1, object p2, object p3, object p4)
+        {
+            TestWithAsserts(enabled: true, () =>
+            {
+                var e = Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, messageFormat, p0, p1, p2, p3, p4));
+                Assert.AreEqual(expectedMessage, e.Message);
+            });
+        }
+
+        [Test, LuceneNetSpecific]
+        [TestCaseSource(typeof(TestDebugging), "GetMessageFormatCases", new object[] { 6 })]
+        public void TestMessageFormatting_6Parameters(string expectedMessage, string messageFormat, object p0, object p1, object p2, object p3, object p4, object p5)
+        {
+            TestWithAsserts(enabled: true, () =>
+            {
+                var e = Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, messageFormat, p0, p1, p2, p3, p4, p5));
+                Assert.AreEqual(expectedMessage, e.Message);
+            });
+        }
+
+        [Test, LuceneNetSpecific]
+        [TestCaseSource(typeof(TestDebugging), "GetMessageFormatCases", new object[] { 7 })]
+        public void TestMessageFormatting_7Parameters(string expectedMessage, string messageFormat, object p0, object p1, object p2, object p3, object p4, object p5, object p6)
+        {
+            TestWithAsserts(enabled: true, () =>
+            {
+                var e = Assert.Throws<AssertionException>(() => Debugging.Assert(condition: false, messageFormat, p0, p1, p2, p3, p4, p5, p6));
+                Assert.AreEqual(expectedMessage, e.Message);
+            });
+        }
+
+        private void TestWithAsserts(bool enabled, Action expression)
+        {
+            var originalAssertsEnabled = Debugging.AssertsEnabled;
+
+            try
+            {
+                Debugging.AssertsEnabled = enabled;
+
+                expression();
+            }
+            finally
+            {
+                Debugging.AssertsEnabled = originalAssertsEnabled;
+            }
+        }
+
+        public static IEnumerable<TestCaseData> GetMessageFormatCases(int parameterCount)
+        {
+            foreach (var test in GetMessageFormatData())
+            {
+                var messageFormat = new StringBuilder();
+                var parameters = new List<object>();
+                var expectedMessage = new StringBuilder();
+                for (int i = 0; i < parameterCount; i++)
+                {
+                    parameters.Add(test.Parameter);
+                    if (i > 0)
+                    {
+                        messageFormat.Append(" ");
+                        expectedMessage.Append(" ");
+                    }
+                    messageFormat.Append(test.MessageFormatPrefix);
+                    messageFormat.Append(i.ToString(CultureInfo.InvariantCulture));
+                    messageFormat.Append(test.MessageFormatSuffix);
+                    expectedMessage.Append(test.ExpectedMessage);
+                }
+
+                var args = new List<object>();
+                args.Add(expectedMessage.ToString());
+                args.Add(messageFormat.ToString());
+                args.AddRange(parameters);
+                yield return new TestCaseData(args.ToArray());
+            }
+        }
+
+        private class MessageFormatData
+        {
+            public MessageFormatData(string messageFormatPrefix, string messageFormatSuffix, object parameter, string expectedMessage)
+            {
+                MessageFormatPrefix = messageFormatPrefix ?? throw new ArgumentNullException(nameof(messageFormatPrefix));
+                MessageFormatSuffix = messageFormatSuffix ?? throw new ArgumentNullException(nameof(messageFormatSuffix));
+                Parameter = parameter;
+                ExpectedMessage = expectedMessage;
+            }
+
+            public string MessageFormatPrefix { get; set; }
+            public string MessageFormatSuffix { get; set; }
+            public object Parameter { get; set; }
+            public string ExpectedMessage { get; set; }
+        }
+
+        private static IEnumerable<MessageFormatData> GetMessageFormatData()
+        {
+            yield return new MessageFormatData("{", "}", "foo", "foo"); // string
+            yield return new MessageFormatData("{", "}", (string)null, "null"); // null string
+            yield return new MessageFormatData("{", "}", 12345, "12345"); // int
+            yield return new MessageFormatData("0x{", ":x}", 12345, "0x3039"); // int hex
+
+            yield return new MessageFormatData("{", "}", new string[] { "foo", "bar", "baz" }, "[foo, bar, baz]"); // string array
+            yield return new MessageFormatData("{", "}", new int[] { 10, 11, 12 }, "[10, 11, 12]"); // int array
+            yield return new MessageFormatData("{", "}", (Array)null, "null"); // null array
+
+            yield return new MessageFormatData("{", "}", new JCG.List<string> { "foo", "bar", "baz" }, "[foo, bar, baz]"); // string list
+            yield return new MessageFormatData("{", "}", new JCG.List<int> { 10, 11, 12 }, "[10, 11, 12]"); // int list
+
+            yield return new MessageFormatData("{", "}", new List<string> { "foo", "bar", "baz" }, "[foo, bar, baz]"); // string list
+            yield return new MessageFormatData("{", "}", new List<int> { 10, 11, 12 }, "[10, 11, 12]"); // int list
+            yield return new MessageFormatData("{", "}", (IList<int>)null, "null"); // null list
+
+            yield return new MessageFormatData("{", "}", new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } }, "{key1=value1, key2=value2}"); // string dictionary
+            yield return new MessageFormatData("{", "}", (IDictionary<string, string>)null, "null"); // null dictionary
+        }
+    }
+}

--- a/src/Lucene.Net.Tests/Util/Automaton/TestUTF32ToUTF8.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestUTF32ToUTF8.cs
@@ -95,7 +95,7 @@ namespace Lucene.Net.Util.Automaton
                     }
                 }
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(code >= startCode && code <= endCode,"code={0} start={1}", code, startCode + " end=" + endCode);
+                if (Debugging.AssertsEnabled) Debugging.Assert(code >= startCode && code <= endCode, "code={0} start={1} end={2}", code, startCode, endCode);
                 if (Debugging.AssertsEnabled) Debugging.Assert(!IsSurrogate(code));
 
                 Assert.IsTrue(Matches(a, code), "DFA for range " + startCode + "-" + endCode + " failed to match code=" + code);

--- a/src/Lucene.Net.Tests/Util/Automaton/TestUTF32ToUTF8.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestUTF32ToUTF8.cs
@@ -95,7 +95,7 @@ namespace Lucene.Net.Util.Automaton
                     }
                 }
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(code >= startCode && code <= endCode, () => "code=" + code + " start=" + startCode + " end=" + endCode);
+                if (Debugging.AssertsEnabled) Debugging.Assert(code >= startCode && code <= endCode,"code={0} start={1}", code, startCode + " end=" + endCode);
                 if (Debugging.AssertsEnabled) Debugging.Assert(!IsSurrogate(code));
 
                 Assert.IsTrue(Matches(a, code), "DFA for range " + startCode + "-" + endCode + " failed to match code=" + code);

--- a/src/Lucene.Net/Codecs/BlockTermState.cs
+++ b/src/Lucene.Net/Codecs/BlockTermState.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Codecs
 
         public override void CopyFrom(TermState other)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(other is BlockTermState, () => "can not copy from " + other.GetType().Name);
+            if (Debugging.AssertsEnabled) Debugging.Assert(other is BlockTermState, "can not copy from {0}", other.GetType().Name);
             BlockTermState other2 = (BlockTermState)other;
             base.CopyFrom(other);
             DocFreq = other2.DocFreq;

--- a/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
@@ -173,7 +173,7 @@ namespace Lucene.Net.Codecs
                     @in.ReadBytes(rootCode.Bytes, 0, numBytes);
                     rootCode.Length = numBytes;
                     FieldInfo fieldInfo = fieldInfos.FieldInfo(field);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(fieldInfo != null, () => "field=" + field);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(fieldInfo != null, "field={0}", field);
                     long sumTotalTermFreq = fieldInfo.IndexOptions == IndexOptions.DOCS_ONLY ? -1 : @in.ReadVInt64();
                     long sumDocFreq = @in.ReadVInt64();
                     int docCount = @in.ReadVInt32();
@@ -478,7 +478,7 @@ namespace Lucene.Net.Codecs
                 }
                 endBlockCount++;
                 long otherBytes = frame.fpEnd - frame.fp - frame.suffixesReader.Length - frame.statsReader.Length;
-                if (Debugging.AssertsEnabled) Debugging.Assert(otherBytes > 0, () => "otherBytes=" + otherBytes + " frame.fp=" + frame.fp + " frame.fpEnd=" + frame.fpEnd);
+                if (Debugging.AssertsEnabled) Debugging.Assert(otherBytes > 0, "otherBytes={0} frame.fp={1} frame.fpEnd={2}", otherBytes, frame.fp, frame.fpEnd);
                 TotalBlockOtherBytes += otherBytes;
             }
 
@@ -491,9 +491,9 @@ namespace Lucene.Net.Codecs
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(startBlockCount == endBlockCount, () => "startBlockCount=" + startBlockCount + " endBlockCount=" + endBlockCount);
-                    Debugging.Assert(TotalBlockCount == FloorSubBlockCount + NonFloorBlockCount, () => "floorSubBlockCount=" + FloorSubBlockCount + " nonFloorBlockCount=" + NonFloorBlockCount + " totalBlockCount=" + TotalBlockCount);
-                    Debugging.Assert(TotalBlockCount == MixedBlockCount + TermsOnlyBlockCount + SubBlocksOnlyBlockCount, () => "totalBlockCount=" + TotalBlockCount + " mixedBlockCount=" + MixedBlockCount + " subBlocksOnlyBlockCount=" + SubBlocksOnlyBlockCount + " termsOnlyBlockCount=" + TermsOnlyBlockCount);
+                    Debugging.Assert(startBlockCount == endBlockCount, "startBlockCount={0} endBlockCount={1}", startBlockCount, endBlockCount);
+                    Debugging.Assert(TotalBlockCount == FloorSubBlockCount + NonFloorBlockCount, "floorSubBlockCount={0} nonFloorBlockCount={1} totalBlockCount={2}", FloorSubBlockCount, NonFloorBlockCount, TotalBlockCount);
+                    Debugging.Assert(TotalBlockCount == MixedBlockCount + TermsOnlyBlockCount + SubBlocksOnlyBlockCount, "totalBlockCount={0} mixedBlockCount={1} subBlocksOnlyBlockCount={2} termsOnlyBlockCount={3}", TotalBlockCount, MixedBlockCount, SubBlocksOnlyBlockCount, TermsOnlyBlockCount);
                 }
             }
 
@@ -909,7 +909,7 @@ namespace Lucene.Net.Codecs
                     public bool NextLeaf()
                     {
                         //if (DEBUG) System.out.println("  frame.next ord=" + ord + " nextEnt=" + nextEnt + " entCount=" + entCount);
-                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount, () => "nextEnt=" + nextEnt + " entCount=" + entCount + " fp=" + fp);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount, "nextEnt={0} entCount={1} fp={2}", nextEnt, entCount, fp);
                         nextEnt++;
                         suffix = suffixesReader.ReadVInt32();
                         startBytePos = suffixesReader.Position;
@@ -920,7 +920,7 @@ namespace Lucene.Net.Codecs
                     public bool NextNonLeaf()
                     {
                         //if (DEBUG) System.out.println("  frame.next ord=" + ord + " nextEnt=" + nextEnt + " entCount=" + entCount);
-                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount, () => "nextEnt=" + nextEnt + " entCount=" + entCount + " fp=" + fp);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount, "nextEnt={0} entCount={1} fp={2}", nextEnt, entCount, fp);
                         nextEnt++;
                         int code = suffixesReader.ReadVInt32();
                         suffix = (int)((uint)code >> 1);
@@ -1430,7 +1430,7 @@ namespace Lucene.Net.Codecs
                         {
                             CopyTerm();
                             //if (DEBUG) System.out.println("      term match to state=" + state + "; return term=" + brToString(term));
-                            if (Debugging.AssertsEnabled) Debugging.Assert(savedStartTerm == null || term.CompareTo(savedStartTerm) > 0, () => "saveStartTerm=" + savedStartTerm.Utf8ToString() + " term=" + term.Utf8ToString());
+                            if (Debugging.AssertsEnabled) Debugging.Assert(savedStartTerm == null || term.CompareTo(savedStartTerm) > 0, "saveStartTerm={0} term={1}", savedStartTerm.Utf8ToString(), term.Utf8ToString());
                             return true;
                         }
                         else
@@ -1848,7 +1848,7 @@ namespace Lucene.Net.Codecs
                             //if (arc.label != (target.bytes[target.offset + targetUpto] & 0xFF)) {
                             //System.out.println("FAIL: arc.label=" + (char) arc.label + " targetLabel=" + (char) (target.bytes[target.offset + targetUpto] & 0xFF));
                             //}
-                            if (Debugging.AssertsEnabled) Debugging.Assert(arc.Label == (target.Bytes[target.Offset + targetUpto] & 0xFF), () => "arc.label=" + (char)arc.Label + " targetLabel=" + (char)(target.Bytes[target.Offset + targetUpto] & 0xFF));
+                            if (Debugging.AssertsEnabled) Debugging.Assert(arc.Label == (target.Bytes[target.Offset + targetUpto] & 0xFF), "arc.label={0} targetLabel={1}", (char)arc.Label, (char)(target.Bytes[target.Offset + targetUpto] & 0xFF));
                             if (arc.Output != outerInstance.outerInstance.NO_OUTPUT)
                             {
                                 output = outerInstance.outerInstance.fstOutputs.Add(output, arc.Output);

--- a/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
@@ -2137,7 +2137,7 @@ namespace Lucene.Net.Codecs
                                 break;
                             }
                             arc = arcs[1 + targetUpto];
-                            if (Debugging.AssertsEnabled) Debugging.Assert(arc.Label == (target.Bytes[target.Offset + targetUpto] & 0xFF), () => "arc.label=" + (char)arc.Label + " targetLabel=" + (char)(target.Bytes[target.Offset + targetUpto] & 0xFF));
+                            if (Debugging.AssertsEnabled) Debugging.Assert(arc.Label == (target.Bytes[target.Offset + targetUpto] & 0xFF),"arc.label={0} targetLabel={1}", (char)arc.Label, (char)(target.Bytes[target.Offset + targetUpto] & 0xFF));
                             // TOOD: we could save the outputs in local
                             // byte[][] instead of making new objs ever
                             // seek; but, often the FST doesn't have any
@@ -2760,7 +2760,7 @@ namespace Lucene.Net.Codecs
                         //if (DEBUG) {
                         //System.out.println("    loadNextFloorBlock fp=" + fp + " fpEnd=" + fpEnd);
                         //}
-                        if (Debugging.AssertsEnabled) Debugging.Assert(arc == null || isFloor, () => "arc=" + arc + " isFloor=" + isFloor);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(arc == null || isFloor,"arc={0} isFloor={1}", arc, isFloor);
                         fp = fpEnd;
                         nextEnt = -1;
                         LoadBlock();
@@ -2917,7 +2917,7 @@ namespace Lucene.Net.Codecs
                     public bool NextLeaf()
                     {
                         //if (DEBUG) System.out.println("  frame.next ord=" + ord + " nextEnt=" + nextEnt + " entCount=" + entCount);
-                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount, () => "nextEnt=" + nextEnt + " entCount=" + entCount + " fp=" + fp);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount,"nextEnt={0} entCount={1}", nextEnt, entCount + " fp=" + fp);
                         nextEnt++;
                         suffix = suffixesReader.ReadVInt32();
                         startBytePos = suffixesReader.Position;
@@ -2935,7 +2935,7 @@ namespace Lucene.Net.Codecs
                     public bool NextNonLeaf()
                     {
                         //if (DEBUG) System.out.println("  frame.next ord=" + ord + " nextEnt=" + nextEnt + " entCount=" + entCount);
-                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount, () => "nextEnt=" + nextEnt + " entCount=" + entCount + " fp=" + fp);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount,"nextEnt={0} entCount={1}", nextEnt, entCount + " fp=" + fp);
                         nextEnt++;
                         int code = suffixesReader.ReadVInt32();
                         suffix = (int)((uint)code >> 1);
@@ -3118,7 +3118,7 @@ namespace Lucene.Net.Codecs
                             //if (DEBUG) System.out.println("    already positioned");
                             return;
                         }
-                        if (Debugging.AssertsEnabled) Debugging.Assert(subFP < fp, () => "fp=" + fp + " subFP=" + subFP);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(subFP < fp,"fp={0} subFP={1}", fp, subFP);
                         long targetSubCode = fp - subFP;
                         //if (DEBUG) System.out.println("    targetSubCode=" + targetSubCode);
                         while (true)

--- a/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Support;
+using Lucene.Net.Util;
 using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
@@ -1430,7 +1431,9 @@ namespace Lucene.Net.Codecs
                         {
                             CopyTerm();
                             //if (DEBUG) System.out.println("      term match to state=" + state + "; return term=" + brToString(term));
-                            if (Debugging.AssertsEnabled) Debugging.Assert(savedStartTerm == null || term.CompareTo(savedStartTerm) > 0, "saveStartTerm={0} term={1}", savedStartTerm.Utf8ToString(), term.Utf8ToString());
+                            if (Debugging.AssertsEnabled) Debugging.Assert(savedStartTerm == null || term.CompareTo(savedStartTerm) > 0, "saveStartTerm={0} term={1}",
+                                // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                                new BytesRefFormatter(savedStartTerm, BytesRefFormat.UTF8), new BytesRefFormatter(term, BytesRefFormat.UTF8));
                             return true;
                         }
                         else
@@ -2388,7 +2391,7 @@ namespace Lucene.Net.Codecs
                 //            }
                 //            if (OuterInstance.Index != null)
                 //            {
-                //                if (Debugging.AssertsEnabled) Debugging.Assert(!isSeekFrame || f.Arc != null, "isSeekFrame=" + isSeekFrame + " f.arc=" + f.Arc);
+                //                if (Debugging.AssertsEnabled) Debugging.Assert(!isSeekFrame || f.Arc != null, "isSeekFrame={0} f.arc={1}", isSeekFrame, f.Arc);
                 //                if (f.Prefix > 0 && isSeekFrame && f.Arc.Label != (term.Bytes[f.Prefix - 1] & 0xFF))
                 //                {
                 //                    @out.println("      broken seek state: arc.label=" + (char)f.Arc.Label + " vs term byte=" + (char)(term.Bytes[f.Prefix - 1] & 0xFF));
@@ -2760,7 +2763,7 @@ namespace Lucene.Net.Codecs
                         //if (DEBUG) {
                         //System.out.println("    loadNextFloorBlock fp=" + fp + " fpEnd=" + fpEnd);
                         //}
-                        if (Debugging.AssertsEnabled) Debugging.Assert(arc == null || isFloor,"arc={0} isFloor={1}", arc, isFloor);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(arc == null || isFloor, "arc={0} isFloor={1}", arc, isFloor);
                         fp = fpEnd;
                         nextEnt = -1;
                         LoadBlock();
@@ -2917,7 +2920,7 @@ namespace Lucene.Net.Codecs
                     public bool NextLeaf()
                     {
                         //if (DEBUG) System.out.println("  frame.next ord=" + ord + " nextEnt=" + nextEnt + " entCount=" + entCount);
-                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount,"nextEnt={0} entCount={1}", nextEnt, entCount + " fp=" + fp);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount, "nextEnt={0} entCount={1} fp={2}", nextEnt, entCount, fp);
                         nextEnt++;
                         suffix = suffixesReader.ReadVInt32();
                         startBytePos = suffixesReader.Position;
@@ -2935,7 +2938,7 @@ namespace Lucene.Net.Codecs
                     public bool NextNonLeaf()
                     {
                         //if (DEBUG) System.out.println("  frame.next ord=" + ord + " nextEnt=" + nextEnt + " entCount=" + entCount);
-                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount,"nextEnt={0} entCount={1}", nextEnt, entCount + " fp=" + fp);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(nextEnt != -1 && nextEnt < entCount, "nextEnt={0} entCount={1} fp={2}", nextEnt, entCount, fp);
                         nextEnt++;
                         int code = suffixesReader.ReadVInt32();
                         suffix = (int)((uint)code >> 1);

--- a/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
@@ -261,7 +261,7 @@ namespace Lucene.Net.Codecs
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(numTerms > 0);
                 this.FieldInfo = fieldInfo;
-                if (Debugging.AssertsEnabled) Debugging.Assert(rootCode != null,"field={0} numTerms={1}", fieldInfo.Name, numTerms);
+                if (Debugging.AssertsEnabled) Debugging.Assert(rootCode != null, "field={0} numTerms={1}", fieldInfo.Name, numTerms);
                 this.RootCode = rootCode;
                 this.IndexStartFP = indexStartFP;
                 this.NumTerms = numTerms;
@@ -490,11 +490,14 @@ namespace Lucene.Net.Codecs
 
             public void CompileIndex(IList<PendingBlock> floorBlocks, RAMOutputStream scratchBytes)
             {
-                // LUCENENET specific - we use a custom wrapper function to display floorBlocks, since
-                // it might contain garbage that cannot be converted into text.
-                if (Debugging.AssertsEnabled) Debugging.Assert((IsFloor && floorBlocks != null && floorBlocks.Count != 0) || (!IsFloor && floorBlocks == null), "isFloor={0} floorBlocks={1}", IsFloor , new PendingBlocksFormatter(floorBlocks));
+                if (Debugging.AssertsEnabled)
+                {
+                    // LUCENENET specific - we use a custom wrapper struct to display floorBlocks, since
+                    // it might contain garbage that cannot be converted into text.
+                    Debugging.Assert((IsFloor && floorBlocks != null && floorBlocks.Count != 0) || (!IsFloor && floorBlocks == null), "isFloor={0} floorBlocks={1}", IsFloor, new PendingBlocksFormatter(floorBlocks));
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(scratchBytes.GetFilePointer() == 0);
+                    Debugging.Assert(scratchBytes.GetFilePointer() == 0);
+                }
 
                 // TODO: try writing the leading vLong in MSB order
                 // (opposite of what Lucene does today), for better
@@ -874,7 +877,7 @@ namespace Lucene.Net.Codecs
                             //System.out.println("    = " + pendingCount);
                             pendingCount = 0;
 
-                            if (Debugging.AssertsEnabled) Debugging.Assert(outerInstance.minItemsInBlock == 1 || subCount > 1,"minItemsInBlock={0} subCount={1}", outerInstance.minItemsInBlock, subCount + " sub=" + sub + " of " + numSubs + " subTermCount=" + subTermCountSums[sub] + " subSubCount=" + subSubCounts[sub] + " depth=" + prefixLength);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(outerInstance.minItemsInBlock == 1 || subCount > 1, "minItemsInBlock={0} subCount={1} sub={2} of {3} subTermCount={4} subSubCount={5} depth={6}", outerInstance.minItemsInBlock, subCount, sub, numSubs, subTermCountSums[sub], subSubCounts[sub], prefixLength);
                             subCount = 0;
                             startLabel = subBytes[sub + 1];
 
@@ -946,7 +949,7 @@ namespace Lucene.Net.Codecs
 
                 int start = pending.Count - startBackwards;
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(start >= 0,"pending.Count={0} startBackwards={1}", pending.Count, startBackwards + " length=" + length);
+                if (Debugging.AssertsEnabled) Debugging.Assert(start >= 0, "pending.Count={0} startBackwards={1} length={2}", pending.Count, startBackwards, length);
 
                 IList<PendingEntry> slice = pending.SubList(start, start + length);
 
@@ -1217,7 +1220,7 @@ namespace Lucene.Net.Codecs
                     blockBuilder.Finish();
 
                     // We better have one final "root" block:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(pending.Count == 1 && !pending[0].IsTerm,"pending.size()={0} pending={1}", pending.Count, pending);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(pending.Count == 1 && !pending[0].IsTerm, "pending.Count={0} pending={1}", pending.Count, pending);
                     PendingBlock root = (PendingBlock)pending[0];
                     if (Debugging.AssertsEnabled)
                     {

--- a/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
@@ -261,7 +261,7 @@ namespace Lucene.Net.Codecs
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(numTerms > 0);
                 this.FieldInfo = fieldInfo;
-                if (Debugging.AssertsEnabled) Debugging.Assert(rootCode != null, () => "field=" + fieldInfo.Name + " numTerms=" + numTerms);
+                if (Debugging.AssertsEnabled) Debugging.Assert(rootCode != null,"field={0} numTerms={1}", fieldInfo.Name, numTerms);
                 this.RootCode = rootCode;
                 this.IndexStartFP = indexStartFP;
                 this.NumTerms = numTerms;
@@ -480,9 +480,7 @@ namespace Lucene.Net.Codecs
             {
                 // LUCENENET specific - we use a custom wrapper function to display floorBlocks, since
                 // it might contain garbage that cannot be converted into text.
-                if (Debugging.AssertsEnabled) Debugging.Assert(
-                    (IsFloor && floorBlocks != null && floorBlocks.Count != 0) || (!IsFloor && floorBlocks == null),
-                    () => "isFloor=" + IsFloor + " floorBlocks=" + ToString(floorBlocks));
+                if (Debugging.AssertsEnabled) Debugging.Assert((IsFloor && floorBlocks != null && floorBlocks.Count != 0) || (!IsFloor && floorBlocks == null), "isFloor={0} floorBlocks={1}", IsFloor , ToString(floorBlocks));
 
                 if (Debugging.AssertsEnabled) Debugging.Assert(scratchBytes.GetFilePointer() == 0);
 
@@ -864,7 +862,7 @@ namespace Lucene.Net.Codecs
                             //System.out.println("    = " + pendingCount);
                             pendingCount = 0;
 
-                            if (Debugging.AssertsEnabled) Debugging.Assert(outerInstance.minItemsInBlock == 1 || subCount > 1, () => "minItemsInBlock=" + outerInstance.minItemsInBlock + " subCount=" + subCount + " sub=" + sub + " of " + numSubs + " subTermCount=" + subTermCountSums[sub] + " subSubCount=" + subSubCounts[sub] + " depth=" + prefixLength);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(outerInstance.minItemsInBlock == 1 || subCount > 1,"minItemsInBlock={0} subCount={1}", outerInstance.minItemsInBlock, subCount + " sub=" + sub + " of " + numSubs + " subTermCount=" + subTermCountSums[sub] + " subSubCount=" + subSubCounts[sub] + " depth=" + prefixLength);
                             subCount = 0;
                             startLabel = subBytes[sub + 1];
 
@@ -936,7 +934,7 @@ namespace Lucene.Net.Codecs
 
                 int start = pending.Count - startBackwards;
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(start >= 0, () => "pending.Count=" + pending.Count + " startBackwards=" + startBackwards + " length=" + length);
+                if (Debugging.AssertsEnabled) Debugging.Assert(start >= 0,"pending.Count={0} startBackwards={1}", pending.Count, startBackwards + " length=" + length);
 
                 IList<PendingEntry> slice = pending.SubList(start, start + length);
 
@@ -1013,7 +1011,7 @@ namespace Lucene.Net.Codecs
                         statsWriter.WriteVInt32(state.DocFreq);
                         if (fieldInfo.IndexOptions != IndexOptions.DOCS_ONLY)
                         {
-                            if (Debugging.AssertsEnabled) Debugging.Assert(state.TotalTermFreq >= state.DocFreq, () => state.TotalTermFreq + " vs " + state.DocFreq);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(state.TotalTermFreq >= state.DocFreq, "{0} vs {1}", state.TotalTermFreq, state.DocFreq);
                             statsWriter.WriteVInt64(state.TotalTermFreq - state.DocFreq);
                         }
 
@@ -1207,7 +1205,7 @@ namespace Lucene.Net.Codecs
                     blockBuilder.Finish();
 
                     // We better have one final "root" block:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(pending.Count == 1 && !pending[0].IsTerm, () => "pending.size()=" + pending.Count + " pending=" + pending);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(pending.Count == 1 && !pending[0].IsTerm,"pending.size()={0} pending={1}", pending.Count, pending);
                     PendingBlock root = (PendingBlock)pending[0];
                     if (Debugging.AssertsEnabled)
                     {

--- a/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
@@ -357,7 +357,7 @@ namespace Lucene.Net.Codecs.Compressing
                 FieldInfo fieldInfo = fieldInfos.FieldInfo(fieldNumber);
 
                 int bits = (int)(infoAndBits & CompressingStoredFieldsWriter.TYPE_MASK);
-                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= CompressingStoredFieldsWriter.NUMERIC_DOUBLE,"bits={0}", bits.ToString("x"));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= CompressingStoredFieldsWriter.NUMERIC_DOUBLE,"bits={0:x}", bits);
 
                 switch (visitor.NeedsField(fieldInfo))
                 {

--- a/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
@@ -357,7 +357,7 @@ namespace Lucene.Net.Codecs.Compressing
                 FieldInfo fieldInfo = fieldInfos.FieldInfo(fieldNumber);
 
                 int bits = (int)(infoAndBits & CompressingStoredFieldsWriter.TYPE_MASK);
-                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= CompressingStoredFieldsWriter.NUMERIC_DOUBLE, () => "bits=" + bits.ToString("x"));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= CompressingStoredFieldsWriter.NUMERIC_DOUBLE,"bits={0}", bits.ToString("x"));
 
                 switch (visitor.NeedsField(fieldInfo))
                 {
@@ -492,14 +492,14 @@ namespace Lucene.Net.Codecs.Compressing
             /// </summary>
             internal void Next(int doc)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(doc >= this.docBase + this.chunkDocs, () => doc + " " + this.docBase + " " + this.chunkDocs);
+                if (Debugging.AssertsEnabled) Debugging.Assert(doc >= this.docBase + this.chunkDocs, "{0} {1} {2}", doc, this.docBase, this.chunkDocs);
                 fieldsStream.Seek(outerInstance.indexReader.GetStartPointer(doc));
 
                 int docBase = fieldsStream.ReadVInt32();
                 int chunkDocs = fieldsStream.ReadVInt32();
                 if (docBase < this.docBase + this.chunkDocs || docBase + chunkDocs > outerInstance.numDocs)
                 {
-                    throw new CorruptIndexException("Corrupted: current docBase=" + this.docBase + ", current numDocs=" + this.chunkDocs + ", new docBase=" + docBase + ", new numDocs=" + chunkDocs + " (resource=" + fieldsStream + ")");
+                    throw new CorruptIndexException($"Corrupted: current docBase={this.docBase}, current numDocs={this.chunkDocs}, new docBase={docBase}, new numDocs={chunkDocs} (resource={fieldsStream})");
                 }
                 this.docBase = docBase;
                 this.chunkDocs = chunkDocs;
@@ -543,7 +543,7 @@ namespace Lucene.Net.Codecs.Compressing
                     }
                     else if (bitsPerLength > 31)
                     {
-                        throw new CorruptIndexException("bitsPerLength=" + bitsPerLength);
+                        throw new CorruptIndexException($"bitsPerLength={bitsPerLength}");
                     }
                     else
                     {

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
@@ -383,7 +383,7 @@ namespace Lucene.Net.Codecs.Compressing
                         totalPayloads += freq;
                     }
                 }
-                if (Debugging.AssertsEnabled) Debugging.Assert(i != totalFields - 1 || termIndex == totalTerms, () => termIndex + " " + totalTerms);
+                if (Debugging.AssertsEnabled) Debugging.Assert(i != totalFields - 1 || termIndex == totalTerms, "{0} {1}", termIndex, totalTerms);
             }
 
             int[][] positionIndex = PositionIndex(skip, numFields, numTerms, termFreqs);
@@ -538,7 +538,7 @@ namespace Lucene.Net.Codecs.Compressing
                     }
                     termIndex += termCount;
                 }
-                if (Debugging.AssertsEnabled) Debugging.Assert(termIndex == totalTerms, () => termIndex + " " + totalTerms);
+                if (Debugging.AssertsEnabled) Debugging.Assert(termIndex == totalTerms, "{0} {1}", termIndex, totalTerms);
             }
 
             // decompress data
@@ -577,7 +577,7 @@ namespace Lucene.Net.Codecs.Compressing
                 }
             }
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(Sum(fieldLengths) == docLen, () => Sum(fieldLengths) + " != " + docLen);
+            if (Debugging.AssertsEnabled) Debugging.Assert(Sum(fieldLengths) == docLen, "{0} != {1}", Sum(fieldLengths), docLen);
 
             return new TVFields(this, fieldNums, FieldFlags, fieldNumOffs, fieldNumTerms, fieldLengths, prefixLengths, suffixLengths, fieldTermFreqs, positionIndex, positions, startOffsets, lengths, payloadBytes, payloadIndex, suffixBytes);
         }

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
@@ -387,7 +387,7 @@ namespace Lucene.Net.Codecs.Compressing
         private void Flush()
         {
             int chunkDocs = pendingDocs.Count;
-            if (Debugging.AssertsEnabled) Debugging.Assert(chunkDocs > 0, chunkDocs.ToString);
+            if (Debugging.AssertsEnabled) Debugging.Assert(chunkDocs > 0, chunkDocs.ToString());
 
             // write the index file
             indexWriter.WriteIndex(chunkDocs, vectorsStream.GetFilePointer());

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
@@ -387,7 +387,7 @@ namespace Lucene.Net.Codecs.Compressing
         private void Flush()
         {
             int chunkDocs = pendingDocs.Count;
-            if (Debugging.AssertsEnabled) Debugging.Assert(chunkDocs > 0, chunkDocs.ToString());
+            if (Debugging.AssertsEnabled) Debugging.Assert(chunkDocs > 0, "{0}", chunkDocs);
 
             // write the index file
             indexWriter.WriteIndex(chunkDocs, vectorsStream.GetFilePointer());

--- a/src/Lucene.Net/Codecs/Compressing/CompressionMode.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressionMode.cs
@@ -275,7 +275,7 @@ namespace Lucene.Net.Codecs.Compressing
 
                 if (resultArray.Length == 0)
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(len == 0, len.ToString());
+                    if (Debugging.AssertsEnabled) Debugging.Assert(len == 0, "{0}", len);
                     output.WriteVInt32(0);
                     return;
                 }

--- a/src/Lucene.Net/Codecs/Compressing/CompressionMode.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressionMode.cs
@@ -275,7 +275,7 @@ namespace Lucene.Net.Codecs.Compressing
 
                 if (resultArray.Length == 0)
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(len == 0, len.ToString);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(len == 0, len.ToString());
                     output.WriteVInt32(0);
                     return;
                 }

--- a/src/Lucene.Net/Codecs/Compressing/LZ4.cs
+++ b/src/Lucene.Net/Codecs/Compressing/LZ4.cs
@@ -365,7 +365,7 @@ namespace Lucene.Net.Codecs.Compressing
                 int v = ReadInt32(bytes, off);
                 int h = HashHC(v);
                 int delta = off - hashTable[h];
-                if (Debugging.AssertsEnabled) Debugging.Assert(delta > 0, delta.ToString);
+                if (Debugging.AssertsEnabled) Debugging.Assert(delta > 0, delta.ToString());
                 if (delta >= MAX_DISTANCE)
                 {
                     delta = MAX_DISTANCE - 1;

--- a/src/Lucene.Net/Codecs/FieldsConsumer.cs
+++ b/src/Lucene.Net/Codecs/FieldsConsumer.cs
@@ -87,7 +87,7 @@ namespace Lucene.Net.Codecs
             foreach (string field in fields)
             {
                 FieldInfo info = mergeState.FieldInfos.FieldInfo(field);
-                if (Debugging.AssertsEnabled) Debugging.Assert(info != null, () => "FieldInfo for field is null: " + field);
+                if (Debugging.AssertsEnabled) Debugging.Assert(info != null,"FieldInfo for field is null: {0}", field);
                 Terms terms = fields.GetTerms(field);
                 if (terms != null)
                 {

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using JCG = J2N.Collections.Generic;
 using Console = Lucene.Net.Util.SystemConsole;
+using Lucene.Net.Util;
 
 namespace Lucene.Net.Codecs.Lucene3x
 {
@@ -926,7 +927,9 @@ namespace Lucene.Net.Codecs.Lucene3x
                     else
                     {
                         current = t2.Bytes;
-                        if (Debugging.AssertsEnabled) Debugging.Assert(!unicodeSortOrder || term.CompareTo(current) < 0,"term={0} vs current={1}", UnicodeUtil.ToHexString(term.Utf8ToString()), UnicodeUtil.ToHexString(current.Utf8ToString()));
+                        if (Debugging.AssertsEnabled) Debugging.Assert(!unicodeSortOrder || term.CompareTo(current) < 0,"term={0} vs current={1}",
+                            // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
+                            new BytesRefFormatter(term, BytesRefFormat.UTF8AsHex), new BytesRefFormatter(current, BytesRefFormat.UTF8AsHex));
                         return SeekStatus.NOT_FOUND;
                     }
                 }

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
@@ -926,7 +926,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                     else
                     {
                         current = t2.Bytes;
-                        if (Debugging.AssertsEnabled) Debugging.Assert(!unicodeSortOrder || term.CompareTo(current) < 0, () => "term=" + UnicodeUtil.ToHexString(term.Utf8ToString()) + " vs current=" + UnicodeUtil.ToHexString(current.Utf8ToString()));
+                        if (Debugging.AssertsEnabled) Debugging.Assert(!unicodeSortOrder || term.CompareTo(current) < 0,"term={0} vs current={1}", UnicodeUtil.ToHexString(term.Utf8ToString()), UnicodeUtil.ToHexString(current.Utf8ToString()));
                         return SeekStatus.NOT_FOUND;
                     }
                 }

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xNormsProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xNormsProducer.cs
@@ -136,7 +136,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                     }
                 }
                 // TODO: change to a real check? see LUCENE-3619
-                if (Debugging.AssertsEnabled) Debugging.Assert(singleNormStream == null || nextNormSeek == singleNormStream.Length, () => singleNormStream != null ? "len: " + singleNormStream.Length + " expected: " + nextNormSeek : "null");
+                if (Debugging.AssertsEnabled) Debugging.Assert(singleNormStream == null || nextNormSeek == singleNormStream.Length, singleNormStream != null ? "len: {0} expected: {1}" : "null", singleNormStream?.Length ?? 0, nextNormSeek);
                 success = true;
             }
             finally

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xSegmentInfoReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xSegmentInfoReader.cs
@@ -193,7 +193,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
             //System.out.println("version=" + version + " name=" + name + " docCount=" + docCount + " delGen=" + delGen + " dso=" + docStoreOffset + " dss=" + docStoreSegment + " dssCFs=" + docStoreIsCompoundFile + " b=" + b + " format=" + format);
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(1 == b, () => "expected 1 but was: " + b + " format: " + format);
+            if (Debugging.AssertsEnabled) Debugging.Assert(1 == b,"expected 1 but was: {0} format: {1}", b, format);
             int numNormGen = input.ReadInt32();
             IDictionary<int, long> normGen;
             if (numNormGen == SegmentInfo.NO)

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xStoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xStoredFieldsReader.cs
@@ -193,7 +193,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                     // Verify the file is long enough to hold all of our
                     // docs
-                    if (Debugging.AssertsEnabled) Debugging.Assert(((int)(indexSize / 8)) >= size + this.docStoreOffset, () => "indexSize=" + indexSize + " size=" + size + " docStoreOffset=" + docStoreOffset);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(((int)(indexSize / 8)) >= size + this.docStoreOffset,"indexSize={0} size={1}", indexSize, size + " docStoreOffset=" + docStoreOffset);
                 }
                 else
                 {
@@ -273,7 +273,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                 FieldInfo fieldInfo = fieldInfos.FieldInfo(fieldNumber);
 
                 int bits = fieldsStream.ReadByte() & 0xFF;
-                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= (FIELD_IS_NUMERIC_MASK | FIELD_IS_BINARY), () => "bits=" + bits.ToString("x"));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= (FIELD_IS_NUMERIC_MASK | FIELD_IS_BINARY),"bits={0}", bits.ToString("x"));
 
                 switch (visitor.NeedsField(fieldInfo))
                 {

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xStoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xStoredFieldsReader.cs
@@ -193,7 +193,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                     // Verify the file is long enough to hold all of our
                     // docs
-                    if (Debugging.AssertsEnabled) Debugging.Assert(((int)(indexSize / 8)) >= size + this.docStoreOffset,"indexSize={0} size={1}", indexSize, size + " docStoreOffset=" + docStoreOffset);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(((int)(indexSize / 8)) >= size + this.docStoreOffset, "indexSize={0} size={1} docStoreOffset={2}", indexSize, size, docStoreOffset);
                 }
                 else
                 {
@@ -273,7 +273,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                 FieldInfo fieldInfo = fieldInfos.FieldInfo(fieldNumber);
 
                 int bits = fieldsStream.ReadByte() & 0xFF;
-                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= (FIELD_IS_NUMERIC_MASK | FIELD_IS_BINARY),"bits={0}", bits.ToString("x"));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= (FIELD_IS_NUMERIC_MASK | FIELD_IS_BINARY),"bits={0:x}", bits);
 
                 switch (visitor.NeedsField(fieldInfo))
                 {

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -160,7 +160,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                     this.size = size;
                     // Verify the file is long enough to hold all of our
                     // docs
-                    if (Debugging.AssertsEnabled) Debugging.Assert(numTotalDocs >= size + docStoreOffset, () => "numTotalDocs=" + numTotalDocs + " size=" + size + " docStoreOffset=" + docStoreOffset);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(numTotalDocs >= size + docStoreOffset,"numTotalDocs={0} size={1}", numTotalDocs, size + " docStoreOffset=" + docStoreOffset);
                 }
 
                 this.fieldInfos = fieldInfos;

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -160,7 +160,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                     this.size = size;
                     // Verify the file is long enough to hold all of our
                     // docs
-                    if (Debugging.AssertsEnabled) Debugging.Assert(numTotalDocs >= size + docStoreOffset,"numTotalDocs={0} size={1}", numTotalDocs, size + " docStoreOffset=" + docStoreOffset);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(numTotalDocs >= size + docStoreOffset, "numTotalDocs={0} size={1} docStoreOffset={2}", numTotalDocs, size, docStoreOffset);
                 }
 
                 this.fieldInfos = fieldInfos;

--- a/src/Lucene.Net/Codecs/Lucene3x/SegmentTermEnum.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/SegmentTermEnum.cs
@@ -107,8 +107,8 @@ namespace Lucene.Net.Codecs.Lucene3x
                 maxSkipLevels = input.ReadInt32();
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(indexInterval > 0, () => "indexInterval=" + indexInterval + " is negative; must be > 0");
-                    Debugging.Assert(skipInterval > 0, () => "skipInterval=" + skipInterval + " is negative; must be > 0");
+                    Debugging.Assert(indexInterval > 0, "indexInterval={0} is negative; must be > 0", indexInterval);
+                    Debugging.Assert(skipInterval > 0, "skipInterval={0} is negative; must be > 0", skipInterval);
                 }
             }
         }

--- a/src/Lucene.Net/Codecs/Lucene3x/TermBuffer.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/TermBuffer.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             newSuffixStart = input.ReadVInt32();
             int length = input.ReadVInt32();
             int totalLength = newSuffixStart + length;
-            if (Debugging.AssertsEnabled) Debugging.Assert(totalLength <= ByteBlockPool.BYTE_BLOCK_SIZE - 2, () => "termLength=" + totalLength + ",resource=" + input);
+            if (Debugging.AssertsEnabled) Debugging.Assert(totalLength <= ByteBlockPool.BYTE_BLOCK_SIZE - 2,"termLength={0},resource={1}", totalLength, input);
             if (bytes.Bytes.Length < totalLength)
             {
                 bytes.Grow(totalLength);
@@ -88,17 +88,14 @@ namespace Lucene.Net.Codecs.Lucene3x
                 }
                 else
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(fieldInfos.FieldInfo(currentFieldNumber) != null, currentFieldNumber.ToString);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(fieldInfos.FieldInfo(currentFieldNumber) != null, "{0}", currentFieldNumber);
                     
                     field = fieldInfos.FieldInfo(currentFieldNumber).Name.Intern();
                 }
             }
             else
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(field.Equals(fieldInfos.FieldInfo(fieldNumber).Name, StringComparison.Ordinal),
-                    () => "currentFieldNumber=" + currentFieldNumber + 
-                    " field=" + field + 
-                    " vs " + fieldInfos.FieldInfo(fieldNumber) == null ? "null" : fieldInfos.FieldInfo(fieldNumber).Name);
+                if (Debugging.AssertsEnabled) Debugging.Assert(field.Equals(fieldInfos.FieldInfo(fieldNumber).Name, StringComparison.Ordinal), "currentFieldNumber={0} field={1} vs {2}", currentFieldNumber, field, fieldInfos.FieldInfo(fieldNumber)?.Name ?? "null");
             }
         }
 

--- a/src/Lucene.Net/Codecs/Lucene40/BitVector.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/BitVector.cs
@@ -175,7 +175,7 @@ namespace Lucene.Net.Codecs.Lucene40
         /// </summary>
         public bool Get(int bit)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(bit >= 0 && bit < size, () => "bit " + bit + " is out of bounds 0.." + (size - 1));
+            if (Debugging.AssertsEnabled) Debugging.Assert(bit >= 0 && bit < size,"bit {0} is out of bounds 0..{1}", bit, (size - 1));
             return (bits[bit >> 3] & (1 << (bit & 7))) != 0;
         }
 
@@ -215,7 +215,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 }
                 count = c;
             }
-            if (Debugging.AssertsEnabled) Debugging.Assert(count <= size, () => "count=" + count + " size=" + size);
+            if (Debugging.AssertsEnabled) Debugging.Assert(count <= size,"count={0} size={1}", count, size);
             return count;
         }
 
@@ -474,7 +474,7 @@ namespace Lucene.Net.Codecs.Lucene40
             if (Debugging.AssertsEnabled) Debugging.Assert(count != -1);
             int countSav = count;
             count = -1;
-            if (Debugging.AssertsEnabled) Debugging.Assert(countSav == Count(), () => "saved count was " + countSav + " but recomputed count is " + count);
+            if (Debugging.AssertsEnabled) Debugging.Assert(countSav == Count(),"saved count was {0} but recomputed count is {1}", countSav, count);
             return true;
         }
 

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40LiveDocsFormat.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40LiveDocsFormat.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Codecs.Lucene40
             BitVector liveDocs = new BitVector(dir, filename, context);
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(liveDocs.Count() == info.Info.DocCount - info.DelCount, () => "liveDocs.count()=" + liveDocs.Count() + " info.docCount=" + info.Info.DocCount + " info.getDelCount()=" + info.DelCount);
+                Debugging.Assert(liveDocs.Count() == info.Info.DocCount - info.DelCount,"liveDocs.count()={0} info.docCount={1}", liveDocs.Count(), info.Info.DocCount + " info.getDelCount()=" + info.DelCount);
                 Debugging.Assert(liveDocs.Length == info.Info.DocCount);
             }
             return liveDocs;

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40LiveDocsFormat.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40LiveDocsFormat.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Codecs.Lucene40
             BitVector liveDocs = new BitVector(dir, filename, context);
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(liveDocs.Count() == info.Info.DocCount - info.DelCount,"liveDocs.count()={0} info.docCount={1}", liveDocs.Count(), info.Info.DocCount + " info.getDelCount()=" + info.DelCount);
+                Debugging.Assert(liveDocs.Count() == info.Info.DocCount - info.DelCount, "liveDocs.Count()={0} info.DocCount={1} info.DelCount={2}", liveDocs.Count(), info.Info.DocCount, info.DelCount);
                 Debugging.Assert(liveDocs.Length == info.Info.DocCount);
             }
             return liveDocs;

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
@@ -933,7 +933,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
                 posPendingCount--;
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(posPendingCount >= 0,"nextPosition() was called too many times (more than freq() times) posPendingCount={0}", posPendingCount);
+                if (Debugging.AssertsEnabled) Debugging.Assert(posPendingCount >= 0,"NextPosition() was called too many times (more than Freq( times) posPendingCount={0}", posPendingCount);
 
                 return position;
             }
@@ -1228,7 +1228,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
                 posPendingCount--;
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(posPendingCount >= 0,"nextPosition() was called too many times (more than freq() times) posPendingCount={0}", posPendingCount);
+                if (Debugging.AssertsEnabled) Debugging.Assert(posPendingCount >= 0,"NextPosition() was called too many times (more than Freq times) posPendingCount={0}", posPendingCount);
 
                 //System.out.println("StandardR.D&PE nextPos   return pos=" + position);
                 return position;

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
@@ -933,7 +933,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
                 posPendingCount--;
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(posPendingCount >= 0, () => "nextPosition() was called too many times (more than freq() times) posPendingCount=" + posPendingCount);
+                if (Debugging.AssertsEnabled) Debugging.Assert(posPendingCount >= 0,"nextPosition() was called too many times (more than freq() times) posPendingCount={0}", posPendingCount);
 
                 return position;
             }
@@ -1228,7 +1228,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
                 posPendingCount--;
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(posPendingCount >= 0, () => "nextPosition() was called too many times (more than freq() times) posPendingCount=" + posPendingCount);
+                if (Debugging.AssertsEnabled) Debugging.Assert(posPendingCount >= 0,"nextPosition() was called too many times (more than freq() times) posPendingCount={0}", posPendingCount);
 
                 //System.out.println("StandardR.D&PE nextPos   return pos=" + position);
                 return position;

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsReader.cs
@@ -177,7 +177,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 FieldInfo fieldInfo = fieldInfos.FieldInfo(fieldNumber);
 
                 int bits = fieldsStream.ReadByte() & 0xFF;
-                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= (Lucene40StoredFieldsWriter.FIELD_IS_NUMERIC_MASK | Lucene40StoredFieldsWriter.FIELD_IS_BINARY),"bits={0}", bits.ToString("x"));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= (Lucene40StoredFieldsWriter.FIELD_IS_NUMERIC_MASK | Lucene40StoredFieldsWriter.FIELD_IS_BINARY),"bits={0:x}", bits);
 
                 switch (visitor.NeedsField(fieldInfo))
                 {

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsReader.cs
@@ -177,7 +177,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 FieldInfo fieldInfo = fieldInfos.FieldInfo(fieldNumber);
 
                 int bits = fieldsStream.ReadByte() & 0xFF;
-                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= (Lucene40StoredFieldsWriter.FIELD_IS_NUMERIC_MASK | Lucene40StoredFieldsWriter.FIELD_IS_BINARY), () => "bits=" + bits.ToString("x"));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bits <= (Lucene40StoredFieldsWriter.FIELD_IS_NUMERIC_MASK | Lucene40StoredFieldsWriter.FIELD_IS_BINARY),"bits={0}", bits.ToString("x"));
 
                 switch (visitor.NeedsField(fieldInfo))
                 {

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsWriter.cs
@@ -113,7 +113,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
         public override void StartField(FieldInfo info, int numTerms, bool positions, bool offsets, bool payloads)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || info.Name.CompareToOrdinal(lastFieldName) > 0, () => "fieldName=" + info.Name + " lastFieldName=" + lastFieldName);
+            if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || info.Name.CompareToOrdinal(lastFieldName) > 0,"fieldName={0} lastFieldName={1}", info.Name, lastFieldName);
             lastFieldName = info.Name;
             this.positions = positions;
             this.offsets = offsets;

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsWriter.cs
@@ -113,7 +113,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
         public override void StartField(FieldInfo info, int numTerms, bool positions, bool offsets, bool payloads)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || info.Name.CompareToOrdinal(lastFieldName) > 0,"fieldName={0} lastFieldName={1}", info.Name, lastFieldName);
+            if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || info.Name.CompareToOrdinal(lastFieldName) > 0, "fieldName={0} lastFieldName={1}", info.Name, lastFieldName);
             lastFieldName = info.Name;
             this.positions = positions;
             this.offsets = offsets;

--- a/src/Lucene.Net/Codecs/Lucene41/ForUtil.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/ForUtil.cs
@@ -88,7 +88,7 @@ namespace Lucene.Net.Codecs.Lucene41
         private static int EncodedSize(PackedInt32s.Format format, int packedIntsVersion, int bitsPerValue)
         {
             long byteCount = format.ByteCount(packedIntsVersion, Lucene41PostingsFormat.BLOCK_SIZE, bitsPerValue);
-            if (Debugging.AssertsEnabled) Debugging.Assert(byteCount >= 0 && byteCount <= int.MaxValue, byteCount.ToString);
+            if (Debugging.AssertsEnabled) Debugging.Assert(byteCount >= 0 && byteCount <= int.MaxValue, byteCount.ToString());
             return (int)byteCount;
         }
 
@@ -169,7 +169,7 @@ namespace Lucene.Net.Codecs.Lucene41
             }
 
             int numBits = BitsRequired(data);
-            if (Debugging.AssertsEnabled) Debugging.Assert(numBits > 0 && numBits <= 32, numBits.ToString);
+            if (Debugging.AssertsEnabled) Debugging.Assert(numBits > 0 && numBits <= 32, numBits.ToString());
             PackedInt32s.IEncoder encoder = encoders[numBits];
             int iters = iterations[numBits];
             if (Debugging.AssertsEnabled) Debugging.Assert(iters * encoder.ByteValueCount >= Lucene41PostingsFormat.BLOCK_SIZE);
@@ -192,7 +192,7 @@ namespace Lucene.Net.Codecs.Lucene41
         internal void ReadBlock(IndexInput @in, byte[] encoded, int[] decoded)
         {
             int numBits = @in.ReadByte();
-            if (Debugging.AssertsEnabled) Debugging.Assert(numBits <= 32, numBits.ToString);
+            if (Debugging.AssertsEnabled) Debugging.Assert(numBits <= 32, numBits.ToString());
 
             if (numBits == ALL_VALUES_EQUAL)
             {
@@ -224,7 +224,7 @@ namespace Lucene.Net.Codecs.Lucene41
                 @in.ReadVInt32();
                 return;
             }
-            if (Debugging.AssertsEnabled) Debugging.Assert(numBits > 0 && numBits <= 32, numBits.ToString);
+            if (Debugging.AssertsEnabled) Debugging.Assert(numBits > 0 && numBits <= 32, numBits.ToString());
             int encodedSize = encodedSizes[numBits];
             @in.Seek(@in.GetFilePointer() + encodedSize);
         }

--- a/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsReader.cs
@@ -528,7 +528,7 @@ namespace Lucene.Net.Codecs.Lucene41
                         // if (DEBUG) {
                         //   System.out.println("skipper moved to docUpto=" + newDocUpto + " vs current=" + docUpto + "; docID=" + skipper.getDoc() + " fp=" + skipper.getDocPointer());
                         // }
-                        if (Debugging.AssertsEnabled) Debugging.Assert(newDocUpto % Lucene41PostingsFormat.BLOCK_SIZE == 0, () => "got " + newDocUpto);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(newDocUpto % Lucene41PostingsFormat.BLOCK_SIZE == 0,"got {0}", newDocUpto);
                         docUpto = newDocUpto;
 
                         // Force to read next block
@@ -894,7 +894,7 @@ namespace Lucene.Net.Codecs.Lucene41
                         //   System.out.println("    skipper moved to docUpto=" + newDocUpto + " vs current=" + docUpto + "; docID=" + skipper.getDoc() + " fp=" + skipper.getDocPointer() + " pos.fp=" + skipper.getPosPointer() + " pos.bufferUpto=" + skipper.getPosBufferUpto());
                         // }
 
-                        if (Debugging.AssertsEnabled) Debugging.Assert(newDocUpto % Lucene41PostingsFormat.BLOCK_SIZE == 0, () => "got " + newDocUpto);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(newDocUpto % Lucene41PostingsFormat.BLOCK_SIZE == 0,"got {0}", newDocUpto);
                         docUpto = newDocUpto;
 
                         // Force to read next block
@@ -1468,7 +1468,7 @@ namespace Lucene.Net.Codecs.Lucene41
                         // if (DEBUG) {
                         //   System.out.println("    skipper moved to docUpto=" + newDocUpto + " vs current=" + docUpto + "; docID=" + skipper.getDoc() + " fp=" + skipper.getDocPointer() + " pos.fp=" + skipper.getPosPointer() + " pos.bufferUpto=" + skipper.getPosBufferUpto() + " pay.fp=" + skipper.getPayPointer() + " lastStartOffset=" + lastStartOffset);
                         // }
-                        if (Debugging.AssertsEnabled) Debugging.Assert(newDocUpto % Lucene41PostingsFormat.BLOCK_SIZE == 0, () => "got " + newDocUpto);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(newDocUpto % Lucene41PostingsFormat.BLOCK_SIZE == 0,"got {0}", newDocUpto);
                         docUpto = newDocUpto;
 
                         // Force to read next block

--- a/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsWriter.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsWriter.cs
@@ -446,7 +446,7 @@ namespace Lucene.Net.Codecs.Lucene41
 
             // TODO: wasteful we are counting this (counting # docs
             // for this term) in two places?
-            if (Debugging.AssertsEnabled) Debugging.Assert(state2.DocFreq == docCount, () => state2.DocFreq + " vs " + docCount);
+            if (Debugging.AssertsEnabled) Debugging.Assert(state2.DocFreq == docCount, "{0} vs {1}", state2.DocFreq, docCount);
 
             // if (DEBUG) {
             //   System.out.println("FPW.finishTerm docFreq=" + state2.docFreq);

--- a/src/Lucene.Net/Codecs/MappingMultiDocsEnum.cs
+++ b/src/Lucene.Net/Codecs/MappingMultiDocsEnum.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Codecs
                         current = subs[upto].DocsEnum;
                         currentBase = mergeState.DocBase[reader];
                         currentMap = mergeState.DocMaps[reader];
-                        if (Debugging.AssertsEnabled) Debugging.Assert(currentMap.MaxDoc == subs[upto].Slice.Length,"readerIndex={0} subs.len={1}", reader, subs.Length + " len1=" + currentMap.MaxDoc + " vs " + subs[upto].Slice.Length);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(currentMap.MaxDoc == subs[upto].Slice.Length, "readerIndex={0} subs.len={1} len1={2} vs {3}", reader, subs.Length, currentMap.MaxDoc, subs[upto].Slice.Length);
                     }
                 }
 

--- a/src/Lucene.Net/Codecs/MappingMultiDocsEnum.cs
+++ b/src/Lucene.Net/Codecs/MappingMultiDocsEnum.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Codecs
                         current = subs[upto].DocsEnum;
                         currentBase = mergeState.DocBase[reader];
                         currentMap = mergeState.DocMaps[reader];
-                        if (Debugging.AssertsEnabled) Debugging.Assert(currentMap.MaxDoc == subs[upto].Slice.Length, () => "readerIndex=" + reader + " subs.len=" + subs.Length + " len1=" + currentMap.MaxDoc + " vs " + subs[upto].Slice.Length);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(currentMap.MaxDoc == subs[upto].Slice.Length,"readerIndex={0} subs.len={1}", reader, subs.Length + " len1=" + currentMap.MaxDoc + " vs " + subs[upto].Slice.Length);
                     }
                 }
 

--- a/src/Lucene.Net/Codecs/MultiLevelSkipListReader.cs
+++ b/src/Lucene.Net/Codecs/MultiLevelSkipListReader.cs
@@ -253,7 +253,7 @@ namespace Lucene.Net.Codecs
         {
             this.skipPointer[0] = skipPointer;
             this.docCount = df;
-            if (Debugging.AssertsEnabled) Debugging.Assert(skipPointer >= 0 && skipPointer <= skipStream[0].Length, () => "invalid skip pointer: " + skipPointer + ", length=" + skipStream[0].Length);
+            if (Debugging.AssertsEnabled) Debugging.Assert(skipPointer >= 0 && skipPointer <= skipStream[0].Length,"invalid skip pointer: {0}, length={1}", skipPointer, skipStream[0].Length);
             Array.Clear(m_skipDoc, 0, m_skipDoc.Length);
             Array.Clear(numSkipped, 0, numSkipped.Length);
             Array.Clear(childPointer, 0, childPointer.Length);

--- a/src/Lucene.Net/Codecs/PerField/PerFieldDocValuesFormat.cs
+++ b/src/Lucene.Net/Codecs/PerField/PerFieldDocValuesFormat.cs
@@ -155,7 +155,7 @@ namespace Lucene.Net.Codecs.PerField
                 string formatName_ = format.Name;
 
                 string previousValue = field.PutAttribute(PER_FIELD_FORMAT_KEY, formatName_);
-                if (Debugging.AssertsEnabled) Debugging.Assert(field.DocValuesGen != -1 || previousValue == null, () => "formatName=" + formatName_ + " prevValue=" + previousValue);
+                if (Debugging.AssertsEnabled) Debugging.Assert(field.DocValuesGen != -1 || previousValue == null,"formatName={0} prevValue={1}", formatName_, previousValue);
 
                 int? suffix = null;
 
@@ -204,7 +204,7 @@ namespace Lucene.Net.Codecs.PerField
                 }
 
                 previousValue = field.PutAttribute(PER_FIELD_SUFFIX_KEY, Convert.ToString(suffix, CultureInfo.InvariantCulture));
-                if (Debugging.AssertsEnabled) Debugging.Assert(field.DocValuesGen != -1 || previousValue == null, () => "suffix=" + Convert.ToString(suffix, CultureInfo.InvariantCulture) + " prevValue=" + previousValue);
+                if (Debugging.AssertsEnabled) Debugging.Assert(field.DocValuesGen != -1 || previousValue == null,"suffix={0} prevValue={1}", Convert.ToString(suffix, CultureInfo.InvariantCulture), previousValue);
 
                 // TODO: we should only provide the "slice" of FIS
                 // that this DVF actually sees ...

--- a/src/Lucene.Net/Codecs/PerField/PerFieldDocValuesFormat.cs
+++ b/src/Lucene.Net/Codecs/PerField/PerFieldDocValuesFormat.cs
@@ -204,7 +204,7 @@ namespace Lucene.Net.Codecs.PerField
                 }
 
                 previousValue = field.PutAttribute(PER_FIELD_SUFFIX_KEY, Convert.ToString(suffix, CultureInfo.InvariantCulture));
-                if (Debugging.AssertsEnabled) Debugging.Assert(field.DocValuesGen != -1 || previousValue == null,"suffix={0} prevValue={1}", Convert.ToString(suffix, CultureInfo.InvariantCulture), previousValue);
+                if (Debugging.AssertsEnabled) Debugging.Assert(field.DocValuesGen != -1 || previousValue == null,"suffix={0} prevValue={1}", suffix, previousValue);
 
                 // TODO: we should only provide the "slice" of FIS
                 // that this DVF actually sees ...

--- a/src/Lucene.Net/Codecs/TermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/TermVectorsWriter.cs
@@ -286,7 +286,7 @@ namespace Lucene.Net.Codecs
                 fieldCount++;
                 FieldInfo fieldInfo = mergeState.FieldInfos.FieldInfo(fieldName);
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || fieldName.CompareToOrdinal(lastFieldName) > 0,"lastFieldName={0} fieldName={1}", lastFieldName, fieldName);
+                if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || fieldName.CompareToOrdinal(lastFieldName) > 0, "lastFieldName={0} fieldName={1}", lastFieldName, fieldName);
                 lastFieldName = fieldName;
 
                 Terms terms = vectors.GetTerms(fieldName);

--- a/src/Lucene.Net/Codecs/TermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/TermVectorsWriter.cs
@@ -286,7 +286,7 @@ namespace Lucene.Net.Codecs
                 fieldCount++;
                 FieldInfo fieldInfo = mergeState.FieldInfos.FieldInfo(fieldName);
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || fieldName.CompareToOrdinal(lastFieldName) > 0, () => "lastFieldName=" + lastFieldName + " fieldName=" + fieldName);
+                if (Debugging.AssertsEnabled) Debugging.Assert(lastFieldName == null || fieldName.CompareToOrdinal(lastFieldName) > 0,"lastFieldName={0} fieldName={1}", lastFieldName, fieldName);
                 lastFieldName = fieldName;
 
                 Terms terms = vectors.GetTerms(fieldName);

--- a/src/Lucene.Net/Index/AutomatonTermsEnum.cs
+++ b/src/Lucene.Net/Index/AutomatonTermsEnum.cs
@@ -166,7 +166,7 @@ namespace Lucene.Net.Index
             for (int i = 0; i < position; i++)
             {
                 state = runAutomaton.Step(state, seekBytesRef.Bytes[i] & 0xff);
-                if (Debugging.AssertsEnabled) Debugging.Assert(state >= 0, () => "state=" + state);
+                if (Debugging.AssertsEnabled) Debugging.Assert(state >= 0,"state={0}", state);
             }
             for (int i = 0; i < allTransitions[state].Length; i++)
             {

--- a/src/Lucene.Net/Index/BitsSlice.cs
+++ b/src/Lucene.Net/Index/BitsSlice.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Index
             this.parent = parent;
             this.start = slice.Start;
             this.length = slice.Length;
-            if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0, () => "length=" + length);
+            if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0,"length={0}", length);
         }
 
         public bool Get(int doc)
@@ -49,7 +49,7 @@ namespace Lucene.Net.Index
             {
                 throw new Exception("doc " + doc + " is out of bounds 0 .. " + (length - 1));
             }
-            if (Debugging.AssertsEnabled) Debugging.Assert(doc < length, () => "doc=" + doc + " length=" + length);
+            if (Debugging.AssertsEnabled) Debugging.Assert(doc < length,"doc={0} length={1}", doc, length);
             return parent.Get(doc + start);
         }
 

--- a/src/Lucene.Net/Index/BufferedUpdatesStream.cs
+++ b/src/Lucene.Net/Index/BufferedUpdatesStream.cs
@@ -688,7 +688,7 @@ namespace Lucene.Net.Index
         {
             if (term != null)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(lastDeleteTerm == null || term.CompareTo(lastDeleteTerm) > 0,"lastTerm={0} vs term={1}", lastDeleteTerm, term);
+                if (Debugging.AssertsEnabled) Debugging.Assert(lastDeleteTerm == null || term.CompareTo(lastDeleteTerm) > 0, "lastTerm={0} vs term={1}", lastDeleteTerm, term);
             }
             // TODO: we re-use term now in our merged iterable, but we shouldn't clone, instead copy for this assert
             lastDeleteTerm = term == null ? null : new Term(term.Field, BytesRef.DeepCopyOf(term.Bytes));

--- a/src/Lucene.Net/Index/BufferedUpdatesStream.cs
+++ b/src/Lucene.Net/Index/BufferedUpdatesStream.cs
@@ -239,7 +239,7 @@ namespace Lucene.Net.Index
                     }
                     else if (packet != null && segGen == packet.DelGen)
                     {
-                        if (Debugging.AssertsEnabled) Debugging.Assert(packet.isSegmentPrivate, () => "Packet and Segments deletegen can only match on a segment private del packet gen=" + segGen);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(packet.isSegmentPrivate,"Packet and Segments deletegen can only match on a segment private del packet gen={0}", segGen);
                         //System.out.println("  eq");
 
                         // Lock order: IW -> BD -> RP
@@ -688,7 +688,7 @@ namespace Lucene.Net.Index
         {
             if (term != null)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(lastDeleteTerm == null || term.CompareTo(lastDeleteTerm) > 0, () => "lastTerm=" + lastDeleteTerm + " vs term=" + term);
+                if (Debugging.AssertsEnabled) Debugging.Assert(lastDeleteTerm == null || term.CompareTo(lastDeleteTerm) > 0,"lastTerm={0} vs term={1}", lastDeleteTerm, term);
             }
             // TODO: we re-use term now in our merged iterable, but we shouldn't clone, instead copy for this assert
             lastDeleteTerm = term == null ? null : new Term(term.Field, BytesRef.DeepCopyOf(term.Bytes));
@@ -707,8 +707,8 @@ namespace Lucene.Net.Index
             }
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(numTerms2 == numTerms, () => "numTerms2=" + numTerms2 + " vs " + numTerms);
-                Debugging.Assert(bytesUsed2 == bytesUsed, () => "bytesUsed2=" + bytesUsed2 + " vs " + bytesUsed);
+                Debugging.Assert(numTerms2 == numTerms,"numTerms2={0} vs {1}", numTerms2, numTerms);
+                Debugging.Assert(bytesUsed2 == bytesUsed,"bytesUsed2={0} vs {1}", bytesUsed2, bytesUsed);
             }
             return true;
         }

--- a/src/Lucene.Net/Index/DocValuesProcessor.cs
+++ b/src/Lucene.Net/Index/DocValuesProcessor.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Index
                 }
                 else
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "unrecognized DocValues.Type: " + dvType);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(false,"unrecognized DocValues.Type: {0}", dvType);
                 }
             }
         }

--- a/src/Lucene.Net/Index/DocumentsWriter.cs
+++ b/src/Lucene.Net/Index/DocumentsWriter.cs
@@ -588,7 +588,7 @@ namespace Lucene.Net.Index
                 SegmentFlushTicket ticket = null;
                 try
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(currentFullFlushDelQueue == null || flushingDWPT.deleteQueue == currentFullFlushDelQueue, () => "expected: " + currentFullFlushDelQueue + "but was: " + flushingDWPT.deleteQueue + " " + flushControl.IsFullFlush);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(currentFullFlushDelQueue == null || flushingDWPT.deleteQueue == currentFullFlushDelQueue,"expected: {0}but was: {1}", currentFullFlushDelQueue, flushingDWPT.deleteQueue + " " + flushControl.IsFullFlush);
                     /*
                      * Since with DWPT the flush process is concurrent and several DWPT
                      * could flush at the same time we must maintain the order of the

--- a/src/Lucene.Net/Index/DocumentsWriter.cs
+++ b/src/Lucene.Net/Index/DocumentsWriter.cs
@@ -588,7 +588,9 @@ namespace Lucene.Net.Index
                 SegmentFlushTicket ticket = null;
                 try
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(currentFullFlushDelQueue == null || flushingDWPT.deleteQueue == currentFullFlushDelQueue,"expected: {0}but was: {1}", currentFullFlushDelQueue, flushingDWPT.deleteQueue + " " + flushControl.IsFullFlush);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(currentFullFlushDelQueue == null
+                        || flushingDWPT.deleteQueue == currentFullFlushDelQueue,
+                        "expected: {0} but was: {1} {2}", currentFullFlushDelQueue, flushingDWPT.deleteQueue, flushControl.IsFullFlush);
                     /*
                      * Since with DWPT the flush process is concurrent and several DWPT
                      * could flush at the same time we must maintain the order of the

--- a/src/Lucene.Net/Index/DocumentsWriterFlushControl.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterFlushControl.cs
@@ -152,7 +152,11 @@ namespace Lucene.Net.Index
                      * fail. To prevent this we only assert if the the largest document seen
                      * is smaller than the 1/2 of the maxRamBufferMB
                      */
-                    if (Debugging.AssertsEnabled) Debugging.Assert(ram <= expected, "actual mem: {0} byte, expected mem: {1} byte, flush mem: {2}, active mem: {3}, pending DWPT: {4}, flushing DWPT: {5}, blocked DWPT: {6}, peakDelta mem: {7} byte", ram, expected, flushBytes, activeBytes, numPending, NumFlushingDWPT, NumBlockedFlushes, peakDelta);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(ram <= expected,
+                        "actual mem: {0} byte, expected mem: {1}"
+                        + " byte, flush mem: {2}, active mem: {3}"
+                        + ", pending DWPT: {4}, flushing DWPT: {5}"
+                        + ", blocked DWPT: {6}, peakDelta mem: {7} byte", ram, expected, flushBytes, activeBytes, numPending, NumFlushingDWPT, NumBlockedFlushes, peakDelta);
                 }
             }
             return true;
@@ -609,8 +613,8 @@ namespace Lucene.Net.Index
             {
                 if (!success) // make sure we unlock if this fails
                 {
-						perThreadPool.Release(perThread);
-					}
+                    perThreadPool.Release(perThread);
+                }
             }
         }
 
@@ -646,7 +650,10 @@ namespace Lucene.Net.Index
                         }
                         continue;
                     }
-                    if (Debugging.AssertsEnabled) Debugging.Assert(next.dwpt.deleteQueue == flushingQueue || next.dwpt.deleteQueue == documentsWriter.deleteQueue," flushingQueue: {0} currentqueue: {1}", flushingQueue, documentsWriter.deleteQueue + " perThread queue: " + next.dwpt.deleteQueue + " numDocsInRam: " + next.dwpt.NumDocsInRAM);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(next.dwpt.deleteQueue == flushingQueue
+                        || next.dwpt.deleteQueue == documentsWriter.deleteQueue,
+                        " flushingQueue: {0} currentqueue: {1} perThread queue: {2} numDocsInRam: {3}",
+                        flushingQueue, documentsWriter.deleteQueue, next.dwpt.deleteQueue, next.dwpt.NumDocsInRAM);
                     if (next.dwpt.deleteQueue != flushingQueue)
                     {
                         // this one is already a new DWPT

--- a/src/Lucene.Net/Index/DocumentsWriterFlushControl.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterFlushControl.cs
@@ -152,11 +152,7 @@ namespace Lucene.Net.Index
                      * fail. To prevent this we only assert if the the largest document seen
                      * is smaller than the 1/2 of the maxRamBufferMB
                      */
-                    if (Debugging.AssertsEnabled) Debugging.Assert(ram <= expected, () => "actual mem: " + ram + " byte, expected mem: " + expected
-                        + " byte, flush mem: " + flushBytes + ", active mem: " + activeBytes
-                        + ", pending DWPT: " + numPending + ", flushing DWPT: "
-                        + NumFlushingDWPT + ", blocked DWPT: " + NumBlockedFlushes
-                        + ", peakDelta mem: " + peakDelta + " byte");
+                    if (Debugging.AssertsEnabled) Debugging.Assert(ram <= expected, "actual mem: {0} byte, expected mem: {1} byte, flush mem: {2}, active mem: {3}, pending DWPT: {4}, flushing DWPT: {5}, blocked DWPT: {6}, peakDelta mem: {7} byte", ram, expected, flushBytes, activeBytes, numPending, NumFlushingDWPT, NumBlockedFlushes, peakDelta);
                 }
             }
             return true;
@@ -392,8 +388,8 @@ namespace Lucene.Net.Index
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(perThread.flushPending, () => "can not block non-pending threadstate");
-                    Debugging.Assert(fullFlush, () => "can not block if fullFlush == false");
+                    Debugging.Assert(perThread.flushPending, "can not block non-pending threadstate");
+                    Debugging.Assert(fullFlush, "can not block if fullFlush == false");
                 }
                 DocumentsWriterPerThread dwpt;
                 long bytes = perThread.bytesUsed;
@@ -626,7 +622,7 @@ namespace Lucene.Net.Index
                 if (Debugging.AssertsEnabled)
                 {
                     Debugging.Assert(!fullFlush, "called DWFC#markForFullFlush() while full flush is still running");
-                    Debugging.Assert(fullFlushBuffer.Count == 0, () => "full flush buffer should be empty: " + fullFlushBuffer);
+                    Debugging.Assert(fullFlushBuffer.Count == 0,"full flush buffer should be empty: {0}", fullFlushBuffer);
                 }
                 fullFlush = true;
                 flushingQueue = documentsWriter.deleteQueue;
@@ -650,7 +646,7 @@ namespace Lucene.Net.Index
                         }
                         continue;
                     }
-                    if (Debugging.AssertsEnabled) Debugging.Assert(next.dwpt.deleteQueue == flushingQueue || next.dwpt.deleteQueue == documentsWriter.deleteQueue, () => " flushingQueue: " + flushingQueue + " currentqueue: " + documentsWriter.deleteQueue + " perThread queue: " + next.dwpt.deleteQueue + " numDocsInRam: " + next.dwpt.NumDocsInRAM);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(next.dwpt.deleteQueue == flushingQueue || next.dwpt.deleteQueue == documentsWriter.deleteQueue," flushingQueue: {0} currentqueue: {1}", flushingQueue, documentsWriter.deleteQueue + " perThread queue: " + next.dwpt.deleteQueue + " numDocsInRam: " + next.dwpt.NumDocsInRAM);
                     if (next.dwpt.deleteQueue != flushingQueue)
                     {
                         // this one is already a new DWPT
@@ -691,7 +687,7 @@ namespace Lucene.Net.Index
                 next.@Lock();
                 try
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(!next.IsInitialized || next.dwpt.deleteQueue == queue, () => "isInitialized: " + next.IsInitialized + " numDocs: " + (next.IsInitialized ? next.dwpt.NumDocsInRAM : 0));
+                    if (Debugging.AssertsEnabled) Debugging.Assert(!next.IsInitialized || next.dwpt.deleteQueue == queue,"isInitialized: {0} numDocs: {1}", next.IsInitialized, (next.IsInitialized ? next.dwpt.NumDocsInRAM : 0));
                 }
                 finally
                 {

--- a/src/Lucene.Net/Index/DocumentsWriterFlushQueue.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterFlushQueue.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Index
         {
             get
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(ticketCount >= 0, () => "ticketCount should be >= 0 but was: " + ticketCount);
+                if (Debugging.AssertsEnabled) Debugging.Assert(ticketCount >= 0,"ticketCount should be >= 0 but was: {0}", ticketCount);
                 return ticketCount != 0;
             }
         }

--- a/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
@@ -236,7 +236,7 @@ namespace Lucene.Net.Index
             pendingUpdates = new BufferedUpdates();
             intBlockAllocator = new Int32BlockAllocator(bytesUsed);
             this.deleteQueue = deleteQueue;
-            if (Debugging.AssertsEnabled) Debugging.Assert(numDocsInRAM == 0, () => "num docs " + numDocsInRAM);
+            if (Debugging.AssertsEnabled) Debugging.Assert(numDocsInRAM == 0,"num docs {0}", numDocsInRAM);
             pendingUpdates.Clear();
             deleteSlice = deleteQueue.NewSlice();
 

--- a/src/Lucene.Net/Index/FilteredTermsEnum.cs
+++ b/src/Lucene.Net/Index/FilteredTermsEnum.cs
@@ -224,7 +224,7 @@ namespace Lucene.Net.Index
                     BytesRef t = NextSeekTerm(actualTerm);
                     //System.out.println("  seek to t=" + (t == null ? "null" : t.utf8ToString()) + " tenum=" + tenum);
                     // Make sure we always seek forward:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(actualTerm == null || t == null || Comparer.Compare(t, actualTerm) > 0, () => "curTerm=" + actualTerm + " seekTerm=" + t);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(actualTerm == null || t == null || Comparer.Compare(t, actualTerm) > 0, "curTerm={0} seekTerm={1}", actualTerm, t);
                     if (t == null || tenum.SeekCeil(t) == SeekStatus.END)
                     {
                         // no more terms to seek to or enum exhausted

--- a/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
+++ b/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
@@ -248,7 +248,7 @@ namespace Lucene.Net.Index
             }
             else if (docState.docID != postings.lastDocIDs[termID])
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(docState.docID > postings.lastDocIDs[termID],"id: {0} postings ID: {1}", docState.docID, postings.lastDocIDs[termID] + " termID: " + termID);
+                if (Debugging.AssertsEnabled) Debugging.Assert(docState.docID > postings.lastDocIDs[termID], "id: {0} postings ID: {1} termID: {2}", docState.docID, postings.lastDocIDs[termID], termID);
                 // Term not yet seen in the current doc but previously
                 // seen in other doc(s) since the last flush
 
@@ -644,7 +644,7 @@ namespace Lucene.Net.Index
                                     {
                                         if (writeOffsets)
                                         {
-                                            if (Debugging.AssertsEnabled) Debugging.Assert(startOffset >= 0 && endOffset >= startOffset,"startOffset={0},endOffset={1}", startOffset, endOffset + ",offset=" + offset);
+                                            if (Debugging.AssertsEnabled) Debugging.Assert(startOffset >= 0 && endOffset >= startOffset, "startOffset={0},endOffset={1},offset={2}", startOffset, endOffset, offset);
                                             postingsConsumer.AddPosition(position, thisPayload, startOffset, endOffset);
                                         }
                                         else

--- a/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
+++ b/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
@@ -248,7 +248,7 @@ namespace Lucene.Net.Index
             }
             else if (docState.docID != postings.lastDocIDs[termID])
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(docState.docID > postings.lastDocIDs[termID], () => "id: " + docState.docID + " postings ID: " + postings.lastDocIDs[termID] + " termID: " + termID);
+                if (Debugging.AssertsEnabled) Debugging.Assert(docState.docID > postings.lastDocIDs[termID],"id: {0} postings ID: {1}", docState.docID, postings.lastDocIDs[termID] + " termID: " + termID);
                 // Term not yet seen in the current doc but previously
                 // seen in other doc(s) since the last flush
 
@@ -559,7 +559,7 @@ namespace Lucene.Net.Index
                     }
 
                     docFreq++;
-                    if (Debugging.AssertsEnabled) Debugging.Assert(docID < state.SegmentInfo.DocCount, () => "doc=" + docID + " maxDoc=" + state.SegmentInfo.DocCount);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(docID < state.SegmentInfo.DocCount,"doc={0} maxDoc={1}", docID, state.SegmentInfo.DocCount);
 
                     // NOTE: we could check here if the docID was
                     // deleted, and skip it.  However, this is somewhat
@@ -644,7 +644,7 @@ namespace Lucene.Net.Index
                                     {
                                         if (writeOffsets)
                                         {
-                                            if (Debugging.AssertsEnabled) Debugging.Assert(startOffset >= 0 && endOffset >= startOffset, () => "startOffset=" + startOffset + ",endOffset=" + endOffset + ",offset=" + offset);
+                                            if (Debugging.AssertsEnabled) Debugging.Assert(startOffset >= 0 && endOffset >= startOffset,"startOffset={0},endOffset={1}", startOffset, endOffset + ",offset=" + offset);
                                             postingsConsumer.AddPosition(position, thisPayload, startOffset, endOffset);
                                         }
                                         else

--- a/src/Lucene.Net/Index/IndexFileDeleter.cs
+++ b/src/Lucene.Net/Index/IndexFileDeleter.cs
@@ -763,14 +763,14 @@ namespace Lucene.Net.Index
                 }
                 else
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(count > 0, () => Thread.CurrentThread.Name + ": RefCount is 0 pre-increment for file \"" + fileName + "\"");
+                    if (Debugging.AssertsEnabled) Debugging.Assert(count > 0, "{0}: RefCount is 0 pre-increment for file \"{1}\"", Thread.CurrentThread.Name, fileName);
                 }
                 return ++count;
             }
 
             public int DecRef()
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(count > 0, () => Thread.CurrentThread.Name + ": RefCount is 0 pre-decrement for file \"" + fileName + "\"");
+                if (Debugging.AssertsEnabled) Debugging.Assert(count > 0, "{0}: RefCount is 0 pre-decrement for file \"{1}\"", Thread.CurrentThread.Name, fileName);
                 return --count;
             }
         }

--- a/src/Lucene.Net/Index/IndexFileDeleter.cs
+++ b/src/Lucene.Net/Index/IndexFileDeleter.cs
@@ -529,9 +529,12 @@ namespace Lucene.Net.Index
         /// </summary>
         public void Checkpoint(SegmentInfos segmentInfos, bool isCommit)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(IsLocked);
+            if (Debugging.AssertsEnabled)
+            {
+                Debugging.Assert(IsLocked);
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(Monitor.IsEntered(writer));
+                Debugging.Assert(Monitor.IsEntered(writer));
+            }
             long t0 = 0;
             if (infoStream.IsEnabled("IFD"))
             {
@@ -722,8 +725,6 @@ namespace Lucene.Net.Index
                 // we assume that when a delete fails it is because
                 // the file is open in another process, and queue
                 // the file for subsequent deletion.
-
-                //if (Debugging.AssertsEnabled) Debugging.Assert(e.Message.Contains("cannot delete"));
 
                 if (infoStream.IsEnabled("IFD"))
                 {

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -462,8 +462,8 @@ namespace Lucene.Net.Index
                 lock (this)
                 {
                     int idx = outerInstance.segmentInfos.IndexOf(info);
-                    Debugging.Assert(idx != -1, () => "info=" + info + " isn't live");
-                    Debugging.Assert(outerInstance.segmentInfos.Info(idx) == info, () => "info=" + info + " doesn't match live info in segmentInfos");
+                    Debugging.Assert(idx != -1, "info={0} isn't live", info);
+                    Debugging.Assert(outerInstance.segmentInfos.Info(idx) == info, "info={0} doesn't match live info in segmentInfos", info);
                     return true;
                 }
             }
@@ -691,7 +691,7 @@ namespace Lucene.Net.Index
             {
                 lock (this)
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(info.Info.Dir == outerInstance.directory, () => "info.dir=" + info.Info.Dir + " vs " + outerInstance.directory);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(info.Info.Dir == outerInstance.directory,"info.dir={0} vs {1}", info.Info.Dir, outerInstance.directory);
 
                     ReadersAndUpdates rld;
                     readerMap.TryGetValue(info, out rld);
@@ -707,7 +707,7 @@ namespace Lucene.Net.Index
                     }
                     else
                     {
-                        if (Debugging.AssertsEnabled) Debugging.Assert(rld.Info == info, () => "rld.info=" + rld.Info + " info=" + info + " isLive?=" + InfoIsLive(rld.Info) + " vs " + InfoIsLive(info));
+                        if (Debugging.AssertsEnabled) Debugging.Assert(rld.Info == info,"rld.info={0} info={1}", rld.Info, info + " isLive?=" + InfoIsLive(rld.Info) + " vs " + InfoIsLive(info));
                     }
 
                     if (create)
@@ -1109,7 +1109,7 @@ namespace Lucene.Net.Index
             }
             foreach (IEvent e in eventQueue)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(e is DocumentsWriter.MergePendingEvent, () => e.ToString());
+                if (Debugging.AssertsEnabled) Debugging.Assert(e is DocumentsWriter.MergePendingEvent, e.ToString());
             }
             return true;
         }
@@ -1276,7 +1276,7 @@ namespace Lucene.Net.Index
                 {
                     closed = true;
                 }
-                if (Debugging.AssertsEnabled) Debugging.Assert(docWriter.perThreadPool.NumDeactivatedThreadStates() == docWriter.perThreadPool.MaxThreadStates, () => "" + docWriter.perThreadPool.NumDeactivatedThreadStates() + " " + docWriter.perThreadPool.MaxThreadStates);
+                if (Debugging.AssertsEnabled) Debugging.Assert(docWriter.perThreadPool.NumDeactivatedThreadStates() == docWriter.perThreadPool.MaxThreadStates,"{0} {1}", docWriter.perThreadPool.NumDeactivatedThreadStates(), docWriter.perThreadPool.MaxThreadStates);
             }
             catch (OutOfMemoryException oom)
             {
@@ -2402,7 +2402,7 @@ namespace Lucene.Net.Index
                 MergePolicy.MergeSpecification spec;
                 if (maxNumSegments != UNBOUNDED_MAX_MERGE_SEGMENTS)
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(trigger == MergeTrigger.EXPLICIT || trigger == MergeTrigger.MERGE_FINISHED, () => "Expected EXPLICT or MERGE_FINISHED as trigger even with maxNumSegments set but was: " + trigger.ToString());
+                    if (Debugging.AssertsEnabled) Debugging.Assert(trigger == MergeTrigger.EXPLICIT || trigger == MergeTrigger.MERGE_FINISHED,"Expected EXPLICT or MERGE_FINISHED as trigger even with maxNumSegments set but was: {0}", trigger.ToString());
                     spec = mergePolicy.FindForcedMerges(segmentInfos, maxNumSegments, segmentsToMerge);
                     newMergesFound = spec != null;
                     if (newMergesFound)
@@ -2587,7 +2587,7 @@ namespace Lucene.Net.Index
                     IOUtils.Dispose(writeLock); // release write lock
                     writeLock = null;
 
-                    if (Debugging.AssertsEnabled) Debugging.Assert(docWriter.perThreadPool.NumDeactivatedThreadStates() == docWriter.perThreadPool.MaxThreadStates, () => "" + docWriter.perThreadPool.NumDeactivatedThreadStates() + " " + docWriter.perThreadPool.MaxThreadStates);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(docWriter.perThreadPool.NumDeactivatedThreadStates() == docWriter.perThreadPool.MaxThreadStates,"{0} {1}", docWriter.perThreadPool.NumDeactivatedThreadStates(), docWriter.perThreadPool.MaxThreadStates);
                 }
 
                 success = true;
@@ -3061,7 +3061,7 @@ namespace Lucene.Net.Index
                         JCG.HashSet<string> copiedFiles = new JCG.HashSet<string>();
                         foreach (SegmentCommitInfo info in sis.Segments)
                         {
-                            if (Debugging.AssertsEnabled) Debugging.Assert(!infos.Contains(info), () => "dup info dir=" + info.Info.Dir + " name=" + info.Info.Name);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(!infos.Contains(info),"dup info dir={0} name={1}", info.Info.Dir, info.Info.Name);
 
                             string newSegName = NewSegmentName();
 
@@ -3450,8 +3450,8 @@ namespace Lucene.Net.Index
 
                     if (Debugging.AssertsEnabled)
                     {
-                        Debugging.Assert(!SlowFileExists(directory, newFileName), () => "file \"" + newFileName + "\" already exists; siFiles=" + string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", siFiles));
-                        Debugging.Assert(!copiedFiles.Contains(file), () => "file \"" + file + "\" is being copied more than once");
+                        Debugging.Assert(!SlowFileExists(directory, newFileName), "file \"{0}\" already exists; siFiles={1}", newFileName, string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", siFiles));
+                        Debugging.Assert(!copiedFiles.Contains(file), "file \"{0}\" is being copied more than once", file);
                     }
                     copiedFiles.Add(file);
                     info.Info.Dir.Copy(directory, file, newFileName, context);
@@ -4018,7 +4018,7 @@ namespace Lucene.Net.Index
                 // when entering the method, all iterators must already be beyond the
                 // deleted document, or right on it, in which case we advance them over
                 // and they must be beyond it now.
-                if (Debugging.AssertsEnabled) Debugging.Assert(iter.Doc > deletedDoc, () => "updateDoc=" + iter.Doc + " deletedDoc=" + deletedDoc);
+                if (Debugging.AssertsEnabled) Debugging.Assert(iter.Doc > deletedDoc,"updateDoc={0} deletedDoc={1}", iter.Doc, deletedDoc);
             }
         }
 
@@ -4070,7 +4070,7 @@ namespace Lucene.Net.Index
                 }
                 else
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(updatesIter.Doc > curDoc, () => "field=" + mergingFields[idx] + " updateDoc=" + updatesIter.Doc + " curDoc=" + curDoc);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(updatesIter.Doc > curDoc,"field={0} updateDoc={1}", mergingFields[idx], updatesIter.Doc + " curDoc=" + curDoc);
                 }
             }
         }
@@ -4115,7 +4115,7 @@ namespace Lucene.Net.Index
                     IBits prevLiveDocs = merge.readers[i].LiveDocs;
                     ReadersAndUpdates rld = readerPool.Get(info, false);
                     // We hold a ref so it should still be in the pool:
-                    if (Debugging.AssertsEnabled) Debugging.Assert(rld != null, () => "seg=" + info.Info.Name);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(rld != null,"seg={0}", info.Info.Name);
                     IBits currentLiveDocs = rld.LiveDocs;
                     IDictionary<string, DocValuesFieldUpdates> mergingFieldUpdates = rld.MergingFieldUpdates;
                     string[] mergingFields;
@@ -5037,7 +5037,7 @@ namespace Lucene.Net.Index
                     }
 
                     merge.readers.Add(reader);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(delCount <= info.Info.DocCount, () => "delCount=" + delCount + " info.docCount=" + info.Info.DocCount + " rld.pendingDeleteCount=" + rld.PendingDeleteCount + " info.getDelCount()=" + info.DelCount);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(delCount <= info.Info.DocCount,"delCount={0} info.docCount={1}", delCount, info.Info.DocCount + " rld.pendingDeleteCount=" + rld.PendingDeleteCount + " info.getDelCount()=" + info.DelCount);
                     segUpto++;
                 }
 
@@ -5379,13 +5379,13 @@ namespace Lucene.Net.Index
             ICollection<string> files = toSync.GetFiles(directory, false);
             foreach (string fileName in files)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(SlowFileExists(directory, fileName), () => "file " + fileName + " does not exist; files=" + Arrays.ToString(directory.ListAll()));
+                if (Debugging.AssertsEnabled) Debugging.Assert(SlowFileExists(directory, fileName), "file {0} does not exist; files={1}, ", fileName, Arrays.ToString(directory.ListAll()));
                 // If this trips it means we are missing a call to
                 // .checkpoint somewhere, because by the time we
                 // are called, deleter should know about every
                 // file referenced by the current head
                 // segmentInfos:
-                if (Debugging.AssertsEnabled) Debugging.Assert(deleter.Exists(fileName), () => "IndexFileDeleter doesn't know about file " + fileName);
+                if (Debugging.AssertsEnabled) Debugging.Assert(deleter.Exists(fileName),"IndexFileDeleter doesn't know about file {0}", fileName);
             }
             return true;
         }
@@ -5445,7 +5445,7 @@ namespace Lucene.Net.Index
 
                 lock (this)
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(lastCommitChangeCount <= changeCount, () => "lastCommitChangeCount=" + lastCommitChangeCount + " changeCount=" + changeCount);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(lastCommitChangeCount <= changeCount,"lastCommitChangeCount={0} changeCount={1}", lastCommitChangeCount, changeCount);
 
                     if (pendingCommitChangeCount == lastCommitChangeCount)
                     {

--- a/src/Lucene.Net/Index/MergePolicy.cs
+++ b/src/Lucene.Net/Index/MergePolicy.cs
@@ -93,12 +93,12 @@ namespace Lucene.Net.Index
                     int target = Map(i);
                     if (target < 0 || target >= maxDoc)
                     {
-                        if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "out of range: " + target + " not in [0-" + maxDoc + "[");
+                        if (Debugging.AssertsEnabled) Debugging.Assert(false, "out of range: {0} not in [0-{1}[", target, maxDoc);
                         return false;
                     }
                     else if (targets.Get(target))
                     {
-                        if (Debugging.AssertsEnabled) Debugging.Assert(false, () => target + " is already taken (" + i + ")");
+                        if (Debugging.AssertsEnabled) Debugging.Assert(false,  "{0} is already taken ({1})", target, i);
                         return false;
                     }
                 }

--- a/src/Lucene.Net/Index/MultiBits.cs
+++ b/src/Lucene.Net/Index/MultiBits.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Index
         private bool CheckLength(int reader, int doc)
         {
             int length = starts[1 + reader] - starts[reader];
-            if (Debugging.AssertsEnabled) Debugging.Assert(doc - starts[reader] < length,"doc={0} reader={1}", doc, reader + " starts[reader]=" + starts[reader] + " length=" + length);
+            if (Debugging.AssertsEnabled) Debugging.Assert(doc - starts[reader] < length, "doc={0} reader={1} starts[reader]={2} length={3}", doc, reader, starts[reader], length);
             return true;
         }
 

--- a/src/Lucene.Net/Index/MultiBits.cs
+++ b/src/Lucene.Net/Index/MultiBits.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Index
         private bool CheckLength(int reader, int doc)
         {
             int length = starts[1 + reader] - starts[reader];
-            if (Debugging.AssertsEnabled) Debugging.Assert(doc - starts[reader] < length, () => "doc=" + doc + " reader=" + reader + " starts[reader]=" + starts[reader] + " length=" + length);
+            if (Debugging.AssertsEnabled) Debugging.Assert(doc - starts[reader] < length,"doc={0} reader={1}", doc, reader + " starts[reader]=" + starts[reader] + " length=" + length);
             return true;
         }
 
@@ -117,7 +117,7 @@ namespace Lucene.Net.Index
             if (Debugging.AssertsEnabled)
             {
                 Debugging.Assert(reader != -1);
-                Debugging.Assert(reader < subs.Length, () => "slice=" + slice + " starts[-1]=" + starts[starts.Length - 1]);
+                Debugging.Assert(reader < subs.Length,"slice={0} starts[-1]={1}", slice, starts[starts.Length - 1]);
             }
             SubResult subResult = new SubResult();
             if (starts[reader] == slice.Start && starts[1 + reader] == slice.Start + slice.Length)

--- a/src/Lucene.Net/Index/MultiTermsEnum.cs
+++ b/src/Lucene.Net/Index/MultiTermsEnum.cs
@@ -495,7 +495,7 @@ namespace Lucene.Net.Index
                     b = null;
                 }
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(entry.Index < docsEnum.subDocsEnum.Length, () => entry.Index + " vs " + docsEnum.subDocsEnum.Length + "; " + subs.Length);
+                if (Debugging.AssertsEnabled) Debugging.Assert(entry.Index < docsEnum.subDocsEnum.Length, "{0} vs {1}; {2}", entry.Index, docsEnum.subDocsEnum.Length, subs.Length);
                 DocsEnum subDocsEnum = entry.Terms.Docs(b, docsEnum.subDocsEnum[entry.Index], flags);
                 if (subDocsEnum != null)
                 {
@@ -507,7 +507,7 @@ namespace Lucene.Net.Index
                 else
                 {
                     // should this be an error?
-                    if (Debugging.AssertsEnabled) Debugging.Assert(false, () => "One of our subs cannot provide a docsenum");
+                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "One of our subs cannot provide a docsenum");
                 }
             }
 
@@ -587,7 +587,7 @@ namespace Lucene.Net.Index
                     b = null;
                 }
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(entry.Index < docsAndPositionsEnum.subDocsAndPositionsEnum.Length, () => entry.Index + " vs " + docsAndPositionsEnum.subDocsAndPositionsEnum.Length + "; " + subs.Length);
+                if (Debugging.AssertsEnabled) Debugging.Assert(entry.Index < docsAndPositionsEnum.subDocsAndPositionsEnum.Length, "{0} vs {1}; {2}", entry.Index, docsAndPositionsEnum.subDocsAndPositionsEnum.Length, subs.Length);
                 DocsAndPositionsEnum subPostings = entry.Terms.DocsAndPositions(b, docsAndPositionsEnum.subDocsAndPositionsEnum[entry.Index], flags);
 
                 if (subPostings != null)
@@ -630,7 +630,7 @@ namespace Lucene.Net.Index
             {
                 this.SubSlice = subSlice;
                 this.Index = index;
-                if (Debugging.AssertsEnabled) Debugging.Assert(subSlice.Length >= 0, () => "length=" + subSlice.Length);
+                if (Debugging.AssertsEnabled) Debugging.Assert(subSlice.Length >= 0,"length={0}", subSlice.Length);
             }
 
             public void Reset(TermsEnum terms, BytesRef term)

--- a/src/Lucene.Net/Index/NormsConsumer.cs
+++ b/src/Lucene.Net/Index/NormsConsumer.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Index
                             }
                             else if (fi.IsIndexed)
                             {
-                                if (Debugging.AssertsEnabled) Debugging.Assert(fi.NormType == DocValuesType.NONE, () => "got " + fi.NormType + "; field=" + fi.Name);
+                                if (Debugging.AssertsEnabled) Debugging.Assert(fi.NormType == DocValuesType.NONE,"got {0}; field={1}", fi.NormType, fi.Name);
                             }
                         }
                     }

--- a/src/Lucene.Net/Index/OrdTermState.cs
+++ b/src/Lucene.Net/Index/OrdTermState.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Index
 
         public override void CopyFrom(TermState other)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(other is OrdTermState, () => "can not copy from " + other.GetType().Name);
+            if (Debugging.AssertsEnabled) Debugging.Assert(other is OrdTermState,"can not copy from {0}", other.GetType().Name);
             this.Ord = ((OrdTermState)other).Ord;
         }
 

--- a/src/Lucene.Net/Index/ReadersAndUpdates.cs
+++ b/src/Lucene.Net/Index/ReadersAndUpdates.cs
@@ -154,7 +154,7 @@ namespace Lucene.Net.Index
                     count = Info.Info.DocCount;
                 }
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(Info.Info.DocCount - Info.DelCount - pendingDeleteCount == count,"info.docCount={0} info.DelCount={1}", Info.Info.DocCount, Info.DelCount + " pendingDeleteCount=" + pendingDeleteCount + " count=" + count);
+                if (Debugging.AssertsEnabled) Debugging.Assert(Info.Info.DocCount - Info.DelCount - pendingDeleteCount == count, "info.docCount={0} info.DelCount={1} pendingDeleteCount={2} count={3}", Info.Info.DocCount, Info.DelCount, pendingDeleteCount, count);
                 return true;
             }
         }
@@ -234,7 +234,7 @@ namespace Lucene.Net.Index
                 {
                     Debugging.Assert(liveDocs != null);
                     Debugging.Assert(Monitor.IsEntered(writer));
-                    Debugging.Assert(docID >= 0 && docID < liveDocs.Length,"out of bounds: docid={0} liveDocsLength={1}", docID, liveDocs.Length + " seg=" + Info.Info.Name + " docCount=" + Info.Info.DocCount);
+                    Debugging.Assert(docID >= 0 && docID < liveDocs.Length, "out of bounds: docid={0} liveDocsLength={1} seg={2} docCount={3}", docID, liveDocs.Length, Info.Info.Name, Info.Info.DocCount);
                     Debugging.Assert(!liveDocsShared);
                 }
                 bool didDelete = liveDocs.Get(docID);

--- a/src/Lucene.Net/Index/ReadersAndUpdates.cs
+++ b/src/Lucene.Net/Index/ReadersAndUpdates.cs
@@ -154,7 +154,7 @@ namespace Lucene.Net.Index
                     count = Info.Info.DocCount;
                 }
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(Info.Info.DocCount - Info.DelCount - pendingDeleteCount == count, () => "info.docCount=" + Info.Info.DocCount + " info.DelCount=" + Info.DelCount + " pendingDeleteCount=" + pendingDeleteCount + " count=" + count);
+                if (Debugging.AssertsEnabled) Debugging.Assert(Info.Info.DocCount - Info.DelCount - pendingDeleteCount == count,"info.docCount={0} info.DelCount={1}", Info.Info.DocCount, Info.DelCount + " pendingDeleteCount=" + pendingDeleteCount + " count=" + count);
                 return true;
             }
         }
@@ -234,7 +234,7 @@ namespace Lucene.Net.Index
                 {
                     Debugging.Assert(liveDocs != null);
                     Debugging.Assert(Monitor.IsEntered(writer));
-                    Debugging.Assert(docID >= 0 && docID < liveDocs.Length, () => "out of bounds: docid=" + docID + " liveDocsLength=" + liveDocs.Length + " seg=" + Info.Info.Name + " docCount=" + Info.Info.DocCount);
+                    Debugging.Assert(docID >= 0 && docID < liveDocs.Length,"out of bounds: docid={0} liveDocsLength={1}", docID, liveDocs.Length + " seg=" + Info.Info.Name + " docCount=" + Info.Info.DocCount);
                     Debugging.Assert(!liveDocsShared);
                 }
                 bool didDelete = liveDocs.Get(docID);

--- a/src/Lucene.Net/Index/SegmentDocValues.cs
+++ b/src/Lucene.Net/Index/SegmentDocValues.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Index
                 foreach (long? gen in dvProducersGens)
                 {
                     RefCount<DocValuesProducer> dvp = genDVProducers[gen];
-                    if (Debugging.AssertsEnabled) Debugging.Assert(dvp != null, () => "gen=" + gen);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(dvp != null,"gen={0}", gen);
                     try
                     {
                         dvp.DecRef();

--- a/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
@@ -203,7 +203,7 @@ namespace Lucene.Net.Index
         {
             AppendingDeltaPackedInt64Buffer.Iterator iter = pendingCounts.GetIterator();
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(pendingCounts.Count == maxDoc, () => "MaxDoc: " + maxDoc + ", pending.Count: " + pending.Count);
+            if (Debugging.AssertsEnabled) Debugging.Assert(pendingCounts.Count == maxDoc,"MaxDoc: {0}, pending.Count: {1}", maxDoc, pending.Count);
 
             for (int i = 0; i < maxDoc; ++i)
             {

--- a/src/Lucene.Net/Index/TermContext.cs
+++ b/src/Lucene.Net/Index/TermContext.cs
@@ -137,9 +137,9 @@ namespace Lucene.Net.Index
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(state != null, () => "state must not be null");
+                Debugging.Assert(state != null, "state must not be null");
                 Debugging.Assert(ord >= 0 && ord < states.Length);
-                Debugging.Assert(states[ord] == null, () => "state for ord: " + ord + " already registered");
+                Debugging.Assert(states[ord] == null, "state for ord: {0} already registered", ord);
             }
             this.docFreq += docFreq;
             if (this.totalTermFreq >= 0 && totalTermFreq >= 0)

--- a/src/Lucene.Net/Index/TermVectorsConsumer.cs
+++ b/src/Lucene.Net/Index/TermVectorsConsumer.cs
@@ -133,7 +133,7 @@ namespace Lucene.Net.Index
             }
             writer.FinishDocument();
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(lastDocID == docState.docID, () => "lastDocID=" + lastDocID + " docState.docID=" + docState.docID);
+            if (Debugging.AssertsEnabled) Debugging.Assert(lastDocID == docState.docID,"lastDocID={0} docState.docID={1}", lastDocID, docState.docID);
 
             lastDocID++;
 

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -135,7 +135,7 @@ namespace Lucene.Net.Search
         /// <seealso cref="IndexReader.Context"/>
         public IndexSearcher(IndexReaderContext context, TaskScheduler executor)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(context.IsTopLevel, () => "IndexSearcher's ReaderContext must be topLevel for reader" + context.Reader);
+            if (Debugging.AssertsEnabled) Debugging.Assert(context.IsTopLevel,"IndexSearcher's ReaderContext must be topLevel for reader{0}", context.Reader);
             reader = context.Reader;
             this.executor = executor;
             this.m_readerContext = context;

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -135,7 +135,7 @@ namespace Lucene.Net.Search
         /// <seealso cref="IndexReader.Context"/>
         public IndexSearcher(IndexReaderContext context, TaskScheduler executor)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(context.IsTopLevel,"IndexSearcher's ReaderContext must be topLevel for reader{0}", context.Reader);
+            if (Debugging.AssertsEnabled) Debugging.Assert(context.IsTopLevel,"IndexSearcher's ReaderContext must be topLevel for reader {0}", context.Reader);
             reader = context.Reader;
             this.executor = executor;
             this.m_readerContext = context;

--- a/src/Lucene.Net/Search/SearcherManager.cs
+++ b/src/Lucene.Net/Search/SearcherManager.cs
@@ -120,7 +120,7 @@ namespace Lucene.Net.Search
         protected override IndexSearcher RefreshIfNeeded(IndexSearcher referenceToRefresh)
         {
             IndexReader r = referenceToRefresh.IndexReader;
-            if (Debugging.AssertsEnabled) Debugging.Assert(r is DirectoryReader, () => "searcher's IndexReader should be a DirectoryReader, but got " + r);
+            if (Debugging.AssertsEnabled) Debugging.Assert(r is DirectoryReader,"searcher's IndexReader should be a DirectoryReader, but got {0}", r);
             IndexReader newReader = DirectoryReader.OpenIfChanged((DirectoryReader)r);
             if (newReader == null)
             {
@@ -152,7 +152,7 @@ namespace Lucene.Net.Search
             try
             {
                 IndexReader r = searcher.IndexReader;
-                if (Debugging.AssertsEnabled) Debugging.Assert(r is DirectoryReader, () => "searcher's IndexReader should be a DirectoryReader, but got " + r);
+                if (Debugging.AssertsEnabled) Debugging.Assert(r is DirectoryReader,"searcher's IndexReader should be a DirectoryReader, but got {0}", r);
                 return ((DirectoryReader)r).IsCurrent();
             }
             finally

--- a/src/Lucene.Net/Search/Spans/NearSpansOrdered.cs
+++ b/src/Lucene.Net/Search/Spans/NearSpansOrdered.cs
@@ -285,7 +285,7 @@ namespace Lucene.Net.Search.Spans
             }
             for (int i = 0; i < subSpansByDoc.Length; i++)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(subSpansByDoc[i].Doc == maxDoc, () => " NearSpansOrdered.toSameDoc() spans " + subSpansByDoc[0] + "\n at doc " + subSpansByDoc[i].Doc + ", but should be at " + maxDoc);
+                if (Debugging.AssertsEnabled) Debugging.Assert(subSpansByDoc[i].Doc == maxDoc," NearSpansOrdered.toSameDoc() spans {0}\n at doc {1}", subSpansByDoc[0], subSpansByDoc[i].Doc + ", but should be at " + maxDoc);
             }
             inSameDoc = true;
             return true;
@@ -298,7 +298,7 @@ namespace Lucene.Net.Search.Spans
         ///              and <paramref name="spans1"/> ends before <paramref name="spans2"/>. </returns>
         internal static bool DocSpansOrdered(Spans spans1, Spans spans2)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(spans1.Doc == spans2.Doc, () => "doc1 " + spans1.Doc + " != doc2 " + spans2.Doc);
+            if (Debugging.AssertsEnabled) Debugging.Assert(spans1.Doc == spans2.Doc,"doc1 {0} != doc2 {1}", spans1.Doc, spans2.Doc);
             int start1 = spans1.Start;
             int start2 = spans2.Start;
             /* Do not call docSpansOrdered(int,int,int,int) to avoid invoking .end() : */

--- a/src/Lucene.Net/Search/Spans/NearSpansOrdered.cs
+++ b/src/Lucene.Net/Search/Spans/NearSpansOrdered.cs
@@ -285,7 +285,7 @@ namespace Lucene.Net.Search.Spans
             }
             for (int i = 0; i < subSpansByDoc.Length; i++)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(subSpansByDoc[i].Doc == maxDoc," NearSpansOrdered.toSameDoc() spans {0}\n at doc {1}", subSpansByDoc[0], subSpansByDoc[i].Doc + ", but should be at " + maxDoc);
+                if (Debugging.AssertsEnabled) Debugging.Assert(subSpansByDoc[i].Doc == maxDoc, " NearSpansOrdered.ToSameDoc() spans {0}\n at doc {1}, but should be at {2}", subSpansByDoc[0], subSpansByDoc[i].Doc, maxDoc);
             }
             inSameDoc = true;
             return true;

--- a/src/Lucene.Net/Search/Spans/SpanFirstQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanFirstQuery.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Search.Spans
 
         protected override AcceptStatus AcceptPosition(Spans spans)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(spans.Start != spans.End, () => "start equals end: " + spans.Start);
+            if (Debugging.AssertsEnabled) Debugging.Assert(spans.Start != spans.End,"start equals end: {0}", spans.Start);
             if (spans.Start >= m_end)
             {
                 return AcceptStatus.NO_AND_ADVANCE;

--- a/src/Lucene.Net/Search/TermQuery.cs
+++ b/src/Lucene.Net/Search/TermQuery.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Search
 
             public override Scorer GetScorer(AtomicReaderContext context, IBits acceptDocs)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(termStates.TopReaderContext == ReaderUtil.GetTopLevelContext(context), () => "The top-reader used to create Weight (" + termStates.TopReaderContext + ") is not the same as the current reader's top-reader (" + ReaderUtil.GetTopLevelContext(context));
+                if (Debugging.AssertsEnabled) Debugging.Assert(termStates.TopReaderContext == ReaderUtil.GetTopLevelContext(context),"The top-reader used to create Weight ({0}) is not the same as the current reader's top-reader ({1}", termStates.TopReaderContext, ReaderUtil.GetTopLevelContext(context));
                 TermsEnum termsEnum = GetTermsEnum(context);
                 if (termsEnum == null)
                 {
@@ -105,7 +105,7 @@ namespace Lucene.Net.Search
                 TermState state = termStates.Get(context.Ord);
                 if (state == null) // term is not present in that reader
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(TermNotInReader(context.AtomicReader, outerInstance.term), () => "no termstate found but term exists in reader term=" + outerInstance.term);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(TermNotInReader(context.AtomicReader, outerInstance.term), "no termstate found but term exists in reader term={0}", outerInstance.term);
                     return null;
                 }
                 //System.out.println("LD=" + reader.getLiveDocs() + " set?=" + (reader.getLiveDocs() != null ? reader.getLiveDocs().get(0) : "null"));

--- a/src/Lucene.Net/Search/TermQuery.cs
+++ b/src/Lucene.Net/Search/TermQuery.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Search
 
             public override Scorer GetScorer(AtomicReaderContext context, IBits acceptDocs)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(termStates.TopReaderContext == ReaderUtil.GetTopLevelContext(context),"The top-reader used to create Weight ({0}) is not the same as the current reader's top-reader ({1}", termStates.TopReaderContext, ReaderUtil.GetTopLevelContext(context));
+                if (Debugging.AssertsEnabled) Debugging.Assert(termStates.TopReaderContext == ReaderUtil.GetTopLevelContext(context),"The top-reader used to create Weight ({0}) is not the same as the current reader's top-reader ({1})", termStates.TopReaderContext, ReaderUtil.GetTopLevelContext(context));
                 TermsEnum termsEnum = GetTermsEnum(context);
                 if (termsEnum == null)
                 {

--- a/src/Lucene.Net/Search/TopTermsRewrite.cs
+++ b/src/Lucene.Net/Search/TopTermsRewrite.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Search
             foreach (ScoreTerm st in scoreTerms)
             {
                 Term term = new Term(query.m_field, st.Bytes);
-                if (Debugging.AssertsEnabled) Debugging.Assert(reader.DocFreq(term) == st.TermState.DocFreq,"reader DF is {0} vs {1}", reader.DocFreq(term), st.TermState.DocFreq + " term=" + term);
+                if (Debugging.AssertsEnabled) Debugging.Assert(reader.DocFreq(term) == st.TermState.DocFreq, "reader DF is {0} vs {1} term={2}", reader.DocFreq(term), st.TermState.DocFreq, term);
                 AddClause(q, term, st.TermState.DocFreq, query.Boost * st.Boost, st.TermState); // add to query
             }
             return q;

--- a/src/Lucene.Net/Search/TopTermsRewrite.cs
+++ b/src/Lucene.Net/Search/TopTermsRewrite.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Search
             foreach (ScoreTerm st in scoreTerms)
             {
                 Term term = new Term(query.m_field, st.Bytes);
-                if (Debugging.AssertsEnabled) Debugging.Assert(reader.DocFreq(term) == st.TermState.DocFreq, () => "reader DF is " + reader.DocFreq(term) + " vs " + st.TermState.DocFreq + " term=" + term);
+                if (Debugging.AssertsEnabled) Debugging.Assert(reader.DocFreq(term) == st.TermState.DocFreq,"reader DF is {0} vs {1}", reader.DocFreq(term), st.TermState.DocFreq + " term=" + term);
                 AddClause(q, term, st.TermState.DocFreq, query.Boost * st.Boost, st.TermState); // add to query
             }
             return q;
@@ -145,7 +145,7 @@ namespace Lucene.Net.Search
                 }
                 else
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(termsEnum.Comparer.Compare(lastTerm, t) < 0, () => "lastTerm=" + lastTerm + " t=" + t);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(termsEnum.Comparer.Compare(lastTerm, t) < 0, "lastTerm={0} t={1}", lastTerm, t);
                     lastTerm.CopyBytes(t);
                 }
                 return true;

--- a/src/Lucene.Net/Store/BufferedIndexInput.cs
+++ b/src/Lucene.Net/Store/BufferedIndexInput.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Store
         /// Change the buffer size used by this <see cref="IndexInput"/> </summary>
         public void SetBufferSize(int newSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(m_buffer == null || bufferSize == m_buffer.Length, () => "buffer=" + m_buffer + " bufferSize=" + bufferSize + " buffer.length=" + (m_buffer != null ? m_buffer.Length : 0));
+            if (Debugging.AssertsEnabled) Debugging.Assert(m_buffer == null || bufferSize == m_buffer.Length,"buffer={0} bufferSize={1}", m_buffer, bufferSize + " buffer.length=" + (m_buffer != null ? m_buffer.Length : 0));
             if (newSize != bufferSize)
             {
                 CheckBufferSize(newSize);

--- a/src/Lucene.Net/Store/BufferedIndexInput.cs
+++ b/src/Lucene.Net/Store/BufferedIndexInput.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Store
         /// Change the buffer size used by this <see cref="IndexInput"/> </summary>
         public void SetBufferSize(int newSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(m_buffer == null || bufferSize == m_buffer.Length,"buffer={0} bufferSize={1}", m_buffer, bufferSize + " buffer.length=" + (m_buffer != null ? m_buffer.Length : 0));
+            if (Debugging.AssertsEnabled) Debugging.Assert(m_buffer == null || bufferSize == m_buffer.Length, "buffer={0} bufferSize={1} buffer.length={2}", m_buffer, bufferSize, (m_buffer != null ? m_buffer.Length : 0));
             if (newSize != bufferSize)
             {
                 CheckBufferSize(newSize);

--- a/src/Lucene.Net/Store/CompoundFileDirectory.cs
+++ b/src/Lucene.Net/Store/CompoundFileDirectory.cs
@@ -120,7 +120,7 @@ namespace Lucene.Net.Store
             }
             else
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(!(directory is CompoundFileDirectory), () => "compound file inside of compound file: " + fileName);
+                if (Debugging.AssertsEnabled) Debugging.Assert(!(directory is CompoundFileDirectory),"compound file inside of compound file: {0}", fileName);
                 this.entries = SENTINEL;
                 this.IsOpen = true;
                 writer = new CompoundFileWriter(directory, fileName);

--- a/src/Lucene.Net/Store/CompoundFileWriter.cs
+++ b/src/Lucene.Net/Store/CompoundFileWriter.cs
@@ -255,7 +255,7 @@ namespace Lucene.Net.Store
                 entry.File = name;
                 entries[name] = entry;
                 string id = IndexFileNames.StripSegmentName(name);
-                if (Debugging.AssertsEnabled) Debugging.Assert(!seenIDs.Contains(id), () => "file=\"" + name + "\" maps to id=\"" + id + "\", which was already written");
+                if (Debugging.AssertsEnabled) Debugging.Assert(!seenIDs.Contains(id), "file=\"{0}\" maps to id=\"{1}\", which was already written", name, id);
                 seenIDs.Add(id);
                 DirectCFSIndexOutput @out;
 

--- a/src/Lucene.Net/Store/DataOutput.cs
+++ b/src/Lucene.Net/Store/DataOutput.cs
@@ -262,7 +262,7 @@ namespace Lucene.Net.Store
         /// Copy numBytes bytes from input to ourself. </summary>
         public virtual void CopyBytes(DataInput input, long numBytes)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(numBytes >= 0, () => "numBytes=" + numBytes);
+            if (Debugging.AssertsEnabled) Debugging.Assert(numBytes >= 0,"numBytes={0}", numBytes);
             long left = numBytes;
             if (copyBuffer == null)
             {

--- a/src/Lucene.Net/Store/Directory.cs
+++ b/src/Lucene.Net/Store/Directory.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -391,6 +392,24 @@ namespace Lucene.Net.Store
             }
 
             public override long Length => length;
+        }
+
+        // LUCENENET specific - formatter to defer building the string of directory contents in string.Format().
+        // This struct is meant to wrap a directory parameter when passed as a string.Format() argument.
+        internal struct ListAllFormatter // For assert/test/debug
+        {
+#pragma warning disable IDE0044 // Add readonly modifier
+            private Directory directory;
+#pragma warning restore IDE0044 // Add readonly modifier
+            public ListAllFormatter(Directory directory)
+            {
+                this.directory = directory ?? throw new ArgumentNullException(nameof(directory));
+            }
+
+            public override string ToString()
+            {
+                return Arrays.ToString(directory.ListAll());
+            }
         }
     }
 }

--- a/src/Lucene.Net/Support/Diagnostics/Debugging.cs
+++ b/src/Lucene.Net/Support/Diagnostics/Debugging.cs
@@ -1,5 +1,6 @@
 using J2N.Text;
 using Lucene.Net.Util;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Diagnostics
@@ -38,6 +39,8 @@ namespace Lucene.Net.Diagnostics
 
         /// <summary>
         /// Checks for a condition; if the condition is <c>false</c>, throws an <see cref="AssertionException"/>.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -49,106 +52,218 @@ namespace Lucene.Net.Diagnostics
 
         /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
-        /// from the specified <paramref name="messageToFormat"/>.
+        /// from the specified <paramref name="messageFormat"/>.
+        /// <para/>
+        /// IMPORTANT: The purpose of using this overload is to defer execution of building the string until it the <paramref name="condition"/> is <c>false</c>. Ideally, we would
+        /// use a <see cref="Func{String}"/> parameter, but doing so allocates extra RAM even when calls to the method are in an unreachable execution path. When passing
+        /// parameters, strive to pass value or reference types without doing any pre-processing or string formatting. If necessary, wrap the parameter in another class or struct and
+        /// override the <see cref="object.ToString()"/> method so any expensive formatting is deferred until after <paramref name="condition"/> is checked.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        /// <param name="messageFormat">A composite format string to use to build a failure message.
+        /// This message contains text intermixed with zero or more format items, which correspond to
+        /// the <paramref name="p0"/> parameter.</param>
+        /// <param name="p0">The parameter corresponding to the format item at index 0 (<c>{0}</c>).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Assert<T0>(bool condition, string messageToFormat, T0 p0)
+        public static void Assert<T0>(bool condition, string messageFormat, T0 p0)
         {
             if (AssertsEnabled && !condition)
-                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0));
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageFormat, p0));
         }
 
         /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
-        /// from the specified <paramref name="messageToFormat"/>.
+        /// from the specified <paramref name="messageFormat"/>.
+        /// <para/>
+        /// IMPORTANT: The purpose of using this overload is to defer execution of building the string until it the <paramref name="condition"/> is <c>false</c>. Ideally, we would
+        /// use a <see cref="Func{String}"/> parameter, but doing so allocates extra RAM even when calls to the method are in an unreachable execution path. When passing
+        /// parameters, strive to pass value or reference types without doing any pre-processing or string formatting. If necessary, wrap the parameter in another class or struct and
+        /// override the <see cref="object.ToString()"/> method so any expensive formatting is deferred until after <paramref name="condition"/> is checked.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        /// <param name="messageFormat">A composite format string to use to build a failure message.
+        /// This message contains text intermixed with zero or more format items, which correspond to
+        /// the <paramref name="p0"/> or <paramref name="p1"/> parameters.</param>
+        /// <param name="p0">The parameter corresponding to the format item at index 0 (<c>{0}</c>).</param>
+        /// <param name="p1">The parameter corresponding to the format item at index 1 (<c>{1}</c>).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Assert<T0, T1>(bool condition, string messageToFormat, T0 p0, T1 p1)
+        public static void Assert<T0, T1>(bool condition, string messageFormat, T0 p0, T1 p1)
         {
             if (AssertsEnabled && !condition)
-                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1));
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageFormat, p0, p1));
         }
 
         /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
-        /// from the specified <paramref name="messageToFormat"/>.
+        /// from the specified <paramref name="messageFormat"/>.
+        /// <para/>
+        /// IMPORTANT: The purpose of using this overload is to defer execution of building the string until it the <paramref name="condition"/> is <c>false</c>. Ideally, we would
+        /// use a <see cref="Func{String}"/> parameter, but doing so allocates extra RAM even when calls to the method are in an unreachable execution path. When passing
+        /// parameters, strive to pass value or reference types without doing any pre-processing or string formatting. If necessary, wrap the parameter in another class or struct and
+        /// override the <see cref="object.ToString()"/> method so any expensive formatting is deferred until after <paramref name="condition"/> is checked.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        /// <param name="messageFormat">A composite format string to use to build a failure message.
+        /// This message contains text intermixed with zero or more format items, which correspond to
+        /// the <paramref name="p0"/>, <paramref name="p1"/> or <paramref name="p2"/> parameters.</param>
+        /// <param name="p0">The parameter corresponding to the format item at index 0 (<c>{0}</c>).</param>
+        /// <param name="p1">The parameter corresponding to the format item at index 1 (<c>{1}</c>).</param>
+        /// <param name="p2">The parameter corresponding to the format item at index 2 (<c>{2}</c>).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Assert<T0, T1, T2>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2)
+        public static void Assert<T0, T1, T2>(bool condition, string messageFormat, T0 p0, T1 p1, T2 p2)
         {
             if (AssertsEnabled && !condition)
-                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2));
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageFormat, p0, p1, p2));
         }
 
         /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
-        /// from the specified <paramref name="messageToFormat"/>.
+        /// from the specified <paramref name="messageFormat"/>.
+        /// <para/>
+        /// IMPORTANT: The purpose of using this overload is to defer execution of building the string until it the <paramref name="condition"/> is <c>false</c>. Ideally, we would
+        /// use a <see cref="Func{String}"/> parameter, but doing so allocates extra RAM even when calls to the method are in an unreachable execution path. When passing
+        /// parameters, strive to pass value or reference types without doing any pre-processing or string formatting. If necessary, wrap the parameter in another class or struct and
+        /// override the <see cref="object.ToString()"/> method so any expensive formatting is deferred until after <paramref name="condition"/> is checked.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        /// <param name="messageFormat">A composite format string to use to build a failure message.
+        /// This message contains text intermixed with zero or more format items, which correspond to
+        /// the <paramref name="p0"/>, <paramref name="p1"/>, <paramref name="p2"/> or <paramref name="p3"/> parameters.</param>
+        /// <param name="p0">The parameter corresponding to the format item at index 0 (<c>{0}</c>).</param>
+        /// <param name="p1">The parameter corresponding to the format item at index 1 (<c>{1}</c>).</param>
+        /// <param name="p2">The parameter corresponding to the format item at index 2 (<c>{2}</c>).</param>
+        /// <param name="p3">The parameter corresponding to the format item at index 3 (<c>{3}</c>).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Assert<T0, T1, T2, T3>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3)
+        public static void Assert<T0, T1, T2, T3>(bool condition, string messageFormat, T0 p0, T1 p1, T2 p2, T3 p3)
         {
             if (AssertsEnabled && !condition)
-                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3));
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageFormat, p0, p1, p2, p3));
         }
 
         /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
-        /// from the specified <paramref name="messageToFormat"/>.
+        /// from the specified <paramref name="messageFormat"/>.
+        /// <para/>
+        /// IMPORTANT: The purpose of using this overload is to defer execution of building the string until it the <paramref name="condition"/> is <c>false</c>. Ideally, we would
+        /// use a <see cref="Func{String}"/> parameter, but doing so allocates extra RAM even when calls to the method are in an unreachable execution path. When passing
+        /// parameters, strive to pass value or reference types without doing any pre-processing or string formatting. If necessary, wrap the parameter in another class or struct and
+        /// override the <see cref="object.ToString()"/> method so any expensive formatting is deferred until after <paramref name="condition"/> is checked.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        /// <param name="messageFormat">A composite format string to use to build a failure message.
+        /// This message contains text intermixed with zero or more format items, which correspond to
+        /// the <paramref name="p0"/>, <paramref name="p1"/>, <paramref name="p2"/>, <paramref name="p3"/>
+        /// or <paramref name="p4"/> parameters.</param>
+        /// <param name="p0">The parameter corresponding to the format item at index 0 (<c>{0}</c>).</param>
+        /// <param name="p1">The parameter corresponding to the format item at index 1 (<c>{1}</c>).</param>
+        /// <param name="p2">The parameter corresponding to the format item at index 2 (<c>{2}</c>).</param>
+        /// <param name="p3">The parameter corresponding to the format item at index 3 (<c>{3}</c>).</param>
+        /// <param name="p4">The parameter corresponding to the format item at index 4 (<c>{4}</c>).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Assert<T0, T1, T2, T3, T4>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4)
+        public static void Assert<T0, T1, T2, T3, T4>(bool condition, string messageFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4)
         {
             if (AssertsEnabled && !condition)
-                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3, p4));
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageFormat, p0, p1, p2, p3, p4));
         }
 
         /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
-        /// from the specified <paramref name="messageToFormat"/>.
+        /// from the specified <paramref name="messageFormat"/>.
+        /// <para/>
+        /// IMPORTANT: The purpose of using this overload is to defer execution of building the string until it the <paramref name="condition"/> is <c>false</c>. Ideally, we would
+        /// use a <see cref="Func{String}"/> parameter, but doing so allocates extra RAM even when calls to the method are in an unreachable execution path. When passing
+        /// parameters, strive to pass value or reference types without doing any pre-processing or string formatting. If necessary, wrap the parameter in another class or struct and
+        /// override the <see cref="object.ToString()"/> method so any expensive formatting is deferred until after <paramref name="condition"/> is checked.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        /// <param name="messageFormat">A composite format string to use to build a failure message.
+        /// This message contains text intermixed with zero or more format items, which correspond to
+        /// the <paramref name="p0"/>, <paramref name="p1"/>, <paramref name="p2"/>, <paramref name="p3"/>,
+        /// <paramref name="p4"/> or <paramref name="p5"/> parameters.</param>
+        /// <param name="p0">The parameter corresponding to the format item at index 0 (<c>{0}</c>).</param>
+        /// <param name="p1">The parameter corresponding to the format item at index 1 (<c>{1}</c>).</param>
+        /// <param name="p2">The parameter corresponding to the format item at index 2 (<c>{2}</c>).</param>
+        /// <param name="p3">The parameter corresponding to the format item at index 3 (<c>{3}</c>).</param>
+        /// <param name="p4">The parameter corresponding to the format item at index 4 (<c>{4}</c>).</param>
+        /// <param name="p5">The parameter corresponding to the format item at index 5 (<c>{5}</c>).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Assert<T0, T1, T2, T3, T4, T5>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5)
+        public static void Assert<T0, T1, T2, T3, T4, T5>(bool condition, string messageFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5)
         {
             if (AssertsEnabled && !condition)
-                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3, p4, p5));
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageFormat, p0, p1, p2, p3, p4, p5));
         }
 
         /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
-        /// from the specified <paramref name="messageToFormat"/>.
+        /// from the specified <paramref name="messageFormat"/>.
+        /// <para/>
+        /// IMPORTANT: The purpose of using this overload is to defer execution of building the string until it the <paramref name="condition"/> is <c>false</c>. Ideally, we would
+        /// use a <see cref="Func{String}"/> parameter, but doing so allocates extra RAM even when calls to the method are in an unreachable execution path. When passing
+        /// parameters, strive to pass value or reference types without doing any pre-processing or string formatting. If necessary, wrap the parameter in another class or struct and
+        /// override the <see cref="object.ToString()"/> method so any expensive formatting is deferred until after <paramref name="condition"/> is checked.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        /// <param name="messageFormat">A composite format string to use to build a failure message.
+        /// This message contains text intermixed with zero or more format items, which correspond to
+        /// the <paramref name="p0"/>, <paramref name="p1"/>, <paramref name="p2"/>, <paramref name="p3"/>,
+        /// <paramref name="p4"/>, <paramref name="p5"/> or <paramref name="p6"/> parameters.</param>
+        /// <param name="p0">The parameter corresponding to the format item at index 0 (<c>{0}</c>).</param>
+        /// <param name="p1">The parameter corresponding to the format item at index 1 (<c>{1}</c>).</param>
+        /// <param name="p2">The parameter corresponding to the format item at index 2 (<c>{2}</c>).</param>
+        /// <param name="p3">The parameter corresponding to the format item at index 3 (<c>{3}</c>).</param>
+        /// <param name="p4">The parameter corresponding to the format item at index 4 (<c>{4}</c>).</param>
+        /// <param name="p5">The parameter corresponding to the format item at index 5 (<c>{5}</c>).</param>
+        /// <param name="p6">The parameter corresponding to the format item at index 6 (<c>{6}</c>).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Assert<T0, T1, T2, T3, T4, T5, T6>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6)
+        public static void Assert<T0, T1, T2, T3, T4, T5, T6>(bool condition, string messageFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6)
         {
             if (AssertsEnabled && !condition)
-                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3, p4, p5, p6));
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageFormat, p0, p1, p2, p3, p4, p5, p6));
         }
 
         /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
-        /// from the specified <paramref name="messageToFormat"/>.
+        /// from the specified <paramref name="messageFormat"/>.
+        /// <para/>
+        /// IMPORTANT: The purpose of using this overload is to defer execution of building the string until it the <paramref name="condition"/> is <c>false</c>. Ideally, we would
+        /// use a <see cref="Func{String}"/> parameter, but doing so allocates extra RAM even when calls to the method are in an unreachable execution path. When passing
+        /// parameters, strive to pass value or reference types without doing any pre-processing or string formatting. If necessary, wrap the parameter in another class or struct and
+        /// override the <see cref="object.ToString()"/> method so any expensive formatting is deferred until after <paramref name="condition"/> is checked.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        /// <param name="messageFormat">A composite format string to use to build a failure message.
+        /// This message contains text intermixed with zero or more format items, which correspond to
+        /// the <paramref name="p0"/>, <paramref name="p1"/>, <paramref name="p2"/>, <paramref name="p3"/>,
+        /// <paramref name="p4"/>, <paramref name="p5"/>, <paramref name="p6"/> or <paramref name="p7"/> parameters.</param>
+        /// <param name="p0">The parameter corresponding to the format item at index 0 (<c>{0}</c>).</param>
+        /// <param name="p1">The parameter corresponding to the format item at index 1 (<c>{1}</c>).</param>
+        /// <param name="p2">The parameter corresponding to the format item at index 2 (<c>{2}</c>).</param>
+        /// <param name="p3">The parameter corresponding to the format item at index 3 (<c>{3}</c>).</param>
+        /// <param name="p4">The parameter corresponding to the format item at index 4 (<c>{4}</c>).</param>
+        /// <param name="p5">The parameter corresponding to the format item at index 5 (<c>{5}</c>).</param>
+        /// <param name="p6">The parameter corresponding to the format item at index 6 (<c>{6}</c>).</param>
+        /// <param name="p7">The parameter corresponding to the format item at index 7 (<c>{7}</c>).</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Assert<T0, T1, T2, T3, T4, T5, T6, T7>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7)
+        public static void Assert<T0, T1, T2, T3, T4, T5, T6, T7>(bool condition, string messageFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7)
         {
             if (AssertsEnabled && !condition)
-                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3, p4, p5, p6, p7));
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageFormat, p0, p1, p2, p3, p4, p5, p6, p7));
         }
 
         /// <summary>
@@ -156,9 +271,11 @@ namespace Lucene.Net.Diagnostics
         /// <para/>
         /// IMPORTANT: If you need to use string concatenation when building the message, use an overload of
         /// <see cref="Assert{T0}(bool, string, T0)"/> for better performance.
+        /// <para/>
+        /// IMPORTANT: For best performance, only call this method after checking to ensure the value of <see cref="AssertsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="message">The message to use.</param>
+        /// <param name="message">The message to use to indicate a failure of <paramref name="condition"/>.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert(bool condition, string message)
         {

--- a/src/Lucene.Net/Support/Diagnostics/Debugging.cs
+++ b/src/Lucene.Net/Support/Diagnostics/Debugging.cs
@@ -1,5 +1,5 @@
+using J2N.Text;
 using Lucene.Net.Util;
-using System;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Diagnostics
@@ -56,7 +56,8 @@ namespace Lucene.Net.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert<T0>(bool condition, string messageToFormat, T0 p0)
         {
-            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0));
+            if (AssertsEnabled && !condition)
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0));
         }
 
         /// <summary>
@@ -68,7 +69,8 @@ namespace Lucene.Net.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert<T0, T1>(bool condition, string messageToFormat, T0 p0, T1 p1)
         {
-            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1));
+            if (AssertsEnabled && !condition)
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1));
         }
 
         /// <summary>
@@ -80,7 +82,8 @@ namespace Lucene.Net.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert<T0, T1, T2>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2)
         {
-            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2));
+            if (AssertsEnabled && !condition)
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2));
         }
 
         /// <summary>
@@ -92,7 +95,8 @@ namespace Lucene.Net.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert<T0, T1, T2, T3>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3)
         {
-            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3));
+            if (AssertsEnabled && !condition)
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3));
         }
 
         /// <summary>
@@ -104,7 +108,8 @@ namespace Lucene.Net.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert<T0, T1, T2, T3, T4>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4)
         {
-            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3, p4));
+            if (AssertsEnabled && !condition)
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3, p4));
         }
 
         /// <summary>
@@ -116,7 +121,8 @@ namespace Lucene.Net.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert<T0, T1, T2, T3, T4, T5>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5)
         {
-            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3, p4, p5));
+            if (AssertsEnabled && !condition)
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3, p4, p5));
         }
 
         /// <summary>
@@ -128,7 +134,8 @@ namespace Lucene.Net.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert<T0, T1, T2, T3, T4, T5, T6>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6)
         {
-            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3, p4, p5, p6));
+            if (AssertsEnabled && !condition)
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3, p4, p5, p6));
         }
 
         /// <summary>
@@ -140,13 +147,15 @@ namespace Lucene.Net.Diagnostics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Assert<T0, T1, T2, T3, T4, T5, T6, T7>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7)
         {
-            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3, p4, p5, p6, p7));
+            if (AssertsEnabled && !condition)
+                throw new AssertionException(string.Format(StringFormatter.InvariantCulture, messageToFormat, p0, p1, p2, p3, p4, p5, p6, p7));
         }
 
         /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the given message.
         /// <para/>
-        /// IMPORTANT: If you need to use string concatenation when building the message, use <see cref="Assert(bool, Func{string})"/> for better performance.
+        /// IMPORTANT: If you need to use string concatenation when building the message, use an overload of
+        /// <see cref="Assert{T0}(bool, string, T0)"/> for better performance.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
         /// <param name="message">The message to use.</param>

--- a/src/Lucene.Net/Support/Diagnostics/Debugging.cs
+++ b/src/Lucene.Net/Support/Diagnostics/Debugging.cs
@@ -96,6 +96,54 @@ namespace Lucene.Net.Diagnostics
         }
 
         /// <summary>
+        /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
+        /// from the specified <paramref name="messageToFormat"/>.
+        /// </summary>
+        /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
+        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Assert<T0, T1, T2, T3, T4>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4)
+        {
+            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3, p4));
+        }
+
+        /// <summary>
+        /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
+        /// from the specified <paramref name="messageToFormat"/>.
+        /// </summary>
+        /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
+        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Assert<T0, T1, T2, T3, T4, T5>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5)
+        {
+            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3, p4, p5));
+        }
+
+        /// <summary>
+        /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
+        /// from the specified <paramref name="messageToFormat"/>.
+        /// </summary>
+        /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
+        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Assert<T0, T1, T2, T3, T4, T5, T6>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6)
+        {
+            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3, p4, p5, p6));
+        }
+
+        /// <summary>
+        /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
+        /// from the specified <paramref name="messageToFormat"/>.
+        /// </summary>
+        /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
+        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Assert<T0, T1, T2, T3, T4, T5, T6, T7>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7)
+        {
+            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3, p4, p5, p6, p7));
+        }
+
+        /// <summary>
         /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the given message.
         /// <para/>
         /// IMPORTANT: If you need to use string concatenation when building the message, use <see cref="Assert(bool, Func{string})"/> for better performance.

--- a/src/Lucene.Net/Support/Diagnostics/Debugging.cs
+++ b/src/Lucene.Net/Support/Diagnostics/Debugging.cs
@@ -48,16 +48,51 @@ namespace Lucene.Net.Diagnostics
         }
 
         /// <summary>
-        /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message returned
-        /// from the specified <paramref name="messageFactory"/>.
+        /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
+        /// from the specified <paramref name="messageToFormat"/>.
         /// </summary>
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
-        /// <param name="messageFactory">A delegate to build the message to use.</param>
+        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Assert(bool condition, Func<string> messageFactory)
+        public static void Assert<T0>(bool condition, string messageToFormat, T0 p0)
         {
-            if (AssertsEnabled && !condition)
-                throw new AssertionException(messageFactory());
+            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0));
+        }
+
+        /// <summary>
+        /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
+        /// from the specified <paramref name="messageToFormat"/>.
+        /// </summary>
+        /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
+        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Assert<T0, T1>(bool condition, string messageToFormat, T0 p0, T1 p1)
+        {
+            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1));
+        }
+
+        /// <summary>
+        /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
+        /// from the specified <paramref name="messageToFormat"/>.
+        /// </summary>
+        /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
+        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Assert<T0, T1, T2>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2)
+        {
+            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2));
+        }
+
+        /// <summary>
+        /// Checks for a condition; if the <paramref name="condition"/> is <c>false</c>, throws an <see cref="AssertionException"/> with the message formated 
+        /// from the specified <paramref name="messageToFormat"/>.
+        /// </summary>
+        /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, no exception is thrown.</param>
+        /// <param name="messageToFormat">A string format (i.e. with {0} that will be filled with the parameters</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Assert<T0, T1, T2, T3>(bool condition, string messageToFormat, T0 p0, T1 p1, T2 p2, T3 p3)
+        {
+            if (AssertsEnabled && !condition) throw new AssertionException(string.Format(messageToFormat, p0, p1, p2, p3));
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/ArrayUtil.cs
+++ b/src/Lucene.Net/Util/ArrayUtil.cs
@@ -270,7 +270,7 @@ namespace Lucene.Net.Util
 
         public static short[] Grow(short[] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?", minSize);
             if (array.Length < minSize)
             {
                 short[] newArray = new short[Oversize(minSize, RamUsageEstimator.NUM_BYTES_INT16)];
@@ -290,7 +290,7 @@ namespace Lucene.Net.Util
 
         public static float[] Grow(float[] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got " + minSize + "): likely integer overflow?");
             if (array.Length < minSize)
             {
                 float[] newArray = new float[Oversize(minSize, RamUsageEstimator.NUM_BYTES_SINGLE)];
@@ -310,7 +310,7 @@ namespace Lucene.Net.Util
 
         public static double[] Grow(double[] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?", minSize);
             if (array.Length < minSize)
             {
                 double[] newArray = new double[Oversize(minSize, RamUsageEstimator.NUM_BYTES_DOUBLE)];
@@ -330,7 +330,7 @@ namespace Lucene.Net.Util
 
         public static short[] Shrink(short[] array, int targetSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, () => "size must be positive (got " + targetSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, "size must be positive (got {0}): likely integer overflow?", targetSize);
             int newSize = GetShrinkSize(array.Length, targetSize, RamUsageEstimator.NUM_BYTES_INT16);
             if (newSize != array.Length)
             {
@@ -346,7 +346,7 @@ namespace Lucene.Net.Util
 
         public static int[] Grow(int[] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?" , minSize);
             if (array.Length < minSize)
             {
                 int[] newArray = new int[Oversize(minSize, RamUsageEstimator.NUM_BYTES_INT32)];
@@ -366,7 +366,7 @@ namespace Lucene.Net.Util
 
         public static int[] Shrink(int[] array, int targetSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, () => "size must be positive (got " + targetSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, "size must be positive (got {0}): likely integer overflow?", targetSize);
             int newSize = GetShrinkSize(array.Length, targetSize, RamUsageEstimator.NUM_BYTES_INT32);
             if (newSize != array.Length)
             {
@@ -382,7 +382,7 @@ namespace Lucene.Net.Util
 
         public static long[] Grow(long[] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?", minSize);
             if (array.Length < minSize)
             {
                 long[] newArray = new long[Oversize(minSize, RamUsageEstimator.NUM_BYTES_INT64)];
@@ -402,7 +402,7 @@ namespace Lucene.Net.Util
 
         public static long[] Shrink(long[] array, int targetSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, () => "size must be positive (got " + targetSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, "size must be positive (got {0}): likely integer overflow?", targetSize);
             int newSize = GetShrinkSize(array.Length, targetSize, RamUsageEstimator.NUM_BYTES_INT64);
             if (newSize != array.Length)
             {
@@ -419,7 +419,7 @@ namespace Lucene.Net.Util
         [CLSCompliant(false)]
         public static sbyte[] Grow(sbyte[] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?", minSize);
             if (array.Length < minSize)
             {
                 var newArray = new sbyte[Oversize(minSize, 1)];
@@ -434,7 +434,7 @@ namespace Lucene.Net.Util
 
         public static byte[] Grow(byte[] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?", minSize);
             if (array.Length < minSize)
             {
                 byte[] newArray = new byte[Oversize(minSize, 1)];
@@ -454,7 +454,7 @@ namespace Lucene.Net.Util
 
         public static byte[] Shrink(byte[] array, int targetSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, () => "size must be positive (got " + targetSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, "size must be positive (got {0}): likely integer overflow?", targetSize);
             int newSize = GetShrinkSize(array.Length, targetSize, 1);
             if (newSize != array.Length)
             {
@@ -470,7 +470,7 @@ namespace Lucene.Net.Util
 
         public static bool[] Grow(bool[] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?", minSize);
             if (array.Length < minSize)
             {
                 bool[] newArray = new bool[Oversize(minSize, 1)];
@@ -490,7 +490,7 @@ namespace Lucene.Net.Util
 
         public static bool[] Shrink(bool[] array, int targetSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, () => "size must be positive (got " + targetSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, "size must be positive (got {0}): likely integer overflow?", targetSize);
             int newSize = GetShrinkSize(array.Length, targetSize, 1);
             if (newSize != array.Length)
             {
@@ -506,7 +506,7 @@ namespace Lucene.Net.Util
 
         public static char[] Grow(char[] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?", minSize);
             if (array.Length < minSize)
             {
                 char[] newArray = new char[Oversize(minSize, RamUsageEstimator.NUM_BYTES_CHAR)];
@@ -526,7 +526,7 @@ namespace Lucene.Net.Util
 
         public static char[] Shrink(char[] array, int targetSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, () => "size must be positive (got " + targetSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, "size must be positive (got {0}): likely integer overflow?", targetSize);
             int newSize = GetShrinkSize(array.Length, targetSize, RamUsageEstimator.NUM_BYTES_CHAR);
             if (newSize != array.Length)
             {
@@ -543,7 +543,7 @@ namespace Lucene.Net.Util
         [CLSCompliant(false)]
         public static int[][] Grow(int[][] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?", minSize);
             if (array.Length < minSize)
             {
                 var newArray = new int[Oversize(minSize, RamUsageEstimator.NUM_BYTES_OBJECT_REF)][];
@@ -565,7 +565,7 @@ namespace Lucene.Net.Util
         [CLSCompliant(false)]
         public static int[][] Shrink(int[][] array, int targetSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, () => "size must be positive (got " + targetSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, "size must be positive (got {0}): likely integer overflow?", targetSize);
             int newSize = GetShrinkSize(array.Length, targetSize, RamUsageEstimator.NUM_BYTES_OBJECT_REF);
             if (newSize != array.Length)
             {
@@ -582,7 +582,7 @@ namespace Lucene.Net.Util
         [CLSCompliant(false)]
         public static float[][] Grow(float[][] array, int minSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, () => "size must be positive (got " + minSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(minSize >= 0, "size must be positive (got {0}): likely integer overflow?", minSize);
             if (array.Length < minSize)
             {
                 float[][] newArray = new float[Oversize(minSize, RamUsageEstimator.NUM_BYTES_OBJECT_REF)][];
@@ -604,7 +604,7 @@ namespace Lucene.Net.Util
         [CLSCompliant(false)]
         public static float[][] Shrink(float[][] array, int targetSize)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, () => "size must be positive (got " + targetSize + "): likely integer overflow?");
+            if (Debugging.AssertsEnabled) Debugging.Assert(targetSize >= 0, "size must be positive (got {0}): likely integer overflow?", targetSize);
             int newSize = GetShrinkSize(array.Length, targetSize, RamUsageEstimator.NUM_BYTES_OBJECT_REF);
             if (newSize != array.Length)
             {

--- a/src/Lucene.Net/Util/Automaton/BasicOperations.cs
+++ b/src/Lucene.Net/Util/Automaton/BasicOperations.cs
@@ -868,7 +868,7 @@ namespace Lucene.Net.Util.Automaton
                         }
                         else
                         {
-                            if (Debugging.AssertsEnabled) Debugging.Assert((accCount > 0) == q.accept, () => "accCount=" + accCount + " vs existing accept=" + q.accept + " states=" + statesSet);
+                            if (Debugging.AssertsEnabled) Debugging.Assert((accCount > 0) == q.accept,"accCount={0} vs existing accept={1}", accCount, q.accept + " states=" + statesSet);
                         }
 
                         r.AddTransition(new Transition(lastPoint, point - 1, q));
@@ -902,7 +902,7 @@ namespace Lucene.Net.Util.Automaton
                     points.points[i].starts.count = 0;
                 }
                 points.Reset();
-                if (Debugging.AssertsEnabled) Debugging.Assert(statesSet.upto == 0, () => "upto=" + statesSet.upto);
+                if (Debugging.AssertsEnabled) Debugging.Assert(statesSet.upto == 0,"upto={0}", statesSet.upto);
             }
             a.deterministic = true;
             a.SetNumberedStates(newStatesArray, newStateUpto);

--- a/src/Lucene.Net/Util/Automaton/BasicOperations.cs
+++ b/src/Lucene.Net/Util/Automaton/BasicOperations.cs
@@ -868,7 +868,7 @@ namespace Lucene.Net.Util.Automaton
                         }
                         else
                         {
-                            if (Debugging.AssertsEnabled) Debugging.Assert((accCount > 0) == q.accept,"accCount={0} vs existing accept={1}", accCount, q.accept + " states=" + statesSet);
+                            if (Debugging.AssertsEnabled) Debugging.Assert((accCount > 0) == q.accept, "accCount={0} vs existing accept={1} states={2}", accCount, q.accept, statesSet);
                         }
 
                         r.AddTransition(new Transition(lastPoint, point - 1, q));

--- a/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
+++ b/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
@@ -131,7 +131,7 @@ namespace Lucene.Net.Util.Automaton
             /// </summary>
             internal State NewState(int label)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(Array.BinarySearch(labels, label) < 0, () => "State already has transition labeled: " + label);
+                if (Debugging.AssertsEnabled) Debugging.Assert(Array.BinarySearch(labels, label) < 0, "State already has transition labeled: {0}", label);
 
                 labels = Arrays.CopyOf(labels, labels.Length + 1);
                 states = Arrays.CopyOf(states, states.Length + 1);
@@ -230,7 +230,7 @@ namespace Lucene.Net.Util.Automaton
             if (Debugging.AssertsEnabled)
             {
                 Debugging.Assert(stateRegistry != null, "Automaton already built.");
-                Debugging.Assert(previous == null || comparer.Compare(previous, current) <= 0, () => "Input must be in sorted UTF-8 order: " + previous + " >= " + current);
+                Debugging.Assert(previous == null || comparer.Compare(previous, current) <= 0, "Input must be in sorted UTF-8 order: {0} >= {1}", previous, current);
                 Debugging.Assert(SetPrevious(current));
             }
 

--- a/src/Lucene.Net/Util/BroadWord.cs
+++ b/src/Lucene.Net/Util/BroadWord.cs
@@ -71,7 +71,7 @@ namespace Lucene.Net.Util
             long b = (long)((ulong)(((long)((ulong)SmallerUpTo7_8(s, (r * L8_L)) >> 7)) * L8_L) >> 53); // & (~7L); // Step 3, side ways addition for byte number times 8
 
             long l = r - (((long)((ulong)(s << 8) >> (int)b)) & 0xFFL); // Step 4, byte wise rank, subtract the rank with byte at b-8, or zero for b=0;
-            if (Debugging.AssertsEnabled) Debugging.Assert(0L <= 1, () => l.ToString(CultureInfo.InvariantCulture));
+            if (Debugging.AssertsEnabled) Debugging.Assert(0L <= 1, l.ToString(CultureInfo.InvariantCulture));
             //assert l < 8 : l; //fails when bit r is not available.
 
             // Select bit l from byte (x >>> b):

--- a/src/Lucene.Net/Util/BroadWord.cs
+++ b/src/Lucene.Net/Util/BroadWord.cs
@@ -71,7 +71,7 @@ namespace Lucene.Net.Util
             long b = (long)((ulong)(((long)((ulong)SmallerUpTo7_8(s, (r * L8_L)) >> 7)) * L8_L) >> 53); // & (~7L); // Step 3, side ways addition for byte number times 8
 
             long l = r - (((long)((ulong)(s << 8) >> (int)b)) & 0xFFL); // Step 4, byte wise rank, subtract the rank with byte at b-8, or zero for b=0;
-            if (Debugging.AssertsEnabled) Debugging.Assert(0L <= 1, l.ToString(CultureInfo.InvariantCulture));
+            if (Debugging.AssertsEnabled) Debugging.Assert(0L <= 1, "{0}", l);
             //assert l < 8 : l; //fails when bit r is not available.
 
             // Select bit l from byte (x >>> b):

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -484,4 +484,53 @@ namespace Lucene.Net.Util
             return a.Length - b.Length;
         }
     }
+
+    // LUCENENET specific
+    internal enum BytesRefFormat // For assert/test/logging
+    {
+        UTF8,
+        UTF8AsHex
+    }
+
+    // LUCENENET specific - when this object is a parameter of 
+    // a method that calls string.Format(),
+    // defers execution of building a string until
+    // string.Format() is called.
+    // This struct is meant to wrap a directory parameter when passed as a string.Format() argument.
+    internal struct BytesRefFormatter // For assert/test/logging
+    {
+#pragma warning disable IDE0044 // Add readonly modifier
+        private BytesRef bytesRef;
+        private BytesRefFormat format;
+#pragma warning restore IDE0044 // Add readonly modifier
+        public BytesRefFormatter(BytesRef bytesRef, BytesRefFormat format)
+        {
+            this.bytesRef = bytesRef; // Allow null
+            this.format = format;
+        }
+
+        public override string ToString()
+        {
+            // Special case: null
+            if (bytesRef is null)
+                return "null";
+
+            switch (format)
+            {
+                case BytesRefFormat.UTF8:
+                    try
+                    {
+                        return bytesRef.Utf8ToString();
+                    }
+                    catch (IndexOutOfRangeException)
+                    {
+                        return bytesRef.ToString();
+                    }
+                case BytesRefFormat.UTF8AsHex:
+                    return UnicodeUtil.ToHexString(bytesRef.Utf8ToString());
+                default:
+                    return bytesRef.ToString();
+            }
+        }
+    }
 }

--- a/src/Lucene.Net/Util/BytesRefHash.cs
+++ b/src/Lucene.Net/Util/BytesRefHash.cs
@@ -552,7 +552,7 @@ namespace Lucene.Net.Util
             if (Debugging.AssertsEnabled)
             {
                 Debugging.Assert(bytesStart != null, "bytesStart is null - not initialized");
-                Debugging.Assert(bytesID >= 0 && bytesID < count, bytesID.ToString());
+                Debugging.Assert(bytesID >= 0 && bytesID < count, "{0}", bytesID);
             }
             return bytesStart[bytesID];
         }

--- a/src/Lucene.Net/Util/BytesRefHash.cs
+++ b/src/Lucene.Net/Util/BytesRefHash.cs
@@ -124,7 +124,7 @@ namespace Lucene.Net.Util
             if (Debugging.AssertsEnabled)
             {
                 Debugging.Assert(bytesStart != null, "bytesStart is null - not initialized");
-                Debugging.Assert(bytesID < bytesStart.Length, () => "bytesID exceeds byteStart len: " + bytesStart.Length);
+                Debugging.Assert(bytesID < bytesStart.Length,"bytesID exceeds byteStart len: {0}", bytesStart.Length);
             }
             pool.SetBytesRef(@ref, bytesStart[bytesID]);
             return @ref;
@@ -327,7 +327,7 @@ namespace Lucene.Net.Util
                 if (count >= bytesStart.Length)
                 {
                     bytesStart = bytesStartArray.Grow();
-                    if (Debugging.AssertsEnabled) Debugging.Assert(count < bytesStart.Length + 1, () => "count: " + count + " len: " + bytesStart.Length);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(count < bytesStart.Length + 1,"count: {0} len: {1}", count, bytesStart.Length);
                 }
                 e = count++;
 
@@ -342,7 +342,7 @@ namespace Lucene.Net.Util
                     // 1 byte to store length
                     buffer[bufferUpto] = (byte)length;
                     pool.ByteUpto += length + 1;
-                    if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0, () => "Length must be positive: " + length);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0,"Length must be positive: {0}", length);
                     System.Buffer.BlockCopy(bytes.Bytes, bytes.Offset, buffer, bufferUpto + 1, length);
                 }
                 else
@@ -434,7 +434,7 @@ namespace Lucene.Net.Util
                 if (count >= bytesStart.Length)
                 {
                     bytesStart = bytesStartArray.Grow();
-                    if (Debugging.AssertsEnabled) Debugging.Assert(count < bytesStart.Length + 1, () => "count: " + count + " len: " + bytesStart.Length);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(count < bytesStart.Length + 1,"count: {0} len: {1}", count, bytesStart.Length);
                 }
                 e = count++;
                 bytesStart[e] = offset;
@@ -552,7 +552,7 @@ namespace Lucene.Net.Util
             if (Debugging.AssertsEnabled)
             {
                 Debugging.Assert(bytesStart != null, "bytesStart is null - not initialized");
-                Debugging.Assert(bytesID >= 0 && bytesID < count, () => bytesID.ToString());
+                Debugging.Assert(bytesID >= 0 && bytesID < count, bytesID.ToString());
             }
             return bytesStart[bytesID];
         }

--- a/src/Lucene.Net/Util/FixedBitSet.cs
+++ b/src/Lucene.Net/Util/FixedBitSet.cs
@@ -259,7 +259,7 @@ namespace Lucene.Net.Util
 
         public bool Get(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, () => "index=" + index + ", numBits=" + numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
             int i = index >> 6; // div 64
             // signed shift will keep a negative index and force an
             // array-index-out-of-bounds-exception, removing the need for an explicit check.
@@ -270,7 +270,7 @@ namespace Lucene.Net.Util
 
         public void Set(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, () => "index=" + index + ", numBits=" + numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}"); 
             int wordNum = index >> 6; // div 64
             int bit = index & 0x3f; // mod 64
             long bitmask = 1L << bit;
@@ -279,7 +279,7 @@ namespace Lucene.Net.Util
 
         public bool GetAndSet(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
             int wordNum = index >> 6; // div 64
             int bit = index & 0x3f; // mod 64
             long bitmask = 1L << bit;
@@ -290,7 +290,7 @@ namespace Lucene.Net.Util
 
         public void Clear(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
             int wordNum = index >> 6;
             int bit = index & 0x03f;
             long bitmask = 1L << bit;
@@ -299,7 +299,7 @@ namespace Lucene.Net.Util
 
         public bool GetAndClear(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
             int wordNum = index >> 6; // div 64
             int bit = index & 0x3f; // mod 64
             long bitmask = 1L << bit;
@@ -314,7 +314,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public int NextSetBit(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, () => "index=" + index + ", numBits=" + numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
             int i = index >> 6;
             int subIndex = index & 0x3f; // index within the word
             long word = bits[i] >> subIndex; // skip all the bits to the right of index
@@ -342,7 +342,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public int PrevSetBit(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, () => "index=" + index + " numBits=" + numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index} numBits={numBits}");
             int i = index >> 6;
             int subIndex = index & 0x3f; // index within the word
             long word = (bits[i] << (63 - subIndex)); // skip all the bits to the left of index
@@ -405,7 +405,7 @@ namespace Lucene.Net.Util
 
         private void Or(long[] otherArr, int otherNumWords)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(otherNumWords <= numWords, () => "numWords=" + numWords + ", otherNumWords=" + otherNumWords);
+            if (Debugging.AssertsEnabled) Debugging.Assert(otherNumWords <= numWords, $"numWords={numWords}, otherNumWords={otherNumWords}");
             long[] thisArr = this.bits;
             int pos = Math.Min(numWords, otherNumWords);
             while (--pos >= 0)
@@ -418,7 +418,7 @@ namespace Lucene.Net.Util
         /// this = this XOR other </summary>
         public void Xor(FixedBitSet other)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords, () => "numWords=" + numWords + ", other.numWords=" + other.numWords);
+            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords, $"numWords={numWords}, other.numWords={other.numWords}");
             long[] thisBits = this.bits;
             long[] otherBits = other.bits;
             int pos = Math.Min(numWords, other.numWords);
@@ -663,8 +663,8 @@ namespace Lucene.Net.Util
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(startIndex >= 0 && startIndex < numBits, () => "startIndex=" + startIndex + ", numBits=" + numBits);
-                Debugging.Assert(endIndex >= 0 && endIndex <= numBits, () => "endIndex=" + endIndex + ", numBits=" + numBits);
+                Debugging.Assert(startIndex >= 0 && startIndex < numBits, $"startIndex={startIndex}, numBits={numBits}");
+                Debugging.Assert(endIndex >= 0 && endIndex <= numBits, $"endIndex={endIndex}, numBits={numBits}");
             }
             if (endIndex <= startIndex)
             {

--- a/src/Lucene.Net/Util/FixedBitSet.cs
+++ b/src/Lucene.Net/Util/FixedBitSet.cs
@@ -259,7 +259,7 @@ namespace Lucene.Net.Util
 
         public bool Get(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0}, numBits={1}", index, numBits);
             int i = index >> 6; // div 64
             // signed shift will keep a negative index and force an
             // array-index-out-of-bounds-exception, removing the need for an explicit check.
@@ -270,7 +270,7 @@ namespace Lucene.Net.Util
 
         public void Set(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}"); 
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0}, numBits={1}", index, numBits);
             int wordNum = index >> 6; // div 64
             int bit = index & 0x3f; // mod 64
             long bitmask = 1L << bit;
@@ -279,7 +279,7 @@ namespace Lucene.Net.Util
 
         public bool GetAndSet(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0}, numBits={1}", index, numBits);
             int wordNum = index >> 6; // div 64
             int bit = index & 0x3f; // mod 64
             long bitmask = 1L << bit;
@@ -290,7 +290,7 @@ namespace Lucene.Net.Util
 
         public void Clear(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0}, numBits={1}", index, numBits);
             int wordNum = index >> 6;
             int bit = index & 0x03f;
             long bitmask = 1L << bit;
@@ -299,7 +299,7 @@ namespace Lucene.Net.Util
 
         public bool GetAndClear(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0}, numBits={1}", index, numBits);
             int wordNum = index >> 6; // div 64
             int bit = index & 0x3f; // mod 64
             long bitmask = 1L << bit;
@@ -314,7 +314,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public int NextSetBit(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index}, numBits={numBits}");
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0}, numBits={1}", index, numBits);
             int i = index >> 6;
             int subIndex = index & 0x3f; // index within the word
             long word = bits[i] >> subIndex; // skip all the bits to the right of index
@@ -342,7 +342,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public int PrevSetBit(int index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, $"index={index} numBits={numBits}");
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0}, numBits={1}", index, numBits);
             int i = index >> 6;
             int subIndex = index & 0x3f; // index within the word
             long word = (bits[i] << (63 - subIndex)); // skip all the bits to the left of index
@@ -405,7 +405,7 @@ namespace Lucene.Net.Util
 
         private void Or(long[] otherArr, int otherNumWords)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(otherNumWords <= numWords, $"numWords={numWords}, otherNumWords={otherNumWords}");
+            if (Debugging.AssertsEnabled) Debugging.Assert(otherNumWords <= numWords, "numWords={0}, otherNumWords={1}", numWords, otherNumWords);
             long[] thisArr = this.bits;
             int pos = Math.Min(numWords, otherNumWords);
             while (--pos >= 0)
@@ -418,7 +418,7 @@ namespace Lucene.Net.Util
         /// this = this XOR other </summary>
         public void Xor(FixedBitSet other)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords, $"numWords={numWords}, other.numWords={other.numWords}");
+            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords, "numWords={0}, other.numWords={1}", numWords, other.numWords);
             long[] thisBits = this.bits;
             long[] otherBits = other.bits;
             int pos = Math.Min(numWords, other.numWords);
@@ -663,8 +663,8 @@ namespace Lucene.Net.Util
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(startIndex >= 0 && startIndex < numBits, $"startIndex={startIndex}, numBits={numBits}");
-                Debugging.Assert(endIndex >= 0 && endIndex <= numBits, $"endIndex={endIndex}, numBits={numBits}");
+                Debugging.Assert(startIndex >= 0 && startIndex < numBits, "startIndex={0}, numBits={1}", startIndex, numBits);
+                Debugging.Assert(endIndex >= 0 && endIndex <= numBits, "endIndex={0}, numBits={1}", endIndex, numBits);
             }
             if (endIndex <= startIndex)
             {

--- a/src/Lucene.Net/Util/Fst/Builder.cs
+++ b/src/Lucene.Net/Util/Fst/Builder.cs
@@ -372,7 +372,7 @@ namespace Lucene.Net.Util.Fst
 
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(lastInput.Length == 0 || input.CompareTo(lastInput) >= 0,"inputs are added out of order lastInput={0} vs input={1}", lastInput, input);
+                Debugging.Assert(lastInput.Length == 0 || input.CompareTo(lastInput) >= 0, "inputs are added out of order lastInput={0} vs input={1}", lastInput, input);
                 Debugging.Assert(ValidOutput(output));
             }
 
@@ -673,7 +673,7 @@ namespace Lucene.Net.Util.Fst
                 if (Debugging.AssertsEnabled) Debugging.Assert(label >= 0);
                 if (NumArcs != 0)
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(label > Arcs[NumArcs - 1].Label,"arc[-1].Label={0} new label={1}", Arcs[NumArcs - 1].Label, label + " numArcs=" + NumArcs);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(label > Arcs[NumArcs - 1].Label, "arc[-1].Label={0} new label={1} numArcs={2}", Arcs[NumArcs - 1].Label, label, NumArcs);
                 }
                 if (NumArcs == Arcs.Length)
                 {

--- a/src/Lucene.Net/Util/Fst/Builder.cs
+++ b/src/Lucene.Net/Util/Fst/Builder.cs
@@ -372,7 +372,7 @@ namespace Lucene.Net.Util.Fst
 
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(lastInput.Length == 0 || input.CompareTo(lastInput) >= 0, () => "inputs are added out of order lastInput=" + lastInput + " vs input=" + input);
+                Debugging.Assert(lastInput.Length == 0 || input.CompareTo(lastInput) >= 0,"inputs are added out of order lastInput={0} vs input={1}", lastInput, input);
                 Debugging.Assert(ValidOutput(output));
             }
 
@@ -673,7 +673,7 @@ namespace Lucene.Net.Util.Fst
                 if (Debugging.AssertsEnabled) Debugging.Assert(label >= 0);
                 if (NumArcs != 0)
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(label > Arcs[NumArcs - 1].Label, () => "arc[-1].Label=" + Arcs[NumArcs - 1].Label + " new label=" + label + " numArcs=" + NumArcs);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(label > Arcs[NumArcs - 1].Label,"arc[-1].Label={0} new label={1}", Arcs[NumArcs - 1].Label, label + " numArcs=" + NumArcs);
                 }
                 if (NumArcs == Arcs.Length)
                 {
@@ -696,7 +696,7 @@ namespace Lucene.Net.Util.Fst
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(NumArcs > 0);
                 Arc<S> arc = Arcs[NumArcs - 1];
-                if (Debugging.AssertsEnabled) Debugging.Assert(arc.Label == labelToMatch, () => "arc.Label=" + arc.Label + " vs " + labelToMatch);
+                if (Debugging.AssertsEnabled) Debugging.Assert(arc.Label == labelToMatch,"arc.Label={0} vs {1}", arc.Label, labelToMatch);
                 arc.Target = target;
                 //assert target.Node != -2;
                 arc.NextFinalOutput = nextFinalOutput;

--- a/src/Lucene.Net/Util/Fst/ByteSequenceOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/ByteSequenceOutputs.cs
@@ -103,7 +103,7 @@ namespace Lucene.Net.Util.Fst
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(inc.Length < output.Length, () => "inc.length=" + inc.Length + " vs output.length=" + output.Length);
+                    Debugging.Assert(inc.Length < output.Length,"inc.length={0} vs output.length={1}", inc.Length, output.Length);
                     Debugging.Assert(inc.Length > 0);
                 }
                 return new BytesRef(output.Bytes, output.Offset + inc.Length, output.Length - inc.Length);

--- a/src/Lucene.Net/Util/Fst/ByteSequenceOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/ByteSequenceOutputs.cs
@@ -103,7 +103,7 @@ namespace Lucene.Net.Util.Fst
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(inc.Length < output.Length,"inc.length={0} vs output.length={1}", inc.Length, output.Length);
+                    Debugging.Assert(inc.Length < output.Length, "inc.length={0} vs output.length={1}", inc.Length, output.Length);
                     Debugging.Assert(inc.Length > 0);
                 }
                 return new BytesRef(output.Bytes, output.Offset + inc.Length, output.Length - inc.Length);

--- a/src/Lucene.Net/Util/Fst/BytesStore.cs
+++ b/src/Lucene.Net/Util/Fst/BytesStore.cs
@@ -131,7 +131,7 @@ namespace Lucene.Net.Util.Fst
         internal virtual void WriteBytes(long dest, byte[] b, int offset, int len)
         {
             //System.out.println("  BS.writeBytes dest=" + dest + " offset=" + offset + " len=" + len);
-            if (Debugging.AssertsEnabled) Debugging.Assert(dest + len <= Position, () => "dest=" + dest + " pos=" + Position + " len=" + len);
+            if (Debugging.AssertsEnabled) Debugging.Assert(dest + len <= Position,"dest={0} pos={1}", dest, Position + " len=" + len);
 
             // Note: weird: must go "backwards" because copyBytes
             // calls us with overlapping src/dest.  If we
@@ -475,7 +475,7 @@ namespace Lucene.Net.Util.Fst
                     nextBuffer = bufferIndex + 1;
                     current = outerInstance.blocks[bufferIndex];
                     nextRead = (int)(value & outerInstance.blockMask);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(this.Position == value, () => "pos=" + value + " Position=" + this.Position);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(this.Position == value,"pos={0} Position={1}", value, this.Position);
                 }
             }
 
@@ -548,7 +548,7 @@ namespace Lucene.Net.Util.Fst
                     nextBuffer = bufferIndex - 1;
                     current = outerInstance.blocks[bufferIndex];
                     nextRead = (int)(value & outerInstance.blockMask);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(this.Position == value, () => "value=" + value + " this.Position=" + this.Position);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(this.Position == value,"value={0} this.Position={1}", value, this.Position);
                 }
             }
 

--- a/src/Lucene.Net/Util/Fst/BytesStore.cs
+++ b/src/Lucene.Net/Util/Fst/BytesStore.cs
@@ -131,7 +131,7 @@ namespace Lucene.Net.Util.Fst
         internal virtual void WriteBytes(long dest, byte[] b, int offset, int len)
         {
             //System.out.println("  BS.writeBytes dest=" + dest + " offset=" + offset + " len=" + len);
-            if (Debugging.AssertsEnabled) Debugging.Assert(dest + len <= Position,"dest={0} pos={1}", dest, Position + " len=" + len);
+            if (Debugging.AssertsEnabled) Debugging.Assert(dest + len <= Position, "dest={0} pos={1} len={2}", dest, Position, len);
 
             // Note: weird: must go "backwards" because copyBytes
             // calls us with overlapping src/dest.  If we
@@ -475,7 +475,7 @@ namespace Lucene.Net.Util.Fst
                     nextBuffer = bufferIndex + 1;
                     current = outerInstance.blocks[bufferIndex];
                     nextRead = (int)(value & outerInstance.blockMask);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(this.Position == value,"pos={0} Position={1}", value, this.Position);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(this.Position == value,"value={0} Position={1}", value, this.Position);
                 }
             }
 

--- a/src/Lucene.Net/Util/Fst/CharSequenceOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/CharSequenceOutputs.cs
@@ -103,7 +103,7 @@ namespace Lucene.Net.Util.Fst
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(inc.Length < output.Length, () => "inc.Length=" + inc.Length + " vs output.Length=" + output.Length);
+                    Debugging.Assert(inc.Length < output.Length,"inc.Length={0} vs output.Length={1}", inc.Length, output.Length);
                     Debugging.Assert(inc.Length > 0);
                 }
                 return new CharsRef(output.Chars, output.Offset + inc.Length, output.Length - inc.Length);

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -807,7 +807,7 @@ namespace Lucene.Net.Util.Fst
                         if (srcPos != destPos)
                         {
                             //System.out.println("  copy len=" + bytesPerArc[arcIdx]);
-                            if (Debugging.AssertsEnabled) Debugging.Assert(destPos > srcPos,"destPos={0} srcPos={1}", destPos, srcPos + " arcIdx=" + arcIdx + " maxBytesPerArc=" + maxBytesPerArc + " bytesPerArc[arcIdx]=" + bytesPerArc[arcIdx] + " nodeIn.numArcs=" + nodeIn.NumArcs);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(destPos > srcPos, "destPos={0} srcPos={1} arcIdx={2} maxBytesPerArc={3} bytesPerArc[arcIdx]={4} nodeIn.numArcs={5}", destPos, srcPos, arcIdx, maxBytesPerArc, bytesPerArc[arcIdx], nodeIn.NumArcs);
                             bytes.CopyBytes(srcPos, destPos, bytesPerArc[arcIdx]);
                         }
                     }

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -584,15 +584,15 @@ namespace Lucene.Net.Util.Fst
         // LUCENENET NOTE: static Read<T>() was moved into the FST class
         private void WriteLabel(DataOutput @out, int v)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(v >= 0, () => "v=" + v);
+            if (Debugging.AssertsEnabled) Debugging.Assert(v >= 0,"v={0}", v);
             if (inputType == FST.INPUT_TYPE.BYTE1)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(v <= 255, () => "v=" + v);
+                if (Debugging.AssertsEnabled) Debugging.Assert(v <= 255,"v={0}", v);
                 @out.WriteByte((byte)(sbyte)v);
             }
             else if (inputType == FST.INPUT_TYPE.BYTE2)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(v <= 65535, () => "v=" + v);
+                if (Debugging.AssertsEnabled) Debugging.Assert(v <= 65535,"v={0}", v);
                 @out.WriteInt16((short)v);
             }
             else
@@ -807,7 +807,7 @@ namespace Lucene.Net.Util.Fst
                         if (srcPos != destPos)
                         {
                             //System.out.println("  copy len=" + bytesPerArc[arcIdx]);
-                            if (Debugging.AssertsEnabled) Debugging.Assert(destPos > srcPos, () => "destPos=" + destPos + " srcPos=" + srcPos + " arcIdx=" + arcIdx + " maxBytesPerArc=" + maxBytesPerArc + " bytesPerArc[arcIdx]=" + bytesPerArc[arcIdx] + " nodeIn.numArcs=" + nodeIn.NumArcs);
+                            if (Debugging.AssertsEnabled) Debugging.Assert(destPos > srcPos,"destPos={0} srcPos={1}", destPos, srcPos + " arcIdx=" + arcIdx + " maxBytesPerArc=" + maxBytesPerArc + " bytesPerArc[arcIdx]=" + bytesPerArc[arcIdx] + " nodeIn.numArcs=" + nodeIn.NumArcs);
                             bytes.CopyBytes(srcPos, destPos, bytesPerArc[arcIdx]);
                         }
                     }
@@ -2025,9 +2025,9 @@ namespace Lucene.Net.Util.Fst
 
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(fst.nodeCount == nodeCount, () => "fst.nodeCount=" + fst.nodeCount + " nodeCount=" + nodeCount);
+                Debugging.Assert(fst.nodeCount == nodeCount,"fst.nodeCount={0} nodeCount={1}", fst.nodeCount, nodeCount);
                 Debugging.Assert(fst.arcCount == arcCount);
-                Debugging.Assert(fst.arcWithOutputCount == arcWithOutputCount, () => "fst.arcWithOutputCount=" + fst.arcWithOutputCount + " arcWithOutputCount=" + arcWithOutputCount);
+                Debugging.Assert(fst.arcWithOutputCount == arcWithOutputCount,"fst.arcWithOutputCount={0} arcWithOutputCount={1}", fst.arcWithOutputCount, arcWithOutputCount);
             }
 
             fst.bytes.Finish();

--- a/src/Lucene.Net/Util/Fst/FSTEnum.cs
+++ b/src/Lucene.Net/Util/Fst/FSTEnum.cs
@@ -202,7 +202,7 @@ namespace Lucene.Net.Util.Fst
                         if (Debugging.AssertsEnabled)
                         {
                             Debugging.Assert(arc.ArcIdx == mid);
-                            Debugging.Assert(arc.Label == targetLabel,"arc.label={0} vs targetLabel={1}", arc.Label, targetLabel + " mid=" + mid);
+                            Debugging.Assert(arc.Label == targetLabel, "arc.label={0} vs targetLabel={1} mid={2}", arc.Label, targetLabel, mid);
                         }
                         m_output[m_upto] = m_fst.Outputs.Add(m_output[m_upto - 1], arc.Output);
                         if (targetLabel == FST.END_LABEL)
@@ -376,7 +376,7 @@ namespace Lucene.Net.Util.Fst
                         if (Debugging.AssertsEnabled)
                         {
                             Debugging.Assert(arc.ArcIdx == mid);
-                            Debugging.Assert(arc.Label == targetLabel,"arc.label={0} vs targetLabel={1}", arc.Label, targetLabel + " mid=" + mid);
+                            Debugging.Assert(arc.Label == targetLabel, "arc.label={0} vs targetLabel={1} mid={2}", arc.Label, targetLabel, mid);
                         }
                         m_output[m_upto] = m_fst.Outputs.Add(m_output[m_upto - 1], arc.Output);
                         if (targetLabel == FST.END_LABEL)

--- a/src/Lucene.Net/Util/Fst/FSTEnum.cs
+++ b/src/Lucene.Net/Util/Fst/FSTEnum.cs
@@ -202,7 +202,7 @@ namespace Lucene.Net.Util.Fst
                         if (Debugging.AssertsEnabled)
                         {
                             Debugging.Assert(arc.ArcIdx == mid);
-                            Debugging.Assert(arc.Label == targetLabel, () => "arc.label=" + arc.Label + " vs targetLabel=" + targetLabel + " mid=" + mid);
+                            Debugging.Assert(arc.Label == targetLabel,"arc.label={0} vs targetLabel={1}", arc.Label, targetLabel + " mid=" + mid);
                         }
                         m_output[m_upto] = m_fst.Outputs.Add(m_output[m_upto - 1], arc.Output);
                         if (targetLabel == FST.END_LABEL)
@@ -376,7 +376,7 @@ namespace Lucene.Net.Util.Fst
                         if (Debugging.AssertsEnabled)
                         {
                             Debugging.Assert(arc.ArcIdx == mid);
-                            Debugging.Assert(arc.Label == targetLabel, () => "arc.label=" + arc.Label + " vs targetLabel=" + targetLabel + " mid=" + mid);
+                            Debugging.Assert(arc.Label == targetLabel,"arc.label={0} vs targetLabel={1}", arc.Label, targetLabel + " mid=" + mid);
                         }
                         m_output[m_upto] = m_fst.Outputs.Add(m_output[m_upto - 1], arc.Output);
                         if (targetLabel == FST.END_LABEL)
@@ -435,7 +435,7 @@ namespace Lucene.Net.Util.Fst
                         if (Debugging.AssertsEnabled)
                         {
                             Debugging.Assert(check);
-                            Debugging.Assert(arc.Label < targetLabel, () => "arc.label=" + arc.Label + " vs targetLabel=" + targetLabel);
+                            Debugging.Assert(arc.Label < targetLabel,"arc.label={0} vs targetLabel={1}", arc.Label, targetLabel);
                         }
                         PushLast();
                         return;

--- a/src/Lucene.Net/Util/Fst/IntSequenceOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/IntSequenceOutputs.cs
@@ -105,7 +105,7 @@ namespace Lucene.Net.Util.Fst
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(inc.Length < output.Length, () => "inc.length=" + inc.Length + " vs output.length=" + output.Length);
+                    Debugging.Assert(inc.Length < output.Length,"inc.length={0} vs output.length={1}", inc.Length, output.Length);
                     Debugging.Assert(inc.Length > 0);
                 }
                 return new Int32sRef(output.Int32s, output.Offset + inc.Length, output.Length - inc.Length);

--- a/src/Lucene.Net/Util/Fst/NoOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/NoOutputs.cs
@@ -86,7 +86,7 @@ namespace Lucene.Net.Util.Fst
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(prefix == NO_OUTPUT, () => "got " + prefix);
+                Debugging.Assert(prefix == NO_OUTPUT,"got {0}", prefix);
                 Debugging.Assert(output == NO_OUTPUT);
             }
             return NO_OUTPUT;

--- a/src/Lucene.Net/Util/Fst/NoOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/NoOutputs.cs
@@ -86,7 +86,7 @@ namespace Lucene.Net.Util.Fst
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(prefix == NO_OUTPUT,"got {0}", prefix);
+                Debugging.Assert(prefix == NO_OUTPUT, "got {0}", prefix);
                 Debugging.Assert(output == NO_OUTPUT);
             }
             return NO_OUTPUT;

--- a/src/Lucene.Net/Util/Fst/NodeHash.cs
+++ b/src/Lucene.Net/Util/Fst/NodeHash.cs
@@ -162,7 +162,12 @@ namespace Lucene.Net.Util.Fst
                     // freeze & add
                     long node = fst.AddNode(nodeIn);
                     //System.out.println("  now freeze node=" + node);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(Hash(node) == h,"frozenHash={0} vs h={1}", Hash(node), h);
+                    if (Debugging.AssertsEnabled)
+                    {
+                        // LUCENENET specific - store hash value and reuse it, since it might be expensive to create
+                        long hash = Hash(node);
+                        Debugging.Assert(hash == h, "frozenHash={0} vs h={1}", hash, h);
+                    }
                     count++;
                     table.Set(pos, node);
                     // Rehash at 2/3 occupancy:

--- a/src/Lucene.Net/Util/Fst/NodeHash.cs
+++ b/src/Lucene.Net/Util/Fst/NodeHash.cs
@@ -162,7 +162,7 @@ namespace Lucene.Net.Util.Fst
                     // freeze & add
                     long node = fst.AddNode(nodeIn);
                     //System.out.println("  now freeze node=" + node);
-                    if (Debugging.AssertsEnabled) Debugging.Assert(Hash(node) == h, () => "frozenHash=" + Hash(node) + " vs h=" + h);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(Hash(node) == h,"frozenHash={0} vs h={1}", Hash(node), h);
                     count++;
                     table.Set(pos, node);
                     // Rehash at 2/3 occupancy:

--- a/src/Lucene.Net/Util/Fst/PositiveIntOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/PositiveIntOutputs.cs
@@ -130,8 +130,8 @@ namespace Lucene.Net.Util.Fst
 
         private bool Valid(long? o)
         {
-            Debugging.Assert(o != null, () => "PositiveIntOutput precondition fail");
-            Debugging.Assert(o == NO_OUTPUT || o > 0, () => "o=" + o);
+            Debugging.Assert(o != null, "PositiveIntOutput precondition fail");
+            Debugging.Assert(o == NO_OUTPUT || o > 0,"o={0}", o);
             return true;
         }
 

--- a/src/Lucene.Net/Util/Fst/Util.cs
+++ b/src/Lucene.Net/Util/Fst/Util.cs
@@ -1068,7 +1068,7 @@ namespace Lucene.Net.Util.Fst
             {
                 int value = input.Int32s[i + input.Offset];
                 // NOTE: we allow -128 to 255
-                if (Debugging.AssertsEnabled) Debugging.Assert(value >= sbyte.MinValue && value <= 255, () => "value " + value + " doesn't fit into byte");
+                if (Debugging.AssertsEnabled) Debugging.Assert(value >= sbyte.MinValue && value <= 255, "value {0} doesn't fit into byte", value);
                 scratch.Bytes[i] = (byte)value;
             }
             scratch.Length = input.Length;

--- a/src/Lucene.Net/Util/LongBitSet.cs
+++ b/src/Lucene.Net/Util/LongBitSet.cs
@@ -122,7 +122,7 @@ namespace Lucene.Net.Util
 
         public bool Get(long index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits,"index={0}", index);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0}", index);
             int i = (int)(index >> 6); // div 64
             // signed shift will keep a negative index and force an
             // array-index-out-of-bounds-exception, removing the need for an explicit check.
@@ -133,7 +133,7 @@ namespace Lucene.Net.Util
 
         public void Set(long index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits,"index={0} numBits={1}", index, numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0} numBits={1}", index, numBits);
             int wordNum = (int)(index >> 6); // div 64
             int bit = (int)(index & 0x3f); // mod 64
             long bitmask = 1L << bit;
@@ -205,7 +205,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public long PrevSetBit(long index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits,"index={0} numBits={1}", index, numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, "index={0} numBits={1}", index, numBits);
             int i = (int)(index >> 6);
             int subIndex = (int)(index & 0x3f); // index within the word
             long word = (bits[i] << (63 - subIndex)); // skip all the bits to the left of index
@@ -231,7 +231,7 @@ namespace Lucene.Net.Util
         /// this = this OR other </summary>
         public void Or(Int64BitSet other)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords,"numWords={0}, other.numWords={1}", numWords, other.numWords);
+            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords, "numWords={0}, other.numWords={1}", numWords, other.numWords);
             int pos = Math.Min(numWords, other.numWords);
             while (--pos >= 0)
             {
@@ -243,7 +243,7 @@ namespace Lucene.Net.Util
         /// this = this XOR other </summary>
         public void Xor(Int64BitSet other)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords,"numWords={0}, other.numWords={1}", numWords, other.numWords);
+            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords, "numWords={0}, other.numWords={1}", numWords, other.numWords);
             int pos = Math.Min(numWords, other.numWords);
             while (--pos >= 0)
             {

--- a/src/Lucene.Net/Util/LongBitSet.cs
+++ b/src/Lucene.Net/Util/LongBitSet.cs
@@ -122,7 +122,7 @@ namespace Lucene.Net.Util
 
         public bool Get(long index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, () => "index=" + index);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits,"index={0}", index);
             int i = (int)(index >> 6); // div 64
             // signed shift will keep a negative index and force an
             // array-index-out-of-bounds-exception, removing the need for an explicit check.
@@ -133,7 +133,7 @@ namespace Lucene.Net.Util
 
         public void Set(long index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, () => "index=" + index + " numBits=" + numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits,"index={0} numBits={1}", index, numBits);
             int wordNum = (int)(index >> 6); // div 64
             int bit = (int)(index & 0x3f); // mod 64
             long bitmask = 1L << bit;
@@ -205,7 +205,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public long PrevSetBit(long index)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits, () => "index=" + index + " numBits=" + numBits);
+            if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < numBits,"index={0} numBits={1}", index, numBits);
             int i = (int)(index >> 6);
             int subIndex = (int)(index & 0x3f); // index within the word
             long word = (bits[i] << (63 - subIndex)); // skip all the bits to the left of index
@@ -231,7 +231,7 @@ namespace Lucene.Net.Util
         /// this = this OR other </summary>
         public void Or(Int64BitSet other)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords, () => "numWords=" + numWords + ", other.numWords=" + other.numWords);
+            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords,"numWords={0}, other.numWords={1}", numWords, other.numWords);
             int pos = Math.Min(numWords, other.numWords);
             while (--pos >= 0)
             {
@@ -243,7 +243,7 @@ namespace Lucene.Net.Util
         /// this = this XOR other </summary>
         public void Xor(Int64BitSet other)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords, () => "numWords=" + numWords + ", other.numWords=" + other.numWords);
+            if (Debugging.AssertsEnabled) Debugging.Assert(other.numWords <= numWords,"numWords={0}, other.numWords={1}", numWords, other.numWords);
             int pos = Math.Min(numWords, other.numWords);
             while (--pos >= 0)
             {

--- a/src/Lucene.Net/Util/OfflineSorter.cs
+++ b/src/Lucene.Net/Util/OfflineSorter.cs
@@ -652,7 +652,7 @@ namespace Lucene.Net.Util
                 }
 #pragma warning restore CA1031 // Do not catch general exception types
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0, () => "Sanity: sequence length < 0: " + length);
+                if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0,"Sanity: sequence length < 0: {0}", length);
                 byte[] result = new byte[length];
                 inputStream.ReadBytes(result, 0, length);
                 return result;

--- a/src/Lucene.Net/Util/OfflineSorter.cs
+++ b/src/Lucene.Net/Util/OfflineSorter.cs
@@ -652,7 +652,7 @@ namespace Lucene.Net.Util
                 }
 #pragma warning restore CA1031 // Do not catch general exception types
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0,"Sanity: sequence length < 0: {0}", length);
+                if (Debugging.AssertsEnabled) Debugging.Assert(length >= 0, "Sanity: sequence length < 0: {0}", length);
                 byte[] result = new byte[length];
                 inputStream.ReadBytes(result, 0, length);
                 return result;

--- a/src/Lucene.Net/Util/PForDeltaDocIdSet.cs
+++ b/src/Lucene.Net/Util/PForDeltaDocIdSet.cs
@@ -316,7 +316,7 @@ namespace Lucene.Net.Util
 
                 ++numBlocks;
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(data.Length - originalLength == blockSize, (data.Length - originalLength) + " <> " + blockSize);
+                if (Debugging.AssertsEnabled) Debugging.Assert(data.Length - originalLength == blockSize, "{0} <> {1}", (data.Length - originalLength), blockSize);
             }
 
             /// <summary>

--- a/src/Lucene.Net/Util/PForDeltaDocIdSet.cs
+++ b/src/Lucene.Net/Util/PForDeltaDocIdSet.cs
@@ -316,7 +316,7 @@ namespace Lucene.Net.Util
 
                 ++numBlocks;
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(data.Length - originalLength == blockSize, () => (data.Length - originalLength) + " <> " + blockSize);
+                if (Debugging.AssertsEnabled) Debugging.Assert(data.Length - originalLength == blockSize, (data.Length - originalLength) + " <> " + blockSize);
             }
 
             /// <summary>

--- a/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
@@ -125,7 +125,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < Count);
                 Debugging.Assert(off + len <= arr.Length);
             }

--- a/src/Lucene.Net/Util/Packed/Direct16.cs
+++ b/src/Lucene.Net/Util/Packed/Direct16.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }
@@ -107,7 +107,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }

--- a/src/Lucene.Net/Util/Packed/Direct32.cs
+++ b/src/Lucene.Net/Util/Packed/Direct32.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }
@@ -107,7 +107,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }

--- a/src/Lucene.Net/Util/Packed/Direct64.cs
+++ b/src/Lucene.Net/Util/Packed/Direct64.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }
@@ -98,7 +98,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }

--- a/src/Lucene.Net/Util/Packed/Direct8.cs
+++ b/src/Lucene.Net/Util/Packed/Direct8.cs
@@ -87,7 +87,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }
@@ -104,7 +104,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }

--- a/src/Lucene.Net/Util/Packed/EliasFanoDecoder.cs
+++ b/src/Lucene.Net/Util/Packed/EliasFanoDecoder.cs
@@ -126,7 +126,7 @@ namespace Lucene.Net.Util.Packed
         ///  <returns> The low value for the current decoding index. </returns>
         private long CurrentLowValue()
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(((efIndex >= 0) && (efIndex < numEncoded)), "efIndex {0}", efIndex.ToString(CultureInfo.InvariantCulture));
+            if (Debugging.AssertsEnabled) Debugging.Assert(((efIndex >= 0) && (efIndex < numEncoded)), "efIndex {0}", efIndex);
             return UnPackValue(efEncoder.lowerLongs, efEncoder.numLowBits, efIndex, efEncoder.lowerBitsMask);
         }
 

--- a/src/Lucene.Net/Util/Packed/EliasFanoDecoder.cs
+++ b/src/Lucene.Net/Util/Packed/EliasFanoDecoder.cs
@@ -126,7 +126,7 @@ namespace Lucene.Net.Util.Packed
         ///  <returns> The low value for the current decoding index. </returns>
         private long CurrentLowValue()
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(((efIndex >= 0) && (efIndex < numEncoded)), () => $"efIndex {efIndex.ToString(CultureInfo.InvariantCulture)}");
+            if (Debugging.AssertsEnabled) Debugging.Assert(((efIndex >= 0) && (efIndex < numEncoded)), "efIndex {0}", efIndex.ToString(CultureInfo.InvariantCulture));
             return UnPackValue(efEncoder.lowerLongs, efEncoder.numLowBits, efIndex, efEncoder.lowerBitsMask);
         }
 
@@ -356,7 +356,7 @@ namespace Lucene.Net.Util.Packed
 
             // curHighLong has enough clear bits to reach highTarget, has at least 1 set bit, and may not have enough set bits.
             int rank = (int)(highTarget - (setBitForIndex - efIndex)); // the rank of the zero bit for highValue.
-            if (Debugging.AssertsEnabled) Debugging.Assert((rank <= (sizeof(long) * 8)), () => ("rank " + rank));
+            if (Debugging.AssertsEnabled) Debugging.Assert((rank <= (sizeof(long) * 8)), "rank {0}", rank);
             if (rank >= 1)
             {
                 long invCurHighLong = ~curHighLong;

--- a/src/Lucene.Net/Util/Packed/EliasFanoEncoder.cs
+++ b/src/Lucene.Net/Util/Packed/EliasFanoEncoder.cs
@@ -220,7 +220,7 @@ namespace Lucene.Net.Util.Packed
         /// </summary>
         private static long NumInt64sForBits(long numBits) // Note: int version in FixedBitSet.bits2words()
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(numBits >= 0, numBits.ToString(CultureInfo.InvariantCulture));
+            if (Debugging.AssertsEnabled) Debugging.Assert(numBits >= 0, "{0}", numBits);
             return (long)((ulong)(numBits + (sizeof(long) * 8 - 1)) >> LOG2_INT64_SIZE);
         }
 

--- a/src/Lucene.Net/Util/Packed/EliasFanoEncoder.cs
+++ b/src/Lucene.Net/Util/Packed/EliasFanoEncoder.cs
@@ -220,7 +220,7 @@ namespace Lucene.Net.Util.Packed
         /// </summary>
         private static long NumInt64sForBits(long numBits) // Note: int version in FixedBitSet.bits2words()
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(numBits >= 0, () => numBits.ToString(CultureInfo.InvariantCulture));
+            if (Debugging.AssertsEnabled) Debugging.Assert(numBits >= 0, numBits.ToString(CultureInfo.InvariantCulture));
             return (long)((ulong)(numBits + (sizeof(long) * 8 - 1)) >> LOG2_INT64_SIZE);
         }
 

--- a/src/Lucene.Net/Util/Packed/Packed16ThreeBlocks.cs
+++ b/src/Lucene.Net/Util/Packed/Packed16ThreeBlocks.cs
@@ -71,7 +71,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }
@@ -96,7 +96,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }

--- a/src/Lucene.Net/Util/Packed/Packed64.cs
+++ b/src/Lucene.Net/Util/Packed/Packed64.cs
@@ -74,17 +74,7 @@ namespace Lucene.Net.Util.Packed
             PackedInt32s.Format format = PackedInt32s.Format.PACKED;
             int longCount = format.Int64Count(PackedInt32s.VERSION_CURRENT, valueCount, bitsPerValue);
             this.blocks = new long[longCount];
-            //            MaskRight = ~0L << (int)((uint)(BLOCK_SIZE - bitsPerValue) >> (BLOCK_SIZE - bitsPerValue));    //original
-            //            MaskRight = (uint)(~0L << (BLOCK_SIZE - bitsPerValue)) >> (BLOCK_SIZE - bitsPerValue);          //mod
-
-            /*var a = ~0L << (int)((uint)(BLOCK_SIZE - bitsPerValue) >> (BLOCK_SIZE - bitsPerValue));    //original
-            var b = (uint)(~0L << (BLOCK_SIZE - bitsPerValue)) >> (BLOCK_SIZE - bitsPerValue);          //mod
-            if (Debugging.AssertsEnabled) Debugging.Assert(a == b, "a: " + a, ", b: " + b);*/
-
-            maskRight = (long)((ulong)(~0L << (BLOCK_SIZE - bitsPerValue)) >> (BLOCK_SIZE - bitsPerValue));    //mod
-
-            //if (Debugging.AssertsEnabled) Debugging.Assert((long)((ulong)(~0L << (BLOCK_SIZE - bitsPerValue)) >> (BLOCK_SIZE - bitsPerValue)) == (uint)(~0L << (BLOCK_SIZE - bitsPerValue)) >> (BLOCK_SIZE - bitsPerValue));
-
+            maskRight = (long)((ulong)(~0L << (BLOCK_SIZE - bitsPerValue)) >> (BLOCK_SIZE - bitsPerValue));
             bpvMinusBlockSize = bitsPerValue - BLOCK_SIZE;
         }
 
@@ -130,7 +120,6 @@ namespace Lucene.Net.Util.Packed
             long majorBitPos = (long)index * m_bitsPerValue;
             // The index in the backing long-array
             int elementPos = (int)(((ulong)majorBitPos) >> BLOCK_BITS);
-            //int elementPos = (int)((long)((ulong)majorBitPos >> BLOCK_BITS));
             // The number of value-bits in the second long
             long endBits = (majorBitPos & MOD_MASK) + bpvMinusBlockSize;
 
@@ -141,36 +130,6 @@ namespace Lucene.Net.Util.Packed
             // Two blocks
             return ((blocks[elementPos] << (int)endBits) | ((long)((ulong)blocks[elementPos + 1] >> (int)(BLOCK_SIZE - endBits)))) & maskRight;
         }
-
-        /*/// <param name="index"> the position of the value. </param>
-        /// <returns> the value at the given index. </returns>
-        public override long Get(int index)
-        {
-            // The abstract index in a bit stream
-            long majorBitPos = (long)index * bitsPerValue;
-            // The index in the backing long-array
-            int elementPos = (int)((long)((ulong)majorBitPos >> BLOCK_BITS));
-            // The number of value-bits in the second long
-            long endBits = (majorBitPos & MOD_MASK) + BpvMinusBlockSize;
-
-            if (endBits <= 0) // Single block
-            {
-                var mod = (long) ((ulong) (Blocks[elementPos]) >> (int) (-endBits)) & MaskRight;
-                var og = ((long) ((ulong) Blocks[elementPos] >> (int) -endBits)) & MaskRight;
-                if (Debugging.AssertsEnabled) Debugging.Assert(mod == og);
-
-                //return (long)((ulong)(Blocks[elementPos]) >> (int)(-endBits)) & MaskRight;
-                return ((long)((ulong)Blocks[elementPos] >> (int)-endBits)) & MaskRight;
-            }
-            // Two blocks
-            var a = (((Blocks[elementPos] << (int)endBits) | (long)(((ulong)(Blocks[elementPos + 1])) >> (int)(BLOCK_SIZE - endBits))) & MaskRight);
-            var b = ((Blocks[elementPos] << (int)endBits) | ((long)((ulong)Blocks[elementPos + 1] >> (int)(BLOCK_SIZE - endBits)))) & MaskRight;
-
-            if (Debugging.AssertsEnabled) Debugging.Assert(a == b);
-
-            //return (((Blocks[elementPos] << (int)endBits) | (long)(((ulong)(Blocks[elementPos + 1])) >> (int)(BLOCK_SIZE - endBits))) & MaskRight);
-            return ((Blocks[elementPos] << (int)endBits) | ((long)((ulong)Blocks[elementPos + 1] >> (int)(BLOCK_SIZE - endBits)))) & MaskRight;
-        }*/
 
         public override int Get(int index, long[] arr, int off, int len)
         {

--- a/src/Lucene.Net/Util/Packed/Packed64.cs
+++ b/src/Lucene.Net/Util/Packed/Packed64.cs
@@ -174,7 +174,7 @@ namespace Lucene.Net.Util.Packed
 
         public override int Get(int index, long[] arr, int off, int len)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+            if (Debugging.AssertsEnabled) Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
             if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < m_valueCount);
             len = Math.Min(len, m_valueCount - index);
             if (Debugging.AssertsEnabled) Debugging.Assert(off + len <= arr.Length);
@@ -242,7 +242,7 @@ namespace Lucene.Net.Util.Packed
 
         public override int Set(int index, long[] arr, int off, int len)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+            if (Debugging.AssertsEnabled) Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
             if (Debugging.AssertsEnabled) Debugging.Assert(index >= 0 && index < m_valueCount);
             len = Math.Min(len, m_valueCount - index);
             if (Debugging.AssertsEnabled) Debugging.Assert(off + len <= arr.Length);

--- a/src/Lucene.Net/Util/Packed/Packed64SingleBlock.cs
+++ b/src/Lucene.Net/Util/Packed/Packed64SingleBlock.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
             }
             len = Math.Min(len, m_valueCount - index);
@@ -130,7 +130,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
             }
             len = Math.Min(len, m_valueCount - index);

--- a/src/Lucene.Net/Util/Packed/Packed8ThreeBlocks.cs
+++ b/src/Lucene.Net/Util/Packed/Packed8ThreeBlocks.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }
@@ -93,7 +93,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                 Debugging.Assert(index >= 0 && index < m_valueCount);
                 Debugging.Assert(off + len <= arr.Length);
             }

--- a/src/Lucene.Net/Util/Packed/PackedDataInput.cs
+++ b/src/Lucene.Net/Util/Packed/PackedDataInput.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Util.Packed
         /// </summary>
         public long ReadInt64(int bitsPerValue)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, () => bitsPerValue.ToString(CultureInfo.InvariantCulture));
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, bitsPerValue.ToString(CultureInfo.InvariantCulture));
             long r = 0;
             while (bitsPerValue > 0)
             {

--- a/src/Lucene.Net/Util/Packed/PackedDataInput.cs
+++ b/src/Lucene.Net/Util/Packed/PackedDataInput.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Util.Packed
         /// </summary>
         public long ReadInt64(int bitsPerValue)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, bitsPerValue.ToString(CultureInfo.InvariantCulture));
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, "{0}", bitsPerValue);
             long r = 0;
             while (bitsPerValue > 0)
             {

--- a/src/Lucene.Net/Util/Packed/PackedInts.cs
+++ b/src/Lucene.Net/Util/Packed/PackedInts.cs
@@ -205,7 +205,7 @@ namespace Lucene.Net.Util.Packed
             /// </summary>
             public virtual long ByteCount(int packedIntsVersion, int valueCount, int bitsPerValue)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue >= 0 && bitsPerValue <= 64, () => bitsPerValue.ToString(CultureInfo.InvariantCulture));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue >= 0 && bitsPerValue <= 64, bitsPerValue.ToString(CultureInfo.InvariantCulture));
                 // assume long-aligned
                 return 8L * Int64Count(packedIntsVersion, valueCount, bitsPerValue);
             }
@@ -218,7 +218,7 @@ namespace Lucene.Net.Util.Packed
             /// </summary>
             public virtual int Int64Count(int packedIntsVersion, int valueCount, int bitsPerValue)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue >= 0 && bitsPerValue <= 64, () => bitsPerValue.ToString(CultureInfo.InvariantCulture));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue >= 0 && bitsPerValue <= 64, bitsPerValue.ToString(CultureInfo.InvariantCulture));
                 long byteCount = ByteCount(packedIntsVersion, valueCount, bitsPerValue);
                 if (Debugging.AssertsEnabled) Debugging.Assert(byteCount < 8L * int.MaxValue);
                 if ((byteCount % 8) == 0)
@@ -533,7 +533,7 @@ namespace Lucene.Net.Util.Packed
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                    Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                     Debugging.Assert(index >= 0 && index < Count);
                     Debugging.Assert(off + len <= arr.Length);
                 }
@@ -674,7 +674,7 @@ namespace Lucene.Net.Util.Packed
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                    Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                     Debugging.Assert(index >= 0 && index < Count);
                 }
                 len = Math.Min(len, Count - index);
@@ -746,7 +746,7 @@ namespace Lucene.Net.Util.Packed
             protected ReaderImpl(int valueCount, int bitsPerValue)
             {
                 this.m_bitsPerValue = bitsPerValue;
-                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, () => "bitsPerValue=" + bitsPerValue);
+                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
                 this.m_valueCount = valueCount;
             }
 
@@ -765,7 +765,7 @@ namespace Lucene.Net.Util.Packed
             protected MutableImpl(int valueCount, int bitsPerValue)
             {
                 this.m_valueCount = valueCount;
-                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, () => "bitsPerValue=" + bitsPerValue);
+                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
                 this.m_bitsPerValue = bitsPerValue;
             }
 
@@ -796,7 +796,7 @@ namespace Lucene.Net.Util.Packed
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(len > 0, () => "len must be > 0 (got " + len + ")");
+                    Debugging.Assert(len > 0, "len must be > 0 (got {0})", len);
                     Debugging.Assert(index >= 0 && index < valueCount);
                 }
                 len = Math.Min(len, valueCount - index);
@@ -986,7 +986,7 @@ namespace Lucene.Net.Util.Packed
         {
             int version = CodecUtil.CheckHeader(@in, CODEC_NAME, VERSION_START, VERSION_CURRENT);
             int bitsPerValue = @in.ReadVInt32();
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, () => "bitsPerValue=" + bitsPerValue);
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
             int valueCount = @in.ReadVInt32();
             Format format = Format.ById(@in.ReadVInt32());
 
@@ -1028,7 +1028,7 @@ namespace Lucene.Net.Util.Packed
         {
             int version = CodecUtil.CheckHeader(@in, CODEC_NAME, VERSION_START, VERSION_CURRENT);
             int bitsPerValue = @in.ReadVInt32();
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, () => "bitsPerValue=" + bitsPerValue);
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
             int valueCount = @in.ReadVInt32();
             Format format = Format.ById(@in.ReadVInt32());
             return GetReaderIteratorNoHeader(@in, format, version, valueCount, bitsPerValue, mem);
@@ -1151,7 +1151,7 @@ namespace Lucene.Net.Util.Packed
         {
             int version = CodecUtil.CheckHeader(@in, CODEC_NAME, VERSION_START, VERSION_CURRENT);
             int bitsPerValue = @in.ReadVInt32();
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, () => "bitsPerValue=" + bitsPerValue);
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
             int valueCount = @in.ReadVInt32();
             Format format = Format.ById(@in.ReadVInt32());
             return GetDirectReaderNoHeader(@in, format, version, valueCount, bitsPerValue);
@@ -1428,7 +1428,7 @@ namespace Lucene.Net.Util.Packed
         {
             int version = CodecUtil.CheckHeader(@in, CODEC_NAME, VERSION_START, VERSION_CURRENT);
             int bitsPerValue = @in.ReadVInt32();
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, () => "bitsPerValue=" + bitsPerValue);
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
             int valueCount = @in.ReadVInt32();
             Format format = Format.ById(@in.ReadVInt32());
             return new Header(format, valueCount, bitsPerValue, version);

--- a/src/Lucene.Net/Util/Packed/PackedInts.cs
+++ b/src/Lucene.Net/Util/Packed/PackedInts.cs
@@ -205,7 +205,7 @@ namespace Lucene.Net.Util.Packed
             /// </summary>
             public virtual long ByteCount(int packedIntsVersion, int valueCount, int bitsPerValue)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue >= 0 && bitsPerValue <= 64, bitsPerValue.ToString(CultureInfo.InvariantCulture));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue >= 0 && bitsPerValue <= 64, "{0}", bitsPerValue);
                 // assume long-aligned
                 return 8L * Int64Count(packedIntsVersion, valueCount, bitsPerValue);
             }
@@ -218,7 +218,7 @@ namespace Lucene.Net.Util.Packed
             /// </summary>
             public virtual int Int64Count(int packedIntsVersion, int valueCount, int bitsPerValue)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue >= 0 && bitsPerValue <= 64, bitsPerValue.ToString(CultureInfo.InvariantCulture));
+                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue >= 0 && bitsPerValue <= 64, "{0}", bitsPerValue);
                 long byteCount = ByteCount(packedIntsVersion, valueCount, bitsPerValue);
                 if (Debugging.AssertsEnabled) Debugging.Assert(byteCount < 8L * int.MaxValue);
                 if ((byteCount % 8) == 0)
@@ -746,7 +746,7 @@ namespace Lucene.Net.Util.Packed
             protected ReaderImpl(int valueCount, int bitsPerValue)
             {
                 this.m_bitsPerValue = bitsPerValue;
-                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
+                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, "bitsPerValue={0}", bitsPerValue);
                 this.m_valueCount = valueCount;
             }
 
@@ -765,7 +765,7 @@ namespace Lucene.Net.Util.Packed
             protected MutableImpl(int valueCount, int bitsPerValue)
             {
                 this.m_valueCount = valueCount;
-                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
+                if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, "bitsPerValue={0}", bitsPerValue);
                 this.m_bitsPerValue = bitsPerValue;
             }
 
@@ -986,7 +986,7 @@ namespace Lucene.Net.Util.Packed
         {
             int version = CodecUtil.CheckHeader(@in, CODEC_NAME, VERSION_START, VERSION_CURRENT);
             int bitsPerValue = @in.ReadVInt32();
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, "bitsPerValue={0}", bitsPerValue);
             int valueCount = @in.ReadVInt32();
             Format format = Format.ById(@in.ReadVInt32());
 
@@ -1028,7 +1028,7 @@ namespace Lucene.Net.Util.Packed
         {
             int version = CodecUtil.CheckHeader(@in, CODEC_NAME, VERSION_START, VERSION_CURRENT);
             int bitsPerValue = @in.ReadVInt32();
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, "bitsPerValue={0}", bitsPerValue);
             int valueCount = @in.ReadVInt32();
             Format format = Format.ById(@in.ReadVInt32());
             return GetReaderIteratorNoHeader(@in, format, version, valueCount, bitsPerValue, mem);
@@ -1151,7 +1151,7 @@ namespace Lucene.Net.Util.Packed
         {
             int version = CodecUtil.CheckHeader(@in, CODEC_NAME, VERSION_START, VERSION_CURRENT);
             int bitsPerValue = @in.ReadVInt32();
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, "bitsPerValue={0}", bitsPerValue);
             int valueCount = @in.ReadVInt32();
             Format format = Format.ById(@in.ReadVInt32());
             return GetDirectReaderNoHeader(@in, format, version, valueCount, bitsPerValue);
@@ -1428,7 +1428,7 @@ namespace Lucene.Net.Util.Packed
         {
             int version = CodecUtil.CheckHeader(@in, CODEC_NAME, VERSION_START, VERSION_CURRENT);
             int bitsPerValue = @in.ReadVInt32();
-            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64,"bitsPerValue={0}", bitsPerValue);
+            if (Debugging.AssertsEnabled) Debugging.Assert(bitsPerValue > 0 && bitsPerValue <= 64, "bitsPerValue={0}", bitsPerValue);
             int valueCount = @in.ReadVInt32();
             Format format = Format.ById(@in.ReadVInt32());
             return new Header(format, valueCount, bitsPerValue, version);

--- a/src/Lucene.Net/Util/Packed/PackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/PackedWriter.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(m_bitsPerValue == 64 || (v >= 0 && v <= PackedInt32s.MaxValue(m_bitsPerValue)), m_bitsPerValue.ToString(CultureInfo.InvariantCulture));
+                Debugging.Assert(m_bitsPerValue == 64 || (v >= 0 && v <= PackedInt32s.MaxValue(m_bitsPerValue)), "{0}", m_bitsPerValue);
                 Debugging.Assert(!finished);
             }
             if (m_valueCount != -1 && written >= m_valueCount)

--- a/src/Lucene.Net/Util/Packed/PackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/PackedWriter.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(m_bitsPerValue == 64 || (v >= 0 && v <= PackedInt32s.MaxValue(m_bitsPerValue)), () => m_bitsPerValue.ToString(CultureInfo.InvariantCulture));
+                Debugging.Assert(m_bitsPerValue == 64 || (v >= 0 && v <= PackedInt32s.MaxValue(m_bitsPerValue)), m_bitsPerValue.ToString(CultureInfo.InvariantCulture));
                 Debugging.Assert(!finished);
             }
             if (m_valueCount != -1 && written >= m_valueCount)

--- a/src/Lucene.Net/Util/PagedBytes.cs
+++ b/src/Lucene.Net/Util/PagedBytes.cs
@@ -166,7 +166,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public PagedBytes(int blockBits)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(blockBits > 0 && blockBits <= 31, blockBits.ToString(CultureInfo.InvariantCulture));
+            if (Debugging.AssertsEnabled) Debugging.Assert(blockBits > 0 && blockBits <= 31, "{0}", blockBits);
             this.blockSize = 1 << blockBits;
             this.blockBits = blockBits;
             blockMask = blockSize - 1;

--- a/src/Lucene.Net/Util/PagedBytes.cs
+++ b/src/Lucene.Net/Util/PagedBytes.cs
@@ -98,8 +98,8 @@ namespace Lucene.Net.Util
             {
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(length >= 0, () => "length=" + length);
-                    Debugging.Assert(length <= blockSize + 1, () => "length=" + length);
+                    Debugging.Assert(length >= 0,"length={0}", length);
+                    Debugging.Assert(length <= blockSize + 1,"length={0}", length);
                 }
                 b.Length = length;
                 if (length == 0)
@@ -166,7 +166,7 @@ namespace Lucene.Net.Util
         /// </summary>
         public PagedBytes(int blockBits)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(blockBits > 0 && blockBits <= 31, () => blockBits.ToString(CultureInfo.InvariantCulture));
+            if (Debugging.AssertsEnabled) Debugging.Assert(blockBits > 0 && blockBits <= 31, blockBits.ToString(CultureInfo.InvariantCulture));
             this.blockSize = 1 << blockBits;
             this.blockBits = blockBits;
             blockMask = blockSize - 1;

--- a/src/Lucene.Net/Util/RamUsageEstimator.cs
+++ b/src/Lucene.Net/Util/RamUsageEstimator.cs
@@ -781,7 +781,7 @@ namespace Lucene.Net.Util
 
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(initialCapacity > 0, () => "Initial capacity must be between (0, " + int.MaxValue + "].");
+                    Debugging.Assert(initialCapacity > 0, "Initial capacity must be between (0, {0}].", int.MaxValue);
                     Debugging.Assert(loadFactor > 0 && loadFactor < 1, "Load factor must be between (0, 1).");
                 }
                 this.LoadFactor = loadFactor;
@@ -909,7 +909,7 @@ namespace Lucene.Net.Util
                 if (Debugging.AssertsEnabled)
                 {
                     Debugging.Assert(current > 0 && ((current & (current - 1)) == 0), "Capacity must be a power of two.");
-                    Debugging.Assert((current << 1) > 0, () => "Maximum capacity exceeded (" + ((int)((uint)0x80000000 >> 1)) + ").");
+                    Debugging.Assert((current << 1) > 0,"Maximum capacity exceeded ({0}", ((int)((uint)0x80000000 >> 1)) + ").");
                 }
 
                 if (current < MIN_CAPACITY / 2)

--- a/src/Lucene.Net/Util/RamUsageEstimator.cs
+++ b/src/Lucene.Net/Util/RamUsageEstimator.cs
@@ -909,7 +909,7 @@ namespace Lucene.Net.Util
                 if (Debugging.AssertsEnabled)
                 {
                     Debugging.Assert(current > 0 && ((current & (current - 1)) == 0), "Capacity must be a power of two.");
-                    Debugging.Assert((current << 1) > 0,"Maximum capacity exceeded ({0}", ((int)((uint)0x80000000 >> 1)) + ").");
+                    Debugging.Assert((current << 1) > 0, "Maximum capacity exceeded ({0}).", ((int)((uint)0x80000000 >> 1)));
                 }
 
                 if (current < MIN_CAPACITY / 2)

--- a/src/Lucene.Net/Util/RecyclingByteBlockAllocator.cs
+++ b/src/Lucene.Net/Util/RecyclingByteBlockAllocator.cs
@@ -129,7 +129,7 @@ namespace Lucene.Net.Util
         /// <returns> The number of actually removed buffers. </returns>
         public int FreeBlocks(int num)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(num >= 0,"free blocks must be >= 0 but was: {0}", num);
+            if (Debugging.AssertsEnabled) Debugging.Assert(num >= 0, "free blocks must be >= 0 but was: {0}", num);
             int stop;
             int count;
             if (num > freeBlocks)

--- a/src/Lucene.Net/Util/RecyclingByteBlockAllocator.cs
+++ b/src/Lucene.Net/Util/RecyclingByteBlockAllocator.cs
@@ -129,7 +129,7 @@ namespace Lucene.Net.Util
         /// <returns> The number of actually removed buffers. </returns>
         public int FreeBlocks(int num)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(num >= 0, () => "free blocks must be >= 0 but was: " + num);
+            if (Debugging.AssertsEnabled) Debugging.Assert(num >= 0,"free blocks must be >= 0 but was: {0}", num);
             int stop;
             int count;
             if (num > freeBlocks)

--- a/src/Lucene.Net/Util/RecyclingIntBlockAllocator.cs
+++ b/src/Lucene.Net/Util/RecyclingIntBlockAllocator.cs
@@ -140,7 +140,7 @@ namespace Lucene.Net.Util
         /// <returns> The number of actually removed buffers. </returns>
         public int FreeBlocks(int num)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(num >= 0, () => "free blocks must be >= 0 but was: " + num);
+            if (Debugging.AssertsEnabled) Debugging.Assert(num >= 0,"free blocks must be >= 0 but was: {0}", num);
             int stop;
             int count;
             if (num > freeBlocks)

--- a/src/Lucene.Net/Util/RecyclingIntBlockAllocator.cs
+++ b/src/Lucene.Net/Util/RecyclingIntBlockAllocator.cs
@@ -140,7 +140,7 @@ namespace Lucene.Net.Util
         /// <returns> The number of actually removed buffers. </returns>
         public int FreeBlocks(int num)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(num >= 0,"free blocks must be >= 0 but was: {0}", num);
+            if (Debugging.AssertsEnabled) Debugging.Assert(num >= 0, "free blocks must be >= 0 but was: {0}", num);
             int stop;
             int count;
             if (num > freeBlocks)

--- a/src/Lucene.Net/Util/RollingBuffer.cs
+++ b/src/Lucene.Net/Util/RollingBuffer.cs
@@ -157,7 +157,7 @@ namespace Lucene.Net.Util
             if (Debugging.AssertsEnabled)
             {
                 Debugging.Assert(toFree >= 0);
-                Debugging.Assert(toFree <= count, () => "toFree=" + toFree + " count=" + count);
+                Debugging.Assert(toFree <= count,"toFree={0} count={1}", toFree, count);
             }
             int index = nextWrite - count;
             if (index < 0)

--- a/src/Lucene.Net/Util/RollingBuffer.cs
+++ b/src/Lucene.Net/Util/RollingBuffer.cs
@@ -157,7 +157,7 @@ namespace Lucene.Net.Util
             if (Debugging.AssertsEnabled)
             {
                 Debugging.Assert(toFree >= 0);
-                Debugging.Assert(toFree <= count,"toFree={0} count={1}", toFree, count);
+                Debugging.Assert(toFree <= count, "toFree={0} count={1}", toFree, count);
             }
             int index = nextWrite - count;
             if (index < 0)

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -844,7 +844,7 @@ namespace Lucene.Net.Util
                 }
                 else
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(b < 0xf8, () => "b = 0x" + b.ToString("x"));
+                    if (Debugging.AssertsEnabled) Debugging.Assert(b < 0xf8,"b = 0x{0}", b.ToString("x"));
                     int ch = ((b & 0x7) << 18) + ((utf8[offset] & 0x3f) << 12) + ((utf8[offset + 1] & 0x3f) << 6) + (utf8[offset + 2] & 0x3f);
                     offset += 3;
                     if (ch < UNI_MAX_BMP)

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -844,7 +844,7 @@ namespace Lucene.Net.Util
                 }
                 else
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(b < 0xf8,"b = 0x{0}", b.ToString("x"));
+                    if (Debugging.AssertsEnabled) Debugging.Assert(b < 0xf8, "b = 0x{0:x}", b);
                     int ch = ((b & 0x7) << 18) + ((utf8[offset] & 0x3f) << 12) + ((utf8[offset + 1] & 0x3f) << 6) + (utf8[offset + 2] & 0x3f);
                     offset += 3;
                     if (ch < UNI_MAX_BMP)

--- a/src/Lucene.Net/Util/WAH8DocIdSet.cs
+++ b/src/Lucene.Net/Util/WAH8DocIdSet.cs
@@ -687,7 +687,7 @@ namespace Lucene.Net.Util
                     allOnesLength = ReadCleanLength(@in, token);
                 }
                 dirtyLength = ReadDirtyLength(@in, token);
-                if (Debugging.AssertsEnabled) Debugging.Assert(@in.Length - @in.Position >= dirtyLength, () => @in.Position + " " + @in.Length + " " + dirtyLength);
+                if (Debugging.AssertsEnabled) Debugging.Assert(@in.Length - @in.Position >= dirtyLength, "{0} {1} {2}", @in.Position, @in.Length, dirtyLength);
                 ++sequenceNum;
                 return true;
             }


### PR DESCRIPTION
This fixes the issue that was discussed at length in #373, #372, and #346. Thanks to @theolivenbaum for initially coming up with this idea. The solution we ended up with was to mimic the built-in `System.Diagnostics.Debug.Assert(bool, string, string, object[])` method signature with some important differences:

1. Instead of passing an object array, we pass generic parameters to avoid boxing on the initial call.
2. Use `J2N.Text.StringFormatter` (in the invariant culture) to automatically format passed in collections and arrays rather than using `Arrays.ToString()` or `Collections.ToString()` helper methods.

Arguments were modified to do a minimum of processing upon the function call. We still have some light math and other processing, but the heavier operations were deferred by wrapping raw parameters into a `struct` that overloads `object.ToString()` in order to do the processing only in the case where the assert fails.

There was only 1 edge case in `IndexWriter` where the `Debug.Assert` method approach was abandoned and the condition and throw were placed inline to avoid unnecessary object locking.

## Benchmarks

### IndexFiles

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1082 (1909/November2018Update/19H2)
Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.403
  [Host]                    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00005           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00006           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00007           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00008           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00009           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00010           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00011           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00012           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-wip00_before_GH-383 : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-wip01_after_GH-383  : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT

InvocationCount=1  IterationCount=15  LaunchCount=2  
UnrollFactor=1  WarmupCount=10  

```
|     Method |                       Job |                               NuGetReferences |     Mean |    Error |   StdDev |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|----------- |-------------------------- |---------------------------------------------- |---------:|---------:|---------:|-----------:|----------:|----------:|----------:|
| IndexFiles |           4.8.0-beta00005 |    Lucene.Net.Analysis.Common 4.8.0-beta00005 | 728.9 ms | 29.40 ms | 44.01 ms | 43000.0000 | 8000.0000 | 7000.0000 | 220.97 MB |
| IndexFiles |           4.8.0-beta00006 |    Lucene.Net.Analysis.Common 4.8.0-beta00006 | 706.2 ms | 31.32 ms | 44.91 ms | 44000.0000 | 8000.0000 | 7000.0000 | 221.05 MB |
| IndexFiles |           4.8.0-beta00007 |    Lucene.Net.Analysis.Common 4.8.0-beta00007 | 682.4 ms | 11.91 ms | 17.08 ms | 43000.0000 | 8000.0000 | 7000.0000 | 220.88 MB |
| IndexFiles |           4.8.0-beta00008 |    Lucene.Net.Analysis.Common 4.8.0-beta00008 | 688.6 ms | 13.02 ms | 18.67 ms | 44000.0000 | 8000.0000 | 7000.0000 | 221.39 MB |
| IndexFiles |           4.8.0-beta00009 |    Lucene.Net.Analysis.Common 4.8.0-beta00009 | 694.2 ms | 17.55 ms | 25.72 ms | 44000.0000 | 8000.0000 | 7000.0000 | 221.23 MB |
| IndexFiles |           4.8.0-beta00010 |    Lucene.Net.Analysis.Common 4.8.0-beta00010 | 686.0 ms |  9.90 ms | 14.19 ms | 44000.0000 | 8000.0000 | 7000.0000 | 221.25 MB |
| IndexFiles |           4.8.0-beta00011 |    Lucene.Net.Analysis.Common 4.8.0-beta00011 | 672.3 ms | 12.04 ms | 17.65 ms | 44000.0000 | 8000.0000 | 7000.0000 | 221.32 MB |
| IndexFiles |           4.8.0-beta00012 |    Lucene.Net.Analysis.Common 4.8.0-beta00012 | 723.5 ms | 15.38 ms | 21.56 ms | 56000.0000 | 7000.0000 | 6000.0000 | 286.98 MB |
| IndexFiles | 4.8.0-wip00_before_GH-383 | Lucene.Net.Analysis.Common 4.8.0-ci0000002206 | 710.9 ms |  9.76 ms | 14.00 ms | 56000.0000 | 7000.0000 | 6000.0000 | 286.92 MB |
| IndexFiles |  4.8.0-wip01_after_GH-383 | Lucene.Net.Analysis.Common 4.8.0-ci0000002207 | 676.7 ms | 13.18 ms | 19.31 ms | 43000.0000 | 8000.0000 | 7000.0000 |    220 MB |

### SearchFiles

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1082 (1909/November2018Update/19H2)
Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.403
  [Host]                    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00005           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00006           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00007           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00008           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00009           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00010           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00011           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00012           : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-wip00_before_GH-383 : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-wip01_after_GH-383  : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT

IterationCount=15  LaunchCount=2  WarmupCount=10  

```
|      Method |                       Job |                                                                         NuGetReferences |      Mean |     Error |    StdDev |    Median |     Gen 0 |     Gen 1 | Gen 2 | Allocated |
|------------ |-------------------------- |---------------------------------------------------------------------------------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|----------:|
| SearchFiles |           4.8.0-beta00005 |       Lucene.Net.Analysis.Common 4.8.0-beta00005,Lucene.Net.QueryParser 4.8.0-beta00005 | 147.19 ms |  4.647 ms |  6.956 ms | 148.25 ms | 8750.0000 |  500.0000 |     - |  41.39 MB |
| SearchFiles |           4.8.0-beta00006 |       Lucene.Net.Analysis.Common 4.8.0-beta00006,Lucene.Net.QueryParser 4.8.0-beta00006 | 147.26 ms |  5.150 ms |  7.550 ms | 148.73 ms | 8750.0000 |  500.0000 |     - |  41.37 MB |
| SearchFiles |           4.8.0-beta00007 |       Lucene.Net.Analysis.Common 4.8.0-beta00007,Lucene.Net.QueryParser 4.8.0-beta00007 | 146.96 ms |  4.879 ms |  7.303 ms | 146.52 ms | 8750.0000 |  250.0000 |     - |  41.26 MB |
| SearchFiles |           4.8.0-beta00008 |       Lucene.Net.Analysis.Common 4.8.0-beta00008,Lucene.Net.QueryParser 4.8.0-beta00008 |  87.58 ms |  1.373 ms |  1.925 ms |  87.11 ms | 8666.6667 |  500.0000 |     - |  40.33 MB |
| SearchFiles |           4.8.0-beta00009 |       Lucene.Net.Analysis.Common 4.8.0-beta00009,Lucene.Net.QueryParser 4.8.0-beta00009 |  98.01 ms | 12.322 ms | 17.274 ms |  87.68 ms | 8666.6667 |  500.0000 |     - |  40.33 MB |
| SearchFiles |           4.8.0-beta00010 |       Lucene.Net.Analysis.Common 4.8.0-beta00010,Lucene.Net.QueryParser 4.8.0-beta00010 |  90.83 ms |  2.601 ms |  3.730 ms |  90.26 ms | 8666.6667 |  500.0000 |     - |  40.19 MB |
| SearchFiles |           4.8.0-beta00011 |       Lucene.Net.Analysis.Common 4.8.0-beta00011,Lucene.Net.QueryParser 4.8.0-beta00011 |  94.19 ms |  3.758 ms |  5.625 ms |  95.31 ms | 8600.0000 |  200.0000 |     - |  40.19 MB |
| SearchFiles |           4.8.0-beta00012 |       Lucene.Net.Analysis.Common 4.8.0-beta00012,Lucene.Net.QueryParser 4.8.0-beta00012 |  97.76 ms |  3.418 ms |  4.903 ms |  96.53 ms | 8833.3333 |  333.3333 |     - |  40.81 MB |
| SearchFiles | 4.8.0-wip00_before_GH-383 | Lucene.Net.Analysis.Common 4.8.0-ci0000002206,Lucene.Net.QueryParser 4.8.0-ci0000002206 |  96.67 ms |  3.957 ms |  5.800 ms |  94.47 ms | 9000.0000 | 2000.0000 |     - |  40.79 MB |
| SearchFiles |  4.8.0-wip01_after_GH-383 | Lucene.Net.Analysis.Common 4.8.0-ci0000002207,Lucene.Net.QueryParser 4.8.0-ci0000002207 |  97.11 ms |  2.398 ms |  3.589 ms |  96.91 ms | 8666.6667 |  333.3333 |     - |  40.17 MB |

With these changes, in both `IndexFiles` and `SearchFiles` RAM consumption was reduced lower than any previously released version and raw performance of `IndexFiles` has also improved.

This basically gives us as good or better performance than we had when we compiled the asserts out of the application.