### PR TITLE
Revert FieldCacheImpl delegate capture (Fixes #370, Closes #371)

### DIFF
--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -580,7 +580,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Bytes(get: (docID) => (byte)valuesIn.Get(docID));
+                return new FieldCache_BytesAnonymousInnerClassHelper(this, valuesIn);
             }
             else
             {
@@ -601,6 +601,24 @@ namespace Lucene.Net.Search
 #pragma warning disable CS0612 // Type or member is obsolete
                 return caches_typeof_sbyte.Get(reader, new CacheKey<FieldCache.IByteParser>(field, parser), setDocsWithField);
 #pragma warning restore CS0612 // Type or member is obsolete
+            }
+        }
+
+        private class FieldCache_BytesAnonymousInnerClassHelper : FieldCache.Bytes
+        {
+            private readonly FieldCacheImpl outerInstance;
+
+            private NumericDocValues valuesIn;
+
+            public FieldCache_BytesAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            {
+                this.outerInstance = outerInstance;
+                this.valuesIn = valuesIn;
+            }
+
+            public override byte Get(int docID)
+            {
+                return (byte)valuesIn.Get(docID);
             }
         }
 
@@ -738,7 +756,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Int16s(get: (docID) => (short)valuesIn.Get(docID));
+                return new FieldCache_Int16sAnonymousInnerClassHelper(this, valuesIn);
             }
             else
             {
@@ -757,6 +775,24 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return caches_typeof_short.Get(reader, new CacheKey<FieldCache.IInt16Parser>(field, parser), setDocsWithField);
+            }
+        }
+
+        private class FieldCache_Int16sAnonymousInnerClassHelper : FieldCache.Int16s
+        {
+            private readonly FieldCacheImpl outerInstance;
+
+            private NumericDocValues valuesIn;
+
+            public FieldCache_Int16sAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            {
+                this.outerInstance = outerInstance;
+                this.valuesIn = valuesIn;
+            }
+
+            public override short Get(int docID)
+            {
+                return (short)valuesIn.Get(docID);
             }
         }
 
@@ -895,7 +931,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Int32s(get: (docID) => (int)valuesIn.Get(docID));
+                return new FieldCache_Int32sAnonymousInnerClassHelper(this, valuesIn);
             }
             else
             {
@@ -914,6 +950,24 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return caches_typeof_int.Get(reader, new CacheKey<FieldCache.IInt32Parser>(field, parser), setDocsWithField);
+            }
+        }
+
+        private class FieldCache_Int32sAnonymousInnerClassHelper : FieldCache.Int32s
+        {
+            private readonly FieldCacheImpl outerInstance;
+
+            private NumericDocValues valuesIn;
+
+            public FieldCache_Int32sAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            {
+                this.outerInstance = outerInstance;
+                this.valuesIn = valuesIn;
+            }
+
+            public override int Get(int docID)
+            {
+                return (int)valuesIn.Get(docID);
             }
         }
 
@@ -1175,7 +1229,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Singles(get: (docID) => J2N.BitConversion.Int32BitsToSingle((int)valuesIn.Get(docID)));
+                return new FieldCache_SinglesAnonymousInnerClassHelper(this, valuesIn);
             }
             else
             {
@@ -1194,6 +1248,24 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return caches_typeof_float.Get(reader, new CacheKey<FieldCache.ISingleParser>(field, parser), setDocsWithField);
+            }
+        }
+
+        private class FieldCache_SinglesAnonymousInnerClassHelper : FieldCache.Singles
+        {
+            private readonly FieldCacheImpl outerInstance;
+
+            private NumericDocValues valuesIn;
+
+            public FieldCache_SinglesAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            {
+                this.outerInstance = outerInstance;
+                this.valuesIn = valuesIn;
+            }
+
+            public override float Get(int docID)
+            {
+                return J2N.BitConversion.Int32BitsToSingle((int)valuesIn.Get(docID));
             }
         }
 
@@ -1326,7 +1398,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Int64s(get: (docID) => valuesIn.Get(docID));
+                return new FieldCache_Int64sAnonymousInnerClassHelper(this, valuesIn);
             }
             else
             {
@@ -1345,6 +1417,24 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return caches_typeof_long.Get(reader, new CacheKey<FieldCache.IInt64Parser>(field, parser), setDocsWithField);
+            }
+        }
+
+        private class FieldCache_Int64sAnonymousInnerClassHelper : FieldCache.Int64s
+        {
+            private readonly FieldCacheImpl outerInstance;
+
+            private NumericDocValues valuesIn;
+
+            public FieldCache_Int64sAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            {
+                this.outerInstance = outerInstance;
+                this.valuesIn = valuesIn;
+            }
+
+            public override long Get(int docID)
+            {
+                return valuesIn.Get(docID);
             }
         }
 
@@ -1489,7 +1579,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache.Doubles(get: (docID) => J2N.BitConversion.Int64BitsToDouble(valuesIn.Get(docID)));
+                return new FieldCache_DoublesAnonymousInnerClassHelper(this, valuesIn);
             }
             else
             {
@@ -1508,6 +1598,24 @@ namespace Lucene.Net.Search
                 }
                 // LUCENENET specific - eliminated unnecessary Dictionary lookup by declaring each cache as a member variable
                 return caches_typeof_double.Get(reader, new CacheKey<FieldCache.IDoubleParser>(field, parser), setDocsWithField);
+            }
+        }
+
+        private class FieldCache_DoublesAnonymousInnerClassHelper : FieldCache.Doubles
+        {
+            private readonly FieldCacheImpl outerInstance;
+
+            private NumericDocValues valuesIn;
+
+            public FieldCache_DoublesAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            {
+                this.outerInstance = outerInstance;
+                this.valuesIn = valuesIn;
+            }
+
+            public override double Get(int docID)
+            {
+                return J2N.BitConversion.Int64BitsToDouble(valuesIn.Get(docID));
             }
         }
 

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -580,7 +580,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_BytesAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache_BytesAnonymousInnerClassHelper(valuesIn);
             }
             else
             {
@@ -606,13 +606,10 @@ namespace Lucene.Net.Search
 
         private class FieldCache_BytesAnonymousInnerClassHelper : FieldCache.Bytes
         {
-            private readonly FieldCacheImpl outerInstance;
+            private readonly NumericDocValues valuesIn;
 
-            private NumericDocValues valuesIn;
-
-            public FieldCache_BytesAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            public FieldCache_BytesAnonymousInnerClassHelper(NumericDocValues valuesIn)
             {
-                this.outerInstance = outerInstance;
                 this.valuesIn = valuesIn;
             }
 
@@ -756,7 +753,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_Int16sAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache_Int16sAnonymousInnerClassHelper(valuesIn);
             }
             else
             {
@@ -780,13 +777,10 @@ namespace Lucene.Net.Search
 
         private class FieldCache_Int16sAnonymousInnerClassHelper : FieldCache.Int16s
         {
-            private readonly FieldCacheImpl outerInstance;
+            private readonly NumericDocValues valuesIn;
 
-            private NumericDocValues valuesIn;
-
-            public FieldCache_Int16sAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            public FieldCache_Int16sAnonymousInnerClassHelper(NumericDocValues valuesIn)
             {
-                this.outerInstance = outerInstance;
                 this.valuesIn = valuesIn;
             }
 
@@ -931,7 +925,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_Int32sAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache_Int32sAnonymousInnerClassHelper(valuesIn);
             }
             else
             {
@@ -955,13 +949,10 @@ namespace Lucene.Net.Search
 
         private class FieldCache_Int32sAnonymousInnerClassHelper : FieldCache.Int32s
         {
-            private readonly FieldCacheImpl outerInstance;
+            private readonly NumericDocValues valuesIn;
 
-            private NumericDocValues valuesIn;
-
-            public FieldCache_Int32sAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            public FieldCache_Int32sAnonymousInnerClassHelper(NumericDocValues valuesIn)
             {
-                this.outerInstance = outerInstance;
                 this.valuesIn = valuesIn;
             }
 
@@ -1229,7 +1220,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_SinglesAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache_SinglesAnonymousInnerClassHelper(valuesIn);
             }
             else
             {
@@ -1253,13 +1244,10 @@ namespace Lucene.Net.Search
 
         private class FieldCache_SinglesAnonymousInnerClassHelper : FieldCache.Singles
         {
-            private readonly FieldCacheImpl outerInstance;
+            private readonly NumericDocValues valuesIn;
 
-            private NumericDocValues valuesIn;
-
-            public FieldCache_SinglesAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            public FieldCache_SinglesAnonymousInnerClassHelper(NumericDocValues valuesIn)
             {
-                this.outerInstance = outerInstance;
                 this.valuesIn = valuesIn;
             }
 
@@ -1398,7 +1386,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_Int64sAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache_Int64sAnonymousInnerClassHelper(valuesIn);
             }
             else
             {
@@ -1422,13 +1410,10 @@ namespace Lucene.Net.Search
 
         private class FieldCache_Int64sAnonymousInnerClassHelper : FieldCache.Int64s
         {
-            private readonly FieldCacheImpl outerInstance;
+            private readonly NumericDocValues valuesIn;
 
-            private NumericDocValues valuesIn;
-
-            public FieldCache_Int64sAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            public FieldCache_Int64sAnonymousInnerClassHelper(NumericDocValues valuesIn)
             {
-                this.outerInstance = outerInstance;
                 this.valuesIn = valuesIn;
             }
 
@@ -1579,7 +1564,7 @@ namespace Lucene.Net.Search
             {
                 // Not cached here by FieldCacheImpl (cached instead
                 // per-thread by SegmentReader):
-                return new FieldCache_DoublesAnonymousInnerClassHelper(this, valuesIn);
+                return new FieldCache_DoublesAnonymousInnerClassHelper(valuesIn);
             }
             else
             {
@@ -1603,13 +1588,10 @@ namespace Lucene.Net.Search
 
         private class FieldCache_DoublesAnonymousInnerClassHelper : FieldCache.Doubles
         {
-            private readonly FieldCacheImpl outerInstance;
+            private readonly NumericDocValues valuesIn;
 
-            private NumericDocValues valuesIn;
-
-            public FieldCache_DoublesAnonymousInnerClassHelper(FieldCacheImpl outerInstance, NumericDocValues valuesIn)
+            public FieldCache_DoublesAnonymousInnerClassHelper(NumericDocValues valuesIn)
             {
-                this.outerInstance = outerInstance;
                 this.valuesIn = valuesIn;
             }
 


### PR DESCRIPTION
As was discussed in #371, we are definitely seeing a negative impact with this change that was introduced in #348 with commit https://github.com/apache/lucenenet/commit/34758c1315391794825f33a3f48b5a3dd6083745. This PR reverts that commit and removes the unnecessary fields from the "anonymous" classes.

## Benchmarks

### IndexFiles
<details>
  <summary>Click to expand</summary>

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.403
  [Host]             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00005    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00006    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00007    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00008    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00009    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00010    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00011    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00012    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-wip09_before : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-wip10_after  : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT

InvocationCount=1  IterationCount=15  LaunchCount=2  
UnrollFactor=1  WarmupCount=10  

```
|     Method |                Job |                               NuGetReferences |     Mean |    Error |   StdDev |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|----------- |------------------- |---------------------------------------------- |---------:|---------:|---------:|-----------:|----------:|----------:|----------:|
| IndexFiles |    4.8.0-beta00005 |    Lucene.Net.Analysis.Common 4.8.0-beta00005 | 628.7 ms |  8.56 ms | 12.55 ms | 43000.0000 | 8000.0000 | 7000.0000 | 220.78 MB |
| IndexFiles |    4.8.0-beta00006 |    Lucene.Net.Analysis.Common 4.8.0-beta00006 | 614.4 ms |  8.24 ms | 11.28 ms | 43000.0000 | 8000.0000 | 7000.0000 | 220.73 MB |
| IndexFiles |    4.8.0-beta00007 |    Lucene.Net.Analysis.Common 4.8.0-beta00007 | 627.2 ms | 12.90 ms | 18.51 ms | 44000.0000 | 8000.0000 | 7000.0000 | 220.65 MB |
| IndexFiles |    4.8.0-beta00008 |    Lucene.Net.Analysis.Common 4.8.0-beta00008 | 603.9 ms |  8.15 ms | 11.42 ms | 43000.0000 | 8000.0000 | 7000.0000 | 220.96 MB |
| IndexFiles |    4.8.0-beta00009 |    Lucene.Net.Analysis.Common 4.8.0-beta00009 | 623.6 ms | 11.10 ms | 15.92 ms | 44000.0000 | 8000.0000 | 7000.0000 | 220.92 MB |
| IndexFiles |    4.8.0-beta00010 |    Lucene.Net.Analysis.Common 4.8.0-beta00010 | 612.4 ms | 11.47 ms | 16.07 ms | 44000.0000 | 8000.0000 | 7000.0000 | 220.92 MB |
| IndexFiles |    4.8.0-beta00011 |    Lucene.Net.Analysis.Common 4.8.0-beta00011 | 622.0 ms | 13.63 ms | 20.40 ms | 43000.0000 | 8000.0000 | 7000.0000 | 220.96 MB |
| IndexFiles |    4.8.0-beta00012 |    Lucene.Net.Analysis.Common 4.8.0-beta00012 | 659.4 ms | 13.05 ms | 19.13 ms | 56000.0000 | 7000.0000 | 6000.0000 | 286.57 MB |
| IndexFiles | 4.8.0-wip09_before | Lucene.Net.Analysis.Common 4.8.0-ci0000002232 | 705.6 ms | 53.68 ms | 80.35 ms | 43000.0000 | 8000.0000 | 7000.0000 | 219.96 MB |
| IndexFiles |  4.8.0-wip10_after | Lucene.Net.Analysis.Common 4.8.0-ci0000002236 | 637.8 ms | 12.61 ms | 18.48 ms | 43000.0000 | 8000.0000 | 7000.0000 | 219.82 MB |

</details>

### SearchFiles
<details>
  <summary>Click to expand</summary>

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.403
  [Host]             : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00005    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00006    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00007    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00008    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00009    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00010    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00011    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-beta00012    : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-wip09_before : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  4.8.0-wip10_after  : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT

IterationCount=15  LaunchCount=2  WarmupCount=10  

```
|      Method |                Job |                                                                         NuGetReferences |     Mean |   Error |   StdDev |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|------------ |------------------- |---------------------------------------------------------------------------------------- |---------:|--------:|---------:|-----------:|----------:|------:|----------:|
| SearchFiles |    4.8.0-beta00005 |       Lucene.Net.Analysis.Common 4.8.0-beta00005,Lucene.Net.QueryParser 4.8.0-beta00005 | 202.4 ms | 7.06 ms | 10.57 ms | 13000.0000 | 1000.0000 |     - |  61.74 MB |
| SearchFiles |    4.8.0-beta00006 |       Lucene.Net.Analysis.Common 4.8.0-beta00006,Lucene.Net.QueryParser 4.8.0-beta00006 | 207.9 ms | 7.74 ms | 11.59 ms | 13000.0000 | 1000.0000 |     - |  61.74 MB |
| SearchFiles |    4.8.0-beta00007 |       Lucene.Net.Analysis.Common 4.8.0-beta00007,Lucene.Net.QueryParser 4.8.0-beta00007 | 203.9 ms | 7.58 ms | 11.34 ms | 13000.0000 | 1000.0000 |     - |  61.58 MB |
| SearchFiles |    4.8.0-beta00008 |       Lucene.Net.Analysis.Common 4.8.0-beta00008,Lucene.Net.QueryParser 4.8.0-beta00008 | 120.4 ms | 1.22 ms |  1.82 ms | 13000.0000 |         - |     - |  60.24 MB |
| SearchFiles |    4.8.0-beta00009 |       Lucene.Net.Analysis.Common 4.8.0-beta00009,Lucene.Net.QueryParser 4.8.0-beta00009 | 118.0 ms | 4.73 ms |  7.08 ms | 13000.0000 |  200.0000 |     - |  60.24 MB |
| SearchFiles |    4.8.0-beta00010 |       Lucene.Net.Analysis.Common 4.8.0-beta00010,Lucene.Net.QueryParser 4.8.0-beta00010 | 121.8 ms | 5.55 ms |  8.30 ms | 13000.0000 |         - |     - |  60.03 MB |
| SearchFiles |    4.8.0-beta00011 |       Lucene.Net.Analysis.Common 4.8.0-beta00011,Lucene.Net.QueryParser 4.8.0-beta00011 | 118.0 ms | 2.51 ms |  3.61 ms | 13000.0000 |         - |     - |  60.03 MB |
| SearchFiles |    4.8.0-beta00012 |       Lucene.Net.Analysis.Common 4.8.0-beta00012,Lucene.Net.QueryParser 4.8.0-beta00012 | 117.0 ms | 1.95 ms |  2.74 ms | 13200.0000 |         - |     - |  60.98 MB |
| SearchFiles | 4.8.0-wip09_before | Lucene.Net.Analysis.Common 4.8.0-ci0000002232,Lucene.Net.QueryParser 4.8.0-ci0000002232 | 114.5 ms | 3.62 ms |  5.31 ms | 10800.0000 |  200.0000 |     - |  49.46 MB |
| SearchFiles |  4.8.0-wip10_after | Lucene.Net.Analysis.Common 4.8.0-ci0000002236,Lucene.Net.QueryParser 4.8.0-ci0000002236 | 112.3 ms | 1.58 ms |  2.26 ms | 10800.0000 |  200.0000 |     - |  49.46 MB |

</details>

This just uses inheritance on the numeric fields like we did originally and ignores the fact that there is a constructor overload that uses a delegate (which is convenient, but a bit slower).

The number of searches has been increased from 1000 to 1500, which is why these numbers are higher than prior benchmarks.