### PR TITLE
Website updates (from oct 2020)

### DIFF
--- a/src/docs/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter.csproj
+++ b/src/docs/JavaDocToMarkdownConverter/JavaDocToMarkdownConverter.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -27,6 +27,9 @@
     </AssemblyOriginatorKeyFile>
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/docs/LuceneDocsPlugins/EnvironmentVariableInlineRule.cs
+++ b/src/docs/LuceneDocsPlugins/EnvironmentVariableInlineRule.cs
@@ -17,40 +17,40 @@
  * under the License.
  */
 
-//using System;
-//using System.Collections.Immutable;
-//using System.Text.RegularExpressions;
-//using Microsoft.DocAsCode.MarkdownLite;
+using System;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+using Microsoft.DocAsCode.MarkdownLite;
 
-//namespace LuceneDocsPlugins
-//{
-//    public class EnvironmentVariableInlineRule : IMarkdownRule
-//    {
-//        // give it a name
-//        public string Name => "EnvVarToken";
+namespace LuceneDocsPlugins
+{
+    public class EnvironmentVariableInlineRule : IMarkdownRule
+    {
+        // give it a name
+        public string Name => "EnvVarToken";
 
-//        // define my regex to match
-//        private static readonly Regex _envVarRegex = new Regex(@"^\[EnvVar:(\w+?)\]", RegexOptions.Compiled);
+        // define my regex to match
+        private static readonly Regex _envVarRegex = new Regex(@"^\<EnvVar:(\w+?)\>", RegexOptions.Compiled);
 
-//        // process the match
-//        public IMarkdownToken TryMatch(IMarkdownParser parser, IMarkdownParsingContext context)
-//        {
-//            // TODO: This does not process this token from within a code block like
+        // process the match
+        public IMarkdownToken TryMatch(IMarkdownParser parser, IMarkdownParsingContext context)
+        {
+            // TODO: This does not process this token from within a code block like
 
-//            // ```
-//            // dotnet tool install lucene-cli -g --version [EnvVar: LuceneNetVersion]
-//            // ```
+            // ```
+            // dotnet tool install lucene-cli -g --version [EnvVar: LuceneNetVersion]
+            // ```
 
-//            var match = _envVarRegex.Match(context.CurrentMarkdown);
-//            if (match.Length == 0) return null;
+            var match = _envVarRegex.Match(context.CurrentMarkdown);
+            if (match.Length == 0) return null;
 
-//            var envVar = match.Groups[1].Value;
-//            var text = Environment.GetEnvironmentVariable(envVar);
-//            if (text == null) return null;
+            var envVar = match.Groups[1].Value;
+            var text = Environment.GetEnvironmentVariable(envVar);
+            if (text == null) return null;
 
-//            // 'eat' the characters of the current markdown token so they anr
-//            var sourceInfo = context.Consume(match.Length);
-//            return new MarkdownTextToken(this, parser.Context, text, sourceInfo);
-//        }
-//    }
-//}
+            // 'eat' the characters of the current markdown token so they anr
+            var sourceInfo = context.Consume(match.Length);
+            return new MarkdownTextToken(this, parser.Context, text, sourceInfo);
+        }
+    }
+}

--- a/src/docs/LuceneDocsPlugins/LuceneDfmEngineCustomizer.cs
+++ b/src/docs/LuceneDocsPlugins/LuceneDfmEngineCustomizer.cs
@@ -32,8 +32,8 @@ namespace LuceneDocsPlugins
     {
         public void Customize(DfmEngineBuilder builder, IReadOnlyDictionary<string, object> parameters)
          {
-            //// insert inline rule at the top
-            //builder.InlineRules = builder.InlineRules.Insert(0, new EnvironmentVariableInlineRule());
+            // insert inline rule at the top
+            builder.InlineRules = builder.InlineRules.Insert(0, new EnvironmentVariableInlineRule());
 
             // insert block rule above header rule. Why? I dunno, that's what the docs say: 
             // https://dotnet.github.io/docfx/tutorial/intro_markdown_lite.html#select-token-kind

--- a/src/docs/LuceneDocsPlugins/LuceneDocsPlugins.csproj
+++ b/src/docs/LuceneDocsPlugins/LuceneDocsPlugins.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -23,6 +23,9 @@ under the License.
     <!-- Ensure this doesn't inherit the strong naming since this tool will no work with a signed assembly due to it's references -->
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -34,7 +34,7 @@ param (
 
 # if the base URL is the lucene live site default value we also need to include the version
 if ($BaseUrl -eq 'https://lucenenet.apache.org/docs/') {
-    $BaseUrl += $LuceneNetVersion + "/"    
+    $BaseUrl += $LuceneNetVersion
 }
 Write-Host "Base URL for xref map set to $BaseUrl"
 

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -41,6 +41,10 @@ if ($BaseUrl -eq 'https://lucenenet.apache.org/docs/') {
 $BaseUrl = $BaseUrl.TrimEnd('/') # Remove any trailing slash
 Write-Host "Base URL for xref map set to $BaseUrl"
 
+# HACK: Our plugin only recognizes the version number through an environment variable,
+# so we set it here.
+$env:LuceneNetVersion = $LuceneNetVersion
+
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $PSScriptFilePath = (Get-Item $MyInvocation.MyCommand.Path).FullName

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -29,10 +29,14 @@ param (
     [Parameter(Mandatory = $false)]
     [string] $LogLevel = 'Warning',
     [Parameter(Mandatory = $false)]
-    [string] $BaseUrl = 'http://localhost:8080',
-    [Parameter(Mandatory = $false)]
-    [int] $StagingPort = 8080
+    [string] $BaseUrl = 'https://lucenenet.apache.org/docs/'
 )
+
+# if the base URL is the lucene live site default value we also need to include the version
+if ($BaseUrl -eq 'https://lucenenet.apache.org/docs/') {
+    $BaseUrl += $LuceneNetVersion + "/"    
+}
+Write-Host "Base URL for xref map set to $BaseUrl"
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
@@ -56,7 +60,7 @@ $DocFxExe = "$ToolsFolder\docfx\docfx.exe"
 if (-not (test-path $DocFxExe)) {
     Write-Host "Retrieving docfx..."
     $DocFxZip = "$ToolsFolder\tmp\docfx.zip"	
-    Invoke-WebRequest "https://github.com/dotnet/docfx/releases/download/v2.56/docfx.zip" -OutFile $DocFxZip -TimeoutSec 60 
+    Invoke-WebRequest "https://github.com/dotnet/docfx/releases/download/v2.56.2/docfx.zip" -OutFile $DocFxZip -TimeoutSec 60 
 	
     #unzip
     Expand-Archive $DocFxZip -DestinationPath (Join-Path -Path $ToolsFolder -ChildPath "docfx")
@@ -177,7 +181,7 @@ if ($? -and $DisableBuild -eq $false) {
 
         $DocFxLog = Join-Path -Path $ApiDocsFolder "obj\${proj}.build.log"
 
-        # build the output		
+        # build the output
         Write-Host "Building site output for $projFile..."
 
         # Before we build the site we have to clear the frickin docfx cache!

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -6,9 +6,9 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the ""License""); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an ""AS IS"" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,9 @@ param (
     [Parameter(Mandatory = $false)]
     [string] $LogLevel = 'Warning',
     [Parameter(Mandatory = $false)]
-    [string] $BaseUrl = 'https://lucenenet.apache.org/docs/'
+    [string] $BaseUrl = 'https://lucenenet.apache.org/docs/',
+    [Parameter(Mandatory = $false)]
+    [int] $StagingPort = 8080
 )
 
 # if the base URL is the lucene live site default value we also need to include the version
@@ -59,9 +61,9 @@ New-Item "$ToolsFolder\docfx" -type directory -force
 $DocFxExe = "$ToolsFolder\docfx\docfx.exe"
 if (-not (test-path $DocFxExe)) {
     Write-Host "Retrieving docfx..."
-    $DocFxZip = "$ToolsFolder\tmp\docfx.zip"	
-    Invoke-WebRequest "https://github.com/dotnet/docfx/releases/download/v2.56.2/docfx.zip" -OutFile $DocFxZip -TimeoutSec 60 
-	
+    $DocFxZip = "$ToolsFolder\tmp\docfx.zip"
+    Invoke-WebRequest "https://github.com/dotnet/docfx/releases/download/v2.56.2/docfx.zip" -OutFile $DocFxZip -TimeoutSec 60
+
     #unzip
     Expand-Archive $DocFxZip -DestinationPath (Join-Path -Path $ToolsFolder -ChildPath "docfx")
 }
@@ -83,7 +85,7 @@ if (-not (test-path $vswhere)) {
     &$nuget install vswhere -OutputDirectory $path
     $dir = Get-ChildItem "$path\vswhere.*" | Sort-Object -property Name -descending | Select-Object -first 1
     $file = Get-ChildItem -path "$dir" -name vswhere.exe -recurse
-    Move-Item "$dir\$file" $vswhere   
+    Move-Item "$dir\$file" $vswhere
 }
 
 Remove-Item  -Recurse -Force "$ToolsFolder\tmp"
@@ -104,11 +106,11 @@ if ($DisablePlugins -eq $false) {
     if (-not (test-path $MSBuild)) {
         throw "MSBuild not found!"
     }
-    
+
     # Build the plugin solution
     $pluginSln = (Join-Path -Path $RepoRoot "src\docs\DocumentationTools.sln")
     & $nuget restore $pluginSln
-    
+
     $PluginsFolder = (Join-Path -Path $ApiDocsFolder "Templates\LuceneTemplate\plugins")
     New-Item $PluginsFolder -type directory -force
     & $msbuild $pluginSln /target:LuceneDocsPlugins "/p:OutDir=$PluginsFolder"
@@ -134,7 +136,7 @@ $DocFxJsonMeta = @(
     "docfx.analysis-smartcn.json",
     "docfx.analysis-stempel.json",
     "docfx.benchmark.json",
-    "docfx.classification.json",    
+    "docfx.classification.json",
     "docfx.expressions.json",
     "docfx.facet.json",
     "docfx.grouping.json",
@@ -157,13 +159,13 @@ $DocFxJsonSite = Join-Path -Path $ApiDocsFolder "docfx.site.json"
 # set env vars that will be replaced in Markdown
 $env:LuceneNetVersion = $LuceneNetVersion
 
-if ($? -and $DisableMetaData -eq $false) { 
+if ($? -and $DisableMetaData -eq $false) {
     foreach ($proj in $DocFxJsonMeta) {
         $projFile = Join-Path -Path $ApiDocsFolder $proj
 
         $DocFxLog = Join-Path -Path $ApiDocsFolder "obj\${proj}.meta.log"
 
-        # build the output		
+        # build the output
         Write-Host "Building api metadata for $projFile..."
 
         if ($Clean) {
@@ -175,7 +177,7 @@ if ($? -and $DisableMetaData -eq $false) {
     }
 }
 
-if ($? -and $DisableBuild -eq $false) { 
+if ($? -and $DisableBuild -eq $false) {
     foreach ($proj in $DocFxJsonMeta) {
         $projFile = Join-Path -Path $ApiDocsFolder $proj
 
@@ -218,7 +220,7 @@ if ($?) {
 
     if ($ServeDocs -eq $false) {
 
-        # build the output		
+        # build the output
         Write-Host "Building docs..."
 
         if ($Clean) {

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -38,6 +38,7 @@ param (
 if ($BaseUrl -eq 'https://lucenenet.apache.org/docs/') {
     $BaseUrl += $LuceneNetVersion
 }
+$BaseUrl = $BaseUrl.TrimEnd('/') # Remove any trailing slash
 Write-Host "Base URL for xref map set to $BaseUrl"
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/websites/apidocs/index.md
+++ b/websites/apidocs/index.md
@@ -3,15 +3,16 @@ title: Lucene.Net Docs - The documentation website for Lucene.Net
 description: The documentation website for Lucene.Net
 ---
 
-# Apache Lucene.Net 4.8.0-beta00009 Documentation
+Apache Lucene.Net <EnvVar:LuceneNetVersion> Documentation
+===============
 
----
+---------------
 
-Lucene is a _.NET full-text search engine_. Lucene.NET is not a complete application,
+Lucene is a _.NET full-text search engine_. Lucene.NET is not a complete application, 
 but rather a code library and API that can easily be used to add search capabilities
 to applications.
 
-This is the official API documentation for **Apache Lucene.NET 4.8.0-beta00009**.
+This is the official API documentation for __Apache Lucene.NET <EnvVar:LuceneNetVersion>__.
 
 ## Getting Started
 
@@ -28,10 +29,10 @@ on some of the conceptual or inner details of Lucene:
 
 ## Reference Documents
 
-- [Changes](https://github.com/apache/lucenenet/releases/tag/Lucene.Net_4_8_0_beta00007): List of changes in this release.
-- System Requirements: Minimum and supported .NET versions. **TODO: Add link**
-- Migration Guide: What changed in Lucene 4; how to migrate code from Lucene 3.x. **TODO: Add link**
-- [File Formats](xref:Lucene.Net.Codecs.Lucene46) : Guide to the supported index format used by Lucene. This can be customized by using [an alternate codec](xref:Lucene.Net.Codecs).
+- [Changes](https://github.com/apache/lucenenet/releases/tag/<EnvVar:LuceneNetReleaseTag>): List of changes in this release.
+- System Requirements: Minimum and supported .NET versions. __TODO: Add link__
+- Migration Guide: What changed in Lucene 4; how to migrate code from Lucene 3.x. __TODO: Add link__
+- [File Formats](xref:Lucene.Net.Codecs.Lucene46) : Guide to the supported index format used by Lucene.  This can be customized by using [an alternate codec](xref:Lucene.Net.Codecs).
 - [Search and Scoring in Lucene](xref:Lucene.Net.Search): Introduction to how Lucene scores documents.
 - [Classic Scoring Formula](xref:Lucene.Net.Search.Similarities.TFIDFSimilarity): Formula of Lucene's classic [Vector Space](http://en.wikipedia.org/wiki/Vector_Space_Model) implementation. (look [here](xref:Lucene.Net.Search.Similarities) for other models)
 - [Classic QueryParser Syntax](xref:Lucene.Net.QueryParsers.Classic): Overview of the Classic QueryParser's syntax and features.

--- a/websites/site/contributing/documentation.md
+++ b/websites/site/contributing/documentation.md
@@ -18,12 +18,26 @@ To submit changes for the website, create a Pull Request to the [Lucene Git repo
 
 ### Build script
 
-To build the website and run it on your machine, run the Powershell script: `/websites/site/site.ps1`. You don't have to pass any parameters in and it will build the site and host it at [http://localhost:8081](http://localhost:8081).
+To build the website and run it on your machine, run the Powershell script: `/websites/site/site.ps1` with the `-ServeDocs` flag. For example:
 
-The script has 2 optional parameters:
+```
+/websites/site/site.ps1 -ServeDocs
+```
 
-- `-ServeDocs` _(default is 1)_ The value of `1` means it will build the docs and host the site, if `0` is specified, it will build the static site to be hosted elsewhere.
-- `-Clean` _(default is 0)_ The value of `1` means that it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occurring with the incremental build.
+When executed this will build the site and host it at [http://localhost:8081](http://localhost:8081).
+
+To build the website for release, run the script:
+
+```
+/websites/site/site.ps1
+```
+
+This will build the site with all live parameters configured correctly and output the built static site into the `_site` folder.
+
+The script parameters are:
+
+- `-ServeDocs` _(optional)_ A boolean switch. If present, it will build the docs and host the site. If not present it will build the static site to be hosted elsewhere.
+- `-Clean` _(optional)_ A boolean switch.  If present, it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occurring with the incremental build.
 
 ### File/folder structure
 
@@ -50,7 +64,7 @@ The file/folder structure is within `/websites/site`:
 
 ### Build script
 
-To build the api docs and run it on your machine, run the powershell script `docs.ps1`. For example: 
+To build the api docs and run it on your machine, run the Powershell script: `/websites/apidocs/docs.ps1`. For example:
 
 ```
 /websites/apidocs/docs.ps1 -ServeDocs -LuceneNetVersion 4.8.0-beta00008 -BaseUrl http://localhost:8080
@@ -64,18 +78,18 @@ To build the api docs for release, run the script:
 /websites/apidocs/docs.ps1 -LuceneNetVersion 4.8.0-beta00008
 ```
 
-This will build the site with all live parameters configured correctly and output the built static site into the `_site` folder. 
+This will build the site with all live parameters configured correctly and output the built static site into the `_site` folder.
 
-The script has several parameters:
+The script parameters are:
 
-* `-LuceneNetVersion` _(mandatory)_ This is the Lucene.Net version including pre-release information that is being built. For example: `4.8.0-beta00008`. _(This value will correspond to the folder and branch name where the docs get hosted, see below)_
-* `-ServeDocs` _(optinonal)_ A boolean switch. If present, it will build the docs and host the site. If not present it will build the static site to be hosted elsewhere.
-* `-Clean` _(optinonal)_ A boolean switch.  If present, it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occuring with the incremental build.
-* `-DisableMetaData` _(optinonal)_ A boolean switch. If present it will disable the docfx metadata build operation of the docs build. Can be handy when debugging the docs build.
-* `-DisableBuild` _(optinonal)_ A boolean switch. If present it will disable the site building operation of the docs build. Can be handy when debugging the docs build.
-* `-DisablePlugins` _(optinonal)_ A boolean switch. If present it will not build the custom Lucene.Net `DocumentationTools.sln` docsfx plugins and exclude them from the build. 
-* `-LogLevel` _(optinonal)_ Default is Warning. Options are: Diagnostic, Verbose, Info, Warning, Error.
-* `-BaseUrl` _(optinonal)_ Default is https://lucenenet.apache.org/docs/. Used to set the base URL of the docfx xref map files for cross linking between project builds. 
+- `-LuceneNetVersion` _(mandatory)_ This is the Lucene.Net version including pre-release information that is being built. For example: `4.8.0-beta00008`. _(This value will correspond to the folder and branch name where the docs get hosted, see below)_
+* `-ServeDocs` _(optional)_ A boolean switch. If present, it will build the docs and host the site. If not present it will build the static site to be hosted elsewhere.
+* `-Clean` _(optional)_ A boolean switch.  If present, it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occurring with the incremental build.
+* `-DisableMetaData` _(optional)_ A boolean switch. If present it will disable the docfx metadata build operation of the docs build. Can be handy when debugging the docs build.
+* `-DisableBuild` _(optional)_ A boolean switch. If present it will disable the site building operation of the docs build. Can be handy when debugging the docs build.
+* `-DisablePlugins` _(optional)_ A boolean switch. If present it will not build the custom Lucene.Net `DocumentationTools.sln` docsfx plugins and exclude them from the build.
+* `-LogLevel` _(optional)_ Default is Warning. Options are: Diagnostic, Verbose, Info, Warning, Error.
+* `-BaseUrl` _(optional)_ Default is https://lucenenet.apache.org/docs/. Used to set the base URL of the docfx xref map files for cross linking between project builds.
 
 ### File/folder structure
 

--- a/websites/site/contributing/documentation.md
+++ b/websites/site/contributing/documentation.md
@@ -50,13 +50,32 @@ The file/folder structure is within `/websites/site`:
 
 ### Build script
 
-To build the api docs and run it on your machine, run the Powershell script: `/websites/apidocs/docs.ps1`. You don't have to pass any parameters in and it will build the site and host it at [http://localhost:8080](http://localhost:8080).
+To build the api docs and run it on your machine, run the powershell script `docs.ps1`. For example: 
 
-The script has 3 parameters:
+```
+/websites/apidocs/docs.ps1 -ServeDocs -LuceneNetVersion 4.8.0-beta00008 -BaseUrl http://localhost:8080
+```
 
-- `-LuceneNetVersion` _(mandatory)_ This is the Lucene.Net version including pre-release information that is being built. For example: `4.8.0-beta00008`. _(This value will correspond to the folder and branch name where the docs get hosted, see below)_
-- `-ServeDocs` _(default is 1)_ The value of `1` means it will build the docs and host the site, if `0` is specified, it will build the static site to be hosted elsewhere.
-- `-Clean` _(default is 0)_ The value of `1` means that it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occurring with the incremental build.
+When executed this will build the site and host it at [http://localhost:8080](http://localhost:8080). _(Ensure to pass in the current version of Lucene.Net you are building.)_
+
+To build the api docs for release, run the script:
+
+```
+/websites/apidocs/docs.ps1 -LuceneNetVersion 4.8.0-beta00008
+```
+
+This will build the site with all live parameters configured correctly and output the built static site into the `_site` folder. 
+
+The script has several parameters:
+
+* `-LuceneNetVersion` _(mandatory)_ This is the Lucene.Net version including pre-release information that is being built. For example: `4.8.0-beta00008`. _(This value will correspond to the folder and branch name where the docs get hosted, see below)_
+* `-ServeDocs` _(optinonal)_ A boolean switch. If present, it will build the docs and host the site. If not present it will build the static site to be hosted elsewhere.
+* `-Clean` _(optinonal)_ A boolean switch.  If present, it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occuring with the incremental build.
+* `-DisableMetaData` _(optinonal)_ A boolean switch. If present it will disable the docfx metadata build operation of the docs build. Can be handy when debugging the docs build.
+* `-DisableBuild` _(optinonal)_ A boolean switch. If present it will disable the site building operation of the docs build. Can be handy when debugging the docs build.
+* `-DisablePlugins` _(optinonal)_ A boolean switch. If present it will not build the custom Lucene.Net `DocumentationTools.sln` docsfx plugins and exclude them from the build. 
+* `-LogLevel` _(optinonal)_ Default is Warning. Options are: Diagnostic, Verbose, Info, Warning, Error.
+* `-BaseUrl` _(optinonal)_ Default is https://lucenenet.apache.org/docs/. Used to set the base URL of the docfx xref map files for cross linking between project builds. 
 
 ### File/folder structure
 

--- a/websites/site/site.ps1
+++ b/websites/site/site.ps1
@@ -6,9 +6,9 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the ""License""); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an ""AS IS"" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,12 +18,8 @@
 # -----------------------------------------------------------------------------------
 
 param (
-	[Parameter(Mandatory=$false)]
-	[int]
-	$ServeDocs = 1,
-	[Parameter(Mandatory=$false)]
-	[int]
-	$Clean = 0,
+	[switch] $ServeDocs = $false,
+	[switch] $Clean = $false,
 	# LogLevel can be: Diagnostic, Verbose, Info, Warning, Error
 	[Parameter(Mandatory=$false)]
 	[string]
@@ -56,7 +52,7 @@ if (-not (test-path $DocFxExe))
 {
 	Write-Host "Retrieving docfx..."
 	$DocFxZip = "$ToolsFolder\tmp\docfx.zip"
-	Invoke-WebRequest "https://github.com/dotnet/docfx/releases/download/v2.50/docfx.zip" -OutFile $DocFxZip -TimeoutSec 60 
+	Invoke-WebRequest "https://github.com/dotnet/docfx/releases/download/v2.50/docfx.zip" -OutFile $DocFxZip -TimeoutSec 60
 	#unzip
 	Expand-Archive $DocFxZip -DestinationPath (Join-Path -Path $ToolsFolder -ChildPath "docfx")
 }
@@ -75,9 +71,9 @@ if ($Clean -eq 1) {
 $DocFxJson = Join-Path -Path $SiteFolder "docfx.json"
 $DocFxLog = Join-Path -Path $SiteFolder "obj\docfx.log"
 
-if($?) { 
+if($?) {
 	if ($ServeDocs -eq 0){
-		# build the output		
+		# build the output
 		Write-Host "Building docs..."
 		& $DocFxExe build $DocFxJson -l "$DocFxLog" --loglevel $LogLevel
 	}


### PR DESCRIPTION
Streamlines some of the build operations:

* Uses powershell flags instead of 0/1
* Updates docs on how to run the scripts including their params
* re-enables our docfx plugins with custom MD parsers so the lucene version is automatically applied throughout the docs
* Ensures the correct base path is used when building the docs for release so that linking works correctly

I have run this locally and the docs build so perhaps it fixes this? https://github.com/apache/lucenenet/issues/380