### PR TITLE
Azure DevOps Pipeline Optimizations and Improvements

### DIFF
--- a/.github/workflows/Generate-TestWorkflows.ps1
+++ b/.github/workflows/Generate-TestWorkflows.ps1
@@ -256,7 +256,7 @@ jobs:
           echo `"title=Test Run for `$project_name - `${{matrix.framework}} - `${{matrix.platform}} - `${{matrix.os}}`" | Out-File -FilePath  `$env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build `${{env.project_path}} --configuration `${{matrix.configuration}} --framework `${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test `${{env.project_path}} --configuration `${{matrix.configuration}} --framework `${{matrix.framework}} --no-build --no-restore --logger:`"console;verbosity=normal`" --logger:`"trx;LogFileName=`${{env.trx_file_name}}`" --logger:`"liquid.md;LogFileName=`${{env.md_file_name}};Title=`${{env.title}};`" --results-directory:`"`${{github.workspace}}/`${{env.test_results_artifact_name}}/`${{env.project_name}}`" -- RunConfiguration.TargetPlatform=`${{matrix.platform}}
+      - run: dotnet test `${{env.project_path}} --configuration `${{matrix.configuration}} --framework `${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:`"console;verbosity=normal`" --logger:`"trx;LogFileName=`${{env.trx_file_name}}`" --logger:`"liquid.md;LogFileName=`${{env.md_file_name}};Title=`${{env.title}};`" --results-directory:`"`${{github.workspace}}/`${{env.test_results_artifact_name}}/`${{env.project_name}}`" -- RunConfiguration.TargetPlatform=`${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Common.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Common.yml
@@ -93,7 +93,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Kuromoji.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Kuromoji.yml
@@ -94,7 +94,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Morfologik.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Morfologik.yml
@@ -94,7 +94,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Analysis-OpenNLP.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-OpenNLP.yml
@@ -98,7 +98,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Phonetic.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Phonetic.yml
@@ -94,7 +94,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Analysis-SmartCn.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-SmartCn.yml
@@ -98,7 +98,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Stempel.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Stempel.yml
@@ -94,7 +94,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Benchmark.yml
+++ b/.github/workflows/Lucene-Net-Tests-Benchmark.yml
@@ -104,7 +104,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Classification.yml
+++ b/.github/workflows/Lucene-Net-Tests-Classification.yml
@@ -95,7 +95,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Cli.yml
+++ b/.github/workflows/Lucene-Net-Tests-Cli.yml
@@ -112,7 +112,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-CodeAnalysis.yml
+++ b/.github/workflows/Lucene-Net-Tests-CodeAnalysis.yml
@@ -93,7 +93,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Codecs.yml
+++ b/.github/workflows/Lucene-Net-Tests-Codecs.yml
@@ -93,7 +93,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Demo.yml
+++ b/.github/workflows/Lucene-Net-Tests-Demo.yml
@@ -101,7 +101,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Expressions.yml
+++ b/.github/workflows/Lucene-Net-Tests-Expressions.yml
@@ -95,7 +95,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Facet.yml
+++ b/.github/workflows/Lucene-Net-Tests-Facet.yml
@@ -97,7 +97,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Grouping.yml
+++ b/.github/workflows/Lucene-Net-Tests-Grouping.yml
@@ -95,7 +95,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Highlighter.yml
+++ b/.github/workflows/Lucene-Net-Tests-Highlighter.yml
@@ -96,7 +96,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-ICU.yml
+++ b/.github/workflows/Lucene-Net-Tests-ICU.yml
@@ -99,7 +99,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Join.yml
+++ b/.github/workflows/Lucene-Net-Tests-Join.yml
@@ -96,7 +96,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Memory.yml
+++ b/.github/workflows/Lucene-Net-Tests-Memory.yml
@@ -97,7 +97,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Misc.yml
+++ b/.github/workflows/Lucene-Net-Tests-Misc.yml
@@ -94,7 +94,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Queries.yml
+++ b/.github/workflows/Lucene-Net-Tests-Queries.yml
@@ -94,7 +94,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-QueryParser.yml
+++ b/.github/workflows/Lucene-Net-Tests-QueryParser.yml
@@ -96,7 +96,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Replicator.yml
+++ b/.github/workflows/Lucene-Net-Tests-Replicator.yml
@@ -99,7 +99,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Sandbox.yml
+++ b/.github/workflows/Lucene-Net-Tests-Sandbox.yml
@@ -94,7 +94,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Spatial.yml
+++ b/.github/workflows/Lucene-Net-Tests-Spatial.yml
@@ -95,7 +95,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-Suggest.yml
+++ b/.github/workflows/Lucene-Net-Tests-Suggest.yml
@@ -96,7 +96,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-TestFramework-DependencyInjection.yml
+++ b/.github/workflows/Lucene-Net-Tests-TestFramework-DependencyInjection.yml
@@ -93,7 +93,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-TestFramework.yml
+++ b/.github/workflows/Lucene-Net-Tests-TestFramework.yml
@@ -93,7 +93,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-_A-D.yml
+++ b/.github/workflows/Lucene-Net-Tests-_A-D.yml
@@ -99,7 +99,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-_E-I.yml
+++ b/.github/workflows/Lucene-Net-Tests-_E-I.yml
@@ -99,7 +99,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-_I-J.yml
+++ b/.github/workflows/Lucene-Net-Tests-_I-J.yml
@@ -99,7 +99,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-_J-S.yml
+++ b/.github/workflows/Lucene-Net-Tests-_J-S.yml
@@ -99,7 +99,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Lucene-Net-Tests-_T-Z.yml
+++ b/.github/workflows/Lucene-Net-Tests-_T-Z.yml
@@ -99,7 +99,7 @@ jobs:
           echo "title=Test Run for $project_name - ${{matrix.framework}} - ${{matrix.platform}} - ${{matrix.os}}" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - run: dotnet build ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} /p:TestFrameworks=true
-      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
+      - run: dotnet test ${{env.project_path}} --configuration ${{matrix.configuration}} --framework ${{matrix.framework}} --no-build --no-restore --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{env.trx_file_name}}" --logger:"liquid.md;LogFileName=${{env.md_file_name}};Title=${{env.title}};" --results-directory:"${{github.workspace}}/${{env.test_results_artifact_name}}/${{env.project_name}}" -- RunConfiguration.TargetPlatform=${{matrix.platform}}
       # upload reports as build artifacts
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,6 +45,10 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
+  <PropertyGroup Label="Assembly Publishing">
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
   <PropertyGroup Label="NuGet Package Defaults">
     <IsPackable>false</IsPackable>
     <IncludeSymbols>true</IncludeSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,6 +47,7 @@
 
   <PropertyGroup Label="Assembly Publishing">
     <IsPublishable>false</IsPublishable>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet Package Defaults">

--- a/TestTargetFramework.props
+++ b/TestTargetFramework.props
@@ -39,6 +39,10 @@
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Label="Assembly Publishing">
+    <IsPublishable>true</IsPublishable>
+  </PropertyGroup>
+
   <PropertyGroup Label="Warnings to be Disabled in Test Projects">
     <NoWarn Label="Nested types should not be visible">$(NoWarn);CA1034</NoWarn>
     <NoWarn Label="Use Literals Where Appropriate">$(NoWarn);CA1802</NoWarn>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ stages:
       vmImage: 'windows-2019'
 
     variables:
-      PublishTempDirectory: '$(Build.BinariesDirectory)/publish'
+      PublishTempDirectory: '$(Build.ArtifactStagingDirectory)/publish'
 
     steps:
     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,9 +121,10 @@ stages:
         $properties = @{
             backup_files='false';
             publish_directory='$(PublishTempDirectory)';
-            nuget_package_directory='$(NuGetArtifactDirectory)'
+            nuget_package_directory='$(NuGetArtifactDirectory)';
             # Lock the build.bat so it only builds this version in the release distribution
-            generateBuildBat=$generateBuildBat
+            generateBuildBat=$generateBuildBat;
+            skipSdkInstallation='true'
         }
         [string[]]$tasks = 'Pack'
         if ($Env:RunTests -ne 'false') {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,6 +108,12 @@ stages:
     - powershell: |
         $configuration = if ($env:BUILDCONFIGURATION) { $env:BUILDCONFIGURATION } else { "Release" }
         Write-Host "##vso[task.setvariable variable=BuildConfiguration;]$configuration"
+        $isRelease = if ($env:ISRELEASE -eq 'true') { 'true' } else { 'false' }
+        Write-Host "##vso[task.setvariable variable=IsRelease;]$isRelease"
+        $isNightly = if ($env:ISNIGHTLY -eq 'true') { 'true' } else { 'false' }
+        Write-Host "##vso[task.setvariable variable=IsNightly;]$isNightly"
+        $isWeekly = if ($env:ISWEEKLY -eq 'true') { 'true' } else { 'false' }
+        Write-Host "##vso[task.setvariable variable=IsWeekly;]$isWeekly"
         $runPack = if ($env:ISRELEASE -eq 'true' -or $env:ARTIFACTFEEDID -ne '' -or $env:GENERATEPACKAGES -ne 'false') { 'true' } else { 'false' }
         Write-Host "##vso[task.setvariable variable=RunPack;]$runPack"
       displayName: 'Setup Default Variable Values'
@@ -119,7 +125,7 @@ stages:
 
     - powershell: |
         Import-Module "$(BuildDirectory)/psake.psm1"
-        $generateBuildBat = if ($Env:ISRELEASE -eq 'true') { 'true' } else { 'false' }
+        $generateBuildBat = $env:ISRELEASE
         $primaryCommand = if ($env:RUNPACK -ne 'false') { 'Pack' } else { 'Compile' }
         $parameters = @{}
         $properties = @{

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,7 +137,7 @@ stages:
             skipSdkInstallation='true'
         }
         [string[]]$tasks = @($primaryCommand)
-        if ($Env:RunTests -ne 'false') {
+        if ($env:RunTests -ne 'false') {
             [string[]]$tasks = $primaryCommand,'Publish'
         }
         Invoke-psake $(BuildDirectory)/build.ps1 -Task $tasks -properties $properties -parameters $parameters
@@ -156,17 +156,17 @@ stages:
 
     - pwsh: |
         # Generate a lucene.testsettings.json file for use with the test framework
-        $assert = if ($Env:AssertsEnabled -ne 'false') { 'true' } else { 'false' }
-        $nightly = if ($Env:IsNightly -eq 'true') { 'true' } else { 'false' }
-        $weekly = if ($Env:IsWeekly -eq 'true') { 'true' } else { 'false' }
-        $slow = if ($Env:RunSlowTests -ne 'false') { 'true' } else { 'false' }
-        $awaitsFix = if ($Env:RunAwaitsFixTests -ne 'false') { 'true' } else { 'false' }
-        $codec = if ($Env:Codec -eq $null) { 'random' } else { $Env:Codec }
-        $docValuesFormat = if ($Env:DocValuesFormat -eq $null) { 'random' } else { $Env:DocValuesFormat }
-        $postingsFormat = if ($Env:PostingsFormat -eq $null) { 'random' } else { $Env:PostingsFormat }
-        $directory = if ($Env:Directory -eq $null) { 'random' } else { $Env:Directory }
-        $verbose = if ($Env:Verbose -eq 'true') { 'true' } else { 'false' }
-        $multiplier = if ($Env:Multiplier -eq $null) { '1' } else { $Env:Multiplier }
+        $assert = if ($env:AssertsEnabled -ne 'false') { 'true' } else { 'false' }
+        $nightly = if ($env:IsNightly -eq 'true') { 'true' } else { 'false' }
+        $weekly = if ($env:IsWeekly -eq 'true') { 'true' } else { 'false' }
+        $slow = if ($env:RunSlowTests -ne 'false') { 'true' } else { 'false' }
+        $awaitsFix = if ($env:RunAwaitsFixTests -ne 'false') { 'true' } else { 'false' }
+        $codec = if ($env:Codec -eq $null) { 'random' } else { $env:Codec }
+        $docValuesFormat = if ($env:DocValuesFormat -eq $null) { 'random' } else { $env:DocValuesFormat }
+        $postingsFormat = if ($env:PostingsFormat -eq $null) { 'random' } else { $env:PostingsFormat }
+        $directory = if ($env:Directory -eq $null) { 'random' } else { $env:Directory }
+        $verbose = if ($env:Verbose -eq 'true') { 'true' } else { 'false' }
+        $multiplier = if ($env:Multiplier -eq $null) { '1' } else { $env:Multiplier }
         $fileText = "{`n`t" +
             """assert"": ""$assert"",`n`t" +
             """tests"": {`n`t`t" +

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,6 +201,7 @@ stages:
         SourceFolder: '$(System.DefaultWorkingDirectory)'
         Contents: '**/bin/$(BuildConfiguration)/**/*.pdb'
         TargetFolder: '$(Build.ArtifactStagingDirectory)/$(DebugArtifactName)'
+      condition: and(succeeded(), ne(variables['ArtifactFeedID'], ''))
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Artifact: $(NuGetArtifactName)'
@@ -215,6 +216,7 @@ stages:
         targetPath: '$(Build.ArtifactStagingDirectory)/$(DebugArtifactName)'
         artifact: '$(DebugArtifactName)'
         publishLocation: 'pipeline'
+      condition: and(succeeded(), ne(variables['ArtifactFeedID'], ''))
 
     - template: 'build/azure-templates/publish-test-binaries.yml'
       parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,7 @@ stages:
     - checkout: self # self represents the repo where the initial Pipelines YAML file was found
       fetchDepth: '1'  # the depth of commits to ask Git to fetch
 
-    - powershell: |
+    - pwsh: |
         $configuration = if ($env:BUILDCONFIGURATION) { $env:BUILDCONFIGURATION } else { "Release" }
         Write-Host "##vso[task.setvariable variable=BuildConfiguration;]$configuration"
         $isRelease = if ($env:ISRELEASE -eq 'true') { 'true' } else { 'false' }
@@ -123,7 +123,7 @@ stages:
       inputs:
         version: 5.0.100
 
-    - powershell: |
+    - pwsh: |
         Import-Module "$(BuildDirectory)/psake.psm1"
         $generateBuildBat = $env:ISRELEASE
         $primaryCommand = if ($env:RUNPACK -ne 'false') { 'Pack' } else { 'Compile' }
@@ -264,7 +264,7 @@ stages:
       vmImage: 'vs2017-win2016'
 
     steps:
-    - powershell: |
+    - pwsh: |
          $(Build.SourcesDirectory)/websites/apidocs/docs.ps1 -LuceneNetVersion $(PackageVersion) -Clean -BaseUrl https://lucenenet.apache.org/docs/
       errorActionPreference: 'continue'
       ignoreLASTEXITCODE: 'true'
@@ -290,7 +290,7 @@ stages:
       vmImage: 'vs2017-win2016'
 
     steps:
-    - powershell: |
+    - pwsh: |
          $(Build.SourcesDirectory)/websites/site/site.ps1 0 1
       errorActionPreference: 'continue'
       ignoreLASTEXITCODE: 'true'
@@ -563,14 +563,14 @@ stages:
         targetPath: '$(System.DefaultWorkingDirectory)/$(VersionArtifactName)'
 
       # For debugging this pipeline
-    - powershell: | 
+    - pwsh: | 
         Get-ChildItem -Path $(System.DefaultWorkingDirectory)
-    - powershell: | 
+    - pwsh: | 
         Get-ChildItem -Path '$(VersionArtifactName)'
 
       # NOTE: We are setting Build.BuildNumber here to the NuGet package version to work around the limitation that
       # the version cannot be passed to the Index Sources & Publish Symbols task.
-    - powershell: |
+    - pwsh: |
         $version = Get-Content '$(VersionArtifactName)/$(PackageVersionFileName)' -Raw
         Write-Host "##vso[task.setvariable variable=PackageVersion;]$version"
         Write-Host "##vso[build.updatebuildnumber]$version"
@@ -617,14 +617,14 @@ stages:
 
       # NOTE: We are setting Build.BuildNumber here to the NuGet package version to work around the limitation that
       # the version cannot be passed to the Index Sources & Publish Symbols task.
-    - powershell: |
+    - pwsh: |
         $version = Get-Content '$(Build.ArtifactStagingDirectory)/$(VersionArtifactName)/$(PackageVersionFileName)' -Raw
         $vcsLabel = 'Lucene.Net_' + $version.Replace('.', '_').Replace('-', '_')
         Write-Host "##vso[task.setvariable variable=VCSLabel;]$vcsLabel"
         Write-Host "##vso[task.setvariable variable=PackageVersion;]$version"
         Write-Host "##vso[build.updatebuildnumber]$version"
       displayName: 'Build VCS Label and Rehydrate Version Variables'
-    - powershell: |
+    - pwsh: |
         $files = 'build.bat','Version.props'
         foreach ($file in $files) {
             Copy-Item -Path "$(Build.ArtifactStagingDirectory)/$(VersionArtifactName)/$file" -Destination "$(Build.SourcesDirectory)/$file" -Force -ErrorAction Continue
@@ -669,7 +669,7 @@ stages:
         includeRootFolder: false
         archiveFile: '$(Build.ArtifactStagingDirectory)/$(ReleaseArtifactName)/Apache-Lucene.Net-$(PackageVersion).bin.zip'
 
-    - powershell: |
+    - pwsh: |
         $dir = '$(Build.ArtifactStagingDirectory)/$(ReleaseArtifactName)'
         if (!(Test-Path $dir)) { New-Item -ItemType Directory -Path "$dir" -Force }
         $nl = [Environment]::NewLine

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,7 @@ name: 'vNext$(rev:.r)' # Format for build number (will be overridden)
 # GenerateDocs: (Optional. Only builds documentation website if set to 'true'.)
 # GenerateWebsite: (Optional. Only builds lucene.net website if set to 'true'.)
 # IsRelease: (Optional. By default the Release job is disabled, setting this to 'true' will enable it)
+# GeneratePackages: (Optional. Defaults to 'true'. Setting to 'false' will cut about 1 minute from the build time by skipping packing the NuGet files and subsequent artiact upload. If ArtifactFeedID is provided or IsRelease is 'true', this setting has no effect.)
 
 # Versioning Variables
 
@@ -107,6 +108,8 @@ stages:
     - powershell: |
         $configuration = if ($env:BUILDCONFIGURATION) { $env:BUILDCONFIGURATION } else { "Release" }
         Write-Host "##vso[task.setvariable variable=BuildConfiguration;]$configuration"
+        $runPack = if ($env:ISRELEASE -eq 'true' -or $env:ARTIFACTFEEDID -ne '' -or $env:GENERATEPACKAGES -ne 'false') { 'true' } else { 'false' }
+        Write-Host "##vso[task.setvariable variable=RunPack;]$runPack"
       displayName: 'Setup Default Variable Values'
 
     - task: UseDotNet@2
@@ -117,6 +120,7 @@ stages:
     - powershell: |
         Import-Module "$(BuildDirectory)/psake.psm1"
         $generateBuildBat = if ($Env:ISRELEASE -eq 'true') { 'true' } else { 'false' }
+        $primaryCommand = if ($env:RUNPACK -ne 'false') { 'Pack' } else { 'Compile' }
         $parameters = @{}
         $properties = @{
             backup_files='false';
@@ -126,9 +130,9 @@ stages:
             generateBuildBat=$generateBuildBat;
             skipSdkInstallation='true'
         }
-        [string[]]$tasks = 'Pack'
+        [string[]]$tasks = @($primaryCommand)
         if ($Env:RunTests -ne 'false') {
-            [string[]]$tasks = 'Pack','Publish'
+            [string[]]$tasks = $primaryCommand,'Publish'
         }
         Invoke-psake $(BuildDirectory)/build.ps1 -Task $tasks -properties $properties -parameters $parameters
         exit !($psake.build_success)
@@ -210,6 +214,7 @@ stages:
         targetPath: '$(Build.ArtifactStagingDirectory)/$(NuGetArtifactName)'
         artifact: '$(NuGetArtifactName)'
         publishLocation: 'pipeline'
+      condition: and(succeeded(), ne(variables['RunPack'], 'false'))
     
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Artifact: $(DebugArtifactName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -143,7 +143,8 @@ stages:
         Invoke-psake $(BuildDirectory)/build.ps1 -Task $tasks -properties $properties -parameters $parameters
         exit !($psake.build_success)
       displayName: 'PSake Build, Pack, and Publish'
-    - template: 'build/azure-templates/show-all-environment-variables.yml'
+
+    #- template: 'build/azure-templates/show-all-environment-variables.yml' # Uncomment for debugging
         
     - pwsh: |
         $dir = '$(Build.ArtifactStagingDirectory)/$(VersionArtifactName)'
@@ -563,10 +564,9 @@ stages:
         targetPath: '$(System.DefaultWorkingDirectory)/$(VersionArtifactName)'
 
       # For debugging this pipeline
-    - pwsh: | 
-        Get-ChildItem -Path $(System.DefaultWorkingDirectory)
-    - pwsh: | 
-        Get-ChildItem -Path '$(VersionArtifactName)'
+    #- pwsh: | 
+    #    Get-ChildItem -Path $(System.DefaultWorkingDirectory)
+    #    Get-ChildItem -Path '$(VersionArtifactName)'
 
       # NOTE: We are setting Build.BuildNumber here to the NuGet package version to work around the limitation that
       # the version cannot be passed to the Index Sources & Publish Symbols task.

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -65,7 +65,7 @@
     <MSTestTestFrameworkPackageVersion>2.0.0</MSTestTestFrameworkPackageVersion>
     <MSTestTestAdapterPackageVersion>$(MSTestTestFrameworkPackageVersion)</MSTestTestAdapterPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
-    <NewtonsoftJsonPackageVersion>10.0.3</NewtonsoftJsonPackageVersion>
+    <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
     <NUnit3TestAdapterPackageVersion>3.16.1</NUnit3TestAdapterPackageVersion>
     <NUnitPackageVersion>3.12.0</NUnitPackageVersion>
     <OpenNLPNETPackageVersion>1.9.1</OpenNLPNETPackageVersion>

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -77,6 +77,7 @@
     <SystemReflectionEmitILGenerationPackageVersion>4.3.0</SystemReflectionEmitILGenerationPackageVersion>
     <SystemReflectionTypeExtensionsPackageVersion>4.3.0</SystemReflectionTypeExtensionsPackageVersion>
     <SystemRuntimeInteropServicesRuntimeInformationPackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>4.7.0</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>4.3.0</SystemTextEncodingCodePagesPackageVersion>
     <XUnitPackageVersion>2.3.1</XUnitPackageVersion>
     <XUnitRunnerVisualStudioPackageVersion>$(XUnitPackageVersion)</XUnitRunnerVisualStudioPackageVersion>

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -57,7 +57,8 @@
     <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>$(MicrosoftExtensionsConfigurationPackageVersion)</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
     <MicrosoftExtensionsConfigurationJsonPackageVersion>$(MicrosoftExtensionsConfigurationPackageVersion)</MicrosoftExtensionsConfigurationJsonPackageVersion>
     <MicrosoftExtensionsConfigurationXmlPackageVersion>$(MicrosoftExtensionsConfigurationPackageVersion)</MicrosoftExtensionsConfigurationXmlPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>3.1.4</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.0.0</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)</MicrosoftExtensionsDependencyInjectionPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>16.6.1</MicrosoftNETTestSdkPackageVersion>
     <MorfologikFsaPackageVersion>2.1.7-beta-0001</MorfologikFsaPackageVersion>
     <MorfologikPolishPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikPolishPackageVersion>

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -40,8 +40,8 @@
     <ICU4NTransliteratorPackageVersion>$(ICU4NPackageVersion)</ICU4NTransliteratorPackageVersion>
     <J2NPackageVersion>2.0.0-beta-0010</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
-    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>1.0.3</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>1.0.3</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.0.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>2.0.0</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftCodeAnalysisAnalyzersPackageVersion>2.9.8</MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.4.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>3.4.0</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -59,6 +59,7 @@
     <MicrosoftExtensionsConfigurationXmlPackageVersion>$(MicrosoftExtensionsConfigurationPackageVersion)</MicrosoftExtensionsConfigurationXmlPackageVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.0.0</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
     <MicrosoftExtensionsDependencyInjectionPackageVersion>$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>2.0.0</MicrosoftExtensionsOptionsPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>16.6.1</MicrosoftNETTestSdkPackageVersion>
     <MorfologikFsaPackageVersion>2.1.7-beta-0001</MorfologikFsaPackageVersion>
     <MorfologikPolishPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikPolishPackageVersion>

--- a/build/TestReferences.Common.targets
+++ b/build/TestReferences.Common.targets
@@ -29,4 +29,8 @@
     <PackageReference Include="NUnit" Version="$(NUnitPackageVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterPackageVersion)" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
+  </ItemGroup>
 </Project>

--- a/build/TestReferences.Common.targets
+++ b/build/TestReferences.Common.targets
@@ -32,5 +32,11 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/build/azure-templates/publish-nuget-packages.yml
+++ b/build/azure-templates/publish-nuget-packages.yml
@@ -27,7 +27,7 @@ parameters:
   testSymbolFilesConvention: '**/*.Tests*.pdb' # The glob pattern (within the debugArtifactName) where to look for test project symbols (.pdb) files, so they can be distinguished from other project file types.
 
 steps:
-- powershell: |
+- pwsh: |
     function EnsureNotNullOrEmpty([string]$param, [string]$nameOfParam) {
         if ([string]::IsNullOrEmpty($param)) {
             Write-Host "##vso[task.logissue type=error;]Missing template parameter \"$nameOfParam\""

--- a/build/azure-templates/publish-test-results-for-test-projects.yml
+++ b/build/azure-templates/publish-test-results-for-test-projects.yml
@@ -54,7 +54,7 @@ parameters:
   testResultsFileName: 'TestResults.trx' # The name of the file (not path) of the test results. Default 'TestResults.trx'.
 
 steps:
-#- powershell: |
+#- pwsh: |
 #    function EnsureNotNullOrEmpty([string]$param, [string]$nameOfParam) {
 #        if ([string]::IsNullOrEmpty($param)) {
 #            Write-Host "##vso[task.logissue type=error;]Missing template parameter \"$nameOfParam\""

--- a/build/azure-templates/publish-test-results.yml
+++ b/build/azure-templates/publish-test-results.yml
@@ -60,7 +60,7 @@ steps:
                     $testResults = "Tests failed: $failed, passed: $passed, ignored: $ignored"
                     Write-Host "##vso[task.setvariable variable=TestResults;]$testResults"
                     # Report a running total of failures
-                    $totalFailures = ([int]$Env:TOTALFAILURES + [int]$failed).ToString()
+                    $totalFailures = ([int]$env:TOTALFAILURES + [int]$failed).ToString()
                     Write-Host "##vso[task.setvariable variable=TotalFailures;]$totalFailures"
                     break;
                 }

--- a/build/azure-templates/publish-test-results.yml
+++ b/build/azure-templates/publish-test-results.yml
@@ -46,23 +46,43 @@ steps:
 #- template: 'show-all-files.yml' # Uncomment for debugging
 
 - pwsh: |
-    $testResultsFileName = "$(Build.ArtifactStagingDirectory)/${{ parameters.testResultsArtifactName }}/${{ parameters.osName }}/${{ parameters.framework }}/${{ parameters.vsTestPlatform }}/${{ parameters.testProjectName }}/${{ parameters.testResultsFileName }}"
+    $testProjectName = "${{ parameters.testProjectName }}"
+    $testResultsFileName = "$(Build.ArtifactStagingDirectory)/${{ parameters.testResultsArtifactName }}/${{ parameters.osName }}/${{ parameters.framework }}/${{ parameters.vsTestPlatform }}/$testProjectName/${{ parameters.testResultsFileName }}"
     $testResultsFileExists = Test-Path $testResultsFileName
     if ($testResultsFileExists) {
-
+    
         $reader = [System.Xml.XmlReader]::Create($testResultsFileName)
         try {
+            $countersFound = $false
+            $crashed = $false
+            $inRunInfos = $false
             while ($reader.Read()) {
-                if ($reader.NodeType -eq [System.Xml.XmlNodeType]::Element -and $reader.Name -eq 'Counters') {
-                    $failed = $reader.GetAttribute('failed')
-                    $passed = $reader.GetAttribute('passed')
-                    $ignored = (([int]$reader.GetAttribute('total')) - ([int]$reader.GetAttribute('executed'))).ToString()
-                    $testResults = "Tests failed: $failed, passed: $passed, ignored: $ignored"
-                    Write-Host "##vso[task.setvariable variable=TestResults;]$testResults"
-                    # Report a running total of failures
-                    $totalFailures = ([int]$env:TOTALFAILURES + [int]$failed).ToString()
-                    Write-Host "##vso[task.setvariable variable=TotalFailures;]$totalFailures"
-                    break;
+                if ($reader.NodeType -eq [System.Xml.XmlNodeType]::Element) {
+                    if (!$countersFound -and $reader.Name -eq 'Counters') {
+                        $failed = $reader.GetAttribute('failed')
+                        $passed = $reader.GetAttribute('passed')
+                        $ignored = (([int]$reader.GetAttribute('total')) - ([int]$reader.GetAttribute('executed'))).ToString()
+                        $testResults = "Tests failed: $failed, passed: $passed, ignored: $ignored"
+                        Write-Host "##vso[task.setvariable variable=TestResults;]$testResults"
+                        # Report a running total of failures
+                        $totalFailures = ([int]$env:TOTALFAILURES + [int]$failed).ToString()
+                        Write-Host "##vso[task.setvariable variable=TotalFailures;]$totalFailures"
+                        $countersFound = $true
+                    }
+                    # Report a crash of the test runner
+                    if ($reader.Name -eq 'RunInfos') {
+                        $inRunInfos = $true
+                    }
+                    if ($inRunInfos -and !$crashed -and $reader.Name -eq 'Text' -and $reader.ReadInnerXml().Contains('Test host process crashed')) {
+                        Write-Host "##vso[task.setvariable variable=HostCrashed;]true"
+                        # Report all of the test projects that crashed
+                        $crashedRuns = "$env:CRASHEDRUNS,$testProjectName".TrimStart(',')
+                        Write-Host "##vso[task.setvariable variable=CrashedRuns;]$crashedRuns"
+                        $crashed = $true
+                    }
+                }
+                if ($reader.NodeType -eq [System.Xml.XmlNodeType]::EndElement -and $reader.Name -eq 'RunInfos') {
+                    $inRunInfos = $false
                 }
             }
         } finally {

--- a/build/azure-templates/publish-test-results.yml
+++ b/build/azure-templates/publish-test-results.yml
@@ -27,7 +27,7 @@ parameters:
   testResultsFileName: 'TestResults.trx' # The name of the file (not path) of the test results. Default 'TestResults.trx'.
 
 steps:
-#- powershell: |
+#- pwsh: |
 #    function EnsureNotNullOrEmpty([string]$param, [string]$nameOfParam) {
 #        if ([string]::IsNullOrEmpty($param)) {
 #            Write-Host "##vso[task.logissue type=error;]Missing template parameter \"$nameOfParam\""
@@ -45,7 +45,7 @@ steps:
 
 #- template: 'show-all-files.yml' # Uncomment for debugging
 
-- powershell: |
+- pwsh: |
     $testResultsFileName = "$(Build.ArtifactStagingDirectory)/${{ parameters.testResultsArtifactName }}/${{ parameters.osName }}/${{ parameters.framework }}/${{ parameters.vsTestPlatform }}/${{ parameters.testProjectName }}/${{ parameters.testResultsFileName }}"
     $testResultsFileExists = Test-Path $testResultsFileName
     if ($testResultsFileExists) {

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -135,10 +135,6 @@ steps:
         Write-Host $testBinaries
         foreach ($testBinary in $testBinaries) {
             $testName = [System.IO.Path]::GetFileNameWithoutExtension($testBinary.FullName)
-            $testDirectory = $testBinary.Directory.Name
-    
-            # Safety check - only run tests for the DLL that matches the directory name so we don't run the same one twice
-            if (!($testName -eq $testDirectory)) { continue }
     
             if ($maximumParalellJobs -gt 1) {
                 # Pause if we have queued too many parallel jobs

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -223,8 +223,16 @@ steps:
     vsTestPlatform: '${{ parameters.vsTestPlatform }}'
 
 - pwsh: |
+    $failed = $false
+    if ($env:HOSTCRASHED -eq 'true') {
+        Write-Host "##vso[task.logissue type=error;]Test host process(es) crashed:  $($env:CRASHEDRUNS)."
+        $failed = $true
+    }
     $maximumAllowedFailures = '${{ parameters.maximumAllowedFailures }}'
     if ([int]$env:TOTALFAILURES -gt [int]$maximumAllowedFailures) {
         Write-Host "##vso[task.logissue type=error;]Test run failed due to too many failed tests. Maximum failures allowed: $maximumAllowedFailures, total failures: $($env:TOTALFAILURES)."
+        $failed = $true
+    }
+    if ($failed) {
         Write-Host "##vso[task.complete result=Failed;]"
     }

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -54,7 +54,7 @@ steps:
 
 
 - task:  DownloadPipelineArtifact@2
-  displayName: 'Download Build Artifacts: ${{ parameters.binaryArtifactName }} to $(System.DefaultWorkingDirectory)\$(parameters.framework)'
+  displayName: 'Download Build Artifacts: ${{ parameters.binaryArtifactName }} to $(System.DefaultWorkingDirectory)/$(parameters.framework)'
   inputs:
     artifactName: '${{ parameters.binaryArtifactName }}_${{ parameters.framework }}'
     targetPath: '$(System.DefaultWorkingDirectory)/${{ parameters.framework }}'
@@ -91,31 +91,7 @@ steps:
     $testResultsFileName = '${{ parameters.testResultsFileName }}'
     $maximumParalellJobs = '${{ parameters.maximumParallelJobs }}'
     $where = '${{ parameters.where }}'
-    
-    function SeparateVersionDigits([string]$digits) {
-        return (&{ for ($i = 0;$i -lt $digits.Length;$i++) { $digits.Substring($i,1) }}) -join '.'
-    }
-    
-    # Convert $framework (i.e. net461) into format for dotnet vstest (i.e. .NETFramework,Version=4.6.1)
-    function ConvertFrameworkName([string]$framework) {
-        $match = [regex]::Match($framework, '^net(4\d+)$') # .NET Framework 4+
-        if ($match.Success) {
-            $ver = SeparateVersionDigits($match.Groups[1].Value)
-            return ".NETFramework,Version=v$($ver)"
-        }
-        $match = [regex]::Match($framework, '^net(?:coreapp)?(\d+\.\d+(?:\.\d+)?)$') # .NET 5 / .NET Core
-        if ($match.Success) {
-            $ver = $match.Groups[1].Value
-            return ".NETCoreApp,Version=v$($ver)"
-        } 
-        $match = [regex]::Match($framework, '^uap(\d+\.\d+)?$') # Universal Windows Platform
-        if ($match.Success) {
-            $ver = $match.Groups[1].Value
-            $ver = if ([string]::IsNullOrEmpty($ver)) { '10' } else { $ver.Replace('.0','').Replace('.','') }
-            return "FrameworkUap$($ver)"
-        }
-        return $framework
-    }
+    $tempDirectory = "$(Agent.TempDirectory)"
     
     function IsSupportedFramework([string]$framework) {
         if ($IsWindows -eq $null) {
@@ -146,21 +122,31 @@ steps:
                 }
             }
     
-            $fwork = ConvertFrameworkName($framework)
             $testResultDirectory = "$testResultsArtifactDirectory/$testOSName/$framework/$testPlatform/$testName"
             if (!(Test-Path "$testResultDirectory")) {
                 New-Item "$testResultDirectory" -ItemType Directory -Force
             }
-    
-            $testExpression = "dotnet vstest ""$($testBinary.FullName)"" --Framework:""$fwork"" --Platform:""$testPlatform""" + `
+            # Test binaries are copied to a temp directory so locking behavior of other processes doesn't interfere with this test run
+            $tempTestDirectory = "$tempDirectory/$framework/$testName"
+            if (!(Test-Path "$tempTestDirectory")) {
+                New-Item "$tempTestDirectory" -ItemType Directory -Force
+            }
+            $testTarget = "$tempTestDirectory/$($testBinary.Name)"
+            $sourceDirectory = $testBinary.Directory.FullName
+
+            Copy-Item -Path "$sourceDirectory/*" -Destination "$tempTestDirectory" -Recurse -Force
+
+            $testExpression = "dotnet test ""$testTarget"" --framework ""$framework"" --blame --no-build --no-restore" + `
                 " --logger:""console;verbosity=normal"" --logger:""trx;LogFileName=$testResultsFileName""" + `
-                " --ResultsDirectory:""$testResultDirectory"" --Blame"
-    
+                " --results-directory:""$testResultDirectory"""
+
             if (![string]::IsNullOrEmpty($where)) {
-                $testExpression = "$testExpression --TestCaseFilter:""$where"""
+                $testExpression = "$testExpression --filter ""$where"""
             }
     
-            Write-Host "Testing '$($testBinary.FullName)' on framework '$fwork' and outputting test results to '$testResultDirectory/$testResultsFileName'..."
+            $testExpression = "$testExpression -- RunConfiguration.TargetPlatform=$testPlatform"
+    
+            Write-Host "Testing '$($testBinary.FullName)' on framework '$framework' and outputting test results to '$testResultDirectory/$testResultsFileName'..."
             Write-Host $testExpression -ForegroundColor Magenta
             if ($maximumParalellJobs -le 1) {
                 Invoke-Expression $testExpression # For running in the foreground

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -36,7 +36,7 @@ parameters:
 steps:
 - checkout: none # self represents the repo where the initial Pipelines YAML file was found
 
-- powershell: |
+- pwsh: |
     function EnsureNotNullOrEmpty([string]$param, [string]$nameOfParam) {
         if ([string]::IsNullOrEmpty($param)) {
             Write-Host "##vso[task.logissue type=error;]Missing template parameter \"$nameOfParam\""
@@ -61,7 +61,7 @@ steps:
     artifactName: '${{ parameters.binaryArtifactName }}_${{ parameters.framework }}'
     targetPath: '$(System.DefaultWorkingDirectory)/${{ parameters.framework }}'
 
-#- powershell: Get-ChildItem -Path $(System.DefaultWorkingDirectory) # Uncomment for debugging
+#- pwsh: Get-ChildItem -Path $(System.DefaultWorkingDirectory) # Uncomment for debugging
 
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 2.1.807'
@@ -81,7 +81,7 @@ steps:
     version: 5.0.100
 
 #- template: 'show-all-files.yml' # Uncomment for debugging
-- powershell: |
+- pwsh: |
     $framework = '${{ parameters.framework }}'
     $testBinaryRootDirectory = "$(System.DefaultWorkingDirectory)"
     $testResultsArtifactDirectory = "${{ format('$(Build.ArtifactStagingDirectory)/{0}',parameters.testResultsArtifactName) }}"

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -106,7 +106,7 @@ steps:
     function RunTests([string]$framework, [string]$fileRegexPattern) {
         if (!(IsSupportedFramework($framework))) { continue }
     
-        $testBinaries = Get-ChildItem -Path "$testBinaryRootDirectory" -File -Recurse | Where-Object {$_.FullName -match "$framework"} | Where-Object {$_.FullName -match "$fileRegexPattern"} | Sort-Object -Property FullName
+        $testBinaries = Get-ChildItem -Path "$testBinaryRootDirectory" -File -Recurse | Where-Object {$_.FullName -match "$framework" -and $_.FullName -match "$fileRegexPattern" -and !$_.Name.EndsWith('.resources.dll') } | Sort-Object -Property FullName
         Write-Host $testBinaries
         foreach ($testBinary in $testBinaries) {
             $testName = [System.IO.Path]::GetFileNameWithoutExtension($testBinary.FullName)

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -224,7 +224,7 @@ steps:
 
 - pwsh: |
     $maximumAllowedFailures = '${{ parameters.maximumAllowedFailures }}'
-    if ([int]$Env:TOTALFAILURES -gt [int]$maximumAllowedFailures) {
-        Write-Host "##vso[task.logissue type=error;]Test run failed due to too many failed tests. Maximum failures allowed: $maximumAllowedFailures, total failures: $($Env:TOTALFAILURES)."
+    if ([int]$env:TOTALFAILURES -gt [int]$maximumAllowedFailures) {
+        Write-Host "##vso[task.logissue type=error;]Test run failed due to too many failed tests. Maximum failures allowed: $maximumAllowedFailures, total failures: $($env:TOTALFAILURES)."
         Write-Host "##vso[task.complete result=Failed;]"
     }

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -63,10 +63,10 @@ steps:
     Get-ChildItem -Path $(System.DefaultWorkingDirectory)
 
 - task: UseDotNet@2
-  displayName: 'Use .NET sdk 5.0.100'
+  displayName: 'Use .NET Core sdk 2.1.807'
   inputs:
-    version: 5.0.100
-  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net5.'))
+    version: 2.1.807
+  condition: and(succeeded(), contains('${{ parameters.framework }}', 'netcoreapp2.'))
 
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 3.1.301'
@@ -75,10 +75,9 @@ steps:
   condition: and(succeeded(), contains('${{ parameters.framework }}', 'netcoreapp3.'))
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 2.1.807'
+  displayName: 'Use .NET sdk 5.0.100'
   inputs:
-    version: 2.1.807
-  condition: and(succeeded(), contains('${{ parameters.framework }}', 'netcoreapp2.'))
+    version: 5.0.100
 
 #- template: 'show-all-files.yml' # Uncomment for debugging
 

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -61,8 +61,7 @@ steps:
     artifactName: '${{ parameters.binaryArtifactName }}_${{ parameters.framework }}'
     targetPath: '$(System.DefaultWorkingDirectory)/${{ parameters.framework }}'
 
-- powershell: | 
-    Get-ChildItem -Path $(System.DefaultWorkingDirectory)
+#- powershell: Get-ChildItem -Path $(System.DefaultWorkingDirectory) # Uncomment for debugging
 
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 2.1.807'

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -19,6 +19,8 @@
 # runs the tests for each project on a background job in parallel,
 # then uploads the results to Azure DevOps pipelines
 
+# NOTE: Depends on environment variables $(IsNightly) and $(IsWeekly)
+
 parameters:
   osName: 'Windows' # The name of the operating system for display purposes.
   framework: '' # The target framework indicating which framework tests will be run on. See: https://docs.microsoft.com/en-us/dotnet/standard/frameworks.
@@ -80,7 +82,6 @@ steps:
     version: 5.0.100
 
 #- template: 'show-all-files.yml' # Uncomment for debugging
-
 - powershell: |
     $framework = '${{ parameters.framework }}'
     $testBinaryRootDirectory = "$(System.DefaultWorkingDirectory)"
@@ -92,6 +93,8 @@ steps:
     $maximumParalellJobs = '${{ parameters.maximumParallelJobs }}'
     $where = '${{ parameters.where }}'
     $tempDirectory = "$(Agent.TempDirectory)"
+    $isNightly = if ($env:ISNIGHTLY -eq 'true') { 'true' } else { 'false' }
+    $isWeekly = if ($env:ISWEEKLY -eq 'true') { 'true' } else { 'false' }
     
     function IsSupportedFramework([string]$framework) {
         if ($IsWindows -eq $null) {
@@ -136,9 +139,16 @@ steps:
 
             Copy-Item -Path "$sourceDirectory/*" -Destination "$tempTestDirectory" -Recurse -Force
 
+            if ($isNighly -ne 'true' -and $isWeekly -ne 'true') {
+                $blameHangTimeout = "--blame-hang-timeout 10minutes"
+            } else {
+                $blameHangTimeout = "--blame-hang-timeout 35minutes"
+            }
+
             $testExpression = "dotnet test ""$testTarget"" --framework ""$framework"" --blame --no-build --no-restore" + `
                 " --logger:""console;verbosity=normal"" --logger:""trx;LogFileName=$testResultsFileName""" + `
-                " --results-directory:""$testResultDirectory"""
+                " --results-directory:""$testResultDirectory""" + `
+                " --blame-hang --blame-hang-dump-type mini $blameHangTimeout"
 
             if (![string]::IsNullOrEmpty($where)) {
                 $testExpression = "$testExpression --filter ""$where"""

--- a/build/azure-templates/show-all-environment-variables.yml
+++ b/build/azure-templates/show-all-environment-variables.yml
@@ -18,7 +18,7 @@
 # Writes all environment variables to the host (helpful for debugging)
 
 steps:
-- powershell: |
+- pwsh: |
     $environmentVars = Get-ChildItem -path env:* | sort Name
     foreach($var in $environmentVars) {
         $keyname = $var.Key

--- a/build/azure-templates/show-all-files.yml
+++ b/build/azure-templates/show-all-files.yml
@@ -22,5 +22,5 @@
 # Writes all file names (from the parent directory) to the host (helpful for debugging)
 
 steps:
-- powershell: cd ..;dir -r  | Where-Object {$_.PsIsContainer -eq $false} | % { $_.FullName }
+- pwsh: cd ..;dir -r  | Where-Object {$_.PsIsContainer -eq $false} | % { $_.FullName }
   displayName: 'Show all Files'

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -28,6 +28,7 @@ properties {
     [string]$solutionFile = "$base_directory/Lucene.Net.sln"
     [string]$sdkPath = "$env:programfiles/dotnet/sdk"
     [string]$sdkVersion = "5.0.100"
+    [bool]$skipSdkInstallation = $false
     [string]$globalJsonFile = "$base_directory/global.json"
     [string]$versionPropsFile = "$base_directory/Version.props"
     [string]$build_bat = "$base_directory/build.bat"
@@ -74,19 +75,21 @@ task UpdateLocalSDKVersion -description "Backs up the project.json file and pins
 }
 
 task InstallSDK -description "This task makes sure the correct SDK version is installed to build" -ContinueOnError {
-    Write-Host "##teamcity[progressMessage 'Installing SDK $sdkVersion']"
-    Write-Host "##vso[task.setprogress]'Installing SDK $sdkVersion'"
-    $installed = Is-Sdk-Version-Installed $sdkVersion
-    if (!$installed) {
-        Write-Host "Requires SDK version $sdkVersion, installing..." -ForegroundColor Red
-        Invoke-Expression "$base_directory\build\dotnet-install.ps1 -Version $sdkVersion"
-    }
+    if (!$skipSdkInstallation) {
+        Write-Host "##teamcity[progressMessage 'Installing SDK $sdkVersion']"
+        Write-Host "##vso[task.setprogress]'Installing SDK $sdkVersion'"
+        $installed = Is-Sdk-Version-Installed $sdkVersion
+        if (!$installed) {
+            Write-Host "Requires SDK version $sdkVersion, installing..." -ForegroundColor Red
+            Invoke-Expression "$base_directory\build\dotnet-install.ps1 -Version $sdkVersion"
+        }
 
-    # Safety check - this should never happen
-    & where.exe dotnet.exe
+        # Safety check - this should never happen
+        & where.exe dotnet.exe
 
-    if ($LASTEXITCODE -ne 0) {
-        throw "Could not find dotnet CLI in PATH. Please install the .NET Core 3.1 SDK, version $sdkVersion."
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not find dotnet CLI in PATH. Please install the .NET SDK, version $sdkVersion."
+        }
     }
 }
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -18,418 +18,418 @@
 # -----------------------------------------------------------------------------------
 
 properties {
-	[string]$base_directory   = Resolve-Path "../."
-	[string]$release_directory  = "$base_directory/release"
-	[string]$source_directory = "$base_directory"
-	[string]$tools_directory  = "$base_directory/lib"
-	[string]$nuget_package_directory = "$release_directory/NuGetPackages"
-	[string]$test_results_directory = "$release_directory/TestResults"
-	[string]$publish_directory = "$release_directory/Publish"
-	[string]$solutionFile = "$base_directory/Lucene.Net.sln"
-	[string]$sdkPath = "$env:programfiles/dotnet/sdk"
-	[string]$sdkVersion = "5.0.100"
-	[string]$globalJsonFile = "$base_directory/global.json"
-	[string]$versionPropsFile = "$base_directory/Version.props"
-	[string]$build_bat = "$base_directory/build.bat"
+    [string]$base_directory   = Resolve-Path "../."
+    [string]$release_directory  = "$base_directory/release"
+    [string]$source_directory = "$base_directory"
+    [string]$tools_directory  = "$base_directory/lib"
+    [string]$nuget_package_directory = "$release_directory/NuGetPackages"
+    [string]$test_results_directory = "$release_directory/TestResults"
+    [string]$publish_directory = "$release_directory/Publish"
+    [string]$solutionFile = "$base_directory/Lucene.Net.sln"
+    [string]$sdkPath = "$env:programfiles/dotnet/sdk"
+    [string]$sdkVersion = "5.0.100"
+    [string]$globalJsonFile = "$base_directory/global.json"
+    [string]$versionPropsFile = "$base_directory/Version.props"
+    [string]$build_bat = "$base_directory/build.bat"
 
-	[string]$buildCounter     = $(if ($buildCounter) { $buildCounter } else { $env:BuildCounter }) #NOTE: Pass in as a parameter (not a property) or environment variable to override
-	[string]$preReleaseCounterPattern = $(if ($preReleaseCounterPattern) { $preReleaseCounterPattern } else { if ($env:PreReleaseCounterPattern) { $env:PreReleaseCounterPattern } else { "0000000000" } })  #NOTE: Pass in as a parameter (not a property) or environment variable to override
-	[string]$versionSuffix    = $(if ($versionSuffix -ne $null) { $versionSuffix } else { if ($env:VersionSuffix -ne $null) { $env:VersionSuffix } else { 'ci' }}) #NOTE: Pass in as a parameter (not a property) or environment variable to override
-	[string]$packageVersion   = Get-Package-Version #NOTE: Pass in as a parameter (not a property) or environment variable to override
-	[string]$version          = Get-Version
-	[string]$configuration    = $(if ($configuration) { $configuration } else { if ($env:BuildConfiguration) { $env:BuildConfiguration } else { "Release" } })  #NOTE: Pass in as a parameter (not a property) or environment variable to override
-	[string]$platform   = $(if ($platform) { $platform } else { if ($env:BuildPlatform) { $env:BuildPlatform } else { "Any CPU" } })  #NOTE: Pass in as a parameter (not a property) or environment variable to override
-	[bool]$backup_files       = $true
-	[bool]$prepareForBuild    = $true
-	[bool]$generateBuildBat   = $false
-	[bool]$zipPublishedArtifacts = $false
-	[string]$publishedArtifactZipFileName = "artifact.zip"
+    [string]$buildCounter     = $(if ($buildCounter) { $buildCounter } else { $env:BuildCounter }) #NOTE: Pass in as a parameter (not a property) or environment variable to override
+    [string]$preReleaseCounterPattern = $(if ($preReleaseCounterPattern) { $preReleaseCounterPattern } else { if ($env:PreReleaseCounterPattern) { $env:PreReleaseCounterPattern } else { "0000000000" } })  #NOTE: Pass in as a parameter (not a property) or environment variable to override
+    [string]$versionSuffix    = $(if ($versionSuffix -ne $null) { $versionSuffix } else { if ($env:VersionSuffix -ne $null) { $env:VersionSuffix } else { 'ci' }}) #NOTE: Pass in as a parameter (not a property) or environment variable to override
+    [string]$packageVersion   = Get-Package-Version #NOTE: Pass in as a parameter (not a property) or environment variable to override
+    [string]$version          = Get-Version
+    [string]$configuration    = $(if ($configuration) { $configuration } else { if ($env:BuildConfiguration) { $env:BuildConfiguration } else { "Release" } })  #NOTE: Pass in as a parameter (not a property) or environment variable to override
+    [string]$platform   = $(if ($platform) { $platform } else { if ($env:BuildPlatform) { $env:BuildPlatform } else { "Any CPU" } })  #NOTE: Pass in as a parameter (not a property) or environment variable to override
+    [bool]$backup_files       = $true
+    [bool]$prepareForBuild    = $true
+    [bool]$generateBuildBat   = $false
+    [bool]$zipPublishedArtifacts = $false
+    [string]$publishedArtifactZipFileName = "artifact.zip"
 
-	[int]$maximumParalellJobs = 8
-	
-	#test paramters
-	[string]$frameworks_to_test = "net5.0,netcoreapp3.1,netcoreapp2.1,net48"
-	[string]$where = ""
+    [int]$maximumParalellJobs = 8
+    
+    #test paramters
+    [string]$frameworks_to_test = "net5.0,netcoreapp3.1,netcoreapp2.1,net48"
+    [string]$where = ""
 }
 
 $backedUpFiles = New-Object System.Collections.ArrayList
 if ($IsWindows -eq $null) {
-	$IsWindows = $Env:OS.StartsWith('Windows')
+    $IsWindows = $Env:OS.StartsWith('Windows')
 }
 
 task default -depends Pack
 
 task Clean -description "This task cleans up the build directory" {
-	Write-Host "##teamcity[progressMessage 'Cleaning']"
-	Write-Host "##vso[task.setprogress]'Cleaning'"
-	Remove-Item $release_directory -Force -Recurse -ErrorAction SilentlyContinue
-	Get-ChildItem $base_directory -Include *.bak -Recurse | foreach ($_) {Remove-Item $_.FullName}
+    Write-Host "##teamcity[progressMessage 'Cleaning']"
+    Write-Host "##vso[task.setprogress]'Cleaning'"
+    Remove-Item $release_directory -Force -Recurse -ErrorAction SilentlyContinue
+    Get-ChildItem $base_directory -Include *.bak -Recurse | foreach ($_) {Remove-Item $_.FullName}
 }
 
 task UpdateLocalSDKVersion -description "Backs up the project.json file and pins the version to $sdkVersion" {
-	Backup-File $globalJsonFile
-	Generate-Global-Json `
-		-sdkVersion $sdkVersion `
-		-file $globalJsonFile
+    Backup-File $globalJsonFile
+    Generate-Global-Json `
+        -sdkVersion $sdkVersion `
+        -file $globalJsonFile
 }
 
 task InstallSDK -description "This task makes sure the correct SDK version is installed to build" -ContinueOnError {
-	Write-Host "##teamcity[progressMessage 'Installing SDK $sdkVersion']"
-	Write-Host "##vso[task.setprogress]'Installing SDK $sdkVersion'"
-	$installed = Is-Sdk-Version-Installed $sdkVersion
-	if (!$installed) {
-		Write-Host "Requires SDK version $sdkVersion, installing..." -ForegroundColor Red
-		Invoke-Expression "$base_directory\build\dotnet-install.ps1 -Version $sdkVersion"
-	}
+    Write-Host "##teamcity[progressMessage 'Installing SDK $sdkVersion']"
+    Write-Host "##vso[task.setprogress]'Installing SDK $sdkVersion'"
+    $installed = Is-Sdk-Version-Installed $sdkVersion
+    if (!$installed) {
+        Write-Host "Requires SDK version $sdkVersion, installing..." -ForegroundColor Red
+        Invoke-Expression "$base_directory\build\dotnet-install.ps1 -Version $sdkVersion"
+    }
 
-	# Safety check - this should never happen
-	& where.exe dotnet.exe
+    # Safety check - this should never happen
+    & where.exe dotnet.exe
 
-	if ($LASTEXITCODE -ne 0) {
-		throw "Could not find dotnet CLI in PATH. Please install the .NET Core 3.1 SDK, version $sdkVersion."
-	}
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not find dotnet CLI in PATH. Please install the .NET Core 3.1 SDK, version $sdkVersion."
+    }
 }
 
 task Init -depends InstallSDK, UpdateLocalSDKVersion -description "This task makes sure the build environment is correctly setup" {
-	#Update TeamCity, MyGet, or Azure Pipelines with packageVersion
-	Write-Output "##teamcity[buildNumber '$packageVersion']"
-	Write-Output "##myget[buildNumber '$packageVersion']"
-	Write-Host "##vso[build.updatebuildnumber]$packageVersion"
+    #Update TeamCity, MyGet, or Azure Pipelines with packageVersion
+    Write-Output "##teamcity[buildNumber '$packageVersion']"
+    Write-Output "##myget[buildNumber '$packageVersion']"
+    Write-Host "##vso[build.updatebuildnumber]$packageVersion"
 
-	& dotnet.exe --version
-	& dotnet.exe --info
-	Write-Host "Base Directory: $base_directory"
-	Write-Host "Release Directory: $release_directory"
-	Write-Host "Source Directory: $source_directory"
-	Write-Host "Tools Directory: $tools_directory"
-	Write-Host "NuGet Package Directory: $nuget_package_directory"
-	Write-Host "BuildCounter: $buildCounter"
-	Write-Host "PreReleaseCounterPattern: $preReleaseCounterPattern"
-	Write-Host "VersionSuffix: $versionSuffix"
-	Write-Host "Package Version: $packageVersion"
-	Write-Host "Version: $version"
-	Write-Host "Configuration: $configuration"
-	Write-Host "Platform: $platform"
-	Write-Host "MaximumParallelJobs: $($maximumParalellJobs.ToString())"
-	Write-Host "Powershell Version: $($PSVersionTable.PSVersion)"
+    & dotnet.exe --version
+    & dotnet.exe --info
+    Write-Host "Base Directory: $base_directory"
+    Write-Host "Release Directory: $release_directory"
+    Write-Host "Source Directory: $source_directory"
+    Write-Host "Tools Directory: $tools_directory"
+    Write-Host "NuGet Package Directory: $nuget_package_directory"
+    Write-Host "BuildCounter: $buildCounter"
+    Write-Host "PreReleaseCounterPattern: $preReleaseCounterPattern"
+    Write-Host "VersionSuffix: $versionSuffix"
+    Write-Host "Package Version: $packageVersion"
+    Write-Host "Version: $version"
+    Write-Host "Configuration: $configuration"
+    Write-Host "Platform: $platform"
+    Write-Host "MaximumParallelJobs: $($maximumParalellJobs.ToString())"
+    Write-Host "Powershell Version: $($PSVersionTable.PSVersion)"
 
-	Ensure-Directory-Exists "$release_directory"
+    Ensure-Directory-Exists "$release_directory"
 }
 
 task Restore -description "This task restores the dependencies" {
-	Write-Host "##teamcity[progressMessage 'Restoring']"
-	Write-Host "##vso[task.setprogress]'Restoring'"
-	Exec { 
-		& dotnet.exe restore $solutionFile --no-dependencies /p:TestFrameworks=true
-	}
+    Write-Host "##teamcity[progressMessage 'Restoring']"
+    Write-Host "##vso[task.setprogress]'Restoring'"
+    Exec { 
+        & dotnet.exe restore $solutionFile --no-dependencies /p:TestFrameworks=true
+    }
 }
 
 task Compile -depends Clean, Init, Restore -description "This task compiles the solution" {
-	Write-Host "##teamcity[progressMessage 'Compiling']"
-	Write-Host "##vso[task.setprogress]'Compiling'"
-	try {
-		if ($prepareForBuild -eq $true) {
-			Prepare-For-Build
-		}
+    Write-Host "##teamcity[progressMessage 'Compiling']"
+    Write-Host "##vso[task.setprogress]'Compiling'"
+    try {
+        if ($prepareForBuild -eq $true) {
+            Prepare-For-Build
+        }
 
-		$testFrameworks = [string]::Join(';', (Get-FrameworksToTest))
+        $testFrameworks = [string]::Join(';', (Get-FrameworksToTest))
 
-		Write-Host "TestFrameworks set to: $testFrameworks" -ForegroundColor Green
+        Write-Host "TestFrameworks set to: $testFrameworks" -ForegroundColor Green
 
-		Exec {
-			# NOTE: Version information is not passed in at the command line,
-			# instead it is output to the Version.props file. This file is then
-			# used during a release to "freeze" the build at a specific version
-			# so it is always a constant in release distributions.
-			& dotnet.exe msbuild $solutionFile /t:Build `
-				/p:Configuration=$configuration `
-				/p:Platform=$platform `
-				/p:PortableDebugTypeOnly=true `
-				/p:TestFrameworks=true # workaround for parsing issue: https://github.com/Microsoft/msbuild/issues/471#issuecomment-181963350
-		}
+        Exec {
+            # NOTE: Version information is not passed in at the command line,
+            # instead it is output to the Version.props file. This file is then
+            # used during a release to "freeze" the build at a specific version
+            # so it is always a constant in release distributions.
+            & dotnet.exe msbuild $solutionFile /t:Build `
+                /p:Configuration=$configuration `
+                /p:Platform=$platform `
+                /p:PortableDebugTypeOnly=true `
+                /p:TestFrameworks=true # workaround for parsing issue: https://github.com/Microsoft/msbuild/issues/471#issuecomment-181963350
+        }
 
-		$success = $true
-	} finally {
-		if ($success -ne $true) {
-			Restore-Files $backedUpFiles
-		}
-	}
+        $success = $true
+    } finally {
+        if ($success -ne $true) {
+            Restore-Files $backedUpFiles
+        }
+    }
 }
 
 task Pack -depends Compile -description "This task creates the NuGet packages" {
-	Write-Host "##teamcity[progressMessage 'Packing']"
-	Write-Host "##vso[task.setprogress]'Packing'"
-	#create the nuget package output directory
-	Ensure-Directory-Exists "$nuget_package_directory"
+    Write-Host "##teamcity[progressMessage 'Packing']"
+    Write-Host "##vso[task.setprogress]'Packing'"
+    #create the nuget package output directory
+    Ensure-Directory-Exists "$nuget_package_directory"
 
-	try {
-		Exec {
-			# NOTE: Package version information is not passed in at the command line,
-			# instead it is output to the Version.props file. This file is then
-			# used during a release to "freeze" the build at a specific version
-			# so it is always a constant in release distributions.
-			& dotnet.exe pack $solutionFile --configuration $configuration --output $nuget_package_directory --no-build
-		}
+    try {
+        Exec {
+            # NOTE: Package version information is not passed in at the command line,
+            # instead it is output to the Version.props file. This file is then
+            # used during a release to "freeze" the build at a specific version
+            # so it is always a constant in release distributions.
+            & dotnet.exe pack $solutionFile --configuration $configuration --output $nuget_package_directory --no-build
+        }
 
-		$success = $true
-	} finally {
-		#if ($success -ne $true) {
-			Restore-Files $backedUpFiles
-			#Remove Version.props, as we don't want it to be committed to the repository
-			if ($backup_files -eq $true -and (Test-Path -Path "$versionPropsFile") -eq $true) {
-				Remove-Item -Path "$versionPropsFile" -Force
-			}
-		#}
-	}
+        $success = $true
+    } finally {
+        #if ($success -ne $true) {
+            Restore-Files $backedUpFiles
+            #Remove Version.props, as we don't want it to be committed to the repository
+            if ($backup_files -eq $true -and (Test-Path -Path "$versionPropsFile") -eq $true) {
+                Remove-Item -Path "$versionPropsFile" -Force
+            }
+        #}
+    }
 }
 
 # Loops through each framework in the TestTargetFrameworks variable and
 # publishes the project in the artifact staging directory with the framework
 # and project name as part of the folder structure.
 task Publish -depends Compile -description "This task uses dotnet publish to package the binaries with all of their dependencies so they can be run xplat" {
-	Write-Host "##teamcity[progressMessage 'Publishing']"
-	Write-Host "##vso[task.setprogress]'Publishing'"
+    Write-Host "##teamcity[progressMessage 'Publishing']"
+    Write-Host "##vso[task.setprogress]'Publishing'"
 
-	try {
-		$frameworksToTest = Get-FrameworksToTest
+    try {
+        $frameworksToTest = Get-FrameworksToTest
 
-		if ($zipPublishedArtifacts) {
-			$outDirectory = New-TemporaryDirectory
-		} else {
-			$outDirectory = $publish_directory
-		}
-		
-		foreach ($framework in $frameworksToTest) {
-			$testProjects = Get-ChildItem -Path "$source_directory/**/*.csproj" -Recurse | ? { $_.Directory.Name.Contains(".Tests") } | Select -ExpandProperty FullName
-			foreach ($testProject in $testProjects) {
-				# Pause if we have queued too many parallel jobs
-				$running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
-				if ($running.Count -ge $maximumParalellJobs) {
-					$running | Wait-Job -Any | Out-Null
-				}
+        if ($zipPublishedArtifacts) {
+            $outDirectory = New-TemporaryDirectory
+        } else {
+            $outDirectory = $publish_directory
+        }
+        
+        foreach ($framework in $frameworksToTest) {
+            $testProjects = Get-ChildItem -Path "$source_directory/**/*.csproj" -Recurse | ? { $_.Directory.Name.Contains(".Tests") } | Select -ExpandProperty FullName
+            foreach ($testProject in $testProjects) {
+                # Pause if we have queued too many parallel jobs
+                $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
+                if ($running.Count -ge $maximumParalellJobs) {
+                    $running | Wait-Job -Any | Out-Null
+                }
 
-				$projectName = [System.IO.Path]::GetFileNameWithoutExtension($testProject)
+                $projectName = [System.IO.Path]::GetFileNameWithoutExtension($testProject)
 
-				# Special case - our CLI tool only supports .NET Core 3.1
-				if ($projectName.Contains("Tests.Cli") -and (!$framework.StartsWith("netcoreapp3.1"))) {
-					continue
-				}
+                # Special case - our CLI tool only supports .NET Core 3.1
+                if ($projectName.Contains("Tests.Cli") -and (!$framework.StartsWith("netcoreapp3.1"))) {
+                    continue
+                }
 
-				# Special case - OpenNLP.NET only supports .NET Framework
-				if ($projectName.Contains("Tests.Analysis.OpenNLP") -and (!$framework.StartsWith("net4"))) {
-					continue
-				}
+                # Special case - OpenNLP.NET only supports .NET Framework
+                if ($projectName.Contains("Tests.Analysis.OpenNLP") -and (!$framework.StartsWith("net4"))) {
+                    continue
+                }
 
-				# Special case - Morfologik doesn't support .NET Standard 1.x
-				if ($projectName.Contains("Tests.Analysis.Morfologik") -and ($framework.StartsWith("netcoreapp1."))) {
-					continue
-				}
+                # Special case - Morfologik doesn't support .NET Standard 1.x
+                if ($projectName.Contains("Tests.Analysis.Morfologik") -and ($framework.StartsWith("netcoreapp1."))) {
+                    continue
+                }
 
-				$logPath = "$outDirectory/$framework"
-				$outputPath = "$logPath/$projectName"
+                $logPath = "$outDirectory/$framework"
+                $outputPath = "$logPath/$projectName"
 
-				# Do this first so there is no conflict
-				Ensure-Directory-Exists $outputPath
+                # Do this first so there is no conflict
+                Ensure-Directory-Exists $outputPath
 
-				$scriptBlock = {
-					param([string]$testProject, [string]$outputPath, [string]$logPath, [string]$framework, [string]$configuration, [string]$projectName)
-					Write-Host "Publishing '$testProject' on '$framework' to '$outputPath'..."
-					# Note: Cannot use Psake Exec in background
-					dotnet publish "$testProject" --output "$outputPath" --framework "$framework" --configuration "$configuration" --no-build --no-restore --verbosity Detailed /p:TestFrameworks=true /p:Platform="$platform" > "$logPath/$projectName-dotnet-publish.log" 2> "$logPath/$projectName-dotnet-publish-error.log"
-				}
+                $scriptBlock = {
+                    param([string]$testProject, [string]$outputPath, [string]$logPath, [string]$framework, [string]$configuration, [string]$projectName)
+                    Write-Host "Publishing '$testProject' on '$framework' to '$outputPath'..."
+                    # Note: Cannot use Psake Exec in background
+                    dotnet publish "$testProject" --output "$outputPath" --framework "$framework" --configuration "$configuration" --no-build --no-restore --verbosity Detailed /p:TestFrameworks=true /p:Platform="$platform" > "$logPath/$projectName-dotnet-publish.log" 2> "$logPath/$projectName-dotnet-publish-error.log"
+                }
 
-				# Execute the jobs in parallel
-				Start-Job $scriptBlock -ArgumentList $testProject,$outputPath,$logPath,$framework,$configuration,$projectName
-			}
-		}
+                # Execute the jobs in parallel
+                Start-Job $scriptBlock -ArgumentList $testProject,$outputPath,$logPath,$framework,$configuration,$projectName
+            }
+        }
 
-		# Wait for it all to complete
-		do {
-			$running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
-			if ($running.Count -gt 0) {
-				Write-Host ""
-				Write-Host "  Almost finished, only $($running.Count) projects left to publish..." -ForegroundColor Cyan
-				$running | Wait-Job -Any | Out-Null
-			}
-		} until ($running.Count -eq 0)
+        # Wait for it all to complete
+        do {
+            $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
+            if ($running.Count -gt 0) {
+                Write-Host ""
+                Write-Host "  Almost finished, only $($running.Count) projects left to publish..." -ForegroundColor Cyan
+                $running | Wait-Job -Any | Out-Null
+            }
+        } until ($running.Count -eq 0)
 
-		# Getting the information back from the jobs (time consuming)
-		#Get-Job | Receive-Job
+        # Getting the information back from the jobs (time consuming)
+        #Get-Job | Receive-Job
 
-		if ($zipPublishedArtifacts) {
-			Ensure-Directory-Exists $publish_directory
-			Add-Type -assembly "System.IO.Compression.Filesystem"
-			[System.IO.Compression.ZipFile]::CreateFromDirectory($outDirectory, "$publish_directory/$publishedArtifactZipFileName")
-		}
+        if ($zipPublishedArtifacts) {
+            Ensure-Directory-Exists $publish_directory
+            Add-Type -assembly "System.IO.Compression.Filesystem"
+            [System.IO.Compression.ZipFile]::CreateFromDirectory($outDirectory, "$publish_directory/$publishedArtifactZipFileName")
+        }
 
-		$success = $true
-	} finally {
-		#if ($success -ne $true) {
-			Restore-Files $backedUpFiles
-		#}
-	}
+        $success = $true
+    } finally {
+        #if ($success -ne $true) {
+            Restore-Files $backedUpFiles
+        #}
+    }
 }
 
 task Test -depends InstallSDK, UpdateLocalSDKVersion, Restore -description "This task runs the tests" {
-	Write-Host "##teamcity[progressMessage 'Testing']"
-	Write-Host "##vso[task.setprogress]'Testing'"
-	Write-Host "Running tests..." -ForegroundColor DarkCyan
+    Write-Host "##teamcity[progressMessage 'Testing']"
+    Write-Host "##vso[task.setprogress]'Testing'"
+    Write-Host "Running tests..." -ForegroundColor DarkCyan
 
-	pushd $base_directory
-	$testProjects = Get-ChildItem -Path "$source_directory/**/*.csproj" -Recurse | ? { $_.Directory.Name.Contains(".Tests") }
-	popd
+    pushd $base_directory
+    $testProjects = Get-ChildItem -Path "$source_directory/**/*.csproj" -Recurse | ? { $_.Directory.Name.Contains(".Tests") }
+    popd
 
-	$testProjects = $testProjects | Sort-Object -Property FullName
+    $testProjects = $testProjects | Sort-Object -Property FullName
 
-	$frameworksToTest = Get-FrameworksToTest
+    $frameworksToTest = Get-FrameworksToTest
 
-	Write-Host "frameworksToTest: $frameworksToTest" -ForegroundColor Yellow
+    Write-Host "frameworksToTest: $frameworksToTest" -ForegroundColor Yellow
 
-	[int]$totalProjects = $testProjects.Length * $frameworksToTest.Length
-	[int]$remainingProjects = $totalProjects
+    [int]$totalProjects = $testProjects.Length * $frameworksToTest.Length
+    [int]$remainingProjects = $totalProjects
 
-	Ensure-Directory-Exists $test_results_directory
+    Ensure-Directory-Exists $test_results_directory
 
-	foreach ($testProject in $testProjects) {
+    foreach ($testProject in $testProjects) {
 
-		foreach ($framework in $frameworksToTest) {
-			$testName = $testProject.Directory.Name
+        foreach ($framework in $frameworksToTest) {
+            $testName = $testProject.Directory.Name
 
-			# Special case - our CLI tool only supports .NET Core 3.1
-			if ($testName.Contains("Tests.Cli") -and (!$framework.StartsWith("netcoreapp3.1"))) {
-				$totalProjects--
-				$remainingProjects--
-				continue
-			}
-			
-			# Special case - OpenNLP.NET only supports .NET Framework
-			if ($testName.Contains("Tests.Analysis.OpenNLP") -and (!$framework.StartsWith("net4"))) {
-				$totalProjects--
-				$remainingProjects--
-				continue
-			}
+            # Special case - our CLI tool only supports .NET Core 3.1
+            if ($testName.Contains("Tests.Cli") -and (!$framework.StartsWith("netcoreapp3.1"))) {
+                $totalProjects--
+                $remainingProjects--
+                continue
+            }
+            
+            # Special case - OpenNLP.NET only supports .NET Framework
+            if ($testName.Contains("Tests.Analysis.OpenNLP") -and (!$framework.StartsWith("net4"))) {
+                $totalProjects--
+                $remainingProjects--
+                continue
+            }
 
-			# Special case - Morfologik doesn't support .NET Standard 1.x
-			if ($testName.Contains("Tests.Analysis.Morfologik") -and ($framework.StartsWith("netcoreapp1."))) {
-				$totalProjects--
-				$remainingProjects--
-				continue
-			}
+            # Special case - Morfologik doesn't support .NET Standard 1.x
+            if ($testName.Contains("Tests.Analysis.Morfologik") -and ($framework.StartsWith("netcoreapp1."))) {
+                $totalProjects--
+                $remainingProjects--
+                continue
+            }
 
-			Write-Host "  Next Project in Queue: $testName, Framework: $framework" -ForegroundColor Yellow
+            Write-Host "  Next Project in Queue: $testName, Framework: $framework" -ForegroundColor Yellow
 
-			# Pause if we have queued too many parallel jobs
-			$running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
-			if ($running.Count -ge $maximumParalellJobs) {
-				Write-Host ""
-				Write-Host "  Running tests in parallel on $($running.Count) projects out of approximately $totalProjects total." -ForegroundColor Cyan
-				Write-Host "  $remainingProjects projects are waiting in the queue to run. This will take a bit, please wait..." -ForegroundColor Cyan
-				$running | Wait-Job -Any | Out-Null
-			}
-			$remainingProjects -= 1
+            # Pause if we have queued too many parallel jobs
+            $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
+            if ($running.Count -ge $maximumParalellJobs) {
+                Write-Host ""
+                Write-Host "  Running tests in parallel on $($running.Count) projects out of approximately $totalProjects total." -ForegroundColor Cyan
+                Write-Host "  $remainingProjects projects are waiting in the queue to run. This will take a bit, please wait..." -ForegroundColor Cyan
+                $running | Wait-Job -Any | Out-Null
+            }
+            $remainingProjects -= 1
 
-			$testResultDirectory = "$test_results_directory/$framework/$testName"
-			Ensure-Directory-Exists $testResultDirectory
+            $testResultDirectory = "$test_results_directory/$framework/$testName"
+            Ensure-Directory-Exists $testResultDirectory
 
-			$testProjectPath = $testProject.FullName
-			$testExpression = "dotnet.exe test $testProjectPath --configuration $configuration --framework $framework --no-build"
-			$testExpression = "$testExpression --no-restore --blame --results-directory $testResultDirectory"
+            $testProjectPath = $testProject.FullName
+            $testExpression = "dotnet.exe test $testProjectPath --configuration $configuration --framework $framework --no-build"
+            $testExpression = "$testExpression --no-restore --blame --results-directory $testResultDirectory"
 
-			# Breaking change: We need to explicitly set the logger for it to work with TeamCity.
-			# See: https://github.com/microsoft/vstest/issues/1590#issuecomment-393460921
+            # Breaking change: We need to explicitly set the logger for it to work with TeamCity.
+            # See: https://github.com/microsoft/vstest/issues/1590#issuecomment-393460921
 
-			# Log to the console normal verbosity. With the TeamCity.VSTest.TestAdapter
-			# referenced by the test DLL, this will output teamcity service messages.
-			# Also, it displays pretty user output on the console.
-			$testExpression = "$testExpression --logger:""console;verbosity=normal"""
+            # Log to the console normal verbosity. With the TeamCity.VSTest.TestAdapter
+            # referenced by the test DLL, this will output teamcity service messages.
+            # Also, it displays pretty user output on the console.
+            $testExpression = "$testExpression --logger:""console;verbosity=normal"""
 
-			# Also log to a file in TRX format, so we have a build artifact both when
-			# doing release inspection and on the CI server.
-			$testExpression = "$testExpression --logger:""trx;LogFileName=TestResults.trx"""
-			
-			if (![string]::IsNullOrEmpty($where)) {
-				$testExpression = "$testExpression --TestCaseFilter:""$where"""
-			}
+            # Also log to a file in TRX format, so we have a build artifact both when
+            # doing release inspection and on the CI server.
+            $testExpression = "$testExpression --logger:""trx;LogFileName=TestResults.trx"""
+            
+            if (![string]::IsNullOrEmpty($where)) {
+                $testExpression = "$testExpression --TestCaseFilter:""$where"""
+            }
 
-			Write-Host $testExpression -ForegroundColor Magenta
+            Write-Host $testExpression -ForegroundColor Magenta
 
-			$scriptBlock = {
-				param([string]$testExpression, [string]$testResultDirectory)
-				$testExpression = "$testExpression > '$testResultDirectory/dotnet-test.log' 2> '$testResultDirectory/dotnet-test-error.log'"
-				Invoke-Expression $testExpression
-			}
+            $scriptBlock = {
+                param([string]$testExpression, [string]$testResultDirectory)
+                $testExpression = "$testExpression > '$testResultDirectory/dotnet-test.log' 2> '$testResultDirectory/dotnet-test-error.log'"
+                Invoke-Expression $testExpression
+            }
 
-			# Execute the jobs in parallel
-			Start-Job -Name "$testName,$framework" -ScriptBlock $scriptBlock -ArgumentList $testExpression,$testResultDirectory
+            # Execute the jobs in parallel
+            Start-Job -Name "$testName,$framework" -ScriptBlock $scriptBlock -ArgumentList $testExpression,$testResultDirectory
 
-			#Invoke-Expression $testExpression
-			## fail the build on negative exit codes (NUnit errors - if positive it is a test count or, if 1, it could be a dotnet error)
-			#if ($LASTEXITCODE -lt 0) {
-			#	throw "Test execution failed"
-			#}
-		}
-	}
+            #Invoke-Expression $testExpression
+            ## fail the build on negative exit codes (NUnit errors - if positive it is a test count or, if 1, it could be a dotnet error)
+            #if ($LASTEXITCODE -lt 0) {
+            #	throw "Test execution failed"
+            #}
+        }
+    }
 
-	do {
-		$running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
-		if ($running.Count -gt 0) {
-			Write-Host ""
-			Write-Host "  Almost finished, only $($running.Count) test projects left..." -ForegroundColor Cyan
-			[int]$number = 0
-			foreach ($runningJob in $running) {
-				$number++
-				$jobName = $runningJob | Select-Object -ExpandProperty Name
-				Write-Host "$number. $jobName"
-			}
-			$running | Wait-Job -Any
-		}
-	} until ($running.Count -eq 0)
+    do {
+        $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
+        if ($running.Count -gt 0) {
+            Write-Host ""
+            Write-Host "  Almost finished, only $($running.Count) test projects left..." -ForegroundColor Cyan
+            [int]$number = 0
+            foreach ($runningJob in $running) {
+                $number++
+                $jobName = $runningJob | Select-Object -ExpandProperty Name
+                Write-Host "$number. $jobName"
+            }
+            $running | Wait-Job -Any
+        }
+    } until ($running.Count -eq 0)
 
-	Summarize-Test-Results -FrameworksToTest $frameworksToTest
+    Summarize-Test-Results -FrameworksToTest $frameworksToTest
 }
 
 function Get-Package-Version() {
-	Write-Host $parameters.packageVersion -ForegroundColor Red
+    Write-Host $parameters.packageVersion -ForegroundColor Red
 
-	#If $packageVersion is not passed in (as a parameter or environment variable), get it from Version.proj
-	if (![string]::IsNullOrWhiteSpace($parameters.packageVersion) -and $parameters.packageVersion -ne "0.0.0") {
-		return $parameters.packageVersion
-	} elseif (![string]::IsNullOrWhiteSpace($env:PackageVersion) -and $env:PackageVersion -ne "0.0.0") {
-		return $env:PackageVersion
-	} else {
-		#Get the version info
-		$versionFile = "$base_directory/Directory.Build.props"
-		$xml = [xml](Get-Content $versionFile)
+    #If $packageVersion is not passed in (as a parameter or environment variable), get it from Version.proj
+    if (![string]::IsNullOrWhiteSpace($parameters.packageVersion) -and $parameters.packageVersion -ne "0.0.0") {
+        return $parameters.packageVersion
+    } elseif (![string]::IsNullOrWhiteSpace($env:PackageVersion) -and $env:PackageVersion -ne "0.0.0") {
+        return $env:PackageVersion
+    } else {
+        #Get the version info
+        $versionFile = "$base_directory/Directory.Build.props"
+        $xml = [xml](Get-Content $versionFile)
 
-		$versionPrefix = ([string]$xml.Project.PropertyGroup.VersionPrefix).Trim()
+        $versionPrefix = ([string]$xml.Project.PropertyGroup.VersionPrefix).Trim()
 
-		if ([string]::IsNullOrWhiteSpace($versionSuffix)) {
-			# this is a production release - use 4 segment version number 0.0.0.0
-			if ([string]::IsNullOrWhiteSpace($buildCounter)) {
-				$buildCounter = "0"
-			}
-			$packageVersion = "$versionPrefix.$buildCounter"
-		} else {
-			if (![string]::IsNullOrWhiteSpace($buildCounter)) {
-				$buildCounter = ([Int32]$buildCounter).ToString($preReleaseCounterPattern)
-			}
-			# this is a pre-release - use 3 segment version number with (optional) zero-padded pre-release tag
-			$packageVersion = "$versionPrefix-$versionSuffix$buildCounter"
-		}
+        if ([string]::IsNullOrWhiteSpace($versionSuffix)) {
+            # this is a production release - use 4 segment version number 0.0.0.0
+            if ([string]::IsNullOrWhiteSpace($buildCounter)) {
+                $buildCounter = "0"
+            }
+            $packageVersion = "$versionPrefix.$buildCounter"
+        } else {
+            if (![string]::IsNullOrWhiteSpace($buildCounter)) {
+                $buildCounter = ([Int32]$buildCounter).ToString($preReleaseCounterPattern)
+            }
+            # this is a pre-release - use 3 segment version number with (optional) zero-padded pre-release tag
+            $packageVersion = "$versionPrefix-$versionSuffix$buildCounter"
+        }
 
-		return $packageVersion
-	}
+        return $packageVersion
+    }
 }
 
 function Get-Version() {
-	#If $version is not passed in, parse it from $packageVersion
-	if ([string]::IsNullOrWhiteSpace($version) -or $version -eq "0.0.0") {
-		$version = Get-Package-Version
-		if ($version.Contains("-") -eq $true) {
-			$version = $version.SubString(0, $version.IndexOf("-"))
-		}
-	}
-	return $version
+    #If $version is not passed in, parse it from $packageVersion
+    if ([string]::IsNullOrWhiteSpace($version) -or $version -eq "0.0.0") {
+        $version = Get-Package-Version
+        if ($version.Contains("-") -eq $true) {
+            $version = $version.SubString(0, $version.IndexOf("-"))
+        }
+    }
+    return $version
 }
 
 function Get-FrameworksToTest() {
@@ -446,85 +446,85 @@ function Get-FrameworksToTest() {
 }
 
 function Is-Sdk-Version-Installed([string]$sdkVersion) {
-	& where.exe dotnet.exe | Out-Null
-	if ($LASTEXITCODE -eq 0) {
-		pushd $PSScriptRoot
-		$version = ((& dotnet --version 2>&1) | Out-String).Trim()
-		popd
+    & where.exe dotnet.exe | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        pushd $PSScriptRoot
+        $version = ((& dotnet --version 2>&1) | Out-String).Trim()
+        popd
 
         # May happen if global.json contains a version that
         # isn't installed, but we have at least one
-		if ($version.Contains('not found')) {
-			return $false
-		} elseif ([version]$version -eq [version]$sdkVersion) {
+        if ($version.Contains('not found')) {
+            return $false
+        } elseif ([version]$version -eq [version]$sdkVersion) {
             return $true
         } elseif ([version]$version -gt [version]"2.1.0") {
             $availableSdks = ((& dotnet --list-sdks) | Out-String)
             if ($LASTEXITCODE -eq 0) {
-			    if ($availableSdks.Contains($sdkVersion)) {
+                if ($availableSdks.Contains($sdkVersion)) {
                     return $true
                 } else {
                     return $false
                 }
             } else {
-			    return (Test-Path "$sdkPath/$sdkVersion")
-		    }
+                return (Test-Path "$sdkPath/$sdkVersion")
+            }
         }
-	}
+    }
     return $false
 }
 
 function Prepare-For-Build() {
-	#Use only the major version as the assembly version.
-	#This ensures binary compatibility unless the major version changes.
-	$version -match "(^\d+)"
-	$assemblyVersion = $Matches[0]
-	$assemblyVersion = "$assemblyVersion.0.0"
+    #Use only the major version as the assembly version.
+    #This ensures binary compatibility unless the major version changes.
+    $version -match "(^\d+)"
+    $assemblyVersion = $Matches[0]
+    $assemblyVersion = "$assemblyVersion.0.0"
 
-	Write-Host "Assembly version set to: $assemblyVersion" -ForegroundColor Green
+    Write-Host "Assembly version set to: $assemblyVersion" -ForegroundColor Green
 
-	$informationalVersion = $packageVersion
-	#check for presense of Git
-	& where.exe git.exe
-	if ($LASTEXITCODE -eq 0) {
-		$gitCommit = ((git rev-parse --verify --short=10 head) | Out-String).Trim()
-		$informationalVersion = "$packageVersion commit:[$gitCommit]"
-	}
+    $informationalVersion = $packageVersion
+    #check for presense of Git
+    & where.exe git.exe
+    if ($LASTEXITCODE -eq 0) {
+        $gitCommit = ((git rev-parse --verify --short=10 head) | Out-String).Trim()
+        $informationalVersion = "$packageVersion commit:[$gitCommit]"
+    }
 
-	Write-Host "##vso[task.setvariable variable=AssemblyVersion;]$assemblyVersion"
-	Write-Host "##vso[task.setvariable variable=FileVersion;]$version"
-	Write-Host "##vso[task.setvariable variable=InformationalVersion;]$informationalVersion"
-	Write-Host "##vso[task.setvariable variable=PackageVersion;]$packageVersion"
+    Write-Host "##vso[task.setvariable variable=AssemblyVersion;]$assemblyVersion"
+    Write-Host "##vso[task.setvariable variable=FileVersion;]$version"
+    Write-Host "##vso[task.setvariable variable=InformationalVersion;]$informationalVersion"
+    Write-Host "##vso[task.setvariable variable=PackageVersion;]$packageVersion"
 
-	Write-Host "Assembly informational version set to: $informationalVersion" -ForegroundColor Green
+    Write-Host "Assembly informational version set to: $informationalVersion" -ForegroundColor Green
 
-	Generate-Version-Props `
-		-AssemblyVersion $assemblyVersion `
-		-FileVersion $version `
-		-InformationalVersion $informationalVersion `
-		-PackageVersion $packageVersion `
-		-File $versionPropsFile
-	Update-Constants-Version $packageVersion
+    Generate-Version-Props `
+        -AssemblyVersion $assemblyVersion `
+        -FileVersion $version `
+        -InformationalVersion $informationalVersion `
+        -PackageVersion $packageVersion `
+        -File $versionPropsFile
+    Update-Constants-Version $packageVersion
 
-	if ($generateBuildBat -eq $true) {
-		Backup-File $build_bat
-		Generate-Build-Bat $build_bat
-	}
+    if ($generateBuildBat -eq $true) {
+        Backup-File $build_bat
+        Generate-Build-Bat $build_bat
+    }
 }
 
 function Update-Constants-Version([string]$version) {
-	$constantsFile = "$base_directory/src/Lucene.Net/Util/Constants.cs"
+    $constantsFile = "$base_directory/src/Lucene.Net/Util/Constants.cs"
 
-	Backup-File $constantsFile
-	(Get-Content $constantsFile) | % {
-		$_-replace "(?<=LUCENE_VERSION\s*?=\s*?"")([^""]*)", $version
-	} | Set-Content $constantsFile -Force
+    Backup-File $constantsFile
+    (Get-Content $constantsFile) | % {
+        $_-replace "(?<=LUCENE_VERSION\s*?=\s*?"")([^""]*)", $version
+    } | Set-Content $constantsFile -Force
 }
 
 function Generate-Global-Json {
 param(
-	[string]$sdkVersion,
-	[string]$file = $(throw "file is a required parameter.")
+    [string]$sdkVersion,
+    [string]$file = $(throw "file is a required parameter.")
 )
 
 $fileText = "{
@@ -533,20 +533,20 @@ $fileText = "{
     ""version"": ""$sdkVersion""
   }
 }"
-	$dir = [System.IO.Path]::GetDirectoryName($file)
-	Ensure-Directory-Exists $dir
+    $dir = [System.IO.Path]::GetDirectoryName($file)
+    Ensure-Directory-Exists $dir
 
-	Write-Host "Generating global.json file: $file"
-	Out-File -filePath $file -encoding UTF8 -inputObject $fileText
+    Write-Host "Generating global.json file: $file"
+    Out-File -filePath $file -encoding UTF8 -inputObject $fileText
 }
 
 function Generate-Version-Props {
 param(
-	[string]$assemblyVersion,
-	[string]$fileVersion,
-	[string]$informationalVersion,
-	[string]$packageVersion,
-	[string]$file = $(throw "file is a required parameter.")
+    [string]$assemblyVersion,
+    [string]$fileVersion,
+    [string]$informationalVersion,
+    [string]$packageVersion,
+    [string]$file = $(throw "file is a required parameter.")
 )
 
 $fileText = "<!--
@@ -573,16 +573,16 @@ $fileText = "<!--
     <PackageVersion>$packageVersion</PackageVersion>
   </PropertyGroup>
 </Project>"
-	$dir = [System.IO.Path]::GetDirectoryName($file)
-	Ensure-Directory-Exists $dir
+    $dir = [System.IO.Path]::GetDirectoryName($file)
+    Ensure-Directory-Exists $dir
 
-	Write-Host "Generating Version.props file: $file"
-	Out-File -filePath $file -encoding UTF8 -inputObject $fileText
+    Write-Host "Generating Version.props file: $file"
+    Out-File -filePath $file -encoding UTF8 -inputObject $fileText
 }
 
 function Generate-Build-Bat {
 param(
-	[string]$file = $(throw "file is a required parameter.")
+    [string]$file = $(throw "file is a required parameter.")
 )
   $buildBat = "
 @echo off
@@ -625,41 +625,41 @@ setlocal enabledelayedexpansion enableextensions
 set runtests=false
 set maximumParallelJobs=8
 FOR %%a IN (%*) DO (
-	FOR /f ""useback tokens=*"" %%a in ('%%a') do (
-		set value=%%~a
-		
-		set test=!value:~0,2!
-		IF /I !test!==-t (
-			set runtests=true
-		)
-		set test=!value:~0,6!
-		IF /I !test!==--test (
-			set runtests=true
-		)
-		set test=!value:~0,4!
-		IF /I !test!==-mp: (
-			set maximumParallelJobs=!value:~4!
-		)
-		set test=!value:~0,22!
-		IF /I !test!==--maximumparalleljobs: (
-			set maximumParallelJobs=!value:~22!
-		)
-	)
+    FOR /f ""useback tokens=*"" %%a in ('%%a') do (
+        set value=%%~a
+        
+        set test=!value:~0,2!
+        IF /I !test!==-t (
+            set runtests=true
+        )
+        set test=!value:~0,6!
+        IF /I !test!==--test (
+            set runtests=true
+        )
+        set test=!value:~0,4!
+        IF /I !test!==-mp: (
+            set maximumParallelJobs=!value:~4!
+        )
+        set test=!value:~0,22!
+        IF /I !test!==--maximumparalleljobs: (
+            set maximumParallelJobs=!value:~22!
+        )
+    )
 )
 set tasks=""Default""
 if ""!runtests!""==""true"" (
-	set tasks=""Default,Test""
+    set tasks=""Default,Test""
 )
 powershell -ExecutionPolicy Bypass -Command ""& { Import-Module .\build\psake.psm1; Invoke-Psake .\build\build.ps1 -Task %tasks% -properties @{prepareForBuild='false';backup_files='false';maximumParalellJobs=%maximumParallelJobs%} }""
 endlocal
 "
-	$dir = [System.IO.Path]::GetDirectoryName($file)
-	Ensure-Directory-Exists $dir
+    $dir = [System.IO.Path]::GetDirectoryName($file)
+    Ensure-Directory-Exists $dir
 
-	Write-Host "Generating build.bat file: $file"
-	#Out-File -filePath $file -encoding UTF8 -inputObject $buildBat -Force
-	$Utf8EncodingNoBom = New-Object System.Text.UTF8Encoding $false
-	[System.IO.File]::WriteAllLines($file, $buildBat, $Utf8EncodingNoBom)
+    Write-Host "Generating build.bat file: $file"
+    #Out-File -filePath $file -encoding UTF8 -inputObject $buildBat -Force
+    $Utf8EncodingNoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllLines($file, $buildBat, $Utf8EncodingNoBom)
 }
 
 function New-CountersObject ([string]$project, [string]$outcome, [int]$total, [int]$executed, [int]$passed, [int]$failed, [int]$warning, [int]$inconclusive) {
@@ -673,10 +673,10 @@ function Summarize-Test-Results([string[]]$frameworksToTest) {
 
     foreach ($framework in $frameworksToTest) {
         pushd $base_directory
-	    $testReports = Get-ChildItem -Path "$test_results_directory/$framework" -Recurse -File -Filter "*.trx" | ForEach-Object {
+        $testReports = Get-ChildItem -Path "$test_results_directory/$framework" -Recurse -File -Filter "*.trx" | ForEach-Object {
             $_.FullName
         }
-	    popd
+        popd
         
         [int]$totalCountForFramework = 0
         [int]$executedCountForFramework = 0
@@ -736,9 +736,9 @@ function Summarize-Test-Results([string[]]$frameworksToTest) {
                             @{Expression={$_.Warning};Label='Warning';Width=7},
                             @{Expression={$_.Inconclusive};Label='Inconclusive';Width=14}
 
-						if ($counters.Failed -gt 0) {
-							$Counters | Format-Table $format
-						}
+                        if ($counters.Failed -gt 0) {
+                            $Counters | Format-Table $format
+                        }
                     }
                 }
 
@@ -769,45 +769,45 @@ function Summarize-Test-Results([string[]]$frameworksToTest) {
         Write-Host "Warning: " -NoNewline; Write-Host "$warningCountForFramework" -ForegroundColor $foreground
         $foreground = if ($failedCountForFramework -gt 0) { 'Cyan' } else { (Get-Host).UI.RawUI.ForegroundColor }
         Write-Host "Inconclusive: " -NoNewline; Write-Host "$inconclusiveCountForFramework" -ForegroundColor $foreground
-		Write-Host ""
-		Write-Host "See the .trx logs in $test_results_directory/$framework for more details." -ForegroundColor DarkCyan
+        Write-Host ""
+        Write-Host "See the .trx logs in $test_results_directory/$framework for more details." -ForegroundColor DarkCyan
     }
 }
 
 function Backup-Files([string[]]$paths) {
-	foreach ($path in $paths) {
-		Backup-File $path
-	}
+    foreach ($path in $paths) {
+        Backup-File $path
+    }
 }
 
 function Backup-File([string]$path) {
-	if ($backup_files -eq $true) {
-		Copy-Item $path "$path.bak" -Force
-		$backedUpFiles.Insert(0, $path)
-	} else {
-		Write-Host "Ignoring backup of file $path" -ForegroundColor DarkRed
-	}
+    if ($backup_files -eq $true) {
+        Copy-Item $path "$path.bak" -Force
+        $backedUpFiles.Insert(0, $path)
+    } else {
+        Write-Host "Ignoring backup of file $path" -ForegroundColor DarkRed
+    }
 }
 
 function Restore-Files([string[]]$paths) {
-	foreach ($path in $paths) {
-		Restore-File $path
-	}
+    foreach ($path in $paths) {
+        Restore-File $path
+    }
 }
 
 function Restore-File([string]$path) {
-	if ($backup_files -eq $true) {
-		if (Test-Path "$path.bak") {
-			Move-Item "$path.bak" $path -Force
-		}
-		$backedUpFiles.Remove($path)
-	}
+    if ($backup_files -eq $true) {
+        if (Test-Path "$path.bak") {
+            Move-Item "$path.bak" $path -Force
+        }
+        $backedUpFiles.Remove($path)
+    }
 }
 
 function Ensure-Directory-Exists([string] $path) {
-	if (!(Test-Path $path)) {
-		New-Item $path -ItemType Directory
-	}
+    if (!(Test-Path $path)) {
+        New-Item $path -ItemType Directory
+    }
 }
 
 function New-TemporaryDirectory {

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -141,11 +141,12 @@ task Compile -depends Clean, Init, Restore -description "This task compiles the 
             # instead it is output to the Version.props file. This file is then
             # used during a release to "freeze" the build at a specific version
             # so it is always a constant in release distributions.
-            & dotnet.exe msbuild $solutionFile /t:Build `
-                /p:Configuration=$configuration `
-                /p:Platform=$platform `
-                /p:PortableDebugTypeOnly=true `
-                /p:TestFrameworks=true # workaround for parsing issue: https://github.com/Microsoft/msbuild/issues/471#issuecomment-181963350
+            & dotnet build "$solutionFile" `
+                --configuration "$configuration" `
+                --no-restore `
+                -p:Platform=$platform `
+                -p:PortableDebugTypeOnly=true `
+                -p:TestFrameworks=true # workaround for parsing issue: https://github.com/Microsoft/msbuild/issues/471#issuecomment-181963350
         }
 
         $success = $true

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -55,7 +55,7 @@ properties {
 
 $backedUpFiles = New-Object System.Collections.ArrayList
 if ($IsWindows -eq $null) {
-    $IsWindows = $Env:OS.StartsWith('Windows')
+    $IsWindows = $env:OS.StartsWith('Windows')
 }
 
 task default -depends Pack

--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -74,6 +74,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="$(MicrosoftExtensionsConfigurationXmlPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -83,6 +83,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion_NET4_5_1)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion_NET4_5_1)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="$(MicrosoftExtensionsConfigurationXmlPackageVersion_NET4_5_1)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -29,6 +29,9 @@
 
     <AssemblyTitle>Lucene.Net.Tests.Analysis.OpenNLP</AssemblyTitle>
     <RootNamespace>Lucene.Net.Analysis.OpenNlp</RootNamespace>
+
+    <IsPublishable>false</IsPublishable>
+    <IsPublishable Condition=" '$(TargetFramework)' == 'net48' ">true</IsPublishable>
   </PropertyGroup>
 
   <!-- OpenNLP is not strong-named -->

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/Lucene.Net.Tests.Analysis.SmartCn.csproj
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/Lucene.Net.Tests.Analysis.SmartCn.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)"/>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/Lucene.Net.Tests.Analysis.SmartCn.csproj
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/Lucene.Net.Tests.Analysis.SmartCn.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -36,6 +36,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="System.Net.Primitives" Version="$(SystemNetPrimitivesPackageVersion)"/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Tests.Benchmark/Lucene.Net.Tests.Benchmark.csproj
+++ b/src/Lucene.Net.Tests.Benchmark/Lucene.Net.Tests.Benchmark.csproj
@@ -51,6 +51,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)"/>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Tests.Benchmark/Lucene.Net.Tests.Benchmark.csproj
+++ b/src/Lucene.Net.Tests.Benchmark/Lucene.Net.Tests.Benchmark.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -47,6 +47,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="System.Net.Primitives" Version="$(SystemNetPrimitivesPackageVersion)"/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Tests.Replicator/Lucene.Net.Tests.Replicator.csproj
+++ b/src/Lucene.Net.Tests.Replicator/Lucene.Net.Tests.Replicator.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -38,6 +38,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Tests.TestFramework/Lucene.Net.Tests.TestFramework.csproj
+++ b/src/Lucene.Net.Tests.TestFramework/Lucene.Net.Tests.TestFramework.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -54,10 +54,6 @@
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion_NET4_5_1)" />
   </ItemGroup>
 
 </Project>

--- a/src/dotnet/Lucene.Net.Replicator.AspNetCore/Lucene.Net.Replicator.AspNetCore.csproj
+++ b/src/dotnet/Lucene.Net.Replicator.AspNetCore/Lucene.Net.Replicator.AspNetCore.csproj
@@ -26,7 +26,7 @@
   
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net451</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net461</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Replicator.AspNetCore</AssemblyTitle>
     <Description>AspNetCore integration of Lucene.Net.Replicator for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>

--- a/src/dotnet/Lucene.Net.Tests.CodeAnalysis/Lucene.Net.Tests.CodeAnalysis.csproj
+++ b/src/dotnet/Lucene.Net.Tests.CodeAnalysis/Lucene.Net.Tests.CodeAnalysis.csproj
@@ -24,6 +24,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Lucene.Net.CodeAnalysis</RootNamespace>
+    
+    <IsPublishable>false</IsPublishable>
+    <IsPublishable Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">true</IsPublishable>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)build/TestReferences.Common.targets" />

--- a/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj
+++ b/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj
@@ -70,6 +70,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)"/>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj
+++ b/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -66,6 +66,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="System.Net.Primitives" Version="$(SystemNetPrimitivesPackageVersion)"/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -24,6 +24,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyTitle>Lucene.Net.Tests.Cli</AssemblyTitle>
+
+    <IsPublishable>false</IsPublishable>
+    <IsPublishable Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">true</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
@@ -45,9 +45,9 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="System.Net.Primitives" Version="$(SystemNetPrimitivesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="$(MicrosoftExtensionsConfigurationXmlPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion)" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)build/TestReferences.Common.targets" />

--- a/src/dotnet/tools/lucene-cli/lucene-cli.csproj
+++ b/src/dotnet/tools/lucene-cli/lucene-cli.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -26,6 +26,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
+    <IsPublishable Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">true</IsPublishable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>lucene</ToolCommandName>
     

--- a/src/dotnet/tools/lucene-cli/lucene-cli.csproj
+++ b/src/dotnet/tools/lucene-cli/lucene-cli.csproj
@@ -66,9 +66,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="$(MicrosoftExtensionsConfigurationXmlPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion)" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 

--- a/src/dotnet/tools/lucene-cli/lucene-cli.csproj
+++ b/src/dotnet/tools/lucene-cli/lucene-cli.csproj
@@ -62,10 +62,14 @@
     <ProjectReference Include="..\..\..\Lucene.Net.Facet\Lucene.Net.Facet.csproj" />
     <ProjectReference Include="..\..\..\Lucene.Net.Misc\Lucene.Net.Misc.csproj" />
     <ProjectReference Include="..\..\..\Lucene.Net.QueryParser\Lucene.Net.QueryParser.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="$(MicrosoftExtensionsConfigurationXmlPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Changed `dotnet publish` to be for the whole solution instead of one project at a time using the [undocumented `IsPublishable` MSBuild property](https://stackoverflow.com/a/58858790).
- Fixed package dependency conflicts.
- Switched to `dotnet build` instead of `dotnet msbuild`.
- Switched to `dotnet test` instead of `dotnet mstest`.
- Commented out extra build steps that are meant for debugging purposes.
- Added `GeneratePackages` option to skip `dotnet pack` and subsequent upload of artifacts for faster testing.
- Added option to disable installing .NET SDK during build (which was double-installing it).
- Fail the build if the test runner crashes.
- Added the `--blame-hang-timeout` option to detect when a test doesn't finish and to provide diagnostic info for debugging. For now, the timeout is hard-coded at 10 minutes (per test) for a regular build and 35 minutes for a nightly build.





