### PR TITLE
Review of ConditionalWeakTable<TKey, TValue>.GetValue() usage (See #417)

### DIFF
--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -315,6 +315,7 @@ namespace Lucene.Net.Util
         {
             return knownImplClasses.GetValue(clazz, (key) =>
             {
+                // we have the slight chance that another thread may do the same, but who cares?
                 LinkedList<WeakReference<Type>> foundInterfaces = new LinkedList<WeakReference<Type>>();
                 // find all interfaces that this attribute instance implements
                 // and that extend the Attribute interface

--- a/src/Lucene.Net/Util/VirtualMethod.cs
+++ b/src/Lucene.Net/Util/VirtualMethod.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Support;
+﻿using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -147,7 +147,7 @@ namespace Lucene.Net.Util
         public int GetImplementationDistance(Type subclazz)
         {
             // LUCENENET: Replaced WeakIdentityMap with ConditionalWeakTable - This operation is simplified over Lucene.
-            return cache.GetValue(subclazz, (key) => Convert.ToInt32(ReflectImplementationDistance(key), CultureInfo.InvariantCulture));
+            return cache.GetValue(subclazz, (key) => ReflectImplementationDistance(key));
         }
 
         /// <summary>


### PR DESCRIPTION
See #417.

This review includes all usage of `ConditionalWeakTable<TKey, TValue>` except for `FieldCacheImpl`, which is another branch that is being worked on. It does **not** include a review of `LurchTable<TKey, TValue>` or `ConcurrentDictionary<TKey, TValue>` usage.

The `ShapeFieldCacheProvider<T>` is almost certainly the fix for #319, but since we have no way to reproduce that exception we will have to get confirmation from the user.