### PR TITLE
Reviewed catch clauses and made improvements to preserve stack details

### DIFF
--- a/src/Lucene.Net.Facet/RandomSamplingFacetsCollector.cs
+++ b/src/Lucene.Net.Facet/RandomSamplingFacetsCollector.cs
@@ -258,9 +258,9 @@ namespace Lucene.Net.Facet
 
                 return new MatchingDocs(docs.Context, sampleDocs, docs.TotalHits, null);
             }
-            catch (IOException)
+            catch (IOException e)
             {
-                throw new Exception();
+                throw new Exception(e.ToString(), e);
             }
         }
 

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
@@ -455,9 +455,12 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                     }
                     sb.Append(i + ": " + category.ToString() + "\n");
                 }
-                catch (IOException)
+                catch (IOException e)
                 {
-                    throw;
+                    // LUCENENET TODO: Should we use a 3rd party logging library?
+
+                    // LUCENENET specific - using System.Diagnostics.Trace rather than using a logging library as a workaround.
+                    System.Diagnostics.Trace.WriteLine(e.ToString(), "FINEST");
                 }
             }
             return sb.ToString();

--- a/src/Lucene.Net.QueryParser/Analyzing/AnalyzingQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Analyzing/AnalyzingQueryParser.cs
@@ -206,10 +206,10 @@ namespace Lucene.Net.QueryParsers.Analyzing
                     throw new ParseException(string.Format(@"Analyzer returned nothing for ""{0}""", chunk));
                 }
             }
-            catch (IOException /*e*/)
+            catch (IOException e)
             {
                 throw new ParseException(
-                    string.Format(@"IO error while trying to analyze single term: ""{0}""", termStr));
+                    string.Format(@"IO error while trying to analyze single term: ""{0}""", termStr), e);
             }
             finally
             {

--- a/src/Lucene.Net.QueryParser/Surround/Parser/QueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Parser/QueryParser.cs
@@ -571,7 +571,7 @@ namespace Lucene.Net.QueryParsers.Surround.Parser
                 }
                 catch (Exception floatExc)
                 {
-                    { if (true) throw new ParseException(boostErrorMessage + weight.Image + " (" + floatExc + ")"); }
+                    { if (true) throw new ParseException(boostErrorMessage + weight.Image + " (" + floatExc + ")", floatExc); }
                 }
                 if (f <= 0.0)
                 {

--- a/src/Lucene.Net.QueryParser/Xml/Builders/SpanOrTermsBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Xml/Builders/SpanOrTermsBuilder.cs
@@ -63,11 +63,9 @@ namespace Lucene.Net.QueryParsers.Xml.Builders
                 soq.Boost = DOMUtils.GetAttribute(e, "boost", 1.0f);
                 return soq;
             }
-#pragma warning disable 168
             catch (IOException ioe)
-#pragma warning restore 168
             {
-                throw new ParserException("IOException parsing value:" + value);
+                throw new ParserException("IOException parsing value:" + value, ioe);
             }
             finally
             {

--- a/src/Lucene.Net.QueryParser/Xml/Builders/TermsFilterBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Xml/Builders/TermsFilterBuilder.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.QueryParsers.Xml.Builders
             }
             catch (IOException ioe)
             {
-                throw new Exception("Error constructing terms from index:" + ioe);
+                throw new Exception("Error constructing terms from index:" + ioe, ioe);
             }
             finally
             {

--- a/src/Lucene.Net.QueryParser/Xml/Builders/TermsQueryBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Xml/Builders/TermsQueryBuilder.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.QueryParsers.Xml.Builders
             }
             catch (IOException ioe)
             {
-                throw new Exception("Error constructing terms from index:" + ioe);
+                throw new Exception("Error constructing terms from index:" + ioe, ioe);
             }
             finally
             {

--- a/src/Lucene.Net.QueryParser/Xml/Builders/UserInputQueryBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Xml/Builders/UserInputQueryBuilder.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.QueryParsers.Xml.Builders
             }
             catch (ParseException e1)
             {
-                throw new ParserException(e1.Message);
+                throw new ParserException(e1.Message, e1);
             }
         }
 

--- a/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
@@ -167,7 +167,7 @@ namespace Lucene.Net.Replicator.Http
                 response.EnsureSuccessStatusCode();
                 //Note: This is unreachable, but the compiler and resharper cant see that EnsureSuccessStatusCode always
                 //      throws an exception in this scenario. So it complains later on in the method.
-                throw;
+                throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
             }
 
             Exception exception;

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -1,4 +1,4 @@
-using J2N.Collections.Generic.Extensions;
+﻿using J2N.Collections.Generic.Extensions;
 using J2N.Threading;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Documents;
@@ -413,7 +413,7 @@ namespace Lucene.Net.Analysis
                 //ts.Reset();
                 ts.ClearAttributes();
                 ts.End();
-                throw;
+                throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
             }
             finally
             {
@@ -722,7 +722,7 @@ namespace Lucene.Net.Analysis
                 catch (Exception e)
                 {
                     //Console.WriteLine("Exception in Thread: " + e);
-                    //throw;
+                    //throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
                     // LUCENENET: Throwing an exception on another thread
                     // is pointless, so we set it to a variable so we can read
                     // it from our main thread (for debugging).
@@ -958,7 +958,7 @@ namespace Lucene.Net.Analysis
                         // TODO: really we should pass a random seed to
                         // checkAnalysisConsistency then print it here too:
                         Console.Error.WriteLine("TEST FAIL: useCharFilter=" + useCharFilter + " text='" + Escape(text) + "'");
-                        throw;
+                        throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
                     }
                 }
             }

--- a/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
@@ -1,4 +1,4 @@
-using J2N.Threading;
+﻿using J2N.Threading;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
@@ -344,7 +344,7 @@ namespace Lucene.Net.Analysis
                 }
                 catch (IOException e)
                 {
-                    throw (Exception)e;
+                    throw new Exception(e.ToString(), e);
                 }
             }
         }

--- a/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
@@ -507,7 +507,7 @@ namespace Lucene.Net.Store
         //                }
         //                //catch (IOException e)
         //                //{
-        //                //    throw;
+        //                //    throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
         //                //}
         //                finally
         //                {
@@ -567,7 +567,7 @@ namespace Lucene.Net.Store
         //                catch (IOException e)
         //                {
         //                    //throw new UncheckedIOException(e);
-        //                    throw;
+        //                    throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
         //                }
         //            }
         //        }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using Lucene.Net.Analysis.CharFilters;
 using Lucene.Net.Analysis.CommonGrams;
 using Lucene.Net.Analysis.Miscellaneous;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCodepointCountFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCodepointCountFilterFactory.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
 using System;

--- a/src/Lucene.Net.Tests.Expressions/JS/TestJavascriptCompiler.cs
+++ b/src/Lucene.Net.Tests.Expressions/JS/TestJavascriptCompiler.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Expressions.JS
             }
             catch (InvalidOperationException)
             {
-				// expected
+                // expected
             }
             try
             {

--- a/src/Lucene.Net.Tests/Index/TestConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net.Tests/Index/TestConcurrentMergeScheduler.cs
@@ -370,14 +370,12 @@ namespace Lucene.Net.Index
                         runningMergeCount.DecrementAndGet();
                     }
                 }
-                catch (Exception /*t*/)
+                catch (Exception t)
                 {
                     failed.Value = (true);
                     m_writer.MergeFinish(merge);
-
-                    // LUCENENET specific - throwing an exception on a background thread causes the test
-                    // runner to crash on .NET Core 2.0.
-                    //throw new Exception(t.ToString(), t);
+                    // LUCENENET NOTE: ThreadJob takes care of propagating the exception to the calling thread
+                    throw new Exception(t.ToString(), t);
                 }
             }
         }

--- a/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
@@ -224,7 +224,7 @@ namespace Lucene.Net.Index
                 catch (IOException e)
 #pragma warning restore 168
                 {
-                    throw new Exception();
+                    throw new Exception(e.ToString(), e);
                 }
                 return i;
             }

--- a/src/Lucene.Net.Tests/Index/TestPersistentSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestPersistentSnapshotDeletionPolicy.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Store;
+﻿using Lucene.Net.Store;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
@@ -144,7 +144,7 @@ namespace Lucene.Net.Index
                 }
                 else
                 {
-                    throw; // LUCENENET: CA2200: Rethrow to preserve stack details
+                    throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
                 }
             }
             Assert.AreEqual(0, psdp.SnapshotCount);

--- a/src/Lucene.Net.Tests/Search/TestBoolean2.cs
+++ b/src/Lucene.Net.Tests/Search/TestBoolean2.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
@@ -356,7 +356,7 @@ namespace Lucene.Net.Search
             {
                 // For easier debugging
                 Console.WriteLine("failed query: " + q1);
-                throw;
+                throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
             }
 
             // System.out.println("Total hits:"+tot);

--- a/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
+++ b/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
@@ -1,4 +1,4 @@
-using J2N.Threading;
+﻿using J2N.Threading;
 using J2N.Threading.Atomic;
 using Lucene.Net.Index.Extensions;
 using Lucene.Net.Util;
@@ -542,7 +542,7 @@ namespace Lucene.Net.Search
 //                }
 //                catch (ThreadInterruptedException) // LUCENENET NOTE: Senseless to catch and rethrow the same exception type
 //                {
-//                    throw;
+//                    throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
 //                }
 //#endif
             }

--- a/src/Lucene.Net.Tests/Search/TestTimeLimitingCollector.cs
+++ b/src/Lucene.Net.Tests/Search/TestTimeLimitingCollector.cs
@@ -408,12 +408,12 @@ namespace Lucene.Net.Search
 //#if !FEATURE_THREAD_INTERRUPT
 //                    catch (Exception)
 //                    {
-//                        throw;
+//                        throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
 //                    }
 //#else
 //                    catch (ThreadInterruptedException) // LUCENENET NOTE: Senseless to catch and rethrow the same exception type
 //                    {
-//                        throw;
+//                        throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
 //                    }
 //#endif
                 }

--- a/src/Lucene.Net/Store/ByteBufferIndexInput.cs
+++ b/src/Lucene.Net/Store/ByteBufferIndexInput.cs
@@ -234,17 +234,17 @@ namespace Lucene.Net.Store
                 this.curBufIndex = bi;
                 this.curBuf = b;
             }
-            catch (IndexOutOfRangeException)
+            catch (IndexOutOfRangeException aioobe)
             {
-                throw new EndOfStreamException("seek past EOF: " + this);
+                throw new EndOfStreamException("seek past EOF: " + this, aioobe);
             }
-            catch (ArgumentException)
+            catch (ArgumentException iae)
             {
-                throw new EndOfStreamException("seek past EOF: " + this);
+                throw new EndOfStreamException("seek past EOF: " + this, iae);
             }
-            catch (NullReferenceException)
+            catch (NullReferenceException npe)
             {
-                throw new ObjectDisposedException(this.GetType().FullName, "Already closed: " + this);
+                throw new ObjectDisposedException("Already closed: " + this, npe);
             }
         }
 

--- a/src/Lucene.Net/Store/LockStressTest.cs
+++ b/src/Lucene.Net/Store/LockStressTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -89,9 +89,9 @@ namespace Lucene.Net.Store
                     c = Type.GetType("Lucene.Net.Store." + lockFactoryClassName);
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                throw new IOException("unable to find LockClass " + lockFactoryClassName);
+                throw new IOException("unable to find LockClass " + lockFactoryClassName, e);
             }
 
             LockFactory lockFactory;

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -1,4 +1,4 @@
-using J2N;
+﻿using J2N;
 using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
@@ -570,7 +570,7 @@ namespace Lucene.Net.Util
         //                {
         //                    if (retryCount == 5)
         //                    {
-        //                        throw;
+        //                        throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
         //                    }
         //#if FEATURE_THREAD_INTERRUPT
         //                    try

--- a/src/Lucene.Net/Util/VirtualMethod.cs
+++ b/src/Lucene.Net/Util/VirtualMethod.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Support;
+﻿using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -136,7 +136,7 @@ namespace Lucene.Net.Util
             }
             catch (NotSupportedException nsme)
             {
-                throw new ArgumentException(baseClass.Name + " has no such method: " + nsme.Message);
+                throw new ArgumentException(baseClass.Name + " has no such method: " + nsme.Message, nsme);
             }
         }
 


### PR DESCRIPTION
This is a review to ensure that stack details are always preserved either by using `throw` without specifying the exception, or by using `innerException` of a new exception class instance.

It also fixes `DirectoryTaxonomyReader.ToString(int)` so it logs any exceptions instead of throwing them, as was the case in Lucene. For the time being, they are being written to `System.Diagnostics.Trace`.