### PR TITLE
Reviewed concurrent collections (Closes #417)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,10 +20,11 @@
 -->
 <Project>
 
-  <!-- Features in .NET Core 3.x and .NET 5 only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) Or '$(TargetFramework)' == 'net5.0' ">
+  <!-- Features in .NET Core 3.x and .NET 5.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ARGITERATOR</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION</DefineConstants>
 
   </PropertyGroup>
   

--- a/src/Lucene.Net.Analysis.OpenNLP/Tools/OpenNLPOpsFactory.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/Tools/OpenNLPOpsFactory.cs
@@ -7,7 +7,6 @@ using opennlp.tools.postag;
 using opennlp.tools.sentdetect;
 using opennlp.tools.tokenize;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -37,13 +36,13 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
     /// </summary>
     public static class OpenNLPOpsFactory // LUCENENET: Made static because all members are static
     {
-        private static readonly IDictionary<string, SentenceModel> sentenceModels = new ConcurrentDictionary<string, SentenceModel>();
+        private static readonly ConcurrentDictionary<string, SentenceModel> sentenceModels = new ConcurrentDictionary<string, SentenceModel>();
         private static readonly ConcurrentDictionary<string, TokenizerModel> tokenizerModels = new ConcurrentDictionary<string, TokenizerModel>();
         private static readonly ConcurrentDictionary<string, POSModel> posTaggerModels = new ConcurrentDictionary<string, POSModel>();
         private static readonly ConcurrentDictionary<string, ChunkerModel> chunkerModels = new ConcurrentDictionary<string, ChunkerModel>();
-        private static readonly IDictionary<string, TokenNameFinderModel> nerModels = new ConcurrentDictionary<string, TokenNameFinderModel>();
-        private static readonly IDictionary<string, LemmatizerModel> lemmatizerModels = new ConcurrentDictionary<string, LemmatizerModel>();
-        private static readonly IDictionary<string, string> lemmaDictionaries = new ConcurrentDictionary<string, string>();
+        private static readonly ConcurrentDictionary<string, TokenNameFinderModel> nerModels = new ConcurrentDictionary<string, TokenNameFinderModel>();
+        private static readonly ConcurrentDictionary<string, LemmatizerModel> lemmatizerModels = new ConcurrentDictionary<string, LemmatizerModel>();
+        private static readonly ConcurrentDictionary<string, string> lemmaDictionaries = new ConcurrentDictionary<string, string>();
 
         public static NLPSentenceDetectorOp GetSentenceDetector(string modelName)
         {
@@ -60,15 +59,12 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
 
         public static SentenceModel GetSentenceModel(string modelName, IResourceLoader loader)
         {
-            if (!sentenceModels.TryGetValue(modelName, out SentenceModel model) || model == null)
+            // LUCENENET: Two competing threads in the add operation is okay as per the original implementation
+            return sentenceModels.GetOrAdd(modelName, (modelName) =>
             {
-                using (Stream resource = loader.OpenResource(modelName))
-                {
-                    model = new SentenceModel(new ikvm.io.InputStreamWrapper(resource));
-                }
-                sentenceModels[modelName] = model;
-            }
-            return model;
+                using Stream resource = loader.OpenResource(modelName);
+                return new SentenceModel(new ikvm.io.InputStreamWrapper(resource));
+            });
         }
 
         public static NLPTokenizerOp GetTokenizer(string modelName)
@@ -86,15 +82,12 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
 
         public static TokenizerModel GetTokenizerModel(string modelName, IResourceLoader loader)
         {
-            if (!tokenizerModels.TryGetValue(modelName, out TokenizerModel model) || model == null)
+            // LUCENENET: Two competing threads in the add operation is okay as per the original implementation
+            return tokenizerModels.GetOrAdd(modelName, (modelName) =>
             {
-                using (Stream resource = loader.OpenResource(modelName))
-                {
-                    model = new TokenizerModel(new ikvm.io.InputStreamWrapper(resource));
-                }
-                tokenizerModels[modelName] = model;
-            }
-            return model;
+                using Stream resource = loader.OpenResource(modelName);
+                return new TokenizerModel(new ikvm.io.InputStreamWrapper(resource));
+            });
         }
 
         public static NLPPOSTaggerOp GetPOSTagger(string modelName)
@@ -105,15 +98,12 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
 
         public static POSModel GetPOSTaggerModel(string modelName, IResourceLoader loader)
         {
-            if (!posTaggerModels.TryGetValue(modelName, out POSModel model) || model == null)
+            // LUCENENET: Two competing threads in the add operation is okay as per the original implementation
+            return posTaggerModels.GetOrAdd(modelName, (modelName) =>
             {
-                using (Stream resource = loader.OpenResource(modelName))
-                {
-                    model = new POSModel(new ikvm.io.InputStreamWrapper(resource));
-                }
-                posTaggerModels[modelName] = model;
-            }
-            return model;
+                using Stream resource = loader.OpenResource(modelName);
+                return new POSModel(new ikvm.io.InputStreamWrapper(resource));
+            });
         }
 
         public static NLPChunkerOp GetChunker(string modelName)
@@ -124,15 +114,12 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
 
         public static ChunkerModel GetChunkerModel(string modelName, IResourceLoader loader)
         {
-            if (!chunkerModels.TryGetValue(modelName, out ChunkerModel model) || model == null)
+            // LUCENENET: Two competing threads in the add operation is okay as per the original implementation
+            return chunkerModels.GetOrAdd(modelName, (modelName) =>
             {
-                using (Stream resource = loader.OpenResource(modelName))
-                {
-                    model = new ChunkerModel(new ikvm.io.InputStreamWrapper(resource));
-                }
-                chunkerModels[modelName] = model;
-            }
-            return model;
+                using Stream resource = loader.OpenResource(modelName);
+                return new ChunkerModel(new ikvm.io.InputStreamWrapper(resource));
+            });
         }
 
         public static NLPNERTaggerOp GetNERTagger(string modelName)
@@ -143,15 +130,12 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
 
         public static TokenNameFinderModel GetNERTaggerModel(string modelName, IResourceLoader loader)
         {
-            if (!nerModels.TryGetValue(modelName, out TokenNameFinderModel model) || model == null)
+            // LUCENENET: Two competing threads in the add operation is okay as per the original implementation
+            return nerModels.GetOrAdd(modelName, (modelName) =>
             {
-                using (Stream resource = loader.OpenResource(modelName))
-                {
-                    model = new TokenNameFinderModel(new ikvm.io.InputStreamWrapper(resource));
-                }
-                nerModels[modelName] = model;
-            }
-            return model;
+                using Stream resource = loader.OpenResource(modelName);
+                return new TokenNameFinderModel(new ikvm.io.InputStreamWrapper(resource));
+            });
         }
 
         public static NLPLemmatizerOp GetLemmatizer(string dictionaryFile, string lemmatizerModelFile)
@@ -169,7 +153,8 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
 
         public static string GetLemmatizerDictionary(string dictionaryFile, IResourceLoader loader)
         {
-            if (!lemmaDictionaries.TryGetValue(dictionaryFile, out string dictionary) || dictionary == null)
+            // LUCENENET: Two competing threads in the add operation is okay as per the original implementation
+            return lemmaDictionaries.GetOrAdd(dictionaryFile, (dictionaryFile) =>
             {
                 using TextReader reader = new StreamReader(loader.OpenResource(dictionaryFile), Encoding.UTF8);
                 StringBuilder builder = new StringBuilder();
@@ -183,23 +168,18 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
                         builder.Append(chars, 0, numRead);
                     }
                 } while (numRead > 0);
-                dictionary = builder.ToString();
-                lemmaDictionaries[dictionaryFile] = dictionary;
-            }
-            return dictionary;
+                return builder.ToString();
+            });
         }
 
         public static LemmatizerModel GetLemmatizerModel(string modelName, IResourceLoader loader)
         {
-            if (!lemmatizerModels.TryGetValue(modelName, out LemmatizerModel model) || model == null)
+            // LUCENENET: Two competing threads in the add operation is okay as per the original implementation
+            return lemmatizerModels.GetOrAdd(modelName, (modelName) =>
             {
-                using (Stream resource = loader.OpenResource(modelName))
-                {
-                    model = new LemmatizerModel(new ikvm.io.InputStreamWrapper(resource));
-                }
-                lemmatizerModels[modelName] = model;
-            }
-            return model;
+                using Stream resource = loader.OpenResource(modelName);
+                return new LemmatizerModel(new ikvm.io.InputStreamWrapper(resource));
+            });
         }
 
         // keeps unit test from blowing out memory

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/NameIntCacheLRU.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/NameIntCacheLRU.cs
@@ -161,9 +161,13 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             }
             else
             {
+#if FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION
+                cache = new Dictionary<TName, int>(capacity: 1000);
+#else
                 // LUCENENET specific - we use ConcurrentDictionary here because it supports deleting while
                 // iterating through the collection, but Dictionary does not.
                 cache = new ConcurrentDictionary<TName, int>(concurrencyLevel: 3, capacity: 1000); //no need for LRU
+#endif
             }
         }
 

--- a/src/Lucene.Net.Join/ToParentBlockJoinCollector.cs
+++ b/src/Lucene.Net.Join/ToParentBlockJoinCollector.cs
@@ -348,12 +348,14 @@ namespace Lucene.Net.Join
             }
             Arrays.Fill(joinScorers, null);
 
-            var queue2 = new ConcurrentQueue<Scorer>();
+            var queue = new Queue<Scorer>();
             //System.out.println("\nqueue: add top scorer=" + value);
-            queue2.Enqueue(scorer);
-
-            while (queue2.TryDequeue(out scorer))
+            queue.Enqueue(scorer);
+            while (queue.Count > 0)
             {
+                // LUCENENET NOTE: This reuses the scorer argument variable, which
+                // differs from this.scorer.
+                scorer = queue.Dequeue();
                 //System.out.println("  poll: " + value + "; " + value.getWeight().getQuery());
                 if (scorer is ToParentBlockJoinQuery.BlockJoinScorer blockJoinScorer)
                 {
@@ -363,7 +365,7 @@ namespace Lucene.Net.Join
                 foreach (Scorer.ChildScorer sub in scorer.GetChildren())
                 {
                     //System.out.println("  add sub: " + sub.child + "; " + sub.child.getWeight().getQuery());
-                    queue2.Enqueue(sub.Child);
+                    queue.Enqueue(sub.Child);
                 }
             }
         }

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -1,4 +1,4 @@
-using J2N.Collections.Generic.Extensions;
+﻿using J2N.Collections.Generic.Extensions;
 using J2N.Threading;
 using Lucene.Net.Analysis;
 using Lucene.Net.Diagnostics;
@@ -412,7 +412,7 @@ namespace Lucene.Net.Search
                         }
                         else
                         {
-                            nodeStats = outerInstance.collectionStatsCache[key];
+                            outerInstance.collectionStatsCache.TryGetValue(key, out nodeStats);
                         }
                         if (nodeStats == null)
                         {

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -416,7 +416,7 @@ namespace Lucene.Net.Search
                         }
                         if (nodeStats == null)
                         {
-                            Console.WriteLine("coll stats myNodeID=" + MyNodeID + ": " + outerInstance.collectionStatsCache.Keys);
+                            Console.WriteLine("coll stats myNodeID=" + MyNodeID + ": " + Collections.ToString(outerInstance.collectionStatsCache.Keys));
                         }
                         // Collection stats are pre-shared on reopen, so,
                         // we better not have a cache miss:

--- a/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
+++ b/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
@@ -1,4 +1,4 @@
-using J2N;
+﻿using J2N;
 using J2N.Collections;
 using J2N.Collections.Generic.Extensions;
 using Lucene.Net.Diagnostics;
@@ -823,9 +823,13 @@ namespace Lucene.Net.Util.Fst
 
             // build all prefixes
 
+#if FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION
+            IDictionary<Int32sRef, CountMinOutput<T>> prefixes = new Dictionary<Int32sRef, CountMinOutput<T>>();
+#else
             // LUCENENET: We use ConcurrentDictionary<TKey, TValue> because Dictionary<TKey, TValue> doesn't support
             // deletion while iterating, but ConcurrentDictionary does.
             IDictionary<Int32sRef, CountMinOutput<T>> prefixes = new ConcurrentDictionary<Int32sRef, CountMinOutput<T>>();
+#endif
             Int32sRef scratch = new Int32sRef(10);
             foreach (InputOutput<T> pair in pairs)
             {

--- a/src/Lucene.Net.Tests.Suggest/Spell/TestSpellChecker.cs
+++ b/src/Lucene.Net.Tests.Suggest/Spell/TestSpellChecker.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Search.Spell
     {
         private SpellCheckerMock spellChecker;
         private Directory userindex, spellindex;
-        internal static ConcurrentBag<IndexSearcher> searchers;
+        internal static ConcurrentQueue<IndexSearcher> searchers;
 
 
         public override void SetUp()
@@ -83,7 +83,7 @@ namespace Lucene.Net.Search.Spell
             }
 
             writer.Dispose();
-            searchers = new ConcurrentBag<IndexSearcher>();
+            searchers = new ConcurrentQueue<IndexSearcher>();
             // create the spellChecker
             spellindex = NewDirectory();
             spellChecker = new SpellCheckerMock(spellindex);
@@ -507,13 +507,7 @@ namespace Lucene.Net.Search.Spell
         private void AssertLastSearcherOpen(int numSearchers)
         {
             assertEquals(numSearchers, searchers.Count);
-
-            // LUCENENET NOTE: The ConcurrentBag.Add() method adds each item to the
-            // beginning of the list, so we end up with a reverse order array.
-            // We can correct that here, since this is the only part of the
-            // test that cares about the order.
-            IndexSearcher[] searcherArray = searchers.Reverse().ToArray();
-
+            IndexSearcher[] searcherArray = searchers.ToArray();
             for (int i = 0; i < searcherArray.Length; i++)
             {
                 if (i == searcherArray.Length - 1)
@@ -634,7 +628,7 @@ namespace Lucene.Net.Search.Spell
             internal override IndexSearcher CreateSearcher(Directory dir)
             {
                 IndexSearcher searcher = base.CreateSearcher(dir);
-                TestSpellChecker.searchers.Add(searcher);
+                TestSpellChecker.searchers.Enqueue(searcher);
                 return searcher;
             }
         }

--- a/src/Lucene.Net/Search/SearcherLifetimeManager.cs
+++ b/src/Lucene.Net/Search/SearcherLifetimeManager.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Support;
+﻿using Lucene.Net.Support;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -139,6 +139,7 @@ namespace Lucene.Net.Search
         // TODO: we could get by w/ just a "set"; need to have
         // Tracker hash by its version and have compareTo(Long)
         // compare to its version
+        // LUCENENET specific - use Lazy<T> to make the create operation atomic. See #417.
         private readonly ConcurrentDictionary<long, Lazy<SearcherTracker>> _searchers = new ConcurrentDictionary<long, Lazy<SearcherTracker>>();
 
         private void EnsureOpen()

--- a/src/Lucene.Net/Support/Configuration/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/Lucene.Net/Support/Configuration/EnvironmentVariablesConfigurationProvider.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Concurrent;
@@ -66,6 +66,8 @@ namespace Lucene.Net.Configuration
         {
             value = Data.GetOrAdd(key, (name) =>
             {
+                // LUCENENET: There is a slight chance that two threads could load the
+                // same environment variable at the same time, but it shouldn't be too expensive. See #417.
                 if (ignoreSecurityExceptionsOnRead)
                 {
                     try

--- a/src/Lucene.Net/Support/IO/FileSupport.cs
+++ b/src/Lucene.Net/Support/IO/FileSupport.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Support.Text;
+﻿using Lucene.Net.Support.Text;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Concurrent;
@@ -360,6 +360,8 @@ namespace Lucene.Net.Support.IO
             newResult[newLength] = 0;
             //newResult = getCanonImpl(newResult);
             newLength = newResult.Length;
+            // LUCENENET: There is a small chance that two threads could load the same string
+            // simultaneously, but it shouldn't be too expensive.
             canonPath = fileCanonPathCache.GetOrAdd(
                 absPath,
                 k => Encoding.UTF8.GetString(newResult, 0, newLength).TrimEnd('\0')); // LUCENENET: Eliminate null terminator char


### PR DESCRIPTION
Combined with #439, this closes #417.

This review included the following collections:

- `LurchTable<TKey, TValue>`
- `ConcurrentDictionary<TKey, TValue>`
- `ConcurrentQueue<T>`
- `ConcurrentStack<T>`
- `ConcurrentBag<T>`
- `BlockingCollection<T>`

With the exception of `FieldCacheImpl`, all access to these collections were checked to ensure proper use. Locks were added in cases where they were missing, and collections were swapped for non-synchronized versions in cases where there was no reason to use one. 

There are a few places we use `ConcurrentDictionary<TKey, TValue>` just to take advantage of the fact that its enumerator allows modification of the collection without throwing an exception. `FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION` was added so we will be able to use `Dictionary<TKey, TValue>` in .NET 5.x+ because it now supports modification during enumeration also.

There were a few bugs found and fixed with `GetOrAdd` method calls and one found in the `LuceneTestCase` class (the base class for all tests in the TestFramework) which replaced the collection with a concurrent one, but didn't take into account the other related code that was inside of the lock that was removed.