### PR TITLE
Reviewed Reverse() calls

### DIFF
--- a/src/Lucene.Net.Suggest/Suggest/SortedInputIterator.cs
+++ b/src/Lucene.Net.Suggest/Suggest/SortedInputIterator.cs
@@ -2,10 +2,8 @@
 using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
 using Lucene.Net.Util;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Suggest
@@ -297,7 +295,6 @@ namespace Lucene.Net.Search.Suggest
             tmpInput.SkipBytes(scratch.Length - 2); //skip to context set size
             ushort ctxSetSize = (ushort)tmpInput.ReadInt16();
             scratch.Length -= 2;
-
             var contextSet = new JCG.HashSet<BytesRef>();
             for (ushort i = 0; i < ctxSetSize; i++)
             {
@@ -311,13 +308,10 @@ namespace Lucene.Net.Search.Suggest
                 contextSet.Add(contextSpare);
                 scratch.Length -= curContextLength;
             }
-
-            // LUCENENET TODO: We are writing the data forward.
-            // Not sure exactly why, but when we read it back it
-            // is reversed. So, we need to fix that before returning the result.
-            // If the underlying problem is found and fixed, then this line can just be
-            // return contextSet;
-            return new JCG.HashSet<BytesRef>(contextSet.Reverse());
+            // LUCENENET NOTE: The result was at one point reversed because of test failures, but since we are
+            // using JCG.HashSet<T> now (whose Equals() implementation respects set equality),
+            // we have reverted back to the original implementation.
+            return contextSet;
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Suggest/Suggest/DocumentValueSourceDictionaryTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/DocumentValueSourceDictionaryTest.cs
@@ -161,6 +161,12 @@ namespace Lucene.Net.Search.Suggest
                 assertTrue(inputIterator.Current.equals(new BytesRef(doc.Get(FIELD_NAME))));
                 assertEquals(inputIterator.Weight, (w1 + w2 + w3));
                 assertTrue(inputIterator.Payload.equals(doc.GetField(PAYLOAD_FIELD_NAME).GetBinaryValue()));
+
+                // LUCENENET NOTE: This test was once failing because we used SCG.HashSet<T> whose
+                // Equals() implementation does not check for set equality. As a result SortedInputEnumerator
+                // had been modified to reverse the results to get the test to pass. However, using JCG.HashSet<T>
+                // ensures that set equality (that is equality that doesn't care about order of items) is respected.
+                // SortedInputEnumerator has also had the specific sorting removed.
                 ISet<BytesRef> originalCtxs = new JCG.HashSet<BytesRef>();
                 foreach (IIndexableField ctxf in doc.GetFields(CONTEXTS_FIELD_NAME))
                 {


### PR DESCRIPTION
Since `Reverse()` on collections is an expensive operation, this review is just to ensure we aren't using it unnecessarily.

There was one instance in `Lucene.Net.Suggest` where using `Stack<T>` could be used instead of reversing the output, and one instance where sorting the output was completely unnecessary. In the latter case, using `JCG.HashSet<T>` has already solved the test failures because its `Equals()` method respects set equality by default.

Also, an unnecessary lock was removed that had been added during the port.

