### PR TITLE
Fixes CLI index page versioning issue (Fixes #416)

### DIFF
--- a/src/dotnet/tools/lucene-cli/docs/index.md
+++ b/src/dotnet/tools/lucene-cli/docs/index.md
@@ -11,7 +11,7 @@ The Lucene.NET command line interface (CLI) is a new cross-platform toolchain wi
 Perform a one-time install of the lucene-cli tool using the following dotnet CLI command:
 
 ```
-dotnet tool install lucene-cli -g --version [EnvVar:LuceneNetVersion]
+dotnet tool install lucene-cli -g --version 4.8.0-beta00013
 ```
 
 > NOTE: The version of the CLI you install should match the version of Lucene.NET you use.

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -41,8 +41,7 @@ if ($BaseUrl -eq 'https://lucenenet.apache.org/docs/') {
 $BaseUrl = $BaseUrl.TrimEnd('/') # Remove any trailing slash
 Write-Host "Base URL for xref map set to $BaseUrl"
 
-# HACK: Our plugin only recognizes the version number through an environment variable,
-# so we set it here.
+# set env vars that will be replaced in Markdown
 $env:LuceneNetVersion = $LuceneNetVersion
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -161,9 +160,6 @@ $DocFxJsonMeta = @(
     "docfx.demo.json"
 )
 $DocFxJsonSite = Join-Path -Path $ApiDocsFolder "docfx.site.json"
-
-# set env vars that will be replaced in Markdown
-$env:LuceneNetVersion = $LuceneNetVersion
 
 if ($? -and $DisableMetaData -eq $false) {
     foreach ($proj in $DocFxJsonMeta) {

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -19,7 +19,8 @@
 
 param (
     [Parameter(Mandatory)]
-    [string] $LuceneNetVersion, # TODO: Validate this with regex
+    [ValidatePattern('\d+?\.\d+?\.\d+?(?:\.\d+?)?(?:-\w+)?')]
+    [string] $LuceneNetVersion,
     [switch] $ServeDocs = $false,
     [switch] $Clean = $false,
     [switch] $DisableMetaData = $false,

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -1,4 +1,4 @@
-# -----------------------------------------------------------------------------------
+﻿# -----------------------------------------------------------------------------------
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -51,6 +51,7 @@ $PSScriptFilePath = (Get-Item $MyInvocation.MyCommand.Path).FullName
 $RepoRoot = (get-item $PSScriptFilePath).Directory.Parent.Parent.FullName;
 $ApiDocsFolder = Join-Path -Path $RepoRoot -ChildPath "websites\apidocs";
 $ToolsFolder = Join-Path -Path $ApiDocsFolder -ChildPath "tools";
+$CliIndexPath = Join-Path -Path $RepoRoot -ChildPath "src\dotnet\tools\lucene-cli\docs\index.md";
 #ensure the /build/tools folder
 New-Item $ToolsFolder -type directory -force
 
@@ -183,6 +184,10 @@ if ($? -and $DisableMetaData -eq $false) {
 }
 
 if ($? -and $DisableBuild -eq $false) {
+    # HACK: DocFx doesn't seem to work with fenced code blocks, so we update the lucene-cli index file manually.
+    # Note it works better this way anyway because we can store a real version number in the file in the repo.
+    (Get-Content -Path $CliIndexPath -Raw) -Replace '(?<=--version\s)\d+?\.\d+?\.\d+?(?:\.\d+?)?(?:-\w+)?', $LuceneNetVersion | Set-Content -Path $CliIndexPath
+
     foreach ($proj in $DocFxJsonMeta) {
         $projFile = Join-Path -Path $ApiDocsFolder $proj
 


### PR DESCRIPTION
Fixes #416.

This works around the problem that DocFx has updating tokens within fenced code blocks by doing the replacement before calling DocFx using Powershell.

I left the change to the version in the document, as the logical time to update it is when there is a release, so we just need to commit it back to the repo (we can automate this, but should start using a release branching scheme first so it doesn't happen live on `master`).

Also removed duplication of setting the environment variable and added regex validation to the version number.