### PR TITLE
Reverts facet locking

### DIFF
--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
@@ -422,10 +422,24 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         public virtual void SetCacheSize(int size)
         {
             EnsureOpen();
-            // LUCENENET specific - removed locking here because these collections
-            // internally use Interlocked.Exchange
-            categoryCache.Limit = size;
-            ordinalCache.Limit = size;
+            categoryCacheLock.EnterWriteLock();
+            try
+            {
+                categoryCache.Limit = size;
+            }
+            finally
+            {
+                categoryCacheLock.ExitWriteLock();
+            }
+            ordinalCacheLock.EnterWriteLock();
+            try
+            {
+                ordinalCache.Limit = size;
+            }
+            finally
+            {
+                ordinalCacheLock.ExitWriteLock();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This reverts locking in `Lucene.Net.Facet` to the state it was in Lucene 4.8.1 and fixes some of the test slowness due to removing locks.

Also removes the timeout of 1 second that was placed in `Cl2oTaxonomyWriterCache`, which was causing intermittent test failures.