### PR TITLE
Fix for lucene-cli appsettings.json required error + installation/run tests (See #453)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -346,6 +346,8 @@ stages:
         osName: $(osName)
         framework: 'net5.0'
         vsTestPlatform: 'x64'
+        testBinariesArtifactName: '$(TestBinariesArtifactName)'
+        nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumParallelJobs: $(maximumParallelJobs)
         maximumAllowedFailures: $(maximumAllowedFailures)
@@ -378,6 +380,8 @@ stages:
         osName: $(osName)
         framework: 'net5.0'
         vsTestPlatform: 'x86'
+        testBinariesArtifactName: '$(TestBinariesArtifactName)'
+        nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumParallelJobs: $(maximumParallelJobs)
         maximumAllowedFailures: $(maximumAllowedFailures)
@@ -410,6 +414,8 @@ stages:
         osName: $(osName)
         framework: 'netcoreapp3.1'
         vsTestPlatform: 'x64'
+        testBinariesArtifactName: '$(TestBinariesArtifactName)'
+        nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumParallelJobs: $(maximumParallelJobs)
         maximumAllowedFailures: $(maximumAllowedFailures)
@@ -442,6 +448,8 @@ stages:
         osName: $(osName)
         framework: 'netcoreapp3.1'
         vsTestPlatform: 'x86'
+        testBinariesArtifactName: '$(TestBinariesArtifactName)'
+        nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumParallelJobs: $(maximumParallelJobs)
         maximumAllowedFailures: $(maximumAllowedFailures)
@@ -474,6 +482,8 @@ stages:
         osName: $(osName)
         framework: 'netcoreapp2.1'
         vsTestPlatform: 'x64'
+        testBinariesArtifactName: '$(TestBinariesArtifactName)'
+        nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumParallelJobs: $(maximumParallelJobs)
         maximumAllowedFailures: $(maximumAllowedFailures)
@@ -506,6 +516,8 @@ stages:
         osName: $(osName)
         framework: 'netcoreapp2.1'
         vsTestPlatform: 'x86'
+        testBinariesArtifactName: '$(TestBinariesArtifactName)'
+        nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumParallelJobs: $(maximumParallelJobs)
         maximumAllowedFailures: $(maximumAllowedFailures)
@@ -521,6 +533,8 @@ stages:
         osName: 'Windows'
         framework: 'net48'
         vsTestPlatform: 'x64'
+        testBinariesArtifactName: '$(TestBinariesArtifactName)'
+        nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumParallelJobs: 8
         maximumAllowedFailures: 2 # Maximum allowed failures for a successful build
@@ -536,6 +550,8 @@ stages:
         osName: 'Windows'
         framework: 'net48'
         vsTestPlatform: 'x86'
+        testBinariesArtifactName: '$(TestBinariesArtifactName)'
+        nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumParallelJobs: 8
         maximumAllowedFailures: 5 # Maximum allowed failures for a successful build

--- a/build/azure-templates/run-tests-on-os.yml
+++ b/build/azure-templates/run-tests-on-os.yml
@@ -25,6 +25,7 @@ parameters:
   osName: 'Windows' # The name of the operating system for display purposes.
   framework: '' # The target framework indicating which framework tests will be run on. See: https://docs.microsoft.com/en-us/dotnet/standard/frameworks.
   binaryArtifactName: 'testbinaries' # The name of the Azure DevOps build artifact where the test assemblies will be downloaded from. Default 'testbinaries'.
+  nugetArtifactName: 'nuget' # The name of the Azure DevOps build artifact where the NuGet packages will be downloaded from. Default 'nuget'.
   testResultsArtifactName: 'testresults' # The name of the Azure DevOps build artifact where the test results will be published. Default 'testresults'.
   vsTestPlatform: 'x64' # Target platform architecture used for test execution. Valid values are x86, x64, and ARM.
   testBinaryFilesPattern: '\.*\.Tests\.?[^\\/]*?\.?[^\\/]*?.dll$' # The regex pattern (within $(System.DefaultWorkingDirectory)/**/<TargetFramework>/) where to look for test .dll files, so they can be distinguished from other .dll file types.
@@ -46,6 +47,7 @@ steps:
     EnsureNotNullOrEmpty('${{ parameters.osName }}', 'osName')
     EnsureNotNullOrEmpty('${{ parameters.framework }}', 'framework')
     EnsureNotNullOrEmpty('${{ parameters.binaryArtifactName }}', 'binaryArtifactName')
+    EnsureNotNullOrEmpty('${{ parameters.nugetArtifactName }}', 'nugetArtifactName')
     EnsureNotNullOrEmpty('${{ parameters.testResultsArtifactName }}', 'testResultsArtifactName')
     EnsureNotNullOrEmpty('${{ parameters.vsTestPlatform }}', 'vsTestPlatform')
     EnsureNotNullOrEmpty('${{ parameters.testBinaryFilesPattern }}', 'testBinaryFilesPattern')
@@ -60,6 +62,14 @@ steps:
   inputs:
     artifactName: '${{ parameters.binaryArtifactName }}_${{ parameters.framework }}'
     targetPath: '$(System.DefaultWorkingDirectory)/${{ parameters.framework }}'
+
+# Tests for lucene-cli depend on the NuGet package for testing, so we do an extra download for that file
+- task:  DownloadPipelineArtifact@2
+  displayName: 'Download Build Artifacts: ${{ parameters.nugetArtifactName }} to $(System.DefaultWorkingDirectory)'
+  inputs:
+    artifactName: '${{ parameters.nugetArtifactName }}'
+    targetPath: '$(System.DefaultWorkingDirectory)'
+    patterns: 'lucene-cli.*'
 
 #- pwsh: Get-ChildItem -Path $(System.DefaultWorkingDirectory) # Uncomment for debugging
 

--- a/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/Compile.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/Compile.cs
@@ -108,8 +108,8 @@ namespace Egothor.Stemmer
             {
                 qq++;
             }
-            // LUCENENET specific - reformatted with :
-            string charset = SystemProperties.GetProperty("egothor:stemmer:charset", "UTF-8");
+            // LUCENENET specific - reformatted with : and changed "charset" to "encoding"
+            string charset = SystemProperties.GetProperty("egothor:stemmer:encoding", "UTF-8");
             var stemmerTables = new List<string>();
 
             // LUCENENET specific
@@ -170,7 +170,7 @@ namespace Egothor.Stemmer
                                 }
                             }
                         }
-                        catch (InvalidOperationException /*x*/)
+                        catch (InvalidOperationException)
                         {
                             // no base token (stem) on a line
                         }

--- a/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/DiffIt.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/DiffIt.cs
@@ -95,8 +95,8 @@ namespace Egothor.Stemmer
             int del = Get(1, args[0]);
             int rep = Get(2, args[0]);
             int nop = Get(3, args[0]);
-            // LUCENENET specific - reformatted with :
-            string charset = SystemProperties.GetProperty("egothor:stemmer:charset", "UTF-8");
+            // LUCENENET specific - reformatted with : and changed "charset" to "encoding"
+            string charset = SystemProperties.GetProperty("egothor:stemmer:encoding", "UTF-8");
             var stemmerTables = new List<string>();
 
             // LUCENENET specific
@@ -138,7 +138,7 @@ namespace Egothor.Stemmer
                             }
                         }
                     }
-                    catch (InvalidOperationException /*x*/)
+                    catch (InvalidOperationException)
                     {
                         // no base token (stem) on a line
                     }

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/ConfigurationSettingsTest.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/ConfigurationSettingsTest.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Cli.Configuration
      * limitations under the License.
      */
 
-    internal class TestConfigurationSettings : ConfigurationSettingsTestCase
+    internal class ConfigurationSettingsTest : ConfigurationSettingsTestCase
     {
         private const string TestJsonFileName = "appsettings.json";
         private readonly static string TempFileDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/TestConfigurationSettings.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/TestConfigurationSettings.cs
@@ -1,4 +1,5 @@
 ﻿using J2N;
+using Lucene.Net.Attributes;
 using Lucene.Net.Configuration;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
@@ -82,6 +83,7 @@ namespace Lucene.Net.Cli.Configuration
         }
 
         [Test]
+        [LuceneNetSpecific]
         public virtual void SetRuntimeEnvironmentTest()
         {
             string testKey = "tests:setting";
@@ -92,6 +94,7 @@ namespace Lucene.Net.Cli.Configuration
         }
 
         [Test]
+        [LuceneNetSpecific]
         public virtual void TestSetandUnset()
         {
             string testKey = "tests:locale";

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/EnvironmentTest.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/EnvironmentTest.cs
@@ -1,6 +1,8 @@
 ﻿using Lucene.Net.Attributes;
 using Lucene.Net.Cli.Commands;
+using Lucene.Net.Util;
 using NUnit.Framework;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Cli
 {
@@ -21,7 +23,7 @@ namespace Lucene.Net.Cli
      * limitations under the License.
      */
 
-    public class EnvironmentTest
+    public class EnvironmentTest : LuceneTestCase
     {
         [Test]
         [LuceneNetSpecific]

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/InstallationTest.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/InstallationTest.cs
@@ -1,0 +1,160 @@
+﻿using Lucene.Net.Attributes;
+using Lucene.Net.Cli;
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Assert = Lucene.Net.TestFramework.Assert;
+
+namespace Lucene.Net.Tests.Cli
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Installs lucene-cli as a local tool in a temp directory from a local NuGet package file and runs commands on it.
+    /// </summary>
+    [Slow]
+    public class InstallationTest : LuceneTestCase
+    {
+        private const string LuceneCliToolName = "lucene-cli";
+        // The relative path from the AppDomain.CurrentDomain.BaseDirectory where we can find the tool project
+        private static readonly string RelativeLuceneCliPath = $"../../../../{LuceneCliToolName}";
+
+        private static DirectoryInfo tempWork;
+        private static string packageVersion;
+
+        public override void BeforeClass()
+        {
+            base.BeforeClass();
+            tempWork = CreateTempDir();
+
+            FileInfo packageFile;
+            // NOTE: If using CI other than Azure DevOps, an environment variable named SYSTEM_DEFAULTWORKINGDIRECTORY can
+            // be added to identify the directory that pre-built lucene-cli tool can be found in. Note that all subdirectories
+            // are checked and since we only target one framework we don't care about target framework.
+            string defaultWorkingDirectory = Environment.GetEnvironmentVariable("SYSTEM_DEFAULTWORKINGDIRECTORY");
+            if (defaultWorkingDirectory is null)
+            {
+                Console.Write($"WARNING: System.DefaultWorkingDirectory environment variable not detected. The test will proceed by attempting to build the {LuceneCliToolName} project locally.");
+
+                DirectoryInfo tempPackages = CreateTempDir();
+
+                // For a local test, build our dotnet tool on the command line using the .csproj file
+                DotNetPackLuceneCli(tempPackages, out packageFile);
+            }
+            else
+            {
+                // For a test on Azure DevOps, we scan for our lucene-cli NuGet package that is already packed.
+                // We know it is somewhere below defaultWorkingDirectory and it is named like "<LuceneCliToolName>.<PackageVersion>.nupkg".
+                var directory = new DirectoryInfo(defaultWorkingDirectory);
+                packageFile = directory.EnumerateFiles("*.nupkg", SearchOption.AllDirectories)
+                    .Where(f => f.Name.StartsWith($"{LuceneCliToolName}.", StringComparison.Ordinal)).FirstOrDefault();
+                Assert.IsNotNull(packageFile, $"lucene-cli NuGet package not found in {defaultWorkingDirectory}");
+            }
+
+            packageVersion = GetPackageVersion(packageFile.Name);
+
+            // Prepare our temp directory with a tool manifest so it can have local tools (we don't install globally to avoid conflicts with tools on dev machines).
+            AssertCommandExitCode(ExitCode.Success, "dotnet", $"new tool-manifest --output \"{tempWork.FullName}\"");
+
+            // Now install our tool and verify that the command succeeded.
+            AssertCommandExitCode(ExitCode.Success, "dotnet", $"tool install {LuceneCliToolName} --version {packageVersion} --add-source \"{packageFile.DirectoryName}\" --tool-path  \"{tempWork.FullName}\"");
+        }
+
+        public override void AfterClass()
+        {
+            // Uninstall our tool - we are done with it.
+            AssertCommandExitCode(ExitCode.Success, "dotnet", $"tool uninstall  {LuceneCliToolName} --tool-path  \"{tempWork.FullName}\"");
+            base.AfterClass();
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestWithoutCommmand()
+        {
+            // Try running without any command. We should get the usage on the stdOut.
+            // This is just a smoke test to make sure we can run the tool after it is installed.
+            AssertLuceneCommandStdOutTextStartsWith("Lucene.Net Command Line Utility, Version:", "");
+        }
+
+
+        /// <summary>
+        /// Makes a temporary build from source versioned specifically <see cref="Constants.LUCENE_VERSION"/> that we can test.
+        /// </summary>
+        private void DotNetPackLuceneCli(DirectoryInfo outputDirectory, out FileInfo packageFile)
+        {
+            string packageVersion = Constants.LUCENE_VERSION;
+            string relativeLuceneCliProjectFile = NormalizeSlashes(Path.Combine(RelativeLuceneCliPath, $"{LuceneCliToolName}.csproj"));
+            string absoluteLuceneCliProjectFile = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, relativeLuceneCliProjectFile));
+            Assert.IsTrue(File.Exists(absoluteLuceneCliProjectFile), $"{absoluteLuceneCliProjectFile} doesn't exist.");
+
+            packageFile = new FileInfo(Path.Combine(outputDirectory.FullName, $"{LuceneCliToolName}.{packageVersion}.nupkg"));
+            AssertCommandExitCode(ExitCode.Success, "dotnet", $"pack \"{absoluteLuceneCliProjectFile}\" --configuration Release --output \"{outputDirectory.FullName}\" -p:PackageVersion={packageVersion}");
+        }
+
+        private string NormalizeSlashes(string input)
+        {
+            return input.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        }
+
+        private string GetPackageVersion(string packageFile)
+        {
+            return packageFile.Replace($"{LuceneCliToolName}.", string.Empty, StringComparison.Ordinal).Replace(".nupkg", string.Empty, StringComparison.Ordinal);
+        }
+
+        private string AppendCommandOutput(string message, string stdOut, string stdErr, int exitCode)
+        {
+            return $"{message}\n\nStdOut:\n{stdOut}\n\nStdErr:\n{stdErr}\n\nExit Code:\n{exitCode}";
+        }
+
+        private void AssertCommandExitCode(int expectedExitCode, string command, string arguments)
+        {
+            int exitCode = RunCommand(command, arguments, out string stdOut, out string stdErr);
+            Assert.AreEqual(expectedExitCode, exitCode, AppendCommandOutput($"{command} {arguments} failed", stdOut, stdErr, exitCode));
+        }
+
+        private void AssertLuceneCommandStdOutTextStartsWith(string expectedStdOutStart, string arguments)
+        {
+            // Make sure to supply the entire path to the command in the temp directory that we installed locally so we don't
+            // execute any globally installed lucene-cli tool.
+            int exitCode = RunCommand(Path.Combine(tempWork.FullName, "lucene"), arguments, out string stdOut, out string stdErr);
+            Assert.IsTrue(stdOut.TrimStart().StartsWith(expectedStdOutStart, StringComparison.Ordinal), AppendCommandOutput($"Expected stdOut to start with {expectedStdOutStart}", stdOut, stdErr, exitCode));
+        }
+
+        // returns exit code
+        private int RunCommand(string executable, string arguments, out string stdOut, out string stdErr)
+        {
+            using Process p = new Process();
+
+            p.StartInfo.UseShellExecute = false;
+            p.StartInfo.RedirectStandardOutput = true;
+            p.StartInfo.RedirectStandardError = true;
+            p.StartInfo.FileName = executable;
+            p.StartInfo.Arguments = arguments;
+            p.Start();
+
+            stdOut = p.StandardOutput.ReadToEnd();
+            stdErr = p.StandardError.ReadToEnd();
+            p.WaitForExit();
+
+            return p.ExitCode;
+        }
+    }
+}

--- a/src/dotnet/tools/lucene-cli/ConfigurationBase.cs
+++ b/src/dotnet/tools/lucene-cli/ConfigurationBase.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Cli
                 if (this.GetOptionByUniqueId(HELP_VALUE_NAME).HasValue())
                 {
                     this.ShowHelp();
-                    return 1;
+                    return ExitCode.Success;
                 }
                 try
                 {
@@ -68,7 +68,7 @@ namespace Lucene.Net.Cli
                     // if the args cannot be parsed.
                     this.ShowHint();
                     this.ShowHelp();
-                    return 1;
+                    return ExitCode.GeneralError;
                 }
             });
         }

--- a/src/dotnet/tools/lucene-cli/Program.cs
+++ b/src/dotnet/tools/lucene-cli/Program.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Cli
         {
             var configuration = new ConfigurationBuilder()
                 .AddEnvironmentVariables(prefix: "lucene:") // Use a custom prefix to only load Lucene.NET settings 
-                .AddJsonFile("appsettings.json")
+                .AddJsonFile("appsettings.json", optional: true)
                 .Build();
             ConfigurationSettings.SetConfigurationFactory(new ConfigurationFactory(configuration));
 

--- a/src/dotnet/tools/lucene-cli/appsettings.json
+++ b/src/dotnet/tools/lucene-cli/appsettings.json
@@ -1,0 +1,4 @@
+﻿{
+  "egothor": { "stemmer": { "encoding": "UTF-8" } },
+  "benchmark": { "work": { "dir": "work" } }
+}

--- a/src/dotnet/tools/lucene-cli/commands/ExitCode.cs
+++ b/src/dotnet/tools/lucene-cli/commands/ExitCode.cs
@@ -1,0 +1,9 @@
+﻿namespace Lucene.Net.Cli
+{
+    public static class ExitCode
+    {
+        public const int Success = 0;
+        public const int GeneralError = 1;
+        public const int NoCommandProvided = -2147450751;
+    }
+}

--- a/src/dotnet/tools/lucene-cli/commands/RootCommand.cs
+++ b/src/dotnet/tools/lucene-cli/commands/RootCommand.cs
@@ -38,7 +38,7 @@
         public int Run(ConfigurationBase cmd)
         {
             cmd.ShowHelp();
-            return 1;
+            return ExitCode.NoCommandProvided;
         }
     }
 }

--- a/src/dotnet/tools/lucene-cli/commands/analysis/AnalysisCommand.cs
+++ b/src/dotnet/tools/lucene-cli/commands/analysis/AnalysisCommand.cs
@@ -39,7 +39,7 @@
         public int Run(ConfigurationBase cmd)
         {
             cmd.ShowHelp();
-            return 1;
+            return ExitCode.NoCommandProvided;
         }
     }
 }

--- a/src/dotnet/tools/lucene-cli/commands/benchmark/BenchmarkCommand.cs
+++ b/src/dotnet/tools/lucene-cli/commands/benchmark/BenchmarkCommand.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Cli
         public int Run(ConfigurationBase cmd)
         {
             cmd.ShowHelp();
-            return 1;
+            return ExitCode.NoCommandProvided;
         }
     }
 }

--- a/src/dotnet/tools/lucene-cli/commands/demo/DemoCommand.cs
+++ b/src/dotnet/tools/lucene-cli/commands/demo/DemoCommand.cs
@@ -43,7 +43,7 @@
         public int Run(ConfigurationBase cmd)
         {
             cmd.ShowHelp();
-            return 1;
+            return ExitCode.NoCommandProvided;
         }
     }
 }

--- a/src/dotnet/tools/lucene-cli/commands/index/IndexCommand.cs
+++ b/src/dotnet/tools/lucene-cli/commands/index/IndexCommand.cs
@@ -47,7 +47,7 @@
         public int Run(ConfigurationBase cmd)
         {
             cmd.ShowHelp();
-            return 1;
+            return ExitCode.NoCommandProvided;
         }
     }
 }

--- a/src/dotnet/tools/lucene-cli/commands/lock/LockCommand.cs
+++ b/src/dotnet/tools/lucene-cli/commands/lock/LockCommand.cs
@@ -36,7 +36,7 @@
         public int Run(ConfigurationBase cmd)
         {
             cmd.ShowHelp();
-            return 1;
+            return ExitCode.NoCommandProvided;
         }
     }
 }

--- a/src/dotnet/tools/lucene-cli/lucene-cli.csproj
+++ b/src/dotnet/tools/lucene-cli/lucene-cli.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -43,9 +43,13 @@
     <NoWarn Label="Remove unused parameter">$(NoWarn);IDE0060</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
-    <!--<EmbeddedResource Include="..\..\..\Lucene.Net.Benchmark\ByTask\Programmatic\Sample.cs;..\..\..\Lucene.Net.Demo\*.cs;..\..\..\Lucene.Net.Demo\Facet\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />-->
     <EmbeddedResource Include="..\..\..\Lucene.Net.Benchmark\ByTask\Programmatic\Sample.cs" Link="Resources\Sample.cs" />
     <EmbeddedResource Include="..\..\..\Lucene.Net.Demo\*.cs" Exclude="bin\**;obj\**;packages\**;@(EmbeddedResource)" />
     <EmbeddedResource Include="..\..\..\Lucene.Net.Demo\Facet\*.cs" Exclude="bin\**;obj\**;packages\**;@(EmbeddedResource)" />
@@ -75,4 +79,5 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Lucene.Net.Tests.Cli" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
See #453.

This fixes the `appsettings.json` to make it optional and also adds a default `appsettings.json` to demonstrate the default settings that are available.

### appsettings.json

```json
{
  "egothor": { "stemmer": { "encoding": "UTF-8" } },
  "benchmark": { "work": { "dir": "work" } }
}

```

Note that `egothor:stemmer:encoding` can be set on the command line already, this is the default setting if no value is supplied. `benchmark:work:directory` can be supplied in a benchmark definition file and this is the default if it is not provided.

This serves as temporary documentation until #307 is completed.

Also, basic tests to install and run `lucene-cli` were added to ensure it can be installed and run without errors.