### PR TITLE
 Docs: Fixes code snippets (#284), list/table formatting, and links (#300)

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Collation/TokenAttributes/package.md
+++ b/src/Lucene.Net.Analysis.Common/Collation/TokenAttributes/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Collation.TokenAttributes
 summary: *content
 ---
@@ -20,4 +20,4 @@ summary: *content
  limitations under the License.
 -->
 
-Custom <xref:Lucene.Net.Util.AttributeImpl> for indexing collation keys as index terms.
+Custom <xref:Lucene.Net.Util.Attribute> for indexing collation keys as index terms.

--- a/src/Lucene.Net.Analysis.Kuromoji/overview.md
+++ b/src/Lucene.Net.Analysis.Kuromoji/overview.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Analysis.Ja
 summary: *content
 ---
@@ -20,8 +20,8 @@ summary: *content
  limitations under the License.
 -->
 
-  Kuromoji is a morphological analyzer for Japanese text.  
+Kuromoji is a morphological analyzer for Japanese text.  
 
- This module provides support for Japanese text analysis, including features such as part-of-speech tagging, lemmatization, and compound word analysis. 
+This module provides support for Japanese text analysis, including features such as part-of-speech tagging, lemmatization, and compound word analysis. 
 
- For an introduction to Lucene's analysis API, see the <xref:Lucene.Net.Analysis> package documentation. 
+For an introduction to Lucene's analysis API, see the [Lucene.Net.Analysis](../core/Lucene.Net.Analysis.html) namespace documentation. 

--- a/src/Lucene.Net.Analysis.Morfologik/overview.md
+++ b/src/Lucene.Net.Analysis.Morfologik/overview.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Analysis.Morfologik
 title: Lucene.Net.Analysis.Morfologik
 summary: *content
@@ -21,8 +21,8 @@ summary: *content
  limitations under the License.
 -->
 
- This package provides dictionary-driven lemmatization ("accurate stemming") filter and analyzer for the Polish Language, driven by the [Morfologik library](http://morfologik.blogspot.com/) developed by Dawid Weiss and Marcin Miłkowski. 
+This package provides dictionary-driven lemmatization ("accurate stemming") filter and analyzer for the Polish Language, driven by the [Morfologik library](http://morfologik.blogspot.com/) developed by Dawid Weiss and Marcin Miłkowski. 
 
- For an introduction to Lucene's analysis API, see the <xref:Lucene.Net.Analysis> package documentation. 
+For an introduction to Lucene's analysis API, see the [Lucene.Net.Analysis](../core/Lucene.Net.Analysis.html) namespace documentation. 
 
- The MorfologikFilter yields one or more terms for each token. Each of those terms is given the same position in the index. 
+The MorfologikFilter yields one or more terms for each token. Each of those terms is given the same position in the index. 

--- a/src/Lucene.Net.Analysis.Phonetic/overview.md
+++ b/src/Lucene.Net.Analysis.Phonetic/overview.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Analysis.Phonetic
 summary: *content
 ---
@@ -20,8 +20,8 @@ summary: *content
  limitations under the License.
 -->
 
-  Analysis for indexing phonetic signatures (for sounds-alike search)
+Analysis for indexing phonetic signatures (for sounds-alike search)
 
- For an introduction to Lucene's analysis API, see the <xref:Lucene.Net.Analysis> package documentation. 
+For an introduction to Lucene's analysis API, see the [Lucene.Net.Analysis](../core/Lucene.Net.Analysis.html) namespace documentation. 
 
- This module provides analysis components (using encoders from [Apache Commons Codec](http://commons.apache.org/codec/)) that index and search phonetic signatures. 
+This module provides analysis components (using encoders ported to .NET from [Apache Commons Codec](http://commons.apache.org/codec/)) that index and search phonetic signatures. 

--- a/src/Lucene.Net.Analysis.SmartCn/overview.md
+++ b/src/Lucene.Net.Analysis.SmartCn/overview.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Analysis.Cn.Smart
 summary: *content
 ---
@@ -20,6 +20,6 @@ summary: *content
  limitations under the License.
 -->
 
-  Analyzer for Simplified Chinese, which indexes words.
+Analyzer for Simplified Chinese, which indexes words.
 
- For an introduction to Lucene's analysis API, see the <xref:Lucene.Net.Analysis> package documentation. 
+For an introduction to Lucene's analysis API, see the [Lucene.Net.Analysis](../core/Lucene.Net.Analysis.html) namespace documentation. 

--- a/src/Lucene.Net.Analysis.SmartCn/package.md
+++ b/src/Lucene.Net.Analysis.SmartCn/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Analysis.Cn.Smart
 summary: *content
 ---
@@ -22,12 +22,12 @@ summary: *content
 
 Analyzer for Simplified Chinese, which indexes words.
 @lucene.experimental
-<div>
+
 Three analyzers are provided for Chinese, each of which treats Chinese text in a different way.
 
 *   StandardAnalyzer: Index unigrams (individual Chinese characters) as a token.
 
-*   CJKAnalyzer (in the analyzers/cjk package): Index bigrams (overlapping groups of two adjacent Chinese characters) as tokens.
+*   CJKAnalyzer (in the <xref:Lucene.Net.Analysis.Cjk> namespace of <xref:Lucene.Net.Analysis.Common>): Index bigrams (overlapping groups of two adjacent Chinese characters) as tokens.
 
 *   SmartChineseAnalyzer (in this package): Index words (attempt to segment Chinese text into words) as tokens.
 
@@ -39,5 +39,3 @@ Example phrase： "我是中国人"
 2.  CJKAnalyzer: 我是－是中－中国－国人
 
 3.  SmartChineseAnalyzer: 我－是－中国－人
-
-</div>

--- a/src/Lucene.Net.Expressions/JS/package.md
+++ b/src/Lucene.Net.Expressions/JS/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Expressions.JS
 summary: *content
 ---
@@ -46,4 +46,4 @@ A Javascript expression is a numeric expression specified using an expression sy
 
  JavaScript order of precedence rules apply for operators. Shortcut evaluation is used for logical operators—the second argument is only evaluated if the value of the expression cannot be determined after evaluating the first argument. For example, in the expression `a || b`, `b` is only evaluated if a is not true. 
 
- To compile an expression, use <xref:Lucene.Net.Expressions.Js.JavascriptCompiler>. 
+ To compile an expression, use <xref:Lucene.Net.Expressions.JS.JavascriptCompiler>. 

--- a/src/Lucene.Net.Expressions/overview.md
+++ b/src/Lucene.Net.Expressions/overview.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Expressions
 summary: *content
 ---
@@ -24,6 +24,9 @@ summary: *content
 
  The expressions module is new to Lucene 4.6. It provides an API for dynamically computing per-document values based on string expressions. 
 
- The module is organized in two sections: 1. <xref:Lucene.Net.Expressions> - The abstractions and simple utilities for common operations like sorting on an expression 2. <xref:Lucene.Net.Expressions.Js> - A compiler for a subset of JavaScript expressions 
+ The module is organized in two sections:
+
+1. <xref:Lucene.Net.Expressions> - The abstractions and simple utilities for common operations like sorting on an expression
+2. <xref:Lucene.Net.Expressions.JS> - A compiler for a subset of JavaScript expressions 
 
  For sample code showing how to use the API, see <xref:Lucene.Net.Expressions.Expression>. 

--- a/src/Lucene.Net.Expressions/package.md
+++ b/src/Lucene.Net.Expressions/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Expressions
 summary: *content
 ---
@@ -22,8 +22,8 @@ summary: *content
 
 # expressions
 
- <xref:Lucene.Net.Expressions.Expression> - result of compiling an expression, which can evaluate it for a given document. Each expression can have external variables are resolved by {@code Bindings}. 
+ <xref:Lucene.Net.Expressions.Expression> - result of compiling an expression, which can evaluate it for a given document. Each expression can have external variables are resolved by <xref:Lucene.Net.Expressions.Bindings>. 
 
  <xref:Lucene.Net.Expressions.Bindings> - abstraction for binding external variables to a way to get a value for those variables for a particular document (ValueSource). 
 
- <xref:Lucene.Net.Expressions.SimpleBindings> - default implementation of bindings which provide easy ways to bind sort fields and other expressions to external variables 
+ <xref:Lucene.Net.Expressions.SimpleBindings> - default implementation of bindings which provide easy ways to bind sort fields and other expressions to external variables.

--- a/src/Lucene.Net.Facet/SortedSet/package.md
+++ b/src/Lucene.Net.Facet/SortedSet/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Facet.SortedSet
 summary: *content
 ---
@@ -20,4 +20,4 @@ summary: *content
  limitations under the License.
 -->
 
-Provides faceting capabilities over facets that were indexed with <xref:Lucene.Net.Facet.Sortedset.SortedSetDocValuesFacetField>.
+Provides faceting capabilities over facets that were indexed with <xref:Lucene.Net.Facet.SortedSet.SortedSetDocValuesFacetField>.

--- a/src/Lucene.Net.Facet/Taxonomy/package.md
+++ b/src/Lucene.Net.Facet/Taxonomy/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Facet.Taxonomy
 summary: *content
 ---
@@ -22,8 +22,7 @@ summary: *content
 
 # Taxonomy of Categories
 
-	Facets are defined using a hierarchy of categories, known as a _Taxonomy_.
-	For example, the taxonomy of a book store application might have the following structure:
+Facets are defined using a hierarchy of categories, known as a _Taxonomy_. For example, the taxonomy of a book store application might have the following structure:
 
 *   Author
 
@@ -41,7 +40,5 @@ summary: *content
 
     *   2009
 
-	The _Taxonomy_ translates category-paths into interger identifiers (often termed _ordinals_) and vice versa.
-	The category `Author/Mark Twain` adds two nodes to the taxonomy: `Author` and 
-	`Author/Mark Twain`, each is assigned a different ordinal. The taxonomy maintains the invariant that a 
-	node always has an ordinal that is < all its children.
+The _Taxonomy_ translates category-paths into interger identifiers (often termed _ordinals_) and vice versa.
+The category `Author/Mark Twain` adds two nodes to the taxonomy: `Author` and `Author/Mark Twain`, each is assigned a different ordinal. The taxonomy maintains the invariant that a node always has an ordinal that is < all its children.

--- a/src/Lucene.Net.Facet/package.md
+++ b/src/Lucene.Net.Facet/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Facet
 summary: *content
 ---
@@ -20,10 +20,14 @@ summary: *content
  limitations under the License.
 -->
 
-# faceted search
+# Lucene.Net.Facet Faceted Search
 
- This module provides multiple methods for computing facet counts and value aggregations: * Taxonomy-based methods rely on a separate taxonomy index to map hierarchical facet paths to global int ordinals for fast counting at search time; these methods can compute counts ((<xref:Lucene.Net.Facet.Taxonomy.FastTaxonomyFacetCounts>, <xref:Lucene.Net.Facet.Taxonomy.TaxonomyFacetCounts>) aggregate long or double values <xref:Lucene.Net.Facet.Taxonomy.TaxonomyFacetSumIntAssociations>, <xref:Lucene.Net.Facet.Taxonomy.TaxonomyFacetSumFloatAssociations>, <xref:Lucene.Net.Facet.Taxonomy.TaxonomyFacetSumValueSource>. Add <xref:Lucene.Net.Facet.FacetField> or <xref:Lucene.Net.Facet.Taxonomy.AssociationFacetField> to your documents at index time to use taxonomy-based methods. * Sorted-set doc values method does not require a separate taxonomy index, and computes counts based on sorted set doc values fields (<xref:Lucene.Net.Facet.Sortedset.SortedSetDocValuesFacetCounts>). Add <xref:Lucene.Net.Facet.Sortedset.SortedSetDocValuesFacetField> to your documents at index time to use sorted set facet counts. * Range faceting <xref:Lucene.Net.Facet.Range.LongRangeFacetCounts>, <xref:Lucene.Net.Facet.Range.DoubleRangeFacetCounts> compute counts for a dynamic numeric range from a provided <xref:Lucene.Net.Queries.Function.ValueSource> (previously indexed numeric field, or a dynamic expression such as distance). 
+ This module provides multiple methods for computing facet counts and value aggregations:
+
+* Taxonomy-based methods rely on a separate taxonomy index to map hierarchical facet paths to global int ordinals for fast counting at search time; these methods can compute counts ((<xref:Lucene.Net.Facet.Taxonomy.FastTaxonomyFacetCounts>, <xref:Lucene.Net.Facet.Taxonomy.TaxonomyFacetCounts>) aggregate long or double values <xref:Lucene.Net.Facet.Taxonomy.TaxonomyFacetSumInt32Associations>, <xref:Lucene.Net.Facet.Taxonomy.TaxonomyFacetSumSingleAssociations>, <xref:Lucene.Net.Facet.Taxonomy.TaxonomyFacetSumValueSource>. Add <xref:Lucene.Net.Facet.FacetField> or <xref:Lucene.Net.Facet.Taxonomy.AssociationFacetField> to your documents at index time to use taxonomy-based methods.
+* Sorted-set doc values method does not require a separate taxonomy index, and computes counts based on sorted set doc values fields (<xref:Lucene.Net.Facet.SortedSet.SortedSetDocValuesFacetCounts>). Add <xref:Lucene.Net.Facet.SortedSet.SortedSetDocValuesFacetField> to your documents at index time to use sorted set facet counts.
+* Range faceting <xref:Lucene.Net.Facet.Range.Int64RangeFacetCounts>, <xref:Lucene.Net.Facet.Range.DoubleRangeFacetCounts> compute counts for a dynamic numeric range from a provided <xref:Lucene.Net.Queries.Function.ValueSource> (previously indexed numeric field, or a dynamic expression such as distance). 
 
  At search time you first run your search, but pass a <xref:Lucene.Net.Facet.FacetsCollector> to gather all hits (and optionally, scores for each hit). Then, instantiate whichever facet methods you'd like to use to compute aggregates. Finally, all methods implement a common <xref:Lucene.Net.Facet.Facets> base API that you use to obtain specific facet counts. 
 
- The various [#search](xref:Lucene.Net.Facet.FacetsCollector) utility methods are useful for doing an "ordinary" search (sorting by score, or by a specified Sort) but also collecting into a <xref:Lucene.Net.Facet.FacetsCollector> for subsequent faceting. 
+ The various [FacetsCollector.Search()](xref:Lucene.Net.Facet.FacetsCollector#Lucene_Net_Facet_FacetsCollector_Search_Lucene_Net_Search_IndexSearcher_Lucene_Net_Search_Query_Lucene_Net_Search_Filter_System_Int32_Lucene_Net_Search_ICollector_) utility methods are useful for doing an "ordinary" search (sorting by score, or by a specified Sort) but also collecting into a <xref:Lucene.Net.Facet.FacetsCollector> for subsequent faceting. 

--- a/src/Lucene.Net.Grouping/Function/package.md
+++ b/src/Lucene.Net.Grouping/Function/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Search.Grouping.Function
 summary: *content
 ---

--- a/src/Lucene.Net.Grouping/package.md
+++ b/src/Lucene.Net.Grouping/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Grouping
 title: Lucene.Net.Grouping
 summary: *content
@@ -21,7 +21,7 @@ summary: *content
  limitations under the License.
 -->
 
-This module enables search result grouping with Lucene, where hits with the same value in the specified single-valued group field are grouped together. For example, if you group by the `author` field, then all documents with the same value in the `author` field fall into a single group.
+This module enables search result grouping with Lucene.NET, where hits with the same value in the specified single-valued group field are grouped together. For example, if you group by the `author` field, then all documents with the same value in the `author` field fall into a single group.
 
 Grouping requires a number of inputs:
 
@@ -56,7 +56,7 @@ Grouping requires a number of inputs:
 *   `withinGroupOffset`: which "slice" of top
       documents you want to retrieve from each group.
 
-The implementation is two-pass: the first pass (<xref:Lucene.Net.Grouping.Term.TermFirstPassGroupingCollector>) gathers the top groups, and the second pass (<xref:Lucene.Net.Grouping.Term.TermSecondPassGroupingCollector>) gathers documents within those groups. If the search is costly to run you may want to use the <xref:Lucene.Net.Search.CachingCollector> class, which caches hits and can (quickly) replay them for the second pass. This way you only run the query once, but you pay a RAM cost to (briefly) hold all hits. Results are returned as a <xref:Lucene.Net.Grouping.TopGroups> instance.
+The implementation is two-pass: the first pass (<xref:Lucene.Net.Search.Grouping.Terms.TermFirstPassGroupingCollector>) gathers the top groups, and the second pass (<xref:Lucene.Net.Search.Grouping.Terms.TermSecondPassGroupingCollector>) gathers documents within those groups. If the search is costly to run you may want to use the <xref:Lucene.Net.Search.CachingCollector> class, which caches hits and can (quickly) replay them for the second pass. This way you only run the query once, but you pay a RAM cost to (briefly) hold all hits. Results are returned as a <xref:Lucene.Net.Search.Grouping.TopGroups> instance.
 
  This module abstracts away what defines group and how it is collected. All grouping collectors are abstract and have currently term based implementations. One can implement collectors that for example group on multiple fields. 
 
@@ -75,71 +75,79 @@ Known limitations:
 
 Typical usage for the generic two-pass grouping search looks like this using the grouping convenience utility (optionally using caching for the second pass search):
 
-      GroupingSearch groupingSearch = new GroupingSearch("author");
-      groupingSearch.setGroupSort(groupSort);
-      groupingSearch.setFillSortFields(fillFields);
-    
-  if (useCache) {
-        // Sets cache in MB
-        groupingSearch.setCachingInMB(4.0, true);
-      }
-    
-  if (requiredTotalGroupCount) {
-        groupingSearch.setAllGroups(true);
-      }
-    
-  TermQuery query = new TermQuery(new Term("content", searchTerm));
-      TopGroups<BytesRef> result = groupingSearch.search(indexSearcher, query, groupOffset, groupLimit);
-    
-  // Render groupsResult...
-      if (requiredTotalGroupCount) {
-        int totalGroupCount = result.totalGroupCount;
-      }
+```cs
+GroupingSearch groupingSearch = new GroupingSearch("author");
+groupingSearch.SetGroupSort(groupSort);
+groupingSearch.SetFillSortFields(fillFields);
+
+if (useCache)
+{
+    // Sets cache in MB
+    groupingSearch.SetCachingInMB(maxCacheRAMMB: 4.0, cacheScores: true);
+}
+
+if (requiredTotalGroupCount)
+{
+    groupingSearch.SetAllGroups(true);
+}
+
+TermQuery query = new TermQuery(new Term("content", searchTerm));
+TopGroups<BytesRef> result = groupingSearch.Search(indexSearcher, query, groupOffset, groupLimit);
+
+// Render groupsResult...
+if (requiredTotalGroupCount)
+{
+    // If null, the value is not computed
+    int? totalGroupCount = result.TotalGroupCount;
+}
+```
 
 To use the single-pass `BlockGroupingCollector`, first, at indexing time, you must ensure all docs in each group are added as a block, and you have some way to find the last document of each group. One simple way to do this is to add a marker binary field:
 
-      // Create Documents from your source:
-      List<Document> oneGroup = ...;
+```cs
+// Create Documents from your source:
+List<Document> oneGroup = ...;
 
-      Field groupEndField = new Field("groupEnd", "x", Field.Store.NO, Field.Index.NOT_ANALYZED);
-      groupEndField.setIndexOptions(IndexOptions.DOCS_ONLY);
-      groupEndField.setOmitNorms(true);
-      oneGroup.get(oneGroup.size()-1).add(groupEndField);
-    
-  // You can also use writer.updateDocuments(); just be sure you
-      // replace an entire previous doc block with this new one.  For
-      // example, each group could have a "groupID" field, with the same
-      // value for all docs in this group:
-      writer.addDocuments(oneGroup);
+Field groupEndField = new StringField("groupEnd", "x", Field.Store.NO);
+oneGroup[oneGroup.Count - 1].Add(groupEndField);
 
+// You can also use writer.UpdateDocuments(); just be sure you
+// replace an entire previous doc block with this new one.  For
+// example, each group could have a "groupID" field, with the same
+// value for all docs in this group:
+writer.AddDocuments(oneGroup);
+```
 
 Then, at search time, do this up front:
 
-      // Set this once in your app & save away for reusing across all queries:
-      Filter groupEndDocs = new CachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("groupEnd", "x"))));
-
+```cs
+// Set this once in your app & save away for reusing across all queries:
+Filter groupEndDocs = new CachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("groupEnd", "x"))));
+```
 
 Finally, do this per search:
 
-      // Per search:
-      BlockGroupingCollector c = new BlockGroupingCollector(groupSort, groupOffset+topNGroups, needsScores, groupEndDocs);
-      s.search(new TermQuery(new Term("content", searchTerm)), c);
-      TopGroups groupsResult = c.getTopGroups(withinGroupSort, groupOffset, docOffset, docOffset+docsPerGroup, fillFields);
-    
-  // Render groupsResult...
+```cs
+// Per search:
+BlockGroupingCollector c = new BlockGroupingCollector(groupSort, groupOffset + topNGroups, needsScores, groupEndDocs);
+s.Search(new TermQuery(new Term("content", searchTerm)), c);
+TopGroups<object> groupsResult = c.GetTopGroups(withinGroupSort, groupOffset, docOffset, docOffset + docsPerGroup, fillFields);
 
+// Render groupsResult...
+```
 
 Or alternatively use the `GroupingSearch` convenience utility:
 
-      // Per search:
-      GroupingSearch groupingSearch = new GroupingSearch(groupEndDocs);
-      groupingSearch.setGroupSort(groupSort);
-      groupingSearch.setIncludeScores(needsScores);
-      TermQuery query = new TermQuery(new Term("content", searchTerm));
-      TopGroups groupsResult = groupingSearch.search(indexSearcher, query, groupOffset, groupLimit);
-    
-  // Render groupsResult...
+```cs
+// Per search:
+GroupingSearch groupingSearch = new GroupingSearch(groupEndDocs);
+groupingSearch.SetGroupSort(groupSort);
+groupingSearch.SetIncludeScores(needsScores);
+TermQuery query = new TermQuery(new Term("content", searchTerm));
+TopGroups<object> groupsResult = groupingSearch.Search(indexSearcher, query, groupOffset, groupLimit);
 
+// Render groupsResult...
+```
 
 Note that the `groupValue` of each `GroupDocs`
 will be `null`, so if you need to present this value you'll
@@ -148,12 +156,14 @@ fields, `FieldCache`, etc.).
 
 Another collector is the `TermAllGroupHeadsCollector` that can be used to retrieve all most relevant documents per group. Also known as group heads. This can be useful in situations when one wants to compute group based facets / statistics on the complete query result. The collector can be executed during the first or second phase. This collector can also be used with the `GroupingSearch` convenience utility, but when if one only wants to compute the most relevant documents per group it is better to just use the collector as done here below.
 
-      AbstractAllGroupHeadsCollector c = TermAllGroupHeadsCollector.create(groupField, sortWithinGroup);
-      s.search(new TermQuery(new Term("content", searchTerm)), c);
-      // Return all group heads as int array
-      int[] groupHeadsArray = c.retrieveGroupHeads()
-      // Return all group heads as FixedBitSet.
-      int maxDoc = s.maxDoc();
-      FixedBitSet groupHeadsBitSet = c.retrieveGroupHeads(maxDoc)
+```cs
+AbstractAllGroupHeadsCollector c = TermAllGroupHeadsCollector.Create(groupField, sortWithinGroup);
+s.Search(new TermQuery(new Term("content", searchTerm)), c);
+// Return all group heads as int array
+int[] groupHeadsArray = c.RetrieveGroupHeads();
+// Return all group heads as FixedBitSet.
+int maxDoc = s.MaxDoc;
+FixedBitSet groupHeadsBitSet = c.RetrieveGroupHeads(maxDoc);
+```
 
-For each of the above collector types there is also a variant that works with `ValueSource` instead of of fields. Concretely this means that these variants can work with functions. These variants are slower than there term based counter parts. These implementations are located in the `org.apache.lucene.search.grouping.function` package, but can also be used with the `GroupingSearch` convenience utility 
+For each of the above collector types there is also a variant that works with `ValueSource` instead of of fields. Concretely this means that these variants can work with functions. These variants are slower than there term based counter parts. These implementations are located in the `Lucene.Net.Search.Grouping.Function` package, but can also be used with the `GroupingSearch` convenience utility 

--- a/src/Lucene.Net.Highlighter/Highlight/package.md
+++ b/src/Lucene.Net.Highlighter/Highlight/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Search.Highlight
 summary: *content
 ---
@@ -25,35 +25,82 @@ The highlight package contains classes to provide "keyword in context" features
 typically used to highlight search terms in the text of results pages.
 The Highlighter class is the central component and can be used to extract the
 most interesting sections of a piece of text and highlight them, with the help of
-Fragmenter, fragment Scorer, and Formatter classes.
+[Fragmenter](xref:Lucene.Net.Search.Highlight.IFragmenter), fragment [Scorer](xref:Lucene.Net.Search.Highlight.IScorer), and [Formatter](xref:Lucene.Net.Search.Highlight.IFormatter) classes.
 
 ## Example Usage
 
-      //... Above, create documents with two fields, one with term vectors (tv) and one without (notv)
-      IndexSearcher searcher = new IndexSearcher(directory);
-      QueryParser parser = new QueryParser("notv", analyzer);
-      Query query = parser.parse("million");
-    
-  TopDocs hits = searcher.search(query, 10);
-    
-  SimpleHTMLFormatter htmlFormatter = new SimpleHTMLFormatter();
-      Highlighter highlighter = new Highlighter(htmlFormatter, new QueryScorer(query));
-      for (int i = 0; i < 10;="" i++)="" {="" int="" id="hits.scoreDocs[i].doc;" document="" doc="searcher.doc(id);" string="" text="doc.get(" notv");"="" tokenstream="" tokenstream="TokenSources.getAnyTokenStream(searcher.getIndexReader()," id,="" "notv",="" analyzer);="" textfragment[]="" frag="highlighter.getBestTextFragments(tokenStream," text,="" false,="" 10);//highlighter.getbestfragments(tokenstream,="" text,="" 3,="" "...");="" for="" (int="" j="0;" j="">< frag.length;="" j++)="" {="" if="" ((frag[j]="" !="null)" &&="" (frag[j].getscore()=""> 0)) {
-            System.out.println((frag[j].toString()));
-          }
-        }
-        //Term vector
-        text = doc.get("tv");
-        tokenStream = TokenSources.getAnyTokenStream(searcher.getIndexReader(), hits.scoreDocs[i].doc, "tv", analyzer);
-        frag = highlighter.getBestTextFragments(tokenStream, text, false, 10);
-        for (int j = 0; j < frag.length;="" j++)="" {="" if="" ((frag[j]="" !="null)" &&="" (frag[j].getscore()=""> 0)) {
-            System.out.println((frag[j].toString()));
-          }
-        }
-        System.out.println("-------------");
-      }
+```cs
+const LuceneVersion matchVersion = LuceneVersion.LUCENE_48;
+Analyzer analyzer = new StandardAnalyzer(matchVersion);
 
-## New features 06/02/2005
+// Create an index to search
+string indexPath = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetTempFileName()));
+Directory dir = FSDirectory.Open(indexPath);
+using IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(matchVersion, analyzer));
+
+// This field must store term vectors and term vector offsets
+var fieldType = new FieldType(TextField.TYPE_STORED)
+{
+    StoreTermVectors = true,
+    StoreTermVectorOffsets = true
+};
+fieldType.Freeze();
+
+// Create documents with two fields, one with term vectors (tv) and one without (notv)
+writer.AddDocument(new Document {
+    new Field("tv", "Thanks a million!", fieldType),
+    new TextField("notv", "A million ways to win.", Field.Store.YES)
+});
+writer.AddDocument(new Document {
+    new Field("tv", "Hopefully, this won't highlight a million times.", fieldType),
+    new TextField("notv", "There are a million different ways to do that!", Field.Store.YES)
+});
+
+using IndexReader indexReader = writer.GetReader(applyAllDeletes: true);
+writer.Dispose();
+
+// Now search our index using an existing or new IndexReader
+
+IndexSearcher searcher = new IndexSearcher(indexReader);
+QueryParser parser = new QueryParser(matchVersion, "notv", analyzer);
+Query query = parser.Parse("million");
+
+TopDocs hits = searcher.Search(query, 10);
+
+SimpleHTMLFormatter htmlFormatter = new SimpleHTMLFormatter();
+Highlighter highlighter = new Highlighter(htmlFormatter, new QueryScorer(query));
+int totalScoreDocs = hits.ScoreDocs.Length > 10 ? 10 : hits.ScoreDocs.Length;
+for (int i = 0; i < totalScoreDocs; i++)
+{
+    int id = hits.ScoreDocs[i].Doc;
+    Document doc = searcher.Doc(id);
+    string text = doc.Get("notv");
+    TokenStream tokenStream = TokenSources.GetAnyTokenStream(searcher.IndexReader, id, "notv", analyzer);
+    TextFragment[] frag = highlighter.GetBestTextFragments(
+        tokenStream, text, mergeContiguousFragments: false, maxNumFragments: 10); // highlighter.GetBestFragments(tokenStream, text, 3, "...");
+    for (int j = 0; j < frag.Length; j++)
+    {
+        if (frag[j] != null && frag[j].Score > 0)
+        {
+            Console.WriteLine(frag[j].ToString());
+        }
+    }
+    //Term vector
+    text = doc.Get("tv");
+    tokenStream = TokenSources.GetAnyTokenStream(searcher.IndexReader, hits.ScoreDocs[i].Doc, "tv", analyzer);
+    frag = highlighter.GetBestTextFragments(tokenStream, text, false, 10);
+    for (int j = 0; j < frag.Length; j++)
+    {
+        if (frag[j] != null && frag[j].Score > 0)
+        {
+            Console.WriteLine(frag[j].ToString());
+        }
+    }
+    Console.WriteLine("-------------");
+}
+```
+
+## New features 2005-02-06
 
 
 This release adds options for encoding (thanks to Nicko Cadell).
@@ -62,7 +109,7 @@ all those non-xhtml standard characters such as & into legal values. This simple
 some languages -  Commons Lang has an implementation that could be used: escapeHtml(String) in
 http://svn.apache.org/viewcvs.cgi/jakarta/commons/proper/lang/trunk/src/java/org/apache/commons/lang/StringEscapeUtils.java?rev=137958&view=markup
 
-## New features 22/12/2004
+## New features 2004-12-22
 
 
 This release adds some new capabilities:
@@ -73,8 +120,8 @@ This release adds some new capabilities:
 
 3.  Options for better summarization by using term IDF scores to influence fragment selection
 
- The highlighter takes a TokenStream as input. Until now these streams have typically been produced using an Analyzer but the new class TokenSources provides helper methods for obtaining TokenStreams from the new TermVector position support (see latest CVS version).
+The highlighter takes a <xref:Lucene.Net.Analysis.TokenStream> as input. Until now these streams have typically been produced using an <xref:Lucene.Net.Analysis.Analyzer> but the new class TokenSources provides helper methods for obtaining TokenStreams from the new TermVector position support (see latest CVS version).
 
-The new class GradientFormatter can use a scale of colors to highlight terms according to their score. A subtle use of color can help emphasise the reasons for matching (useful when doing "MoreLikeThis" queries and you want to see what the basis of the similarities are).
+The new class <xref:Lucene.Net.Search.Highlight.GradientFormatter> can use a scale of colors to highlight terms according to their score. A subtle use of color can help emphasize the reasons for matching (useful when doing "MoreLikeThis" queries and you want to see what the basis of the similarities are).
 
-The QueryScorer class has a new constructor which can use an IndexReader to derive the IDF (inverse document frequency) for each term in order to influence the score. This is useful for helping to extracting the most significant sections of a document and in supplying scores used by the new GradientFormatter to color significant words more strongly. The QueryScorer.getMaxWeight method is useful when passed to the GradientFormatter constructor to define the top score which is associated with the top color.
+The <xref:Lucene.Net.Search.Highlight.QueryScorer> class has a new constructor which can use an <xref:Lucene.Net.Index.IndexReader> to derive the IDF (inverse document frequency) for each term in order to influence the score. This is useful for helping to extracting the most significant sections of a document and in supplying scores used by the new GradientFormatter to color significant words more strongly. The [QueryScorer.MaxTermWeight](xref:Lucene.Net.Search.Highlight.QueryScorer#Lucene_Net_Search_Highlight_QueryScorer_MaxTermWeight) method is useful when passed to the GradientFormatter constructor to define the top score which is associated with the top color.

--- a/src/Lucene.Net.Highlighter/overview.md
+++ b/src/Lucene.Net.Highlighter/overview.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Highlighter
 title: Lucene.Net.Highlighter
 summary: *content
@@ -21,5 +21,10 @@ summary: *content
  limitations under the License.
 -->
 
-  The highlight package contains classes to provide "keyword in context" features
-  typically used to highlight search terms in the text of results pages.
+The highlight package contains classes to provide "keyword in context" features typically used to highlight search terms in the text of results pages. There are 3 main highlighters:
+
+* <xref:Lucene.Net.Search.Highlight> - A lightweight highlighter for basic usage.
+
+* <xref:Lucene.Net.Search.PostingsHighlight> (In the <xref:Lucene.Net.ICU> package) - Highlighter implementation that uses offsets from postings lists. This highlighter supports Unicode.
+
+* <xref:Lucene.Net.Search.VectorHighlight> - This highlighter is fast for large docs, supports N-gram fields, multi-term highlighting, colored highlight tags, and more. There is a <xref:Lucene.Net.Search.VectorHighlight.BreakIteratorBoundaryScanner> in the <xref:Lucene.Net.ICU> package that can be added on for Unicode support.

--- a/src/Lucene.Net.Join/package.md
+++ b/src/Lucene.Net.Join/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Join
 summary: *content
 ---
@@ -24,21 +24,21 @@ This modules support index-time and query-time joins.
 
 ## Index-time joins
 
-The index-time joining support joins while searching, where joined documents are indexed as a single document block using [IndexWriter.addDocuments](xref:Lucene.Net.Index.IndexWriter#methods). This is useful for any normalized content (XML documents or database tables). In database terms, all rows for all joined tables matching a single row of the primary table must be indexed as a single document block, with the parent document being last in the group.
+The index-time joining support joins while searching, where joined documents are indexed as a single document block using [IndexWriter.AddDocuments()](xref:Lucene.Net.Index.IndexWriter#Lucene_Net_Index_IndexWriter_AddDocuments_System_Collections_Generic_IEnumerable_System_Collections_Generic_IEnumerable_Lucene_Net_Index_IIndexableField___). This is useful for any normalized content (XML documents or database tables). In database terms, all rows for all joined tables matching a single row of the primary table must be indexed as a single document block, with the parent document being last in the group.
 
 When you index in this way, the documents in your index are divided into parent documents (the last document of each block) and child documents (all others). You provide a <xref:Lucene.Net.Search.Filter> that identifies the parent documents, as Lucene does not currently record any information about doc blocks.
 
 At search time, use <xref:Lucene.Net.Join.ToParentBlockJoinQuery> to remap/join matches from any child <xref:Lucene.Net.Search.Query> (ie, a query that matches only child documents) up to the parent document space. The resulting query can then be used as a clause in any query that matches parent.
 
-If you only care about the parent documents matching the query, you can use any collector to collect the parent hits, but if you'd also like to see which child documents match for each parent document, use the <xref:Lucene.Net.Join.ToParentBlockJoinCollector> to collect the hits. Once the search is done, you retrieve a <xref:Lucene.Net.Grouping.TopGroups> instance from the [ToParentBlockJoinCollector.getTopGroups](xref:Lucene.Net.Join.ToParentBlockJoinCollector#methods) method.
+If you only care about the parent documents matching the query, you can use any collector to collect the parent hits, but if you'd also like to see which child documents match for each parent document, use the <xref:Lucene.Net.Join.ToParentBlockJoinCollector> to collect the hits. Once the search is done, you retrieve a <xref:Lucene.Net.Search.Grouping.ITopGroups`1> instance from the [ToParentBlockJoinCollector.GetTopGroups()](xref:Lucene.Net.Join.ToParentBlockJoinCollector#Lucene_Net_Join_ToParentBlockJoinCollector_GetTopGroups_Lucene_Net_Join_ToParentBlockJoinQuery_Lucene_Net_Search_Sort_System_Int32_System_Int32_System_Int32_System_Boolean_) method.
 
 To map/join in the opposite direction, use <xref:Lucene.Net.Join.ToChildBlockJoinQuery>.  This wraps
-  any query matching parent documents, creating the joined query
-  matching only child documents.
+any query matching parent documents, creating the joined query
+matching only child documents.
 
 ## Query-time joins
 
- The query time joining is index term based and implemented as two pass search. The first pass collects all the terms from a fromField that match the fromQuery. The second pass returns all documents that have matching terms in a toField to the terms collected in the first pass. 
+The query time joining is index term based and implemented as two pass search. The first pass collects all the terms from a `fromField` that match the `fromQuery`. The second pass returns all documents that have matching terms in a `toField` to the terms collected in the first pass. 
 
 Query time joining has the following input:
 
@@ -46,22 +46,25 @@ Query time joining has the following input:
 
 *   `fromQuery`:  The query executed to collect the from terms. This is usually the user specified query.
 
-*   `multipleValuesPerDocument`:  Whether the fromField contains more than one value per document
+*   `multipleValuesPerDocument`:  Whether the `fromField` contains more than one value per document
 
 *   `scoreMode`:  Defines how scores are translated to the other join side. If you don't care about scoring
-  use [#None](xref:Lucene.Net.Join.ScoreMode) mode. This will disable scoring and is therefore more
+  use [ScoreMode.None](xref:Lucene.Net.Join.ScoreMode#Lucene_Net_Join_ScoreMode_None) mode. This will disable scoring and is therefore more
   efficient (requires less memory and is faster).
 
 *   `toField`: The to field to join to
 
- Basically the query-time joining is accessible from one static method. The user of this method supplies the method with the described input and a `IndexSearcher` where the from terms need to be collected from. The returned query can be executed with the same `IndexSearcher`, but also with another `IndexSearcher`. Example usage of the [JoinUtil.createJoinQuery](xref:Lucene.Net.Join.JoinUtil#methods) : 
+Basically the query-time joining is accessible from one static method. The user of this method supplies the method with the described input and a `IndexSearcher` where the from terms need to be collected from. The returned query can be executed with the same `IndexSearcher`, but also with another `IndexSearcher`. Example usage of the [JoinUtil.CreateJoinQuery()](xref:Lucene.Net.Join.JoinUtil#Lucene_Net_Join_JoinUtil_CreateJoinQuery_System_String_System_Boolean_System_String_Lucene_Net_Search_Query_Lucene_Net_Search_IndexSearcher_Lucene_Net_Join_ScoreMode_): 
 
-      String fromField = "from"; // Name of the from field
-      boolean multipleValuesPerDocument = false; // Set only yo true in the case when your fromField has multiple values per document in your index
-      String toField = "to"; // Name of the to field
-      ScoreMode scoreMode = ScoreMode.Max // Defines how the scores are translated into the other side of the join.
-      Query fromQuery = new TermQuery(new Term("content", searchTerm)); // Query executed to collect from values to join to the to values
-    
-  Query joinQuery = JoinUtil.createJoinQuery(fromField, multipleValuesPerDocument, toField, fromQuery, fromSearcher, scoreMode);
-      TopDocs topDocs = toSearcher.search(joinQuery, 10); // Note: toSearcher can be the same as the fromSearcher
-      // Render topDocs...
+
+```cs
+string fromField = "from"; // Name of the from field
+bool multipleValuesPerDocument = false; // Set only yo true in the case when your fromField has multiple values per document in your index
+string toField = "to"; // Name of the to field
+ScoreMode scoreMode = ScoreMode.Max; // Defines how the scores are translated into the other side of the join.
+Query fromQuery = new TermQuery(new Term("content", searchTerm)); // Query executed to collect from values to join to the to values
+
+Query joinQuery = JoinUtil.CreateJoinQuery(fromField, multipleValuesPerDocument, toField, fromQuery, fromSearcher, scoreMode);
+TopDocs topDocs = toSearcher.Search(joinQuery, 10); // Note: toSearcher can be the same as the fromSearcher
+// Render topDocs...
+```

--- a/src/Lucene.Net.Misc/Index/Sorter/package.md
+++ b/src/Lucene.Net.Misc/Index/Sorter/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Index.Sorter
 summary: *content
 ---
@@ -20,9 +20,9 @@ summary: *content
  limitations under the License.
 -->
 
-Provides index sorting capablities. The application can use any
+Provides index sorting capabilities. The application can use any
 Sort specification, e.g. to sort by fields using DocValues or FieldCache, or to
-reverse the order of the documents (by using SortField.Type.DOC in reverse).
+reverse the order of the documents (by using [SortFieldType.DOC](xref:Lucene.Net.Search.SortFieldType#Lucene_Net_Search_SortFieldType_DOC) in reverse).
 Multi-level sorts can be specified the same way you would when searching, by
 building Sort from multiple SortFields.
 

--- a/src/Lucene.Net.Misc/overview.md
+++ b/src/Lucene.Net.Misc/overview.md
@@ -26,6 +26,12 @@ summary: *content
 The misc package has various tools for splitting/merging indices,
 changing norms, finding high freq terms, and others.
 
+
+<!--
+
+LUCENENET specific - we didn't port the NativeUnixDirectory, and it is not clear whether there is any advantage to doing so in .NET.
+See: https://github.com/apache/lucenenet/issues/276
+
 ## NativeUnixDirectory
 
 __NOTE__: This uses C++ sources (accessible via JNI), which you'll
@@ -56,3 +62,4 @@ NativePosixUtil.cpp/java also expose access to the posix_madvise,
 madvise, posix_fadvise functions, which are somewhat more cross
 platform than O_DIRECT, however, in testing (see above link), these
 APIs did not seem to help prevent buffer cache eviction.
+-->

--- a/src/Lucene.Net.QueryParser/Surround/Parser/package.md
+++ b/src/Lucene.Net.QueryParser/Surround/Parser/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.QueryParsers.Surround.Parser
 summary: *content
 ---
@@ -20,7 +20,6 @@ summary: *content
  limitations under the License.
 -->
 
-    This package contains the QueryParser.jj source file for the Surround parser.
+This package contains the `QueryParser.jj` source file for the Surround parser.
 
-    Parsing the text of a query results in a SrndQuery in the
-    org.apache.lucene.queryparser.surround.query package.
+Parsing the text of a query results in a SrndQuery in the <xref:Lucene.Net.QueryParsers.Surround.Query> namespace.

--- a/src/Lucene.Net.QueryParser/Surround/Query/package.md
+++ b/src/Lucene.Net.QueryParser/Surround/Query/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.QueryParsers.Surround.Query
 summary: *content
 ---
@@ -20,11 +20,8 @@ summary: *content
  limitations under the License.
 -->
 
-    This package contains SrndQuery and its subclasses.
+This package contains <xref:Lucene.Net.QueryParsers.Surround.Query.SrndQuery> and its subclasses.
 
-    The parser in the org.apache.lucene.queryparser.surround.parser package
-    normally generates a SrndQuery.
+The parser in the <xref:Lucene.Net.QueryParsers.Surround.Parser> namespace normally generates a SrndQuery.
 
-    For searching an org.apache.lucene.search.Query is provided by
-    the SrndQuery.makeLuceneQueryField method.
-    For this, TermQuery, BooleanQuery and SpanQuery are used from Lucene.
+For searching an <xref:Lucene.Net.Search.Query> is provided by the [SrndQuery.MakeLuceneQueryField()](xref:Lucene.Net.QueryParsers.Surround.Query.SrndQuery#Lucene_Net_QueryParsers_Surround_Query_SrndQuery_MakeLuceneQueryField_System_String_Lucene_Net_QueryParsers_Surround_Query_BasicQueryFactory_) method. For this, TermQuery, BooleanQuery and SpanQuery are used from Lucene.

--- a/src/Lucene.Net.Spatial/overview.md
+++ b/src/Lucene.Net.Spatial/overview.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Spatial
 summary: *content
 ---
@@ -20,12 +20,17 @@ summary: *content
  limitations under the License.
 -->
 
-# The Spatial Module for Apache Lucene
+# The Spatial Module for Apache Lucene.NET
 
- The spatial module is new to Lucene 4, replacing the old "contrib" module that came before it. The principle interface to the module is a <xref:Lucene.Net.Spatial.SpatialStrategy> which encapsulates an approach to indexing and searching based on shapes. Different Strategies have different features and performance profiles, which are documented at each Strategy implementation class level. 
+The spatial module is new to Lucene.NET 4, replacing the old "Lucene.Net.Contrib" module that came before it. The principle interface to the module is a <xref:Lucene.Net.Spatial.SpatialStrategy> which encapsulates an approach to indexing and searching based on shapes. Different Strategies have different features and performance profiles, which are documented at each Strategy implementation class level. 
 
- For some sample code showing how to use the API, see SpatialExample.java in the tests. 
+For some sample code showing how to use the API, see SpatialExample.cs in the tests. 
 
- The spatial module uses [Spatial4j](https://github.com/spatial4j/spatial4j) heavily. Spatial4j is an ASL licensed library with these capabilities: * Provides shape implementations, namely point, rectangle, and circle. Both geospatial contexts and plain 2D Euclidean/Cartesian contexts are supported. With an additional dependency, it adds polygon and other geometry shape support via integration with [JTS Topology Suite](http://sourceforge.net/projects/jts-topo-suite/). This includes dateline wrap support. * Shape parsing and serialization, including [Well-Known Text (WKT)](http://en.wikipedia.org/wiki/Well-known_text) (via JTS). * Distance and other spatial related math calculations. 
+The spatial module uses [Spatial4n](https://github.com/NightOwl888/Spatial4n), a .NET port of the ASL licensed [Spatial4j](https://github.com/spatial4j/spatial4j) heavily. Spatial4n is a library with these capabilities:
 
- Historical note: The new spatial module was once known as Lucene Spatial Playground (LSP) as an external project. In ~March 2012, LSP split into this new module as part of Lucene and Spatial4j externally. A large chunk of the LSP implementation originated as SOLR-2155 which uses trie/prefix-tree algorithms with a geohash encoding. That approach is implemented in <xref:Lucene.Net.Spatial.Prefix.RecursivePrefixTreeStrategy> today. 
+* Provides shape implementations, namely point, rectangle, and circle. Both geospatial contexts and plain 2D Euclidean/Cartesian contexts are supported. With an additional dependency, it adds polygon and other geometry shape support via integration with [NetTopologySuite](https://github.com/NetTopologySuite/NetTopologySuite) (often referred to as NTS). This includes dateline wrap support.
+* Shape parsing and serialization, including [Well-Known Text (WKT)](http://en.wikipedia.org/wiki/Well-known_text) (via NTS).
+* Distance and other spatial related math calculations. 
+
+> [!NOTE]
+> Historical Fact: The new spatial module was once known as Lucene Spatial Playground (LSP) as an external project. In ~March 2012, LSP split into this new module as part of Lucene and Spatial4j externally. A large chunk of the LSP implementation originated as SOLR-2155 which uses trie/prefix-tree algorithms with a geohash encoding. That approach is implemented in <xref:Lucene.Net.Spatial.Prefix.RecursivePrefixTreeStrategy> today. 

--- a/src/Lucene.Net.TestFramework/Analysis/package.md
+++ b/src/Lucene.Net.TestFramework/Analysis/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Analysis
 summary: *content
 ---
@@ -22,4 +22,8 @@ summary: *content
 
 Support for testing analysis components.
 
- The main classes of interest are: * <xref:Lucene.Net.Analysis.BaseTokenStreamTestCase>: Highly recommended to use its helper methods, (especially in conjunction with <xref:Lucene.Net.Analysis.MockAnalyzer> or <xref:Lucene.Net.Analysis.MockTokenizer>), as it contains many assertions and checks to catch bugs. * <xref:Lucene.Net.Analysis.MockTokenizer>: Tokenizer for testing. Tokenizer that serves as a replacement for WHITESPACE, SIMPLE, and KEYWORD tokenizers. If you are writing a component such as a TokenFilter, its a great idea to test it wrapping this tokenizer instead for extra checks. * <xref:Lucene.Net.Analysis.MockAnalyzer>: Analyzer for testing. Analyzer that uses MockTokenizer for additional verification. If you are testing a custom component such as a queryparser or analyzer-wrapper that consumes analysis streams, its a great idea to test it with this analyzer instead. 
+The main classes of interest are:
+
+* <xref:Lucene.Net.Analysis.BaseTokenStreamTestCase>: Highly recommended to use its helper methods, (especially in conjunction with <xref:Lucene.Net.Analysis.MockAnalyzer> or <xref:Lucene.Net.Analysis.MockTokenizer>), as it contains many assertions and checks to catch bugs.
+* <xref:Lucene.Net.Analysis.MockTokenizer>: Tokenizer for testing. Tokenizer that serves as a replacement for WHITESPACE, SIMPLE, and KEYWORD tokenizers. If you are writing a component such as a TokenFilter, its a great idea to test it wrapping this tokenizer instead for extra checks.
+* <xref:Lucene.Net.Analysis.MockAnalyzer>: Analyzer for testing. Analyzer that uses MockTokenizer for additional verification. If you are testing a custom component such as a query parser or analyzer-wrapper that consumes analysis streams, its a great idea to test it with this analyzer instead. 

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene41Ords/package.md
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene41Ords/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Codecs.Lucene41Ords
 summary: *content
 ---
@@ -20,4 +20,4 @@ summary: *content
  limitations under the License.
 -->
 
-Codec for testing that supports [#ord()](xref:Lucene.Net.Index.TermsEnum)
+Codec for testing that supports [TermsEnum.Ord](xref:Lucene.Net.Index.TermsEnum#Lucene_Net_Index_TermsEnum_Ord)

--- a/src/Lucene.Net.TestFramework/Index/package.md
+++ b/src/Lucene.Net.TestFramework/Index/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Index
 summary: *content
 ---
@@ -22,4 +22,7 @@ summary: *content
 
 Support for testing of indexes. 
 
- The primary classes are: * <xref:Lucene.Net.Index.RandomIndexWriter>: Randomizes the indexing experience. * <xref:Lucene.Net.Index.MockRandomMergePolicy>: MergePolicy that makes random decisions. 
+The primary classes are:
+
+* <xref:Lucene.Net.Index.RandomIndexWriter>: Randomizes the indexing experience.
+* <xref:Lucene.Net.Index.MockRandomMergePolicy>: MergePolicy that makes random decisions. 

--- a/src/Lucene.Net.TestFramework/Search/package.md
+++ b/src/Lucene.Net.TestFramework/Search/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Search
 summary: *content
 ---
@@ -22,4 +22,7 @@ summary: *content
 
 Support for testing search components. 
 
- The primary classes are: * <xref:Lucene.Net.Search.QueryUtils>: Useful methods for testing Query classes. * <xref:Lucene.Net.Search.ShardSearchingTestBase>: Base class for simulating distributed search. 
+The primary classes are:
+
+* <xref:Lucene.Net.Search.QueryUtils>: Useful methods for testing Query classes.
+* <xref:Lucene.Net.Search.ShardSearchingTestBase>: Base class for simulating distributed search. 

--- a/src/Lucene.Net.TestFramework/Util/package.md
+++ b/src/Lucene.Net.TestFramework/Util/package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Lucene.Net.Util
 summary: *content
 ---
@@ -21,4 +21,4 @@ summary: *content
 -->
 
 General test support.  The primary class is <xref:Lucene.Net.Util.LuceneTestCase>,
-which extends JUnit with additional functionality.
+which extends NUnit with additional functionality.

--- a/src/Lucene.Net/overview.md
+++ b/src/Lucene.Net/overview.md
@@ -134,7 +134,7 @@ queries and searches an index.
 
 To demonstrate this, try something like:
 
-```
+```console
 > dotnet demo index-files index rec.food.recipies/soups
 adding rec.food.recipes/soups/abalone-chowder
 [...]

--- a/src/dotnet/tools/lucene-cli/docs/analysis/kuromoji-build-dictionary.md
+++ b/src/dotnet/tools/lucene-cli/docs/analysis/kuromoji-build-dictionary.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene analysis kuromoji-build-dictionary \<FORMAT> \<INPUT_DIRECTORY> \<OUTPUT_DIRECTORY> [-e|--encoding] [-n|--normalize] [?|-h|--help]</code>
+```console
+lucene analysis kuromoji-build-dictionary <FORMAT> <INPUT_DIRECTORY> <OUTPUT_DIRECTORY> [-e|--encoding] [-n|--normalize] [?|-h|--help]
+```
 
 ### Description
 
@@ -56,5 +58,7 @@ Normalize the entries using normalization form KC.
 
 ### Example
 
-<code>lucene analysis kuromoji-build-dictionary IPADIC X:\kuromoji-data X:\kuromoji-dictionary --normalize</code>
+```console
+lucene analysis kuromoji-build-dictionary IPADIC X:\kuromoji-data X:\kuromoji-dictionary --normalize
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/analysis/stempel-compile-stems.md
+++ b/src/dotnet/tools/lucene-cli/docs/analysis/stempel-compile-stems.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene analysis stempel-compile-stems \<STEMMING_ALGORITHM> \<STEMMER_TABLE_FILE> [-e|--encoding] [?|-h|--help]</code>
+```console
+lucene analysis stempel-compile-stems <STEMMING_ALGORITHM> <STEMMER_TABLE_FILE> [-e|--encoding] [?|-h|--help]
+```
 
 ### Description
 
@@ -34,4 +36,6 @@ The file encoding used by the stemmer files. If not supplied, the default value 
 
 ### Example
 
-<code>lucene analysis stempel-compile-stems test X:\stemmer-data\table1.txt X:\stemmer-data\table2.txt</code>
+```console
+lucene analysis stempel-compile-stems test X:\stemmer-data\table1.txt X:\stemmer-data\table2.txt
+```

--- a/src/dotnet/tools/lucene-cli/docs/analysis/stempel-patch-stems.md
+++ b/src/dotnet/tools/lucene-cli/docs/analysis/stempel-patch-stems.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene analysis stempel-patch-stems \<STEMMER_TABLE_FILE> [-e|--encoding] [?|-h|--help]</code>
+```console
+lucene analysis stempel-patch-stems <STEMMER_TABLE_FILE> [-e|--encoding] [?|-h|--help]
+```
 
 ### Description
 
@@ -30,5 +32,7 @@ The file encoding used by the stemmer files. If not supplied, the default value 
 
 ### Example
 
-<code>lucene analysis stempel-patch-stems X:\stemmer-data\table1.txt X:\stemmer-data\table2.txt --encoding UTF-16</code>
+```console
+lucene analysis stempel-patch-stems X:\stemmer-data\table1.txt X:\stemmer-data\table2.txt --encoding UTF-16
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/benchmark/extract-reuters.md
+++ b/src/dotnet/tools/lucene-cli/docs/benchmark/extract-reuters.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene benchmark extract-reuters \<INPUT_DIRECTORY> \<OUTPUT_DIRECTORY> [?|-h|--help]</code>
+```console
+lucene benchmark extract-reuters <INPUT_DIRECTORY> <OUTPUT_DIRECTORY> [?|-h|--help]
+```
 
 ### Arguments
 
@@ -28,4 +30,6 @@ Prints out a short help for the command.
 
 Extracts the reuters SGML files in the `z:\input` directory and places the content in the `z:\output` directory.
 
-<code>lucene benchmark extract-reuters z:\input z:\output</code>
+```console
+lucene benchmark extract-reuters z:\input z:\output
+```

--- a/src/dotnet/tools/lucene-cli/docs/benchmark/extract-wikipedia.md
+++ b/src/dotnet/tools/lucene-cli/docs/benchmark/extract-wikipedia.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene benchmark extract-wikipedia \<INPUT_WIKIPEDIA_FILE> \<OUTPUT_DIRECTORY> [-d|--discard-image-only-docs] [?|-h|--help]</code>
+```console
+lucene benchmark extract-wikipedia <INPUT_WIKIPEDIA_FILE> <OUTPUT_DIRECTORY> [-d|--discard-image-only-docs] [?|-h|--help]
+```
 
 ### Arguments
 
@@ -32,4 +34,6 @@ Tells the extractor to skip WIKI docs that contain only images.
 
 Extracts the `c:\wiki.xml` file into the `c:\out` directory, skipping any docs that only contain images.
 
-<code>lucene benchmark extract-wikipedia c:\wiki.xml c:\out -d</code>
+```console
+lucene benchmark extract-wikipedia c:\wiki.xml c:\out -d
+```

--- a/src/dotnet/tools/lucene-cli/docs/benchmark/find-quality-queries.md
+++ b/src/dotnet/tools/lucene-cli/docs/benchmark/find-quality-queries.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene benchmark find-quality-queries \<INPUT_DIRECTORY> [?|-h|--help]</code>
+```console
+lucene benchmark find-quality-queries <INPUT_DIRECTORY> [?|-h|--help]
+```
 
 ### Arguments
 
@@ -24,4 +26,6 @@ Prints out a short help for the command.
 
 Finds quality queries on the `c:\lucene-index` index directory.
 
-<code>lucene benchmark find-quality-queries c:\lucene-index</code>
+```console
+lucene benchmark find-quality-queries c:\lucene-index
+```

--- a/src/dotnet/tools/lucene-cli/docs/benchmark/run-trec-eval.md
+++ b/src/dotnet/tools/lucene-cli/docs/benchmark/run-trec-eval.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene benchmark run-trec-eval \<INPUT_TOPICS_FILE> \<INPUT_QUERY_RELEVANCE_FILE> \<OUTPUT_SUBMISSION_FILE> \<INDEX_DIRECTORY> [-t|--query-on-title] [-d|--query-on-description] [-n|--query-on-narrative] [?|-h|--help]</code>
+```console
+lucene benchmark run-trec-eval <INPUT_TOPICS_FILE> <INPUT_QUERY_RELEVANCE_FILE> <OUTPUT_SUBMISSION_FILE> <INDEX_DIRECTORY> [-t|--query-on-title] [-d|--query-on-description] [-n|--query-on-narrative] [?|-h|--help]
+```
 
 ### Arguments
 

--- a/src/dotnet/tools/lucene-cli/docs/benchmark/run.md
+++ b/src/dotnet/tools/lucene-cli/docs/benchmark/run.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene benchmark run \<ALGORITHM_FILE> \<OUTPUT_DIRECTORY> [?|-h|--help]</code>
+```console
+lucene benchmark run <ALGORITHM_FILE> <OUTPUT_DIRECTORY> [?|-h|--help]
+```
 
 ### Arguments
 
@@ -28,4 +30,6 @@ Prints out a short help for the command.
 
 Runs a benchmark on the `c:\check.alg` algorithm file.
 
-<code>lucene benchmark run c:\check.alg</code>
+```console
+lucene benchmark run c:\check.alg
+```

--- a/src/dotnet/tools/lucene-cli/docs/benchmark/sample.md
+++ b/src/dotnet/tools/lucene-cli/docs/benchmark/sample.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene benchmark sample [-src|--view-source-code] [-out|--output-source-code]  [?|-h|--help]</code>
+```console
+lucene benchmark sample [-src|--view-source-code] [-out|--output-source-code]  [?|-h|--help]
+```
 
 ### Options
 
@@ -26,4 +28,6 @@ Outputs the source code to the specified directory.
 
 Runs the sample.
 
-<code>lucene benchmark sample</code>
+```console
+lucene benchmark sample
+```

--- a/src/dotnet/tools/lucene-cli/docs/demo/associations-facets.md
+++ b/src/dotnet/tools/lucene-cli/docs/demo/associations-facets.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene demo associations-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]</code>
+```console
+lucene demo associations-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]
+```
 
 ### Options
 
@@ -24,4 +26,6 @@ Outputs the source code to the specified directory.
 
 ### Example
 
-<code>lucene demo associations-facets</code>
+```console
+lucene demo associations-facets
+```

--- a/src/dotnet/tools/lucene-cli/docs/demo/distance-facets.md
+++ b/src/dotnet/tools/lucene-cli/docs/demo/distance-facets.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene demo distance-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]</code>
+```console
+lucene demo distance-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]
+```
 
 ### Options
 
@@ -24,4 +26,6 @@ Outputs the source code to the specified directory.
 
 ### Example
 
-<code>lucene demo distance-facets</code>
+```console
+lucene demo distance-facets
+```

--- a/src/dotnet/tools/lucene-cli/docs/demo/expression-aggregation-facets.md
+++ b/src/dotnet/tools/lucene-cli/docs/demo/expression-aggregation-facets.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene demo expression-aggregation-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]</code>
+```console
+lucene demo expression-aggregation-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]
+```
 
 ### Options
 
@@ -24,4 +26,6 @@ Outputs the source code to the specified directory.
 
 ### Example
 
-<code>lucene demo expression-aggregation-facets</code>
+```console
+lucene demo expression-aggregation-facets
+```

--- a/src/dotnet/tools/lucene-cli/docs/demo/index-files.md
+++ b/src/dotnet/tools/lucene-cli/docs/demo/index-files.md
@@ -6,8 +6,8 @@
 
 ### Synopsis
 
-```
-lucene demo index-files \<INDEX_DIRECTORY> \<SOURCE_DIRECTORY> [-u|--update] [?|-h|--help]
+```console
+lucene demo index-files <INDEX_DIRECTORY> <SOURCE_DIRECTORY> [-u|--update] [?|-h|--help]
 lucene demo index-files [-src|--view-source-code] [-out|--output-source-code]
 ```
 
@@ -47,5 +47,7 @@ Outputs the source code to the specified directory.
 
 Indexes the contents of `C:\Users\BGates\Documents\` and places the Lucene.Net index in `X:\test-index\`.
 
-<code>lucene demo index-files X:\test-index C:\Users\BGates\Documents</code>
+```console
+lucene demo index-files X:\test-index C:\Users\BGates\Documents
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/demo/multi-category-lists-facets.md
+++ b/src/dotnet/tools/lucene-cli/docs/demo/multi-category-lists-facets.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene demo multi-category-lists-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]</code>
+```console
+lucene demo multi-category-lists-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]
+```
 
 ### Options
 
@@ -25,4 +27,6 @@ Outputs the source code to the specified directory.
 
 ### Example
 
-<code>lucene demo multi-category-lists-facets</code>
+```console
+lucene demo multi-category-lists-facets
+```

--- a/src/dotnet/tools/lucene-cli/docs/demo/range-facets.md
+++ b/src/dotnet/tools/lucene-cli/docs/demo/range-facets.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene demo range-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]</code>
+```console
+lucene demo range-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]
+```
 
 ### Options
 
@@ -24,4 +26,6 @@ Outputs the source code to the specified directory.
 
 ### Example
 
-<code>lucene demo range-facets</code>
+```console
+lucene demo range-facets
+```

--- a/src/dotnet/tools/lucene-cli/docs/demo/search-files.md
+++ b/src/dotnet/tools/lucene-cli/docs/demo/search-files.md
@@ -6,8 +6,8 @@
 
 ### Synopsis
 
-```
-lucene demo search-files \<INDEX_DIRECTORY> [-f|--field] [-r|--repeat] [-qf|--queries-file] [-q|--query] [--raw] [-p|--page-size] [?|-h|--help]
+```console
+lucene demo search-files <INDEX_DIRECTORY> [-f|--field] [-r|--repeat] [-qf|--queries-file] [-q|--query] [--raw] [-p|--page-size] [?|-h|--help]
 lucene demo search-files [-src|--view-source-code] [-out|--output-source-code]
 ```
 
@@ -65,8 +65,12 @@ Outputs the source code to the specified directory.
 
 Search the index located in the `X:\test-index` directory interactively, showing 15 results per page in raw format:
 
-<code>lucene demo search-files X:\test-index -p 15 --raw</code>
+```console
+lucene demo search-files X:\test-index -p 15 --raw
+```
 
 Run the query "foobar" against the "path" field in the index located in the `X:\test-index` directory:
 
-<code>lucene demo search-files X:\test-index --field path --query foobar</code>
+```console
+lucene demo search-files X:\test-index --field path --query foobar
+```

--- a/src/dotnet/tools/lucene-cli/docs/demo/simple-facets.md
+++ b/src/dotnet/tools/lucene-cli/docs/demo/simple-facets.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-</code>lucene demo simple-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]</code>
+```console
+lucene demo simple-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]
+```
 
 ### Options
 
@@ -24,4 +26,6 @@ Outputs the source code to the specified directory.
 
 ### Example
 
-<code>lucene demo simple-facets</code>
+```console
+lucene demo simple-facets
+```

--- a/src/dotnet/tools/lucene-cli/docs/demo/simple-sorted-set-facets.md
+++ b/src/dotnet/tools/lucene-cli/docs/demo/simple-sorted-set-facets.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene demo simple-sorted-set-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]</code>
+```console
+lucene demo simple-sorted-set-facets [-src|--view-source-code] [-out|--output-source-code] [?|-h|--help]
+```
 
 ### Options
 
@@ -24,6 +26,8 @@ Outputs the source code to the specified directory.
 
 ### Example
 
-<code>lucene demo simple-sorted-set-facets</code>
+```console
+lucene demo simple-sorted-set-facets
+```
 
 

--- a/src/dotnet/tools/lucene-cli/docs/index.md
+++ b/src/dotnet/tools/lucene-cli/docs/index.md
@@ -10,11 +10,12 @@ The Lucene.NET command line interface (CLI) is a new cross-platform toolchain wi
 
 Perform a one-time install of the lucene-cli tool using the following dotnet CLI command:
 
-```
+```console
 dotnet tool install lucene-cli -g --version 4.8.0-beta00014
 ```
 
-> NOTE: The version of the CLI you install should match the version of Lucene.NET you use.
+> [!NOTE]
+> The version of the CLI you install should match the version of Lucene.NET you use.
 
 You may then use the lucene-cli tool to analyze and update Lucene.NET indexes and use its demos.
 
@@ -31,7 +32,9 @@ The following commands are installed:
 
 CLI command structure consists of the driver ("lucene"), the command, and possibly command arguments and options. You see this pattern in most CLI operations, such as checking a Lucene.NET index for problematic segments and fixing (removing) them:
 
-```
+```console
 lucene index check C:\my-index --verbose
 lucene index fix C:\my-index
 ```
+
+

--- a/src/dotnet/tools/lucene-cli/docs/index/check.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/check.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index check [\<INDEX_DIRECTORY>] [-v|--verbose] [-c|--cross-check-term-vectors] [-dir|--directory-type] [-s|--segment] [?|-h|--help]</code>
+```console
+lucene index check [<INDEX_DIRECTORY>] [-v|--verbose] [-c|--cross-check-term-vectors] [-dir|--directory-type] [-s|--segment] [?|-h|--help]
+```
 
 ### Description
 
@@ -46,10 +48,14 @@ Only check the specified segment(s). This can be specified multiple times, to ch
 
 Check the index located at `X:\lucenenet-index\` verbosely, scanning only the segments named `_1j_Lucene41_0` and `_2u_Lucene41_0` for problems:
 
-<code>lucene index check X:\lucenenet-index -v -s _1j_Lucene41_0 -s _2u_Lucene41_0</code>
+```console
+lucene index check X:\lucenenet-index -v -s _1j_Lucene41_0 -s _2u_Lucene41_0
+```
 
 
 Check the index located at `C:\taxonomy\` using the `MMapDirectory` memory-mapped directory implementation:
 
-<code>lucene index check C:\taxonomy --directory-type MMapDirectory</code>
+```console
+lucene index check C:\taxonomy --directory-type MMapDirectory
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/index/copy-segments.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/copy-segments.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index copy-segments \<INPUT_DIRECTORY> \<OUTPUT_DIRECTORY> \<SEGMENT>[ \<SEGMENT_2>...] [?|-h|--help]</code>
+```console
+lucene index copy-segments <INPUT_DIRECTORY> <OUTPUT_DIRECTORY> <SEGMENT>[ <SEGMENT_2>...] [?|-h|--help]
+```
 
 ### Description
 
@@ -36,5 +38,7 @@ Prints out a short help for the command.
 
 Copy the `_71_Lucene41_0` segment from the index located at `X:\lucene-index` to the index located at `X:\output`:
 
-<code>lucene index copy-segments X:\lucene-index X:\output _71_Lucene41_0</code>
+```console
+lucene index copy-segments X:\lucene-index X:\output _71_Lucene41_0
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/index/delete-segments.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/delete-segments.md
@@ -6,11 +6,16 @@
 
 ### Synopsis
 
-<code>lucene index delete-segments \<INDEX_DIRECTORY> \<SEGMENT>[ \<SEGMENT_2>...] [?|-h|--help]</code>
+```console
+lucene index delete-segments <INDEX_DIRECTORY> <SEGMENT>[ <SEGMENT_2>...] [?|-h|--help]
+```
 
 ### Description
 
-You can easily accidentally remove segments from your index, so be careful! Always make a backup of your index first.
+Deletes segments from an index.
+
+> [!WARNING]
+> You can easily accidentally remove segments from your index, so be careful! Always make a backup of your index first.
 
 ### Arguments
 
@@ -32,4 +37,6 @@ Prints out a short help for the command.
 
 Delete the segments named `_8c` and `_83` from the index located at `X:\category-data\`:
 
-<code>lucene index delete-segments X:\category-data _8c _83</code>
+```console
+lucene index delete-segments X:\category-data _8c _83
+```

--- a/src/dotnet/tools/lucene-cli/docs/index/extract-cfs.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/extract-cfs.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index extract-cfs \<CFS_FILE_NAME> [-dir|--directory-type] [?|-h|--help]</code>
+```console
+lucene index extract-cfs <CFS_FILE_NAME> [-dir|--directory-type] [?|-h|--help]
+```
 
 ### Description
 
@@ -34,9 +36,13 @@ The FSDirectory implementation to use. If ommitted, it defaults to the optimal F
 
 Extract the files from the compound file at `X:\lucene-index\_81.cfs` to the current working directory:
 
-<code>lucene index extract-cfs X:\lucene-index\_81.cfs</code>
+```console
+lucene index extract-cfs X:\lucene-index\_81.cfs
+```
 
 
 Extract the files from the compound file at `X:\lucene-index\_64.cfs` to the current working directory using the `SimpleFSDirectory` implementation:
 
-<code>lucene index extract-cfs X:\lucene-index\_64.cfs --directory-type SimpleFSDirectory</code>
+```console
+lucene index extract-cfs X:\lucene-index\_64.cfs --directory-type SimpleFSDirectory
+```

--- a/src/dotnet/tools/lucene-cli/docs/index/fix.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/fix.md
@@ -6,13 +6,16 @@
 
 ### Synopsis
 
-<code>lucene index fix [\<INDEX_DIRECTORY>] [-v|--verbose] [-c|--cross-check-term-vectors] [-dir|--directory-type] [--dry-run] [?|-h|--help]</code>
+```console
+lucene index fix [<INDEX_DIRECTORY>] [-v|--verbose] [-c|--cross-check-term-vectors] [-dir|--directory-type] [--dry-run] [?|-h|--help]
+```
 
 ### Description
 
 Basic tool to write a new segments file that removes reference to problematic segments. As this tool checks every byte in the index, on a large index it can take quite a long time to run.
 
-> **WARNING:** This command should only be used on an emergency basis as it will cause documents (perhaps many) to be permanently removed from the index. Always make a backup copy of your index before running this! Do not run this tool on an index that is actively being written to. You have been warned!
+> [!WARNING] 
+> This command should only be used on an emergency basis as it will cause documents (perhaps many) to be permanently removed from the index. Always make a backup copy of your index before running this! Do not run this tool on an index that is actively being written to. You have been warned!
 
 ### Arguments
 
@@ -51,4 +54,6 @@ Check what a fix operation would do if run on the index located at `X:\product-i
 
 Fix the index located at `X:\product-index` and cross check term vectors:
 
-<code>lucene index fix X:\product-index -c</code>
+```console
+lucene index fix X:\product-index -c
+```

--- a/src/dotnet/tools/lucene-cli/docs/index/index.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/index.md
@@ -4,7 +4,8 @@
 
 Utilities to manage specialized analyzers.
 
-> **WARNING:** Many of these operations change an index in ways that cannot be reversed. Always make a backup of your index before running these commands. 
+> [!WARNING]
+> Many of these operations change an index in ways that cannot be reversed. Always make a backup of your index before running these commands. 
 
 ## Commands
 

--- a/src/dotnet/tools/lucene-cli/docs/index/list-cfs.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/list-cfs.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index list-cfs \<CFS_FILE_NAME> [-dir|--directory-type] [?|-h|--help]</code>
+```console
+lucene index list-cfs <CFS_FILE_NAME> [-dir|--directory-type] [?|-h|--help]
+```
 
 ### Description
 
@@ -32,5 +34,7 @@ The `FSDirectory` implementation to use. If omitted, defaults to the optimal `FS
 
 Lists the files within the `X:\categories\_53.cfs` compound file using the `NIOFSDirectory` directory implementation:
 
-<code>lucene index list-cfs X:\categories\_53.cfs -dir NIOFSDirectory</code>
+```console
+lucene index list-cfs X:\categories\_53.cfs -dir NIOFSDirectory
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/index/list-high-freq-terms.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/list-high-freq-terms.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index list-high-freq-terms [\<INDEX_DIRECTORY>] [-t|--total-term-frequency] [-n|--number-of-terms] [-f|--field] [?|-h|--help]</code>
+```console
+lucene index list-high-freq-terms [<INDEX_DIRECTORY>] [-t|--total-term-frequency] [-n|--number-of-terms] [-f|--field] [?|-h|--help]
+```
 
 ### Description
 
@@ -41,9 +43,12 @@ The field to consider. If omitted, considers all fields.
 
 List the high frequency terms in the index located at `F:\product-index\` on the `description` field, reporting both document frequency and term frequency:
 
-<code>lucene index list-high-freq-terms F:\product-index --total-term-frequency --field description</code>
-
+```console
+lucene index list-high-freq-terms F:\product-index --total-term-frequency --field description
+```
 
 List the high frequency terms in the index located at `C:\lucene-index\` on the `name` field, tracking 30 terms:
 
-<code>lucene index list-high-freq-terms C:\lucene-index --f name -n 30</code>
+```console
+lucene index list-high-freq-terms C:\lucene-index --f name -n 30
+```

--- a/src/dotnet/tools/lucene-cli/docs/index/list-segments.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/list-segments.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index list-segments [\<INDEX_DIRECTORY>] [?|-h|--help]</code>
+```console
+lucene index list-segments [\<INDEX_DIRECTORY>] [?|-h|--help]
+```
 
 ### Description
 
@@ -28,5 +30,7 @@ Prints out a short help for the command.
 
 List the segments in the index located at `X:\lucene-index\`:
 
-<code>lucene index list-segments X:\lucene-index</code>
+```console
+lucene index list-segments X:\lucene-index
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/index/list-taxonomy-stats.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/list-taxonomy-stats.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index list-taxonomy-stats [\<INDEX_DIRECTORY>] [-tree|--show-tree] [?|-h|--help]</code>
+```console
+lucene index list-taxonomy-stats [<INDEX_DIRECTORY>] [-tree|--show-tree] [?|-h|--help]
+```
 
 ### Description
 
@@ -18,7 +20,8 @@ Prints how many ords are under each dimension.
 
 The directory of the index. If omitted, it defaults to the current working directory.
 
-> **NOTE:** This directory must be a facet taxonomy directory for the command to succeed.
+> [!NOTE] 
+> This directory must be a facet taxonomy directory for the command to succeed.
 
 ### Options
 
@@ -34,5 +37,7 @@ Recursively lists all descendant nodes.
 
 List the taxonomy statistics from the index located at `X:\category-taxonomy-index\`, viewing all descendant nodes:
 
-<code>lucene index list-taxonomy-stats X:\category-taxonomy-index -tree</code>
+```console
+lucene index list-taxonomy-stats X:\category-taxonomy-index -tree
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/index/list-term-info.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/list-term-info.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index list-term-info \<INDEX_DIRECTORY> \<FIELD> \<TERM> [?|-h|--help]</code>
+```console
+lucene index list-term-info <INDEX_DIRECTORY> <FIELD> <TERM> [?|-h|--help]
+```
 
 ### Description
 
@@ -36,5 +38,7 @@ Prints out a short help for the command.
 
 List the term information from the index located at `C:\project-index\`:
 
-<code>lucene index list-term-info C:\project-index</code>
+```console
+lucene index list-term-info C:\project-index
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/index/merge.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/merge.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index merge \<OUTPUT_DIRECTORY> \<INPUT_DIRECTORY> \<INPUT_DIRECTORY_2>[ \<INPUT_DIRECTORY_N>...] [?|-h|--help]</code>
+```console
+lucene index merge <OUTPUT_DIRECTORY> <INPUT_DIRECTORY> <INPUT_DIRECTORY_2>[ <INPUT_DIRECTORY_N>...] [?|-h|--help]
+```
 
 ### Description
 
@@ -32,5 +34,7 @@ Prints out a short help for the command.
 
 Merge the indexes `C:\product-index1` and `C:\product-index2` into an index located at `X:\merged-index`:
 
-<code>lucene index merge X:\merged-index C:\product-index1 C:\product-index2</code>
+```console
+lucene index merge X:\merged-index C:\product-index1 C:\product-index2
+```
 

--- a/src/dotnet/tools/lucene-cli/docs/index/split.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/split.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index split \<OUTPUT_DIRECTORY> \<INPUT_DIRECTORY>[ \<INPUT_DIRECTORY_2>...] [-n|--number-of-parts] [-s|--sequential] [?|-h|--help]</code>
+```console
+lucene index split <OUTPUT_DIRECTORY> <INPUT_DIRECTORY>[ <INPUT_DIRECTORY_2>...] [-n|--number-of-parts] [-s|--sequential] [?|-h|--help]
+```
 
 ### Description
 
@@ -16,7 +18,8 @@ Deletes are only applied to a buffered list of deleted documents and don't affec
 
 The disadvantage of this tool is that source index needs to be read as many times as there are parts to be created. The multiple passes may be slow.
 
-> **NOTE:** This tool is unaware of documents added automatically via `IndexWriter.AddDocuments(IEnumerable&lt;IEnumerable&lt;IIndexableField&gt;&gt;, Analyzer)` or `IndexWriter.UpdateDocuments(Term, IEnumerable&lt;IEnumerable&lt;IIndexableField&gt;&gt;, Analyzer)`, which means it can easily break up such document groups.
+> [!NOTE]
+> This tool is unaware of documents added automatically via `IndexWriter.AddDocuments(IEnumerable<IEnumerable<IIndexableField>>, Analyzer)` or `IndexWriter.UpdateDocuments(Term, IEnumerable<IEnumerable<IIndexableField>>, Analyzer)`, which means it can easily break up such document groups.
 
 ### Arguments
 
@@ -46,9 +49,13 @@ Sequential doc-id range split (default is round-robin).
 
 Split the index located at `X:\old-index\` sequentially, placing the resulting 2 indices into the `X:\new-index\` directory:
 
-<code>lucene index split X:\new-index X:\old-index --sequential</code>
+```console
+lucene index split X:\new-index X:\old-index --sequential
+```
 
 
 Split the index located at `T:\in\` into 4 parts and place them into the `T:\out\` directory:
 
-<code>lucene index split T:\out T:\in -n 4</code>
+```console
+lucene index split T:\out T:\in -n 4
+```

--- a/src/dotnet/tools/lucene-cli/docs/index/upgrade.md
+++ b/src/dotnet/tools/lucene-cli/docs/index/upgrade.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene index upgrade [\<INDEX_DIRECTORY>] [-d|--delete-prior-commits] [-v|--verbose] [-dir|--directory-type] [?|-h|--help]</code>
+```console
+lucene index upgrade [<INDEX_DIRECTORY>] [-d|--delete-prior-commits] [-v|--verbose] [-dir|--directory-type] [?|-h|--help]
+```
 
 ### Description
 
@@ -14,7 +16,8 @@ This tool keeps only the last commit in an index; for this reason, if the incomi
 
 Specify an FSDirectory implementation through the --directory-type option to force its use. If not qualified by an AssemblyName, the Lucene.Net.dll assembly will be used. 
 
-> **WARNING:** This tool may reorder document IDs! Be sure to make a backup of your index before you use this. Also, ensure you are using the correct version of this utility to match your application's version of Lucene.Net. This operation cannot be reversed.
+> [!WARNING]
+> This tool may reorder document IDs! Be sure to make a backup of your index before you use this. Also, ensure you are using the correct version of this utility to match your application's version of Lucene.NET. This operation cannot be reversed.
 
 ### Arguments
 
@@ -44,9 +47,13 @@ The `FSDirectory` implementation to use. Defaults to the optional `FSDirectory` 
 
 Upgrade the index format of the index located at `X:\lucene-index\` to the same version as this tool, using the `SimpleFSDirectory` implementation:
 
-<code>lucene index upgrade X:\lucene-index -dir SimpleFSDirectory</code>
+```console
+lucene index upgrade X:\lucene-index -dir SimpleFSDirectory
+```
 
 
 Upgrade the index located at `C:\indexes\category-index\` verbosely, deleting all but the last commit:
 
-<code>lucene index upgrade C:\indexes\category-index --verbose --delete-prior-commits</code>
+```console
+lucene index upgrade C:\indexes\category-index --verbose --delete-prior-commits
+```

--- a/src/dotnet/tools/lucene-cli/docs/lock/stress-test.md
+++ b/src/dotnet/tools/lucene-cli/docs/lock/stress-test.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene lock stress-test \<ID> \<VERIFIER_HOST> \<VERIFIER_PORT> \<LOCK_FACTORY_TYPE> \<LOCK_DIRECTORY> \<SLEEP_TIME_MS> \<TRIES> [?|-h|--help]</code>
+```console
+lucene lock stress-test <ID> <VERIFIER_HOST> <VERIFIER_PORT> <LOCK_FACTORY_TYPE> <LOCK_DIRECTORY> <SLEEP_TIME_MS> <TRIES> [?|-h|--help]
+```
 
 ### Description
 
@@ -52,4 +54,6 @@ Prints out a short help for the command.
 
 Run the client (stress test), connecting to the server on IP address `127.0.0.4` and port `54464` using the ID 3, the `NativeFSLockFactory`, specifying the lock directory as `F:\temp`, sleep for 50 milliseconds, and try to obtain a lock up to 10 times:
 
-<code>lucene lock stress-test 3 127.0.0.4 54464 NativeFSLockFactory F:\temp 50 10</code>
+```console
+lucene lock stress-test 3 127.0.0.4 54464 NativeFSLockFactory F:\temp 50 10
+```

--- a/src/dotnet/tools/lucene-cli/docs/lock/verify-server.md
+++ b/src/dotnet/tools/lucene-cli/docs/lock/verify-server.md
@@ -6,7 +6,9 @@
 
 ### Synopsis
 
-<code>lucene lock verify-server \<IP_HOSTNAME> \<MAX_CLIENTS> [?|-h|--help]</code>
+```console
+lucene lock verify-server <IP_HOSTNAME> <MAX_CLIENTS> [?|-h|--help]
+```
 
 ### Description
 
@@ -32,4 +34,6 @@ Prints out a short help for the command.
 
 Run the server on IP `127.0.0.4` with a 10 connected clients:
 
-<code>lucene lock verify-server 127.0.0.4 10</code>
+```console
+lucene lock verify-server 127.0.0.4 10
+```

--- a/websites/apidocs/index.md
+++ b/websites/apidocs/index.md
@@ -30,7 +30,7 @@ on some of the conceptual or inner details of Lucene:
 ## Reference Documents
 
 - [Changes](https://github.com/apache/lucenenet/releases/tag/<EnvVar:LuceneNetReleaseTag>): List of changes in this release.
-- System Requirements: Minimum and supported .NET versions. __TODO: Add link__
+<!-- - System Requirements: Minimum and supported .NET versions. LUCENENT TODO: Add link -->
 - [Migration Guide](xref:Lucene.Net.Migration.Guide): What changed in Lucene 4; how to migrate code from Lucene 3.x.
 - [File Formats](xref:Lucene.Net.Codecs.Lucene46) : Guide to the supported index format used by Lucene.  This can be customized by using [an alternate codec](xref:Lucene.Net.Codecs).
 - [Search and Scoring in Lucene](xref:Lucene.Net.Search): Introduction to how Lucene scores documents.
@@ -43,7 +43,7 @@ on some of the conceptual or inner details of Lucene:
 - <xref:Lucene.Net.Analysis.Common> - Analyzers for indexing content in different languages and domains
 - [Lucene.Net.Analysis.Kuromoji](xref:Lucene.Net.Analysis.Ja) - Japanese Morphological Analyzer
 - <xref:Lucene.Net.Analysis.Morfologik> - Analyzer for dictionary stemming, built-in Polish dictionary
-- <xref:Lucene.Net.Analysis.OpenNlp> - OpenNLP Library Integration
+- [Lucene.Net.Analysis.OpenNLP](xref:Lucene.Net.Analysis.OpenNlp) - OpenNLP Library Integration
 - <xref:Lucene.Net.Analysis.Phonetic> - Analyzer for indexing phonetic signatures (for sounds-alike search)
 - [Lucene.Net.Analysis.SmartCn](xref:Lucene.Net.Analysis.Cn.Smart) - Analyzer for indexing Chinese
 - <xref:Lucene.Net.Analysis.Stempel> - Analyzer for indexing Polish
@@ -53,7 +53,7 @@ on some of the conceptual or inner details of Lucene:
 - [Lucene.Net.Expressions](xref:Lucene.Net.Expressions) - Dynamically computed values to sort/facet/search on based on a pluggable grammar
 - [Lucene.Net.Facet](xref:Lucene.Net.Facet) - Faceted indexing and search capabilities
 - <xref:Lucene.Net.Grouping> - Collectors for grouping search results
-- <xref:Lucene.Net.Search.Highlight> - Highlights search keywords in results
+- <xref:Lucene.Net.Highlighter> - Highlights search keywords in results
 - <xref:Lucene.Net.ICU> - Specialized ICU (International Components for Unicode) Analyzers and Highlighters
 - <xref:Lucene.Net.Join> - Index-time and Query-time joins for normalized content
 - [Lucene.Net.Memory](xref:Lucene.Net.Index.Memory) - Single-document in-memory index implementation


### PR DESCRIPTION
See #284, #300.

Yet more code snippet, formatting, and link fixes. This clears up all but 33 of the documents to review in #284, focusing primarily on the most popular packages.

All that are left are:

- Lucene.Net.Benchmark
- Lucene.Net.Demo
- Lucene.Net.QueryParser
- Lucene.Net.Replicator

Note that benchmark and demo are blocked (and tracked) by #457, so we can close #284 after QueryParser and Replicator are done.
