### PR TITLE
Added Strong Name for Lucene.Net.Analysis.OpenNLP

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -70,7 +70,7 @@
     <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
     <NUnit3TestAdapterPackageVersion>3.17.0</NUnit3TestAdapterPackageVersion>
     <NUnitPackageVersion>3.13.1</NUnitPackageVersion>
-    <OpenNLPNETPackageVersion>1.9.1</OpenNLPNETPackageVersion>
+    <OpenNLPNETPackageVersion>1.9.1.1</OpenNLPNETPackageVersion>
     <SharpZipLibPackageVersion>1.1.0</SharpZipLibPackageVersion>
     <Spatial4nCorePackageVersion>0.4.1</Spatial4nCorePackageVersion>
     <Spatial4nCoreNTSPackageVersion>$(Spatial4nCorePackageVersion)</Spatial4nCoreNTSPackageVersion>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -35,11 +35,6 @@
     <RootNamespace>Lucene.Net.Analysis.OpenNlp</RootNamespace>
   </PropertyGroup>
 
-  <!-- OpenNLP is not strong-named -->
-  <PropertyGroup Label="Assembly Signing">
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\dotnet\Lucene.Net.ICU\Lucene.Net.ICU.csproj" />
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -32,11 +32,6 @@
 
     <IsPublishable>false</IsPublishable>
     <IsPublishable Condition=" '$(TargetFramework)' == 'net48' ">true</IsPublishable>
-  </PropertyGroup>
-
-  <!-- OpenNLP is not strong-named -->
-  <PropertyGroup Label="Assembly Signing">
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPSentenceBreakIterator.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPSentenceBreakIterator.cs
@@ -6,7 +6,7 @@ using Lucene.Net.Analysis.Util;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
-//using Assert = Lucene.Net.TestFramework.Assert;
+using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Analysis.OpenNlp
 {
@@ -239,16 +239,5 @@ namespace Lucene.Net.Analysis.OpenNlp
             assertEquals(BreakIterator.Done, bi.Next(13));
             assertEquals(BreakIterator.Done, bi.Next(-8));
         }
-
-        internal static void assertEquals(object expected, object actual)
-        {
-            Assert.AreEqual(expected, actual);
-        }
-
-        internal static void assertEquals(long expected, long actual)
-        {
-            Assert.AreEqual(expected, actual);
-        }
-
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPTokenizerFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPTokenizerFactory.cs
@@ -132,10 +132,5 @@ namespace Lucene.Net.Analysis.OpenNlp
             ts.SetReader(new StringReader(SENTENCES));
             AssertTokenStreamContents(ts, SENTENCES_punc);
         }
-
-        internal static void assertTrue(bool condition)
-        {
-            Assert.IsTrue(condition);
-        }
     }
 }


### PR DESCRIPTION
See: https://github.com/apache/lucenenet/issues/460#issuecomment-813392889

The [OpenNLP.NET assembly is now strong named](https://github.com/sergey-tihon/OpenNLP.NET/issues/6), so this updates the Lucene.Net.Analysis.OpenNLP to also be strong named. This takes care of some of the friction we have had with lack of `InternalsVisibleTo` support.

