### PR TITLE
Fix for SimpleTextStoredFieldsWriter.Abort() and SimpleTextTermVectorsWriter.Abort() to correctly swallow Dispose() exceptions

### DIFF
--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsWriter.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsWriter.cs
@@ -192,11 +192,11 @@ namespace Lucene.Net.Codecs.SimpleText
             {
                 Dispose();
             }
-            finally
+            catch // ignored
             {
-                IOUtils.DeleteFilesIgnoringExceptions(_directory,
-                    IndexFileNames.SegmentFileName(_segment, "", FIELDS_EXTENSION));
             }
+            IOUtils.DeleteFilesIgnoringExceptions(_directory,
+                    IndexFileNames.SegmentFileName(_segment, "", FIELDS_EXTENSION));
         }
 
         public override void Finish(FieldInfos fis, int numDocs)

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsWriter.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsWriter.cs
@@ -183,12 +183,11 @@ namespace Lucene.Net.Codecs.SimpleText
             {
                 Dispose();
             }
-            finally
+            catch // ignored
             {
-
-                IOUtils.DeleteFilesIgnoringExceptions(_directory,
-                    IndexFileNames.SegmentFileName(_segment, "", VECTORS_EXTENSION));
             }
+            IOUtils.DeleteFilesIgnoringExceptions(_directory,
+                    IndexFileNames.SegmentFileName(_segment, "", VECTORS_EXTENSION));
         }
 
         public override void Finish(FieldInfos fis, int numDocs)


### PR DESCRIPTION
This is to sync with the correct Lucene 4.8.0 behavior.