### PR TITLE
Fix for code analyzer support on Visual Studio 2017 (fixes #394)

### DIFF
--- a/Lucene.Net.sln
+++ b/Lucene.Net.sln
@@ -205,6 +205,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lucene.Net.CodeAnalysis.VisualBasic", "src\dotnet\Lucene.Net.CodeAnalysis.VisualBasic\Lucene.Net.CodeAnalysis.VisualBasic.csproj", "{5CD4D4E8-6132-4384-98FC-6AB1C97E0B80}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Lucene.Net.CodeAnalysis", "Lucene.Net.CodeAnalysis", "{E5E8C5DC-7048-4818-B884-FB2D037D2EF2}"
+	ProjectSection(SolutionItems) = preProject
+		src\dotnet\Lucene.Net.CodeAnalysis\Version.props = src\dotnet\Lucene.Net.CodeAnalysis\Version.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{4D0ED7D9-ABEE-4890-B06C-477E3A32B9A0}"
 	ProjectSection(SolutionItems) = preProject

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -43,8 +43,10 @@
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.0.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
     <MicrosoftAspNetCoreTestHostPackageVersion>2.0.0</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftCodeAnalysisAnalyzersPackageVersion>2.9.8</MicrosoftCodeAnalysisAnalyzersPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.4.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>3.4.0</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>2.6.1</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicPackageVersion>2.6.1</MicrosoftCodeAnalysisVisualBasicPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>$(MicrosoftCodeAnalysisVisualBasicPackageVersion)</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
     <MicrosoftExtensionsConfigurationPackageVersion_NET4_5_1>1.1.2</MicrosoftExtensionsConfigurationPackageVersion_NET4_5_1>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion_NET4_5_1>$(MicrosoftExtensionsConfigurationPackageVersion_NET4_5_1)</MicrosoftExtensionsConfigurationAbstractionsPackageVersion_NET4_5_1>
     <MicrosoftExtensionsConfigurationCommandLinePackageVersion_NET4_5_1>$(MicrosoftExtensionsConfigurationPackageVersion_NET4_5_1)</MicrosoftExtensionsConfigurationCommandLinePackageVersion_NET4_5_1>

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -36,8 +36,8 @@
   <PropertyGroup Label="NuGet Package File Paths">
     <LuceneNetDotNetDir>$(SolutionDir)src\dotnet\</LuceneNetDotNetDir>
     <LuceneNetCodeAnalysisToolsDir>$(LuceneNetDotNetDir)Lucene.Net.CodeAnalysis\tools\</LuceneNetCodeAnalysisToolsDir>
-    <LuceneNetCodeAnalysisCSAssemblyFile>$(LuceneNetDotNetDir)\Lucene.Net.CodeAnalysis.CSharp\bin\$(Configuration)\netstandard2.0\*.dll</LuceneNetCodeAnalysisCSAssemblyFile>
-    <LuceneNetCodeAnalysisVBAssemblyFile>$(LuceneNetDotNetDir)\Lucene.Net.CodeAnalysis.VisualBasic\bin\$(Configuration)\netstandard2.0\*.dll</LuceneNetCodeAnalysisVBAssemblyFile>
+    <LuceneNetCodeAnalysisCSAssemblyFile>$(LuceneNetDotNetDir)\Lucene.Net.CodeAnalysis.CSharp\bin\$(Configuration)\netstandard1.3\*.dll</LuceneNetCodeAnalysisCSAssemblyFile>
+    <LuceneNetCodeAnalysisVBAssemblyFile>$(LuceneNetDotNetDir)\Lucene.Net.CodeAnalysis.VisualBasic\bin\$(Configuration)\netstandard1.3\*.dll</LuceneNetCodeAnalysisVBAssemblyFile>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Package Files">

--- a/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene.Net.CodeAnalysis.CSharp.csproj
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene.Net.CodeAnalysis.CSharp.csproj
@@ -22,7 +22,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>

--- a/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene.Net.CodeAnalysis.CSharp.csproj
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene.Net.CodeAnalysis.CSharp.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -25,6 +25,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
+
+  <Import Project="..\Lucene.Net.CodeAnalysis\Version.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPackageVersion)" PrivateAssets="all" />

--- a/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene.Net.CodeAnalysis.VisualBasic.csproj
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene.Net.CodeAnalysis.VisualBasic.csproj
@@ -22,7 +22,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVisualBasicPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion)" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>

--- a/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene.Net.CodeAnalysis.VisualBasic.csproj
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene.Net.CodeAnalysis.VisualBasic.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -25,6 +25,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
+
+  <Import Project="..\Lucene.Net.CodeAnalysis\Version.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPackageVersion)" PrivateAssets="all" />

--- a/src/dotnet/Lucene.Net.CodeAnalysis/Version.props
+++ b/src/dotnet/Lucene.Net.CodeAnalysis/Version.props
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ ""License""); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ ""AS IS"" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<Project>
+  <PropertyGroup Label="Version Override Properties">
+    <!-- Visual Studio doesn't reload analyzers with changes if you don't manually bump the assembly version on each change to the
+         analyzer (or the install/uninstall scripts). See: https://github.com/dotnet/roslyn/issues/4381#issuecomment-342867710
+
+         IMPORTANT: Make sure you update the AssemblyVersionRevision number on every code change!
+     -->
+    <AssemblyVersionRevision>1</AssemblyVersionRevision>
+
+    <AssemblyMajorMinorPatchPattern>^\d+\.\d+\.\d+</AssemblyMajorMinorPatchPattern>
+    <AssemblyMajorMinorPatch>$([System.Text.RegularExpressions.Regex]::Match($(AssemblyVersion), $(AssemblyMajorMinorPatchPattern)))</AssemblyMajorMinorPatch>
+    
+    <AssemblyVersion>$(AssemblyMajorMinorPatch).$(AssemblyVersionRevision)</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/dotnet/Lucene.Net.CodeAnalysis/Version.props
+++ b/src/dotnet/Lucene.Net.CodeAnalysis/Version.props
@@ -20,9 +20,9 @@
     <!-- Visual Studio doesn't reload analyzers with changes if you don't manually bump the assembly version on each change to the
          analyzer (or the install/uninstall scripts). See: https://github.com/dotnet/roslyn/issues/4381#issuecomment-342867710
 
-         IMPORTANT: Make sure you update the AssemblyVersionRevision number on every code change!
+         IMPORTANT: Make sure you update the AssemblyVersionRevision number on every code/dependency/script change!
      -->
-    <AssemblyVersionRevision>1</AssemblyVersionRevision>
+    <AssemblyVersionRevision>10</AssemblyVersionRevision>
 
     <AssemblyMajorMinorPatchPattern>^\d+\.\d+\.\d+</AssemblyMajorMinorPatchPattern>
     <AssemblyMajorMinorPatch>$([System.Text.RegularExpressions.Regex]::Match($(AssemblyVersion), $(AssemblyMajorMinorPatchPattern)))</AssemblyMajorMinorPatch>

--- a/src/dotnet/Lucene.Net.Tests.CodeAnalysis/Lucene.Net.Tests.CodeAnalysis.csproj
+++ b/src/dotnet/Lucene.Net.Tests.CodeAnalysis/Lucene.Net.Tests.CodeAnalysis.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
Fixes #394.

This downgrades our code analyzers from .NET Standard 2.0 to .NET Standard 1.3 to fix analyzer loading issues in Visual Studio 2017 when referencing the `Lucene.Net` NuGet package.

![image](https://user-images.githubusercontent.com/1538288/114800897-cb9ac200-9dc4-11eb-8805-63fc6b088dc1.png)

It also downgrades `Microsoft.CodeAnalysis.CSharp.Workspaces` and `Microsoft.CodeAnalysis.VisualBasic.Workspaces` to 2.6.1 and adds direct dependencies on  `Microsoft.CodeAnalysis.CSharp` and `Microsoft.CodeAnalysis.VisualBasic`. There is an [unofficial guide that describes how this versioning works](https://roslyn-analyzers.readthedocs.io/en/latest/nuget-packages.html#nuget-packages), but this should add support for Visual Studio 15.6.1 and higher (previously it was 16.4.0 and higher).

The patch was confirmed to work on Visual Studio 15.9.29 as well as Visual Studio 16.8.2 in both C# and Visual Basic.

A `Version.props` file was also added so we can manually bump the binary version (version revision only) whenever a change is made, which is [a requirement of Visual Studio](https://github.com/dotnet/roslyn/issues/4381#issuecomment-342867710) to be able to reload an analyzer. This will prevent workarounds like https://github.com/apache/lucenenet/issues/286#issuecomment-663833490 from being necessary, and helps to ensure we are verifying the correct copy when debugging.

> NOTE: An attempt was made to detect the [Visual Studio version](https://docs.microsoft.com/en-us/dotnet/api/envdte._dte.version?redirectedfrom=MSDN&view=visualstudiosdk-2019#EnvDTE__DTE_Version) and disable installation of the analyzer using the `install.ps1` script, but it turns out that [scripting support in NuGet packages is now deprecated](https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks#content-files-and-powershell-scripts) and analyzers are now loaded by convention rather than with scripts. The scripts (which even Microsoft's NuGet-packaged analyzers ship with) are only for backward compatibility support with older VS versions and exit early to prevent double-installation from happening when convention-based support exists.

### References

- [Analyzer NuGet formats](https://docs.microsoft.com/en-us/nuget/guides/analyzers-conventions)
- [How to create a Roslyn Analyzer project for C#](https://roslyn-analyzers.readthedocs.io/en/latest/how-to-start.html#how-to-create-a-roslyn-analyzer-project-for-c) (unofficial guide to mult-targeting Visual Studio versions)
- [xunit.analyzers](https://github.com/xunit/xunit.analyzers/blob/main/src/xunit.analyzers/xunit.analyzers.csproj)
- [StyleCop.Analyzers](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/3c877565bcfeae0e737158d7c5a7092a87ef9186/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj)
- [Tutorial: Write your first analyzer and code fix](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix)