### PR TITLE
BREAKING: Changed Lucene.Net.Index.Term::Text() method into Text property

### DIFF
--- a/src/Lucene.Net.Highlighter/Highlight/QueryTermExtractor.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/QueryTermExtractor.cs
@@ -117,7 +117,7 @@ namespace Lucene.Net.Search.Highlight
                     {
                         if ((fieldName == null) || (term.Field.Equals(fieldName, StringComparison.Ordinal)))
                         {
-                            terms.Add(new WeightedTerm(query.Boost, term.Text()));
+                            terms.Add(new WeightedTerm(query.Boost, term.Text));
                         }
                     }
                 }

--- a/src/Lucene.Net.Highlighter/Highlight/WeightedSpanTermExtractor.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/WeightedSpanTermExtractor.cs
@@ -317,12 +317,12 @@ namespace Lucene.Net.Search.Highlight
             {
                 if (FieldNameComparer(queryTerm.Field))
                 {
-                    if (!terms.TryGetValue(queryTerm.Text(), out WeightedSpanTerm weightedSpanTerm) || weightedSpanTerm == null)
+                    if (!terms.TryGetValue(queryTerm.Text, out WeightedSpanTerm weightedSpanTerm) || weightedSpanTerm == null)
                     {
-                        weightedSpanTerm = new WeightedSpanTerm(spanQuery.Boost, queryTerm.Text());
+                        weightedSpanTerm = new WeightedSpanTerm(spanQuery.Boost, queryTerm.Text);
                         weightedSpanTerm.AddPositionSpans(spanPositions);
                         weightedSpanTerm.IsPositionSensitive = true;
-                        terms[queryTerm.Text()] = weightedSpanTerm;
+                        terms[queryTerm.Text] = weightedSpanTerm;
                     }
                     else
                     {
@@ -352,8 +352,8 @@ namespace Lucene.Net.Search.Highlight
 
                 if (FieldNameComparer(queryTerm.Field))
                 {
-                    WeightedSpanTerm weightedSpanTerm = new WeightedSpanTerm(query.Boost, queryTerm.Text());
-                    terms[queryTerm.Text()] = weightedSpanTerm;
+                    WeightedSpanTerm weightedSpanTerm = new WeightedSpanTerm(query.Boost, queryTerm.Text);
+                    terms[queryTerm.Text] = weightedSpanTerm;
                 }
             }
         }

--- a/src/Lucene.Net.Highlighter/PostingsHighlight/MultiTermHighlighting.cs
+++ b/src/Lucene.Net.Highlighter/PostingsHighlight/MultiTermHighlighting.cs
@@ -98,7 +98,7 @@ namespace Lucene.Net.Search.PostingsHighlight
                 if (prefix.Field.Equals(field, StringComparison.Ordinal))
                 {
                     list.Add(new CharacterRunAutomatonToStringAnonymousClass(
-                        BasicOperations.Concatenate(BasicAutomata.MakeString(prefix.Text()), BasicAutomata.MakeAnyString()),
+                        BasicOperations.Concatenate(BasicAutomata.MakeString(prefix.Text), BasicAutomata.MakeAnyString()),
                         () => pq.ToString()));
                 }
             }
@@ -106,7 +106,7 @@ namespace Lucene.Net.Search.PostingsHighlight
             {
                 if (fq.Field.Equals(field, StringComparison.Ordinal))
                 {
-                    string utf16 = fq.Term.Text();
+                    string utf16 = fq.Term.Text;
                     int[] termText = new int[utf16.CodePointCount(0, utf16.Length)];
                     for (int cp, i = 0, j = 0; i < utf16.Length; i += Character.CharCount(cp))
                     {

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldQuery.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldQuery.cs
@@ -270,7 +270,7 @@ namespace Lucene.Net.Search.VectorHighlight
                 bool overlap = true;
                 for (int j = i; j < src.Length; j++)
                 {
-                    if ((j - i) < dest.Length && !src[j].Text().Equals(dest[j - i].Text(), StringComparison.Ordinal))
+                    if ((j - i) < dest.Length && !src[j].Text.Equals(dest[j - i].Text, StringComparison.Ordinal))
                     {
                         overlap = false;
                         break;
@@ -283,7 +283,7 @@ namespace Lucene.Net.Search.VectorHighlight
                         pq.Add(srcTerm);
                     for (int k = src.Length - i; k < dest.Length; k++)
                     {
-                        pq.Add(new Term(src[0].Field, dest[k].Text()));
+                        pq.Add(new Term(src[0].Field, dest[k].Text));
                     }
                     pq.Slop = slop;
                     pq.Boost = boost;
@@ -354,18 +354,18 @@ namespace Lucene.Net.Search.VectorHighlight
             {
                 ISet<string> termSet = GetTermSet(query);
                 if (query is TermQuery termQuery)
-                    termSet.Add(termQuery.Term.Text());
+                    termSet.Add(termQuery.Term.Text);
                 else if (query is PhraseQuery phraseQuery)
                 {
                     foreach (Term term in phraseQuery.GetTerms())
-                        termSet.Add(term.Text());
+                        termSet.Add(term.Text);
                 }
                 else if (query is MultiTermQuery && reader != null)
                 {
                     BooleanQuery mtqTerms = (BooleanQuery)query.Rewrite(reader);
                     foreach (BooleanClause clause in mtqTerms.GetClauses())
                     {
-                        termSet.Add(((TermQuery)clause.Query).Term.Text());
+                        termSet.Add(((TermQuery)clause.Query).Term.Text);
                     }
                 }
                 else
@@ -438,7 +438,7 @@ namespace Lucene.Net.Search.VectorHighlight
 
             internal void AddTerm(Term term, float boost)
             {
-                QueryPhraseMap map = GetOrNewMap(subMap, term.Text());
+                QueryPhraseMap map = GetOrNewMap(subMap, term.Text);
                 map.MarkTerminal(boost);
             }
 
@@ -465,7 +465,7 @@ namespace Lucene.Net.Search.VectorHighlight
                     QueryPhraseMap qpm = null;
                     foreach (Term term in terms)
                     {
-                        qpm = GetOrNewMap(map, term.Text());
+                        qpm = GetOrNewMap(map, term.Text);
                         map = qpm.subMap;
                     }
                     qpm.MarkTerminal(pq.Slop, pq.Boost);

--- a/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
+++ b/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Misc
         public static void TermInfo(Store.Directory dir, Term term)
         {
             IndexReader reader = DirectoryReader.Open(dir);
-            Console.WriteLine("{0}:{1} \t totalTF = {2:#,##0} \t doc freq = {3:#,##0} \n", term.Field, term.Text(), reader.TotalTermFreq(term), reader.DocFreq(term));
+            Console.WriteLine("{0}:{1} \t totalTF = {2:#,##0} \t doc freq = {3:#,##0} \n", term.Field, term.Text, reader.TotalTermFreq(term), reader.DocFreq(term));
         }
 
         // LUCENENET specific - our wrapper console shows the correct usage

--- a/src/Lucene.Net.Queries/TermFilter.cs
+++ b/src/Lucene.Net.Queries/TermFilter.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Queries
 
         public override string ToString()
         {
-            return term.Field + ":" + term.Text();
+            return term.Field + ":" + term.Text;
         }
     }
 }

--- a/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
@@ -579,7 +579,7 @@ namespace Lucene.Net.QueryParsers.Classic
         protected internal virtual Query NewFuzzyQuery(Term term, float minimumSimilarity, int prefixLength)
         {
             // FuzzyQuery doesn't yet allow constant score rewrite
-            string text = term.Text();
+            string text = term.Text;
 #pragma warning disable 612, 618
             int numEdits = FuzzyQuery.SingleToEdits(minimumSimilarity,
                 text.CodePointCount(0, text.Length));

--- a/src/Lucene.Net.Sandbox/Queries/SlowFuzzyQuery.cs
+++ b/src/Lucene.Net.Sandbox/Queries/SlowFuzzyQuery.cs
@@ -93,7 +93,7 @@ namespace Lucene.Net.Sandbox.Queries
 
             MultiTermRewriteMethod = new MultiTermQuery.TopTermsScoringBooleanQueryRewrite(maxExpansions);
 
-            string text = term.Text();
+            string text = term.Text;
             int len = text.CodePointCount(0, text.Length);
             if (len > 0 && (minimumSimilarity >= 1f || len > 1.0f / (1.0f - minimumSimilarity)))
             {
@@ -163,7 +163,7 @@ namespace Lucene.Net.Sandbox.Queries
                 buffer.Append(m_term.Field);
                 buffer.Append(":");
             }
-            buffer.Append(m_term.Text());
+            buffer.Append(m_term.Text);
             buffer.Append('~');
             buffer.Append(Number.ToString(minimumSimilarity));
             buffer.Append(ToStringUtils.Boost(Boost));

--- a/src/Lucene.Net.Suggest/Spell/DirectSpellChecker.cs
+++ b/src/Lucene.Net.Suggest/Spell/DirectSpellChecker.cs
@@ -322,7 +322,7 @@ namespace Lucene.Net.Search.Spell
             SuggestMode suggestMode, float accuracy)
         {
             CharsRef spare = new CharsRef();
-            string text = term.Text();
+            string text = term.Text;
             if (minQueryLength > 0 && text.CodePointCount(0, text.Length) < minQueryLength)
             {
                 return Arrays.Empty<SuggestWord>();
@@ -433,7 +433,7 @@ namespace Lucene.Net.Search.Spell
 
             var stQueue = new JCG.PriorityQueue<ScoreTerm>();
 
-            BytesRef queryTerm = new BytesRef(term.Text());
+            BytesRef queryTerm = new BytesRef(term.Text);
             BytesRef candidateTerm;
             ScoreTerm st = new ScoreTerm();
             IBoostAttribute boostAtt = e.Attributes.AddAttribute<IBoostAttribute>();
@@ -474,7 +474,7 @@ namespace Lucene.Net.Search.Spell
                 {
                     UnicodeUtil.UTF8toUTF16(candidateTerm, spare);
                     termAsString = spare.ToString();
-                    score = distance.GetDistance(term.Text(), termAsString);
+                    score = distance.GetDistance(term.Text, termAsString);
                 }
 
                 if (score < accuracy)

--- a/src/Lucene.Net.Suggest/Spell/WordBreakSpellChecker.cs
+++ b/src/Lucene.Net.Suggest/Spell/WordBreakSpellChecker.cs
@@ -182,7 +182,7 @@ namespace Lucene.Net.Search.Spell
                 {
                     continue;
                 }
-                string leftTermText = terms[i].Text();
+                string leftTermText = terms[i].Text;
                 int leftTermLength = leftTermText.CodePointCount(0, leftTermText.Length);
                 if (leftTermLength > maxCombineWordLength)
                 {
@@ -203,7 +203,7 @@ namespace Lucene.Net.Search.Spell
                     {
                         break;
                     }
-                    string rightTermText = terms[j].Text();
+                    string rightTermText = terms[j].Text;
                     int rightTermLength = rightTermText.CodePointCount(0, rightTermText.Length);
                     combinedTermText += rightTermText;
                     combinedLength += rightTermLength;
@@ -236,7 +236,7 @@ namespace Lucene.Net.Search.Spell
                                 SuggestWord word = new SuggestWord();
                                 word.Freq = combinedTermFreq;
                                 word.Score = origIndexes.Length - 1;
-                                word.String = combinedTerm.Text();
+                                word.String = combinedTerm.Text;
                                 CombineSuggestionWrapper suggestion = new CombineSuggestionWrapper(new CombineSuggestion(word, origIndexes), (origIndexes.Length - 1));
                                 suggestions.Enqueue(suggestion);
                                 if (suggestions.Count > maxSuggestions)
@@ -266,7 +266,7 @@ namespace Lucene.Net.Search.Spell
             SuggestWord[] prefix, JCG.PriorityQueue<SuggestWordArrayWrapper> suggestions, 
             int totalEvaluations, BreakSuggestionSortMethod sortMethod)
         {
-            string termText = term.Text();
+            string termText = term.Text;
             int termLength = termText.CodePointCount(0, termText.Length);
             int useMinBreakWordLength = minBreakWordLength;
             if (useMinBreakWordLength < 1)

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
@@ -120,7 +120,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
         private static void AddField(Document doc)
         {
-            doc.Add(new StringField(A.Field, A.Text(), Store.NO));
+            doc.Add(new StringField(A.Field, A.Text, Store.NO));
         }
 
         private static void AddFacets(Document doc, FacetsConfig config, bool updateTermExpectedCounts)

--- a/src/Lucene.Net.Tests.Misc/Index/TestMultiPassIndexSplitter.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/TestMultiPassIndexSplitter.cs
@@ -159,8 +159,8 @@ namespace Lucene.Net.Index
                     // make sure the deleted doc is not here
                     TermsEnum te = MultiFields.GetTerms(ir, "id").GetEnumerator();
                     Term t = new Term("id", (NUM_DOCS - 1) + "");
-                    assertEquals(TermsEnum.SeekStatus.NOT_FOUND, te.SeekCeil(new BytesRef(t.Text())));
-                    assertNotSame(t.Text(), te.Term.Utf8ToString());
+                    assertEquals(TermsEnum.SeekStatus.NOT_FOUND, te.SeekCeil(new BytesRef(t.Text)));
+                    assertNotSame(t.Text, te.Term.Utf8ToString());
                 }
             }
             finally

--- a/src/Lucene.Net.Tests.Queries/CommonTermsQueryTest.cs
+++ b/src/Lucene.Net.Tests.Queries/CommonTermsQueryTest.cs
@@ -618,7 +618,7 @@ namespace Lucene.Net.Tests.Queries
             protected override Query NewTermQuery(Term term, TermContext context)
             {
                 Query query = base.NewTermQuery(term, context);
-                if (term.Text().Equals(@"universe", StringComparison.Ordinal))
+                if (term.Text.Equals(@"universe", StringComparison.Ordinal))
                 {
                     query.Boost = 100f;
                 }

--- a/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
+++ b/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
@@ -96,12 +96,12 @@ namespace Lucene.Net.Tests.Queries.Mlt
             foreach (BooleanClause clause in clauses)
             {
                 TermQuery tq = (TermQuery)clause.Query;
-                float? termBoost = originalValues[tq.Term.Text()];
-                assertNotNull("Expected term " + tq.Term.Text(), termBoost);
+                float? termBoost = originalValues[tq.Term.Text];
+                assertNotNull("Expected term " + tq.Term.Text, termBoost);
 
                 float totalBoost = (float) (termBoost * boostFactor);
                 assertEquals("Expected boost of " + totalBoost + " for term '"
-                    + tq.Term.Text() + "' got " + tq.Boost, totalBoost, tq.Boost, 0.0001);
+                    + tq.Term.Text + "' got " + tq.Boost, totalBoost, tq.Boost, 0.0001);
             }
         }
         
@@ -123,7 +123,7 @@ namespace Lucene.Net.Tests.Queries.Mlt
                 foreach (BooleanClause clause in clauses)
                 {
                     TermQuery tq = (TermQuery)clause.Query;
-                    originalValues[tq.Term.Text()] = tq.Boost;
+                    originalValues[tq.Term.Text] = tq.Boost;
                 }
                 return originalValues;
             }

--- a/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
@@ -233,37 +233,37 @@ namespace Lucene.Net.QueryParsers.Classic
             TermQuery tq;
 
             tq = (TermQuery)qp.Parse("foo:zoo*");
-            assertEquals("zoo", tq.Term.Text());
+            assertEquals("zoo", tq.Term.Text);
             assertEquals(2, qp.type[0]);
 
             tq = (TermQuery)qp.Parse("foo:zoo*^2");
-            assertEquals("zoo", tq.Term.Text());
+            assertEquals("zoo", tq.Term.Text);
             assertEquals(2, qp.type[0]);
             assertEquals(tq.Boost, 2, 0);
 
             tq = (TermQuery)qp.Parse("foo:*");
-            assertEquals("*", tq.Term.Text());
+            assertEquals("*", tq.Term.Text);
             assertEquals(1, qp.type[0]); // could be a valid prefix query in the future too
 
             tq = (TermQuery)qp.Parse("foo:*^2");
-            assertEquals("*", tq.Term.Text());
+            assertEquals("*", tq.Term.Text);
             assertEquals(1, qp.type[0]);
             assertEquals(tq.Boost, 2, 0);
 
             tq = (TermQuery)qp.Parse("*:foo");
             assertEquals("*", tq.Term.Field);
-            assertEquals("foo", tq.Term.Text());
+            assertEquals("foo", tq.Term.Text);
             assertEquals(3, qp.type[0]);
 
             tq = (TermQuery)qp.Parse("*:*");
             assertEquals("*", tq.Term.Field);
-            assertEquals("*", tq.Term.Text());
+            assertEquals("*", tq.Term.Text);
             assertEquals(1, qp.type[0]); // could be handled as a prefix query in the
             // future
 
             tq = (TermQuery)qp.Parse("(*:*)");
             assertEquals("*", tq.Term.Field);
-            assertEquals("*", tq.Term.Text());
+            assertEquals("*", tq.Term.Text);
             assertEquals(1, qp.type[0]);
         }
 

--- a/src/Lucene.Net.Tests.QueryParser/Ext/TestExtendableQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Ext/TestExtendableQueryParser.cs
@@ -87,7 +87,7 @@ namespace Lucene.Net.QueryParsers.Ext
                 TermQuery tquery = (TermQuery)query;
                 assertEquals("aField", tquery.Term
                     .Field);
-                assertEquals("foo", tquery.Term.Text());
+                assertEquals("foo", tquery.Term.Text);
 
                 booleanClause = clauses[1];
                 query = booleanClause.Query;
@@ -95,7 +95,7 @@ namespace Lucene.Net.QueryParsers.Ext
                     query is TermQuery);
                 tquery = (TermQuery)query;
                 assertEquals(DefaultField, tquery.Term.Field);
-                assertEquals("bar", tquery.Term.Text());
+                assertEquals("bar", tquery.Term.Text);
             }
         }
 
@@ -114,7 +114,7 @@ namespace Lucene.Net.QueryParsers.Ext
                     parse is TermQuery);
                 TermQuery tquery = (TermQuery)parse;
                 assertEquals(DefaultField, tquery.Term.Field);
-                assertEquals("foo & bar", tquery.Term.Text());
+                assertEquals("foo & bar", tquery.Term.Text);
             }
         }
 
@@ -138,7 +138,7 @@ namespace Lucene.Net.QueryParsers.Ext
                     parse is TermQuery);
                 TermQuery tquery = (TermQuery)parse;
                 assertEquals("afield", tquery.Term.Field);
-                assertEquals("foo & bar", tquery.Term.Text());
+                assertEquals("foo & bar", tquery.Term.Text);
             }
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene3x/TestSurrogates.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene3x/TestSurrogates.cs
@@ -1,4 +1,4 @@
-using J2N.Text;
+﻿using J2N.Text;
 using Lucene.Net.Analysis;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
@@ -78,7 +78,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         private static string ToHexString(Term t)
         {
-            return t.Field + ":" + UnicodeUtil.ToHexString(t.Text());
+            return t.Field + ":" + UnicodeUtil.ToHexString(t.Text);
         }
 
         private string GetRandomString(Random r)
@@ -148,7 +148,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                         if (Verbose)
                         {
                             Console.WriteLine("  got term=" + field + ":" + UnicodeUtil.ToHexString(text.Utf8ToString()));
-                            Console.WriteLine("       exp=" + exp.Field + ":" + UnicodeUtil.ToHexString(exp.Text()));
+                            Console.WriteLine("       exp=" + exp.Field + ":" + UnicodeUtil.ToHexString(exp.Text));
                             Console.WriteLine();
                         }
                         if (lastText == null)
@@ -195,7 +195,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                 if (Verbose)
                 {
-                    Console.WriteLine("TEST: exist seek field=" + field + " term=" + UnicodeUtil.ToHexString(term.Text()));
+                    Console.WriteLine("TEST: exist seek field=" + field + " term=" + UnicodeUtil.ToHexString(term.Text));
                 }
 
                 // seek to it
@@ -239,7 +239,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                         if (Verbose)
                         {
                             Console.WriteLine("  got term=" + (t == null ? null : UnicodeUtil.ToHexString(t.Utf8ToString())));
-                            Console.WriteLine("       exp=" + UnicodeUtil.ToHexString(term.Text().ToString()));
+                            Console.WriteLine("       exp=" + UnicodeUtil.ToHexString(term.Text.ToString()));
                         }
 
                         Assert.AreEqual(term.Bytes, t);
@@ -271,7 +271,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                     {
                         if (Verbose)
                         {
-                            Console.WriteLine("TEST: non-exist seek to " + field + ":" + UnicodeUtil.ToHexString(tx.Text()));
+                            Console.WriteLine("TEST: non-exist seek to " + field + ":" + UnicodeUtil.ToHexString(tx.Text));
                         }
 
                         // term does not exist:
@@ -299,7 +299,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                             if (Verbose)
                             {
                                 Console.WriteLine("  got term=" + UnicodeUtil.ToHexString(te.Term.Utf8ToString()));
-                                Console.WriteLine("  exp term=" + UnicodeUtil.ToHexString(fieldTerms[spot].Text()));
+                                Console.WriteLine("  exp term=" + UnicodeUtil.ToHexString(fieldTerms[spot].Text));
                             }
 
                             Assert.AreEqual(fieldTerms[spot].Bytes, te.Term);
@@ -330,7 +330,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                                     if (Verbose)
                                     {
                                         Console.WriteLine("  got term=" + (t == null ? null : UnicodeUtil.ToHexString(t.Utf8ToString())));
-                                        Console.WriteLine("       exp=" + UnicodeUtil.ToHexString(term.Text().ToString()));
+                                        Console.WriteLine("       exp=" + UnicodeUtil.ToHexString(term.Text.ToString()));
                                     }
 
                                     Assert.AreEqual(term.Bytes, t);

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
@@ -350,7 +350,7 @@ namespace Lucene.Net.Index
 
         internal virtual void AssertTermDocsCount(string msg, IndexReader reader, Term term, int expected)
         {
-            DocsEnum tdocs = TestUtil.Docs(Random, reader, term.Field, new BytesRef(term.Text()), MultiFields.GetLiveDocs(reader), null, 0);
+            DocsEnum tdocs = TestUtil.Docs(Random, reader, term.Field, new BytesRef(term.Text), MultiFields.GetLiveDocs(reader), null, 0);
             int count = 0;
             if (tdocs != null)
             {

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -635,7 +635,7 @@ namespace Lucene.Net.Index
 
             // Make sure the doc that hit the exception was marked
             // as deleted:
-            DocsEnum tdocs = TestUtil.Docs(Random, reader, t.Field, new BytesRef(t.Text()), MultiFields.GetLiveDocs(reader), null, 0);
+            DocsEnum tdocs = TestUtil.Docs(Random, reader, t.Field, new BytesRef(t.Text), MultiFields.GetLiveDocs(reader), null, 0);
 
             int count = 0;
             while (tdocs.NextDoc() != DocIdSetIterator.NO_MORE_DOCS)

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Index
         public static int Count(Term t, IndexReader r)
         {
             int count = 0;
-            DocsEnum td = TestUtil.Docs(Random, r, t.Field, new BytesRef(t.Text()), MultiFields.GetLiveDocs(r), null, 0);
+            DocsEnum td = TestUtil.Docs(Random, r, t.Field, new BytesRef(t.Text), MultiFields.GetLiveDocs(r), null, 0);
 
             if (td != null)
             {

--- a/src/Lucene.Net.Tests/Index/TestMultiLevelSkipList.cs
+++ b/src/Lucene.Net.Tests/Index/TestMultiLevelSkipList.cs
@@ -1,4 +1,4 @@
-using J2N.Threading.Atomic;
+﻿using J2N.Threading.Atomic;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Documents;
@@ -87,7 +87,7 @@ namespace Lucene.Net.Index
             for (int i = 0; i < 5000; i++)
             {
                 Document d1 = new Document();
-                d1.Add(NewTextField(term.Field, term.Text(), Field.Store.NO));
+                d1.Add(NewTextField(term.Field, term.Text, Field.Store.NO));
                 writer.AddDocument(d1);
             }
             writer.Commit();

--- a/src/Lucene.Net.Tests/Index/TestPayloads.cs
+++ b/src/Lucene.Net.Tests/Index/TestPayloads.cs
@@ -154,7 +154,7 @@ namespace Lucene.Net.Index
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < terms.Length; i++)
             {
-                sb.Append(terms[i].Text());
+                sb.Append(terms[i].Text);
                 sb.Append(" ");
             }
             string content = sb.ToString();
@@ -200,7 +200,7 @@ namespace Lucene.Net.Index
             var tps = new DocsAndPositionsEnum[numTerms];
             for (int i = 0; i < numTerms; i++)
             {
-                tps[i] = MultiFields.GetTermPositionsEnum(reader, MultiFields.GetLiveDocs(reader), terms[i].Field, new BytesRef(terms[i].Text()));
+                tps[i] = MultiFields.GetTermPositionsEnum(reader, MultiFields.GetLiveDocs(reader), terms[i].Field, new BytesRef(terms[i].Text));
             }
 
             while (tps[0].NextDoc() != DocIdSetIterator.NO_MORE_DOCS)
@@ -231,7 +231,7 @@ namespace Lucene.Net.Index
             /*
              *  test lazy skipping
              */
-            DocsAndPositionsEnum tp = MultiFields.GetTermPositionsEnum(reader, MultiFields.GetLiveDocs(reader), terms[0].Field, new BytesRef(terms[0].Text()));
+            DocsAndPositionsEnum tp = MultiFields.GetTermPositionsEnum(reader, MultiFields.GetLiveDocs(reader), terms[0].Field, new BytesRef(terms[0].Text));
             tp.NextDoc();
             tp.NextPosition();
             // NOTE: prior rev of this test was failing to first
@@ -255,7 +255,7 @@ namespace Lucene.Net.Index
             /*
              * Test different lengths at skip points
              */
-            tp = MultiFields.GetTermPositionsEnum(reader, MultiFields.GetLiveDocs(reader), terms[1].Field, new BytesRef(terms[1].Text()));
+            tp = MultiFields.GetTermPositionsEnum(reader, MultiFields.GetLiveDocs(reader), terms[1].Field, new BytesRef(terms[1].Text));
             tp.NextDoc();
             tp.NextPosition();
             Assert.AreEqual(1, tp.GetPayload().Length, "Wrong payload length.");

--- a/src/Lucene.Net.Tests/Index/TestPerSegmentDeletes.cs
+++ b/src/Lucene.Net.Tests/Index/TestPerSegmentDeletes.cs
@@ -249,7 +249,7 @@ namespace Lucene.Net.Index
             Fields fields = MultiFields.GetFields(reader);
             Terms cterms = fields.GetTerms(term.Field);
             TermsEnum ctermsEnum = cterms.GetEnumerator();
-            if (ctermsEnum.SeekExact(new BytesRef(term.Text())))
+            if (ctermsEnum.SeekExact(new BytesRef(term.Text)))
             {
                 DocsEnum docsEnum = TestUtil.Docs(Random, ctermsEnum, bits, null, DocsFlags.NONE);
                 return ToArray(docsEnum);

--- a/src/Lucene.Net.Tests/Index/TestSegmentTermDocs.cs
+++ b/src/Lucene.Net.Tests/Index/TestSegmentTermDocs.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using Assert = Lucene.Net.TestFramework.Assert;
@@ -149,7 +149,7 @@ namespace Lucene.Net.Index
 
             IndexReader reader = DirectoryReader.Open(dir, indexDivisor);
 
-            DocsEnum tdocs = TestUtil.Docs(Random, reader, ta.Field, new BytesRef(ta.Text()), MultiFields.GetLiveDocs(reader), null, DocsFlags.FREQS);
+            DocsEnum tdocs = TestUtil.Docs(Random, reader, ta.Field, new BytesRef(ta.Text), MultiFields.GetLiveDocs(reader), null, DocsFlags.FREQS);
 
             // without optimization (assumption skipInterval == 16)
 
@@ -169,7 +169,7 @@ namespace Lucene.Net.Index
             Assert.IsFalse(tdocs.Advance(10) != DocIdSetIterator.NO_MORE_DOCS);
 
             // without next
-            tdocs = TestUtil.Docs(Random, reader, ta.Field, new BytesRef(ta.Text()), MultiFields.GetLiveDocs(reader), null, 0);
+            tdocs = TestUtil.Docs(Random, reader, ta.Field, new BytesRef(ta.Text), MultiFields.GetLiveDocs(reader), null, 0);
 
             Assert.IsTrue(tdocs.Advance(0) != DocIdSetIterator.NO_MORE_DOCS);
             Assert.AreEqual(0, tdocs.DocID);
@@ -182,7 +182,7 @@ namespace Lucene.Net.Index
             // exactly skipInterval documents and therefore with optimization
 
             // with next
-            tdocs = TestUtil.Docs(Random, reader, tb.Field, new BytesRef(tb.Text()), MultiFields.GetLiveDocs(reader), null, DocsFlags.FREQS);
+            tdocs = TestUtil.Docs(Random, reader, tb.Field, new BytesRef(tb.Text), MultiFields.GetLiveDocs(reader), null, DocsFlags.FREQS);
 
             Assert.IsTrue(tdocs.NextDoc() != DocIdSetIterator.NO_MORE_DOCS);
             Assert.AreEqual(10, tdocs.DocID);
@@ -201,7 +201,7 @@ namespace Lucene.Net.Index
             Assert.IsFalse(tdocs.Advance(26) != DocIdSetIterator.NO_MORE_DOCS);
 
             // without next
-            tdocs = TestUtil.Docs(Random, reader, tb.Field, new BytesRef(tb.Text()), MultiFields.GetLiveDocs(reader), null, DocsFlags.FREQS);
+            tdocs = TestUtil.Docs(Random, reader, tb.Field, new BytesRef(tb.Text), MultiFields.GetLiveDocs(reader), null, DocsFlags.FREQS);
 
             Assert.IsTrue(tdocs.Advance(5) != DocIdSetIterator.NO_MORE_DOCS);
             Assert.AreEqual(10, tdocs.DocID);
@@ -216,7 +216,7 @@ namespace Lucene.Net.Index
             // much more than skipInterval documents and therefore with optimization
 
             // with next
-            tdocs = TestUtil.Docs(Random, reader, tc.Field, new BytesRef(tc.Text()), MultiFields.GetLiveDocs(reader), null, DocsFlags.FREQS);
+            tdocs = TestUtil.Docs(Random, reader, tc.Field, new BytesRef(tc.Text), MultiFields.GetLiveDocs(reader), null, DocsFlags.FREQS);
 
             Assert.IsTrue(tdocs.NextDoc() != DocIdSetIterator.NO_MORE_DOCS);
             Assert.AreEqual(26, tdocs.DocID);
@@ -237,7 +237,7 @@ namespace Lucene.Net.Index
             Assert.IsFalse(tdocs.Advance(76) != DocIdSetIterator.NO_MORE_DOCS);
 
             //without next
-            tdocs = TestUtil.Docs(Random, reader, tc.Field, new BytesRef(tc.Text()), MultiFields.GetLiveDocs(reader), null, 0);
+            tdocs = TestUtil.Docs(Random, reader, tc.Field, new BytesRef(tc.Text), MultiFields.GetLiveDocs(reader), null, 0);
             Assert.IsTrue(tdocs.Advance(5) != DocIdSetIterator.NO_MORE_DOCS);
             Assert.AreEqual(26, tdocs.DocID);
             Assert.IsTrue(tdocs.Advance(40) != DocIdSetIterator.NO_MORE_DOCS);

--- a/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using NUnit.Framework;
 using System;
 using System.Diagnostics;
@@ -190,7 +190,7 @@ namespace Lucene.Net.Search
             foreach (BooleanClause clause in bq.Clauses)
             {
                 TermQuery mtq = (TermQuery)clause.Query;
-                Assert.AreEqual(Convert.ToSingle(mtq.Term.Text()), mtq.Boost, 0, "Parallel sorting of boosts in rewrite mode broken");
+                Assert.AreEqual(Convert.ToSingle(mtq.Term.Text), mtq.Boost, 0, "Parallel sorting of boosts in rewrite mode broken");
             }
         }
 

--- a/src/Lucene.Net.Tests/Search/TestRegexpRandom2.cs
+++ b/src/Lucene.Net.Tests/Search/TestRegexpRandom2.cs
@@ -116,7 +116,7 @@ namespace Lucene.Net.Search
             internal DumbRegexpQuery(Term term, RegExpSyntax flags)
                 : base(term.Field)
             {
-                RegExp re = new RegExp(term.Text(), flags);
+                RegExp re = new RegExp(term.Text, flags);
                 automaton = re.ToAutomaton();
             }
 

--- a/src/Lucene.Net.Tests/Search/TestScorerPerf.cs
+++ b/src/Lucene.Net.Tests/Search/TestScorerPerf.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Search
                 {
                     if (Random.Next(freq[j]) == 0)
                     {
-                        d.Add(NewStringField("f", terms[j].Text(), Field.Store.NO));
+                        d.Add(NewStringField("f", terms[j].Text, Field.Store.NO));
                         //System.out.println(d);
                     }
                 }

--- a/src/Lucene.Net.Tests/Search/TestTermRangeQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestTermRangeQuery.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Analysis;
+﻿using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
@@ -169,7 +169,7 @@ namespace Lucene.Net.Search
             {
                 Assert.IsTrue(c.Query is TermQuery);
                 TermQuery tq = (TermQuery)c.Query;
-                string term = tq.Term.Text();
+                string term = tq.Term.Text;
                 Assert.IsTrue(allowedTerms.Contains(term), "invalid term: " + term);
                 allowedTerms.Remove(term); // remove to fail on double terms
             }

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
@@ -1,4 +1,4 @@
-using J2N.Text;
+﻿using J2N.Text;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Util;
@@ -358,7 +358,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                 if (DEBUG_SURROGATES)
                 {
-                    Console.WriteLine("      got term=" + UnicodeUtil.ToHexString(t2.Text()));
+                    Console.WriteLine("      got term=" + UnicodeUtil.ToHexString(t2.Text));
                 }
 
                 // Now test if prefix is identical and we found
@@ -497,7 +497,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                     {
                         if (DEBUG_SURROGATES)
                         {
-                            Console.WriteLine("      got term=" + UnicodeUtil.ToHexString(t2.Text()) + " " + t2.Bytes);
+                            Console.WriteLine("      got term=" + UnicodeUtil.ToHexString(t2.Text) + " " + t2.Bytes);
                         }
 
                         BytesRef b2 = t2.Bytes;
@@ -696,7 +696,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                             }
                             else
                             {
-                                Console.WriteLine($"      hit term={UnicodeUtil.ToHexString(t2.Text())} {t2?.Bytes}");
+                                Console.WriteLine($"      hit term={UnicodeUtil.ToHexString(t2.Text)} {t2?.Bytes}");
                             }
                         }
 
@@ -908,7 +908,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                     if (DEBUG_SURROGATES)
                     {
-                        Console.WriteLine("  seek hit non-exact term=" + UnicodeUtil.ToHexString(t.Text()));
+                        Console.WriteLine("  seek hit non-exact term=" + UnicodeUtil.ToHexString(t.Text));
                     }
 
                     BytesRef br = t.Bytes;

--- a/src/Lucene.Net/Codecs/Lucene3x/TermInfosReaderIndex.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/TermInfosReaderIndex.cs
@@ -92,7 +92,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                 TermInfo termInfo = indexEnum.TermInfo();
                 indexToTerms.Set(i, dataOutput.GetPosition());
                 dataOutput.WriteVInt32(fieldCounter);
-                dataOutput.WriteString(term.Text());
+                dataOutput.WriteString(term.Text);
                 dataOutput.WriteVInt32(termInfo.DocFreq);
                 if (termInfo.DocFreq >= skipInterval)
                 {

--- a/src/Lucene.Net/Index/Term.cs
+++ b/src/Lucene.Net/Index/Term.cs
@@ -84,10 +84,7 @@ namespace Lucene.Net.Index
         /// text of the word.  In the case of dates and other types, this is an
         /// encoding of the object as a string.
         /// </summary>
-        public string Text() // LUCENENET TODO: API - Change to a property. While this calls a method internally, its expected usage is that it will return a deterministic value.
-        {
-            return ToString(Bytes);
-        }
+        public string Text => ToString(Bytes); // LUCENENET: Changed to a property. While this calls a method internally, its expected usage is that it will return a deterministic value.
 
         /// <summary>
         /// Returns human-readable form of the term text. If the term is not unicode,
@@ -193,7 +190,7 @@ namespace Lucene.Net.Index
 
         public override string ToString()
         {
-            return Field + ":" + Text();
+            return Field + ":" + Text;
         }
     }
 }

--- a/src/Lucene.Net/Search/FuzzyQuery.cs
+++ b/src/Lucene.Net/Search/FuzzyQuery.cs
@@ -148,7 +148,7 @@ namespace Lucene.Net.Search
 
         protected override TermsEnum GetTermsEnum(Terms terms, AttributeSource atts)
         {
-            if (maxEdits == 0 || prefixLength >= term.Text().Length) // can only match if it's exact
+            if (maxEdits == 0 || prefixLength >= term.Text.Length) // can only match if it's exact
             {
                 return new SingleTermsEnum(terms.GetEnumerator(), term.Bytes);
             }
@@ -168,7 +168,7 @@ namespace Lucene.Net.Search
                 buffer.Append(term.Field);
                 buffer.Append(":");
             }
-            buffer.Append(term.Text());
+            buffer.Append(term.Text);
             buffer.Append('~');
             buffer.Append(Convert.ToString(maxEdits));
             buffer.Append(ToStringUtils.Boost(Boost));

--- a/src/Lucene.Net/Search/FuzzyTermsEnum.cs
+++ b/src/Lucene.Net/Search/FuzzyTermsEnum.cs
@@ -124,7 +124,7 @@ namespace Lucene.Net.Search
             this.term = term;
 
             // convert the string into a utf32 int[] representation for fast comparisons
-            string utf16 = term.Text();
+            string utf16 = term.Text;
             this.m_termText = new int[utf16.CodePointCount(0, utf16.Length)];
             for (int cp, i = 0, j = 0; i < utf16.Length; i += Character.CharCount(cp))
             {
@@ -375,7 +375,7 @@ namespace Lucene.Net.Search
                 {
                     this.matchers[i] = compiled[i].RunAutomaton;
                 }
-                termRef = new BytesRef(outerInstance.term.Text());
+                termRef = new BytesRef(outerInstance.term.Text);
             }
 
             /// <summary>

--- a/src/Lucene.Net/Search/MultiPhraseQuery.cs
+++ b/src/Lucene.Net/Search/MultiPhraseQuery.cs
@@ -285,7 +285,7 @@ namespace Lucene.Net.Search
                         {
                             // term does exist, but has no positions
                             if (Debugging.AssertsEnabled) Debugging.Assert(termsEnum.Docs(liveDocs, null, DocsFlags.NONE) != null, "termstate found but no term exists in reader");
-                            throw IllegalStateException.Create("field \"" + term.Field + "\" was indexed without position data; cannot run PhraseQuery (term=" + term.Text() + ")");
+                            throw IllegalStateException.Create("field \"" + term.Field + "\" was indexed without position data; cannot run PhraseQuery (term=" + term.Text + ")");
                         }
 
                         docFreq = termsEnum.DocFreq;
@@ -407,7 +407,7 @@ namespace Lucene.Net.Search
                     buffer.Append("(");
                     for (int j = 0; j < terms.Length; j++)
                     {
-                        buffer.Append(terms[j].Text());
+                        buffer.Append(terms[j].Text);
                         if (j < terms.Length - 1)
                         {
                             buffer.Append(" ");
@@ -417,7 +417,7 @@ namespace Lucene.Net.Search
                 }
                 else
                 {
-                    buffer.Append(terms[0].Text());
+                    buffer.Append(terms[0].Text);
                 }
                 lastPos = position;
                 ++k;
@@ -621,7 +621,7 @@ namespace Lucene.Net.Search
                 if (postings == null)
                 {
                     // term does exist, but has no positions
-                    throw IllegalStateException.Create("field \"" + term.Field + "\" was indexed without position data; cannot run PhraseQuery (term=" + term.Text() + ")");
+                    throw IllegalStateException.Create("field \"" + term.Field + "\" was indexed without position data; cannot run PhraseQuery (term=" + term.Text + ")");
                 }
                 _cost += postings.GetCost();
                 docsEnums.Add(postings);

--- a/src/Lucene.Net/Search/PhraseQuery.cs
+++ b/src/Lucene.Net/Search/PhraseQuery.cs
@@ -369,7 +369,7 @@ namespace Lucene.Net.Search
                     {
                         if (Debugging.AssertsEnabled) Debugging.Assert(te.SeekExact(t.Bytes), "termstate found but no term exists in reader");
                         // term does exist, but has no positions
-                        throw IllegalStateException.Create("field \"" + t.Field + "\" was indexed without position data; cannot run PhraseQuery (term=" + t.Text() + ")");
+                        throw IllegalStateException.Create("field \"" + t.Field + "\" was indexed without position data; cannot run PhraseQuery (term=" + t.Text + ")");
                     }
                     postingsFreqs[i] = new PostingsAndFreq(postingsEnum, te.DocFreq, (int)outerInstance.positions[i], t);
                 }
@@ -458,11 +458,11 @@ namespace Lucene.Net.Search
                 string s = pieces[pos];
                 if (s == null)
                 {
-                    s = (terms[i]).Text();
+                    s = terms[i].Text;
                 }
                 else
                 {
-                    s = s + "|" + (terms[i]).Text();
+                    s = s + "|" + terms[i].Text;
                 }
                 pieces[pos] = s;
             }

--- a/src/Lucene.Net/Search/PrefixQuery.cs
+++ b/src/Lucene.Net/Search/PrefixQuery.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 
 namespace Lucene.Net.Search
@@ -72,7 +72,7 @@ namespace Lucene.Net.Search
                 buffer.Append(Field);
                 buffer.Append(":");
             }
-            buffer.Append(_prefix.Text());
+            buffer.Append(_prefix.Text);
             buffer.Append('*');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();

--- a/src/Lucene.Net/Search/RegexpQuery.cs
+++ b/src/Lucene.Net/Search/RegexpQuery.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Util.Automaton;
+﻿using Lucene.Net.Util.Automaton;
 using System;
 using System.Text;
 
@@ -93,7 +93,7 @@ namespace Lucene.Net.Search
         /// <param name="flags"> Optional <see cref="RegExp"/> features from <see cref="RegExpSyntax"/> </param>
         /// <param name="provider"> Custom <see cref="IAutomatonProvider"/> for named automata </param>
         public RegexpQuery(Term term, RegExpSyntax flags, IAutomatonProvider provider)
-            : base(term, (new RegExp(term.Text(), flags)).ToAutomaton(provider))
+            : base(term, (new RegExp(term.Text, flags)).ToAutomaton(provider))
         {
         }
 
@@ -108,7 +108,7 @@ namespace Lucene.Net.Search
                 buffer.Append(":");
             }
             buffer.Append('/');
-            buffer.Append(m_term.Text());
+            buffer.Append(m_term.Text);
             buffer.Append('/');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();

--- a/src/Lucene.Net/Search/Spans/SpanTermQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanTermQuery.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Index;
+﻿using Lucene.Net.Index;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -62,7 +62,7 @@ namespace Lucene.Net.Search.Spans
             StringBuilder buffer = new StringBuilder();
             if (m_term.Field.Equals(field, StringComparison.Ordinal))
             {
-                buffer.Append(m_term.Text());
+                buffer.Append(m_term.Text);
             }
             else
             {
@@ -164,7 +164,7 @@ namespace Lucene.Net.Search.Spans
             else
             {
                 // term does exist, but has no positions
-                throw IllegalStateException.Create("field \"" + m_term.Field + "\" was indexed without position data; cannot run SpanTermQuery (term=" + m_term.Text() + ")");
+                throw IllegalStateException.Create("field \"" + m_term.Field + "\" was indexed without position data; cannot run SpanTermQuery (term=" + m_term.Text + ")");
             }
         }
     }

--- a/src/Lucene.Net/Search/TermQuery.cs
+++ b/src/Lucene.Net/Search/TermQuery.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -219,7 +219,7 @@ namespace Lucene.Net.Search
                 buffer.Append(term.Field);
                 buffer.Append(":");
             }
-            buffer.Append(term.Text());
+            buffer.Append(term.Text);
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Search/WildcardQuery.cs
+++ b/src/Lucene.Net/Search/WildcardQuery.cs
@@ -1,4 +1,4 @@
-using J2N;
+﻿using J2N;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -73,7 +73,7 @@ namespace Lucene.Net.Search
         {
             IList<Automaton> automata = new List<Automaton>();
 
-            string wildcardText = wildcardquery.Text();
+            string wildcardText = wildcardquery.Text;
 
             for (int i = 0; i < wildcardText.Length; )
             {
@@ -124,7 +124,7 @@ namespace Lucene.Net.Search
                 buffer.Append(Field);
                 buffer.Append(":");
             }
-            buffer.Append(Term.Text());
+            buffer.Append(Term.Text);
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Support/ObsoleteAPI/TermExtensions.cs
+++ b/src/Lucene.Net/Support/ObsoleteAPI/TermExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace Lucene.Net.Index
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public static class TermExtensions
+    {
+        /// <summary>
+        /// Returns the text of this term.  In the case of words, this is simply the
+        /// text of the word.  In the case of dates and other types, this is an
+        /// encoding of the object as a string.
+        /// </summary>
+        [Obsolete("Use Text property instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static string Text(this Term term)
+        {
+            return term.Text;
+        }
+    }
+}


### PR DESCRIPTION
This changes `Text()` method into `Text` property for `Lucene.Net.Index.Term`.

It also adds an obsolete `Text()` extension method to the `Lucene.Net.Index` namespace for backward compatibility. This extension method will be removed in the first 4.8.0 release candidate. 

> NOTE: This is meant to be a best effort to reduce breaking changes, but of course the `Lucene.Net.Index` namespace may not be imported in your code. It is recommended to utilize the property rather than importing the namespace.