### PR TITLE
Changed Lucene.Net.Documents.FieldType::Freeze() to return a reference to this

### DIFF
--- a/src/Lucene.Net.Facet/FacetField.cs
+++ b/src/Lucene.Net.Facet/FacetField.cs
@@ -36,16 +36,11 @@ namespace Lucene.Net.Facet
     /// </summary>
     public class FacetField : Field
     {
-        internal static readonly FieldType TYPE = LoadType();
-        private static FieldType LoadType() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        internal static readonly FieldType TYPE = new FieldType
         {
-            var type = new FieldType
-            {
-                IsIndexed = true
-            };
-            type.Freeze();
-            return type;
-        }
+            IsIndexed = true
+        }.Freeze();
 
         /// <summary>
         /// Dimension for this field.

--- a/src/Lucene.Net.Facet/SortedSet/SortedSetDocValuesFacetField.cs
+++ b/src/Lucene.Net.Facet/SortedSet/SortedSetDocValuesFacetField.cs
@@ -30,16 +30,11 @@ namespace Lucene.Net.Facet.SortedSet
     {
         /// <summary>
         /// Indexed <see cref="FieldType"/>. </summary>
-        public static readonly FieldType TYPE = LoadType();
-        private static FieldType LoadType() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE = new FieldType
         {
-            var type = new FieldType
-            {
-                IsIndexed = true
-            };            
-            type.Freeze();
-            return type;
-        }
+            IsIndexed = true
+        }.Freeze();
 
         /// <summary>
         /// Dimension. </summary>

--- a/src/Lucene.Net.Facet/Taxonomy/AssociationFacetField.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/AssociationFacetField.cs
@@ -42,16 +42,11 @@ namespace Lucene.Net.Facet.Taxonomy
         /// <summary>
         /// Indexed <see cref="FieldType"/>.
         /// </summary>
-        public static readonly FieldType TYPE = LoadType();
-        private static FieldType LoadType() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE = new FieldType
         {
-            var type = new FieldType
-            {
-                IsIndexed = true
-            };
-            type.Freeze();
-            return type;
-        }
+            IsIndexed = true
+        }.Freeze();
 
         /// <summary>
         /// Dimension for this field.

--- a/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
+++ b/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
@@ -143,20 +143,14 @@ namespace Lucene.Net.Spatial.Prefix
         /// <summary>
         /// Indexed, tokenized, not stored.
         /// </summary>
-        public static readonly FieldType FIELD_TYPE = LoadFieldType();
-
-        private static FieldType LoadFieldType() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType FIELD_TYPE = new FieldType
         {
-            var fieldType = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY
-            };
-            fieldType.Freeze();
-            return fieldType;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY
+        }.Freeze();
 
         /// <summary>Outputs the tokenString of a cell, and if its a leaf, outputs it again with the leaf byte.</summary>
         internal sealed class CellTokenStream : TokenStream

--- a/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
@@ -1413,8 +1413,7 @@ namespace Lucene.Net.Index
                 {
                     continue;
                 }
-                var ft = new FieldType { IndexOptions = opts, IsIndexed = true, OmitNorms = true};
-                ft.Freeze();
+                var ft = new FieldType { IndexOptions = opts, IsIndexed = true, OmitNorms = true}.Freeze();
                 int numFields = Random.Next(5);
                 for (int j = 0; j < numFields; ++j)
                 {

--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -160,15 +160,13 @@ namespace Lucene.Net.Index
 
         protected virtual FieldType FieldType(Options options)
         {
-            var ft = new FieldType(TextField.TYPE_NOT_STORED)
+            return new FieldType(TextField.TYPE_NOT_STORED)
             {
                 StoreTermVectors = true,
                 StoreTermVectorPositions = (new OptionsWrapper(options)).positions,
                 StoreTermVectorOffsets = (new OptionsWrapper(options)).offsets,
                 StoreTermVectorPayloads = (new OptionsWrapper(options)).payloads
-            };
-            ft.Freeze();
-            return ft;
+            }.Freeze();
         }
 
         protected virtual BytesRef RandomPayload()

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
@@ -125,17 +125,9 @@ namespace Lucene.Net.Index.Sorter
         protected static readonly string SORTED_SET_DV_FIELD = "sorted_set";
         protected static readonly string TERM_VECTORS_FIELD = "term_vectors";
 
-        private static readonly FieldType TERM_VECTORS_TYPE = new FieldType(TextField.TYPE_NOT_STORED);
-        private static readonly FieldType POSITIONS_TYPE = new FieldType(TextField.TYPE_NOT_STORED);
-        static SorterTestBase()
-        {
-            TERM_VECTORS_TYPE.StoreTermVectors = true;
-            TERM_VECTORS_TYPE.Freeze();
-            POSITIONS_TYPE.IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS;
-            POSITIONS_TYPE.Freeze();
-        }
-
-
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        private static readonly FieldType TERM_VECTORS_TYPE = new FieldType(TextField.TYPE_NOT_STORED) { StoreTermVectors = true }.Freeze();
+        private static readonly FieldType POSITIONS_TYPE = new FieldType(TextField.TYPE_NOT_STORED) { IndexOptions = IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS }.Freeze();
 
 
         protected static Directory dir;

--- a/src/Lucene.Net.Tests/Support/Document/Extensions/TestDocumentExtensions.cs
+++ b/src/Lucene.Net.Tests/Support/Document/Extensions/TestDocumentExtensions.cs
@@ -128,8 +128,7 @@ namespace Lucene.Net.Documents.Extensions
                 IndexOptions = IndexOptions.DOCS_ONLY,
                 NumericType = NumericType.DOUBLE,
                 IsStored = true
-            };
-            fieldType.Freeze();
+            }.Freeze();
             AssertDocumentExtensionAddsToDocument(document => field = document.AddDoubleField("theName", value, fieldType));
             Assert.AreEqual("theName", field.Name);
             Assert.AreEqual(value, field.GetDoubleValueOrDefault(), 0.0000001d); // We don't really care about precision, just checking to see if the value got passed through
@@ -174,8 +173,7 @@ namespace Lucene.Net.Documents.Extensions
                 IndexOptions = IndexOptions.DOCS_ONLY,
                 NumericType = NumericType.SINGLE,
                 IsStored = true
-            };
-            fieldType.Freeze();
+            }.Freeze();
             AssertDocumentExtensionAddsToDocument(document => field = document.AddSingleField("theName", value, fieldType));
             Assert.AreEqual("theName", field.Name);
             Assert.AreEqual(value, field.GetSingleValueOrDefault(), 0.0000001f); // We don't really care about precision, just checking to see if the value got passed through
@@ -211,8 +209,7 @@ namespace Lucene.Net.Documents.Extensions
                 IndexOptions = IndexOptions.DOCS_ONLY,
                 NumericType = NumericType.INT32,
                 IsStored = true
-            };
-            fieldType.Freeze();
+            }.Freeze();
             AssertDocumentExtensionAddsToDocument(document => field = document.AddInt32Field("theName", value, fieldType));
             Assert.AreEqual("theName", field.Name);
             Assert.AreEqual(value, field.GetInt32ValueOrDefault());
@@ -248,8 +245,7 @@ namespace Lucene.Net.Documents.Extensions
                 IndexOptions = IndexOptions.DOCS_ONLY,
                 NumericType = NumericType.INT64,
                 IsStored = true
-            };
-            fieldType.Freeze();
+            }.Freeze();
             AssertDocumentExtensionAddsToDocument(document => field = document.AddInt64Field("theName", value, fieldType));
             Assert.AreEqual("theName", field.Name);
             Assert.AreEqual(value, field.GetInt64ValueOrDefault());

--- a/src/Lucene.Net/Document/BinaryDocValuesField.cs
+++ b/src/Lucene.Net/Document/BinaryDocValuesField.cs
@@ -42,13 +42,13 @@ namespace Lucene.Net.Documents
         /// <summary>
         /// Type for straight bytes <see cref="DocValues"/>.
         /// </summary>
-        public static readonly FieldType fType = new FieldType();
+        [Obsolete("Use TYPE instead. This field will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly FieldType fType = new FieldType() { DocValueType = DocValuesType.BINARY }.Freeze();
 
-        static BinaryDocValuesField()
-        {
-            fType.DocValueType = DocValuesType.BINARY;
-            fType.Freeze();
-        }
+        /// <summary>
+        /// Type for straight bytes <see cref="DocValues"/>.
+        /// </summary>
+        public static readonly FieldType TYPE = new FieldType() { DocValueType = DocValuesType.BINARY }.Freeze();
 
         /// <summary>
         /// Create a new binary <see cref="DocValues"/> field. </summary>
@@ -56,7 +56,7 @@ namespace Lucene.Net.Documents
         /// <param name="value"> binary content </param>
         /// <exception cref="ArgumentNullException"> if the field <paramref name="name"/> is <c>null</c>. </exception>
         public BinaryDocValuesField(string name, BytesRef value)
-            : base(name, fType)
+            : base(name, TYPE)
         {
             FieldsData = value;
         }

--- a/src/Lucene.Net/Document/DoubleField.cs
+++ b/src/Lucene.Net/Document/DoubleField.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Index;
+﻿using Lucene.Net.Index;
 using System;
 
 namespace Lucene.Net.Documents
@@ -114,42 +114,30 @@ namespace Lucene.Net.Documents
         /// Type for a <see cref="DoubleField"/> that is not stored:
         /// normalization factors, frequencies, and positions are omitted.
         /// </summary>
-        public static readonly FieldType TYPE_NOT_STORED = LoadTypeNotStored();
-
-        private static FieldType LoadTypeNotStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_NOT_STORED = new FieldType
         {
-            var typeNotStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                NumericType = Documents.NumericType.DOUBLE
-            };
-            typeNotStored.Freeze();
-            return typeNotStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            NumericType = Documents.NumericType.DOUBLE
+        }.Freeze();
 
         /// <summary>
         /// Type for a stored <see cref="DoubleField"/>:
         /// normalization factors, frequencies, and positions are omitted.
         /// </summary>
-        public static readonly FieldType TYPE_STORED = LoadTypeStored();
-
-        private static FieldType LoadTypeStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_STORED = new FieldType
         {
-            var typeStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                NumericType = Documents.NumericType.DOUBLE,
-                IsStored = true
-            };
-            typeStored.Freeze();
-            return typeStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            NumericType = Documents.NumericType.DOUBLE,
+            IsStored = true
+        }.Freeze();
 
         /// <summary>
         /// Creates a stored or un-stored <see cref="DoubleField"/> with the provided value

--- a/src/Lucene.Net/Document/FieldType.cs
+++ b/src/Lucene.Net/Document/FieldType.cs
@@ -82,9 +82,13 @@ namespace Lucene.Net.Documents
         /// the <see cref="FieldType"/>'s properties have been set, to prevent unintentional state
         /// changes.
         /// </summary>
-        public virtual void Freeze()
+        /// <returns><c>this</c></returns>
+        // LUCENENET specific - returing self to make it possible to chain this to newing up the class so we can set and freeze on a single line.
+        // This is especially important for static field initializers.
+        public virtual FieldType Freeze()
         {
             this.frozen = true;
+            return this;
         }
 
         /// <summary>

--- a/src/Lucene.Net/Document/FloatField.cs
+++ b/src/Lucene.Net/Document/FloatField.cs
@@ -118,42 +118,30 @@ namespace Lucene.Net.Documents
         /// Type for a <see cref="SingleField"/> that is not stored:
         /// normalization factors, frequencies, and positions are omitted.
         /// </summary>
-        public static readonly FieldType TYPE_NOT_STORED = LoadTypeNotStored();
-
-        private static FieldType LoadTypeNotStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_NOT_STORED = new FieldType
         {
-            var typeNotStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                NumericType = Documents.NumericType.SINGLE
-            };
-            typeNotStored.Freeze();
-            return typeNotStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            NumericType = Documents.NumericType.SINGLE
+        }.Freeze();
 
         /// <summary>
         /// Type for a stored <see cref="SingleField"/>:
         /// normalization factors, frequencies, and positions are omitted.
         /// </summary>
-        public static readonly FieldType TYPE_STORED = LoadTypeStored();
-
-        private static FieldType LoadTypeStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_STORED = new FieldType
         {
-            var typeStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                NumericType = Documents.NumericType.SINGLE,
-                IsStored = true
-            };
-            typeStored.Freeze();
-            return typeStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            NumericType = Documents.NumericType.SINGLE,
+            IsStored = true
+        }.Freeze();
 
         /// <summary>
         /// Creates a stored or un-stored <see cref="SingleField"/> with the provided value

--- a/src/Lucene.Net/Document/IntField.cs
+++ b/src/Lucene.Net/Document/IntField.cs
@@ -117,42 +117,30 @@ namespace Lucene.Net.Documents
         /// Type for an <see cref="Int32Field"/> that is not stored:
         /// normalization factors, frequencies, and positions are omitted.
         /// </summary>
-        public static readonly FieldType TYPE_NOT_STORED = LoadTypeNotStored();
-
-        private static FieldType LoadTypeNotStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_NOT_STORED = new FieldType
         {
-            var typeNotStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                NumericType = Documents.NumericType.INT32
-            };
-            typeNotStored.Freeze();
-            return typeNotStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            NumericType = Documents.NumericType.INT32
+        }.Freeze();
 
         /// <summary>
         /// Type for a stored <see cref="Int32Field"/>:
         /// normalization factors, frequencies, and positions are omitted.
         /// </summary>
-        public static readonly FieldType TYPE_STORED = LoadTypeStored();
-
-        private static FieldType LoadTypeStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_STORED = new FieldType
         {
-            var typeStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                NumericType = Documents.NumericType.INT32,
-                IsStored = true
-            };
-            typeStored.Freeze();
-            return typeStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            NumericType = Documents.NumericType.INT32,
+            IsStored = true
+        }.Freeze();
 
         /// <summary>
         /// Creates a stored or un-stored <see cref="Int32Field"/> with the provided value

--- a/src/Lucene.Net/Document/LongField.cs
+++ b/src/Lucene.Net/Document/LongField.cs
@@ -128,42 +128,30 @@ namespace Lucene.Net.Documents
         /// Type for a <see cref="Int64Field"/> that is not stored:
         /// normalization factors, frequencies, and positions are omitted.
         /// </summary>
-        public static readonly FieldType TYPE_NOT_STORED = LoadTypeNotStored();
-
-        private static FieldType LoadTypeNotStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_NOT_STORED = new FieldType
         {
-            var typeNotStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                NumericType = Documents.NumericType.INT64
-            };
-            typeNotStored.Freeze();
-            return typeNotStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            NumericType = Documents.NumericType.INT64
+        }.Freeze();
 
         /// <summary>
         /// Type for a stored <see cref="Int64Field"/>:
         /// normalization factors, frequencies, and positions are omitted.
         /// </summary>
-        public static readonly FieldType TYPE_STORED = LoadTypeStored();
-
-        private static FieldType LoadTypeStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_STORED = new FieldType
         {
-            var typeStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                NumericType = Documents.NumericType.INT64,
-                IsStored = true
-            };
-            typeStored.Freeze();
-            return typeStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            NumericType = Documents.NumericType.INT64,
+            IsStored = true
+        }.Freeze();
 
         /// <summary>
         /// Creates a stored or un-stored <see cref="Int64Field"/> with the provided value

--- a/src/Lucene.Net/Document/NumericDocValuesField.cs
+++ b/src/Lucene.Net/Document/NumericDocValuesField.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Index;
+﻿using Lucene.Net.Index;
 using System;
 
 namespace Lucene.Net.Documents
@@ -36,17 +36,11 @@ namespace Lucene.Net.Documents
         /// <summary>
         /// Type for numeric <see cref="DocValues"/>.
         /// </summary>
-        public static readonly FieldType TYPE = LoadType();
-
-        private static FieldType LoadType() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE = new FieldType
         {
-            var type = new FieldType
-            {
-                DocValueType = DocValuesType.NUMERIC
-            };
-            type.Freeze();
-            return type;
-        }
+            DocValueType = DocValuesType.NUMERIC
+        }.Freeze();
 
         /// <summary>
         /// Creates a new <see cref="DocValues"/> field with the specified 64-bit <see cref="long"/> value </summary>

--- a/src/Lucene.Net/Document/SortedDocValuesField.cs
+++ b/src/Lucene.Net/Document/SortedDocValuesField.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Index;
+﻿using Lucene.Net.Index;
 using Lucene.Net.Util;
 using System;
 
@@ -40,17 +40,11 @@ namespace Lucene.Net.Documents
         /// <summary>
         /// Type for sorted bytes <see cref="DocValues"/>
         /// </summary>
-        public static readonly FieldType TYPE = LoadType();
-
-        private static FieldType LoadType() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE = new FieldType
         {
-            var type = new FieldType
-            {
-                DocValueType = DocValuesType.SORTED
-            };
-            type.Freeze();
-            return type;
-        }
+            DocValueType = DocValuesType.SORTED
+        }.Freeze();
 
         /// <summary>
         /// Create a new sorted <see cref="DocValues"/> field. </summary>

--- a/src/Lucene.Net/Document/SortedSetDocValuesField.cs
+++ b/src/Lucene.Net/Document/SortedSetDocValuesField.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Index;
+﻿using Lucene.Net.Index;
 using Lucene.Net.Util;
 using System;
 
@@ -42,17 +42,11 @@ namespace Lucene.Net.Documents
         /// <summary>
         /// Type for sorted bytes <see cref="DocValues"/>
         /// </summary>
-        public static readonly FieldType TYPE = LoadType();
-
-        private static FieldType LoadType() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE = new FieldType
         {
-            var type = new FieldType
-            {
-                DocValueType = DocValuesType.SORTED_SET
-            };
-            type.Freeze();
-            return type;
-        }
+            DocValueType = DocValuesType.SORTED_SET
+        }.Freeze();
 
         /// <summary>
         /// Create a new sorted <see cref="DocValues"/> field. </summary>

--- a/src/Lucene.Net/Document/StoredField.cs
+++ b/src/Lucene.Net/Document/StoredField.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Util;
+﻿using Lucene.Net.Util;
 using System;
 
 namespace Lucene.Net.Documents
@@ -30,17 +30,11 @@ namespace Lucene.Net.Documents
         /// <summary>
         /// Type for a stored-only field.
         /// </summary>
-        public static readonly FieldType TYPE = LoadType();
-
-        private static FieldType LoadType() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE = new FieldType
         {
-            var type = new FieldType
-            {
-                IsStored = true
-            };
-            type.Freeze();
-            return type;
-        }
+            IsStored = true
+        }.Freeze();
 
         /// <summary>
         /// Create a stored-only field with the given binary value.

--- a/src/Lucene.Net/Document/StringField.cs
+++ b/src/Lucene.Net/Document/StringField.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Index;
+﻿using Lucene.Net.Index;
 using System;
 
 namespace Lucene.Net.Documents
@@ -33,40 +33,28 @@ namespace Lucene.Net.Documents
         /// Indexed, not tokenized, omits norms, indexes
         /// <see cref="IndexOptions.DOCS_ONLY"/>, not stored.
         /// </summary>
-        public static readonly FieldType TYPE_NOT_STORED = LoadTypeNotStored();
-
-        private static FieldType LoadTypeNotStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_NOT_STORED = new FieldType
         {
-            var typeNotStored = new FieldType
-            {
-                IsIndexed = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                IsTokenized = false
-            };
-            typeNotStored.Freeze();
-            return typeNotStored;
-        }
+            IsIndexed = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            IsTokenized = false
+        }.Freeze();
 
         /// <summary>
         /// Indexed, not tokenized, omits norms, indexes
         /// <see cref="IndexOptions.DOCS_ONLY"/>, stored
         /// </summary>
-        public static readonly FieldType TYPE_STORED = LoadTypeStored();
-
-        private static FieldType LoadTypeStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_STORED = new FieldType
         {
-            var typeStored = new FieldType
-            {
-                IsIndexed = true,
-                OmitNorms = true,
-                IndexOptions = IndexOptions.DOCS_ONLY,
-                IsStored = true,
-                IsTokenized = false
-            };
-            typeStored.Freeze();
-            return typeStored;
-        }
+            IsIndexed = true,
+            OmitNorms = true,
+            IndexOptions = IndexOptions.DOCS_ONLY,
+            IsStored = true,
+            IsTokenized = false
+        }.Freeze();
 
         /// <summary>
         /// Creates a new <see cref="StringField"/> (a field that is indexed but not tokenized)

--- a/src/Lucene.Net/Document/TextField.cs
+++ b/src/Lucene.Net/Document/TextField.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Analysis;
+﻿using Lucene.Net.Analysis;
 using System;
 using System.IO;
 
@@ -30,34 +30,22 @@ namespace Lucene.Net.Documents
     {
         /// <summary>
         /// Indexed, tokenized, not stored. </summary>
-        public static readonly FieldType TYPE_NOT_STORED = LoadTypeNotStored();
-
-        private static FieldType LoadTypeNotStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_NOT_STORED = new FieldType
         {
-            var typeNotStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true
-            };
-            typeNotStored.Freeze();
-            return typeNotStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true
+        }.Freeze();
 
         /// <summary>
         /// Indexed, tokenized, stored. </summary>
-        public static readonly FieldType TYPE_STORED = LoadTypeStored();
-
-        private static FieldType LoadTypeStored() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        public static readonly FieldType TYPE_STORED = new FieldType
         {
-            var typeStored = new FieldType
-            {
-                IsIndexed = true,
-                IsTokenized = true,
-                IsStored = true
-            };
-            typeStored.Freeze();
-            return typeStored;
-        }
+            IsIndexed = true,
+            IsTokenized = true,
+            IsStored = true
+        }.Freeze();
 
         // TODO: add sugar for term vectors...?
 


### PR DESCRIPTION
Changed `Lucene.Net.Documents.FieldType::Freeze()` from void return to return this `FieldType`. This allows chaining the method at the end of a class initializer so the entire `FieldType` instance can be created on one line (which is important for static field initializers).

Chained the `Freeze()` method in all static field initializers of `Field` subclasses to eliminate extra helper load methods. 

Marked `BinaryDocValuesField.fType` static field obsolete and added `BinaryDocValuesField.TYPE` static field as it was in Lucene.