### PR TITLE
BREAKING: Changed GetFilePointer() methods into Position properties

### DIFF
--- a/src/Lucene.Net.Codecs/BlockTerms/BlockTermsReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/BlockTermsReader.cs
@@ -891,7 +891,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                     // bsearch w/in the block...
 
                     //System.out.println("BTR.nextBlock() fp=" + in.getFilePointer() + " this=" + this);
-                    state.BlockFilePointer = input.GetFilePointer();
+                    state.BlockFilePointer = input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     blockTermCount = input.ReadVInt32();
                     //System.out.println("  blockTermCount=" + blockTermCount);
                     if (blockTermCount == 0)

--- a/src/Lucene.Net.Codecs/BlockTerms/BlockTermsWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/BlockTermsWriter.cs
@@ -1,4 +1,4 @@
-using J2N.Text;
+﻿using J2N.Text;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
@@ -127,7 +127,7 @@ namespace Lucene.Net.Codecs.BlockTerms
             //System.out.println("\nBTW.addField seg=" + segment + " field=" + field.name);
             if (Debugging.AssertsEnabled) Debugging.Assert(currentField == null || currentField.Name.CompareToOrdinal(field.Name) < 0);
             currentField = field;
-            TermsIndexWriterBase.FieldWriter fieldIndexWriter = termsIndexWriter.AddField(field, m_output.GetFilePointer());
+            TermsIndexWriterBase.FieldWriter fieldIndexWriter = termsIndexWriter.AddField(field, m_output.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             return new TermsWriter(this, fieldIndexWriter, field, postingsWriter);
         }
 
@@ -139,7 +139,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 {
                     try
                     {
-                        long dirStart = m_output.GetFilePointer();
+                        long dirStart = m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                         m_output.WriteVInt32(fields.Count);
                         foreach (FieldMetaData field in fields)
@@ -219,7 +219,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 {
                     pendingTerms[i] = new TermEntry();
                 }
-                termsStartPointer = outerInstance.m_output.GetFilePointer();
+                termsStartPointer = outerInstance.m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 this.postingsWriter = postingsWriter;
                 this.longsSize = postingsWriter.SetField(fieldInfo);
             }
@@ -251,7 +251,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                         // entire block in between index terms:
                         FlushBlock();
                     }
-                    fieldIndexWriter.Add(text, stats, outerInstance.m_output.GetFilePointer());
+                    fieldIndexWriter.Add(text, stats, outerInstance.m_output.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     //System.out.println("  index term!");
                 }
 
@@ -289,7 +289,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 //this.sumTotalTermFreq = sumTotalTermFreq; // LUCENENET: Not used
                 //this.sumDocFreq = sumDocFreq; // LUCENENET: Not used
                 //this.docCount = docCount; // LUCENENET: Not used
-                fieldIndexWriter.Finish(outerInstance.m_output.GetFilePointer());
+                fieldIndexWriter.Finish(outerInstance.m_output.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (numTerms > 0)
                 {
                     outerInstance.fields.Add(new FieldMetaData(fieldInfo,
@@ -354,7 +354,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                     bytesWriter.WriteVInt32(suffix);
                     bytesWriter.WriteBytes(pendingTerms[termCount].Term.Bytes, commonPrefix, suffix);
                 }
-                outerInstance.m_output.WriteVInt32((int)bytesWriter.GetFilePointer());
+                outerInstance.m_output.WriteVInt32((int)bytesWriter.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 bytesWriter.WriteTo(outerInstance.m_output);
                 bytesWriter.Reset();
 
@@ -371,7 +371,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                         bytesWriter.WriteVInt64(state.TotalTermFreq - state.DocFreq);
                     }
                 }
-                outerInstance.m_output.WriteVInt32((int)bytesWriter.GetFilePointer());
+                outerInstance.m_output.WriteVInt32((int)bytesWriter.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 bytesWriter.WriteTo(outerInstance.m_output);
                 bytesWriter.Reset();
 
@@ -390,7 +390,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                     bufferWriter.Reset();
                     absolute = false;
                 }
-                outerInstance.m_output.WriteVInt32((int)bytesWriter.GetFilePointer());
+                outerInstance.m_output.WriteVInt32((int)bytesWriter.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 bytesWriter.WriteTo(outerInstance.m_output);
                 bytesWriter.Reset();
 

--- a/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexWriter.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
@@ -140,7 +140,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 this.outerInstance = outerInstance;
 
                 this.fieldInfo = fieldInfo;
-                indexStart = outerInstance.m_output.GetFilePointer();
+                indexStart = outerInstance.m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 termsStart = lastTermsPointer = termsFilePointer;
                 termLengths = EMPTY_INT16S;
                 termsPointerDeltas = EMPTY_INT32S;
@@ -200,7 +200,7 @@ namespace Lucene.Net.Codecs.BlockTerms
             public override void Finish(long termsFilePointer)
             {
                 // write primary terms dict offsets
-                packedIndexStart = outerInstance.m_output.GetFilePointer();
+                packedIndexStart = outerInstance.m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                 PackedInt32s.Writer w = PackedInt32s.GetWriter(outerInstance.m_output, numIndexTerms, PackedInt32s.BitsRequired(termsFilePointer), PackedInt32s.DEFAULT);
 
@@ -213,7 +213,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 }
                 w.Finish();
 
-                packedOffsetsStart = outerInstance.m_output.GetFilePointer();
+                packedOffsetsStart = outerInstance.m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                 // write offsets into the byte[] terms
                 w = PackedInt32s.GetWriter(outerInstance.m_output, 1 + numIndexTerms, PackedInt32s.BitsRequired(totTermLength), PackedInt32s.DEFAULT);
@@ -242,7 +242,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                     bool success = false;
                     try
                     {
-                        long dirStart = m_output.GetFilePointer();
+                        long dirStart = m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         int fieldCount = fields.Count;
 
                         int nonNullFieldCount = 0;

--- a/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexWriter.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
@@ -259,7 +259,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 this.fieldInfo = fieldInfo;
                 fstOutputs = PositiveInt32Outputs.Singleton;
                 fstBuilder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, fstOutputs);
-                indexStart = outerInstance.m_output.GetFilePointer();
+                indexStart = outerInstance.m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 ////System.out.println("VGW: field=" + fieldInfo.name);
 
                 // Always put empty string in
@@ -326,7 +326,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 {
                     try
                     {
-                        long dirStart = m_output.GetFilePointer();
+                        long dirStart = m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         int fieldCount = fields.Count;
 
                         int nonNullFieldCount = 0;

--- a/src/Lucene.Net.Codecs/IntBlock/FixedIntBlockIndexInput.cs
+++ b/src/Lucene.Net.Codecs/IntBlock/FixedIntBlockIndexInput.cs
@@ -132,7 +132,7 @@ namespace Lucene.Net.Codecs.IntBlock
                 else if (upto == blockSize)
                 {
                     // Load new block
-                    lastBlockFP = input.GetFilePointer();
+                    lastBlockFP = input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     blockReader.ReadBlock();
                     upto = 0;
                 }

--- a/src/Lucene.Net.Codecs/IntBlock/FixedIntBlockIndexOutput.cs
+++ b/src/Lucene.Net.Codecs/IntBlock/FixedIntBlockIndexOutput.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Codecs.IntBlock
 
             public override void Mark()
             {
-                fp = outerInstance.m_output.GetFilePointer();
+                fp = outerInstance.m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 upto = outerInstance.upto;
             }
 

--- a/src/Lucene.Net.Codecs/IntBlock/VariableIntBlockIndexInput.cs
+++ b/src/Lucene.Net.Codecs/IntBlock/VariableIntBlockIndexInput.cs
@@ -148,7 +148,7 @@ namespace Lucene.Net.Codecs.IntBlock
                     while (upto >= blockSize)
                     {
                         upto -= blockSize;
-                        lastBlockFP = input.GetFilePointer();
+                        lastBlockFP = input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         blockSize = blockReader.ReadBlock();
                     }
                     seekPending = false;
@@ -160,7 +160,7 @@ namespace Lucene.Net.Codecs.IntBlock
                 this.MaybeSeek();
                 if (upto == blockSize)
                 {
-                    lastBlockFP = input.GetFilePointer();
+                    lastBlockFP = input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     blockSize = blockReader.ReadBlock();
                     upto = 0;
                 }

--- a/src/Lucene.Net.Codecs/IntBlock/VariableIntBlockIndexOutput.cs
+++ b/src/Lucene.Net.Codecs/IntBlock/VariableIntBlockIndexOutput.cs
@@ -89,7 +89,7 @@ namespace Lucene.Net.Codecs.IntBlock
 
             public override void Mark()
             {
-                fp = outerInstance.m_output.GetFilePointer();
+                fp = outerInstance.m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 upto = outerInstance.upto;
             }
 

--- a/src/Lucene.Net.Codecs/Memory/DirectDocValuesConsumer.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectDocValuesConsumer.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Codecs.Memory
 
         private void AddNumericFieldValues(FieldInfo field, IEnumerable<long?> values)
         {
-            meta.WriteInt64(data.GetFilePointer());
+            meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             long minValue = long.MaxValue;
             long maxValue = long.MinValue;
             bool missing = false;
@@ -103,10 +103,10 @@ namespace Lucene.Net.Codecs.Memory
 
             if (missing)
             {
-                long start = data.GetFilePointer();
+                long start = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 WriteMissingBitset(values);
                 meta.WriteInt64(start);
-                meta.WriteInt64(data.GetFilePointer() - start);
+                meta.WriteInt64(data.Position - start); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             else
             {
@@ -196,7 +196,7 @@ namespace Lucene.Net.Codecs.Memory
         private void AddBinaryFieldValues(FieldInfo field, IEnumerable<BytesRef> values)
         {
             // write the byte[] data
-            long startFP = data.GetFilePointer();
+            long startFP = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             bool missing = false;
             long totalBytes = 0;
             int count = 0;
@@ -225,10 +225,10 @@ namespace Lucene.Net.Codecs.Memory
             meta.WriteInt32(count);
             if (missing)
             {
-                long start = data.GetFilePointer();
+                long start = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 WriteMissingBitset(values);
                 meta.WriteInt64(start);
-                meta.WriteInt64(data.GetFilePointer() - start);
+                meta.WriteInt64(data.Position - start); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             else
             {

--- a/src/Lucene.Net.Codecs/Memory/FSTOrdTermsWriter.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTOrdTermsWriter.cs
@@ -198,7 +198,7 @@ namespace Lucene.Net.Codecs.Memory
                 Exception ioe = null; // LUCENENET: No need to cast to IOExcpetion
                 try
                 {
-                    var blockDirStart = blockOut.GetFilePointer();
+                    var blockDirStart = blockOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                     // write field summary
                     blockOut.WriteVInt32(_fields.Count);
@@ -213,9 +213,9 @@ namespace Lucene.Net.Codecs.Memory
                         blockOut.WriteVInt64(field.SumDocFreq);
                         blockOut.WriteVInt32(field.DocCount);
                         blockOut.WriteVInt32(field.Int64sSize);
-                        blockOut.WriteVInt64(field.StatsOut.GetFilePointer());
-                        blockOut.WriteVInt64(field.MetaInt64sOut.GetFilePointer());
-                        blockOut.WriteVInt64(field.MetaBytesOut.GetFilePointer());
+                        blockOut.WriteVInt64(field.StatsOut.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                        blockOut.WriteVInt64(field.MetaInt64sOut.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                        blockOut.WriteVInt64(field.MetaBytesOut.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                         field.SkipOut.WriteTo(blockOut);
                         field.StatsOut.WriteTo(blockOut);
@@ -364,12 +364,12 @@ namespace Lucene.Net.Codecs.Memory
                     _metaLongsOut.WriteVInt64(longs[i] - _lastLongs[i]);
                     _lastLongs[i] = longs[i];
                 }
-                _metaLongsOut.WriteVInt64(_metaBytesOut.GetFilePointer() - _lastMetaBytesFp);
+                _metaLongsOut.WriteVInt64(_metaBytesOut.Position - _lastMetaBytesFp); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                 _builder.Add(Util.ToInt32sRef(text, _scratchTerm), _numTerms);
                 _numTerms++;
 
-                _lastMetaBytesFp = _metaBytesOut.GetFilePointer();
+                _lastMetaBytesFp = _metaBytesOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
 
             public override void Finish(long sumTotalTermFreq, long sumDocFreq, int docCount)
@@ -395,16 +395,16 @@ namespace Lucene.Net.Codecs.Memory
 
             private void BufferSkip()
             {
-                _skipOut.WriteVInt64(_statsOut.GetFilePointer() - _lastBlockStatsFp);
-                _skipOut.WriteVInt64(_metaLongsOut.GetFilePointer() - _lastBlockMetaLongsFp);
-                _skipOut.WriteVInt64(_metaBytesOut.GetFilePointer() - _lastBlockMetaBytesFp);
+                _skipOut.WriteVInt64(_statsOut.Position - _lastBlockStatsFp); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                _skipOut.WriteVInt64(_metaLongsOut.Position - _lastBlockMetaLongsFp); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                _skipOut.WriteVInt64(_metaBytesOut.Position - _lastBlockMetaBytesFp); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 for (var i = 0; i < _longsSize; i++)
                 {
                     _skipOut.WriteVInt64(_lastLongs[i] - _lastBlockLongs[i]);
                 }
-                _lastBlockStatsFp = _statsOut.GetFilePointer();
-                _lastBlockMetaLongsFp = _metaLongsOut.GetFilePointer();
-                _lastBlockMetaBytesFp = _metaBytesOut.GetFilePointer();
+                _lastBlockStatsFp = _statsOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                _lastBlockMetaLongsFp = _metaLongsOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                _lastBlockMetaBytesFp = _metaBytesOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 Array.Copy(_lastLongs, 0, _lastBlockLongs, 0, _longsSize);
             }
         }

--- a/src/Lucene.Net.Codecs/Memory/FSTTermsWriter.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermsWriter.cs
@@ -178,7 +178,7 @@ namespace Lucene.Net.Codecs.Memory
                 try
                 {
                     // write field summary
-                    var dirStart = _output.GetFilePointer();
+                    var dirStart = _output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                     _output.WriteVInt32(_fields.Count);
                     foreach (var field in _fields)
@@ -282,7 +282,7 @@ namespace Lucene.Net.Codecs.Memory
                 };
                 _outerInstance._postingsWriter.FinishTerm(state);
                 _outerInstance._postingsWriter.EncodeTerm(meta.longs, _metaWriter, _fieldInfo, state, true);
-                var bytesSize = (int) _metaWriter.GetFilePointer();
+                var bytesSize = (int) _metaWriter.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (bytesSize > 0)
                 {
                     meta.bytes = new byte[bytesSize];

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Codecs.Memory
         {
             meta.WriteVInt32(field.Number);
             meta.WriteByte(MemoryDocValuesProducer.NUMBER);
-            meta.WriteInt64(data.GetFilePointer());
+            meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             long minValue = long.MaxValue;
             long maxValue = long.MinValue;
             long gcd = 0;
@@ -151,10 +151,10 @@ namespace Lucene.Net.Codecs.Memory
 
             if (missing)
             {
-                long start = data.GetFilePointer();
+                long start = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 WriteMissingBitset(values);
                 meta.WriteInt64(start);
-                meta.WriteInt64(data.GetFilePointer() - start);
+                meta.WriteInt64(data.Position - start); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             else
             {
@@ -276,7 +276,7 @@ namespace Lucene.Net.Codecs.Memory
             var minLength = int.MaxValue;
             var maxLength = int.MinValue;
 
-            var startFP = data.GetFilePointer();
+            var startFP = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             var missing = false;
             foreach (var v in values)
             {
@@ -303,13 +303,13 @@ namespace Lucene.Net.Codecs.Memory
                 }
             }
             meta.WriteInt64(startFP);
-            meta.WriteInt64(data.GetFilePointer() - startFP);
+            meta.WriteInt64(data.Position - startFP); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (missing)
             {
-                long start = data.GetFilePointer();
+                long start = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 WriteMissingBitset(values);
                 meta.WriteInt64(start);
-                meta.WriteInt64(data.GetFilePointer() - start);
+                meta.WriteInt64(data.Position - start); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             else
             {
@@ -344,7 +344,7 @@ namespace Lucene.Net.Codecs.Memory
         {
             meta.WriteVInt32(field.Number);
             meta.WriteByte(MemoryDocValuesProducer.FST);
-            meta.WriteInt64(data.GetFilePointer());
+            meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
             var builder = new Builder<long?>(INPUT_TYPE.BYTE1, outputs);
             var scratch = new Int32sRef();

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
@@ -357,7 +357,7 @@ namespace Lucene.Net.Codecs.Memory
             }
             else
             {
-                data.Seek(data.GetFilePointer() + entry.missingBytes);
+                data.Seek(data.Position + entry.missingBytes); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 var addresses = new MonotonicBlockPackedReader(data, entry.packedIntsVersion,
                     entry.blockSize, maxDoc, false);
                 ramBytesUsed.AddAndGet(bytes.RamBytesUsed() + addresses.RamBytesUsed());

--- a/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
@@ -233,7 +233,7 @@ namespace Lucene.Net.Codecs.Memory
 
                 public virtual PostingsWriter Reset()
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(buffer.GetFilePointer() == 0);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(buffer.Position == 0); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     lastDocID = 0;
                     docCount = 0;
                     lastPayloadLen = 0;
@@ -259,18 +259,18 @@ namespace Lucene.Net.Codecs.Memory
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(postingsWriter.docCount == stats.DocFreq);
 
-                if (Debugging.AssertsEnabled) Debugging.Assert(buffer2.GetFilePointer() == 0);
+                if (Debugging.AssertsEnabled) Debugging.Assert(buffer2.Position == 0); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                 buffer2.WriteVInt32(stats.DocFreq);
                 if (field.IndexOptions != IndexOptions.DOCS_ONLY)
                 {
                     buffer2.WriteVInt64(stats.TotalTermFreq - stats.DocFreq);
                 }
-                int pos = (int)buffer2.GetFilePointer();
+                int pos = (int)buffer2.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 buffer2.WriteTo(finalBuffer, 0);
                 buffer2.Reset();
 
-                int totalBytes = pos + (int)postingsWriter.buffer.GetFilePointer();
+                int totalBytes = pos + (int)postingsWriter.buffer.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (totalBytes > finalBuffer.Length)
                 {
                     finalBuffer = ArrayUtil.Grow(finalBuffer, totalBytes);

--- a/src/Lucene.Net.Codecs/Pulsing/PulsingPostingsWriter.cs
+++ b/src/Lucene.Net.Codecs/Pulsing/PulsingPostingsWriter.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
@@ -402,7 +402,7 @@ namespace Lucene.Net.Codecs.Pulsing
                     }
                 }
 
-                state2.bytes = new byte[(int)_buffer.GetFilePointer()];
+                state2.bytes = new byte[(int)_buffer.Position]; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 _buffer.WriteTo(state2.bytes, 0);
                 _buffer.Reset();
             }

--- a/src/Lucene.Net.Codecs/Sep/SepPostingsReader.cs
+++ b/src/Lucene.Net.Codecs/Sep/SepPostingsReader.cs
@@ -728,7 +728,7 @@ namespace Lucene.Net.Codecs.Sep
 
                 if (pendingPayloadBytes > payloadLength)
                 {
-                    payloadIn.Seek(payloadIn.GetFilePointer() + (pendingPayloadBytes - payloadLength));
+                    payloadIn.Seek(payloadIn.Position + (pendingPayloadBytes - payloadLength)); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
 
                 if (payload == null)

--- a/src/Lucene.Net.Codecs/Sep/SepPostingsWriter.cs
+++ b/src/Lucene.Net.Codecs/Sep/SepPostingsWriter.cs
@@ -186,7 +186,7 @@ namespace Lucene.Net.Codecs.Sep
             if (indexOptions == IndexOptions.DOCS_AND_FREQS_AND_POSITIONS)
             {
                 posIndex.Mark();
-                payloadStart = payloadOut.GetFilePointer();
+                payloadStart = payloadOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 lastPayloadLength = -1;
             }
 
@@ -350,7 +350,7 @@ namespace Lucene.Net.Codecs.Sep
 
             if (df >= skipMinimum)
             {
-                state_.SkipFP = skipOut.GetFilePointer();
+                state_.SkipFP = skipOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 //System.out.println("  skipFP=" + skipFP);
                 skipListWriter.WriteSkip(skipOut);
                 //System.out.println("    numBytes=" + (skipOut.getFilePointer()-skipFP));

--- a/src/Lucene.Net.Codecs/Sep/SepSkipListWriter.cs
+++ b/src/Lucene.Net.Codecs/Sep/SepSkipListWriter.cs
@@ -124,7 +124,7 @@ namespace Lucene.Net.Codecs.Sep
             this.curPayloadLength = payloadLength;
             if (payloadOutput != null)
             {
-                this.curPayloadPointer = payloadOutput.GetFilePointer();
+                this.curPayloadPointer = payloadOutput.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
         }
 
@@ -150,7 +150,7 @@ namespace Lucene.Net.Codecs.Sep
             }
             if (payloadOutput != null)
             {
-                Arrays.Fill(lastSkipPayloadPointer, payloadOutput.GetFilePointer());
+                Arrays.Fill(lastSkipPayloadPointer, payloadOutput.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
         }
 

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
@@ -97,8 +97,8 @@ namespace Lucene.Net.Codecs.SimpleText
                     ReadLine();
                     if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.PATTERN));
                     field.Pattern = StripPrefix(SimpleTextDocValuesWriter.PATTERN);
-                    field.DataStartFilePointer = data.GetFilePointer();
-                    data.Seek(data.GetFilePointer() + (1 + field.Pattern.Length + 2)*maxDoc);
+                    field.DataStartFilePointer = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    data.Seek(data.Position + (1 + field.Pattern.Length + 2)*maxDoc); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
                 else if (dvType == DocValuesType.BINARY)
                 {
@@ -108,8 +108,8 @@ namespace Lucene.Net.Codecs.SimpleText
                     ReadLine();
                     if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.PATTERN));
                     field.Pattern = StripPrefix(SimpleTextDocValuesWriter.PATTERN);
-                    field.DataStartFilePointer = data.GetFilePointer();
-                    data.Seek(data.GetFilePointer() + (9 + field.Pattern.Length + field.MaxLength + 2)*maxDoc);
+                    field.DataStartFilePointer = data.Position;
+                    data.Seek(data.Position + (9 + field.Pattern.Length + field.MaxLength + 2)*maxDoc);
                 }
                 else if (dvType == DocValuesType.SORTED || dvType == DocValuesType.SORTED_SET)
                 {
@@ -125,9 +125,9 @@ namespace Lucene.Net.Codecs.SimpleText
                     ReadLine();
                     if (Debugging.AssertsEnabled) Debugging.Assert(StartsWith(SimpleTextDocValuesWriter.ORDPATTERN));
                     field.OrdPattern = StripPrefix(SimpleTextDocValuesWriter.ORDPATTERN);
-                    field.DataStartFilePointer = data.GetFilePointer();
-                    data.Seek(data.GetFilePointer() + (9 + field.Pattern.Length + field.MaxLength)*field.NumValues +
-                              (1 + field.OrdPattern.Length)*maxDoc);
+                    field.DataStartFilePointer = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    data.Seek(data.Position + (9 + field.Pattern.Length + field.MaxLength)*field.NumValues +
+                              (1 + field.OrdPattern.Length)*maxDoc); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
                 else
                 {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 {
                     var fieldName = Encoding.UTF8.GetString(scratch.Bytes, scratch.Offset + SimpleTextFieldsWriter.FIELD.Length,
                         scratch.Length - SimpleTextFieldsWriter.FIELD.Length);
-                    fields[fieldName] = input.GetFilePointer();
+                    fields[fieldName] = input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
             }
         }
@@ -265,7 +265,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 int termFreq = 0;
                 while (true)
                 {
-                    long lineStart = _in.GetFilePointer();
+                    long lineStart = _in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     SimpleTextUtil.ReadLine(_in, _scratch);
                     if (StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.DOC))
                     {
@@ -397,7 +397,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 long posStart = 0;
                 while (true)
                 {
-                    long lineStart = _in.GetFilePointer();
+                    long lineStart = _in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     SimpleTextUtil.ReadLine(_in, _scratch);
                     //System.out.println("NEXT DOC: " + scratch.utf8ToString());
                     if (StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.DOC))
@@ -419,7 +419,7 @@ namespace Lucene.Net.Codecs.SimpleText
                         UnicodeUtil.UTF8toUTF16(_scratch.Bytes, _scratch.Offset + SimpleTextFieldsWriter.FREQ.Length,
                             _scratch.Length - SimpleTextFieldsWriter.FREQ.Length, _scratchUtf16);
                         _tf = ArrayUtil.ParseInt32(_scratchUtf16.Chars, 0, _scratchUtf16.Length);
-                        posStart = _in.GetFilePointer();
+                        posStart = _in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     }
                     else if (StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.POS))
                     {
@@ -492,7 +492,7 @@ namespace Lucene.Net.Codecs.SimpleText
                     _endOffset = ArrayUtil.ParseInt32(_scratchUtf162.Chars, 0, _scratchUtf162.Length);
                 }
 
-                long fp = _in.GetFilePointer();
+                long fp = _in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 SimpleTextUtil.ReadLine(_in, _scratch);
                 if (StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.PAYLOAD))
                 {
@@ -618,7 +618,7 @@ namespace Lucene.Net.Codecs.SimpleText
                             b.Add(Util.ToInt32sRef(lastTerm, scratchIntsRef),
                                 outputs.NewPair(lastDocsStart, outputsInner.NewPair(docFreq, totalTermFreq)));
                         }
-                        lastDocsStart = input.GetFilePointer();
+                        lastDocsStart = input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         int len = _scratch.Length - SimpleTextFieldsWriter.TERM.Length;
                         if (len > lastTerm.Length)
                         {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsReader.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 SimpleTextUtil.ReadLine(input, _scratch);
                 if (StringHelper.StartsWith(_scratch, SimpleTextStoredFieldsWriter.DOC))
                 {
-                    _offsets[upto] = input.GetFilePointer();
+                    _offsets[upto] = input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     upto++;
                 }
             }

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 SimpleTextUtil.ReadLine(input, _scratch);
                 if (StringHelper.StartsWith(_scratch, SimpleTextTermVectorsWriter.DOC))
                 {
-                    _offsets[upto] = input.GetFilePointer();
+                    _offsets[upto] = input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     upto++;
                 }
             }

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextUtil.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextUtil.cs
@@ -116,7 +116,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 throw new CorruptIndexException("SimpleText checksum failure: " + actualChecksum + " != " +
                                                 expectedChecksum + " (resource=" + input + ")");
             }
-            if (input.Length != input.GetFilePointer())
+            if (input.Length != input.Position) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             {
                 throw new CorruptIndexException(
                     "Unexpected stuff at the end of file, please be careful with your text editor! (resource=" + input +

--- a/src/Lucene.Net.Misc/Index/Sorter/SortingAtomicReader.cs
+++ b/src/Lucene.Net.Misc/Index/Sorter/SortingAtomicReader.cs
@@ -623,7 +623,7 @@ namespace Lucene.Net.Index.Sorter
                             offsets = Arrays.CopyOf(offsets, newLength);
                         }
                         docs[i] = docMap.OldToNew(doc);
-                        offsets[i] = @out.GetFilePointer();
+                        offsets[i] = @out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         AddPositions(@in, @out);
                         i++;
                     }

--- a/src/Lucene.Net.Replicator/IndexInputInputStream.cs
+++ b/src/Lucene.Net.Replicator/IndexInputInputStream.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Replicator
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            int remaining = (int) (input.Length - input.GetFilePointer());
+            int remaining = (int) (input.Length - input.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             int readCount = Math.Min(remaining, count);
             input.ReadBytes(buffer, offset, readCount);
             return readCount;
@@ -83,7 +83,7 @@ namespace Lucene.Net.Replicator
 
         public override long Position
         {
-            get => input.GetFilePointer();
+            get => input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             set => input.Seek(value);
         }
 

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWFieldInfosReader.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWFieldInfosReader.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Index;
+﻿using Lucene.Net.Index;
 using Lucene.Net.Store;
 using System.Collections.Generic;
 
@@ -111,9 +111,9 @@ namespace Lucene.Net.Codecs.Lucene3x
                                             null);
                 }
 
-                if (input.GetFilePointer() != input.Length)
+                if (input.Position != input.Length) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 {
-                    throw new CorruptIndexException("did not read all bytes from file \"" + fileName + "\": read " + input.GetFilePointer() + " vs size " + input.Length + " (resource: " + input + ")");
+                    throw new CorruptIndexException("did not read all bytes from file \"" + fileName + "\": read " + input.Position + " vs size " + input.Length + " (resource: " + input + ")");
                 }
                 return new FieldInfos(infos);
             }

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWFieldsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWFieldsWriter.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
@@ -227,10 +227,10 @@ namespace Lucene.Net.Codecs.Lucene3x
             {
                 //System.out.println("  w term=" + text.utf8ToString());
                 outerInstance.skipListWriter.ResetSkip();
-                termInfo.FreqPointer = outerInstance.freqOut.GetFilePointer();
+                termInfo.FreqPointer = outerInstance.freqOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (outerInstance.proxOut != null)
                 {
-                    termInfo.ProxPointer = outerInstance.proxOut.GetFilePointer();
+                    termInfo.ProxPointer = outerInstance.proxOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
                 return postingsWriter.Reset();
             }

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWSkipListWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWSkipListWriter.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Store;
+﻿using Lucene.Net.Store;
 using Lucene.Net.Support;
 
 namespace Lucene.Net.Codecs.Lucene3x
@@ -61,10 +61,10 @@ namespace Lucene.Net.Codecs.Lucene3x
             this.curDoc = doc;
             this.curStorePayloads = storePayloads;
             this.curPayloadLength = payloadLength;
-            this.curFreqPointer = freqOutput.GetFilePointer();
+            this.curFreqPointer = freqOutput.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (proxOutput != null)
             {
-                this.curProxPointer = proxOutput.GetFilePointer();
+                this.curProxPointer = proxOutput.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
         }
 
@@ -73,10 +73,10 @@ namespace Lucene.Net.Codecs.Lucene3x
             base.ResetSkip();
             Arrays.Fill(lastSkipDoc, 0);
             Arrays.Fill(lastSkipPayloadLength, -1); // we don't have to write the first length in the skip list
-            Arrays.Fill(lastSkipFreqPointer, freqOutput.GetFilePointer());
+            Arrays.Fill(lastSkipFreqPointer, freqOutput.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (proxOutput != null)
             {
-                Arrays.Fill(lastSkipProxPointer, proxOutput.GetFilePointer());
+                Arrays.Fill(lastSkipProxPointer, proxOutput.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWStoredFieldsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWStoredFieldsWriter.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         // in the correct fields format.
         public override void StartDocument(int numStoredFields)
         {
-            indexStream.WriteInt64(fieldsStream.GetFilePointer());
+            indexStream.WriteInt64(fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             fieldsStream.WriteVInt32(numStoredFields);
         }
 
@@ -196,14 +196,14 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override void Finish(FieldInfos fis, int numDocs)
         {
-            if (4 + ((long)numDocs) * 8 != indexStream.GetFilePointer())
+            if (4 + ((long)numDocs) * 8 != indexStream.Position) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             // this is most likely a bug in Sun JRE 1.6.0_04/_05;
             // we detect that the bug has struck, here, and
             // throw an exception to prevent the corruption from
             // entering the index.  See LUCENE-1282 for
             // details.
             {
-                throw RuntimeException.Create("fdx size mismatch: docCount is " + numDocs + " but fdx file size is " + indexStream.GetFilePointer() + " file=" + indexStream.ToString() + "; now aborting this merge to prevent index corruption");
+                throw RuntimeException.Create("fdx size mismatch: docCount is " + numDocs + " but fdx file size is " + indexStream.Position + " file=" + indexStream.ToString() + "; now aborting this merge to prevent index corruption");
             }
         }
     }

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsWriter.cs
@@ -63,8 +63,8 @@ namespace Lucene.Net.Codecs.Lucene3x
         {
             lastFieldName = null;
             this.numVectorFields = numVectorFields;
-            tvx.WriteInt64(tvd.GetFilePointer());
-            tvx.WriteInt64(tvf.GetFilePointer());
+            tvx.WriteInt64(tvd.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            tvx.WriteInt64(tvf.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             tvd.WriteVInt32(numVectorFields);
             fieldCount = 0;
             fps = ArrayUtil.Grow(fps, numVectorFields);
@@ -86,7 +86,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             this.positions = positions;
             this.offsets = offsets;
             lastTerm.Length = 0;
-            fps[fieldCount++] = tvf.GetFilePointer();
+            fps[fieldCount++] = tvf.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             tvd.WriteVInt32(info.Number);
             tvf.WriteVInt32(numTerms);
             sbyte bits = 0x0;
@@ -204,14 +204,14 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         public override void Finish(FieldInfos fis, int numDocs)
         {
-            if (4 + ((long)numDocs) * 16 != tvx.GetFilePointer())
+            if (4 + ((long)numDocs) * 16 != tvx.Position) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             // this is most likely a bug in Sun JRE 1.6.0_04/_05;
             // we detect that the bug has struck, here, and
             // throw an exception to prevent the corruption from
             // entering the index.  See LUCENE-1282 for
             // details.
             {
-                throw RuntimeException.Create("tvx size mismatch: mergedDocs is " + numDocs + " but tvx size is " + tvx.GetFilePointer() + " file=" + tvx.ToString() + "; now aborting this merge to prevent index corruption");
+                throw RuntimeException.Create("tvx size mismatch: mergedDocs is " + numDocs + " but tvx size is " + tvx.Position + " file=" + tvx.ToString() + "; now aborting this merge to prevent index corruption");
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/TermInfosWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/TermInfosWriter.cs
@@ -268,8 +268,8 @@ namespace Lucene.Net.Codecs.Lucene3x
 
             if (isIndex)
             {
-                output.WriteVInt64(other.output.GetFilePointer() - lastIndexPointer);
-                lastIndexPointer = other.output.GetFilePointer(); // write pointer
+                output.WriteVInt64(other.output.Position - lastIndexPointer); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                lastIndexPointer = other.output.Position; // write pointer // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
 
             lastFieldNumber = fieldNumber;

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40DocValuesWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40DocValuesWriter.cs
@@ -317,7 +317,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
             /* values */
 
-            long startPos = data.GetFilePointer();
+            long startPos = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             foreach (BytesRef v in values)
             {
@@ -329,7 +329,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
             /* addresses */
 
-            long maxAddress = data.GetFilePointer() - startPos;
+            long maxAddress = data.Position - startPos; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             index.WriteVInt64(maxAddress);
 
             int maxDoc = state.SegmentInfo.DocCount;
@@ -412,19 +412,19 @@ namespace Lucene.Net.Codecs.Lucene40
             }
 
             /* values */
-            long startPosition = data.GetFilePointer();
+            long startPosition = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             long currentAddress = 0;
             Dictionary<BytesRef, long> valueToAddress = new Dictionary<BytesRef, long>();
             foreach (BytesRef v in dictionary)
             {
-                currentAddress = data.GetFilePointer() - startPosition;
+                currentAddress = data.Position - startPosition; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 valueToAddress[v] = currentAddress;
                 WriteVInt16(data, v.Length);
                 data.WriteBytes(v.Bytes, v.Offset, v.Length);
             }
 
             /* ordinals */
-            long totalBytes = data.GetFilePointer() - startPosition;
+            long totalBytes = data.Position - startPosition; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             index.WriteInt64(totalBytes);
             int maxDoc = state.SegmentInfo.DocCount;
             PackedInt32s.Writer w = PackedInt32s.GetWriter(index, maxDoc, PackedInt32s.BitsRequired(currentAddress), PackedInt32s.DEFAULT);
@@ -564,7 +564,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
             /* values */
 
-            long startPos = data.GetFilePointer();
+            long startPos = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             int valueCount = 0;
             foreach (BytesRef v in values)
@@ -575,7 +575,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
             /* addresses */
 
-            long maxAddress = data.GetFilePointer() - startPos;
+            long maxAddress = data.Position - startPos; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             index.WriteInt64(maxAddress);
 
             if (Debugging.AssertsEnabled) Debugging.Assert(valueCount != int.MaxValue); // unsupported by the 4.0 impl

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40PostingsWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40PostingsWriter.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
@@ -152,11 +152,11 @@ namespace Lucene.Net.Codecs.Lucene40
 
         public override void StartTerm()
         {
-            freqStart = freqOut.GetFilePointer();
+            freqStart = freqOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             //if (DEBUG) System.out.println("SPW: startTerm freqOut.fp=" + freqStart);
             if (proxOut != null)
             {
-                proxStart = proxOut.GetFilePointer();
+                proxStart = proxOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             // force first payload to write its length
             lastPayloadLength = -1;

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40SkipListWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40SkipListWriter.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Store;
 using Lucene.Net.Support;
 using System;
@@ -74,10 +74,10 @@ namespace Lucene.Net.Codecs.Lucene40
             this.curPayloadLength = payloadLength;
             this.curStoreOffsets = storeOffsets;
             this.curOffsetLength = offsetLength;
-            this.curFreqPointer = freqOutput.GetFilePointer();
+            this.curFreqPointer = freqOutput.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (proxOutput != null)
             {
-                this.curProxPointer = proxOutput.GetFilePointer();
+                this.curProxPointer = proxOutput.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
         }
 
@@ -87,10 +87,10 @@ namespace Lucene.Net.Codecs.Lucene40
             Arrays.Fill(lastSkipDoc, 0);
             Arrays.Fill(lastSkipPayloadLength, -1); // we don't have to write the first length in the skip list
             Arrays.Fill(lastSkipOffsetLength, -1); // we don't have to write the first length in the skip list
-            Arrays.Fill(lastSkipFreqPointer, freqOutput.GetFilePointer());
+            Arrays.Fill(lastSkipFreqPointer, freqOutput.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (proxOutput != null)
             {
-                Arrays.Fill(lastSkipProxPointer, proxOutput.GetFilePointer());
+                Arrays.Fill(lastSkipProxPointer, proxOutput.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Codecs.Lucene42
         {
             meta.WriteVInt32(field.Number);
             meta.WriteByte((byte)Lucene42DocValuesProducer.NUMBER);
-            meta.WriteInt64(data.GetFilePointer());
+            meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             long minValue = long.MaxValue;
             long maxValue = long.MinValue;
             long gcd = 0;
@@ -233,7 +233,7 @@ namespace Lucene.Net.Codecs.Lucene42
             meta.WriteByte((byte)Lucene42DocValuesProducer.BYTES);
             int minLength = int.MaxValue;
             int maxLength = int.MinValue;
-            long startFP = data.GetFilePointer();
+            long startFP = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             foreach (BytesRef v in values)
             {
                 int length = v == null ? 0 : v.Length;
@@ -249,7 +249,7 @@ namespace Lucene.Net.Codecs.Lucene42
                 }
             }
             meta.WriteInt64(startFP);
-            meta.WriteInt64(data.GetFilePointer() - startFP);
+            meta.WriteInt64(data.Position - startFP); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             meta.WriteVInt32(minLength);
             meta.WriteVInt32(maxLength);
 
@@ -278,7 +278,7 @@ namespace Lucene.Net.Codecs.Lucene42
         {
             meta.WriteVInt32(field.Number);
             meta.WriteByte((byte)Lucene42DocValuesProducer.FST);
-            meta.WriteInt64(data.GetFilePointer());
+            meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
             Builder<long?> builder = new Builder<long?>(INPUT_TYPE.BYTE1, outputs);
             Int32sRef scratch = new Int32sRef();

--- a/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSingleIntIndexOutput.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MockSep/MockSingleIntIndexOutput.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Codecs.Sep;
+﻿using Lucene.Net.Codecs.Sep;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
 
@@ -72,7 +72,7 @@ namespace Lucene.Net.Codecs.MockSep
 
         public override string ToString()
         {
-            return "MockSingleIntIndexOutput fp=" + @out.GetFilePointer();
+            return "MockSingleIntIndexOutput fp=" + @out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         }
 
         private class MockSingleInt32IndexOutputIndex : Index // LUCENENET specific: Renamed from MockSingleIntIndexOutputIndex
@@ -88,7 +88,7 @@ namespace Lucene.Net.Codecs.MockSep
 
             public override void Mark()
             {
-                fp = outerClass.@out.GetFilePointer();
+                fp = outerClass.@out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
 
             public override void CopyFrom(Index other, bool copyLast)

--- a/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
@@ -301,7 +301,7 @@ namespace Lucene.Net.Store
         //            {
         //                assertEquals(i, input.ReadZInt32());
         //            }
-        //            assertEquals(input.Length, input.GetFilePointer());
+        //            assertEquals(input.Length, input.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         //        } // input.close();
         //    }
         //}
@@ -346,7 +346,7 @@ namespace Lucene.Net.Store
         //            {
         //                assertEquals(l, input.ReadZInt64());
         //            }
-        //            assertEquals(input.Length, input.GetFilePointer());
+        //            assertEquals(input.Length, input.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         //        } // input.close();
         //    }
         //}
@@ -388,7 +388,7 @@ namespace Lucene.Net.Store
         //                set3.Add("bogus");
         //            });
 
-        //            assertEquals(input.Length, input.GetFilePointer());
+        //            assertEquals(input.Length, input.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         //        } // input.close();
         //    }
         //}
@@ -435,7 +435,7 @@ namespace Lucene.Net.Store
         //                map3["bogus1"] = "bogus2";
         //            });
 
-        //            assertEquals(input.Length, input.GetFilePointer());
+        //            assertEquals(input.Length, input.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         //        } // input.close();
         //    }
         //}
@@ -756,7 +756,7 @@ namespace Lucene.Net.Store
                 }
 
                 @out.WriteBytes(bytes, 0, byteUpto);
-                assertEquals(size, @out.GetFilePointer());
+                assertEquals(size, @out.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             } // @out.close();
             assertEquals(size, dir.FileLength("test"));
 
@@ -1222,7 +1222,7 @@ namespace Lucene.Net.Store
         //            for (int i = 0; i < num; i += 16)
         //            {
         //                IndexInput slice1 = input.Slice("slice1", i, num - i);
-        //                assertEquals(0, slice1.GetFilePointer());
+        //                assertEquals(0, slice1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         //                assertEquals(num - i, slice1.Length);
 
         //                // seek to a random spot shouldnt impact slicing.
@@ -1230,7 +1230,7 @@ namespace Lucene.Net.Store
         //                for (int j = 0; j < slice1.Length; j += 16)
         //                {
         //                    IndexInput slice2 = slice1.Slice("slice2", j, num - i - j);
-        //                    assertEquals(0, slice2.GetFilePointer());
+        //                    assertEquals(0, slice2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         //                    assertEquals(num - i - j, slice2.Length);
         //                    byte[] data = new byte[num];
         //                    System.Array.Copy(bytes, 0, data, 0, i + j);
@@ -1269,10 +1269,10 @@ namespace Lucene.Net.Store
             byte[] largeBuf = new byte[2048];
             Random.NextBytes(largeBuf);
 
-            long currentPos = os.GetFilePointer();
+            long currentPos = os.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             os.WriteBytes(largeBuf, largeBuf.Length);
 
-            assertEquals(currentPos + largeBuf.Length, os.GetFilePointer());
+            assertEquals(currentPos + largeBuf.Length, os.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         }
 
         // LUCENENET: This test compiles, but is not compatible with 4.8.0 (tested in Java Lucene), as it was ported from 8.2.0
@@ -1389,9 +1389,9 @@ namespace Lucene.Net.Store
             }
             using IndexInput @in = dir.OpenInput("a", IOContext.DEFAULT);
             @in.Seek(100);
-            assertEquals(100, @in.GetFilePointer());
+            assertEquals(100, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             @in.Seek(1024);
-            assertEquals(1024, @in.GetFilePointer());
+            assertEquals(1024, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         }
 
         // LUCENENET: This test compiles, but is not compatible with 4.8.0 (tested in Java Lucene), as it was ported from 8.2.0
@@ -1410,7 +1410,7 @@ namespace Lucene.Net.Store
         //        using (IndexInput @in = dir.OpenInput("a", IOContext.DEFAULT))
         //        {
         //            @in.Seek(100);
-        //            assertEquals(100, @in.GetFilePointer());
+        //            assertEquals(100, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         //            Assert.Throws<EndOfStreamException>(() => {
         //                @in.Seek(1025);
         //            });
@@ -1436,7 +1436,7 @@ namespace Lucene.Net.Store
         //            string candidate = IndexFileNames.SegmentFileName(TestUtil.RandomSimpleString(Random, 1, 6), TestUtil.RandomSimpleString(Random), "test");
         //            using (IndexOutput @out = dir.CreateOutput(candidate, IOContext.DEFAULT))
         //            {
-        //                @out.GetFilePointer(); // just fake access to prevent compiler warning
+        //                @out.Position; // just fake access to prevent compiler warning // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         //            }
         //            fsDir.DeleteFile(candidate);
         //            if (fsDir.GetPendingDeletions().Count > 0)

--- a/src/Lucene.Net.TestFramework/Store/MockIndexInputWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockIndexInputWrapper.cs
@@ -99,10 +99,13 @@ namespace Lucene.Net.Store
             return clone;
         }
 
-        public override long GetFilePointer()
+        public override long Position // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         {
-            EnsureOpen();
-            return @delegate.GetFilePointer();
+            get
+            {
+                EnsureOpen();
+                return @delegate.Position;
+            }
         }
 
         public override void Seek(long pos)

--- a/src/Lucene.Net.TestFramework/Store/MockIndexOutputWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockIndexOutputWrapper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Threading;
 using Console = Lucene.Net.Util.SystemConsole;
@@ -169,10 +169,7 @@ namespace Lucene.Net.Store
             }
         }
 
-        public override long GetFilePointer()
-        {
-            return @delegate.GetFilePointer();
-        }
+        public override long Position => @delegate.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
         [Obsolete("(4.1) this method will be removed in Lucene 5.0")]
         public override void Seek(long pos)

--- a/src/Lucene.Net.TestFramework/Util/ThrottledIndexOutput.cs
+++ b/src/Lucene.Net.TestFramework/Util/ThrottledIndexOutput.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Store;
 using Lucene.Net.Support;
 using System;
@@ -91,10 +91,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        public override long GetFilePointer()
-        {
-            return @delegate.GetFilePointer();
-        }
+        public override long Position => @delegate.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
         [Obsolete("(4.1) this method will be removed in Lucene 5.0")]
         public override void Seek(long pos)

--- a/src/Lucene.Net.Tests.Facet/SlowRAMDirectory.cs
+++ b/src/Lucene.Net.Tests.Facet/SlowRAMDirectory.cs
@@ -155,10 +155,7 @@ namespace Lucene.Net.Facet
                 return ii.Equals(o);
             }
 
-            public override long GetFilePointer()
-            {
-                return ii.GetFilePointer();
-            }
+            public override long Position => ii.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             public override int GetHashCode()
             {
@@ -233,10 +230,7 @@ namespace Lucene.Net.Facet
                 io.Flush();
             }
 
-            public override long GetFilePointer()
-            {
-                return io.GetFilePointer();
-            }
+            public override long Position => io.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             public override long Length
             {

--- a/src/Lucene.Net.Tests/Codecs/Lucene41/TestForUtil.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene41/TestForUtil.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Codecs.Lucene41
                 {
                     forUtil.WriteBlock(Arrays.CopyOfRange(values, i * Lucene41PostingsFormat.BLOCK_SIZE, values.Length), new byte[Lucene41.ForUtil.MAX_ENCODED_SIZE], @out);
                 }
-                endPointer = @out.GetFilePointer();
+                endPointer = @out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 @out.Dispose();
             }
 
@@ -91,7 +91,7 @@ namespace Lucene.Net.Codecs.Lucene41
                     forUtil.ReadBlock(@in, new byte[Lucene41.ForUtil.MAX_ENCODED_SIZE], restored);
                     Assert.AreEqual(Arrays.CopyOfRange(values, i * Lucene41PostingsFormat.BLOCK_SIZE, (i + 1) * Lucene41PostingsFormat.BLOCK_SIZE), Arrays.CopyOf(restored, Lucene41PostingsFormat.BLOCK_SIZE));
                 }
-                assertEquals(endPointer, @in.GetFilePointer());
+                assertEquals(endPointer, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 @in.Dispose();
             }
         }

--- a/src/Lucene.Net.Tests/Index/TestCompoundFile.cs
+++ b/src/Lucene.Net.Tests/Index/TestCompoundFile.cs
@@ -91,12 +91,12 @@ namespace Lucene.Net.Index
             Assert.IsNotNull(expected, msg + " null expected");
             Assert.IsNotNull(test, msg + " null test");
             Assert.AreEqual(expected.Length, test.Length, msg + " length");
-            Assert.AreEqual(expected.GetFilePointer(), test.GetFilePointer(), msg + " position");
+            Assert.AreEqual(expected.Position, test.Position, msg + " position"); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             var expectedBuffer = new byte[512];
             var testBuffer = new byte[expectedBuffer.Length];
 
-            long remainder = expected.Length - expected.GetFilePointer();
+            long remainder = expected.Length - expected.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             while (remainder > 0)
             {
                 int readLen = (int)Math.Min(remainder, expectedBuffer.Length);
@@ -401,8 +401,8 @@ namespace Lucene.Net.Index
             // Seek the first pair
             e1.Seek(100);
             a1.Seek(100);
-            Assert.AreEqual(100, e1.GetFilePointer());
-            Assert.AreEqual(100, a1.GetFilePointer());
+            Assert.AreEqual(100, e1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(100, a1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             byte be1 = e1.ReadByte();
             byte ba1 = a1.ReadByte();
             Assert.AreEqual(be1, ba1);
@@ -410,15 +410,15 @@ namespace Lucene.Net.Index
             // Now seek the second pair
             e2.Seek(1027);
             a2.Seek(1027);
-            Assert.AreEqual(1027, e2.GetFilePointer());
-            Assert.AreEqual(1027, a2.GetFilePointer());
+            Assert.AreEqual(1027, e2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(1027, a2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             byte be2 = e2.ReadByte();
             byte ba2 = a2.ReadByte();
             Assert.AreEqual(be2, ba2);
 
             // Now make sure the first one didn't move
-            Assert.AreEqual(101, e1.GetFilePointer());
-            Assert.AreEqual(101, a1.GetFilePointer());
+            Assert.AreEqual(101, e1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(101, a1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be1 = e1.ReadByte();
             ba1 = a1.ReadByte();
             Assert.AreEqual(be1, ba1);
@@ -426,15 +426,15 @@ namespace Lucene.Net.Index
             // Now more the first one again, past the buffer length
             e1.Seek(1910);
             a1.Seek(1910);
-            Assert.AreEqual(1910, e1.GetFilePointer());
-            Assert.AreEqual(1910, a1.GetFilePointer());
+            Assert.AreEqual(1910, e1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(1910, a1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be1 = e1.ReadByte();
             ba1 = a1.ReadByte();
             Assert.AreEqual(be1, ba1);
 
             // Now make sure the second set didn't move
-            Assert.AreEqual(1028, e2.GetFilePointer());
-            Assert.AreEqual(1028, a2.GetFilePointer());
+            Assert.AreEqual(1028, e2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(1028, a2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be2 = e2.ReadByte();
             ba2 = a2.ReadByte();
             Assert.AreEqual(be2, ba2);
@@ -442,16 +442,16 @@ namespace Lucene.Net.Index
             // Move the second set back, again cross the buffer size
             e2.Seek(17);
             a2.Seek(17);
-            Assert.AreEqual(17, e2.GetFilePointer());
-            Assert.AreEqual(17, a2.GetFilePointer());
+            Assert.AreEqual(17, e2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(17, a2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be2 = e2.ReadByte();
             ba2 = a2.ReadByte();
             Assert.AreEqual(be2, ba2);
 
             // Finally, make sure the first set didn't move
             // Now make sure the first one didn't move
-            Assert.AreEqual(1911, e1.GetFilePointer());
-            Assert.AreEqual(1911, a1.GetFilePointer());
+            Assert.AreEqual(1911, e1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(1911, a1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be1 = e1.ReadByte();
             ba1 = a1.ReadByte();
             Assert.AreEqual(be1, ba1);
@@ -483,8 +483,8 @@ namespace Lucene.Net.Index
             // Seek the first pair
             e1.Seek(100);
             a1.Seek(100);
-            Assert.AreEqual(100, e1.GetFilePointer());
-            Assert.AreEqual(100, a1.GetFilePointer());
+            Assert.AreEqual(100, e1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(100, a1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             byte be1 = e1.ReadByte();
             byte ba1 = a1.ReadByte();
             Assert.AreEqual(be1, ba1);
@@ -492,15 +492,15 @@ namespace Lucene.Net.Index
             // Now seek the second pair
             e2.Seek(1027);
             a2.Seek(1027);
-            Assert.AreEqual(1027, e2.GetFilePointer());
-            Assert.AreEqual(1027, a2.GetFilePointer());
+            Assert.AreEqual(1027, e2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(1027, a2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             byte be2 = e2.ReadByte();
             byte ba2 = a2.ReadByte();
             Assert.AreEqual(be2, ba2);
 
             // Now make sure the first one didn't move
-            Assert.AreEqual(101, e1.GetFilePointer());
-            Assert.AreEqual(101, a1.GetFilePointer());
+            Assert.AreEqual(101, e1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(101, a1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be1 = e1.ReadByte();
             ba1 = a1.ReadByte();
             Assert.AreEqual(be1, ba1);
@@ -508,15 +508,15 @@ namespace Lucene.Net.Index
             // Now more the first one again, past the buffer length
             e1.Seek(1910);
             a1.Seek(1910);
-            Assert.AreEqual(1910, e1.GetFilePointer());
-            Assert.AreEqual(1910, a1.GetFilePointer());
+            Assert.AreEqual(1910, e1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(1910, a1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be1 = e1.ReadByte();
             ba1 = a1.ReadByte();
             Assert.AreEqual(be1, ba1);
 
             // Now make sure the second set didn't move
-            Assert.AreEqual(1028, e2.GetFilePointer());
-            Assert.AreEqual(1028, a2.GetFilePointer());
+            Assert.AreEqual(1028, e2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(1028, a2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be2 = e2.ReadByte();
             ba2 = a2.ReadByte();
             Assert.AreEqual(be2, ba2);
@@ -524,16 +524,16 @@ namespace Lucene.Net.Index
             // Move the second set back, again cross the buffer size
             e2.Seek(17);
             a2.Seek(17);
-            Assert.AreEqual(17, e2.GetFilePointer());
-            Assert.AreEqual(17, a2.GetFilePointer());
+            Assert.AreEqual(17, e2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(17, a2.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be2 = e2.ReadByte();
             ba2 = a2.ReadByte();
             Assert.AreEqual(be2, ba2);
 
             // Finally, make sure the first set didn't move
             // Now make sure the first one didn't move
-            Assert.AreEqual(1911, e1.GetFilePointer());
-            Assert.AreEqual(1911, a1.GetFilePointer());
+            Assert.AreEqual(1911, e1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            Assert.AreEqual(1911, a1.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             be1 = e1.ReadByte();
             ba1 = a1.ReadByte();
             Assert.AreEqual(be1, ba1);
@@ -618,12 +618,12 @@ namespace Lucene.Net.Index
                 largeBuf[i] = (byte)(new Random(1).NextDouble() * 256);
             }
 
-            long currentPos = os.GetFilePointer();
+            long currentPos = os.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             os.WriteBytes(largeBuf, largeBuf.Length);
 
             try
             {
-                Assert.AreEqual(currentPos + largeBuf.Length, os.GetFilePointer());
+                Assert.AreEqual(currentPos + largeBuf.Length, os.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             finally
             {

--- a/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
@@ -194,7 +194,7 @@ namespace Lucene.Net.Index
             protected override void ReadInternal(byte[] b, int offset, int length)
             {
                 SimOutage();
-                @delegate.Seek(GetFilePointer());
+                @delegate.Seek(Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 @delegate.ReadBytes(b, offset, length);
             }
 
@@ -218,7 +218,7 @@ namespace Lucene.Net.Index
                 // seek the clone to our current position
                 try
                 {
-                    i.Seek(GetFilePointer());
+                    i.Seek(Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
                 catch (Exception e) when (e.IsIOException())
                 {

--- a/src/Lucene.Net.Tests/Index/TestLazyProxSkipping.cs
+++ b/src/Lucene.Net.Tests/Index/TestLazyProxSkipping.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Analysis;
+﻿using Lucene.Net.Analysis;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
@@ -225,10 +225,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            public override long GetFilePointer()
-            {
-                return this.input.GetFilePointer();
-            }
+            public override long Position => this.input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             public override void Seek(long pos)
             {

--- a/src/Lucene.Net.Tests/Index/TestMultiLevelSkipList.cs
+++ b/src/Lucene.Net.Tests/Index/TestMultiLevelSkipList.cs
@@ -197,10 +197,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            public override long GetFilePointer()
-            {
-                return this.input.GetFilePointer();
-            }
+            public override long Position => this.input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             public override void Seek(long pos)
             {

--- a/src/Lucene.Net.Tests/Store/TestBufferedIndexInput.cs
+++ b/src/Lucene.Net.Tests/Store/TestBufferedIndexInput.cs
@@ -140,8 +140,8 @@ namespace Lucene.Net.Store
             // add an arbitrary offset at the beginning of the array
             int offset = size % 10; // arbitrary
             buffer = ArrayUtil.Grow(buffer, offset + size);
-            Assert.AreEqual(pos, input.GetFilePointer());
-            long left = TEST_FILE_LENGTH - input.GetFilePointer();
+            Assert.AreEqual(pos, input.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            long left = TEST_FILE_LENGTH - input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (left <= 0)
             {
                 return;
@@ -151,7 +151,7 @@ namespace Lucene.Net.Store
                 size = (int)left;
             }
             input.ReadBytes(buffer, offset, size);
-            Assert.AreEqual(pos + size, input.GetFilePointer());
+            Assert.AreEqual(pos + size, input.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             for (int i = 0; i < size; i++)
             {
                 Assert.AreEqual(Byten(pos + i), (byte)buffer[offset + i], "pos=" + i + " filepos=" + (pos + i));

--- a/src/Lucene.Net.Tests/Store/TestCopyBytes.cs
+++ b/src/Lucene.Net.Tests/Store/TestCopyBytes.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Store
                 }
 
                 @out.WriteBytes(bytes, 0, byteUpto);
-                Assert.AreEqual(size, @out.GetFilePointer());
+                Assert.AreEqual(size, @out.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 @out.Dispose();
                 Assert.AreEqual(size, dir.FileLength("test"));
 

--- a/src/Lucene.Net.Tests/Util/Packed/TestPackedInts.cs
+++ b/src/Lucene.Net.Tests/Util/Packed/TestPackedInts.cs
@@ -111,7 +111,7 @@ namespace Lucene.Net.Util.Packed
                         acceptableOverhead = Random.NextSingle();
                     }
                     PackedInt32s.Writer w = PackedInt32s.GetWriter(@out, valueCount, nbits, acceptableOverhead);
-                    long startFp = @out.GetFilePointer();
+                    long startFp = @out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                     int actualValueCount = Random.NextBoolean() ? valueCount : TestUtil.NextInt32(Random, 0, valueCount);
                     long[] values = new long[valueCount];
@@ -128,7 +128,7 @@ namespace Lucene.Net.Util.Packed
                         w.Add(values[i]);
                     }
                     w.Finish();
-                    long fp = @out.GetFilePointer();
+                    long fp = @out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     @out.Dispose();
 
                     // ensure that finish() added the (valueCount-actualValueCount) missing values
@@ -142,14 +142,14 @@ namespace Lucene.Net.Util.Packed
                         Assert.AreEqual(w.BitsPerValue, @in.ReadVInt32());
                         Assert.AreEqual(valueCount, @in.ReadVInt32());
                         Assert.AreEqual(w.Format.Id, @in.ReadVInt32());
-                        Assert.AreEqual(startFp, @in.GetFilePointer());
+                        Assert.AreEqual(startFp, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         @in.Dispose();
                     }
 
                     { // test reader
                         IndexInput @in = d.OpenInput("out.bin", NewIOContext(Random));
                         PackedInt32s.Reader r = PackedInt32s.GetReader(@in);
-                        Assert.AreEqual(fp, @in.GetFilePointer());
+                        Assert.AreEqual(fp, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         for (int i = 0; i < valueCount; i++)
                         {
                             Assert.AreEqual(values[i], r.Get(i), "index=" + i + " valueCount=" + valueCount + " nbits=" + nbits + " for " + r.GetType().Name);
@@ -169,7 +169,7 @@ namespace Lucene.Net.Util.Packed
                             Assert.AreEqual(values[i], r.Next(), "index=" + i + " valueCount=" + valueCount + " nbits=" + nbits + " for " + r.GetType().Name);
                             Assert.AreEqual(i, r.Ord);
                         }
-                        assertEquals(fp, @in.GetFilePointer());
+                        assertEquals(fp, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         @in.Dispose();
                     }
 
@@ -187,7 +187,7 @@ namespace Lucene.Net.Util.Packed
                             }
                             i += next.Length;
                         }
-                        Assert.AreEqual(fp, @in.GetFilePointer());
+                        Assert.AreEqual(fp, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         @in.Dispose();
                     }
 
@@ -201,7 +201,7 @@ namespace Lucene.Net.Util.Packed
                             Assert.AreEqual(values[index], intsEnum.Get(index), msg);
                         }
                         intsEnum.Get(intsEnum.Count - 1);
-                        Assert.AreEqual(fp, @in.GetFilePointer());
+                        Assert.AreEqual(fp, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         @in.Dispose();
                     }
                     d.Dispose();
@@ -241,18 +241,18 @@ namespace Lucene.Net.Util.Packed
                         {
                             it.Next();
                         }
-                        Assert.AreEqual(byteCount, @in.GetFilePointer(), msg);
+                        Assert.AreEqual(byteCount, @in.Position, msg); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                         // test direct reader
                         @in.Seek(0L);
                         PackedInt32s.Reader directReader = PackedInt32s.GetDirectReaderNoHeader(@in, format, version, valueCount, bpv);
                         directReader.Get(valueCount - 1);
-                        Assert.AreEqual(byteCount, @in.GetFilePointer(), msg);
+                        Assert.AreEqual(byteCount, @in.Position, msg); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                         // test reader
                         @in.Seek(0L);
                         PackedInt32s.GetReaderNoHeader(@in, format, version, valueCount, bpv);
-                        Assert.AreEqual(byteCount, @in.GetFilePointer(), msg);
+                        Assert.AreEqual(byteCount, @in.Position, msg); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     }
                 }
             }
@@ -477,7 +477,7 @@ namespace Lucene.Net.Util.Packed
                 long value = 17L & PackedInt32s.MaxValue(bitsPerValue);
                 w.Add(value);
                 w.Finish();
-                long end = @out.GetFilePointer();
+                long end = @out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 @out.Dispose();
 
                 IndexInput @in = dir.OpenInput("out", NewIOContext(Random));
@@ -485,7 +485,7 @@ namespace Lucene.Net.Util.Packed
                 string msg = "Impl=" + w.GetType().Name + ", bitsPerValue=" + bitsPerValue;
                 Assert.AreEqual(1, reader.Count, msg);
                 Assert.AreEqual(value, reader.Get(0), msg);
-                Assert.AreEqual(end, @in.GetFilePointer(), msg);
+                Assert.AreEqual(end, @in.Position, msg); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 @in.Dispose();
 
                 dir.Dispose();
@@ -1275,7 +1275,7 @@ namespace Lucene.Net.Util.Packed
                 }
             }
             pout.Flush();
-            Assert.AreEqual((long)Math.Ceiling((double)totalBits / 8), @out.GetFilePointer());
+            Assert.AreEqual((long)Math.Ceiling((double)totalBits / 8), @out.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             @out.Dispose();
             IndexInput @in = dir.OpenInput("out.bin", IOContext.READ_ONCE);
             PackedDataInput pin = new PackedDataInput(@in);
@@ -1287,7 +1287,7 @@ namespace Lucene.Net.Util.Packed
                     pin.SkipToNextByte();
                 }
             }
-            assertEquals((long)Math.Ceiling((double)totalBits / 8), @in.GetFilePointer());
+            assertEquals((long)Math.Ceiling((double)totalBits / 8), @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             @in.Dispose();
             dir.Dispose();
         }
@@ -1335,7 +1335,7 @@ namespace Lucene.Net.Util.Packed
                 Assert.AreEqual(valueCount, writer.Ord);
                 writer.Finish();
                 Assert.AreEqual(valueCount, writer.Ord);
-                long fp = @out.GetFilePointer();
+                long fp = @out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 @out.Dispose();
 
                 IndexInput in1 = dir.OpenInput("out.bin", IOContext.DEFAULT);
@@ -1363,7 +1363,7 @@ namespace Lucene.Net.Util.Packed
                     }
                     Assert.AreEqual(i, it.Ord);
                 }
-                assertEquals(fp, @in is ByteArrayDataInput ? ((ByteArrayDataInput)@in).Position : ((IndexInput)@in).GetFilePointer());
+                assertEquals(fp, @in is ByteArrayDataInput ? ((ByteArrayDataInput)@in).Position : ((IndexInput)@in).Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 try
                 {
                     it.Next();
@@ -1400,7 +1400,7 @@ namespace Lucene.Net.Util.Packed
                         ++k;
                     }
                 }
-                assertEquals(fp, @in is ByteArrayDataInput ? ((ByteArrayDataInput)@in).Position : (((IndexInput)@in).GetFilePointer()));
+                assertEquals(fp, @in is ByteArrayDataInput ? ((ByteArrayDataInput)@in).Position : (((IndexInput)@in).Position)); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 try
                 {
                     it2.Skip(1);
@@ -1413,7 +1413,7 @@ namespace Lucene.Net.Util.Packed
 
                 in1.Seek(0L);
                 BlockPackedReader reader = new BlockPackedReader(in1, PackedInt32s.VERSION_CURRENT, blockSize, valueCount, Random.NextBoolean());
-                assertEquals(in1.GetFilePointer(), in1.Length);
+                assertEquals(in1.Position, in1.Length); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 for (k = 0; k < valueCount; ++k)
                 {
                     Assert.AreEqual(values[k], reader.Get(k), "i=" + k);
@@ -1457,12 +1457,12 @@ namespace Lucene.Net.Util.Packed
                 Assert.AreEqual(valueCount, writer.Ord);
                 writer.Finish();
                 Assert.AreEqual(valueCount, writer.Ord);
-                long fp = @out.GetFilePointer();
+                long fp = @out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 @out.Dispose();
 
                 IndexInput @in = dir.OpenInput("out.bin", IOContext.DEFAULT);
                 MonotonicBlockPackedReader reader = new MonotonicBlockPackedReader(@in, PackedInt32s.VERSION_CURRENT, blockSize, valueCount, Random.NextBoolean());
-                assertEquals(fp, @in.GetFilePointer());
+                assertEquals(fp, @in.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 for (int i = 0; i < valueCount; ++i)
                 {
                     Assert.AreEqual(values[i], reader.Get(i),"i=" + i);

--- a/src/Lucene.Net.Tests/Util/Test2BPagedBytes.cs
+++ b/src/Lucene.Net.Tests/Util/Test2BPagedBytes.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Util
                 byte[] bytes = new byte[numBytes];
                 r2.NextBytes(bytes);
                 dataOutput.WriteBytes(bytes, bytes.Length);
-                long fp = dataOutput.GetFilePointer();
+                long fp = dataOutput.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (Debugging.AssertsEnabled) Debugging.Assert(fp == lastFP + numBytes);
                 lastFP = fp;
                 netBytes += numBytes;

--- a/src/Lucene.Net.Tests/Util/TestPagedBytes.cs
+++ b/src/Lucene.Net.Tests/Util/TestPagedBytes.cs
@@ -202,12 +202,12 @@ namespace Lucene.Net.Util
             var @out = dir.CreateOutput("foo", IOContext.DEFAULT);
             for (long i = 0; i < numBytes;)
             {
-                Assert.AreEqual(i, @out.GetFilePointer());
+                Assert.AreEqual(i, @out.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 int len = (int)Math.Min(arr.Length, numBytes - i);
                 @out.WriteBytes(arr, len);
                 i += len;
             }
-            Assert.AreEqual(numBytes, @out.GetFilePointer());
+            Assert.AreEqual(numBytes, @out.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             @out.Dispose();
             IndexInput @in = dir.OpenInput("foo", IOContext.DEFAULT);
             p.Copy(@in, numBytes);

--- a/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
@@ -894,7 +894,7 @@ namespace Lucene.Net.Codecs
                         {
                             // Sub-blocks of a single floor block are always
                             // written one after another -- tail recurse:
-                            fpEnd = outerInstance.@in.GetFilePointer();
+                            fpEnd = outerInstance.@in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         }
                     }
 
@@ -2799,7 +2799,7 @@ namespace Lucene.Net.Codecs
 
                         // Sub-blocks of a single floor block are always
                         // written one after another -- tail recurse:
-                        fpEnd = outerInstance.@in.GetFilePointer();
+                        fpEnd = outerInstance.@in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         // if (DEBUG) {
                         //   System.out.println("      fpEnd=" + fpEnd);
                         // }

--- a/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
@@ -501,7 +501,7 @@ namespace Lucene.Net.Codecs
                     // it might contain garbage that cannot be converted into text.
                     Debugging.Assert((IsFloor && floorBlocks != null && floorBlocks.Count != 0) || (!IsFloor && floorBlocks == null), "isFloor={0} floorBlocks={1}", IsFloor, new PendingBlocksFormatter(floorBlocks));
 
-                    Debugging.Assert(scratchBytes.GetFilePointer() == 0);
+                    Debugging.Assert(scratchBytes.Position == 0); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
 
                 // TODO: try writing the leading vLong in MSB order
@@ -525,7 +525,7 @@ namespace Lucene.Net.Codecs
 
                 ByteSequenceOutputs outputs = ByteSequenceOutputs.Singleton;
                 Builder<BytesRef> indexBuilder = new Builder<BytesRef>(FST.INPUT_TYPE.BYTE1, 0, 0, true, false, int.MaxValue, outputs, null, false, PackedInt32s.COMPACT, true, 15);
-                var bytes = new byte[(int)scratchBytes.GetFilePointer()];
+                var bytes = new byte[(int)scratchBytes.Position]; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (Debugging.AssertsEnabled) Debugging.Assert(bytes.Length > 0);
                 scratchBytes.WriteTo(bytes, 0);
                 indexBuilder.Add(Util.ToInt32sRef(Prefix, scratchIntsRef), new BytesRef(bytes, 0, bytes.Length));
@@ -964,7 +964,7 @@ namespace Lucene.Net.Codecs
 
                 IList<PendingEntry> slice = pending.SubList(start, start + length);
 
-                long startFP = outerInstance.@out.GetFilePointer();
+                long startFP = outerInstance.@out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                 BytesRef prefix = new BytesRef(indexPrefixLength);
                 for (int m = 0; m < indexPrefixLength; m++)
@@ -1138,17 +1138,17 @@ namespace Lucene.Net.Codecs
                 // search on lookup
 
                 // Write suffixes byte[] blob to terms dict output:
-                outerInstance.@out.WriteVInt32((int)(suffixWriter.GetFilePointer() << 1) | (isLeafBlock ? 1 : 0));
+                outerInstance.@out.WriteVInt32((int)(suffixWriter.Position << 1) | (isLeafBlock ? 1 : 0)); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 suffixWriter.WriteTo(outerInstance.@out);
                 suffixWriter.Reset();
 
                 // Write term stats byte[] blob
-                outerInstance.@out.WriteVInt32((int)statsWriter.GetFilePointer());
+                outerInstance.@out.WriteVInt32((int)statsWriter.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 statsWriter.WriteTo(outerInstance.@out);
                 statsWriter.Reset();
 
                 // Write term meta data byte[] blob
-                outerInstance.@out.WriteVInt32((int)metaWriter.GetFilePointer());
+                outerInstance.@out.WriteVInt32((int)metaWriter.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 metaWriter.WriteTo(outerInstance.@out);
                 metaWriter.Reset();
 
@@ -1245,7 +1245,7 @@ namespace Lucene.Net.Codecs
                     this.docCount = docCount;
 
                     // Write FST to index
-                    indexStartFP = outerInstance.indexOut.GetFilePointer();
+                    indexStartFP = outerInstance.indexOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     root.Index.Save(outerInstance.indexOut);
                     //System.out.println("  write FST " + indexStartFP + " field=" + fieldInfo.name);
 
@@ -1286,8 +1286,8 @@ namespace Lucene.Net.Codecs
                 Exception ioe = null; // LUCENENET: No need to cast to IOExcpetion
                 try
                 {
-                    long dirStart = @out.GetFilePointer();
-                    long indexDirStart = indexOut.GetFilePointer();
+                    long dirStart = @out.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    long indexDirStart = indexOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                     @out.WriteVInt32(fields.Count);
 

--- a/src/Lucene.Net/Codecs/CodecUtil.cs
+++ b/src/Lucene.Net/Codecs/CodecUtil.cs
@@ -213,9 +213,9 @@ namespace Lucene.Net.Codecs
             {
                 throw new IOException("checksum failed (hardware problem?) : expected=" + expectedChecksum.ToString("x") + " actual=" + actualChecksum.ToString("x") + " (resource=" + @in + ")");
             }
-            if (@in.GetFilePointer() != @in.Length)
+            if (@in.Position != @in.Length) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             {
-                throw new IOException("did not read all bytes from file: read " + @in.GetFilePointer() + " vs size " + @in.Length + " (resource: " + @in + ")");
+                throw new IOException("did not read all bytes from file: read " + @in.Position + " vs size " + @in.Length + " (resource: " + @in + ")"); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             return actualChecksum;
         }
@@ -253,9 +253,9 @@ namespace Lucene.Net.Codecs
         [Obsolete("Use CheckFooter(ChecksumIndexInput) instead, this should only used for files without checksums.")]
         public static void CheckEOF(IndexInput @in)
         {
-            if (@in.GetFilePointer() != @in.Length)
+            if (@in.Position != @in.Length) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             {
-                throw new IOException("did not read all bytes from file: read " + @in.GetFilePointer() + " vs size " + @in.Length + " (resource: " + @in + ")");
+                throw new IOException("did not read all bytes from file: read " + @in.Position + " vs size " + @in.Length + " (resource: " + @in + ")");
             }
         }
 
@@ -270,7 +270,7 @@ namespace Lucene.Net.Codecs
             IndexInput clone = (IndexInput)input.Clone();
             clone.Seek(0);
             ChecksumIndexInput @in = new BufferedChecksumIndexInput(clone);
-            if (Debugging.AssertsEnabled) Debugging.Assert(@in.GetFilePointer() == 0);
+            if (Debugging.AssertsEnabled) Debugging.Assert(@in.Position == 0); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             @in.Seek(@in.Length - FooterLength());
             return CheckFooter(@in);
         }

--- a/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Codecs.Compressing
                 indexStream = d.OpenChecksumInput(indexStreamFN, context);
                 string codecNameIdx = formatName + CompressingStoredFieldsWriter.CODEC_SFX_IDX;
                 version = CodecUtil.CheckHeader(indexStream, codecNameIdx, CompressingStoredFieldsWriter.VERSION_START, CompressingStoredFieldsWriter.VERSION_CURRENT);
-                if (Debugging.AssertsEnabled) Debugging.Assert(CodecUtil.HeaderLength(codecNameIdx) == indexStream.GetFilePointer());
+                if (Debugging.AssertsEnabled) Debugging.Assert(CodecUtil.HeaderLength(codecNameIdx) == indexStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 indexReader = new CompressingStoredFieldsIndexReader(indexStream, si);
 
                 long maxPointer = -1;
@@ -143,7 +143,7 @@ namespace Lucene.Net.Codecs.Compressing
                 {
                     throw new CorruptIndexException("Version mismatch between stored fields index and data: " + version + " != " + fieldsVersion);
                 }
-                if (Debugging.AssertsEnabled) Debugging.Assert(CodecUtil.HeaderLength(codecNameDat) == fieldsStream.GetFilePointer());
+                if (Debugging.AssertsEnabled) Debugging.Assert(CodecUtil.HeaderLength(codecNameDat) == fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                 if (version >= CompressingStoredFieldsWriter.VERSION_BIG_CHUNKS)
                 {
@@ -289,7 +289,7 @@ namespace Lucene.Net.Codecs.Compressing
                 }
                 else
                 {
-                    long filePointer = fieldsStream.GetFilePointer();
+                    long filePointer = fieldsStream.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     PackedInt32s.Reader reader = PackedInt32s.GetDirectReaderNoHeader(fieldsStream, PackedInt32s.Format.PACKED, packedIntsVersion, chunkDocs, bitsPerStoredFields);
                     numStoredFields = (int)(reader.Get(docID - docBase));
                     fieldsStream.Seek(filePointer + PackedInt32s.Format.PACKED.ByteCount(packedIntsVersion, chunkDocs, bitsPerStoredFields));
@@ -596,7 +596,7 @@ namespace Lucene.Net.Codecs.Compressing
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(outerInstance.Version == CompressingStoredFieldsWriter.VERSION_CURRENT);
                 long chunkEnd = docBase + chunkDocs == outerInstance.numDocs ? outerInstance.maxPointer : outerInstance.indexReader.GetStartPointer(docBase + chunkDocs);
-                @out.CopyBytes(fieldsStream, chunkEnd - fieldsStream.GetFilePointer());
+                @out.CopyBytes(fieldsStream, chunkEnd - fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
 
             /// <summary>

--- a/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsWriter.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsWriter.cs
@@ -116,8 +116,8 @@ namespace Lucene.Net.Codecs.Compressing
                 CodecUtil.WriteHeader(fieldsStream, codecNameDat, VERSION_CURRENT);
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(CodecUtil.HeaderLength(codecNameDat) == fieldsStream.GetFilePointer());
-                    Debugging.Assert(CodecUtil.HeaderLength(codecNameIdx) == indexStream.GetFilePointer());
+                    Debugging.Assert(CodecUtil.HeaderLength(codecNameDat) == fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    Debugging.Assert(CodecUtil.HeaderLength(codecNameIdx) == indexStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
 
                 indexWriter = new CompressingStoredFieldsIndexWriter(indexStream);
@@ -243,7 +243,7 @@ namespace Lucene.Net.Codecs.Compressing
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void Flush()
         {
-            indexWriter.WriteIndex(numBufferedDocs, fieldsStream.GetFilePointer());
+            indexWriter.WriteIndex(numBufferedDocs, fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             // transform end offsets into lengths
             int[] lengths = endOffsets;
@@ -384,7 +384,7 @@ namespace Lucene.Net.Codecs.Compressing
             {
                 throw RuntimeException.Create("Wrote " + docBase + " docs, finish called with numDocs=" + numDocs);
             }
-            indexWriter.Finish(numDocs, fieldsStream.GetFilePointer());
+            indexWriter.Finish(numDocs, fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             CodecUtil.WriteFooter(fieldsStream);
             if (Debugging.AssertsEnabled) Debugging.Assert(bufferedDocs.Length == 0);
         }
@@ -450,7 +450,7 @@ namespace Lucene.Net.Codecs.Compressing
                                 if (Debugging.AssertsEnabled) Debugging.Assert(docID == it.docBase);
 
                                 // no need to decompress, just copy data
-                                indexWriter.WriteIndex(it.chunkDocs, fieldsStream.GetFilePointer());
+                                indexWriter.WriteIndex(it.chunkDocs, fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                                 WriteHeader(this.docBase, it.chunkDocs, it.numStoredFields, it.lengths);
                                 it.CopyCompressedData(fieldsStream);
                                 this.docBase += it.chunkDocs;

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Codecs.Compressing
                 indexStream = d.OpenChecksumInput(indexStreamFN, context);
                 string codecNameIdx = formatName + CompressingTermVectorsWriter.CODEC_SFX_IDX;
                 version = CodecUtil.CheckHeader(indexStream, codecNameIdx, CompressingTermVectorsWriter.VERSION_START, CompressingTermVectorsWriter.VERSION_CURRENT);
-                if (Debugging.AssertsEnabled) Debugging.Assert(CodecUtil.HeaderLength(codecNameIdx) == indexStream.GetFilePointer());
+                if (Debugging.AssertsEnabled) Debugging.Assert(CodecUtil.HeaderLength(codecNameIdx) == indexStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 indexReader = new CompressingStoredFieldsIndexReader(indexStream, si);
 
                 if (version >= CompressingTermVectorsWriter.VERSION_CHECKSUM)
@@ -108,7 +108,7 @@ namespace Lucene.Net.Codecs.Compressing
                 {
                     throw RuntimeException.Create("Version mismatch between stored fields index and data: " + version + " != " + version2);
                 }
-                if (Debugging.AssertsEnabled) Debugging.Assert(CodecUtil.HeaderLength(codecNameDat) == vectorsStream.GetFilePointer());
+                if (Debugging.AssertsEnabled) Debugging.Assert(CodecUtil.HeaderLength(codecNameDat) == vectorsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                 packedIntsVersion = vectorsStream.ReadVInt32();
                 chunkSize = vectorsStream.ReadVInt32();

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
@@ -275,8 +275,8 @@ namespace Lucene.Net.Codecs.Compressing
                 CodecUtil.WriteHeader(vectorsStream, codecNameDat, VERSION_CURRENT);
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(CodecUtil.HeaderLength(codecNameDat) == vectorsStream.GetFilePointer());
-                    Debugging.Assert(CodecUtil.HeaderLength(codecNameIdx) == indexStream.GetFilePointer());
+                    Debugging.Assert(CodecUtil.HeaderLength(codecNameDat) == vectorsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    Debugging.Assert(CodecUtil.HeaderLength(codecNameIdx) == indexStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
 
                 indexWriter = new CompressingStoredFieldsIndexWriter(indexStream);
@@ -399,7 +399,7 @@ namespace Lucene.Net.Codecs.Compressing
             if (Debugging.AssertsEnabled) Debugging.Assert(chunkDocs > 0, "{0}", chunkDocs);
 
             // write the index file
-            indexWriter.WriteIndex(chunkDocs, vectorsStream.GetFilePointer());
+            indexWriter.WriteIndex(chunkDocs, vectorsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             int docBase = numDocs - chunkDocs;
             vectorsStream.WriteVInt32(docBase);
@@ -801,7 +801,7 @@ namespace Lucene.Net.Codecs.Compressing
             {
                 throw RuntimeException.Create("Wrote " + this.numDocs + " docs, finish called with numDocs=" + numDocs);
             }
-            indexWriter.Finish(numDocs, vectorsStream.GetFilePointer());
+            indexWriter.Finish(numDocs, vectorsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             CodecUtil.WriteFooter(vectorsStream);
         }
 
@@ -927,7 +927,7 @@ namespace Lucene.Net.Codecs.Compressing
                         // We make sure to move the checksum input in any case, otherwise the final
                         // integrity check might need to read the whole file a second time
                         long startPointer = index.GetStartPointer(i);
-                        if (startPointer > vectorsStream.GetFilePointer())
+                        if (startPointer > vectorsStream.Position) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         {
                             vectorsStream.Seek(startPointer);
                         }
@@ -939,8 +939,8 @@ namespace Lucene.Net.Codecs.Compressing
                             if (docBase + chunkDocs < matchingSegmentReader.MaxDoc && NextDeletedDoc(docBase, liveDocs, docBase + chunkDocs) == docBase + chunkDocs)
                             {
                                 long chunkEnd = index.GetStartPointer(docBase + chunkDocs);
-                                long chunkLength = chunkEnd - vectorsStream.GetFilePointer();
-                                indexWriter.WriteIndex(chunkDocs, this.vectorsStream.GetFilePointer());
+                                long chunkLength = chunkEnd - vectorsStream.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                                indexWriter.WriteIndex(chunkDocs, this.vectorsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                                 this.vectorsStream.WriteVInt32(docCount);
                                 this.vectorsStream.WriteVInt32(chunkDocs);
                                 this.vectorsStream.CopyBytes(vectorsStream, chunkLength);

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFieldInfosReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFieldInfosReader.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Support;
+﻿using Lucene.Net.Support;
 using System;
 
 namespace Lucene.Net.Codecs.Lucene3x
@@ -126,9 +126,9 @@ namespace Lucene.Net.Codecs.Lucene3x
                         Collections.EmptyMap<string, string>());
                 }
 
-                if (input.GetFilePointer() != input.Length)
+                if (input.Position != input.Length) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 {
-                    throw new CorruptIndexException("did not read all bytes from file \"" + fileName + "\": read " + input.GetFilePointer() + " vs size " + input.Length + " (resource: " + input + ")");
+                    throw new CorruptIndexException("did not read all bytes from file \"" + fileName + "\": read " + input.Position + " vs size " + input.Length + " (resource: " + input + ")");
                 }
                 FieldInfos fieldInfos = new FieldInfos(infos);
                 success = true;

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xStoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xStoredFieldsReader.cs
@@ -363,7 +363,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             else
             {
                 int length = fieldsStream.ReadVInt32();
-                fieldsStream.Seek(fieldsStream.GetFilePointer() + length);
+                fieldsStream.Seek(fieldsStream.Position + length); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
         }
 

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -371,7 +371,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                 byte bits = outerInstance.tvf.ReadByte();
                 storePositions = (bits & STORE_POSITIONS_WITH_TERMVECTOR) != 0;
                 storeOffsets = (bits & STORE_OFFSET_WITH_TERMVECTOR) != 0;
-                tvfFPStart = outerInstance.tvf.GetFilePointer();
+                tvfFPStart = outerInstance.tvf.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 unicodeSortOrder = outerInstance.SortTermsByUnicode();
             }
 

--- a/src/Lucene.Net/Codecs/Lucene3x/SegmentTermPositions.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/SegmentTermPositions.cs
@@ -182,7 +182,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         {
             if (needToLoadPayload && payloadLength > 0)
             {
-                proxStream.Seek(proxStream.GetFilePointer() + payloadLength);
+                proxStream.Seek(proxStream.Position + payloadLength); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             needToLoadPayload = false;
         }

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
@@ -1139,7 +1139,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 if (payloadPending && payloadLength > 0)
                 {
                     // payload of last position was never retrieved -- skip it
-                    proxIn.Seek(proxIn.GetFilePointer() + payloadLength);
+                    proxIn.Seek(proxIn.Position + payloadLength); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     payloadPending = false;
                 }
 
@@ -1170,7 +1170,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
                     if (storePayloads)
                     {
-                        proxIn.Seek(proxIn.GetFilePointer() + payloadLength);
+                        proxIn.Seek(proxIn.Position + payloadLength); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     }
 
                     posPendingCount--;
@@ -1184,7 +1184,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 if (payloadPending && payloadLength > 0)
                 {
                     // payload wasn't retrieved for last position
-                    proxIn.Seek(proxIn.GetFilePointer() + payloadLength);
+                    proxIn.Seek(proxIn.Position + payloadLength); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
 
                 int code_ = proxIn.ReadVInt32();

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsReader.cs
@@ -95,8 +95,8 @@ namespace Lucene.Net.Codecs.Lucene40
                 CodecUtil.CheckHeader(fieldsStream, Lucene40StoredFieldsWriter.CODEC_NAME_DAT, Lucene40StoredFieldsWriter.VERSION_START, Lucene40StoredFieldsWriter.VERSION_CURRENT);
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(Lucene40StoredFieldsWriter.HEADER_LENGTH_DAT == fieldsStream.GetFilePointer());
-                    Debugging.Assert(Lucene40StoredFieldsWriter.HEADER_LENGTH_IDX == indexStream.GetFilePointer());
+                    Debugging.Assert(Lucene40StoredFieldsWriter.HEADER_LENGTH_DAT == fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    Debugging.Assert(Lucene40StoredFieldsWriter.HEADER_LENGTH_IDX == indexStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
                 long indexSize = indexStream.Length - Lucene40StoredFieldsWriter.HEADER_LENGTH_IDX;
                 this.size = (int)(indexSize >> 3);
@@ -268,7 +268,7 @@ namespace Lucene.Net.Codecs.Lucene40
             else
             {
                 int length = fieldsStream.ReadVInt32();
-                fieldsStream.Seek(fieldsStream.GetFilePointer() + length);
+                fieldsStream.Seek(fieldsStream.Position + length); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
         }
 

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsWriter.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsWriter.cs
@@ -106,8 +106,8 @@ namespace Lucene.Net.Codecs.Lucene40
                 CodecUtil.WriteHeader(indexStream, CODEC_NAME_IDX, VERSION_CURRENT);
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(HEADER_LENGTH_DAT == fieldsStream.GetFilePointer());
-                    Debugging.Assert(HEADER_LENGTH_IDX == indexStream.GetFilePointer());
+                    Debugging.Assert(HEADER_LENGTH_DAT == fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    Debugging.Assert(HEADER_LENGTH_IDX == indexStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
                 success = true;
             }
@@ -127,7 +127,7 @@ namespace Lucene.Net.Codecs.Lucene40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override void StartDocument(int numStoredFields)
         {
-            indexStream.WriteInt64(fieldsStream.GetFilePointer());
+            indexStream.WriteInt64(fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             fieldsStream.WriteVInt32(numStoredFields);
         }
 
@@ -261,7 +261,7 @@ namespace Lucene.Net.Codecs.Lucene40
         /// </summary>
         public void AddRawDocuments(IndexInput stream, int[] lengths, int numDocs)
         {
-            long position = fieldsStream.GetFilePointer();
+            long position = fieldsStream.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             long start = position;
             for (int i = 0; i < numDocs; i++)
             {
@@ -269,20 +269,20 @@ namespace Lucene.Net.Codecs.Lucene40
                 position += lengths[i];
             }
             fieldsStream.CopyBytes(stream, position - start);
-            if (Debugging.AssertsEnabled) Debugging.Assert(fieldsStream.GetFilePointer() == position);
+            if (Debugging.AssertsEnabled) Debugging.Assert(fieldsStream.Position == position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override void Finish(FieldInfos fis, int numDocs)
         {
-            if (HEADER_LENGTH_IDX + ((long)numDocs) * 8 != indexStream.GetFilePointer())
+            if (HEADER_LENGTH_IDX + ((long)numDocs) * 8 != indexStream.Position) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             // this is most likely a bug in Sun JRE 1.6.0_04/_05;
             // we detect that the bug has struck, here, and
             // throw an exception to prevent the corruption from
             // entering the index.  See LUCENE-1282 for
             // details.
             {
-                throw RuntimeException.Create("fdx size mismatch: docCount is " + numDocs + " but fdx file size is " + indexStream.GetFilePointer() + " file=" + indexStream.ToString() + "; now aborting this merge to prevent index corruption");
+                throw RuntimeException.Create("fdx size mismatch: docCount is " + numDocs + " but fdx file size is " + indexStream.Position + " file=" + indexStream.ToString() + "; now aborting this merge to prevent index corruption");
             }
         }
 

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
@@ -125,9 +125,9 @@ namespace Lucene.Net.Codecs.Lucene40
                 int tvfVersion = CodecUtil.CheckHeader(tvf, CODEC_NAME_FIELDS, VERSION_START, VERSION_CURRENT);
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(HEADER_LENGTH_INDEX == tvx.GetFilePointer());
-                    Debugging.Assert(HEADER_LENGTH_DOCS == tvd.GetFilePointer());
-                    Debugging.Assert(HEADER_LENGTH_FIELDS == tvf.GetFilePointer());
+                    Debugging.Assert(HEADER_LENGTH_INDEX == tvx.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    Debugging.Assert(HEADER_LENGTH_DOCS == tvd.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    Debugging.Assert(HEADER_LENGTH_FIELDS == tvf.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     Debugging.Assert(tvxVersion == tvdVersion);
                     Debugging.Assert(tvxVersion == tvfVersion);
                 }
@@ -339,7 +339,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 storePositions = (bits & STORE_POSITIONS_WITH_TERMVECTOR) != 0;
                 storeOffsets = (bits & STORE_OFFSET_WITH_TERMVECTOR) != 0;
                 storePayloads = (bits & STORE_PAYLOAD_WITH_TERMVECTOR) != 0;
-                tvfFPStart = outerInstance.tvf.GetFilePointer();
+                tvfFPStart = outerInstance.tvf.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsWriter.cs
@@ -82,9 +82,9 @@ namespace Lucene.Net.Codecs.Lucene40
                 CodecUtil.WriteHeader(tvf, Lucene40TermVectorsReader.CODEC_NAME_FIELDS, Lucene40TermVectorsReader.VERSION_CURRENT);
                 if (Debugging.AssertsEnabled)
                 {
-                    Debugging.Assert(Lucene40TermVectorsReader.HEADER_LENGTH_INDEX == tvx.GetFilePointer());
-                    Debugging.Assert(Lucene40TermVectorsReader.HEADER_LENGTH_DOCS == tvd.GetFilePointer());
-                    Debugging.Assert(Lucene40TermVectorsReader.HEADER_LENGTH_FIELDS == tvf.GetFilePointer());
+                    Debugging.Assert(Lucene40TermVectorsReader.HEADER_LENGTH_INDEX == tvx.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    Debugging.Assert(Lucene40TermVectorsReader.HEADER_LENGTH_DOCS == tvd.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                    Debugging.Assert(Lucene40TermVectorsReader.HEADER_LENGTH_FIELDS == tvf.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
                 success = true;
             }
@@ -102,8 +102,8 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             lastFieldName = null;
             this.numVectorFields = numVectorFields;
-            tvx.WriteInt64(tvd.GetFilePointer());
-            tvx.WriteInt64(tvf.GetFilePointer());
+            tvx.WriteInt64(tvd.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            tvx.WriteInt64(tvf.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             tvd.WriteVInt32(numVectorFields);
             fieldCount = 0;
             fps = ArrayUtil.Grow(fps, numVectorFields);
@@ -123,7 +123,7 @@ namespace Lucene.Net.Codecs.Lucene40
             this.payloads = payloads;
             lastTerm.Length = 0;
             lastPayloadLength = -1; // force first payload to write its length
-            fps[fieldCount++] = tvf.GetFilePointer();
+            fps[fieldCount++] = tvf.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             tvd.WriteVInt32(info.Number);
             tvf.WriteVInt32(numTerms);
             sbyte bits = 0x0;
@@ -351,8 +351,8 @@ namespace Lucene.Net.Codecs.Lucene40
         /// </summary>
         private void AddRawDocuments(Lucene40TermVectorsReader reader, int[] tvdLengths, int[] tvfLengths, int numDocs)
         {
-            long tvdPosition = tvd.GetFilePointer();
-            long tvfPosition = tvf.GetFilePointer();
+            long tvdPosition = tvd.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            long tvfPosition = tvf.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             long tvdStart = tvdPosition;
             long tvfStart = tvfPosition;
             for (int i = 0; i < numDocs; i++)
@@ -366,8 +366,8 @@ namespace Lucene.Net.Codecs.Lucene40
             tvf.CopyBytes(reader.TvfStream, tvfPosition - tvfStart);
             if (Debugging.AssertsEnabled)
             {
-                Debugging.Assert(tvd.GetFilePointer() == tvdPosition);
-                Debugging.Assert(tvf.GetFilePointer() == tvfPosition);
+                Debugging.Assert(tvd.Position == tvdPosition); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                Debugging.Assert(tvf.Position == tvfPosition); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
         }
 
@@ -508,14 +508,14 @@ namespace Lucene.Net.Codecs.Lucene40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override void Finish(FieldInfos fis, int numDocs)
         {
-            if (Lucene40TermVectorsReader.HEADER_LENGTH_INDEX + ((long)numDocs) * 16 != tvx.GetFilePointer())
+            if (Lucene40TermVectorsReader.HEADER_LENGTH_INDEX + ((long)numDocs) * 16 != tvx.Position) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             // this is most likely a bug in Sun JRE 1.6.0_04/_05;
             // we detect that the bug has struck, here, and
             // throw an exception to prevent the corruption from
             // entering the index.  See LUCENE-1282 for
             // details.
             {
-                throw RuntimeException.Create("tvx size mismatch: mergedDocs is " + numDocs + " but tvx size is " + tvx.GetFilePointer() + " file=" + tvx.ToString() + "; now aborting this merge to prevent index corruption");
+                throw RuntimeException.Create("tvx size mismatch: mergedDocs is " + numDocs + " but tvx size is " + tvx.Position + " file=" + tvx.ToString() + "; now aborting this merge to prevent index corruption");
             }
         }
 

--- a/src/Lucene.Net/Codecs/Lucene41/ForUtil.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/ForUtil.cs
@@ -229,7 +229,7 @@ namespace Lucene.Net.Codecs.Lucene41
             }
             if (Debugging.AssertsEnabled) Debugging.Assert(numBits > 0 && numBits <= 32, numBits.ToString());
             int encodedSize = encodedSizes[numBits];
-            @in.Seek(@in.GetFilePointer() + encodedSize);
+            @in.Seek(@in.Position + encodedSize); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsReader.cs
@@ -751,7 +751,7 @@ namespace Lucene.Net.Codecs.Lucene41
                 // if (DEBUG) {
                 //   System.out.println("      refillPositions");
                 // }
-                if (posIn.GetFilePointer() == lastPosBlockFP)
+                if (posIn.Position == lastPosBlockFP) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 {
                     // if (DEBUG) {
                     //   System.out.println("        vInt pos block @ fp=" + posIn.getFilePointer() + " hasPayloads=" + indexHasPayloads + " hasOffsets=" + indexHasOffsets);
@@ -770,7 +770,7 @@ namespace Lucene.Net.Codecs.Lucene41
                             posDeltaBuffer[i] = code.TripleShift(1);
                             if (payloadLength != 0)
                             {
-                                posIn.Seek(posIn.GetFilePointer() + payloadLength);
+                                posIn.Seek(posIn.Position + payloadLength); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                             }
                         }
                         else
@@ -969,7 +969,7 @@ namespace Lucene.Net.Codecs.Lucene41
                         // if (DEBUG) {
                         //   System.out.println("        skip whole block @ fp=" + posIn.getFilePointer());
                         // }
-                        if (Debugging.AssertsEnabled) Debugging.Assert(posIn.GetFilePointer() != lastPosBlockFP);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(posIn.Position != lastPosBlockFP); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         outerInstance.forUtil.SkipBlock(posIn);
                         toSkip -= Lucene41PostingsFormat.BLOCK_SIZE;
                     }
@@ -1260,7 +1260,7 @@ namespace Lucene.Net.Codecs.Lucene41
                 // if (DEBUG) {
                 //   System.out.println("      refillPositions");
                 // }
-                if (posIn.GetFilePointer() == lastPosBlockFP)
+                if (posIn.Position == lastPosBlockFP) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 {
                     // if (DEBUG) {
                     //   System.out.println("        vInt pos block @ fp=" + posIn.getFilePointer() + " hasPayloads=" + indexHasPayloads + " hasOffsets=" + indexHasOffsets);
@@ -1348,7 +1348,7 @@ namespace Lucene.Net.Codecs.Lucene41
                             // this works, because when writing a vint block we always force the first length to be written
                             outerInstance.forUtil.SkipBlock(payIn); // skip over lengths
                             int numBytes = payIn.ReadVInt32(); // read length of payloadBytes
-                            payIn.Seek(payIn.GetFilePointer() + numBytes); // skip over payloadBytes
+                            payIn.Seek(payIn.Position + numBytes); // skip over payloadBytes // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         }
                         payloadByteUpto = 0;
                     }
@@ -1559,7 +1559,7 @@ namespace Lucene.Net.Codecs.Lucene41
                         // if (DEBUG) {
                         //   System.out.println("        skip whole block @ fp=" + posIn.getFilePointer());
                         // }
-                        if (Debugging.AssertsEnabled) Debugging.Assert(posIn.GetFilePointer() != lastPosBlockFP);
+                        if (Debugging.AssertsEnabled) Debugging.Assert(posIn.Position != lastPosBlockFP); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         outerInstance.forUtil.SkipBlock(posIn);
 
                         if (indexHasPayloads)
@@ -1569,7 +1569,7 @@ namespace Lucene.Net.Codecs.Lucene41
 
                             // Skip payloadBytes block:
                             int numBytes = payIn.ReadVInt32();
-                            payIn.Seek(payIn.GetFilePointer() + numBytes);
+                            payIn.Seek(payIn.Position + numBytes); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         }
 
                         if (indexHasOffsets)

--- a/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsWriter.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsWriter.cs
@@ -281,13 +281,13 @@ namespace Lucene.Net.Codecs.Lucene41
 
         public override void StartTerm()
         {
-            docStartFP = docOut.GetFilePointer();
+            docStartFP = docOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (fieldHasPositions)
             {
-                posStartFP = posOut.GetFilePointer();
+                posStartFP = posOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (fieldHasPayloads || fieldHasOffsets)
                 {
-                    payStartFP = payOut.GetFilePointer();
+                    payStartFP = payOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
             }
             lastDocID = 0;
@@ -431,9 +431,9 @@ namespace Lucene.Net.Codecs.Lucene41
                 {
                     if (payOut != null)
                     {
-                        lastBlockPayFP = payOut.GetFilePointer();
+                        lastBlockPayFP = payOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     }
-                    lastBlockPosFP = posOut.GetFilePointer();
+                    lastBlockPosFP = posOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     lastBlockPosBufferUpto = posBufferUpto;
                     lastBlockPayloadByteUpto = payloadByteUpto;
                 }
@@ -512,7 +512,7 @@ namespace Lucene.Net.Codecs.Lucene41
                 if (state2.TotalTermFreq > Lucene41PostingsFormat.BLOCK_SIZE)
                 {
                     // record file offset for last pos in last block
-                    lastPosBlockOffset = posOut.GetFilePointer() - posStartFP;
+                    lastPosBlockOffset = posOut.Position - posStartFP; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
                 else
                 {

--- a/src/Lucene.Net/Codecs/Lucene41/Lucene41SkipWriter.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/Lucene41SkipWriter.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Support;
+﻿using Lucene.Net.Support;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs.Lucene41
@@ -97,17 +97,17 @@ namespace Lucene.Net.Codecs.Lucene41
         {
             base.ResetSkip();
             Arrays.Fill(lastSkipDoc, 0);
-            Arrays.Fill(lastSkipDocPointer, docOut.GetFilePointer());
+            Arrays.Fill(lastSkipDocPointer, docOut.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (fieldHasPositions)
             {
-                Arrays.Fill(lastSkipPosPointer, posOut.GetFilePointer());
+                Arrays.Fill(lastSkipPosPointer, posOut.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (fieldHasPayloads)
                 {
                     Arrays.Fill(lastPayloadByteUpto, 0);
                 }
                 if (fieldHasOffsets || fieldHasPayloads)
                 {
-                    Arrays.Fill(lastSkipPayPointer, payOut.GetFilePointer());
+                    Arrays.Fill(lastSkipPayPointer, payOut.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
             }
         }
@@ -118,7 +118,7 @@ namespace Lucene.Net.Codecs.Lucene41
         public void BufferSkip(int doc, int numDocs, long posFP, long payFP, int posBufferUpto, int payloadByteUpto)
         {
             this.curDoc = doc;
-            this.curDocPointer = docOut.GetFilePointer();
+            this.curDocPointer = docOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             this.curPosPointer = posFP;
             this.curPayPointer = payFP;
             this.curPosBufferUpto = posBufferUpto;

--- a/src/Lucene.Net/Codecs/Lucene42/Lucene42NormsConsumer.cs
+++ b/src/Lucene.Net/Codecs/Lucene42/Lucene42NormsConsumer.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
@@ -81,7 +81,7 @@ namespace Lucene.Net.Codecs.Lucene42
         {
             meta.WriteVInt32(field.Number);
             meta.WriteByte((byte)NUMBER);
-            meta.WriteInt64(data.GetFilePointer());
+            meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             long minValue = long.MaxValue;
             long maxValue = long.MinValue;
             long gcd = 0;

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
@@ -204,7 +204,7 @@ namespace Lucene.Net.Codecs.Lucene45
             meta.WriteVInt32(format);
             if (missing)
             {
-                meta.WriteInt64(data.GetFilePointer());
+                meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 WriteMissingBitset(values);
             }
             else
@@ -212,7 +212,7 @@ namespace Lucene.Net.Codecs.Lucene45
                 meta.WriteInt64(-1L);
             }
             meta.WriteVInt32(PackedInt32s.VERSION_CURRENT);
-            meta.WriteInt64(data.GetFilePointer());
+            meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             meta.WriteVInt64(count);
             meta.WriteVInt32(BLOCK_SIZE);
 
@@ -296,7 +296,7 @@ namespace Lucene.Net.Codecs.Lucene45
             meta.WriteByte((byte)Lucene45DocValuesFormat.BINARY);
             int minLength = int.MaxValue;
             int maxLength = int.MinValue;
-            long startFP = data.GetFilePointer();
+            long startFP = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             long count = 0;
             bool missing = false;
             foreach (BytesRef v in values)
@@ -322,7 +322,7 @@ namespace Lucene.Net.Codecs.Lucene45
             meta.WriteVInt32(minLength == maxLength ? BINARY_FIXED_UNCOMPRESSED : BINARY_VARIABLE_UNCOMPRESSED);
             if (missing)
             {
-                meta.WriteInt64(data.GetFilePointer());
+                meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 WriteMissingBitset(values);
             }
             else
@@ -338,7 +338,7 @@ namespace Lucene.Net.Codecs.Lucene45
             // otherwise, we need to record the length fields...
             if (minLength != maxLength)
             {
-                meta.WriteInt64(data.GetFilePointer());
+                meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 meta.WriteVInt32(PackedInt32s.VERSION_CURRENT);
                 meta.WriteVInt32(BLOCK_SIZE);
 
@@ -381,7 +381,7 @@ namespace Lucene.Net.Codecs.Lucene45
                 meta.WriteVInt32(BINARY_PREFIX_COMPRESSED);
                 meta.WriteInt64(-1L);
                 // now write the bytes: sharing prefixes within a block
-                long startFP = data.GetFilePointer();
+                long startFP = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 // currently, we have to store the delta from expected for every 1/nth term
                 // we could avoid this, but its not much and less overall RAM than the previous approach!
                 RAMOutputStream addressBuffer = new RAMOutputStream();
@@ -392,7 +392,7 @@ namespace Lucene.Net.Codecs.Lucene45
                 {
                     if (count % ADDRESS_INTERVAL == 0)
                     {
-                        termAddresses.Add(data.GetFilePointer() - startFP);
+                        termAddresses.Add(data.Position - startFP); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         // force the first term in a block to be abs-encoded
                         lastTerm.Length = 0;
                     }
@@ -405,7 +405,7 @@ namespace Lucene.Net.Codecs.Lucene45
                     lastTerm.CopyBytes(v);
                     count++;
                 }
-                long indexStartFP = data.GetFilePointer();
+                long indexStartFP = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 // write addresses of indexed terms
                 termAddresses.Finish();
                 addressBuffer.WriteTo(data);
@@ -468,7 +468,7 @@ namespace Lucene.Net.Codecs.Lucene45
             meta.WriteVInt32(DELTA_COMPRESSED);
             meta.WriteInt64(-1L);
             meta.WriteVInt32(PackedInt32s.VERSION_CURRENT);
-            meta.WriteInt64(data.GetFilePointer());
+            meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             meta.WriteVInt64(maxDoc);
             meta.WriteVInt32(BLOCK_SIZE);
 

--- a/src/Lucene.Net/Codecs/MultiLevelSkipListReader.cs
+++ b/src/Lucene.Net/Codecs/MultiLevelSkipListReader.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Runtime.CompilerServices;
 
@@ -165,7 +165,7 @@ namespace Lucene.Net.Codecs
                 else
                 {
                     // no more skips on this level, go down one level
-                    if (level > 0 && lastChildPointer > skipStream[level - 1].GetFilePointer())
+                    if (level > 0 && lastChildPointer > skipStream[level - 1].Position) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     {
                         SeekChild(level - 1);
                     }
@@ -293,7 +293,7 @@ namespace Lucene.Net.Codecs
                 long length = skipStream[0].ReadVInt64();
 
                 // the start pointer of the current level
-                skipPointer[i] = skipStream[0].GetFilePointer();
+                skipPointer[i] = skipStream[0].Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (toBuffer > 0)
                 {
                     // buffer this level
@@ -310,12 +310,12 @@ namespace Lucene.Net.Codecs
                     }
 
                     // move base stream beyond the current level
-                    skipStream[0].Seek(skipStream[0].GetFilePointer() + length);
+                    skipStream[0].Seek(skipStream[0].Position + length); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 }
             }
 
             // use base stream for the lowest level
-            skipPointer[0] = skipStream[0].GetFilePointer();
+            skipPointer[0] = skipStream[0].Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         }
 
         /// <summary>
@@ -346,7 +346,7 @@ namespace Lucene.Net.Codecs
                 : base("SkipBuffer on " + input)
             {
                 data = new byte[length];
-                pointer = input.GetFilePointer();
+                pointer = input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 input.ReadBytes(data, 0, length);
             }
 
@@ -358,11 +358,7 @@ namespace Lucene.Net.Codecs
                 }
             }
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public override long GetFilePointer()
-            {
-                return pointer + pos;
-            }
+            public override long Position => pointer + pos; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             public override long Length => data.Length;
 

--- a/src/Lucene.Net/Codecs/MultiLevelSkipListWriter.cs
+++ b/src/Lucene.Net/Codecs/MultiLevelSkipListWriter.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 
@@ -167,7 +167,7 @@ namespace Lucene.Net.Codecs
             {
                 WriteSkipData(level, skipBuffer[level]);
 
-                long newChildPointer = skipBuffer[level].GetFilePointer();
+                long newChildPointer = skipBuffer[level].Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                 if (level != 0)
                 {
@@ -187,7 +187,7 @@ namespace Lucene.Net.Codecs
         /// <returns> The pointer the skip list starts. </returns>
         public virtual long WriteSkip(IndexOutput output)
         {
-            long skipPointer = output.GetFilePointer();
+            long skipPointer = output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             //System.out.println("skipper.writeSkip fp=" + skipPointer);
             if (skipBuffer == null || skipBuffer.Length == 0)
             {
@@ -196,7 +196,7 @@ namespace Lucene.Net.Codecs
 
             for (int level = m_numberOfSkipLevels - 1; level > 0; level--)
             {
-                long length = skipBuffer[level].GetFilePointer();
+                long length = skipBuffer[level].Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (length > 0)
                 {
                     output.WriteVInt64(length);

--- a/src/Lucene.Net/Index/PrefixCodedTerms.cs
+++ b/src/Lucene.Net/Index/PrefixCodedTerms.cs
@@ -104,8 +104,8 @@ namespace Lucene.Net.Index
             {
                 // LUCENENET specific - Since there is no way to check for a next element
                 // without calling this method in .NET, the assert is redundant and ineffective.
-                //if (Debugging.AssertsEnabled) Debugging.Assert(input.GetFilePointer() < input.Length); // Has next
-                if (input.GetFilePointer() < input.Length)
+                //if (Debugging.AssertsEnabled) Debugging.Assert(input.Position < input.Length); // Has next
+                if (input.Position < input.Length) // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 {
                     try
                     {

--- a/src/Lucene.Net/Index/ReadersAndUpdates.cs
+++ b/src/Lucene.Net/Index/ReadersAndUpdates.cs
@@ -512,7 +512,7 @@ namespace Lucene.Net.Index
                         // create new fields or update existing ones to have BinaryDV type
                         foreach (string f in dvUpdates.binaryDVUpdates.Keys)
                         {
-                            builder.AddOrUpdate(f, BinaryDocValuesField.fType);
+                            builder.AddOrUpdate(f, BinaryDocValuesField.TYPE);
                         }
 
                         fieldInfos = builder.Finish();

--- a/src/Lucene.Net/Store/BufferedChecksumIndexInput.cs
+++ b/src/Lucene.Net/Store/BufferedChecksumIndexInput.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Support;
+﻿using Lucene.Net.Support;
 using System;
 
 namespace Lucene.Net.Store
@@ -61,10 +61,7 @@ namespace Lucene.Net.Store
             }
         }
 
-        public override long GetFilePointer()
-        {
-            return main.GetFilePointer();
-        }
+        public override long Position => main.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
         public override long Length => main.Length;
 

--- a/src/Lucene.Net/Store/BufferedIndexInput.cs
+++ b/src/Lucene.Net/Store/BufferedIndexInput.cs
@@ -400,11 +400,7 @@ namespace Lucene.Net.Store
         /// <param name="length"> the number of bytes to read </param>
         protected abstract void ReadInternal(byte[] b, int offset, int length);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override sealed long GetFilePointer()
-        {
-            return bufferStart + bufferPosition;
-        }
+        public override sealed long Position => bufferStart + bufferPosition; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
         public override sealed void Seek(long pos)
         {
@@ -434,7 +430,7 @@ namespace Lucene.Net.Store
             clone.m_buffer = null;
             clone.bufferLength = 0;
             clone.bufferPosition = 0;
-            clone.bufferStart = GetFilePointer();
+            clone.bufferStart = Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             return clone;
         }

--- a/src/Lucene.Net/Store/BufferedIndexOutput.cs
+++ b/src/Lucene.Net/Store/BufferedIndexOutput.cs
@@ -167,10 +167,7 @@ namespace Lucene.Net.Store
             }
         }
 
-        public override long GetFilePointer()
-        {
-            return bufferStart + bufferPosition;
-        }
+        public override long Position => bufferStart + bufferPosition; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
         [Obsolete("(4.1) this method will be removed in Lucene 5.0")]
         public override void Seek(long pos)

--- a/src/Lucene.Net/Store/ByteBufferIndexInput.cs
+++ b/src/Lucene.Net/Store/ByteBufferIndexInput.cs
@@ -206,12 +206,15 @@ namespace Lucene.Net.Store
             return base.ReadInt64();
         }
 
-        public override sealed long GetFilePointer()
+        public override sealed long Position // LUCENENET specific: Renamed from getFilePointer() to match FileStream
         {
-            // LUCENENET: Refactored to avoid calls on invalid conditions instead of
-            // catching and re-throwing exceptions in the normal workflow.
-            EnsureOpen();
-            return (((long)curBufIndex) << chunkSizePower) + curBuf.Position - offset;
+            get
+            {
+                // LUCENENET: Refactored to avoid calls on invalid conditions instead of
+                // catching and re-throwing exceptions in the normal workflow.
+                EnsureOpen();
+                return (((long)curBufIndex) << chunkSizePower) + curBuf.Position - offset;
+            }
         }
 
         public override sealed void Seek(long pos)
@@ -258,7 +261,7 @@ namespace Lucene.Net.Store
             ByteBufferIndexInput clone = BuildSlice(0L, this.length);
             try
             {
-                clone.Seek(GetFilePointer());
+                clone.Seek(Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             catch (Exception ioe) when (ioe.IsIOException())
             {

--- a/src/Lucene.Net/Store/CheckSumIndexInput.cs
+++ b/src/Lucene.Net/Store/CheckSumIndexInput.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Lucene.Net.Store
 {
@@ -48,7 +48,7 @@ namespace Lucene.Net.Store
         /// </summary>
         public override void Seek(long pos)
         {
-            long skip = pos - GetFilePointer();
+            long skip = pos - Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (skip < 0)
             {
                 throw IllegalStateException.Create(this.GetType() + " cannot seek backwards");

--- a/src/Lucene.Net/Store/CompoundFileWriter.cs
+++ b/src/Lucene.Net/Store/CompoundFileWriter.cs
@@ -201,11 +201,11 @@ namespace Lucene.Net.Store
             bool success = false;
             try
             {
-                long startPtr = dataOut.GetFilePointer();
+                long startPtr = dataOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 long length = fileEntry.Length;
                 dataOut.CopyBytes(@is, length);
                 // Verify that the output length diff is equal to original file
-                long endPtr = dataOut.GetFilePointer();
+                long endPtr = dataOut.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 long diff = endPtr - startPtr;
                 if (diff != length)
                 {
@@ -357,7 +357,7 @@ namespace Lucene.Net.Store
                 this.outerInstance = outerInstance;
                 this.@delegate = @delegate;
                 this.entry = entry;
-                entry.Offset = offset = @delegate.GetFilePointer();
+                entry.Offset = offset = @delegate.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 this.isSeparate = isSeparate;
             }
 
@@ -389,11 +389,7 @@ namespace Lucene.Net.Store
                 }
             }
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public override long GetFilePointer()
-            {
-                return @delegate.GetFilePointer() - offset;
-            }
+            public override long Position => @delegate.Position - offset; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
             [Obsolete("(4.1) this method will be removed in Lucene 5.0")]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lucene.Net/Store/Directory.cs
+++ b/src/Lucene.Net/Store/Directory.cs
@@ -354,7 +354,7 @@ namespace Lucene.Net.Store
             /// <param name="len"> the number of bytes to read </param>
             protected override void ReadInternal(byte[] b, int offset, int len)
             {
-                long start = GetFilePointer();
+                long start = Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 if (start + len > length)
                 {
                     throw EOFException.Create("read past EOF: " + this);

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -588,10 +588,7 @@ namespace Lucene.Net.Store
             public override long Checksum => crc.Value; // LUCENENET specific - need to override, since we are buffering locally
 
             /// <inheritdoc/>
-            public override long GetFilePointer() // LUCENENET specific - need to override, since we are buffering locally
-            {
-                return file.Position;
-            }
+            public override long Position => file.Position; // LUCENENET specific - need to override, since we are buffering locally, renamed from getFilePointer() to match FileStream
         }
 
         // LUCENENET specific: Fsync is pointless in .NET, since we are 

--- a/src/Lucene.Net/Store/IndexInput.cs
+++ b/src/Lucene.Net/Store/IndexInput.cs
@@ -64,14 +64,17 @@ namespace Lucene.Net.Store
 
         /// <summary>
         /// Returns the current position in this file, where the next read will
-        /// occur. </summary>
+        /// occur.
+        /// <para/>
+        /// This was getFilePointer() in Lucene.
+        /// </summary>
         /// <seealso cref="Seek(long)"/>
-        public abstract long GetFilePointer(); // LUCENENET TODO: API - make into property
+        public abstract long Position { get; } // LUCENENET specific: Renamed Position to match FileStream
 
         /// <summary>
         /// Sets current position in this file, where the next read will occur.
         /// </summary>
-        /// <seealso cref="GetFilePointer()"/>
+        /// <seealso cref="Position"/>
         public abstract void Seek(long pos);
 
         /// <summary>

--- a/src/Lucene.Net/Store/IndexOutput.cs
+++ b/src/Lucene.Net/Store/IndexOutput.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Store
@@ -51,13 +51,16 @@ namespace Lucene.Net.Store
 
         /// <summary>
         /// Returns the current position in this file, where the next write will
-        /// occur. </summary>
+        /// occur.
+        /// <para/>
+        /// This was getFilePointer() in Lucene.
+        /// </summary>
         /// <seealso cref="Seek(long)"/>
-        public abstract long GetFilePointer(); // LUCENENET TODO: API - Make into property
+        public abstract long Position { get; } // LUCENENET specific: Renamed Position to match FileStream
 
         /// <summary>
         /// Sets current position in this file, where the next write will occur. </summary>
-        /// <seealso cref="GetFilePointer()"/>
+        /// <seealso cref="Position"/>
         [Obsolete("(4.1) this method will be removed in Lucene 5.0")]
         public abstract void Seek(long pos);
 

--- a/src/Lucene.Net/Store/NIOFSDirectory.cs
+++ b/src/Lucene.Net/Store/NIOFSDirectory.cs
@@ -246,7 +246,7 @@ namespace Lucene.Net.Store
 
                 int readOffset = bb.Position;
                 int readLength = bb.Limit - readOffset;
-                long pos = GetFilePointer() + m_off;
+                long pos = Position + m_off; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
                 if (pos + len > m_end)
                 {

--- a/src/Lucene.Net/Store/RAMInputStream.cs
+++ b/src/Lucene.Net/Store/RAMInputStream.cs
@@ -117,10 +117,7 @@ namespace Lucene.Net.Store
             }
         }
 
-        public override long GetFilePointer()
-        {
-            return currentBufferIndex < 0 ? 0 : bufferStart + bufferPosition;
-        }
+        public override long Position => currentBufferIndex < 0 ? 0 : bufferStart + bufferPosition; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
         public override void Seek(long pos)
         {

--- a/src/Lucene.Net/Store/RAMOutputStream.cs
+++ b/src/Lucene.Net/Store/RAMOutputStream.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Support;
+﻿using Lucene.Net.Support;
 using System;
 using Lucene.Net.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -211,10 +211,7 @@ namespace Lucene.Net.Store
             SetFileLength();
         }
 
-        public override long GetFilePointer()
-        {
-            return currentBufferIndex < 0 ? 0 : bufferStart + bufferPosition;
-        }
+        public override long Position => currentBufferIndex < 0 ? 0 : bufferStart + bufferPosition; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
 
         /// <summary>
         /// Returns byte usage of all buffers. </summary>

--- a/src/Lucene.Net/Store/SimpleFSDirectory.cs
+++ b/src/Lucene.Net/Store/SimpleFSDirectory.cs
@@ -207,7 +207,7 @@ namespace Lucene.Net.Store
             {
                 lock (m_file)
                 {
-                    long position = m_off + GetFilePointer();
+                    long position = m_off + Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     m_file.Seek(position, SeekOrigin.Begin);
                     int total = 0;
 

--- a/src/Lucene.Net/Support/ObsoleteAPI/IndexInputExtensions.cs
+++ b/src/Lucene.Net/Support/ObsoleteAPI/IndexInputExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Lucene.Net.Store
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public static class IndexInputExtensions
+    {
+        /// <summary>
+        /// Returns the current position in this file, where the next read will
+        /// occur. </summary>
+        /// <seealso cref="IndexInput.Seek(long)"/>
+        [Obsolete("Use Position property instead. This extension method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static long GetFilePointer(this IndexInput indexInput)
+        {
+            return indexInput.Position;
+        }
+    }
+}

--- a/src/Lucene.Net/Support/ObsoleteAPI/IndexOutputExtensions.cs
+++ b/src/Lucene.Net/Support/ObsoleteAPI/IndexOutputExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Lucene.Net.Store
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public static class IndexOutputExtensions
+    {
+        /// <summary>
+        /// Returns the current position in this file, where the next write will
+        /// occur. </summary>
+        /// <seealso cref="IndexOutput.Seek(long)"/>
+        [Obsolete("Use Position property instead. This extension method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static long GetFilePointer(this IndexOutput indexOutput)
+        {
+            return indexOutput.Position;
+        }
+    }
+}

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -512,7 +512,7 @@ namespace Lucene.Net.Util.Fst
                 var ros = new RAMOutputStream();
                 Outputs.WriteFinalOutput(emptyOutput, ros);
 
-                var emptyOutputBytes = new byte[(int)ros.GetFilePointer()];
+                var emptyOutputBytes = new byte[(int)ros.Position]; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 ros.WriteTo(emptyOutputBytes, 0);
 
                 if (!packed)

--- a/src/Lucene.Net/Util/Packed/BlockPackedReader.cs
+++ b/src/Lucene.Net/Util/Packed/BlockPackedReader.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Util.Packed
                     int size = (int)Math.Min(blockSize, valueCount - (long)i * blockSize);
                     if (direct)
                     {
-                        long pointer = @in.GetFilePointer();
+                        long pointer = @in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         subReaders[i] = PackedInt32s.GetDirectReaderNoHeader(@in, PackedInt32s.Format.PACKED, packedIntsVersion, size, bitsPerValue);
                         @in.Seek(pointer + PackedInt32s.Format.PACKED.ByteCount(packedIntsVersion, size, bitsPerValue));
                     }

--- a/src/Lucene.Net/Util/Packed/BlockPackedReaderIterator.cs
+++ b/src/Lucene.Net/Util/Packed/BlockPackedReaderIterator.cs
@@ -195,7 +195,7 @@ namespace Lucene.Net.Util.Packed
         {
             if (@in is IndexInput input)
             {
-                input.Seek(input.GetFilePointer() + count);
+                input.Seek(input.Position + count); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             }
             else
             {

--- a/src/Lucene.Net/Util/Packed/DirectPacked64SingleBlockReader.cs
+++ b/src/Lucene.Net/Util/Packed/DirectPacked64SingleBlockReader.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Util.Packed
             : base(valueCount, bitsPerValue)
         {
             this.@in = @in;
-            startPointer = @in.GetFilePointer();
+            startPointer = @in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             valuesPerBlock = 64 / bitsPerValue;
             mask = ~(~0L << bitsPerValue);
         }

--- a/src/Lucene.Net/Util/Packed/DirectPackedReader.cs
+++ b/src/Lucene.Net/Util/Packed/DirectPackedReader.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Util.Packed
         {
             this.@in = @in;
 
-            startPointer = @in.GetFilePointer();
+            startPointer = @in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             if (bitsPerValue == 64)
             {
                 valueMask = -1L;

--- a/src/Lucene.Net/Util/Packed/MonotonicBlockPackedReader.cs
+++ b/src/Lucene.Net/Util/Packed/MonotonicBlockPackedReader.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Util.Packed
                     int size = (int)Math.Min(blockSize, valueCount - (long)i * blockSize);
                     if (direct)
                     {
-                        long pointer = @in.GetFilePointer();
+                        long pointer = @in.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                         subReaders[i] = PackedInt32s.GetDirectReaderNoHeader(@in, PackedInt32s.Format.PACKED, packedIntsVersion, size, bitsPerValue);
                         @in.Seek(pointer + PackedInt32s.Format.PACKED.ByteCount(packedIntsVersion, size, bitsPerValue));
                     }

--- a/src/Lucene.Net/Util/Packed/PackedInts.cs
+++ b/src/Lucene.Net/Util/Packed/PackedInts.cs
@@ -1079,7 +1079,7 @@ namespace Lucene.Net.Util.Packed
                 if (byteCount != format.ByteCount(VERSION_CURRENT, valueCount, bitsPerValue))
                 {
                     if (Debugging.AssertsEnabled) Debugging.Assert(version == VERSION_START);
-                    long endPointer = @in.GetFilePointer() + byteCount;
+                    long endPointer = @in.Position + byteCount; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                     // Some consumers of direct readers assume that reading the last value
                     // will make the underlying IndexInput go to the end of the packed
                     // stream, but this is not true because packed ints storage used to be

--- a/src/Lucene.Net/migration-guide.md
+++ b/src/Lucene.Net/migration-guide.md
@@ -51,6 +51,8 @@ Several Java conventions were replaced with their .NET counterparts:
 
 * For arrays and files, the `Size` property is now named `Length`.
 
+* For `IndexInput` and `IndexOutput` subclasses, `GetFilePointer()` method has been changed to a `Position` property to match `System.IO.FileStream.Position`.
+
 * Some classes, enums, and interfaces have been de-nested from their original Lucene location to make them easier to find when using Intellisense.
 
 * Some methods were lacking a verb, so the verb `Get` was added to make the method's function more clear. For example, instead of `Analysis.TokenStream()` we now have `Analysis.GetTokenStream()`.


### PR DESCRIPTION
This changes `GetFilePointer()` methods to properties named `Position`, which matches the convention used by [System.IO.FileStream.Position](https://docs.microsoft.com/en-us/dotnet/api/system.io.filestream.position). Affected types:

- `Lucene.Net.Store.IndexInput` (and subclasses)
- `Lucene.Net.Store.IndexOutput` (and subclasses)

Extension methods were also added in the `Lucene.Net.Store` namespace for backward compatibility. These extension methods are hidden from Intellisense and marked obsolete. They will be removed in the first 4.8.0 release candidate. 

> NOTE: These are meant to be a best effort to reduce breaking changes, but of course the `Lucene.Net.Store` namespace may not be imported in your code. It is recommended to utilize the property rather than importing the `Lucene.Net.Store` namespace.

This also changes a call in `ReadersAndUpdates` from the obsolete `BinaryDocValuesField.fType` to `BinaryDocValuesField.TYPE` (which was missed in #482).


