### PR TITLE
BUG: Changed usage of floating point MinValue constants to Epsilon to match Java

### DIFF
--- a/src/Lucene.Net.Grouping/AbstractSecondPassGroupingCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractSecondPassGroupingCollector.cs
@@ -126,7 +126,7 @@ namespace Lucene.Net.Search.Grouping
             GroupDocs<TGroupValue>[] groupDocsResult = new GroupDocs<TGroupValue>[groups.Count()];
 
             int groupIDX = 0;
-            float maxScore = float.MinValue;
+            float maxScore = float.Epsilon; // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
             foreach (var group in groups)
             {
                 AbstractSecondPassGroupingCollector.SearchGroupDocs<TGroupValue> groupDocs = m_groupMap[group.GroupValue];

--- a/src/Lucene.Net.Grouping/BlockGroupingCollector.cs
+++ b/src/Lucene.Net.Grouping/BlockGroupingCollector.cs
@@ -394,7 +394,7 @@ namespace Lucene.Net.Search.Grouping
 
             FakeScorer fakeScorer = new FakeScorer();
 
-            float maxScore = float.MinValue;
+            float maxScore = float.Epsilon; // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
 
             GroupDocs<TGroupValue>[] groups = new GroupDocs<TGroupValue>[groupQueue.Count - groupOffset];
             for (int downTo = groupQueue.Count - groupOffset - 1; downTo >= 0; downTo--)

--- a/src/Lucene.Net.Grouping/TopGroups.cs
+++ b/src/Lucene.Net.Grouping/TopGroups.cs
@@ -173,13 +173,13 @@ namespace Lucene.Net.Search.Grouping
             var mergedGroupDocs = new GroupDocs<T>[numGroups];
 
             TopDocs[] shardTopDocs = new TopDocs[shardGroups.Length];
-            float totalMaxScore = float.MinValue;
+            float totalMaxScore = float.Epsilon; // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
 
             for (int groupIDX = 0; groupIDX < numGroups; groupIDX++)
             {
                 T groupValue = shardGroups[0].Groups[groupIDX].GroupValue;
                 //System.out.println("  merge groupValue=" + groupValue + " sortValues=" + Arrays.toString(shardGroups[0].groups[groupIDX].groupSortValues));
-                float maxScore = float.MinValue;
+                float maxScore = float.Epsilon; // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
                 int totalHits = 0;
                 double scoreSum = 0.0;
                 for (int shardIdx = 0; shardIdx < shardGroups.Length; shardIdx++)

--- a/src/Lucene.Net.Join/Support/ToParentBlockJoinCollector.cs
+++ b/src/Lucene.Net.Join/Support/ToParentBlockJoinCollector.cs
@@ -115,7 +115,7 @@ namespace Lucene.Net.Join
             this.trackMaxScore = trackMaxScore;
             if (trackMaxScore)
             {
-                maxScore = float.MinValue;
+                maxScore = float.Epsilon; // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
             }
             //System.out.println("numParentHits=" + numParentHits);
             this.trackScores = trackScores;

--- a/src/Lucene.Net.Join/ToParentBlockJoinCollector.cs
+++ b/src/Lucene.Net.Join/ToParentBlockJoinCollector.cs
@@ -113,7 +113,7 @@ namespace Lucene.Net.Search.Join
             this.trackMaxScore = trackMaxScore;
             if (trackMaxScore)
             {
-                maxScore = float.MinValue;
+                maxScore = float.Epsilon; // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
             }
             //System.out.println("numParentHits=" + numParentHits);
             this.trackScores = trackScores;

--- a/src/Lucene.Net.Tests.TestFramework/Codecs/Compressing/TestCompressingStoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Codecs/Compressing/TestCompressingStoredFieldsFormat.cs
@@ -122,7 +122,7 @@
 //        +0.0f,
 //        float.NegativeInfinity,
 //        float.PositiveInfinity,
-//        float.MinValue,
+//        float.Epsilon, // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
 //        float.MaxValue,
 //        float.NaN,
 //    };
@@ -180,11 +180,11 @@
 //            double[] special = {
 //        -0.0d,
 //        +0.0d,
-//        Double.NegativeInfinity,
-//        Double.PositiveInfinity,
-//        Double.MinValue,
-//        Double.MaxValue,
-//        Double.NaN
+//        double.NegativeInfinity,
+//        double.PositiveInfinity,
+//        double.Epsilon, // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
+//        double.MaxValue,
+//        double.NaN
 //    };
 
 //            foreach (double x in special)

--- a/src/Lucene.Net/Search/TopDocs.cs
+++ b/src/Lucene.Net/Search/TopDocs.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -271,7 +271,7 @@ namespace Lucene.Net.Search
 
             int totalHitCount = 0;
             int availHitCount = 0;
-            float maxScore = float.MinValue;
+            float maxScore = float.Epsilon; // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
             for (int shardIDX = 0; shardIDX < shardHits.Length; shardIDX++)
             {
                 TopDocs shard = shardHits[shardIDX];


### PR DESCRIPTION
Changed all references that were `float.MinValue` and `double.MinValue` to `float.Epsilon` and `double.Epsilon` because those are the .NET equivalent constants to `Float.MIN_VALUE` and `Double.MIN_VALUE` in Java

### References:

- [Why is Double.MIN_VALUE in not negative](https://stackoverflow.com/a/3884879)
- [Why is Float.MIN_VALUE in Java a positive value?](https://stackoverflow.com/a/11420190)
- [Java: Float.MIN_VALUE vs Float.MIN_NORMAL](https://programming.guide/java/float-min-value-vs-float-min-normal.html)
- [Float Javadocs](https://docs.oracle.com/javase/7/docs/api/java/lang/Float.html#MIN_VALUE)