### PR TITLE
Fix SonarQube's "Any() should be used to test for emptiness" / Code Smell

### DIFF
--- a/src/Lucene.Net.Grouping/AbstractSecondPassGroupingCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractSecondPassGroupingCollector.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Search.Grouping
         {
 
             //System.out.println("SP init");
-            if (groups.Count() == 0)
+            if (!groups.Any())
             {
                 throw new ArgumentException("no groups to collect (groups.Count is 0)");
             }

--- a/src/Lucene.Net.Grouping/AbstractSecondPassGroupingCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractSecondPassGroupingCollector.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Search.Grouping
         {
 
             //System.out.println("SP init");
-            if (!groups.Any())
+            if (!groups.Any()) // LUCENENET TODO: Change back to .Count if/when IEnumerable<T> is changed to ICollection<T> or IReadOnlyCollection<T>
             {
                 throw new ArgumentException("no groups to collect (groups.Count is 0)");
             }

--- a/src/Lucene.Net.Grouping/SearchGroup.cs
+++ b/src/Lucene.Net.Grouping/SearchGroup.cs
@@ -402,7 +402,7 @@ namespace Lucene.Net.Search.Grouping
                 for (int shardIDX = 0; shardIDX < shards.Count; shardIDX++)
                 {
                     IEnumerable<ISearchGroup<T>> shard = shards[shardIDX];
-                    if (shard.Any())
+                    if (shard.Any()) // LUCENENET TODO: Change back to .Count if/when IEnumerable<T> is changed to ICollection<T> or IReadOnlyCollection<T>
                     {
                         //System.out.println("  insert shard=" + shardIDX);
                         UpdateNextGroup(maxQueueSize, new ShardIter<T>(shard, shardIDX));

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/EnumerableExtensions.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/EnumerableExtensions.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Cli
     {
         public static IEnumerable<IEnumerable<T>> OptionalParameters<T>(this IEnumerable<IEnumerable<T>> input)
         {
-            if (input.Count() == 0)
+            if (!input.Any())
                 yield break;
             else
             {


### PR DESCRIPTION
Hello,

This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "Any() should be used to test for emptiness" [rule](https://rules.sonarsource.com/csharp/RSPEC-1155) in SonarQube.

Let me know if you are interested in similar contributions.

Best,
Martin