### PR TITLE
BREAKING: QueryParser.Flexible updates

### DIFF
--- a/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/QueryNode.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/QueryNode.cs
@@ -57,6 +57,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
         /// </summary>
         object GetTag(string tagName);
 
+        /// <summary>
+        /// Gets the tag associated with the specified tagName.
+        /// </summary>
+        bool TryGetTag(string tagName, out object tag);
+
         IQueryNode Parent { get; }
 
         /// <summary>

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/QueryNode.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/QueryNode.cs
@@ -102,5 +102,12 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
         /// Removes this query node from its parent.
         /// </summary>
         void RemoveFromParent();
+
+        // LUCENENET: From Lucene 8.8.1, patch to broken RemoveFromParent() behavior
+        /// <summary>
+        /// Remove a child node.
+        /// </summary>
+        /// <param name="childNode">Which child to remove.</param>
+        void RemoveChildren(IQueryNode childNode);
     }
 }

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/QueryNodeImpl.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/QueryNodeImpl.cs
@@ -181,7 +181,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
             return this.tags[CultureInfo.InvariantCulture.TextInfo.ToLower(tagName)];
         }
 
-        // LUCENENET TODO: API - Create TryGetTag method to combine the above 2 operations
+        /// <inheritdoc/>
+        public virtual bool TryGetTag(string tagName, out object tag)
+        {
+            return this.tags.TryGetValue(tagName, out tag);
+        }
 
         private IQueryNode parent = null;
 

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Core/Nodes/TestQueryNode.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Core/Nodes/TestQueryNode.cs
@@ -62,11 +62,28 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
 
             fieldNode.RemoveFromParent();
             assertNull(fieldNode.Parent);
+            /* LUCENE-5805 - QueryNodeImpl.removeFromParent does a lot of work without any effect */
+            assertFalse(booleanNode.GetChildren().Contains(fieldNode));
 
             booleanNode.Add(fieldNode);
             assertNotNull(fieldNode.Parent);
 
             booleanNode.Set(Collections.EmptyList<IQueryNode>());
+            assertNull(fieldNode.Parent);
+        }
+
+        // LUCENENET: Added this patch in Lucene.NET 4.8.0 from Lucene 5.3.0
+        [Test]
+        public void TestRemoveChildren()
+        {
+            BooleanQueryNode booleanNode = new BooleanQueryNode(Collections.EmptyList<IQueryNode>());
+            FieldQueryNode fieldNode = new FieldQueryNode("foo", "A", 0, 1);
+
+            booleanNode.Add(fieldNode);
+            assertTrue(booleanNode.GetChildren().Count == 1);
+
+            booleanNode.RemoveChildren(fieldNode);
+            assertTrue(booleanNode.GetChildren().Count == 0);
             assertNull(fieldNode.Parent);
         }
     }


### PR DESCRIPTION
Patches [LUCENE-5805: QueryNodeImpl.removeFromParent does a lot of work without any effect](https://issues.apache.org/jira/browse/LUCENE-5805).

Also adds a .NETified `TryGetTag()` method to combine the `ContainsTag()` and `GetTag()` operations.