### PR TITLE
Patch for #497 - Time.NanoTime() conversion

### DIFF
--- a/src/Lucene.Net.Tests/Index/TestDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestDeletionPolicy.cs
@@ -273,7 +273,7 @@ namespace Lucene.Net.Index
             IndexWriter writer = new IndexWriter(dir, conf);
             ExpirationTimeDeletionPolicy policy = (ExpirationTimeDeletionPolicy)writer.Config.IndexDeletionPolicy;
             IDictionary<string, string> commitData = new Dictionary<string, string>();
-            commitData["commitTime"] = Convert.ToString(Environment.TickCount);
+            commitData["commitTime"] = Convert.ToString(J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond); // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
             writer.SetCommitData(commitData);
             writer.Commit();
             writer.Dispose();
@@ -284,7 +284,7 @@ namespace Lucene.Net.Index
             {
                 // Record last time when writer performed deletes of
                 // past commits
-                lastDeleteTime = Environment.TickCount;
+                lastDeleteTime = J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond; // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
                 conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetIndexDeletionPolicy(policy);
                 mp = conf.MergePolicy;
                 mp.NoCFSRatio = 1.0;
@@ -295,7 +295,7 @@ namespace Lucene.Net.Index
                     AddDoc(writer);
                 }
                 commitData = new Dictionary<string, string>();
-                commitData["commitTime"] = Convert.ToString(Environment.TickCount);
+                commitData["commitTime"] = Convert.ToString(J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond); // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
                 writer.SetCommitData(commitData);
                 writer.Commit();
                 writer.Dispose();

--- a/src/Lucene.Net.Tests/Search/TestSearchWithThreads.cs
+++ b/src/Lucene.Net.Tests/Search/TestSearchWithThreads.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Search
 #endif
                 Random, dir);
 
-            long startTime = Environment.TickCount;
+            long startTime = J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond; // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
 
             // TODO: replace w/ the @nightly test data; make this
             // into an optional @nightly stress test
@@ -84,7 +84,7 @@ namespace Lucene.Net.Search
             IndexReader r = w.GetReader();
             w.Dispose();
 
-            long endTime = Environment.TickCount;
+            long endTime = J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond; // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
             if (Verbose)
             {
                 Console.WriteLine("BUILD took " + (endTime - startTime));
@@ -146,8 +146,8 @@ namespace Lucene.Net.Search
                 {
                     long totHits = 0;
                     long totSearch = 0;
-                    long stopAt = Environment.TickCount + outerInstance.RUN_TIME_MSEC;
-                    while (Environment.TickCount < stopAt && !failed)
+                    long stopAt = (J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond) + outerInstance.RUN_TIME_MSEC; // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
+                    while (J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond < stopAt && !failed) // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
                     {
                         s.Search(new TermQuery(new Term("body", "aaa")), col);
                         totHits += col.TotalHits;

--- a/src/Lucene.Net.Tests/Search/TestSearcherManager.cs
+++ b/src/Lucene.Net.Tests/Search/TestSearcherManager.cs
@@ -149,7 +149,7 @@ namespace Lucene.Net.Search
                         Console.WriteLine("[" + Thread.CurrentThread.Name + "]: launch reopen thread");
                     }
 
-                    while (Environment.TickCount < stopTime)
+                    while (J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond < stopTime) // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
                     {
                         Thread.Sleep(TestUtil.NextInt32(Random, 1, 100));
                         outerInstance.m_writer.Commit();


### PR DESCRIPTION
BUG: Fixed several tests that were still using `Environment.TickCount`. `TestSearcherManager` was using it in combination with `Time.NanoTime() / Time.MillisecondsPerNanosecond` which caused the test to run forever.