### PR TITLE
Added additional "Building and Testing" info to the repo's readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Building on the Command Line is currently only supported on Windows.
 
 ##### Execution
 
-To build the source, clone or download and unzip the repository. From the repository root, execute:
+To build the source, clone or download and unzip the repository. From the repository root, execute the `batch.bat` file from a command prompt and include the desired options from the build options table below:
 
 ```
 > build [options]
@@ -227,6 +227,14 @@ To build the source, clone or download and unzip the repository. From the reposi
         <td>build&nbsp;&#8209;pv:4.8.0&#8209;beta00001&nbsp;&#8209;v:4.8.0</td>
     </tr>
 </table>
+
+For example the following command creates a Release build with NuGet package version 4.8.0‑beta00014b and assembly file version 4.8.0:
+
+```
+> build ‑‑Configuration:Release ‑pv:4.8.0‑beta00014b ‑v:4.8.0
+```
+
+In the above example we are using "b" at the end of the version to indicate this is not a publically released beta version but rather the ouput of a build from master which occured after beta00014 but before beta00015 was released.  
 
 NuGet packages are output by the build to the `/release/NuGetPackages/` directory. Test results (if applicable) are output to the `/release/TestResults/` directory.
 


### PR DESCRIPTION
When I was trying to generate nuget files from master for the first time I miss understood the instructions and thought I needed to run build from powershell.  But later realized that while powershell is required by the script, the execution of the script needs to be at a command prompt.  I was also unclear in what ways I might be able to modify the version number PackageVersion in order to distinguish the generated private build nuget files from a publicly released beta one.  After being successful I'm now updating the readme file to include my learnings to make it easier for the next person.  The existing docs were already great.  Hopefully this makes them a bit better.