### PR TITLE
Review of "Collections.synchronizedXXX" to ensure we aren't missing locks

### DIFF
--- a/src/Lucene.Net.Tests/Store/TestLockFactory.cs
+++ b/src/Lucene.Net.Tests/Store/TestLockFactory.cs
@@ -1,6 +1,7 @@
 ﻿using J2N.Threading;
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
+using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -441,7 +442,7 @@ namespace Lucene.Net.Store
             }
 
             public bool LockPrefixSet;
-            public IDictionary<string, Lock> LocksCreated = /*CollectionsHelper.SynchronizedMap(*/new Dictionary<string, Lock>()/*)*/;
+            public IDictionary<string, Lock> LocksCreated = new Dictionary<string, Lock>().AsConcurrent();
             public int MakeLockCount = 0;
 
             public override string LockPrefix

--- a/src/Lucene.Net/Index/SegmentCoreReaders.cs
+++ b/src/Lucene.Net/Index/SegmentCoreReaders.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
 
@@ -195,7 +196,7 @@ namespace Lucene.Net.Index
 
         private void NotifyCoreClosedListeners(Exception th)
         {
-            lock (coreClosedListeners)
+            lock (((ICollection)coreClosedListeners).SyncRoot) // LUCENENET: We need to lock on SyncRoot to ensure we are synchronized with the rest of ConcurrentSet<T>
             {
                 foreach (ICoreDisposedListener listener in coreClosedListeners)
                 {


### PR DESCRIPTION
Reviewed all occurrences of `Collections.synchronizedSet()`, `Collections.synchronizedMap()`, and `Collections.synchronizedList()` calls in Lucene and fixed issues with missing locks and non-concurrent collections where concurrency is required.