### PR TITLE
Removed FEATURE_THREAD_YIELD and FEATURE_THREAD_PRIORITY

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -70,7 +70,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_STACKTRACE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_CLOSE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_INITIALIZELIFETIMESERVICE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_THREAD_PRIORITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREADPOOL_UNSAFEQUEUEWORKITEM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETMETHOD__BINDINGFLAGS_PARAMS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XSLT</DefineConstants>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -71,7 +71,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_CLOSE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_INITIALIZELIFETIMESERVICE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_PRIORITY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_THREAD_YIELD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREADPOOL_UNSAFEQUEUEWORKITEM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETMETHOD__BINDINGFLAGS_PARAMS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XSLT</DefineConstants>

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/TaskSequence.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/TaskSequence.cs
@@ -206,9 +206,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                             bgTasks = new List<RunBackgroundTask>();
                         }
                         RunBackgroundTask bgTask = new RunBackgroundTask(task, letChildReport);
-#if FEATURE_THREAD_PRIORITY
                         bgTask.Priority = (task.BackgroundDeltaPriority + Thread.CurrentThread.Priority);
-#endif
                         bgTask.Start();
                         bgTasks.Add(bgTask);
                     }

--- a/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
@@ -8,6 +8,7 @@ using RandomizedTesting.Generators;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Index
@@ -65,7 +66,7 @@ namespace Lucene.Net.Index
             {
                 if (random.Next(4) == 2)
                 {
-                    System.Threading.Thread.Sleep(0);
+                    Thread.Yield();
                 }
             }
         }

--- a/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
@@ -501,11 +501,7 @@ namespace Lucene.Net.Store
         //                        using (IndexOutput output = this.dir.CreateOutput(fileName, NewIOContext(Random)))
         //                        {
         //                            // Add some lags so that the other thread can read the content of the directory.
-        //#if !FEATURE_THREAD_YIELD
-        //                            Thread.Sleep(0);
-        //#else
         //                            Thread.Yield();
-        //#endif
         //                        }
         //                        assertTrue(SlowFileExists(this.dir, fileName));
         //                    }

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -534,11 +534,7 @@ namespace Lucene.Net.Store
         {
             if (randomState.NextBoolean())
             {
-#if !FEATURE_THREAD_YIELD
-                Thread.Sleep(0);
-#else
                 Thread.Yield();
-#endif
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Store/MockIndexOutputWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockIndexOutputWrapper.cs
@@ -150,7 +150,7 @@ namespace Lucene.Net.Store
             {
                 int half = len / 2;
                 @delegate.WriteBytes(b, offset, half);
-                Thread.Sleep(0);
+                Thread.Yield();
                 @delegate.WriteBytes(b, offset + half, len - half);
             }
             else

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyCombined.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyCombined.cs
@@ -896,9 +896,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
             public override void Run()
             {
-#if FEATURE_THREAD_PRIORITY
                 Priority = 1 + Priority;
-#endif 
                 try
                 {
                     while (!stop)

--- a/src/Lucene.Net.Tests.Suggest/Spell/TestSpellChecker.cs
+++ b/src/Lucene.Net.Tests.Suggest/Spell/TestSpellChecker.cs
@@ -561,9 +561,7 @@ namespace Lucene.Net.Search.Spell
 
             public override void Run()
             {
-#if FEATURE_THREAD_PRIORITY
                 Priority += 1;
-#endif
                 try
                 {
                     while (!stop)

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
@@ -539,9 +539,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             public override void Run()
             {
-#if FEATURE_THREAD_PRIORITY
                 Priority += 1;
-#endif
                 while (!stop)
                 {
                     string query = RandomText();

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -755,7 +755,7 @@ namespace Lucene.Net.Index
 
             internal override void Handle(Exception t)
             {
-                Console.Error.WriteLine(t.StackTrace);
+                t.printStackTrace(Console.Out);
                 lock (failures)
                 {
                     failures.Add(t);
@@ -853,9 +853,9 @@ namespace Lucene.Net.Index
 
             internal override void Handle(Exception t)
             {
-                if (!(t is ObjectDisposedException) && !(t is NullReferenceException))
+                if (!t.IsAlreadyClosedException() && !(t is NullReferenceException))
                 {
-                    Console.Error.WriteLine(t.StackTrace);
+                    t.printStackTrace(Console.Out);
                     lock (failures)
                     {
                         failures.Add(t);
@@ -942,7 +942,7 @@ namespace Lucene.Net.Index
             {
                 bool report = true;
 
-                if (t is ObjectDisposedException || t is MergePolicy.MergeAbortedException || t is NullReferenceException)
+                if (t.IsAlreadyClosedException() || t is MergePolicy.MergeAbortedException || t is NullReferenceException)
                 {
                     report = !didClose;
                 }
@@ -950,7 +950,7 @@ namespace Lucene.Net.Index
                 {
                     report = !didClose;
                 }
-                else if (t is IOException)
+                else if (t.IsIOException())
                 {
                     Exception t2 = t.InnerException;
                     if (t2 is MergePolicy.MergeAbortedException)
@@ -960,7 +960,7 @@ namespace Lucene.Net.Index
                 }
                 if (report)
                 {
-                    Console.Out.WriteLine(t.StackTrace);
+                    t.printStackTrace(Console.Out);
                     lock (failures)
                     {
                         failures.Add(t);

--- a/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
@@ -2,6 +2,7 @@
 using J2N.Threading;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Attributes;
 using Lucene.Net.Codecs;
 using Lucene.Net.Codecs.SimpleText;
 using Lucene.Net.Diagnostics;
@@ -1429,6 +1430,7 @@ namespace Lucene.Net.Index
         [Test]
         [Slow]
         [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/269")] // LUCENENET TODO: this test occasionally fails
+        [Deadlock][Timeout(900000)] // LUCENENET TODO: this test occasionally deadlocks
         public virtual void TestThreadInterruptDeadlock()
         {
             IndexerThreadInterrupt t = new IndexerThreadInterrupt(this);
@@ -1470,6 +1472,7 @@ namespace Lucene.Net.Index
         [Test]
         [Slow]
         [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/269")] // LUCENENET TODO: this test occasionally fails
+        [Deadlock][Timeout(900000)] // LUCENENET TODO: this test occasionally deadlocks
         public virtual void TestTwoThreadsInterruptDeadlock()
         {
             IndexerThreadInterrupt t1 = new IndexerThreadInterrupt(this);

--- a/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
@@ -785,7 +785,6 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-#if FEATURE_THREAD_PRIORITY
         // LUCENE-1036
         [Test]
         public virtual void TestMaxThreadPriority()
@@ -814,7 +813,6 @@ namespace Lucene.Net.Index
                 Thread.CurrentThread.Priority = pri;
             }
         }
-#endif
 
         [Test]
         public virtual void TestVariableSchema()

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterMerging.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterMerging.cs
@@ -464,7 +464,7 @@ namespace Lucene.Net.Index
                             break;
                         }
 #pragma warning disable 168
-                        catch (NullReferenceException e)
+                        catch (NullReferenceException e) // LUCENENET TODO: We should fix the components so this cannot occur (assuming it can).
 #pragma warning restore 168
                         {
                             done = true;
@@ -478,7 +478,7 @@ namespace Lucene.Net.Index
                             break;
                         }
                     }
-                    Thread.Sleep(0);
+                    Thread.Yield();
                 }
             }
         }

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
@@ -780,10 +780,10 @@ namespace Lucene.Net.Index
                                 {
                                     // ok
                                 }
-                                //catch (NullReferenceException) // LUCENENET specific - NullReferenceException must be allowed to propagate so we can defensively avoid it in .NET
-                                //{
-                                //    // ok
-                                //}
+                                catch (NullReferenceException) // LUCENENET TODO: - NullReferenceException must be allowed to propagate so we can defensively avoid it in .NET
+                                {
+                                    // ok
+                                }
                                 finally
                                 {
                                     commitLock.Unlock();
@@ -803,10 +803,10 @@ namespace Lucene.Net.Index
                                 {
                                     // ok
                                 }
-                                //catch (NullReferenceException) // LUCENENET specific - NullReferenceException must be allowed to propagate so we can defensively avoid it in .NET
-                                //{
-                                //    // ok
-                                //}
+                                catch (NullReferenceException) // LUCENENET TODO: - NullReferenceException must be allowed to propagate so we can defensively avoid it in .NET
+                                {
+                                    // ok
+                                }
                                 catch (Exception ae) when (ae.IsAssertionError())
                                 {
                                     // ok

--- a/src/Lucene.Net.Tests/Index/TestStressIndexing2.cs
+++ b/src/Lucene.Net.Tests/Index/TestStressIndexing2.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Index
                 //      if (name.equals("startCommit")) {
                 if (Random.Next(4) == 2)
                 {
-                    Thread.Sleep(0);
+                    Thread.Yield();
                 }
             }
         }

--- a/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
+++ b/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
@@ -282,17 +282,13 @@ namespace Lucene.Net.Search
 
             nrtDeletesThread = new ControlledRealTimeReopenThread<IndexSearcher>(genWriter, nrtDeletes, maxReopenSec, minReopenSec);
             nrtDeletesThread.Name = "NRTDeletes Reopen Thread";
-#if FEATURE_THREAD_PRIORITY
             nrtDeletesThread.Priority = (ThreadPriority)Math.Min((int)Thread.CurrentThread.Priority + 2, (int)ThreadPriority.Highest);
-#endif
             nrtDeletesThread.IsBackground = (true);
             nrtDeletesThread.Start();
 
             nrtNoDeletesThread = new ControlledRealTimeReopenThread<IndexSearcher>(genWriter, nrtNoDeletes, maxReopenSec, minReopenSec);
             nrtNoDeletesThread.Name = "NRTNoDeletes Reopen Thread";
-#if FEATURE_THREAD_PRIORITY
             nrtNoDeletesThread.Priority = (ThreadPriority)Math.Min((int)Thread.CurrentThread.Priority + 2, (int)ThreadPriority.Highest);
-#endif
             nrtNoDeletesThread.IsBackground = (true);
             nrtNoDeletesThread.Start();
         }

--- a/src/Lucene.Net.Tests/TestWorstCaseTestBehavior.cs
+++ b/src/Lucene.Net.Tests/TestWorstCaseTestBehavior.cs
@@ -26,7 +26,6 @@ namespace Lucene.Net
 
     public class TestWorstCaseTestBehavior : LuceneTestCase
     {
-#if FEATURE_THREAD_YIELD
         [Ignore("Ignored in Lucene")]
         [Test]
         public virtual void TestThreadLeak()
@@ -41,7 +40,6 @@ namespace Lucene.Net
 
             // once alive, leave it to run outside of the test scope.
         }
-#endif
 
         private class ThreadAnonymousClass : ThreadJob
         {

--- a/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
@@ -113,13 +113,7 @@ namespace Lucene.Net.Index
         /// <summary>
         /// Return the priority that merge threads run at. This is always the same.
         /// </summary>
-        public int MergeThreadPriority =>
-#if !FEATURE_THREAD_PRIORITY
-            2;
-#else
-            (int)ThreadPriority.Normal;
-#endif
-
+        public int MergeThreadPriority => (int)ThreadPriority.Normal;
 
         /// <summary>
         /// This method has no effect in <see cref="TaskMergeScheduler"/> because the


### PR DESCRIPTION
Removed FEATURE_THREAD_YIELD and FEATURE_THREAD_PRIORITY, both features that pertained only to .NET Standard 1.1.

- Reviewed and changed all instances of `Thread.Sleep(0)` back to `Thread.Yield()` (as was the case in Lucene). `Thread.Sleep(0)` was a workaround on .NET Standard 1.1.

This fixes some issues with deadlocks during test runs (noticed when #511 was submitted).

An unrelated bug in `TestIndexWriterWithThreads` (introduced in #476) was also found and fixed.