### PR TITLE
Lucene.Net.Replicator Bug Fixes (Fixes #363)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -44,7 +44,7 @@
 
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ADDORUPDATE</DefineConstants>
-    
+    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
     
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,6 +20,13 @@
 -->
 <Project>
 
+  <!-- Features in .NET 5.x and .NET 6.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
+
+    <DefineConstants>$(DefineConstants);FEATURE_ASPNETCORE_ENDPOINT_CONFIG</DefineConstants>
+
+  </PropertyGroup>
+  
   <!-- Features in .NET Core 3.x, .NET 5.x, and .NET 6.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or '$(TargetFramework)' == 'net6.0' ">
 

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -41,7 +41,8 @@
     <J2NPackageVersion>2.0.0-beta-0017</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.0.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>2.0.0</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>5.0.0</MicrosoftAspNetCoreTestHostPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netcoreapp')) ">2.0.0</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftCodeAnalysisAnalyzersPackageVersion>2.9.8</MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.6.1</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>

--- a/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
@@ -264,9 +264,10 @@ namespace Lucene.Net.Replicator.Http
         /// Internal utility: input stream of the provided response.
         /// </summary>
         /// <exception cref="IOException"></exception>
+        [Obsolete("Use GetResponseStream(HttpResponseMessage) instead.  This extension method will be removed in 4.8.0 release candidate.")]
         public virtual Stream ResponseInputStream(HttpResponseMessage response)
         {
-            return ResponseInputStream(response, false);
+            return GetResponseStream(response, false);
         }
 
         // TODO: can we simplify this Consuming !?!?!?
@@ -275,7 +276,28 @@ namespace Lucene.Net.Replicator.Http
         /// consumes the response's resources when the input stream is exhausted.
         /// </summary>
         /// <exception cref="IOException"></exception>
+        [Obsolete("Use GetResponseStream(HttpResponseMessage, bool) instead.  This extension method will be removed in 4.8.0 release candidate.")]
         public virtual Stream ResponseInputStream(HttpResponseMessage response, bool consume)
+        {
+            return GetResponseStream(response, consume);
+        }
+
+        /// <summary>
+        /// Internal utility: input stream of the provided response.
+        /// </summary>
+        /// <exception cref="IOException"></exception>
+        public virtual Stream GetResponseStream(HttpResponseMessage response) // LUCENENET: This was ResponseInputStream in Lucene
+        {
+            return GetResponseStream(response, false);
+        }
+
+        // TODO: can we simplify this Consuming !?!?!?
+        /// <summary>
+        /// Internal utility: input stream of the provided response, which optionally 
+        /// consumes the response's resources when the input stream is exhausted.
+        /// </summary>
+        /// <exception cref="IOException"></exception>
+        public virtual Stream GetResponseStream(HttpResponseMessage response, bool consume) // LUCENENET: This was ResponseInputStream in Lucene
         {
             Stream result = response.Content.ReadAsStreamAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             if (consume)

--- a/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
@@ -227,11 +227,7 @@ namespace Lucene.Net.Replicator.Http
             req.Content = new StringContent(JToken.FromObject(entity, JsonSerializer.Create(ReplicationService.JSON_SERIALIZER_SETTINGS))
                 .ToString(Formatting.None), Encoding.UTF8, "application/json");
 
-            //.NET Note: Bridging from Async to Sync, this is not ideal and we could consider changing the interface to be Async or provide Async overloads
-            //      and have these Sync methods with their caveats.
-            HttpResponseMessage response = httpc.SendAsync(req).ConfigureAwait(false).GetAwaiter().GetResult();
-            VerifyStatus(response);
-            return response;
+            return Execute(req);
         }
 
         /// <summary>
@@ -241,11 +237,17 @@ namespace Lucene.Net.Replicator.Http
         protected virtual HttpResponseMessage ExecuteGet(string request, params string[] parameters)
         {
             EnsureOpen();
+
             //Note: No headers? No ContentType?... Bad use of Http?
             HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, QueryString(request, parameters));
+            return Execute(req);
+        }
+
+        private HttpResponseMessage Execute(HttpRequestMessage request)
+        {
             //.NET Note: Bridging from Async to Sync, this is not ideal and we could consider changing the interface to be Async or provide Async overloads
             //      and have these Sync methods with their caveats.
-            HttpResponseMessage response = httpc.SendAsync(req).ConfigureAwait(false).GetAwaiter().GetResult();
+            HttpResponseMessage response = httpc.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false).GetAwaiter().GetResult();
             VerifyStatus(response);
             return response;
         }

--- a/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
@@ -458,7 +458,7 @@ namespace Lucene.Net.Replicator.Http
                             input.Dispose();
                         }
                     }
-                    catch (Exception ioe) when (ioe.IsIOException())
+                    catch (Exception e) when (e.IsException())
                     {
                         // ignored on purpose
                     }

--- a/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using System.Threading;
 
 namespace Lucene.Net.Replicator.Http
 {
@@ -38,11 +39,16 @@ namespace Lucene.Net.Replicator.Http
     /// </remarks>
     public abstract class HttpClientBase : IDisposable
     {
-        /// <summary>
-        /// Default connection timeout for this client, in milliseconds.
-        /// <see cref="ConnectionTimeout"/>
-        /// </summary>
+        // LUCENENET specific - removed DEFAULT_CONNECTION_TIMEOUT because it is irrelevant in .NET
+
+        [Obsolete("Use DEFAULT_TIMEOUT instead.  This extension method will be removed in 4.8.0 release candidate.")]
         public const int DEFAULT_CONNECTION_TIMEOUT = 1000;
+
+        /// <summary>
+        /// Default request timeout for this client (100 seconds).
+        /// <see cref="Timeout"/>.
+        /// </summary>
+        public readonly static TimeSpan DEFAULT_TIMEOUT = TimeSpan.FromSeconds(100); // LUCENENET: This was DEFAULT_SO_TIMEOUT in Lucene, using .NET's default timeout value of 100 instead of 61 seconds
 
         // TODO compression?
 
@@ -84,7 +90,7 @@ namespace Lucene.Net.Replicator.Http
         /// <param name="messageHandler">Optional, The HTTP handler stack to use for sending requests.</param>
         //Note: LUCENENET Specific
         protected HttpClientBase(string url, HttpMessageHandler messageHandler = null)
-            : this(url, new HttpClient(messageHandler ?? new HttpClientHandler()) { Timeout = TimeSpan.FromMilliseconds(DEFAULT_CONNECTION_TIMEOUT) })
+            : this(url, new HttpClient(messageHandler ?? new HttpClientHandler()) {  Timeout = DEFAULT_TIMEOUT })
         {
         }
 
@@ -102,17 +108,17 @@ namespace Lucene.Net.Replicator.Http
         {
             Url = url;
             httpc = client;
-            ConnectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
+            Timeout = DEFAULT_TIMEOUT;
         }
 
         /// <summary>
         /// Gets or Sets the connection timeout for this client, in milliseconds. This setting
         /// is used to modify <see cref="HttpClient.Timeout"/>.
         /// </summary>
-        public virtual int ConnectionTimeout
+        public virtual TimeSpan Timeout
         {
-            get => (int)httpc.Timeout.TotalMilliseconds;
-            set => httpc.Timeout = TimeSpan.FromMilliseconds(value);
+            get => httpc.Timeout;
+            set => httpc.Timeout = value;
         }
 
         /// <summary>

--- a/src/Lucene.Net.Replicator/Http/HttpReplicator.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpReplicator.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Replicator.Http
         /// </summary>
         //Note: LUCENENET Specific
         public HttpReplicator(string url, HttpMessageHandler messageHandler = null)
-            : this(url, new HttpClient(messageHandler ?? new HttpClientHandler()) { Timeout = TimeSpan.FromMilliseconds(DEFAULT_CONNECTION_TIMEOUT) })
+            : this(url, new HttpClient(messageHandler ?? new HttpClientHandler()) { Timeout = DEFAULT_TIMEOUT })
         {
         }
 

--- a/src/Lucene.Net.Replicator/Http/HttpReplicator.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpReplicator.cs
@@ -71,7 +71,7 @@ namespace Lucene.Net.Replicator.Http
             HttpResponseMessage response = base.ExecuteGet(ReplicationService.ReplicationAction.UPDATE.ToString(), parameters);
             return DoAction(response, () =>
             {
-                using DataInputStream inputStream = new DataInputStream(ResponseInputStream(response));
+                using DataInputStream inputStream = new DataInputStream(GetResponseStream(response));
                 return inputStream.ReadByte() == 0 ? null : new SessionToken(inputStream);
             });
         }
@@ -85,7 +85,7 @@ namespace Lucene.Net.Replicator.Http
                 ReplicationService.REPLICATE_SESSION_ID_PARAM, sessionId,
                 ReplicationService.REPLICATE_SOURCE_PARAM, source,
                 ReplicationService.REPLICATE_FILENAME_PARAM, fileName);
-            return DoAction(response, false, () => ResponseInputStream(response));
+            return DoAction(response, false, () => GetResponseStream(response));
         }
 
         /// <summary>

--- a/src/Lucene.Net.Replicator/IndexAndTaxonomyReplicationHandler.cs
+++ b/src/Lucene.Net.Replicator/IndexAndTaxonomyReplicationHandler.cs
@@ -156,16 +156,20 @@ namespace Lucene.Net.Replicator
             // against those errors, app will probably hit them elsewhere.
             IndexReplicationHandler.CleanupOldIndexFiles(indexDirectory, indexSegmentsFile);
             IndexReplicationHandler.CleanupOldIndexFiles(taxonomyDirectory, taxonomySegmentsFile);
-            
+
             // successfully updated the index, notify the callback that the index is
             // ready.
-            if (callback != null) {
-              try {
-                callback.Invoke();
-              } catch (Exception e) {
-                throw new IOException(e.Message, e);
-              }
-            } 
+            if (callback != null)
+            {
+                try
+                {
+                    callback.Invoke();
+                }
+                catch (Exception e) when (e.IsException())
+                {
+                    throw new IOException(e.ToString(), e);
+                }
+            }
         }
 
         // LUCENENET specific utility method

--- a/src/Lucene.Net.Replicator/IndexReplicationHandler.cs
+++ b/src/Lucene.Net.Replicator/IndexReplicationHandler.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Index;
+﻿using Lucene.Net.Index;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
 using System;
@@ -138,7 +138,7 @@ namespace Lucene.Net.Replicator
                 {
                     directory.DeleteFile(file);
                 }
-                catch
+                catch (Exception t) when (t.IsThrowable())
                 {
                     // suppress any exception because if we're here, it means copy
                     // failed, and we must cleanup after ourselves.
@@ -182,7 +182,7 @@ namespace Lucene.Net.Replicator
                             {
                                 directory.DeleteFile(file);
                             }
-                            catch
+                            catch (Exception t) when (t.IsThrowable())
                             {
                                 // suppress, it's just a best effort
                             }
@@ -191,7 +191,7 @@ namespace Lucene.Net.Replicator
 
                 }
             }
-            catch 
+            catch (Exception t) when (t.IsThrowable())
             {
                 // ignore any errors that happens during this state and only log it. this
                 // cleanup will have a chance to succeed the next time we get a new
@@ -230,7 +230,7 @@ namespace Lucene.Net.Replicator
             {
                 directory.DeleteFile(IndexFileNames.SEGMENTS_GEN);
             }
-            catch
+            catch (Exception t) when (t.IsThrowable())
             {
                 // suppress any errors while deleting this file.
             }
@@ -326,7 +326,7 @@ namespace Lucene.Net.Replicator
                 {
                     callback.Invoke();
                 }
-                catch (Exception e)
+                catch (Exception e) when (e.IsException())
                 {
                     throw new IOException(e.ToString(), e);
                 }

--- a/src/Lucene.Net.Replicator/IndexRevision.cs
+++ b/src/Lucene.Net.Replicator/IndexRevision.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Replicator
         public IndexRevision(IndexWriter writer)
         {
             sdp = writer.Config.IndexDeletionPolicy as SnapshotDeletionPolicy;
-            if (sdp == null)
+            if (sdp is null)
                 throw new ArgumentException("IndexWriter must be created with SnapshotDeletionPolicy", nameof(writer));
 
             this.writer = writer;

--- a/src/Lucene.Net.Replicator/LocalReplicator.cs
+++ b/src/Lucene.Net.Replicator/LocalReplicator.cs
@@ -123,7 +123,7 @@ namespace Lucene.Net.Replicator
 
         private long expirationThreshold = DEFAULT_SESSION_EXPIRATION_THRESHOLD;
 
-        private readonly object padlock = new object();
+        private readonly object syncLock = new object();
 
         private volatile RefCountedRevision currentRevision;
         private volatile bool disposed = false;
@@ -160,7 +160,7 @@ namespace Lucene.Net.Replicator
         /// <exception cref="ObjectDisposedException">This replicator has already been disposed.</exception>
         protected void EnsureOpen()
         {
-            UninterruptableMonitor.Enter(padlock);
+            UninterruptableMonitor.Enter(syncLock);
             try
             {
                 if (!disposed)
@@ -170,13 +170,13 @@ namespace Lucene.Net.Replicator
             }
             finally
             {
-                UninterruptableMonitor.Exit(padlock);
+                UninterruptableMonitor.Exit(syncLock);
             }
         }
 
         public virtual SessionToken CheckForUpdate(string currentVersion)
         {
-            UninterruptableMonitor.Enter(padlock);
+            UninterruptableMonitor.Enter(syncLock);
             try
             {
                 EnsureOpen();
@@ -196,7 +196,7 @@ namespace Lucene.Net.Replicator
             }
             finally
             {
-                UninterruptableMonitor.Exit(padlock);
+                UninterruptableMonitor.Exit(syncLock);
             }
         }
 
@@ -205,7 +205,7 @@ namespace Lucene.Net.Replicator
             if (disposed || !disposing)
                 return;
 
-            UninterruptableMonitor.Enter(padlock);
+            UninterruptableMonitor.Enter(syncLock);
             try
             {
                 foreach (ReplicationSession session in sessions.Values)
@@ -214,7 +214,7 @@ namespace Lucene.Net.Replicator
             }
             finally
             {
-                UninterruptableMonitor.Exit(padlock);
+                UninterruptableMonitor.Exit(syncLock);
             }
             disposed = true;
         }
@@ -237,7 +237,7 @@ namespace Lucene.Net.Replicator
             get => expirationThreshold;
             set
             {
-                UninterruptableMonitor.Enter(padlock);
+                UninterruptableMonitor.Enter(syncLock);
                 try
                 {
                     EnsureOpen();
@@ -246,14 +246,14 @@ namespace Lucene.Net.Replicator
                 }
                 finally
                 {
-                    UninterruptableMonitor.Exit(padlock);
+                    UninterruptableMonitor.Exit(syncLock);
                 }
             }
         }
 
         public virtual Stream ObtainFile(string sessionId, string source, string fileName)
         {
-            UninterruptableMonitor.Enter(padlock);
+            UninterruptableMonitor.Enter(syncLock);
             try
             {
                 EnsureOpen();
@@ -273,13 +273,13 @@ namespace Lucene.Net.Replicator
             }
             finally
             {
-                UninterruptableMonitor.Exit(padlock);
+                UninterruptableMonitor.Exit(syncLock);
             }
         }
 
         public virtual void Publish(IRevision revision)
         {
-            UninterruptableMonitor.Enter(padlock);
+            UninterruptableMonitor.Enter(syncLock);
             try
             {
                 EnsureOpen();
@@ -310,14 +310,14 @@ namespace Lucene.Net.Replicator
             }
             finally
             {
-                UninterruptableMonitor.Exit(padlock);
+                UninterruptableMonitor.Exit(syncLock);
             }
         }
 
         /// <exception cref="InvalidOperationException"></exception>
         public virtual void Release(string sessionId)
         {
-            UninterruptableMonitor.Enter(padlock);
+            UninterruptableMonitor.Enter(syncLock);
             try
             {
                 EnsureOpen();
@@ -325,7 +325,7 @@ namespace Lucene.Net.Replicator
             }
             finally
             {
-                UninterruptableMonitor.Exit(padlock);
+                UninterruptableMonitor.Exit(syncLock);
             }
         }
     }

--- a/src/Lucene.Net.Replicator/PerSessionDirectoryFactory.cs
+++ b/src/Lucene.Net.Replicator/PerSessionDirectoryFactory.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Store;
+﻿using Lucene.Net.Store;
 using System;
 using System.IO;
 using Directory = Lucene.Net.Store.Directory;
@@ -44,6 +44,8 @@ namespace Lucene.Net.Replicator
         {
             string sourceDirectory = Path.Combine(workingDirectory, sessionId, source);
             System.IO.Directory.CreateDirectory(sourceDirectory);
+            if (!System.IO.Directory.Exists(sourceDirectory))
+                throw new IOException("failed to create source directory " + sourceDirectory);
             return FSDirectory.Open(sourceDirectory);
         }
 

--- a/src/Lucene.Net.Replicator/ReplicationClient.cs
+++ b/src/Lucene.Net.Replicator/ReplicationClient.cs
@@ -167,9 +167,9 @@ namespace Lucene.Net.Replicator
                 {
                     doUpdate();
                 }
-                catch (Exception exception)
+                catch (Exception t) when (t.IsThrowable())
                 {
-                    handleException(exception);
+                    handleException(t);
                 }
                 finally
                 {

--- a/src/Lucene.Net.Tests.Replicator/Http/HttpReplicatorTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/Http/HttpReplicatorTest.cs
@@ -92,7 +92,6 @@ namespace Lucene.Net.Replicator.Http
 
 
         [Test]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/269")] // LUCENENET TODO: this test occasionally fails
         public void TestBasic()
         {
             IReplicator replicator = new HttpReplicator(host, port, ReplicationService.REPLICATION_CONTEXT + "/s1", server.CreateHandler());

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -301,7 +301,6 @@ namespace Lucene.Net.Replicator
         // handler copies them to the index directory.
         [Test]
         [Slow]
-        [Deadlock][Timeout(600000)]
         public void TestConsistencyOnExceptions()
         {
             // so the handler's index isn't empty

--- a/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
@@ -232,7 +232,6 @@ namespace Lucene.Net.Replicator
         // a client copies files from the server to the temporary space, or when the
         // handler copies them to the index directory.
         [Test]
-        [Deadlock][Timeout(600000)]
         public void TestConsistencyOnExceptions()
         {
             // so the handler's index isn't empty

--- a/src/Lucene.Net.Tests.Replicator/Properties/AssemblyInfo.cs
+++ b/src/Lucene.Net.Tests.Replicator/Properties/AssemblyInfo.cs
@@ -35,8 +35,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("418e9d8e-2369-4b52-8d2f-5a987213999b")]
-
-
-// LUCENENET specific - time out this test project at 47 minutes to allow for time before this
-// test runs and the results to be uploaded before the 60 minute Azure DevOps job cutoff for easier troubleshooting
-[assembly: Timeout(2820000)]

--- a/src/Lucene.Net.Tests.Replicator/ReplicatorTestCase.cs
+++ b/src/Lucene.Net.Tests.Replicator/ReplicatorTestCase.cs
@@ -1,10 +1,16 @@
-using Lucene.Net.Replicator.Http;
+﻿using Lucene.Net.Replicator.Http;
 using Lucene.Net.Replicator.Http.Abstractions;
 using Lucene.Net.Util;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Threading.Tasks;
+
+#if FEATURE_ASPNETCORE_ENDPOINT_CONFIG
+using Microsoft.AspNetCore.Builder;
+#endif
 
 namespace Lucene.Net.Replicator
 {
@@ -28,16 +34,73 @@ namespace Lucene.Net.Replicator
     [SuppressCodecs("Lucene3x")]
     public class ReplicatorTestCase : LuceneTestCase
     {
-        public static TestServer NewHttpServer<TStartUp>(IReplicationService service) where TStartUp : class
+
+#if FEATURE_ASPNETCORE_ENDPOINT_CONFIG
+        /// <summary>
+        /// Call this overload to use <see cref="ReplicationServiceMiddleware"/> to host <see cref="ReplicationService"/>.
+        /// </summary>
+        /// <param name="service">The <see cref="ReplicationService"/> that will be registered as singleton.</param>
+        /// <param name="mockErrorConfig">The <see cref="MockErrorConfig"/> that will be registered as singleton.</param>
+        /// <returns>A configured <see cref="TestServer"/> instance.</returns>
+        public static TestServer NewHttpServer(IReplicationService service, MockErrorConfig mockErrorConfig)
         {
-            var server = new TestServer(new WebHostBuilder()
+            var builder = new WebHostBuilder()
+                .ConfigureServices(container =>
+                {
+                    container.AddRouting();
+                    container.AddSingleton(service);
+                    container.AddSingleton(mockErrorConfig);
+                    container.AddSingleton<ReplicationServiceMiddleware>();
+                    container.AddSingleton<MockErrorMiddleware>();
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+
+                    // Middleware so we can mock a server exception and toggle the exception on and off.
+                    app.UseMiddleware<MockErrorMiddleware>();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        // This is to define the endpoint for Replicator.
+                        // All URLs with the pattern /replicate/{shard?}/{action?} terminate here and any middleware that
+                        // is expected to run for Replicator must be registered before this call.
+                        endpoints.MapReplicator(ReplicationService.REPLICATION_CONTEXT + "/{shard?}/{action?}");
+
+                        endpoints.MapGet("/{controller?}/{action?}/{id?}", async context =>
+                        {
+                            // This is just to demonstrate allowing requests to other services/controllers in the same
+                            // application. This isn't required, but is allowed.
+                            await context.Response.WriteAsync("Hello World!");
+                        });
+                    });
+                });
+            var server = new TestServer(builder);
+            return server;
+        }
+#else
+        /// <summary>
+        /// Call this overload to use <typeparamref name="TStartUp"/> as the Startup Class.
+        /// </summary>
+        /// <typeparam name="TStartUp">The type of startup class.</typeparam>
+        /// <param name="service">The <see cref="ReplicationService"/> that will be registered as singleton.</param>
+        /// <param name="mockErrorConfig">The <see cref="MockErrorConfig"/> that will be registered as singleton.</param>
+        /// <returns>A configured <see cref="TestServer"/> instance.</returns>
+        public static TestServer NewHttpServer<TStartUp>(IReplicationService service, MockErrorConfig mockErrorConfig) where TStartUp : class
+        {
+            var builder = new WebHostBuilder()
                 .ConfigureServices(container =>
                 {
                     container.AddSingleton(service);
-                }).UseStartup<TStartUp>());
+                    container.AddSingleton(mockErrorConfig);
+                })
+                .UseStartup<TStartUp>();
+
+            var server = new TestServer(builder);
             server.BaseAddress = new Uri("http://localhost" + ReplicationService.REPLICATION_CONTEXT);
             return server;
         }
+#endif
 
         /// <summary>
         /// Returns a <see cref="server"/>'s port. 
@@ -61,6 +124,45 @@ namespace Lucene.Net.Replicator
         public static void StopHttpServer(TestServer server)
         {
             server.Dispose();
+        }
+
+        public class HttpResponseException : Exception
+        {
+            public int Status { get; set; } = 500;
+
+            public object Value { get; set; }
+        }
+
+        public class MockErrorMiddleware
+        {
+            private readonly RequestDelegate next;
+            private readonly MockErrorConfig mockErrorConfig;
+
+            public MockErrorMiddleware(RequestDelegate next, MockErrorConfig mockErrorConfig)
+            {
+                this.next = next ?? throw new ArgumentNullException(nameof(next));
+                this.mockErrorConfig = mockErrorConfig ?? throw new ArgumentNullException(nameof(mockErrorConfig));
+            }
+
+            public async Task InvokeAsync(HttpContext context)
+            {
+                var path = context.Request.Path;
+                if (path.StartsWithSegments(ReplicationService.REPLICATION_CONTEXT))
+                {
+                    if (mockErrorConfig.RespondWithError)
+                    {
+                        throw new HttpResponseException();
+                    }
+                }
+
+                // Call the next delegate/middleware in the pipeline
+                await next(context);
+            }
+        }
+
+        public class MockErrorConfig
+        {
+            public bool RespondWithError { get; set; } = false;
         }
     }
 }

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/ServletException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/ServletException.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+
+namespace Lucene
+{
+    /// <summary>
+    /// The Java description is:
+    /// Defines a general exception a servlet can throw when it encounters difficulty.
+    /// <para/>
+    /// This is a Java compatibility exception, and should be thrown in
+    /// Lucene.NET everywhere Lucene throws it.
+    /// </summary>
+
+    // LUCENENET: It is no longer good practice to use binary serialization. 
+    // See: https://github.com/dotnet/corefx/issues/23584#issuecomment-325724568
+#if FEATURE_SERIALIZABLE_EXCEPTIONS
+    [Serializable]
+#endif
+    internal class ServletException : Exception
+    {
+        [Obsolete("Use ServletException.Create() instead.", error: true)]
+        public ServletException()
+        {
+        }
+
+        [Obsolete("Use ServletException.Create() instead.", error: true)]
+        public ServletException(string message) : base(message)
+        {
+        }
+
+        [Obsolete("Use ServletException.Create() instead.", error: true)]
+        public ServletException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        [Obsolete("Use ServletException.Create() instead.", error: true)]
+        public ServletException(Exception cause)
+            : base(cause?.ToString(), cause)
+        {
+        }
+
+#if FEATURE_SERIALIZABLE_EXCEPTIONS
+        /// <summary>
+        /// Initializes a new instance of this class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        protected ServletException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+
+        // Static factory methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Exception Create() => new HttpRequestException();
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Exception Create(string message) => new HttpRequestException(message);
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Exception Create(string message, Exception innerException) => new HttpRequestException(message, innerException);
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Exception Create(Exception cause) => new HttpRequestException(cause.Message, cause);
+    }
+}


### PR DESCRIPTION
This fixes several issues with `Lucene.Net.Replicator`.

#### Failing Intermittently

- `Lucene.Net.Replicator.Http.HttpReplicatorTest::TestBasic()`

This was failing due to the `Timeout` value being set to 1 second instead of the 60 second value that was used in Java. It has been increased to the .NET default of 100 seconds.

Fixes #363

#### Failing Intermittently & Deadlocking Intermittently

- `Lucene.Net.Replicator.IndexAndTaxonomyReplicationClientTest::TestConsistencyOnExceptions()`
- `Lucene.Net.Replicator.IndexReplicationClientTest::TestConsistencyOnExceptions()`

These were failing due to the fact that they were throwing exceptions on the worker thread, which causes it to stop immediately when they are unhandled. The `Lucene.Net.Replicator.ReplicationClient.ReplicationThread` class was re-ported from Lucene 4.8.1 to subclass `ThreadJob` which handles re-throwing any unhandled exception when calling `Join()` on the thread.

There were also 4 methods that were missing locks in `Lucene.Net.Replicator.ReplicationClient` that likely explains why we were getting deadlocks.

The rest of the replicator changes were also ported from Lucene 4.8.1, and `ReplicatorTestCase` was set up to use a .NET 5 example using `ReplicationService` as middleware with its own endpoint mapping, which allows other routes to be handled elsewhere rather than being the only termination point.

The throw statements and catch blocks were also reviewed to make sure we aren't swallowing exceptions we shouldn't be.