### PR TITLE
BUG: Modified all TermsEnum.MoveNext() methods to return a check for null rather than returning true

### DIFF
--- a/src/Lucene.Net.Codecs/BlockTerms/BlockTermsReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/BlockTermsReader.cs
@@ -707,7 +707,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                     // NOTE: meaningless in the non-ord case
                     state.Ord++;
 
-                    return true;
+                    return term != null;
                 }
 
                 [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net.Codecs/Bloom/BloomFilteringPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Bloom/BloomFilteringPostingsFormat.cs
@@ -287,7 +287,7 @@ namespace Lucene.Net.Codecs.Bloom
                     delegateTermsEnum = null;
                 }
 
-                private TermsEnum Delegate =>
+                private TermsEnum @delegate =>
                     // pull the iterator only if we really need it -
                     // this can be a relativly heavy operation depending on the 
                     // delegate postings format and they underlying directory
@@ -296,13 +296,13 @@ namespace Lucene.Net.Codecs.Bloom
 
                 public override bool MoveNext()
                 {
-                    return Delegate.MoveNext();
+                    return @delegate.MoveNext();
                 }
 
                 [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
                 public override sealed BytesRef Next()
                 {
-                    return Delegate.Next();
+                    return @delegate.Next();
                 }
 
                 public override sealed IComparer<BytesRef> Comparer => _delegateTerms.Comparer;
@@ -318,36 +318,36 @@ namespace Lucene.Net.Codecs.Bloom
                     {
                         return false;
                     }
-                    return Delegate.SeekExact(text);
+                    return @delegate.SeekExact(text);
                 }
 
                 public override sealed SeekStatus SeekCeil(BytesRef text)
                 {
-                    return Delegate.SeekCeil(text);
+                    return @delegate.SeekCeil(text);
                 }
 
                 public override sealed void SeekExact(long ord)
                 {
-                    Delegate.SeekExact(ord);
+                    @delegate.SeekExact(ord);
                 }
 
-                public override sealed BytesRef Term => Delegate.Term;
+                public override sealed BytesRef Term => @delegate.Term;
 
-                public override sealed long Ord => Delegate.Ord;
+                public override sealed long Ord => @delegate.Ord;
 
-                public override sealed int DocFreq => Delegate.DocFreq;
+                public override sealed int DocFreq => @delegate.DocFreq;
 
-                public override sealed long TotalTermFreq => Delegate.TotalTermFreq;
+                public override sealed long TotalTermFreq => @delegate.TotalTermFreq;
 
                 public override DocsAndPositionsEnum DocsAndPositions(IBits liveDocs,
                     DocsAndPositionsEnum reuse, DocsAndPositionsFlags flags)
                 {
-                    return Delegate.DocsAndPositions(liveDocs, reuse, flags);
+                    return @delegate.DocsAndPositions(liveDocs, reuse, flags);
                 }
 
                 public override DocsEnum Docs(IBits liveDocs, DocsEnum reuse, DocsFlags flags)
                 {
-                    return Delegate.Docs(liveDocs, reuse, flags);
+                    return @delegate.Docs(liveDocs, reuse, flags);
                 }
             }
 

--- a/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
@@ -514,7 +514,7 @@ namespace Lucene.Net.Codecs.Memory
                     }
                     decoded = false;
                     seekPending = false;
-                    return moved;
+                    return moved && term != null;
                 }
 
                 [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -664,7 +664,7 @@ namespace Lucene.Net.Codecs.Memory
                     {
                         pending = false;
                         DecodeStats();
-                        return true;
+                        return term != null;
                     }
                     decoded = false;
                     while (level > 0)
@@ -698,7 +698,7 @@ namespace Lucene.Net.Codecs.Memory
                     }
                 DFSBreak:
                     DecodeStats();
-                    return true;
+                    return term != null;
                 }
 
                 [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
@@ -386,7 +386,7 @@ namespace Lucene.Net.Codecs.Memory
                     }
                     decoded = false;
                     seekPending = false;
-                    return moved;
+                    return moved && term != null;
                 }
 
                 [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -582,7 +582,7 @@ namespace Lucene.Net.Codecs.Memory
                     {
                         pending = false;
                         LoadMetaData();
-                        return true;
+                        return term != null;
                     }
                     decoded = false;
                     while (level > 0)
@@ -616,7 +616,7 @@ namespace Lucene.Net.Codecs.Memory
                     }
                 DFSBreak:
                     LoadMetaData();
-                    return true;
+                    return term != null;
                 }
 
                 [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
@@ -779,7 +779,9 @@ namespace Lucene.Net.Codecs.Memory
 
             public override bool MoveNext()
             {
-                return input.MoveNext();
+                if (input.MoveNext())
+                    return input.Current.Input != null;
+                return false;
             }
 
             [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
@@ -841,7 +841,7 @@ namespace Lucene.Net.Codecs.Memory
                     current = fstEnum.Current;
                     didDecode = false;
                     //System.out.println("  term=" + field.name + ":" + current.input.utf8ToString());
-                    return true;
+                    return current != null;
                 }
                 current = null;
                 //System.out.println("  END");

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
@@ -168,7 +168,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 _docsStart = pair1.Output1.Value;
                 _docFreq = (int)pair2.Output1;
                 _totalTermFreq = pair2.Output2.Value;
-                return true;
+                return _fstEnum.Current.Input != null;
             }
 
             [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
@@ -391,7 +391,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 if (_iterator.MoveNext())
                 {
                     _current = _iterator.Current;
-                    return true;
+                    return _current.Key != null;
                 }
                 else
                 {

--- a/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
@@ -301,7 +301,7 @@ namespace Lucene.Net.Index.Memory
                     else
                     {
                         info.terms.Get(info.sortedTerms[termUpto], br);
-                        return true;
+                        return br != null;
                     }
                 }
 

--- a/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
@@ -367,7 +367,7 @@ namespace Lucene.Net.Codecs.RAMOnly
                 if (it.MoveNext())
                 {
                     current = it.Current;
-                    return true;
+                    return current != null;
                 }
                 else
                 {
@@ -427,7 +427,7 @@ namespace Lucene.Net.Codecs.RAMOnly
                 => throw UnsupportedOperationException.Create();
 
             // TODO: reuse BytesRef
-            public override BytesRef Term => new BytesRef(current);
+            public override BytesRef Term => current is null ? null : new BytesRef(current);
 
             public override int DocFreq
                 => ramField.termToDocs[current].docs.Count;

--- a/src/Lucene.Net.TestFramework/Index/AssertingAtomicReader.cs
+++ b/src/Lucene.Net.TestFramework/Index/AssertingAtomicReader.cs
@@ -454,7 +454,7 @@ namespace Lucene.Net.Index
                 {
                     if (Debugging.AssertsEnabled) Debugging.Assert(base.Term.IsValid());
                     state = State.POSITIONED;
-                    return true;
+                    return base.Term != null;
                 }
             }
 

--- a/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsReader.cs
@@ -2472,7 +2472,7 @@ namespace Lucene.Net.Codecs
                         else
                         {
                             //if (DEBUG) System.out.println("  return term=" + term.utf8ToString() + " " + term + " currentFrame.ord=" + currentFrame.ord);
-                            return true;
+                            return term != null;
                         }
                     }
                 }

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
@@ -865,7 +865,7 @@ namespace Lucene.Net.Codecs.Compressing
                 }
                 @in.ReadBytes(term.Bytes, prefixLengths[ord], suffixLengths[ord]);
 
-                return true;
+                return term != null;
             }
 
             [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
@@ -995,7 +995,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                     else
                     {
                         current = termEnum.Term().Bytes;
-                        return true;
+                        return current != null;
                     }
                 }
 

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -564,7 +564,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                 {
                     return false;
                 }
-                return true;
+                return termAndPostings[currentTerm].Term != null;
             }
 
             [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
@@ -541,7 +541,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
                 lastTerm.CopyBytes(term);
                 nextTerm++;
-                return true;
+                return term != null;
             }
 
             [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net/Codecs/Lucene42/Lucene42DocValuesProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene42/Lucene42DocValuesProducer.cs
@@ -755,7 +755,12 @@ namespace Lucene.Net.Codecs.Lucene42
                 bytesReader = fst.GetBytesReader();
             }
 
-            public override bool MoveNext() => @in.MoveNext();
+            public override bool MoveNext()
+            {
+                if (@in.MoveNext())
+                    return @in.Current.Input != null;
+                return false;
+            }
 
             [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
             public override BytesRef Next()

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesProducer.cs
@@ -1123,7 +1123,7 @@ namespace Lucene.Net.Codecs.Lucene45
                         input.ReadBytes(termBuffer.Bytes, start, suffix);
                         termBuffer.Length = start + suffix;
                         SetTerm();
-                        return true;
+                        return true; // LUCENENET: term is readonly so cannot be null
                     }
                 }
 

--- a/src/Lucene.Net/Index/FilterAtomicReader.cs
+++ b/src/Lucene.Net/Index/FilterAtomicReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -163,7 +163,9 @@ namespace Lucene.Net.Index
 
             public override bool MoveNext()
             {
-                return m_input.MoveNext();
+                if (m_input.MoveNext())
+                    return m_input.Term != null;
+                return false;
             }
 
             [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net/Index/FilteredTermsEnum.cs
+++ b/src/Lucene.Net/Index/FilteredTermsEnum.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -257,7 +257,7 @@ namespace Lucene.Net.Index
                         goto case FilteredTermsEnum.AcceptStatus.YES;
                     case FilteredTermsEnum.AcceptStatus.YES:
                         // term accepted
-                        return true;
+                        return actualTerm != null;
 
                     case FilteredTermsEnum.AcceptStatus.NO_AND_SEEK:
                         // invalid term, seek next time

--- a/src/Lucene.Net/Index/SortedDocValuesTermsEnum.cs
+++ b/src/Lucene.Net/Index/SortedDocValuesTermsEnum.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 
@@ -107,7 +107,7 @@ namespace Lucene.Net.Index
                 return false;
             }
             values.LookupOrd(currentOrd, term);
-            return true;
+            return term != null;
         }
 
         [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net/Index/SortedSetDocValuesTermsEnum.cs
+++ b/src/Lucene.Net/Index/SortedSetDocValuesTermsEnum.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 
@@ -107,7 +107,7 @@ namespace Lucene.Net.Index
                 return false;
             }
             values.LookupOrd(currentOrd, term);
-            return true;
+            return term != null;
         }
 
         [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net/Search/FuzzyTermsEnum.cs
+++ b/src/Lucene.Net/Search/FuzzyTermsEnum.cs
@@ -295,7 +295,7 @@ namespace Lucene.Net.Search
                 queuedBottom = BytesRef.DeepCopyOf(actualEnum.Term);
             }
 
-            return moved;
+            return moved && actualEnum.Term != null;
         }
 
         [Obsolete("Use MoveNext() and Term instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]


### PR DESCRIPTION
The original logic returned a `null` `BytesRef` instance to indicate that iteration is finished. We correctly got the `false` case when Lucene explicitly returned `null`, but in cases where it may have implicitly returned a `null` `BytesRef` we need to explicitly return `term != null` rather than `true` to ensure we correctly signal the end of iteration.