### PR TITLE
BUG: Lucene.Net.Grouping.Term.TermAllGroupHeadsCollector: Use NumericUtils.SingleToSortableInt32() to compare floating point numbers

### DIFF
--- a/src/Lucene.Net.Grouping/Term/TermAllGroupHeadsCollector.cs
+++ b/src/Lucene.Net.Grouping/Term/TermAllGroupHeadsCollector.cs
@@ -418,11 +418,13 @@ namespace Lucene.Net.Search.Grouping.Terms
                 if (outerInstance.fields[compIDX].Type == SortFieldType.SCORE)
                 {
                     float score = outerInstance.scorer.GetScore();
-                    if (scores[compIDX] < score)
+                    // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
+                    if (NumericUtils.SingleToSortableInt32(scores[compIDX]) < NumericUtils.SingleToSortableInt32(score))
                     {
                         return 1;
                     }
-                    else if (scores[compIDX] > score)
+                    // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
+                    else if (NumericUtils.SingleToSortableInt32(scores[compIDX]) > NumericUtils.SingleToSortableInt32(score))
                     {
                         return -1;
                     }
@@ -775,11 +777,13 @@ namespace Lucene.Net.Search.Grouping.Terms
             public override int Compare(int compIDX, int doc)
             {
                 float score = outerInstance.scorer.GetScore();
-                if (scores[compIDX] < score)
+                // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
+                if (NumericUtils.SingleToSortableInt32(scores[compIDX]) < NumericUtils.SingleToSortableInt32(score))
                 {
                     return 1;
                 }
-                else if (scores[compIDX] > score)
+                // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
+                else if (NumericUtils.SingleToSortableInt32(scores[compIDX]) > NumericUtils.SingleToSortableInt32(score))
                 {
                     return -1;
                 }

--- a/src/Lucene.Net.Tests.Grouping/AllGroupHeadsCollectorTest.cs
+++ b/src/Lucene.Net.Tests.Grouping/AllGroupHeadsCollectorTest.cs
@@ -565,11 +565,13 @@ namespace Lucene.Net.Search.Grouping
                     int cmp;
                     if (sf.Type == SortFieldType.SCORE)
                     {
-                        if (d1.score > d2.score)
+                        // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
+                        if (NumericUtils.SingleToSortableInt32(d1.score) > NumericUtils.SingleToSortableInt32(d2.score))
                         {
                             cmp = -1;
                         }
-                        else if (d1.score < d2.score)
+                        // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
+                        else if (NumericUtils.SingleToSortableInt32(d1.score) < NumericUtils.SingleToSortableInt32(d2.score))
                         {
                             cmp = 1;
                         }


### PR DESCRIPTION
Fixes `AllGroupHeadCollectorTest.TestRandom()` on .NET Framework x86