### PR TITLE
BUG: Lucene.Net.Codecs.SimpleText.SimpleTextFieldsReader::NextDoc(): Fixed assert that was throwing on BytesRef.Utf8ToString()

### DIFF
--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
@@ -311,7 +311,7 @@ namespace Lucene.Net.Codecs.SimpleText
                     {
                         if (Debugging.AssertsEnabled) Debugging.Assert(
                             StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.TERM) || StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.FIELD) ||
-                            StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.END), "scratch={0}", _scratch.Utf8ToString());
+                            StringHelper.StartsWith(_scratch, SimpleTextFieldsWriter.END), "scratch={0}", new BytesRefFormatter(_scratch, BytesRefFormat.UTF8));
 
                         if (!first && (_liveDocs == null || _liveDocs.Get(_docId)))
                         {


### PR DESCRIPTION
Assert statement was using `BytesRef.Utf8ToString()`, which was causing exceptions when the `BytesRef` didn't contain valid UTF8. Changed to use [`BytesRefFormatter`](Lucene.Net.Codecs.SimpleText.SimpleTextFieldsReader::NextDoc()), which defers the call to convert the `BytesRef` until after the assert fails.

This was causing several tests to randomly fail that use `SimpleText` to compare other codecs with.