### PR TITLE
BUG: Lucene.Net.Util.Automation.MinimizationOperations::MinimizeHopcroft(): Fixed range in OpenBitSet.Clear()

### DIFF
--- a/src/Lucene.Net/Util/Automaton/MinimizationOperations.cs
+++ b/src/Lucene.Net/Util/Automaton/MinimizationOperations.cs
@@ -1,5 +1,4 @@
 ﻿using J2N;
-using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using JCG = J2N.Collections.Generic;
@@ -214,7 +213,7 @@ namespace Lucene.Net.Util.Automaton
                     }
                     sb.Clear();
                 }
-                refine.Clear(0, refine.Length - 1);
+                refine.Clear(0, refine.Length);
             }
             // make a new state for each equivalence class, set initial state
             State[] newstates = new State[k];

--- a/src/Lucene.Net/Util/FixedBitSet.cs
+++ b/src/Lucene.Net/Util/FixedBitSet.cs
@@ -659,7 +659,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="startIndex"> Lower index </param>
         /// <param name="endIndex"> One-past the last bit to clear </param>
-        public void Clear(int startIndex, int endIndex)
+        public void Clear(int startIndex, int endIndex) // LUCENENET TODO: API: Change this to use startIndex and length to match .NET
         {
             if (Debugging.AssertsEnabled)
             {

--- a/src/Lucene.Net/Util/OpenBitSet.cs
+++ b/src/Lucene.Net/Util/OpenBitSet.cs
@@ -312,7 +312,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="startIndex"> Lower index </param>
         /// <param name="endIndex"> One-past the last bit to set </param>
-        public virtual void Set(long startIndex, long endIndex)
+        public virtual void Set(long startIndex, long endIndex) // LUCENENET TODO: API: Change this to use startIndex and length to match .NET
         {
             if (endIndex <= startIndex)
             {
@@ -401,7 +401,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="startIndex"> Lower index </param>
         /// <param name="endIndex"> One-past the last bit to clear </param>
-        public virtual void Clear(int startIndex, int endIndex)
+        public virtual void Clear(int startIndex, int endIndex) // LUCENENET TODO: API: Change this to use startIndex and length to match .NET
         {
             if (endIndex <= startIndex)
             {
@@ -448,7 +448,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="startIndex"> Lower index </param>
         /// <param name="endIndex"> One-past the last bit to clear </param>
-        public virtual void Clear(long startIndex, long endIndex)
+        public virtual void Clear(long startIndex, long endIndex) // LUCENENET TODO: API: Change this to use startIndex and length to match .NET
         {
             if (endIndex <= startIndex)
             {
@@ -587,7 +587,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="startIndex"> Lower index </param>
         /// <param name="endIndex"> One-past the last bit to flip </param>
-        public virtual void Flip(long startIndex, long endIndex)
+        public virtual void Flip(long startIndex, long endIndex) // LUCENENET TODO: API: Change this to use startIndex and length to match .NET
         {
             if (endIndex <= startIndex)
             {


### PR DESCRIPTION
`OpenBitSet.Clear()` requires parameters, unlike `java.util.BitSet`. However, the second parameter of `OpenBitSet.Clear()` must be **one past** the end index per the docs. This was causing `Lucene.Net.Codecs.Lucene41.TestBlockPostingsFormat3.Test()` to fail randomly with an `IndexOutOfRangeException` and affects all components that depend on `Lucene.Net.Util.Automaton`.