### PR TITLE
BUG: Lucene.Net.Tests.QueryParser.Flexible.Standard.TestQPHelper: Use ParseExact to specify the date format

### DIFF
--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
@@ -741,7 +741,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             //DateFormat df = DateFormat.getDateInstance(DateFormat.SHORT, Locale.getDefault());
             //return getDate(df.parse(s), resolution);
 
-            return GetDate(DateTime.Parse(s), resolution); // TODO: Locale...
+            return GetDate(DateTime.ParseExact(s, "d", null), resolution);
         }
 
         /** for testing DateTools support */


### PR DESCRIPTION
This was causing `Lucene.Net.Tests.QueryParser.Flexible.Standard.TestQPHelper::TestDateRange()` to fail when the random culture is Arabic.

Reference: https://github.com/dotnet/runtime/issues/61708#issuecomment-971116350