### PR TITLE
BUG: Lucene.Net.QueryParser.Flexible.Standard: Fixed calendar handling on .NET Core

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -82,6 +82,7 @@
     <SystemSecurityCryptographyXmlPackageVersion>4.7.0</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>4.3.0</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion Condition=" '$(TargetFramework)' == 'net461' ">5.0.0</SystemTextEncodingCodePagesPackageVersion>
+    <TimeZoneConverterPackageVersion>3.5.0</TimeZoneConverterPackageVersion>
     <XUnitPackageVersion>2.3.1</XUnitPackageVersion>
     <XUnitRunnerVisualStudioPackageVersion>$(XUnitPackageVersion)</XUnitRunnerVisualStudioPackageVersion>
   </PropertyGroup>

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
@@ -96,9 +96,13 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
 
         public override object Parse(string source)
         {
-            DateTimeOffset d = DateTimeOffset.ParseExact(source, GetDateFormat(), FormatProvider, DateTimeStyles.None);
-            d = TimeZoneInfo.ConvertTime(d, TimeZone);
-            return DateTimeOffsetUtil.ToUnixTimeMilliseconds(d);
+            DateTimeOffset parsedDate = DateTimeOffset.ParseExact(source, GetDateFormat(), FormatProvider, DateTimeStyles.None);
+            DateTimeOffset timeZoneAdjusted;
+            if (parsedDate.DateTime.Kind == DateTimeKind.Unspecified)
+                timeZoneAdjusted = new DateTimeOffset(parsedDate.DateTime, TimeZoneInfo.ConvertTime(parsedDate.ToUniversalTime(), TimeZone).Offset);
+            else
+                timeZoneAdjusted = TimeZoneInfo.ConvertTime(parsedDate, TimeZone);
+            return DateTimeOffsetUtil.ToUnixTimeMilliseconds(timeZoneAdjusted);
         }
 
         public override string Format(object number)

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
@@ -162,7 +162,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
                     timePattern = dateTimeFormat.LongTimePattern.Replace("z", "").Trim() + " z";
                     break;
                 case DateFormat.FULL:
-                    timePattern = dateTimeFormat.LongTimePattern.Replace("z", "").Trim() + " z"; // LUCENENET TODO: Time zone info not being added to match behavior of Java, but Java doc is unclear on what the difference is between this and LONG
+                    timePattern = dateTimeFormat.LongTimePattern.Replace("z", "").Trim() + " zzz";
                     break;
             }
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
@@ -172,9 +172,6 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
     // Source: https://github.com/dotnet/runtime/blob/af4efb1936b407ca5f4576e81484cf5687b79a26/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
     internal static class DateTimeOffsetUtil
     {
-        public const long MinMilliseconds = /*DateTime.*/MinTicks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
-        public const long MaxMilliseconds = /*DateTime.*/MaxTicks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
-
         /// <summary>
         /// The .NET ticks representing January 1, 1970 0:00:00, also known as the "epoch".
         /// </summary>
@@ -182,6 +179,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
 
         private const long UnixEpochMilliseconds = UnixEpochTicks / TimeSpan.TicksPerMillisecond; // 62,135,596,800,000
 
+        public const long MinMilliseconds = /*DateTime.*/MinTicks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
+        public const long MaxMilliseconds = /*DateTime.*/MaxTicks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
 
         // From System.DateTime
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
@@ -97,6 +97,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
         public override object Parse(string source)
         {
             DateTimeOffset d = DateTimeOffset.ParseExact(source, GetDateFormat(), FormatProvider, DateTimeStyles.None);
+            d = TimeZoneInfo.ConvertTime(d, TimeZone);
             return DateTimeOffsetUtil.ToUnixTimeMilliseconds(d);
         }
 

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -178,7 +178,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
                 // not all date patterns includes era, full year, timezone and second,
                 // so we add them here
-                DATE_FORMAT.SetDateFormat(DATE_FORMAT.GetDateFormat() + " g s z yyyy");
+                DATE_FORMAT.SetDateFormat(DATE_FORMAT.GetDateFormat() + " %g s zzz yyyy");
 
 
                 //dateFormat = DATE_FORMAT.GetDateFormat();

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -10,7 +10,6 @@ using Lucene.Net.Store;
 using Lucene.Net.Support;
 using Lucene.Net.Util;
 using NUnit.Framework;
-using RandomizedTesting.Generators;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -50,26 +49,26 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
         private readonly static int PRECISION_STEP = 8;
         private readonly static String FIELD_NAME = "field";
-        private static CultureInfo LOCALE;
-        private static TimeZoneInfo TIMEZONE;
-        private static IDictionary<String, /*Number*/ object> RANDOM_NUMBER_MAP;
+        private static CultureInfo? LOCALE;
+        private static TimeZoneInfo? TIMEZONE;
+        private static IDictionary<String, /*Number*/ object>? RANDOM_NUMBER_MAP;
         private readonly static IEscapeQuerySyntax ESCAPER = new Standard.Parser.EscapeQuerySyntax();
         private readonly static String DATE_FIELD_NAME = "date";
         private static DateFormat DATE_STYLE;
         private static DateFormat TIME_STYLE;
 
-        private static Analyzer ANALYZER;
+        private static Analyzer? ANALYZER;
 
-        private static NumberFormat NUMBER_FORMAT;
+        private static NumberFormat? NUMBER_FORMAT;
         
 
-        private static StandardQueryParser qp;
+        private static StandardQueryParser? qp;
 
-        private static NumberDateFormat DATE_FORMAT;
+        private static NumberDateFormat? DATE_FORMAT;
 
-        private static Directory directory = null;
-        private static IndexReader reader = null;
-        private static IndexSearcher searcher = null;
+        private static Directory? directory = null;
+        private static IndexReader? reader = null;
+        private static IndexSearcher? searcher = null;
 
         private static bool checkDateFormatSanity(NumberDateFormat dateFormat, long date, TimeZoneInfo timeZone)
         {
@@ -286,7 +285,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                         break;
                     default:
                         fail();
-                        field = null;
+                        field = null!;
                         break;
                 }
                 numericFieldMap.Put(type.ToString(), field);
@@ -315,7 +314,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
         }
 
-        private static /*Number*/ object GetNumberType(NumberType? numberType, String fieldName)
+        private static /*Number*/ object? GetNumberType(NumberType? numberType, String fieldName)
         {
 
             if (numberType == null)
@@ -327,11 +326,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             {
 
                 case NumberType.POSITIVE:
-                    return RANDOM_NUMBER_MAP[fieldName];
+                    return RANDOM_NUMBER_MAP![fieldName];
 
                 case NumberType.NEGATIVE:
                     /*Number*/
-                    object number = RANDOM_NUMBER_MAP[fieldName];
+                    object number = RANDOM_NUMBER_MAP![fieldName];
 
                     if (NumericType.INT64.ToString().Equals(fieldName, StringComparison.Ordinal)
                         || DATE_FIELD_NAME.Equals(fieldName, StringComparison.Ordinal))
@@ -374,7 +373,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         {
 
             /*Number*/
-            object number = GetNumberType(numberType, NumericType.DOUBLE
+            object? number = GetNumberType(numberType, NumericType.DOUBLE
                 .ToString());
             numericFieldMap[NumericType.DOUBLE.ToString()].SetDoubleValue(Convert.ToDouble(
                 number));
@@ -514,9 +513,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             }
 
             /*Number*/
-            object lowerDateNumber = GetNumberType(lowerType, DATE_FIELD_NAME);
+            object? lowerDateNumber = GetNumberType(lowerType, DATE_FIELD_NAME);
             /*Number*/
-            object upperDateNumber = GetNumberType(upperType, DATE_FIELD_NAME);
+            object? upperDateNumber = GetNumberType(upperType, DATE_FIELD_NAME);
             String lowerDateStr;
             String upperDateStr;
 
@@ -527,7 +526,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                 //    EscapeQuerySyntax.Type.STRING).toString();
 
                 lowerDateStr = ESCAPER.Escape(
-                            DATE_FORMAT.Format(Convert.ToInt64(lowerDateNumber, CultureInfo.InvariantCulture)),
+                            DATE_FORMAT!.Format(Convert.ToInt64(lowerDateNumber, CultureInfo.InvariantCulture)),
                             LOCALE,
                             EscapeQuerySyntaxType.STRING).toString();
             }
@@ -543,7 +542,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                 //      EscapeQuerySyntax.Type.STRING).toString();
 
                 upperDateStr = ESCAPER.Escape(
-                                DATE_FORMAT.Format(Convert.ToInt64(upperDateNumber, CultureInfo.InvariantCulture)),
+                                DATE_FORMAT!.Format(Convert.ToInt64(upperDateNumber, CultureInfo.InvariantCulture)),
                                 LOCALE,
                                 EscapeQuerySyntaxType.STRING).toString();
             }
@@ -584,7 +583,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             //        .longValue())), LOCALE, EscapeQuerySyntax.Type.STRING).toString();
 
             string boundDateStr = ESCAPER.Escape(
-                                DATE_FORMAT.Format(Convert.ToInt64(GetNumberType(boundType, DATE_FIELD_NAME))),
+                                DATE_FORMAT!.Format(Convert.ToInt64(GetNumberType(boundType, DATE_FIELD_NAME))),
                                 LOCALE,
                                 EscapeQuerySyntaxType.STRING).toString();
 
@@ -615,7 +614,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             //        .longValue())), LOCALE, EscapeQuerySyntax.Type.STRING).toString();
 
             string dateStr = ESCAPER.Escape(
-                                DATE_FORMAT.Format(Convert.ToInt64(GetNumberType(numberType, DATE_FIELD_NAME))),
+                                DATE_FORMAT!.Format(Convert.ToInt64(GetNumberType(numberType, DATE_FIELD_NAME))),
                                 LOCALE,
                                 EscapeQuerySyntaxType.STRING).toString();
 
@@ -631,9 +630,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         {
             if (Verbose) Console.WriteLine("Parsing: " + queryStr);
 
-            Query query = qp.Parse(queryStr, FIELD_NAME);
+            Query query = qp!.Parse(queryStr, FIELD_NAME);
             if (Verbose) Console.WriteLine("Querying: " + query);
-            TopDocs topDocs = searcher.Search(query, 1000);
+            TopDocs topDocs = searcher!.Search(query, 1000);
 
             String msg = "Query <" + queryStr + "> retrieved " + topDocs.TotalHits
                 + " document(s), " + expectedDocCount + " document(s) expected.";
@@ -644,15 +643,15 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             assertEquals(msg, expectedDocCount, topDocs.TotalHits);
         }
 
-        private static String NumberToString(/*Number*/ object number)
+        private static String NumberToString(/*Number*/ object? number)
         {
-            return number == null ? "*" : ESCAPER.Escape(NUMBER_FORMAT.Format(number),
+            return number == null ? "*" : ESCAPER.Escape(NUMBER_FORMAT!.Format(number),
                 LOCALE, EscapeQuerySyntaxType.STRING).toString();
         }
 
         private static /*Number*/ object NormalizeNumber(/*Number*/ object number)
         {
-            return NUMBER_FORMAT.Parse(NUMBER_FORMAT.Format(number));
+            return NUMBER_FORMAT!.Parse(NUMBER_FORMAT.Format(number));
         }
 
         [OneTimeTearDown]

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using System.Text;
 using Console = Lucene.Net.Util.SystemConsole;
 using JCG = J2N.Collections.Generic;
+#nullable enable
 
 namespace Lucene.Net.QueryParsers.Flexible.Standard
 {
@@ -70,7 +71,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         private static IndexReader reader = null;
         private static IndexSearcher searcher = null;
 
-        private static bool checkDateFormatSanity(NumberDateFormat dateFormat, long date)
+        private static bool checkDateFormatSanity(NumberDateFormat dateFormat, long date, TimeZoneInfo timeZone)
         {
             IFormatProvider provider = dateFormat.FormatProvider ?? CultureInfo.CurrentCulture;
 
@@ -79,6 +80,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
             string format = dateFormat.GetDateFormat();
             DateTimeOffset offset = DateTimeOffsetUtil.FromUnixTimeMilliseconds(Convert.ToInt64(date));
+            offset = TimeZoneInfo.ConvertTime(offset, timeZone);
             string formattedDate = offset.ToString(format, provider);
 
             return DateTimeOffset.TryParseExact(formattedDate, format, provider, DateTimeStyles.None, out DateTimeOffset _);
@@ -196,12 +198,12 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                     randomDate = Math.Abs(randomDate);
                 } while (randomDate == 0L);
 
-                dateFormatSanityCheckPass &= checkDateFormatSanity(DATE_FORMAT, randomDate);
+                dateFormatSanityCheckPass &= checkDateFormatSanity(DATE_FORMAT, randomDate, TIMEZONE);
 
-                dateFormatSanityCheckPass &= checkDateFormatSanity(DATE_FORMAT, 0);
+                dateFormatSanityCheckPass &= checkDateFormatSanity(DATE_FORMAT, 0, TIMEZONE);
 
                 dateFormatSanityCheckPass &= checkDateFormatSanity(DATE_FORMAT,
-                          -randomDate);
+                          -randomDate, TIMEZONE);
 
                 count++;
             } while (!dateFormatSanityCheckPass);

--- a/src/Lucene.Net.Tests.QueryParser/Lucene.Net.Tests.QueryParser.csproj
+++ b/src/Lucene.Net.Tests.QueryParser/Lucene.Net.Tests.QueryParser.csproj
@@ -86,4 +86,8 @@
     <Folder Include="Resources\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="TimeZoneConverter" Version="$(TimeZoneConverterPackageVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Standard/Config/TestNumberDateFormat.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Standard/Config/TestNumberDateFormat.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Lucene.Net.Attributes;
+using Lucene.Net.Util;
+using TimeZoneConverter;
+using NUnit.Framework;
+
+
+namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    [LuceneNetSpecific]
+    public class TestNumberDateFormat : LuceneTestCase
+    {
+        [Test]
+        [LuceneNetSpecific]
+        public void TestTimeZone_PacificTime()
+        {
+            TimeZoneInfo timeZone = TZConvert.GetTimeZoneInfo("Pacific Standard Time");
+
+            CultureInfo culture = new CultureInfo("en-US");
+
+            var formatter = new NumberDateFormat(DateFormat.LONG, DateFormat.LONG, culture)
+            {
+                TimeZone = timeZone
+            };
+
+            DateTime dateToParse = J2N.Time.UnixEpoch.ToCalendar(culture).ToTimeZone(timeZone);
+
+            long dateAsLong = (long)(dateToParse - J2N.Time.UnixEpoch.ToCalendar(culture)).TotalMilliseconds;
+
+            string actual = formatter.Format(dateAsLong);
+
+
+            // Make sure time zone is correct in the string
+            if (timeZone.IsDaylightSavingTime(dateToParse))
+                Assert.IsTrue(Regex.IsMatch(actual, @"\+\s?0?8"));
+            else
+                Assert.IsTrue(Regex.IsMatch(actual, @"\+\s?0?7"));
+
+
+            long parsedLong = Convert.ToInt64(formatter.Parse(actual));
+
+            // Make sure round trip results in the same number
+            Assert.AreEqual(dateAsLong, parsedLong);
+        }
+    }
+}

--- a/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Standard/Config/TestNumberDateFormat.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Standard/Config/TestNumberDateFormat.cs
@@ -9,6 +9,7 @@ using Lucene.Net.Attributes;
 using Lucene.Net.Util;
 using TimeZoneConverter;
 using NUnit.Framework;
+using Console = Lucene.Net.Util.SystemConsole;
 
 
 namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
@@ -51,6 +52,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
             long dateAsLong = (long)(dateToParse - J2N.Time.UnixEpoch.ToCalendar(culture)).TotalMilliseconds;
 
             string actual = formatter.Format(dateAsLong);
+
+            Console.WriteLine("Output of formatter.Format():");
+            Console.WriteLine($"\"{actual}\"");
 
 
             // Make sure time zone is correct in the string

--- a/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Standard/Config/TestNumberDateFormat.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Standard/Config/TestNumberDateFormat.cs
@@ -72,5 +72,72 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
             // Make sure round trip results in the same number
             Assert.AreEqual(dateAsLong, parsedLong);
         }
+
+        // Verify that we can round-trip and convert to the time zone that is set after the parse.
+        [Test]
+        [LuceneNetSpecific]
+        public void TestTimeZone_ShortTimeFormat()
+        {
+            TimeZoneInfo timeZone = TZConvert.GetTimeZoneInfo("Pacific Standard Time");
+
+            CultureInfo culture = new CultureInfo("en-US");
+
+            var formatter = new NumberDateFormat(DateFormat.LONG, DateFormat.SHORT, culture) // Short time = no time zone info
+            {
+                TimeZone = timeZone
+            };
+
+            // Convert from Unix epoch to time zone.
+            DateTime dateToParse = TimeZoneInfo.ConvertTimeFromUtc(J2N.Time.UnixEpoch, timeZone);
+
+            // Get the difference since the Unix epoch in milliseconds.
+            long dateAsLong = dateToParse.GetMillisecondsSinceUnixEpoch();
+
+            string actual = formatter.Format(dateAsLong);
+
+            Console.WriteLine("Output of formatter.Format():");
+            Console.WriteLine($"\"{actual}\"");
+
+
+            // Convert the parsed result back to a long
+            long parsedLong = Convert.ToInt64(formatter.Parse(actual));
+
+            // Make sure round trip results in the same number
+            Assert.AreEqual(dateAsLong, parsedLong);
+        }
+
+        // Verify that we can round-trip and convert to the time zone that is set after the parse
+        // in a time zone with different rules prior to 1903. See: https://github.com/dotnet/runtime/issues/62247
+        [Test]
+        [LuceneNetSpecific]
+        public void TestTimeZone_ShortTimeFormat_CentralAfricaTime()
+        {
+            TimeZoneInfo timeZone = TZConvert.GetTimeZoneInfo("Africa/Gaborone");
+
+            CultureInfo culture = new CultureInfo("en-US");
+
+            var formatter = new NumberDateFormat(DateFormat.LONG, DateFormat.MEDIUM, culture) // Medium time = no time zone info, but contains seconds
+            {
+                TimeZone = timeZone
+            };
+
+            const long Oct_31_1871_Ticks = 590376582130000000L; // Oct 31, 1871 05:30:13 UTC
+
+            DateTime dateToParse = TimeZoneInfo.ConvertTime(new DateTime(Oct_31_1871_Ticks, DateTimeKind.Utc), timeZone);
+
+            // Get the difference since the Unix epoch in milliseconds.
+            long dateAsLong = dateToParse.GetMillisecondsSinceUnixEpoch();
+
+            string actual = formatter.Format(dateAsLong);
+
+            Console.WriteLine("Output of formatter.Format():");
+            Console.WriteLine($"\"{actual}\"");
+
+            // Convert the parsed result back to a long
+            long parsedLong = Convert.ToInt64(formatter.Parse(actual));
+
+            // Make sure round trip results in the same number
+            Assert.AreEqual(dateAsLong, parsedLong);
+        }
     }
 }

--- a/src/Lucene.Net.Tests.QueryParser/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Support/TestApiConsistency.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.QueryParsers
         [TestCase(typeof(Lucene.Net.QueryParsers.Classic.ICharStream))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly, @"Snowball\.Ext\..+Stemmer");
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"DateTimeOffsetUtil");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net/Support/Util/NumberFormat.cs
+++ b/src/Lucene.Net/Support/Util/NumberFormat.cs
@@ -33,19 +33,19 @@ namespace Lucene.Net.Util
     // types instead of just the ones that Java supports, as well.
     public class NumberFormat
     {
-        private readonly CultureInfo culture;
+        private readonly IFormatProvider formatProvider;
 
         //private int maximumIntegerDigits;
         //private int minimumIntegerDigits;
         //private int maximumFractionDigits;
         //private int minimumFractionDigits;
 
-        public NumberFormat(CultureInfo culture)
+        public NumberFormat(IFormatProvider formatProvider)
         {
-            this.culture = culture;
+            this.formatProvider = formatProvider;
         }
 
-        protected CultureInfo Culture => culture;
+        public IFormatProvider FormatProvider => formatProvider;
 
         public virtual string Format(object number)
         {
@@ -53,27 +53,27 @@ namespace Lucene.Net.Util
 
             if (number is int i)
             {
-                return i.ToString(format, culture);
+                return i.ToString(format, formatProvider);
             }
             else if (number is long l)
             {
-                return l.ToString(format, culture);
+                return l.ToString(format, formatProvider);
             }
             else if (number is short s)
             {
-                return s.ToString(format, culture);
+                return s.ToString(format, formatProvider);
             }
             else if (number is float f)
             {
-                return f.ToString(format, culture);
+                return f.ToString(format, formatProvider);
             }
             else if (number is double d)
             {
-                return d.ToString(format, culture);
+                return d.ToString(format, formatProvider);
             }
             else if (number is decimal dec)
             {
-                return dec.ToString(format, culture);
+                return dec.ToString(format, formatProvider);
             }
 
             throw new ArgumentException("Cannot format given object as a Number");
@@ -82,13 +82,13 @@ namespace Lucene.Net.Util
         public virtual string Format(double number)
         {
             string format = GetNumberFormat();
-            return number.ToString(format, culture);
+            return number.ToString(format, formatProvider);
         }
 
         public virtual string Format(long number)
         {
             string format = GetNumberFormat();
-            return number.ToString(format, culture);
+            return number.ToString(format, formatProvider);
         }
 
         /// <summary>
@@ -104,12 +104,12 @@ namespace Lucene.Net.Util
 
         public virtual /*Number*/ object Parse(string source)
         {
-            return decimal.Parse(source, culture);
+            return decimal.Parse(source, formatProvider);
         }
 
         public override string ToString()
         {
-            return base.ToString() + " - " + GetNumberFormat() + " - " + culture.ToString();
+            return base.ToString() + " - " + GetNumberFormat() + " - " + formatProvider.ToString();
         }
 
         // LUCENENET TODO: Add additional functionality to edit the NumberFormatInfo


### PR DESCRIPTION
- Fixed calendar check so we don't produce random numbers that are out of bounds of the calendar of the random culture
- Added TimeZone support
- BREAKING: Changed constructors of `Lucene.Net.Util.NumberFormat` and `Lucene.Net.QueryParsers.Flexible.Standard.Config.NumberDateFormat` to accept `IFormatProvider` rather than `CultureInfo` and changed `NumberFormat.Culture` property to `NumberFormat.FormatProvider`.