### PR TITLE
BUG: Lucene.Net.Suggest.Jaspell.JaspellTernarySearchTree: Fixed random number generator so it produces random numbers

### DIFF
--- a/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
@@ -33,6 +33,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Suggest.Jaspell
@@ -362,6 +363,11 @@ namespace Lucene.Net.Search.Suggest.Jaspell
             }
         }
 
+        // LUCENENET: .NET has no Math.Random() method, so we need to lazy initialize an instance for this purpose.
+        // Note that the J2N.Randomizer.Next() method is threadsafe.
+        private static Random random;
+        private static Random Random => LazyInitializer.EnsureInitialized(ref random, () => new J2N.Randomizer());
+
         /// <summary>
         /// Recursively visits each node to be deleted.
         /// 
@@ -433,7 +439,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
             TSTNode targetNode;
             if (deltaHi == deltaLo)
             {
-                if (new Random(1).NextDouble() < 0.5)
+                if (Random.NextDouble() < 0.5)
                 {
                     deltaHi++;
                 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Support/TestApiConsistency.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Analysis
         [TestCase(typeof(Lucene.Net.Analysis.Standard.ClassicAnalyzer))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Analysis.Ja.Support
         [TestCase(typeof(Lucene.Net.Analysis.Ja.GraphvizFormatter))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [TestCase(typeof(Lucene.Net.Analysis.Phonetic.BeiderMorseFilter))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Analysis.Cn.Smart.Support
         [TestCase(typeof(Lucene.Net.Analysis.Cn.Smart.AnalyzerProfile))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Analysis.Stempel/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Analysis.Stempel/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Analysis.Stempel
         [TestCase(typeof(Lucene.Net.Analysis.Stempel.StempelFilter))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Benchmark/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Benchmark/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Benchmarks.Support
         [TestCase(typeof(Lucene.Net.Benchmarks.Constants))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Classification/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Classification/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Classification
         [TestCase(typeof(Lucene.Net.Classification.KNearestNeighborClassifier))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Codecs/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Codecs/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Codecs.Tests
         [TestCase(typeof(Lucene.Net.Codecs.BlockTerms.BlockTermsReader))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Grouping/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Grouping/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Tests.Grouping
         [TestCase(typeof(Lucene.Net.Search.Grouping.ICollectedSearchGroup))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Highlighter/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Search
         [TestCase(typeof(Lucene.Net.Search.Highlight.DefaultEncoder))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Join/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Join/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Search.Join
         [TestCase(typeof(Lucene.Net.Search.Join.FakeScorer))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Memory/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Memory/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Tests.Memory
         [TestCase(typeof(Lucene.Net.Index.Memory.MemoryIndex))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Misc/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Misc/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Tests.Misc
         [TestCase(typeof(Lucene.Net.Misc.SweetSpotSimilarity))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Queries/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Queries/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Tests.Queries
         [TestCase(typeof(Lucene.Net.Queries.BooleanFilter))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Sandbox/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Sandbox/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Sandbox
         [TestCase(typeof(Lucene.Net.Sandbox.Queries.DuplicateFilter))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests.Suggest/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Suggest/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Tests.Suggest
         [TestCase(typeof(Lucene.Net.Search.Suggest.IInputEnumerator))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/dotnet/Lucene.Net.Tests.ICU/Support/TestApiConsistency.cs
+++ b/src/dotnet/Lucene.Net.Tests.ICU/Support/TestApiConsistency.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Support
         [TestCase(typeof(Lucene.Net.Collation.ICUCollationAttributeFactory))]
         public override void TestPublicFields(Type typeFromTargetAssembly)
         {
-            base.TestPublicFields(typeFromTargetAssembly);
+            base.TestPublicFields(typeFromTargetAssembly, @"^System\.Runtime\.CompilerServices");
         }
 
         [Test, LuceneNetSpecific]


### PR DESCRIPTION
Lazy initialize a `J2N.Randomizer()` instance so we hit both paths approximately evenly instead of one path when deleting nodes recursively. The previous implementation used a `System.Random`, but always initialized it to the same seed, so we didn't actually generate random numbers.