### PR TITLE
Deprecated support for Thread.Interrupt()

### DIFF
--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -864,7 +864,6 @@ namespace Lucene.Net.Util
         //    {
         //      try
         //      {
-        //        UninterruptableMonitor.RestoreInterrupt();
         //        ex.shutdown();
         //        ex.awaitTermination(1, TimeUnit.SECONDS);
         //      }

--- a/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
@@ -1476,7 +1476,7 @@ namespace Lucene.Net.Index
 
         [Test]
         [Slow]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/544")] // LUCENENET TODO: This test occasionally fails
+        [Ignore("Lucene.NET does not support Thread.Interrupt(). See https://github.com/apache/lucenenet/issues/526.")]
         public virtual void TestThreadInterruptDeadlock()
         {
             IndexerThreadInterrupt t = new IndexerThreadInterrupt(this);
@@ -1517,7 +1517,7 @@ namespace Lucene.Net.Index
         /// testThreadInterruptDeadlock but with 2 indexer threads </summary>
         [Test]
         [Slow]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/544")] // LUCENENET TODO: This test occasionally fails
+        [Ignore("Lucene.NET does not support Thread.Interrupt(). See https://github.com/apache/lucenenet/issues/526.")]
         public virtual void TestTwoThreadsInterruptDeadlock()
         {
             IndexerThreadInterrupt t1 = new IndexerThreadInterrupt(this);

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
@@ -106,7 +106,6 @@
 //            {
 //                try
 //                {
-//                    UninterruptableMonitor.RestoreInterrupt();
 //                    Thread.Sleep(CrashTime);
 //                }
 //                catch (Exception e) when (e.IsInterruptedException())

--- a/src/Lucene.Net.Tests/Support/Threading/TestUninterruptableMonitor.cs
+++ b/src/Lucene.Net.Tests/Support/Threading/TestUninterruptableMonitor.cs
@@ -237,6 +237,7 @@ namespace Lucene.Net.Support
 
         [Test, LuceneNetSpecific]
         [Slow]
+        [Ignore("Lucene.NET does not support Thread.Interrupt(). See https://github.com/apache/lucenenet/issues/526.")]
         public virtual void TestThreadInterrupt()
         {
             TransactionlThreadInterrupt t = new TransactionlThreadInterrupt();
@@ -270,6 +271,7 @@ namespace Lucene.Net.Support
 
         [Test, LuceneNetSpecific]
         [Slow]
+        [Ignore("Lucene.NET does not support Thread.Interrupt(). See https://github.com/apache/lucenenet/issues/526.")]
         public virtual void TestTwoThreadsInterrupt()
         {
             TransactionlThreadInterrupt t1 = new TransactionlThreadInterrupt();

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -155,12 +155,17 @@ namespace Lucene.Net.Index
     /// this may cause deadlock; use your own (non-Lucene) objects
     /// instead. </para>
     ///
-    /// <para><b>NOTE</b>: If you call
-    /// <see cref="Thread.Interrupt()"/> on a thread that's within
-    /// <see cref="IndexWriter"/>, <see cref="IndexWriter"/> will try to catch this (eg, if
-    /// it's in a <see cref="Monitor.Wait(object)"/> or <see cref="Thread.Sleep(int)"/>), and will then throw
-    /// the unchecked exception <see cref="Util.ThreadInterruptedException"/>
-    /// and <b>clear</b> the interrupt status on the thread.</para>
+    /// <para><b>NOTE</b>:
+    /// Do not use <see cref="Thread.Interrupt()"/> on a thread that's within
+    /// <see cref="IndexWriter"/>, as .NET will throw <see cref="ThreadInterruptedException"/> on any
+    /// wait, sleep, or join including any lock statement with contention on it.
+    /// As a result, it is not practical to try to support <see cref="Thread.Interrupt()"/> due to the
+    /// chance <see cref="ThreadInterruptedException"/> could potentially be thrown in the middle of a
+    /// <see cref="Commit()"/> or somewhere in the application that will cause a deadlock.</para>
+    /// <para>
+    /// We recommend using another shutdown mechanism to safely cancel a parallel operation.
+    /// See: <a href="https://github.com/apache/lucenenet/issues/526">https://github.com/apache/lucenenet/issues/526</a>.
+    /// </para>
     /// </remarks>
 
     /*

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -48,16 +48,12 @@ namespace Lucene.Net.Store
     ///         synchronizes when multiple threads read from the
     ///         same file.</description></item>
     ///
-    ///     <item><description> <see cref="NIOFSDirectory"/> uses java.nio's
-    ///         FileChannel's positional io when reading to avoid
-    ///         synchronization when reading from the same file.
-    ///         Unfortunately, due to a Windows-only <a
-    ///         href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6265734">Sun
-    ///         JRE bug</a> this is a poor choice for Windows, but
-    ///         on all other platforms this is the preferred
-    ///         choice. Applications using <see cref="Thread.Interrupt()"/> or
+    ///     <item><description> <see cref="NIOFSDirectory"/>
+    ///         uses <see cref="FileStream"/>'s positional read,
+    ///         which allows multiple threads to read from the same
+    ///         file without synchronizing. Applications using
     ///         <see cref="Task{TResult}"/> should use
-    ///         <see cref="SimpleFSDirectory"/> instead. See <see cref="NIOFSDirectory"/> java doc
+    ///         <see cref="SimpleFSDirectory"/> instead. See <see cref="NIOFSDirectory"/> documentation
     ///         for details.</description></item>
     ///
     ///     <item><description> <see cref="MMapDirectory"/> uses memory-mapped IO when
@@ -67,8 +63,7 @@ namespace Lucene.Net.Store
     ///         running on a 32 bit runtime but your index sizes are
     ///         small enough to fit into the virtual memory space.
     ///         <para/>
-    ///         Applications using <see cref="Thread.Interrupt()"/> or
-    ///         <see cref="Task{TResult}"/> should use
+    ///         Applications using <see cref="Task{TResult}"/> should use
     ///         <see cref="SimpleFSDirectory"/> instead. See <see cref="MMapDirectory"/>
     ///         doc for details.</description></item>
     /// </list>

--- a/src/Lucene.Net/Store/NIOFSDirectory.cs
+++ b/src/Lucene.Net/Store/NIOFSDirectory.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Store
     /// underlying file descriptor immediately if at the same time the thread is
     /// blocked on IO. The file descriptor will remain closed and subsequent access
     /// to <see cref="NIOFSDirectory"/> will throw a <see cref="ObjectDisposedException"/>. If
-    /// your application uses either <see cref="System.Threading.Thread.Interrupt()"/> or
+    /// your application uses
     /// <see cref="System.Threading.Tasks.Task"/> you should use <see cref="SimpleFSDirectory"/> in
     /// favor of <see cref="NIOFSDirectory"/>.</font>
     /// </para>


### PR DESCRIPTION
Closes #526  and closes #544.

This PR just adds the [Ignore] attribute to the following tests and updates the `IndexWriter` and directory documentation to indicate that `Thread.Interrupt()` is not supported in Lucene.NET due to the high possibility that it could break a `Commit()` or cause a deadlock.

- [Lucene.Net.TestIndexWriter.TestThreadInterruptDeadlock()](https://github.com/apache/lucenenet/blob/54c9a76ea22a1451e899577b296d4a58382d6a76/src/Lucene.Net.Tests/Index/TestIndexWriter.cs#L1480)
- [Lucene.Net.TestIndexWriter.TestTwoThreadsInterruptDeadlock()](https://github.com/apache/lucenenet/blob/54c9a76ea22a1451e899577b296d4a58382d6a76/src/Lucene.Net.Tests/Index/TestIndexWriter.cs#L1521)
- [Lucene.Net.Support.Threading.TestUninterruptableMonitor.TestThreadInterrupt()](https://github.com/apache/lucenenet/blob/54c9a76ea22a1451e899577b296d4a58382d6a76/src/Lucene.Net.Tests/Support/Threading/TestUninterruptableMonitor.cs#L240)
- [Lucene.Net.Support.Threading.TestUninterruptableMonitor.TestTwoThreadsInterrupt()](https://github.com/apache/lucenenet/blob/54c9a76ea22a1451e899577b296d4a58382d6a76/src/Lucene.Net.Tests/Support/Threading/TestUninterruptableMonitor.cs#L273)

The code for `Thread.Interrupt()` still exists in the codebase and we won't remove it, but it is just a best effort. Due to the fact that any code that we don't own that uses `lock ()` or `Monitor.Enter()` could throw `System.Threading.ThreadInterruptedException` in a part of the application where we don't expect it, it is not practical to support such a feature in .NET.