### PR TITLE
BUG: Lucene.Net.Search.DisjunctionMaxScorer: x86 floating point precision issue (fixes #546)

### DIFF
--- a/src/Lucene.Net.Tests/Search/TestSimpleExplanations.cs
+++ b/src/Lucene.Net.Tests/Search/TestSimpleExplanations.cs
@@ -274,9 +274,6 @@ namespace Lucene.Net.Search
         }
 
         [Test]
-#if NETFRAMEWORK
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/546")] // LUCENENET TODO: This test fails on x86 .NET Framework in Release mode only
-#endif
         public virtual void TestDMQ8()
         {
             DisjunctionMaxQuery q = new DisjunctionMaxQuery(0.5f);

--- a/src/Lucene.Net/Search/DisjunctionMaxScorer.cs
+++ b/src/Lucene.Net/Search/DisjunctionMaxScorer.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Search
 {
@@ -78,7 +79,8 @@ namespace Lucene.Net.Search
         {
             if (root < m_numScorers && m_subScorers[root].DocID == m_doc)
             {
-                float sub = m_subScorers[root].GetScore();
+                // LUCENENET specific: The explicit cast to float is required here to prevent us from losing precision on x86 .NET Framework with optimizations enabled
+                float sub = (float)m_subScorers[root].GetScore();
                 freq++;
                 scoreSum += sub;
                 scoreMax = Math.Max(scoreMax, sub);


### PR DESCRIPTION
.NET Framework x86 requires an explicit cast to float to prevent it from losing precision. Fixes #546.