### PR TITLE
BUG: Lucene.Net.Expressions.ScoreFunctionValues: Fixed x86 floating point issue

### DIFF
--- a/src/Lucene.Net.Expressions/ScoreFunctionValues.cs
+++ b/src/Lucene.Net.Expressions/ScoreFunctionValues.cs
@@ -45,12 +45,8 @@ namespace Lucene.Net.Expressions
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(document == scorer.DocID);
 
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-                return scorer.GetScore();
-#else
-                // LUCENENET specific: The intermediate cast to decimal is required here to prevent us from losing precision on x86 .NET Framework with optimizations enabled
-                return (double)(decimal)scorer.GetScore();
-#endif
+                // LUCENENET specific: The explicit cast to float is required here to prevent us from losing precision on x86 .NET Framework with optimizations enabled
+                return (float)scorer.GetScore();
             }
             catch (Exception exception) when (exception.IsIOException())
             {


### PR DESCRIPTION
Changed to explicit cast to (float) to prevent JIT from losing precision when assigning the value to double. Fixes `Lucene.Net.Expressions.TestExpressionSorts::TestQueries()`.

Reproducible in `net48`, x86, Release mode with the following attributes.

```c#
[assembly: Lucene.Net.Util.RandomSeed(0x23cc862e070f9ee8)]
[assembly: NUnit.Framework.SetCulture("lo")]
```