### PR TITLE
BUG: Lucene.Net.Spatial.Prefix.SpatialOpRecursivePrefixTreeTest::TestContains() (fixes #559)

### DIFF
--- a/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
+++ b/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
@@ -122,7 +122,6 @@ namespace Lucene.Net.Spatial.Prefix
         }
 
         [Test , Repeat(ITERATIONS)]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/559")]
         public virtual void TestContains()
         {
             SetupGrid(-1);


### PR DESCRIPTION
Ported over patch from https://github.com/apache/lucene/commit/e9906a334b8e123e93b917c3feb6e55fed0a8c57 (from Lucene 4.9.0) (fixes #559).

Contains requires a non-geo instance of `SpatialContext` to compare corners, otherwise it may match in cases where it isn't supposed to. This is entirely a patch that fixes the test, it has no impact on the production code.

The test was made non-random and ported to Java to determine whether or not the same issue happens in Lucene (and it does). Here are the tests:

### .NET

```c#
[Test]
[LuceneNetSpecific]
public virtual void TestContains_Fixed()
{
    this.ctx = SpatialContext.GEO;
    ////A fairly shallow grid, and default 2.5% distErrPct
    //if (maxLevels == -1)
    //    maxLevels = randomIntBetween(1, 3);//max 16k cells (32^3)
    this.grid = new GeohashPrefixTree(ctx, maxLevels: 2);
    this.strategy = new RecursivePrefixTreeStrategy(grid, GetType().Name);

    //Main index loop:
    IDictionary<String, IShape> indexedShapes = new JCG.LinkedDictionary<String, IShape>();
    IDictionary<String, IShape> indexedShapesGS = new JCG.LinkedDictionary<String, IShape>();//grid snapped

    IShape shape0 = ctx.MakeRectangle(-126, -124, -72, -69);
    IShape shape1 = null;
    IShape shape2 = ctx.MakeRectangle(6, 66, -61, 45);

    IShape shape3a = ctx.MakeRectangle(-114, -109, 73, 81);
    IShape shape3b = ctx.MakeRectangle(-40, -39, -37, -37);
    IShape shape3 = new ShapePair(shape3a, shape3b, true, ctx, ctx2D);

    IShape shape4a = ctx.MakeRectangle(-180, 118, -90, 90);
    IShape shape4b = ctx.MakeRectangle(-118, -106, -43, -28);
    IShape shape4 = new ShapePair(shape4a, shape4b, true, ctx, ctx2D);

    IShape shape5 = ctx.MakeRectangle(-92, 66, -61, 45);


    indexedShapes["0"] = shape0;
    indexedShapes["1"] = shape1;
    indexedShapes["2"] = shape2;
    indexedShapes["3"] = shape3;
    indexedShapes["4"] = shape4;
    indexedShapes["5"] = shape5;

    indexedShapesGS["0"] = gridSnap(shape0);
    indexedShapesGS["1"] = gridSnap(shape1);
    indexedShapesGS["2"] = gridSnap(shape2);
    indexedShapesGS["3"] = gridSnap(shape3);
    indexedShapesGS["4"] = gridSnap(shape4);
    indexedShapesGS["5"] = gridSnap(shape5);

    adoc("0", shape0);
    adoc("1", shape1);
    adoc("2", shape2);
    adoc("3", shape3);
    adoc("4", shape4);
    adoc("5", shape5);

    Commit();
    indexSearcher = new IndexSearcher(indexReader);

    ((RecursivePrefixTreeStrategy)strategy).PrefixGridScanLevel = 2;

    IShape queryShape = ctx.MakeRectangle(-180, 180, -81, 79);
    IShape queryShapeGS = gridSnap(queryShape);

    SpatialOperation operation = SpatialOperation.Contains;

    //Generate truth via brute force:
    // We ensure true-positive matches (if the predicate on the raw shapes match
    //  then the search should find those same matches).
    // approximations, false-positive matches
    ISet<string> expectedIds = new JCG.LinkedHashSet<string>();//true-positives
    ISet<string> secondaryIds = new JCG.LinkedHashSet<string>();//false-positives (unless disjoint)
    foreach (var entry in indexedShapes)
    {
        string id = entry.Key;
        IShape indexedShapeCompare = entry.Value;
        if (indexedShapeCompare == null)
            continue;
        IShape queryShapeCompare = queryShape;

        if (operation.Evaluate(indexedShapeCompare, queryShapeCompare))
        {
            expectedIds.Add(id);
        }
        else
        {
            //buffer either the indexed or query shape (via gridSnap) and try again
            indexedShapeCompare = indexedShapesGS[id];

            if (operation.Evaluate(indexedShapeCompare, queryShapeCompare))
                secondaryIds.Add(id);
        }
    }

    //Search and verify results
    SpatialArgs args = new SpatialArgs(operation, queryShape);
    if (queryShape is ShapePair)
        args.DistErrPct = (0.0);//a hack; we want to be more detailed than gridSnap(queryShape)
    Query query = strategy.MakeQuery(args);
    SearchResults got = executeQuery(query, 100);
    ISet<String> remainingExpectedIds = new JCG.LinkedHashSet<string>(expectedIds);
    foreach (SearchResult result in got.results)
    {
        String id = result.GetId();
        bool removed = remainingExpectedIds.Remove(id);
        if (!removed && (!secondaryIds.Contains(id)))
        {
            fail("Shouldn't match", id, indexedShapes, indexedShapesGS, queryShape);
        }
    }
    if (remainingExpectedIds.Count > 0)
    {
        var iter = remainingExpectedIds.GetEnumerator();
        iter.MoveNext();
        String id = iter.Current;
        fail("Should have matched", id, indexedShapes, indexedShapesGS, queryShape);
    }
}
```

### Java

```c#
  @Test
  public void testContains_Fixed() throws IOException {
    this.ctx = SpatialContext.GEO;
    ////A fairly shallow grid, and default 2.5% distErrPct
    //if (maxLevels == -1)
    //    maxLevels = randomIntBetween(1, 3);//max 16k cells (32^3)
    this.grid = new GeohashPrefixTree(ctx, /*maxLevels:*/ 2);
    this.strategy = new RecursivePrefixTreeStrategy(grid, getClass().getSimpleName());
    
  //Main index loop:
    Map<String, Shape> indexedShapes = new LinkedHashMap<>();
    Map<String, Shape> indexedShapesGS = new LinkedHashMap<>();//grid snapped
    
    Shape shape0 = ctx.makeRectangle(-126, -124, -72, -69);
    Shape shape1 = null;
    Shape shape2 = ctx.makeRectangle(6, 66, -61, 45);

    Shape shape3a = ctx.makeRectangle(-114, -109, 73, 81);
    Shape shape3b = ctx.makeRectangle(-40, -39, -37, -37);
    Shape shape3 = new ShapePair(shape3a, shape3b, true);

    Shape shape4a = ctx.makeRectangle(-180, 118, -90, 90);
    Shape shape4b = ctx.makeRectangle(-118, -106, -43, -28);
    Shape shape4 = new ShapePair(shape4a, shape4b, true);

    Shape shape5 = ctx.makeRectangle(-92, 66, -61, 45);


    indexedShapes.put("0", shape0);
    indexedShapes.put("1", shape1);
    indexedShapes.put("2", shape2);
    indexedShapes.put("3", shape3);
    indexedShapes.put("4", shape4);
    indexedShapes.put("5", shape5);

    indexedShapesGS.put("0", gridSnap(shape0));
    indexedShapesGS.put("1", gridSnap(shape1));
    indexedShapesGS.put("2", gridSnap(shape2));
    indexedShapesGS.put("3", gridSnap(shape3));
    indexedShapesGS.put("4", gridSnap(shape4));
    indexedShapesGS.put("5", gridSnap(shape5));

    adoc("0", shape0);
    adoc("1", shape1);
    adoc("2", shape2);
    adoc("3", shape3);
    adoc("4", shape4);
    adoc("5", shape5);

    commit();
    indexSearcher = new org.apache.lucene.search.IndexSearcher(indexReader);
    
    ((RecursivePrefixTreeStrategy) strategy).setPrefixGridScanLevel(/*scanLevel*/ 2);
    
    final Shape queryShape = ctx.makeRectangle(-180, 180, -81, 79);
    final Shape queryShapeGS = gridSnap(queryShape);
    
    SpatialOperation operation = SpatialOperation.Contains;
    
    //Generate truth via brute force:
    // We ensure true-positive matches (if the predicate on the raw shapes match
    //  then the search should find those same matches).
    // approximations, false-positive matches
    Set<String> expectedIds = new LinkedHashSet<>();//true-positives
    Set<String> secondaryIds = new LinkedHashSet<>();//false-positives (unless disjoint)
    for (Map.Entry<String, Shape> entry : indexedShapes.entrySet()) {
      String id = entry.getKey();
      Shape indexedShapeCompare = entry.getValue();
      if (indexedShapeCompare == null)
        continue;
      Shape queryShapeCompare = queryShape;

      if (operation.evaluate(indexedShapeCompare, queryShapeCompare)) {
        expectedIds.add(id);
      } else {
        //buffer either the indexed or query shape (via gridSnap) and try again
        indexedShapeCompare = indexedShapesGS.get(id);
        if (operation.evaluate(indexedShapeCompare, queryShapeCompare))
          secondaryIds.add(id);
      }
    }

    //Search and verify results
    SpatialArgs args = new SpatialArgs(operation, queryShape);
    if (queryShape instanceof ShapePair)
      args.setDistErrPct(0.0);//a hack; we want to be more detailed than gridSnap(queryShape)
    Query query = strategy.makeQuery(args);
    SearchResults got = executeQuery(query, 100);
    Set<String> remainingExpectedIds = new LinkedHashSet<>(expectedIds);
    for (SearchResult result : got.results) {
      String id = result.getId();
      boolean removed = remainingExpectedIds.remove(id);
      if (!removed && (!secondaryIds.contains(id))) {
        fail("Shouldn't match", id, indexedShapes, indexedShapesGS, queryShape);
      }
    }
    if (!remainingExpectedIds.isEmpty()) {
      String id = remainingExpectedIds.iterator().next();
      fail("Should have matched", id, indexedShapes, indexedShapesGS, queryShape);
    }
  }
```
