### PR TITLE
BUG: Lucene.Net.Search.TestJoinUtil::TestMultiValueRandomJoin() (fixes #549)

### DIFF
--- a/src/Lucene.Net.Tests.Join/Support/TestJoinUtil.cs
+++ b/src/Lucene.Net.Tests.Join/Support/TestJoinUtil.cs
@@ -393,9 +393,6 @@ namespace Lucene.Net.Tests.Join
 
         [Test]
         // [Slow] // LUCENENET specific - Not slow in .NET
-#if NETFRAMEWORK
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/549")] // LUCENENET TODO: This test fails on x86 .NET Framework in Release mode only
-#endif
         public void TestMultiValueRandomJoin()
         // this test really takes more time, that is why the number of iterations are smaller.
         {

--- a/src/Lucene.Net.Tests.Join/TestJoinUtil.cs
+++ b/src/Lucene.Net.Tests.Join/TestJoinUtil.cs
@@ -390,9 +390,6 @@ namespace Lucene.Net.Search.Join
 
         [Test]
         // [Slow] // LUCENENET specific - Not slow in .NET
-#if NETFRAMEWORK
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/549")] // LUCENENET TODO: This test fails on x86 .NET Framework in Release mode only
-#endif
         public void TestMultiValueRandomJoin()
             // this test really takes more time, that is why the number of iterations are smaller.
         {

--- a/src/Lucene.Net/Search/TermScorer.cs
+++ b/src/Lucene.Net/Search/TermScorer.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 
 namespace Lucene.Net.Search
 {
@@ -63,7 +63,9 @@ namespace Lucene.Net.Search
         public override float GetScore()
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(DocID != NO_MORE_DOCS);
-            return docScorer.Score(docsEnum.DocID, docsEnum.Freq);
+
+            // LUCENENET specific: The explicit cast to float is required here to prevent us from losing precision on x86 .NET Framework with optimizations enabled
+            return (float)docScorer.Score(docsEnum.DocID, docsEnum.Freq);
         }
 
         /// <summary>


### PR DESCRIPTION
`Lucene.Net.Search.TermScorer`: Added cast to fix calculation in .NET Framework x86 with optimizations enabled (fixes #549 / `Lucene.Net.Search.TestJoinUtil::TestMultiValueRandomJoin()`).