### PR TITLE
BREAKING: Lucene.Net.Index.DocValuesFieldUpdates: Fixed boxing issue

### DIFF
--- a/src/Lucene.Net/Index/BufferedUpdates.cs
+++ b/src/Lucene.Net/Index/BufferedUpdates.cs
@@ -1,5 +1,7 @@
 ﻿using J2N.Collections.Generic;
 using J2N.Threading.Atomic;
+using Lucene.Net.Search;
+using Lucene.Net.Util;
 using JCG = J2N.Collections.Generic;
 using SCG = System.Collections.Generic;
 
@@ -21,12 +23,6 @@ namespace Lucene.Net.Index
      * See the License for the specific language governing permissions and
      * limitations under the License.
      */
-
-    using BinaryDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.BinaryDocValuesUpdate;
-    using NumericDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.NumericDocValuesUpdate;
-    using Query = Lucene.Net.Search.Query;
-    using RamUsageEstimator = Lucene.Net.Util.RamUsageEstimator;
-
 
     /// <summary>
     /// Holds buffered deletes and updates, by docID, term or query for a
@@ -148,7 +144,7 @@ namespace Lucene.Net.Index
         /// <summary>
         /// NOTE: This was MAX_INT in Lucene
         /// </summary>
-        public static readonly int MAX_INT32 = int.MaxValue;
+        internal static readonly int MAX_INT32 = int.MaxValue; // LUCENENET specific - Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
 
         internal readonly AtomicInt64 bytesUsed;
 
@@ -158,7 +154,7 @@ namespace Lucene.Net.Index
 
         internal long gen;
 
-        internal BufferedUpdates() // LUCENENET NOTE: Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
+        internal BufferedUpdates() // LUCENENET specific - Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
         {
             this.bytesUsed = new AtomicInt64();
         }
@@ -204,7 +200,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        public virtual void AddQuery(Query query, int docIDUpto)
+        internal virtual void AddQuery(Query query, int docIDUpto) // LUCENENET specific - Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
         {
             bool prevExists = queries.TryGetValue(query, out _);
             queries[query] = docIDUpto;
@@ -215,13 +211,13 @@ namespace Lucene.Net.Index
             }
         }
 
-        public virtual void AddDocID(int docID)
+        internal virtual void AddDocID(int docID) // LUCENENET specific - Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
         {
             docIDs.Add(docID);
             bytesUsed.AddAndGet(BYTES_PER_DEL_DOCID);
         }
 
-        public virtual void AddTerm(Term term, int docIDUpto)
+        internal virtual void AddTerm(Term term, int docIDUpto) // LUCENENET specific - Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
         {
             bool currentExists = terms.TryGetValue(term, out int current);
             if (currentExists && docIDUpto < current)
@@ -247,7 +243,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        public virtual void AddNumericUpdate(NumericDocValuesUpdate update, int docIDUpto)
+        internal virtual void AddNumericUpdate(NumericDocValuesUpdate update, int docIDUpto) // LUCENENET specific - Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
         {
             if (!numericUpdates.TryGetValue(update.field, out LinkedDictionary<Term, NumericDocValuesUpdate> fieldUpdates))
             {
@@ -280,7 +276,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        public virtual void AddBinaryUpdate(BinaryDocValuesUpdate update, int docIDUpto)
+        internal virtual void AddBinaryUpdate(BinaryDocValuesUpdate update, int docIDUpto) // LUCENENET specific - Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
         {
             if (!binaryUpdates.TryGetValue(update.field, out LinkedDictionary<Term, BinaryDocValuesUpdate> fieldUpdates))
             {

--- a/src/Lucene.Net/Index/BufferedUpdatesStream.cs
+++ b/src/Lucene.Net/Index/BufferedUpdatesStream.cs
@@ -659,7 +659,9 @@ namespace Lucene.Net.Index
                             {
                                 break; // no more docs that can be updated for this term
                             }
-                            dvUpdates.Add(doc, update.value);
+                            // LUCENENET specific handling - dvUpdates handles getting the value so we don't
+                            // have to deal with boxing/unboxing
+                            dvUpdates.AddFromUpdate(doc, update);
                         }
                     }
                 }

--- a/src/Lucene.Net/Index/CoalescedUpdates.cs
+++ b/src/Lucene.Net/Index/CoalescedUpdates.cs
@@ -22,9 +22,7 @@ namespace Lucene.Net.Index
      * limitations under the License.
      */
 
-    using BinaryDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.BinaryDocValuesUpdate;
     using BytesRef = Lucene.Net.Util.BytesRef;
-    using NumericDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.NumericDocValuesUpdate;
     using Query = Lucene.Net.Search.Query;
     using QueryAndLimit = Lucene.Net.Index.BufferedUpdatesStream.QueryAndLimit;
 
@@ -53,7 +51,7 @@ namespace Lucene.Net.Index
 
             foreach (NumericDocValuesUpdate nu in @in.numericDVUpdates)
             {
-                NumericDocValuesUpdate clone = new NumericDocValuesUpdate(nu.term, nu.field, (long?)nu.value);
+                NumericDocValuesUpdate clone = new NumericDocValuesUpdate(nu.term, nu.field, nu.value);
                 clone.docIDUpto = int.MaxValue;
                 numericDVUpdates.Add(clone);
             }

--- a/src/Lucene.Net/Index/DocumentsWriter.cs
+++ b/src/Lucene.Net/Index/DocumentsWriter.cs
@@ -28,13 +28,11 @@ namespace Lucene.Net.Index
      */
 
     using Analyzer = Lucene.Net.Analysis.Analyzer;
-    using BinaryDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.BinaryDocValuesUpdate;
     using BytesRef = Lucene.Net.Util.BytesRef;
     using Directory = Lucene.Net.Store.Directory;
     using FlushedSegment = Lucene.Net.Index.DocumentsWriterPerThread.FlushedSegment;
     using IEvent = Lucene.Net.Index.IndexWriter.IEvent;
     using InfoStream = Lucene.Net.Util.InfoStream;
-    using NumericDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.NumericDocValuesUpdate;
     using Query = Lucene.Net.Search.Query;
     using SegmentFlushTicket = Lucene.Net.Index.DocumentsWriterFlushQueue.SegmentFlushTicket;
     using ThreadState = Lucene.Net.Index.DocumentsWriterPerThreadPool.ThreadState;

--- a/src/Lucene.Net/Index/DocumentsWriterDeleteQueue.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterDeleteQueue.cs
@@ -1,4 +1,5 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
+using Lucene.Net.Search;
 using Lucene.Net.Support;
 using Lucene.Net.Support.Threading;
 using System;
@@ -22,10 +23,6 @@ namespace Lucene.Net.Index
      * See the License for the specific language governing permissions and
      * limitations under the License.
      */
-
-    using BinaryDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.BinaryDocValuesUpdate;
-    using NumericDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.NumericDocValuesUpdate;
-    using Query = Lucene.Net.Search.Query;
 
     /// <summary>
     /// <see cref="DocumentsWriterDeleteQueue"/> is a non-blocking linked pending deletes

--- a/src/Lucene.Net/Index/FrozenBufferedUpdates.cs
+++ b/src/Lucene.Net/Index/FrozenBufferedUpdates.cs
@@ -1,9 +1,11 @@
 ﻿using J2N.Collections.Generic.Extensions;
 using Lucene.Net.Diagnostics;
-using System;
+using Lucene.Net.Search;
+using Lucene.Net.Util;
 using System.Collections;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
+using QueryAndLimit = Lucene.Net.Index.BufferedUpdatesStream.QueryAndLimit;
 
 namespace Lucene.Net.Index
 {
@@ -23,13 +25,6 @@ namespace Lucene.Net.Index
      * See the License for the specific language governing permissions and
      * limitations under the License.
      */
-
-    using ArrayUtil = Lucene.Net.Util.ArrayUtil;
-    using BinaryDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.BinaryDocValuesUpdate;
-    using NumericDocValuesUpdate = Lucene.Net.Index.DocValuesUpdate.NumericDocValuesUpdate;
-    using Query = Lucene.Net.Search.Query;
-    using QueryAndLimit = Lucene.Net.Index.BufferedUpdatesStream.QueryAndLimit;
-    using RamUsageEstimator = Lucene.Net.Util.RamUsageEstimator;
 
     /// <summary>
     /// Holds buffered deletes and updates by term or query, once pushed. Pushed

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -4355,9 +4355,9 @@ namespace Lucene.Net.Index
             }
         }
 
-        private static void SkipDeletedDoc(DocValuesFieldUpdates.Iterator[] updatesIters, int deletedDoc) // LUCENENET: CA1822: Mark members as static
+        private static void SkipDeletedDoc(DocValuesFieldUpdatesIterator[] updatesIters, int deletedDoc) // LUCENENET: CA1822: Mark members as static
         {
-            foreach (DocValuesFieldUpdates.Iterator iter in updatesIters)
+            foreach (DocValuesFieldUpdatesIterator iter in updatesIters)
             {
                 if (iter.Doc == deletedDoc)
                 {
@@ -4396,12 +4396,12 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void MaybeApplyMergedDVUpdates(MergePolicy.OneMerge merge, MergeState mergeState, int docUpto, MergedDeletesAndUpdates holder, string[] mergingFields, DocValuesFieldUpdates[] dvFieldUpdates, DocValuesFieldUpdates.Iterator[] updatesIters, int curDoc)
+        private void MaybeApplyMergedDVUpdates(MergePolicy.OneMerge merge, MergeState mergeState, int docUpto, MergedDeletesAndUpdates holder, string[] mergingFields, DocValuesFieldUpdates[] dvFieldUpdates, DocValuesFieldUpdatesIterator[] updatesIters, int curDoc)
         {
             int newDoc = -1;
             for (int idx = 0; idx < mergingFields.Length; idx++)
             {
-                DocValuesFieldUpdates.Iterator updatesIter = updatesIters[idx];
+                DocValuesFieldUpdatesIterator updatesIter = updatesIters[idx];
                 if (updatesIter.Doc == curDoc) // document has an update
                 {
                     if (holder.mergedDeletesAndUpdates == null)
@@ -4413,7 +4413,8 @@ namespace Lucene.Net.Index
                         newDoc = holder.docMap.Map(docUpto);
                     }
                     DocValuesFieldUpdates dvUpdates = dvFieldUpdates[idx];
-                    dvUpdates.Add(newDoc, updatesIter.Value);
+                    // LUCENENET specific - dvUpdates handles getting the value so we don't need to deal with boxing/unboxing here.
+                    dvUpdates.AddFromIterator(newDoc, updatesIter);
                     updatesIter.NextDoc(); // advance to next document
                 }
                 else
@@ -4469,7 +4470,7 @@ namespace Lucene.Net.Index
                     IDictionary<string, DocValuesFieldUpdates> mergingFieldUpdates = rld.MergingFieldUpdates;
                     string[] mergingFields;
                     DocValuesFieldUpdates[] dvFieldUpdates;
-                    DocValuesFieldUpdates.Iterator[] updatesIters;
+                    DocValuesFieldUpdatesIterator[] updatesIters;
                     if (mergingFieldUpdates.Count == 0)
                     {
                         mergingFields = null;
@@ -4480,7 +4481,7 @@ namespace Lucene.Net.Index
                     {
                         mergingFields = new string[mergingFieldUpdates.Count];
                         dvFieldUpdates = new DocValuesFieldUpdates[mergingFieldUpdates.Count];
-                        updatesIters = new DocValuesFieldUpdates.Iterator[mergingFieldUpdates.Count];
+                        updatesIters = new DocValuesFieldUpdatesIterator[mergingFieldUpdates.Count];
                         int idx = 0;
                         foreach (KeyValuePair<string, DocValuesFieldUpdates> e in mergingFieldUpdates)
                         {

--- a/src/Lucene.Net/Index/ReadersAndUpdates.cs
+++ b/src/Lucene.Net/Index/ReadersAndUpdates.cs
@@ -757,7 +757,7 @@ namespace Lucene.Net.Index
             {
                 if (curDoc == updateDoc) //document has an updated value
                 {
-                    long? value = (long?)iter.Value; // either null or updated
+                    long? value = iter.Value; // either null or updated
                     updateDoc = iter.NextDoc(); //prepare for next round
                     yield return value;
                 }


### PR DESCRIPTION
Refactored so the subclasses will handle getting the values from `DocValuesFieldUpdatesIterator` or `DocValuesUpdate` via a cast rather than boxing the value. Also marked internal (as well as all members of `BufferedUpdates`), since this was not supposed to be part of the public API.