### PR TITLE
BREAKING: Lucene.Net.Index.SegmentInfos: Changed Info() method to an indexer (.NET Convention)

### DIFF
--- a/src/Lucene.Net.Misc/Index/IndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/IndexSplitter.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Index
         {
             for (int x = 0; x < Infos.Count; x++)
             {
-                SegmentCommitInfo info = Infos.Info(x);
+                SegmentCommitInfo info = Infos[x];
                 string sizeStr = string.Format(CultureInfo.InvariantCulture, "{0:###,###.###}", info.GetSizeInBytes());
                 Console.WriteLine(info.Info.Name + " " + sizeStr);
             }
@@ -114,7 +114,7 @@ namespace Lucene.Net.Index
         {
             for (int x = 0; x < Infos.Count; x++)
             {
-                if (name.Equals(Infos.Info(x).Info.Name, StringComparison.Ordinal))
+                if (name.Equals(Infos[x].Info.Name, StringComparison.Ordinal))
                 {
                     return x;
                 }
@@ -126,9 +126,9 @@ namespace Lucene.Net.Index
         {
             for (int x = 0; x < Infos.Count; x++)
             {
-                if (name.Equals(Infos.Info(x).Info.Name, StringComparison.Ordinal))
+                if (name.Equals(Infos[x].Info.Name, StringComparison.Ordinal))
                 {
-                    return Infos.Info(x);
+                    return Infos[x];
                 }
             }
             return null;

--- a/src/Lucene.Net.Tests.Misc/Index/TestIndexSplitter.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/TestIndexSplitter.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Index
             iw.Dispose();
             // we should have 2 segments now
             IndexSplitter @is = new IndexSplitter(dir);
-            string splitSegName = @is.Infos.Info(1).Info.Name;
+            string splitSegName = @is.Infos[1].Info.Name;
             @is.Split(destDir, new string[] { splitSegName });
             Store.Directory fsDirDest = NewFSDirectory(destDir);
             DirectoryReader r = DirectoryReader.Open(fsDirDest);

--- a/src/Lucene.Net.Tests/Index/TestConsistentFieldNumbers.cs
+++ b/src/Lucene.Net.Tests/Index/TestConsistentFieldNumbers.cs
@@ -79,8 +79,8 @@ namespace Lucene.Net.Index
                 sis.Read(dir);
                 Assert.AreEqual(2, sis.Count);
 
-                FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis.Info(0));
-                FieldInfos fis2 = SegmentReader.ReadFieldInfos(sis.Info(1));
+                FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis[0]);
+                FieldInfos fis2 = SegmentReader.ReadFieldInfos(sis[1]);
 
                 Assert.AreEqual("f1", fis1.FieldInfo(0).Name);
                 Assert.AreEqual("f2", fis1.FieldInfo(1).Name);
@@ -97,7 +97,7 @@ namespace Lucene.Net.Index
                 sis.Read(dir);
                 Assert.AreEqual(1, sis.Count);
 
-                FieldInfos fis3 = SegmentReader.ReadFieldInfos(sis.Info(0));
+                FieldInfos fis3 = SegmentReader.ReadFieldInfos(sis[0]);
 
                 Assert.AreEqual("f1", fis3.FieldInfo(0).Name);
                 Assert.AreEqual("f2", fis3.FieldInfo(1).Name);
@@ -142,8 +142,8 @@ namespace Lucene.Net.Index
             sis.Read(dir1);
             Assert.AreEqual(2, sis.Count);
 
-            FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis.Info(0));
-            FieldInfos fis2 = SegmentReader.ReadFieldInfos(sis.Info(1));
+            FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis[0]);
+            FieldInfos fis2 = SegmentReader.ReadFieldInfos(sis[1]);
 
             Assert.AreEqual("f1", fis1.FieldInfo(0).Name);
             Assert.AreEqual("f2", fis1.FieldInfo(1).Name);
@@ -174,7 +174,7 @@ namespace Lucene.Net.Index
                     SegmentInfos sis = new SegmentInfos();
                     sis.Read(dir);
                     Assert.AreEqual(1, sis.Count);
-                    FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis.Info(0));
+                    FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis[0]);
                     Assert.AreEqual("f1", fis1.FieldInfo(0).Name);
                     Assert.AreEqual("f2", fis1.FieldInfo(1).Name);
                 }
@@ -189,8 +189,8 @@ namespace Lucene.Net.Index
                     SegmentInfos sis = new SegmentInfos();
                     sis.Read(dir);
                     Assert.AreEqual(2, sis.Count);
-                    FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis.Info(0));
-                    FieldInfos fis2 = SegmentReader.ReadFieldInfos(sis.Info(1));
+                    FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis[0]);
+                    FieldInfos fis2 = SegmentReader.ReadFieldInfos(sis[1]);
                     Assert.AreEqual("f1", fis1.FieldInfo(0).Name);
                     Assert.AreEqual("f2", fis1.FieldInfo(1).Name);
                     Assert.AreEqual("f1", fis2.FieldInfo(0).Name);
@@ -209,9 +209,9 @@ namespace Lucene.Net.Index
                     SegmentInfos sis = new SegmentInfos();
                     sis.Read(dir);
                     Assert.AreEqual(3, sis.Count);
-                    FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis.Info(0));
-                    FieldInfos fis2 = SegmentReader.ReadFieldInfos(sis.Info(1));
-                    FieldInfos fis3 = SegmentReader.ReadFieldInfos(sis.Info(2));
+                    FieldInfos fis1 = SegmentReader.ReadFieldInfos(sis[0]);
+                    FieldInfos fis2 = SegmentReader.ReadFieldInfos(sis[1]);
+                    FieldInfos fis3 = SegmentReader.ReadFieldInfos(sis[2]);
                     Assert.AreEqual("f1", fis1.FieldInfo(0).Name);
                     Assert.AreEqual("f2", fis1.FieldInfo(1).Name);
                     Assert.AreEqual("f1", fis2.FieldInfo(0).Name);
@@ -238,7 +238,7 @@ namespace Lucene.Net.Index
                 SegmentInfos sis_ = new SegmentInfos();
                 sis_.Read(dir);
                 Assert.AreEqual(1, sis_.Count);
-                FieldInfos fis1_ = SegmentReader.ReadFieldInfos(sis_.Info(0));
+                FieldInfos fis1_ = SegmentReader.ReadFieldInfos(sis_[0]);
                 Assert.AreEqual("f1", fis1_.FieldInfo(0).Name);
                 Assert.AreEqual("f2", fis1_.FieldInfo(1).Name);
                 Assert.AreEqual("f3", fis1_.FieldInfo(2).Name);

--- a/src/Lucene.Net.Tests/Index/TestPerSegmentDeletes.cs
+++ b/src/Lucene.Net.Tests/Index/TestPerSegmentDeletes.cs
@@ -138,8 +138,8 @@ namespace Lucene.Net.Index
             /// fsmp.length = 2;
             /// System.out.println("maybeMerge "+writer.SegmentInfos);
             ///
-            /// SegmentInfo info0 = writer.SegmentInfos.Info(0);
-            /// SegmentInfo info1 = writer.SegmentInfos.Info(1);
+            /// SegmentInfo info0 = writer.SegmentInfos[0];
+            /// SegmentInfo info1 = writer.SegmentInfos[1];
             ///
             /// writer.MaybeMerge();
             /// System.out.println("maybeMerge after "+writer.SegmentInfos);
@@ -214,7 +214,7 @@ namespace Lucene.Net.Index
             // deletes for info1, the newly created segment from the
             // merge should have no deletes because they were applied in
             // the merge
-            //SegmentInfo info1 = writer.SegmentInfos.Info(1);
+            //SegmentInfo info1 = writer.SegmentInfos[1];
             //Assert.IsFalse(exists(info1, writer.docWriter.segmentDeletes));
 
             //System.out.println("infos4:"+writer.SegmentInfos);

--- a/src/Lucene.Net.Tests/Index/TestSizeBoundedForceMerge.cs
+++ b/src/Lucene.Net.Tests/Index/TestSizeBoundedForceMerge.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using Assert = Lucene.Net.TestFramework.Assert;
@@ -80,7 +80,7 @@ namespace Lucene.Net.Index
 
             SegmentInfos sis = new SegmentInfos();
             sis.Read(dir);
-            double min = sis.Info(0).GetSizeInBytes();
+            double min = sis[0].GetSizeInBytes();
 
             conf = NewWriterConfig();
             LogByteSizeMergePolicy lmp = new LogByteSizeMergePolicy();
@@ -340,7 +340,7 @@ namespace Lucene.Net.Index
             SegmentInfos sis = new SegmentInfos();
             sis.Read(dir);
             Assert.AreEqual(3, sis.Count);
-            Assert.IsFalse(sis.Info(2).HasDeletions);
+            Assert.IsFalse(sis[2].HasDeletions);
         }
 
         [Test]
@@ -398,7 +398,7 @@ namespace Lucene.Net.Index
             SegmentInfos sis = new SegmentInfos();
             sis.Read(dir);
             Assert.AreEqual(1, sis.Count);
-            Assert.IsTrue(sis.Info(0).HasDeletions);
+            Assert.IsTrue(sis[0].HasDeletions);
         }
     }
 }

--- a/src/Lucene.Net/Index/CheckIndex.cs
+++ b/src/Lucene.Net/Index/CheckIndex.cs
@@ -676,7 +676,7 @@ namespace Lucene.Net.Index
 
             for (int i = 0; i < numSegments; i++)
             {
-                SegmentCommitInfo info = sis.Info(i);
+                SegmentCommitInfo info = sis[i];
                 int segmentName = 0;
                 try
                 {

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -488,7 +488,7 @@ namespace Lucene.Net.Index
                 {
                     int idx = outerInstance.segmentInfos.IndexOf(info);
                     Debugging.Assert(idx != -1, "info={0} isn't live", info);
-                    Debugging.Assert(outerInstance.segmentInfos.Info(idx) == info, "info={0} doesn't match live info in segmentInfos", info);
+                    Debugging.Assert(outerInstance.segmentInfos[idx] == info, "info={0} doesn't match live info in segmentInfos", info);
                     return true;
                 }
                 finally
@@ -2098,7 +2098,7 @@ namespace Lucene.Net.Index
             {
                 if (i >= 0 && i < segmentInfos.Count)
                 {
-                    return segmentInfos.Info(i).Info.DocCount;
+                    return segmentInfos[i].Info.DocCount;
                 }
                 else
                 {
@@ -5719,7 +5719,7 @@ namespace Lucene.Net.Index
             UninterruptableMonitor.Enter(this);
             try
             {
-                return segmentInfos.Count > 0 ? segmentInfos.Info(segmentInfos.Count - 1) : null;
+                return segmentInfos.Count > 0 ? segmentInfos[segmentInfos.Count - 1] : null;
             }
             finally
             {

--- a/src/Lucene.Net/Index/LogMergePolicy.cs
+++ b/src/Lucene.Net/Index/LogMergePolicy.cs
@@ -231,7 +231,7 @@ namespace Lucene.Net.Index
             bool segmentIsOriginal = false;
             for (int i = 0; i < numSegments && numToMerge <= maxNumSegments; i++)
             {
-                SegmentCommitInfo info = infos.Info(i);
+                SegmentCommitInfo info = infos[i];
                 if (segmentsToMerge.TryGetValue(info, out bool isOriginal))
                 {
                     segmentIsOriginal = isOriginal;
@@ -260,7 +260,7 @@ namespace Lucene.Net.Index
             int start = last - 1;
             while (start >= 0)
             {
-                SegmentCommitInfo info = infos.Info(start);
+                SegmentCommitInfo info = infos[start];
                 if (Size(info) > m_maxMergeSizeForForcedMerge || SizeDocs(info) > m_maxMergeDocs)
                 {
                     if (IsVerbose)
@@ -269,7 +269,7 @@ namespace Lucene.Net.Index
                     }
                     // need to skip that segment + add a merge for the 'right' segments,
                     // unless there is only 1 which is merged.
-                    if (last - start - 1 > 1 || (start != last - 1 && !IsMerged(infos, infos.Info(start + 1))))
+                    if (last - start - 1 > 1 || (start != last - 1 && !IsMerged(infos, infos[start + 1])))
                     {
                         // there is more than 1 segment to the right of
                         // this one, or a mergeable single segment.
@@ -288,7 +288,7 @@ namespace Lucene.Net.Index
 
             // Add any left-over segments, unless there is just 1
             // already fully merged
-            if (last > 0 && (++start + 1 < last || !IsMerged(infos, infos.Info(start))))
+            if (last > 0 && (++start + 1 < last || !IsMerged(infos, infos[start])))
             {
                 spec.Add(new OneMerge(segments.GetView(start, last - start))); // LUCENENET: Converted end index to length
             }
@@ -322,7 +322,7 @@ namespace Lucene.Net.Index
                 {
                     // Since we must merge down to 1 segment, the
                     // choice is simple:
-                    if (last > 1 || !IsMerged(infos, infos.Info(0)))
+                    if (last > 1 || !IsMerged(infos, infos[0]))
                     {
                         spec.Add(new OneMerge(segments.GetView(0, last))); // LUCENENET: Converted end index to length
                     }
@@ -349,9 +349,9 @@ namespace Lucene.Net.Index
                         long sumSize = 0;
                         for (int j = 0; j < finalMergeSize; j++)
                         {
-                            sumSize += Size(infos.Info(j + i));
+                            sumSize += Size(infos[j + i]);
                         }
-                        if (i == 0 || (sumSize < 2 * Size(infos.Info(i - 1)) && sumSize < bestSize))
+                        if (i == 0 || (sumSize < 2 * Size(infos[i - 1]) && sumSize < bestSize))
                         {
                             bestStart = i;
                             bestSize = sumSize;
@@ -402,7 +402,7 @@ namespace Lucene.Net.Index
             int last = infos.Count;
             while (last > 0)
             {
-                SegmentCommitInfo info = infos.Info(--last);
+                SegmentCommitInfo info = infos[--last];
                 if (segmentsToMerge.ContainsKey(info))
                 {
                     last++;
@@ -420,7 +420,7 @@ namespace Lucene.Net.Index
             }
 
             // There is only one segment already, and it is merged
-            if (maxNumSegments == 1 && last == 1 && IsMerged(infos, infos.Info(0)))
+            if (maxNumSegments == 1 && last == 1 && IsMerged(infos, infos[0]))
             {
                 if (IsVerbose)
                 {
@@ -433,7 +433,7 @@ namespace Lucene.Net.Index
             bool anyTooLarge = false;
             for (int i = 0; i < last; i++)
             {
-                SegmentCommitInfo info = infos.Info(i);
+                SegmentCommitInfo info = infos[i];
                 if (Size(info) > m_maxMergeSizeForForcedMerge || SizeDocs(info) > m_maxMergeDocs)
                 {
                     anyTooLarge = true;
@@ -472,7 +472,7 @@ namespace Lucene.Net.Index
             if (Debugging.AssertsEnabled) Debugging.Assert(w != null);
             for (int i = 0; i < numSegments; i++)
             {
-                SegmentCommitInfo info = segmentInfos.Info(i);
+                SegmentCommitInfo info = segmentInfos[i];
                 int delCount = w.NumDeletedDocs(info);
                 if (delCount > 0)
                 {
@@ -568,7 +568,7 @@ namespace Lucene.Net.Index
 
             for (int i = 0; i < numSegments; i++)
             {
-                SegmentCommitInfo info = infos.Info(i);
+                SegmentCommitInfo info = infos[i];
                 long size = Size(info);
 
                 // Floor tiny segments

--- a/src/Lucene.Net/Index/SegmentInfos.cs
+++ b/src/Lucene.Net/Index/SegmentInfos.cs
@@ -167,7 +167,6 @@ namespace Lucene.Net.Index
         /// <para/>
         /// This also implements the switch for <see cref="UseLegacySegmentNames"/> so it doesn't have to be dealt with externally.
         /// </summary>
-        /// <
         internal static string SegmentNumberToString(long segment, bool allowLegacyNames = true)
         {
             switch (segment)
@@ -322,14 +321,19 @@ namespace Lucene.Net.Index
         {
         }
 
-        /// <summary>
-        /// Returns <see cref="SegmentCommitInfo"/> at the provided
-        /// index.
-        /// </summary>
-        public SegmentCommitInfo Info(int i) // LUCENENET TODO: API - add indexer for this class
+        [Obsolete("Use indexer instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public SegmentCommitInfo Info(int i)
         {
             return segments[i];
         }
+
+        /// <summary>
+        /// Returns <see cref="SegmentCommitInfo"/> at the provided
+        /// index.
+        /// <para/>
+        /// This was info(int) in Lucene.
+        /// </summary>
+        public SegmentCommitInfo this[int index] => segments[index];
 
         /// <summary>
         /// Get the generation of the most recent commit to the
@@ -1296,7 +1300,7 @@ namespace Lucene.Net.Index
             var size = Count;
             for (int i = 0; i < size; i++)
             {
-                var info = Info(i);
+                var info = this[i];
                 if (Debugging.AssertsEnabled) Debugging.Assert(info.Info.Dir == dir);
                 if (info.Info.Dir == dir)
                 {
@@ -1413,7 +1417,7 @@ namespace Lucene.Net.Index
                 {
                     buffer.Append(' ');
                 }
-                SegmentCommitInfo info = Info(i);
+                SegmentCommitInfo info = this[i];
                 buffer.Append(info.ToString(directory, 0));
             }
             return buffer.ToString();

--- a/src/Lucene.Net/Index/StandardDirectoryReader.cs
+++ b/src/Lucene.Net/Index/StandardDirectoryReader.cs
@@ -76,7 +76,7 @@ namespace Lucene.Net.Index
                     bool success = false;
                     try
                     {
-                        readers[i] = new SegmentReader(sis.Info(i), termInfosIndexDivisor, IOContext.READ);
+                        readers[i] = new SegmentReader(sis[i], termInfosIndexDivisor, IOContext.READ);
                         success = true;
                     }
                     finally
@@ -114,7 +114,7 @@ namespace Lucene.Net.Index
                     // segmentInfos here, so that we are passing the
                     // actual instance of SegmentInfoPerCommit in
                     // IndexWriter's segmentInfos:
-                    SegmentCommitInfo info = infos.Info(i);
+                    SegmentCommitInfo info = infos[i];
                     if (Debugging.AssertsEnabled) Debugging.Assert(info.Info.Dir == dir);
                     ReadersAndUpdates rld = writer.readerPool.Get(info, true);
                     try
@@ -191,7 +191,7 @@ namespace Lucene.Net.Index
             for (int i = infos.Count - 1; i >= 0; i--)
             {
                 // find SegmentReader for this segment
-                if (!segmentReaders.TryGetValue(infos.Info(i).Info.Name, out int oldReaderIndex))
+                if (!segmentReaders.TryGetValue(infos[i].Info.Name, out int oldReaderIndex))
                 {
                     // this is a new segment, no old SegmentReader can be reused
                     newReaders[i] = null;
@@ -207,16 +207,16 @@ namespace Lucene.Net.Index
                 try
                 {
                     SegmentReader newReader;
-                    if (newReaders[i] == null || infos.Info(i).Info.UseCompoundFile != newReaders[i].SegmentInfo.Info.UseCompoundFile)
+                    if (newReaders[i] == null || infos[i].Info.UseCompoundFile != newReaders[i].SegmentInfo.Info.UseCompoundFile)
                     {
                         // this is a new reader; in case we hit an exception we can close it safely
-                        newReader = new SegmentReader(infos.Info(i), termInfosIndexDivisor, IOContext.READ);
+                        newReader = new SegmentReader(infos[i], termInfosIndexDivisor, IOContext.READ);
                         readerShared[i] = false;
                         newReaders[i] = newReader;
                     }
                     else
                     {
-                        if (newReaders[i].SegmentInfo.DelGen == infos.Info(i).DelGen && newReaders[i].SegmentInfo.FieldInfosGen == infos.Info(i).FieldInfosGen)
+                        if (newReaders[i].SegmentInfo.DelGen == infos[i].DelGen && newReaders[i].SegmentInfo.FieldInfosGen == infos[i].FieldInfosGen)
                         {
                             // No change; this reader will be shared between
                             // the old and the new one, so we must incRef
@@ -231,18 +231,18 @@ namespace Lucene.Net.Index
                             // Steal the ref returned by SegmentReader ctor:
                             if (Debugging.AssertsEnabled)
                             {
-                                Debugging.Assert(infos.Info(i).Info.Dir == newReaders[i].SegmentInfo.Info.Dir);
-                                Debugging.Assert(infos.Info(i).HasDeletions || infos.Info(i).HasFieldUpdates);
+                                Debugging.Assert(infos[i].Info.Dir == newReaders[i].SegmentInfo.Info.Dir);
+                                Debugging.Assert(infos[i].HasDeletions || infos[i].HasFieldUpdates);
                             }
-                            if (newReaders[i].SegmentInfo.DelGen == infos.Info(i).DelGen)
+                            if (newReaders[i].SegmentInfo.DelGen == infos[i].DelGen)
                             {
                                 // only DV updates
-                                newReaders[i] = new SegmentReader(infos.Info(i), newReaders[i], newReaders[i].LiveDocs, newReaders[i].NumDocs);
+                                newReaders[i] = new SegmentReader(infos[i], newReaders[i], newReaders[i].LiveDocs, newReaders[i].NumDocs);
                             }
                             else
                             {
                                 // both DV and liveDocs have changed
-                                newReaders[i] = new SegmentReader(infos.Info(i), newReaders[i]);
+                                newReaders[i] = new SegmentReader(infos[i], newReaders[i]);
                             }
                         }
                     }


### PR DESCRIPTION
Changed `Lucene.Net.Index.SegmentInfos.Info()` method into an indexer for the class to make it simpler to understand (we had `Infos.Info(x).Info.Name`, it is now `Infos[x].Info.Name`). Marked `Info()` obsolete.