### PR TITLE
Lucene.Net.Facet: Added culture-sensitve ToString() overload on FacetResult and LabelAndValue

### DIFF
--- a/src/Lucene.Net.Facet/FacetResult.cs
+++ b/src/Lucene.Net.Facet/FacetResult.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
+#nullable enable
 
 namespace Lucene.Net.Facet
 {
@@ -27,7 +28,7 @@ namespace Lucene.Net.Facet
     /// <summary>
     /// Counts or aggregates for a single dimension.
     /// </summary>
-    public sealed class FacetResult
+    public sealed class FacetResult : IFormattable
     {
         /// <summary>
         /// Dimension that was requested.
@@ -98,31 +99,50 @@ namespace Lucene.Net.Facet
             this.ChildCount = childCount;
         }
 
+        /// <summary>
+        /// Converts the value of this instance to its equivalent string representation.
+        /// </summary>
+        /// <returns>A string representation of the values of <see cref="FacetResult"/>.</returns>
         public override string ToString()
+        {
+            return ToString(null);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to its equivalent string representation
+        /// using the specified culture-specific format information.
+        /// </summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <returns>A string representation of the values of <see cref="FacetResult"/>
+        /// as specified by <paramref name="provider"/>.</returns>
+        // LUCENENET specific - allow passing in a format provider to format the numbers.
+        public string ToString(IFormatProvider? provider)
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("dim=");
             sb.Append(Dim);
             sb.Append(" path=");
-            sb.Append(Arrays.ToString(Path));
+            sb.Append(Arrays.ToString(Path, provider));
             sb.Append(" value=");
             if (TypeOfValue == typeof(int))
             {
-                sb.AppendFormat(CultureInfo.InvariantCulture, "{0:0}", Value); // No formatting (looks like int)
+                sb.Append(J2N.Numerics.Int32.ToString(Convert.ToInt32(Value), provider)); // No formatting (looks like int)
             }
             else
             {
-                sb.AppendFormat(CultureInfo.InvariantCulture, "{0:0.0#####}", Value); // Decimal formatting
+                sb.Append(J2N.Numerics.Single.ToString(Value, provider)); // Decimal formatting
             }
             sb.Append(" childCount=");
             sb.Append(ChildCount);
             sb.Append('\n');
             foreach (LabelAndValue labelValue in LabelValues)
             {
-                sb.Append("  " + labelValue + "\n");
+                sb.Append("  " + labelValue.ToString(provider) + "\n");
             }
             return sb.ToString();
         }
+
+        string IFormattable.ToString(string? format, IFormatProvider? provider) => ToString(provider);
 
         public override bool Equals(object other)
         {

--- a/src/Lucene.Net.Facet/FacetResult.cs
+++ b/src/Lucene.Net.Facet/FacetResult.cs
@@ -71,10 +71,13 @@ namespace Lucene.Net.Facet
         /// print the <paramref name="value"/> as a <see cref="float"/> with at least 1 number after the decimal.
         /// </summary>
         public FacetResult(string dim, string[] path, float value, LabelAndValue[] labelValues, int childCount)
-            : this(dim, path, labelValues, childCount)
         {
+            this.Dim = dim ?? throw new ArgumentNullException(nameof(dim)); // LUCENENET: Added guard clause
+            this.Path = path ?? throw new ArgumentNullException(nameof(path)); // LUCENENET: Added guard clause
             this.Value = value;
             this.TypeOfValue = typeof(float);
+            this.LabelValues = labelValues ?? throw new ArgumentNullException(nameof(labelValues)); // LUCENENET: Added guard clause
+            this.ChildCount = childCount;
         }
 
         /// <summary>
@@ -82,20 +85,12 @@ namespace Lucene.Net.Facet
         /// print the <paramref name="value"/> as an <see cref="int"/> with no decimal.
         /// </summary>
         public FacetResult(string dim, string[] path, int value, LabelAndValue[] labelValues, int childCount)
-            : this(dim, path, labelValues, childCount)
         {
+            this.Dim = dim ?? throw new ArgumentNullException(nameof(dim)); // LUCENENET: Added guard clause
+            this.Path = path ?? throw new ArgumentNullException(nameof(path)); // LUCENENET: Added guard clause
             this.Value = value;
             this.TypeOfValue = typeof(int);
-        }
-
-        /// <summary>
-        /// Private constructor for shared parameters to be called by public constructors.
-        /// </summary>
-        private FacetResult(string dim, string[] path, LabelAndValue[] labelValues, int childCount)
-        {
-            this.Dim = dim;
-            this.Path = path;
-            this.LabelValues = labelValues;
+            this.LabelValues = labelValues ?? throw new ArgumentNullException(nameof(labelValues)); // LUCENENET: Added guard clause
             this.ChildCount = childCount;
         }
 
@@ -144,7 +139,7 @@ namespace Lucene.Net.Facet
 
         string IFormattable.ToString(string? format, IFormatProvider? provider) => ToString(provider);
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             if ((other is FacetResult) == false)
             {

--- a/src/Lucene.Net.Facet/LabelAndValue.cs
+++ b/src/Lucene.Net.Facet/LabelAndValue.cs
@@ -89,7 +89,7 @@ namespace Lucene.Net.Facet
 
         string IFormattable.ToString(string? format, IFormatProvider? provider) => ToString(provider);
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             if ((other is LabelAndValue) == false)
             {

--- a/src/Lucene.Net.Facet/LabelAndValue.cs
+++ b/src/Lucene.Net.Facet/LabelAndValue.cs
@@ -1,6 +1,7 @@
 ﻿// Lucene version compatibility level 4.8.1
 using System;
 using System.Globalization;
+#nullable enable
 
 namespace Lucene.Net.Facet
 {
@@ -25,7 +26,7 @@ namespace Lucene.Net.Facet
     /// Single label and its value, usually contained in a
     /// <see cref="FacetResult"/>. 
     /// </summary>
-    public sealed class LabelAndValue
+    public sealed class LabelAndValue : IFormattable
     {
         /// <summary>
         /// Facet's label. </summary>
@@ -62,13 +63,31 @@ namespace Lucene.Net.Facet
             this.TypeOfValue = typeof(int);
         }
 
+        /// <summary>
+        /// Converts the value of this instance to its equivalent string representation.
+        /// </summary>
+        /// <returns>The string representation of the label and value of this instance.</returns>
         public override string ToString()
         {
+            return ToString(null);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to its equivalent string representation
+        /// using the specified culture-specific format information.
+        /// </summary>
+        /// <returns>The string representation of the label and value of this instance
+        /// as specified by <paramref name="provider"/>.</returns>
+        // LUCENENET specific - allow passing in a format provider to format the numbers.
+        public string ToString(IFormatProvider? provider)
+        {
             string valueString = (TypeOfValue == typeof(int))
-                ? Value.ToString("0", CultureInfo.InvariantCulture)
-                : Value.ToString("0.0#####", CultureInfo.InvariantCulture);
+                ? J2N.Numerics.Int32.ToString(Convert.ToInt32(Value), provider)
+                : J2N.Numerics.Single.ToString(Value, provider);
             return Label + " (" + valueString + ")";
         }
+
+        string IFormattable.ToString(string? format, IFormatProvider? provider) => ToString(provider);
 
         public override bool Equals(object other)
         {

--- a/src/Lucene.Net.Tests.Demo/Facet/TestAssociationsFacetsExample.cs
+++ b/src/Lucene.Net.Tests.Demo/Facet/TestAssociationsFacetsExample.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Lucene.Net.Demo.Facet
 {
@@ -29,16 +30,16 @@ namespace Lucene.Net.Demo.Facet
         public void TestExamples()
         {
             IList<FacetResult> res = new AssociationsFacetsExample().RunSumAssociations();
-            assertEquals("Wrong number of results", 2, res.size());
-            assertEquals("dim=tags path=[] value=-1 childCount=2\n  lucene (4)\n  solr (2)\n", res[0].toString());
-            assertEquals("dim=genre path=[] value=-1.0 childCount=2\n  computing (1.62)\n  software (0.34)\n", res[1].toString());
+            assertEquals("Wrong number of results", 2, res.Count);
+            assertEquals("dim=tags path=[] value=-1 childCount=2\n  lucene (4)\n  solr (2)\n", res[0].ToString(CultureInfo.InvariantCulture));
+            assertEquals("dim=genre path=[] value=-1.0 childCount=2\n  computing (1.62)\n  software (0.34)\n", res[1].ToString(CultureInfo.InvariantCulture));
         }
 
         [Test]
         public void TestDrillDown()
         {
             FacetResult result = new AssociationsFacetsExample().RunDrillDown();
-            assertEquals("dim=genre path=[] value=-1.0 childCount=2\n  computing (0.75)\n  software (0.34)\n", result.toString());
+            assertEquals("dim=genre path=[] value=-1.0 childCount=2\n  computing (0.75)\n  software (0.34)\n", result.ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/src/Lucene.Net.Tests.Demo/Facet/TestExpressionAggregationFacetsExample.cs
+++ b/src/Lucene.Net.Tests.Demo/Facet/TestExpressionAggregationFacetsExample.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Facet;
 using Lucene.Net.Util;
 using NUnit.Framework;
+using System.Globalization;
 
 namespace Lucene.Net.Demo.Facet
 {
@@ -28,9 +29,7 @@ namespace Lucene.Net.Demo.Facet
         public void TestSimple()
         {
             FacetResult result = new ExpressionAggregationFacetsExample().RunSearch();
-            //assertEquals("dim=A path=[] value=3.9681187 childCount=2\n  B (2.236068)\n  C (1.7320508)\n", result.toString());
-            // LUCENENET TODO: string output is not quite the same as in Java, but it is close enough not to be considered a bug
-            assertEquals("dim=A path=[] value=3.968119 childCount=2\n  B (2.236068)\n  C (1.732051)\n", result.toString());
+            assertEquals("dim=A path=[] value=3.9681187 childCount=2\n  B (2.236068)\n  C (1.7320508)\n", result.ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
@@ -1,6 +1,8 @@
 ﻿// Lucene version compatibility level 4.8.1
+using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
+using System.Globalization;
 using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Facet.Taxonomy
@@ -124,7 +126,7 @@ namespace Lucene.Net.Facet.Taxonomy
             searcher.Search(new MatchAllDocsQuery(), fc);
 
             Facets facets = new TaxonomyFacetSumInt32Associations("$facets.int", taxoReader, config, fc);
-            Assert.AreEqual("dim=int path=[] value=-1 childCount=2\n  a (200)\n  b (150)\n", facets.GetTopChildren(10, "int").ToString());
+            Assert.AreEqual("dim=int path=[] value=-1 childCount=2\n  a (200)\n  b (150)\n", facets.GetTopChildren(10, "int").ToString(CultureInfo.InvariantCulture));
             Assert.AreEqual(200, (int)facets.GetSpecificValue("int", "a"), "Wrong count for category 'a'!");
             Assert.AreEqual(150, (int)facets.GetSpecificValue("int", "b"), "Wrong count for category 'b'!");
         }
@@ -138,9 +140,10 @@ namespace Lucene.Net.Facet.Taxonomy
             searcher.Search(new MatchAllDocsQuery(), fc);
 
             Facets facets = new TaxonomyFacetSumSingleAssociations("$facets.float", taxoReader, config, fc);
-            Assert.AreEqual("dim=float path=[] value=-1.0 childCount=2\n  a (50.0)\n  b (9.999995)\n", facets.GetTopChildren(10, "float").ToString());
-            Assert.AreEqual(50f, (float)facets.GetSpecificValue("float", "a"), 0.00001, "Wrong count for category 'a'!");
-            Assert.AreEqual(10f, (float)facets.GetSpecificValue("float", "b"), 0.00001, "Wrong count for category 'b'!");
+
+            Assert.AreEqual("dim=float path=[] value=-1.0 childCount=2\n  a (50.0)\n  b (9.999995)\n", facets.GetTopChildren(10, "float").ToString(CultureInfo.InvariantCulture));
+            Assert.AreEqual(50f, (float)facets.GetSpecificValue("float", "a"), 0.00001f, "Wrong count for category 'a'!");
+            Assert.AreEqual(10f, (float)facets.GetSpecificValue("float", "b"), 0.00001f, "Wrong count for category 'b'!");
         }
 
         /// <summary>
@@ -156,8 +159,8 @@ namespace Lucene.Net.Facet.Taxonomy
             searcher.Search(new MatchAllDocsQuery(), fc);
 
             Facets facets = new TaxonomyFacetSumSingleAssociations("$facets.float", taxoReader, config, fc);
-            Assert.AreEqual(50f, (float)facets.GetSpecificValue("float", "a"), 0.00001, "Wrong count for category 'a'!");
-            Assert.AreEqual(10f, (float)facets.GetSpecificValue("float", "b"), 0.00001, "Wrong count for category 'b'!");
+            Assert.AreEqual(50f, (float)facets.GetSpecificValue("float", "a"), 0.00001f, "Wrong count for category 'a'!");
+            Assert.AreEqual(10f, (float)facets.GetSpecificValue("float", "b"), 0.00001f, "Wrong count for category 'b'!");
 
             facets = new TaxonomyFacetSumInt32Associations("$facets.int", taxoReader, config, fc);
             Assert.AreEqual(200, (int)facets.GetSpecificValue("int", "a"), "Wrong count for category 'a'!");
@@ -292,7 +295,7 @@ namespace Lucene.Net.Facet.Taxonomy
             searcher.Search(q, fc);
 
             Facets facets = new TaxonomyFacetSumInt32Associations("$facets.int", taxoReader, config, fc);
-            Assert.AreEqual("dim=int path=[] value=-1 childCount=2\n  b (150)\n  a (100)\n", facets.GetTopChildren(10, "int").ToString());
+            Assert.AreEqual("dim=int path=[] value=-1 childCount=2\n  b (150)\n  a (100)\n", facets.GetTopChildren(10, "int").ToString(CultureInfo.InvariantCulture));
             Assert.AreEqual(100, (int)facets.GetSpecificValue("int", "a"), "Wrong count for category 'a'!");
             Assert.AreEqual(150, (int)facets.GetSpecificValue("int", "b"), "Wrong count for category 'b'!");
         }

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
@@ -419,7 +419,7 @@ namespace Lucene.Net.Facet.Taxonomy
             Assert.AreEqual(1, facets.GetSpecificValue("dim", "test\u001Etwo"));
 
             FacetResult result = facets.GetTopChildren(10, "dim");
-            Assert.AreEqual("dim=dim path=[] value=-1 childCount=2\n  test\u001Fone (1)\n  test\u001Etwo (1)\n", result.ToString());
+            Assert.AreEqual("dim=dim path=[] value=-1 childCount=2\n  test\u001Fone (1)\n  test\u001Etwo (1)\n", result.ToString(CultureInfo.InvariantCulture));
             IOUtils.Dispose(writer, taxoWriter, searcher.IndexReader, taxoReader, dir, taxoDir);
         }
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
@@ -132,7 +132,7 @@ namespace Lucene.Net.Facet.Taxonomy
             TaxonomyFacetSumValueSource facets = new TaxonomyFacetSumValueSource(taxoReader, new FacetsConfig(), c, new Int32FieldSource("num"));
 
             // Retrieve & verify results:
-            Assert.AreEqual("dim=Author path=[] value=145.0 childCount=4\n  Lisa (50.0)\n  Frank (45.0)\n  Susan (40.0)\n  Bob (10.0)\n", facets.GetTopChildren(10, "Author").ToString());
+            Assert.AreEqual("dim=Author path=[] value=145.0 childCount=4\n  Lisa (50.0)\n  Frank (45.0)\n  Susan (40.0)\n  Bob (10.0)\n", facets.GetTopChildren(10, "Author").ToString(CultureInfo.InvariantCulture));
 
             taxoReader.Dispose();
             searcher.IndexReader.Dispose();
@@ -203,9 +203,9 @@ namespace Lucene.Net.Facet.Taxonomy
             IList<FacetResult> results = facets.GetAllDims(10);
 
             Assert.AreEqual(3, results.Count);
-            Assert.AreEqual("dim=a path=[] value=60.0 childCount=3\n  foo3 (30.0)\n  foo2 (20.0)\n  foo1 (10.0)\n", results[0].ToString());
-            Assert.AreEqual("dim=b path=[] value=50.0 childCount=2\n  bar2 (30.0)\n  bar1 (20.0)\n", results[1].ToString());
-            Assert.AreEqual("dim=c path=[] value=30.0 childCount=1\n  baz1 (30.0)\n", results[2].ToString());
+            Assert.AreEqual("dim=a path=[] value=60.0 childCount=3\n  foo3 (30.0)\n  foo2 (20.0)\n  foo1 (10.0)\n", results[0].ToString(CultureInfo.InvariantCulture));
+            Assert.AreEqual("dim=b path=[] value=50.0 childCount=2\n  bar2 (30.0)\n  bar1 (20.0)\n", results[1].ToString(CultureInfo.InvariantCulture));
+            Assert.AreEqual("dim=c path=[] value=30.0 childCount=1\n  baz1 (30.0)\n", results[2].ToString(CultureInfo.InvariantCulture));
 
             IOUtils.Dispose(searcher.IndexReader, taxoReader, dir, taxoDir);
         }
@@ -336,7 +336,7 @@ namespace Lucene.Net.Facet.Taxonomy
             FacetsCollector sfc = new FacetsCollector();
             NewSearcher(r).Search(new MatchAllDocsQuery(), sfc);
             Facets facets = new TaxonomyFacetSumValueSource(taxoReader, config, sfc, new Int64FieldSource("price"));
-            Assert.AreEqual("dim=a path=[] value=10.0 childCount=2\n  1 (6.0)\n  0 (4.0)\n", facets.GetTopChildren(10, "a").ToString());
+            Assert.AreEqual("dim=a path=[] value=10.0 childCount=2\n  1 (6.0)\n  0 (4.0)\n", facets.GetTopChildren(10, "a").ToString(CultureInfo.InvariantCulture));
 
             IOUtils.Dispose(taxoWriter, iw, taxoReader, taxoDir, r, indexDir);
         }
@@ -370,7 +370,7 @@ namespace Lucene.Net.Facet.Taxonomy
             FacetsCollector.Search(NewSearcher(r), q, 10, fc);
             Facets facets = new TaxonomyFacetSumValueSource(taxoReader, config, fc, valueSource);
 
-            Assert.AreEqual("dim=a path=[] value=10.0 childCount=2\n  1 (6.0)\n  0 (4.0)\n", facets.GetTopChildren(10, "a").ToString());
+            Assert.AreEqual("dim=a path=[] value=10.0 childCount=2\n  1 (6.0)\n  0 (4.0)\n", facets.GetTopChildren(10, "a").ToString(CultureInfo.InvariantCulture));
 
             IOUtils.Dispose(taxoWriter, iw, taxoReader, taxoDir, r, indexDir);
         }
@@ -462,7 +462,7 @@ namespace Lucene.Net.Facet.Taxonomy
             NewSearcher(r).Search(new MatchAllDocsQuery(), sfc);
             Facets facets = new TaxonomyFacetSumValueSource(taxoReader, config, sfc, valueSource);
 
-            Assert.AreEqual("dim=a path=[] value=10.0 childCount=2\n  1 (6.0)\n  0 (4.0)\n", facets.GetTopChildren(10, "a").ToString());
+            Assert.AreEqual("dim=a path=[] value=10.0 childCount=2\n  1 (6.0)\n  0 (4.0)\n", facets.GetTopChildren(10, "a").ToString(CultureInfo.InvariantCulture));
 
             IOUtils.Dispose(taxoWriter, iw, taxoReader, taxoDir, r, indexDir);
         }

--- a/src/Lucene.Net/Support/Arrays.cs
+++ b/src/Lucene.Net/Support/Arrays.cs
@@ -151,7 +151,8 @@ namespace Lucene.Net.Support
         /// the array is <c>null</c>, then <c>"null"</c> is returned.
         /// </summary>
         /// <typeparam name="T">The type of array element.</typeparam>
-        /// <param name="array"></param>
+        /// <param name="array">The array to convert.</param>
+        /// <returns>The converted array string.</returns>
         public static string ToString<T>(T[] array)
         {
             if (array == null)
@@ -165,6 +166,35 @@ namespace Lucene.Net.Support
             {
                 sb.Append(", "); //$NON-NLS-1$
                 sb.AppendFormat(J2N.Text.StringFormatter.InvariantCulture, "{0}", array[i]);
+            }
+            sb.Append(']');
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Creates a <see cref="string"/> representation of the array passed.
+        /// The result is surrounded by brackets <c>"[]"</c>, each
+        /// element is converted to a <see cref="string"/> via the
+        /// <paramref name="provider"/> and separated by <c>", "</c>. If
+        /// the array is <c>null</c>, then <c>"null"</c> is returned.
+        /// </summary>
+        /// <typeparam name="T">The type of array element.</typeparam>
+        /// <param name="array">The array to convert.</param>
+        /// <param name="provider">A <see cref="IFormatProvider"/> instance that supplies the culture formatting information.</param>
+        /// <returns>The converted array string.</returns>
+        public static string ToString<T>(T[] array, IFormatProvider provider)
+        {
+            if (array == null)
+                return "null"; //$NON-NLS-1$
+            if (array.Length == 0)
+                return "[]"; //$NON-NLS-1$
+            StringBuilder sb = new StringBuilder(2 + array.Length * 4);
+            sb.Append('[');
+            sb.AppendFormat(provider, "{0}", array[0]);
+            for (int i = 1; i < array.Length; i++)
+            {
+                sb.Append(", "); //$NON-NLS-1$
+                sb.AppendFormat(provider, "{0}", array[i]);
             }
             sb.Append(']');
             return sb.ToString();


### PR DESCRIPTION
Added overload of `ToString()` that accepts `IFormatProvider` to `FacetResult` and `LabelAndValue` classes. Also implemented `IFormattable` on both classes.

The default format has changed from invariant culture to current culture to match .NET.