### PR TITLE
BREAKING: Lucene.Net.Documents.DateTools/Lucene.Net.QueryParser Updates

### DIFF
--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/DocData.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/DocData.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
 
         /// <summary>
         /// Gets the date. If the ctor with <see cref="DateTime"/> was called, then the string
-        /// returned is the output of <see cref="DateTools.DateToString(DateTime, DateTools.Resolution)"/>.
+        /// returned is the output of <see cref="DateTools.DateToString(DateTime, DateResolution)"/>.
         /// Otherwise it's the string passed to the other ctor.
         /// </summary>
         public virtual string Date => date;
@@ -54,7 +54,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         {
             if (date.HasValue)
             {
-                SetDate(DateTools.DateToString(date.Value, DateTools.Resolution.SECOND));
+                SetDate(DateTools.DateToString(date.Value, DateResolution.SECOND));
             }
             else
             {

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/TrecContentSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/TrecContentSource.cs
@@ -67,23 +67,23 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         private static readonly string[] DATE_FORMATS = {
             // LUCENENET specific: in JAVA, they don't care if it is an abbreviated or a full month name when parsing
             // so we provide definitions for both ways.
-            "ddd, dd MMM yyyy hh:mm:ss K",   // Tue, 09 Dec 2003 22:39:08 GMT
-            "ddd, dd MMMM yyyy hh:mm:ss K",  // Tue, 09 December 2003 22:39:08 GMT
-            "ddd MMM dd hh:mm:ss yyyy K",    // Tue Dec 09 16:45:08 2003 EST
-            "ddd MMMM dd hh:mm:ss yyyy K",   // Tue December 09 16:45:08 2003 EST
-            "ddd, dd-MMM-':'y hh:mm:ss K",   // Tue, 09 Dec 2003 22:39:08 GMT
-            "ddd, dd-MMMM-':'y hh:mm:ss K",  // Tue, 09 December 2003 22:39:08 GMT
-            "ddd, dd-MMM-yyy hh:mm:ss K",    // Tue, 09 Dec 2003 22:39:08 GMT
-            "ddd, dd-MMMM-yyy hh:mm:ss K",   // Tue, 09 December 2003 22:39:08 GMT
-            "ddd MMM dd hh:mm:ss yyyy",      // Tue Dec 09 16:45:08 2003
-            "ddd MMMM dd hh:mm:ss yyyy",     // Tue December 09 16:45:08 2003
-            "dd MMM yyyy",                   // 1 Mar 1994
-            "dd MMMM yyyy",                  // 1 March 1994
-            "MMM dd, yyyy",                  // Feb 3, 1994
-            "MMMM dd, yyyy",                 // February 3, 1994
-            "yyMMdd",                        // 910513
-            "hhmm K.K.K. MMM dd, yyyy",      // 0901 u.t.c. Apr 28, 1994
-            "hhmm K.K.K. MMMM dd, yyyy",     // 0901 u.t.c. April 28, 1994
+            "ddd, dd MMM yyyy hh:mm:ss zzz",   // Tue, 09 Dec 2003 22:39:08 GMT (format not supported in .NET, must specify +0:00 instead of GMT)
+            "ddd, dd MMMM yyyy hh:mm:ss zzz",  // Tue, 09 December 2003 22:39:08 GMT (format not supported in .NET, must specify +0:00 instead of GMT)
+            "ddd MMM dd hh:mm:ss yyyy zzz",    // Tue Dec 09 16:45:08 2003 EST (format not supported in .NET, must specify +5:00/+4:00 instead of EST)
+            "ddd MMMM dd hh:mm:ss yyyy zzz",   // Tue December 09 16:45:08 2003 EST (format not supported in .NET, must specify +5:00/+4:00 instead of EST)
+            "ddd, dd-MMM-':'y hh:mm:ss zzz",   // Tue, 09 Dec 2003 22:39:08 GMT (format not supported in .NET, must specify +0:00 instead of GMT)
+            "ddd, dd-MMMM-':'y hh:mm:ss zzz",  // Tue, 09 December 2003 22:39:08 GMT (format not supported in .NET, must specify +0:00 instead of GMT)
+            "ddd, dd-MMM-yyy hh:mm:ss zzz",    // Tue, 09 Dec 2003 22:39:08 GMT (format not supported in .NET, must specify +0:00 instead of GMT)
+            "ddd, dd-MMMM-yyy hh:mm:ss zzz",   // Tue, 09 December 2003 22:39:08 GMT (format not supported in .NET, must specify +0:00 instead of GMT)
+            "ddd MMM dd hh:mm:ss yyyy",        // Tue Dec 09 16:45:08 2003
+            "ddd MMMM dd hh:mm:ss yyyy",       // Tue December 09 16:45:08 2003
+            "dd MMM yyyy",                     // 1 Mar 1994
+            "dd MMMM yyyy",                    // 1 March 1994
+            "MMM dd, yyyy",                    // Feb 3, 1994
+            "MMMM dd, yyyy",                   // February 3, 1994
+            "yyMMdd",                          // 910513
+            "hhmm zzz MMM dd, yyyy",           // 0901 u.t.c. Apr 28, 1994 (format not supported in .NET, must specify +0:00 instead of u.t.c.)
+            "hhmm zzz MMMM dd, yyyy",          // 0901 u.t.c. April 28, 1994 (format not supported in .NET, must specify +0:00 instead of u.t.c.)
         };
 
         private readonly DisposableThreadLocal<StringBuilder> trecDocBuffer = new DisposableThreadLocal<StringBuilder>();
@@ -203,11 +203,11 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             dateStr = dateStr.Trim();
             if (DateTime.TryParseExact(dateStr, DATE_FORMATS, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime d))
             {
-                return d;
+                return d.ToUniversalTime();
             }
             else if (DateTime.TryParse(dateStr, CultureInfo.InvariantCulture, DateTimeStyles.None, out d))
             {
-                return d;
+                return d.ToUniversalTime();
             }
 
             // do not fail test just because a date could not be parsed

--- a/src/Lucene.Net.QueryParser/Classic/QueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParser.cs
@@ -68,13 +68,13 @@ namespace Lucene.Net.QueryParsers.Classic
     /// <tt>date:[6/1/2005 TO 6/4/2005]</tt> produces a range query that searches
     /// for "date" fields between 2005-06-01 and 2005-06-04. Note that the format
     /// of the accepted input depends on the <see cref="System.Globalization.CultureInfo" />.
-    /// A <see cref="Documents.DateTools.Resolution" /> has to be set,
+    /// A <see cref="Documents.DateResolution" /> has to be set,
     /// if you want to use <see cref="Documents.DateTools"/> for date conversion.<p/>
     /// </para>
     /// <para>
     /// The date resolution that shall be used for RangeQueries can be set
-    /// using <see cref="QueryParserBase.SetDateResolution(Documents.DateTools.Resolution)" />
-    /// or <see cref="QueryParserBase.SetDateResolution(string, Documents.DateTools.Resolution)" />. The former
+    /// using <see cref="QueryParserBase.SetDateResolution(Documents.DateResolution)" />
+    /// or <see cref="QueryParserBase.SetDateResolution(string, Documents.DateResolution)" />. The former
     /// sets the default date resolution for all fields, whereas the latter can
     /// be used to set field specific date resolutions. Field specific date
     /// resolutions take, if set, precedence over the default date resolution.

--- a/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
@@ -1,4 +1,5 @@
 ﻿using J2N;
+using J2N.Globalization;
 using J2N.Numerics;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.TokenAttributes;
@@ -872,20 +873,18 @@ namespace Lucene.Net.QueryParsers.Classic
         internal virtual Query HandleBareFuzzy(string qfield, Token fuzzySlop, string termImage)
         {
             Query q;
-            float fms = FuzzyMinSim;
-            try
+            string fuzzySlopStr = fuzzySlop.Image.Substring(1);
+            if (fuzzySlopStr == string.Empty || !J2N.Numerics.Single.TryParse(fuzzySlopStr, NumberStyle.Float, Locale, out float fms))
             {
-                // LUCENENET NOTE: Apparently a "feature" of Lucene is to always
-                // use "." as the decimal specifier for fuzzy slop, even if the culture uses
-                // a different one, such as ",".
-
-                // LUCENENET TODO: It would probably be more intuitive to use
-                // the current Locale to specify the decimal identifier than
-                // to hard code it to be ".", but this would differ from Java Lucene.
-                // Perhaps just make it a non-default option?
-                fms = float.Parse(fuzzySlop.Image.Substring(1), CultureInfo.InvariantCulture);
+                // LUCENENET: Fallback on invariant culture
+                if (fuzzySlopStr == string.Empty || !J2N.Numerics.Single.TryParse(fuzzySlopStr, NumberStyle.Float, CultureInfo.InvariantCulture, out fms))
+                {
+                    fms = FuzzyMinSim;
+                    /* Should this be handled somehow? (defaults to "no boost", if
+                     * boost number is invalid)
+                     */
+                }
             }
-            catch (Exception ignored) when (ignored.IsException()) { }
             if (fms < 0.0f)
             {
                 throw new ParseException("Minimum similarity for a FuzzyQuery has to be between 0.0f and 1.0f !");
@@ -904,19 +903,19 @@ namespace Lucene.Net.QueryParsers.Classic
             int s = PhraseSlop;  // default
             if (fuzzySlop != null)
             {
-                try
+                string fuzzySlopStr = fuzzySlop.Image.Substring(1);
+                if (fuzzySlopStr != string.Empty)
                 {
-                    // LUCENENET NOTE: Apparently a "feature" of Lucene is to always
-                    // use "." as the decimal specifier for fuzzy slop, even if the culture uses
-                    // a different one, such as ",".
-
-                    // LUCENENET TODO: It would probably be more intuitive to use
-                    // the current Locale to specify the decimal identifier than
-                    // to hard code it to be ".", but this would differ from Java Lucene.
-                    // Perhaps just make it a non-default option?
-                    s = (int)float.Parse(fuzzySlop.Image.Substring(1), CultureInfo.InvariantCulture);
+                    if (J2N.Numerics.Single.TryParse(fuzzySlopStr, NumberStyle.Float, Locale, out float f))
+                    {
+                        s = (int)f;
+                    }
+                    // LUCENENET: Fallback on invariant culture
+                    else if (J2N.Numerics.Single.TryParse(fuzzySlopStr, NumberStyle.Float, CultureInfo.InvariantCulture, out f))
+                    {
+                        s = (int)f;
+                    }
                 }
-                catch (Exception ignored) when (ignored.IsException()) { }
             }
             return GetFieldQuery(qfield, DiscardEscapeChar(term.Image.Substring(1, term.Image.Length - 2)), s);
         }
@@ -926,24 +925,16 @@ namespace Lucene.Net.QueryParsers.Classic
         {
             if (boost != null)
             {
-                float f = (float)1.0;
-                try
+                if (!J2N.Numerics.Single.TryParse(boost.Image, NumberStyle.Float, Locale, out float f))
                 {
-                    // LUCENENET NOTE: Apparently a "feature" of Lucene is to always
-                    // use "." as the decimal specifier for boost, even if the culture uses
-                    // a different one, such as ",".
-
-                    // LUCENENET TODO: It would probably be more intuitive to use
-                    // the current Locale to specify the decimal identifier than
-                    // to hard code it to be ".", but this would differ from Java Lucene.
-                    // Perhaps just make it a non-default option?
-                    f = float.Parse(boost.Image, CultureInfo.InvariantCulture);
-                }
-                catch (Exception ignored) when (ignored.IsException())
-                {
-                    /* Should this be handled somehow? (defaults to "no boost", if
-                     * boost number is invalid)
-                     */
+                    // LUCENENET: Fallback on invariant culture
+                    if (!J2N.Numerics.Single.TryParse(boost.Image, NumberStyle.Float, CultureInfo.InvariantCulture, out f))
+                    {
+                        f = 1.0f;
+                        /* Should this be handled somehow? (defaults to "no boost", if
+                         * boost number is invalid)
+                         */
+                    }
                 }
 
                 // avoid boosting null queries, such as those caused by stop words

--- a/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
@@ -511,7 +511,7 @@ namespace Lucene.Net.QueryParsers.Classic
 
             if (DateTime.TryParseExact(part1, shortDateFormat, Locale, DateTimeStyles.None, out DateTime d1))
             {
-                part1 = DateTools.DateToString(d1, resolution);
+                part1 = DateTools.DateToString(d1, TimeZone, resolution);
             }
 
             if (DateTime.TryParseExact(part2, shortDateFormat, Locale, DateTimeStyles.None, out DateTime d2))
@@ -530,7 +530,7 @@ namespace Lucene.Net.QueryParsers.Classic
                     d2 = cal.AddMilliseconds(d2, 999);
                 }
 
-                part2 = DateTools.DateToString(d2, resolution);
+                part2 = DateTools.DateToString(d2, TimeZone, resolution);
             }
 
             return NewRangeQuery(field, part1, part2, startInclusive, endInclusive);

--- a/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
@@ -122,11 +122,11 @@ namespace Lucene.Net.QueryParsers.Classic
         /// <summary>
         /// the default date resolution
         /// </summary>
-        private DateTools.Resolution dateResolution = DateTools.Resolution.DAY;
+        private DateResolution dateResolution = DateResolution.DAY;
         /// <summary>
         ///  maps field names to date resolutions
         /// </summary>
-        private IDictionary<string, DateTools.Resolution> fieldToDateResolution = null;
+        private IDictionary<string, DateResolution> fieldToDateResolution = null;
 
         /// <summary>
         /// Whether or not to analyze range terms when constructing RangeQuerys
@@ -315,9 +315,9 @@ namespace Lucene.Net.QueryParsers.Classic
         /// <summary>
         /// Gets or Sets the default date resolution used by RangeQueries for fields for which no
         /// specific date resolutions has been set. Field specific resolutions can be set
-        /// with <see cref="SetDateResolution(string,DateTools.Resolution)"/>.
+        /// with <see cref="SetDateResolution(string, DateResolution)"/>.
         /// </summary>
-        public virtual void SetDateResolution(DateTools.Resolution dateResolution)
+        public virtual void SetDateResolution(DateResolution dateResolution)
         {
             this.dateResolution = dateResolution;
         }
@@ -327,7 +327,7 @@ namespace Lucene.Net.QueryParsers.Classic
         /// </summary>
         /// <param name="fieldName">field for which the date resolution is to be set</param>
         /// <param name="dateResolution">date resolution to set</param>
-        public virtual void SetDateResolution(string fieldName, DateTools.Resolution dateResolution)
+        public virtual void SetDateResolution(string fieldName, DateResolution dateResolution)
         {
             if (string.IsNullOrEmpty(fieldName))
             {
@@ -337,7 +337,7 @@ namespace Lucene.Net.QueryParsers.Classic
             if (fieldToDateResolution == null)
             {
                 // lazily initialize Dictionary
-                fieldToDateResolution = new Dictionary<string, DateTools.Resolution>();
+                fieldToDateResolution = new Dictionary<string, DateResolution>();
             }
 
             fieldToDateResolution[fieldName] = dateResolution;
@@ -348,7 +348,7 @@ namespace Lucene.Net.QueryParsers.Classic
         /// Returns null, if no default or field specific date resolution has been set 
         /// for the given field.
         /// </summary>
-        public virtual DateTools.Resolution GetDateResolution(string fieldName)
+        public virtual DateResolution GetDateResolution(string fieldName)
         {
             if (string.IsNullOrEmpty(fieldName))
             {
@@ -361,7 +361,7 @@ namespace Lucene.Net.QueryParsers.Classic
                 return this.dateResolution;
             }
 
-            if (!fieldToDateResolution.TryGetValue(fieldName, out DateTools.Resolution resolution))
+            if (!fieldToDateResolution.TryGetValue(fieldName, out DateResolution resolution))
             {
                 // no date resolutions set for the given field; return default date resolution instead
                 return this.dateResolution;
@@ -486,7 +486,7 @@ namespace Lucene.Net.QueryParsers.Classic
             }
 
             string shortDateFormat = Locale.DateTimeFormat.ShortDatePattern;
-            DateTools.Resolution resolution = GetDateResolution(field);
+            DateResolution resolution = GetDateResolution(field);
 
             // LUCENENET specific: This doesn't emulate java perfectly.
             // See LUCENENET-423 - DateRange differences with Java and .NET

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Builders/NumericRangeQueryNodeBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Builders/NumericRangeQueryNodeBuilder.cs
@@ -48,10 +48,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Builders
             NumericQueryNode lowerNumericNode = (NumericQueryNode)numericRangeNode.LowerBound;
             NumericQueryNode upperNumericNode = (NumericQueryNode)numericRangeNode.UpperBound;
 
-            /*Number*/
-            object lowerNumber = lowerNumericNode.Value;
-            /*Number*/
-            object upperNumber = upperNumericNode.Value;
+            J2N.Numerics.Number lowerNumber = lowerNumericNode.Value;
+            J2N.Numerics.Number upperNumber = upperNumericNode.Value;
 
             NumericConfig numericConfig = numericRangeNode.NumericConfig;
             NumericType numberType = numericConfig.Type;
@@ -64,21 +62,21 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Builders
             {
                 case NumericType.INT64:
                     return NumericRangeQuery.NewInt64Range(field, precisionStep,
-                        (long?)lowerNumber, (long?)upperNumber, minInclusive, maxInclusive);
+                        lowerNumber?.ToInt64(), upperNumber?.ToInt64(), minInclusive, maxInclusive);
 
                 case NumericType.INT32:
                     return NumericRangeQuery.NewInt32Range(field, precisionStep,
-                        (int?)lowerNumber, (int?)upperNumber, minInclusive,
+                        lowerNumber?.ToInt32(), upperNumber?.ToInt32(), minInclusive,
                         maxInclusive);
 
                 case NumericType.SINGLE:
                     return NumericRangeQuery.NewSingleRange(field, precisionStep,
-                        (float?)lowerNumber, (float?)upperNumber, minInclusive,
+                        lowerNumber?.ToSingle(), upperNumber?.ToSingle(), minInclusive,
                         maxInclusive);
 
                 case NumericType.DOUBLE:
                     return NumericRangeQuery.NewDoubleRange(field, precisionStep,
-                        (double?)lowerNumber, (double?)upperNumber, minInclusive,
+                        lowerNumber?.ToDouble(), upperNumber?.ToDouble(), minInclusive,
                         maxInclusive);
 
                 default:

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/CommonQueryParserConfiguration.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/CommonQueryParserConfiguration.cs
@@ -98,9 +98,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         float FuzzyMinSim { get; set; }
 
         /// <summary>
-        /// Sets the default <see cref="DateTools.Resolution"/> used for certain field when
-        /// no <see cref="DateTools.Resolution"/> is defined for this field.
+        /// Sets the default <see cref="DateResolution"/> used for certain field when
+        /// no <see cref="DateResolution"/> is defined for this field.
         /// </summary>
-        void SetDateResolution(DateTools.Resolution dateResolution);
+        void SetDateResolution(DateResolution dateResolution);
     }
 }

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/FieldDateResolutionFCListener.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/FieldDateResolutionFCListener.cs
@@ -24,7 +24,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
     /// <summary>
     /// This listener listens for every field configuration request and assign a
     /// <see cref="ConfigurationKeys.DATE_RESOLUTION"/> to the equivalent <see cref="FieldConfig"/> based
-    /// on a defined map: fieldName -> <see cref="DateTools.Resolution"/> stored in
+    /// on a defined map: fieldName -> <see cref="DateResolution"/> stored in
     /// <see cref="ConfigurationKeys.FIELD_DATE_RESOLUTION_MAP"/>.
     /// </summary>
     /// <seealso cref="ConfigurationKeys.DATE_RESOLUTION"/>
@@ -42,8 +42,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
 
         public virtual void BuildFieldConfig(FieldConfig fieldConfig)
         {
-            DateTools.Resolution? dateRes = null;
-            IDictionary<string, DateTools.Resolution?> dateResMap = this.config.Get(ConfigurationKeys.FIELD_DATE_RESOLUTION_MAP);
+            DateResolution? dateRes = null;
+            IDictionary<string, DateResolution?> dateResMap = this.config.Get(ConfigurationKeys.FIELD_DATE_RESOLUTION_MAP);
 
             if (dateResMap != null)
             {

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
@@ -1,4 +1,5 @@
-﻿using Lucene.Net.Util;
+﻿using Lucene.Net.Support;
+using Lucene.Net.Util;
 using System;
 using System.Globalization;
 #nullable enable
@@ -171,77 +172,6 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
             }
 
             return string.Concat(datePattern, " ", timePattern);
-        }
-    }
-
-    // Source: https://github.com/dotnet/runtime/blob/af4efb1936b407ca5f4576e81484cf5687b79a26/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
-    internal static class DateTimeOffsetUtil
-    {
-        /// <summary>
-        /// The .NET ticks representing January 1, 1970 0:00:00, also known as the "epoch".
-        /// </summary>
-        private const long UnixEpochTicks = 621355968000000000L;
-
-        private const long UnixEpochMilliseconds = UnixEpochTicks / TimeSpan.TicksPerMillisecond; // 62,135,596,800,000
-
-        public const long MinMilliseconds = /*DateTime.*/MinTicks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
-        public const long MaxMilliseconds = /*DateTime.*/MaxTicks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
-
-        // From System.DateTime
-
-        // Number of 100ns ticks per time unit
-        private const long TicksPerMillisecond = 10000;
-        private const long TicksPerSecond = TicksPerMillisecond * 1000;
-        private const long TicksPerMinute = TicksPerSecond * 60;
-        private const long TicksPerHour = TicksPerMinute * 60;
-        private const long TicksPerDay = TicksPerHour * 24;
-
-        // Number of days in a non-leap year
-        private const int DaysPerYear = 365;
-        // Number of days in 4 years
-        private const int DaysPer4Years = DaysPerYear * 4 + 1;       // 1461
-        // Number of days in 100 years
-        private const int DaysPer100Years = DaysPer4Years * 25 - 1;  // 36524
-        // Number of days in 400 years
-        private const int DaysPer400Years = DaysPer100Years * 4 + 1; // 146097
-
-        // Number of days from 1/1/0001 to 12/31/9999
-        private const int DaysTo10000 = DaysPer400Years * 25 - 366;  // 3652059
-
-        internal const long MinTicks = 0;
-        internal const long MaxTicks = DaysTo10000 * TicksPerDay - 1;
-
-
-        public static long GetTicksFromUnixTimeMilliseconds(long milliseconds)
-        {
-            if (milliseconds < MinMilliseconds || milliseconds > MaxMilliseconds)
-            {
-                throw new ArgumentOutOfRangeException(nameof(milliseconds),
-                    string.Format("Valid values are between {0} and {1}, inclusive.", MinMilliseconds, MaxMilliseconds));
-            }
-
-            long ticks = milliseconds * TimeSpan.TicksPerMillisecond + UnixEpochTicks;
-            return ticks;
-        }
-
-        public static DateTimeOffset FromUnixTimeMilliseconds(long milliseconds)
-        {
-            if (milliseconds < MinMilliseconds || milliseconds > MaxMilliseconds)
-            {
-                throw new ArgumentOutOfRangeException(nameof(milliseconds),
-                    string.Format("Valid values are between {0} and {1}, inclusive.", MinMilliseconds, MaxMilliseconds));
-            }
-
-            long ticks = milliseconds * TimeSpan.TicksPerMillisecond + UnixEpochTicks;
-            return new DateTimeOffset(ticks, TimeSpan.Zero);
-        }
-
-        public static long ToUnixTimeMilliseconds(DateTimeOffset offset)
-        {
-            // Truncate sub-millisecond precision before offsetting by the Unix Epoch to avoid
-            // the last digit being off by one for dates that result in negative Unix times
-            long milliseconds = offset.UtcDateTime.Ticks / TimeSpan.TicksPerMillisecond;
-            return milliseconds - UnixEpochMilliseconds;
         }
     }
 }

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumberDateFormat.cs
@@ -136,7 +136,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
             return timeZoneAdjusted.ToString(GetDateFormat(), FormatProvider);
         }
 
-        public override object Parse(string source)
+        public override J2N.Numerics.Number Parse(string source)
         {
             DateTimeOffset parsedDate = DateTimeOffset.ParseExact(source, GetDateFormat(), FormatProvider, DateTimeStyles.None);
             DateTimeOffset timeZoneAdjusted;
@@ -145,13 +145,14 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
             else
                 timeZoneAdjusted = TimeZoneInfo.ConvertTime(parsedDate, TimeZone);
             long ticks = timeZoneAdjusted.UtcDateTime.Ticks;
-            return NumericRepresentation switch
+            long result = NumericRepresentation switch
             {
                 NumericRepresentation.UNIX_TIME_MILLISECONDS => DateTools.TicksToUnixTimeMilliseconds(ticks),
                 NumericRepresentation.TICKS => ticks,
                 NumericRepresentation.TICKS_AS_MILLISECONDS => ticks / TimeSpan.TicksPerMillisecond,
                 _ => throw new ArgumentException($"'{NumericRepresentation}' is not a valid {nameof(NumericRepresentation)}.")
             };
+            return J2N.Numerics.Int64.GetInstance(result);
         }
 
         public override string Format(object number)

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/StandardQueryConfigHandler.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/StandardQueryConfigHandler.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
             Set(ConfigurationKeys.FUZZY_CONFIG, new FuzzyConfig());
             Set(ConfigurationKeys.LOCALE, null);
             Set(ConfigurationKeys.MULTI_TERM_REWRITE_METHOD, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE_DEFAULT);
-            Set(ConfigurationKeys.FIELD_DATE_RESOLUTION_MAP, new JCG.Dictionary<string, DateTools.Resolution?>());
+            Set(ConfigurationKeys.FIELD_DATE_RESOLUTION_MAP, new JCG.Dictionary<string, DateResolution?>());
         }
 
         /// <summary>
@@ -137,11 +137,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
         public readonly static ConfigurationKey<IDictionary<string, float?>> FIELD_BOOST_MAP = ConfigurationKey.NewInstance<IDictionary<string, float?>>();
 
         /// <summary>
-        /// Key used to set a field to <see cref="DateTools.Resolution"/> map that is used
+        /// Key used to set a field to <see cref="DateResolution"/> map that is used
         /// to normalize each date field value.
         /// </summary>
         /// <seealso cref="StandardQueryParser.DateResolutionMap"/>
-        public readonly static ConfigurationKey<IDictionary<string, DateTools.Resolution?>> FIELD_DATE_RESOLUTION_MAP = ConfigurationKey.NewInstance<IDictionary<string, DateTools.Resolution?>>();
+        public readonly static ConfigurationKey<IDictionary<string, DateResolution?>> FIELD_DATE_RESOLUTION_MAP = ConfigurationKey.NewInstance<IDictionary<string, DateResolution?>>();
 
         /// <summary>
         /// Key used to set the <see cref="FuzzyConfig"/> used to create fuzzy queries.
@@ -151,11 +151,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
         public readonly static ConfigurationKey<FuzzyConfig> FUZZY_CONFIG = ConfigurationKey.NewInstance<FuzzyConfig>();
 
         /// <summary>
-        /// Key used to set default <see cref="DateTools.Resolution"/>.
+        /// Key used to set default <see cref="DateResolution"/>.
         /// </summary>
-        /// <seealso cref="StandardQueryParser.SetDateResolution(DateTools.Resolution)"/>
+        /// <seealso cref="StandardQueryParser.SetDateResolution(DateResolution)"/>
         /// <seealso cref="StandardQueryParser.DateResolution"/>
-        public readonly static ConfigurationKey<DateTools.Resolution> DATE_RESOLUTION = ConfigurationKey.NewInstance<DateTools.Resolution>();
+        public readonly static ConfigurationKey<DateResolution> DATE_RESOLUTION = ConfigurationKey.NewInstance<DateResolution>();
 
         /// <summary>
         /// Key used to set the boost value in <see cref="FieldConfig"/> objects.

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/NumericQueryNode.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/NumericQueryNode.cs
@@ -28,13 +28,13 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Nodes
     /// <see cref="object"/> representing a .NET numeric type.
     /// </summary>
     /// <seealso cref="Standard.Config.NumericConfig"/>
-    public class NumericQueryNode : QueryNode, IFieldValuePairQueryNode<object>
+    public class NumericQueryNode : QueryNode, IFieldValuePairQueryNode<J2N.Numerics.Number>
     {
         private NumberFormat numberFormat;
 
         private string field;
 
-        private /*Number*/ object value;
+        private J2N.Numerics.Number value;
 
         /// <summary>
         /// Creates a <see cref="NumericQueryNode"/> object using the given field,
@@ -44,7 +44,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Nodes
         /// <param name="field">the field associated with this query node</param>
         /// <param name="value">the value hold by this node</param>
         /// <param name="numberFormat">the <see cref="Util.NumberFormat"/> used to convert the value to <see cref="string"/></param>
-        public NumericQueryNode(string field, /*Number*/ object value,
+        public NumericQueryNode(string field, J2N.Numerics.Number value,
             NumberFormat numberFormat)
             : base()
         {
@@ -97,9 +97,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Nodes
         }
 
         /// <summary>
-        /// Gets or Sets the numeric value as <see cref="object"/> representing a .NET numeric type.
+        /// Gets or Sets the numeric value as a <see cref="J2N.Numerics.Number"/>.
         /// </summary>
-        public virtual object Value
+        public virtual J2N.Numerics.Number Value
         {
             get => value;
             set => this.value = value;

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/NumericRangeQueryNode.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/NumericRangeQueryNode.cs
@@ -50,21 +50,21 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Nodes
             SetBounds(lower, upper, lowerInclusive, upperInclusive, numericConfig);
         }
 
-        private static NumericType GetNumericDataType(/*Number*/ object number)
+        private static NumericType GetNumericDataType(J2N.Numerics.Number number)
         {
-            if (number is long)
+            if (number is J2N.Numerics.Int64)
             {
                 return NumericType.INT64;
             }
-            else if (number is int)
+            else if (number is J2N.Numerics.Int32)
             {
                 return NumericType.INT32;
             }
-            else if (number is double)
+            else if (number is J2N.Numerics.Double)
             {
                 return NumericType.DOUBLE;
             }
-            else if (number is float)
+            else if (number is J2N.Numerics.Single)
             {
                 return NumericType.SINGLE;
             }

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/NumericQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/NumericQueryNodeProcessor.cs
@@ -1,4 +1,5 @@
-﻿using Lucene.Net.Documents;
+﻿using J2N.Numerics;
+using Lucene.Net.Documents;
 using Lucene.Net.QueryParsers.Flexible.Core;
 using Lucene.Net.QueryParsers.Flexible.Core.Config;
 using Lucene.Net.QueryParsers.Flexible.Core.Messages;
@@ -79,8 +80,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                         {
                             NumberFormat numberFormat = numericConfig.NumberFormat;
                             string text = fieldNode.GetTextAsString();
-                            /*Number*/
-                            object number; // LUCENENET: IDE0059: Remove unnecessary value assignment
+                            Number number; // LUCENENET: IDE0059: Remove unnecessary value assignment
 
                             if (text.Length > 0)
                             {
@@ -100,16 +100,16 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                                 switch (numericConfig.Type)
                                 {
                                     case NumericType.INT64:
-                                        number = Convert.ToInt64(number); // LUCENENET TODO: Find a way to pass culture
+                                        number = J2N.Numerics.Int64.GetInstance(number.ToInt64());
                                         break;
                                     case NumericType.INT32:
-                                        number = Convert.ToInt32(number); // LUCENENET TODO: Find a way to pass culture
+                                        number = J2N.Numerics.Int32.GetInstance(number.ToInt32());
                                         break;
                                     case NumericType.DOUBLE:
-                                        number = Convert.ToDouble(number); // LUCENENET TODO: Find a way to pass culture
+                                        number = J2N.Numerics.Double.GetInstance(number.ToDouble());
                                         break;
                                     case NumericType.SINGLE:
-                                        number = Convert.ToSingle(number); // LUCENENET TODO: Find a way to pass culture
+                                        number = J2N.Numerics.Single.GetInstance(number.ToSingle());
                                         break;
                                 }
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/NumericRangeQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/NumericRangeQueryNodeProcessor.cs
@@ -77,8 +77,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                             string lowerText = lower.GetTextAsString();
                             string upperText = upper.GetTextAsString();
                             NumberFormat numberFormat = numericConfig.NumberFormat;
-                            /*Number*/
-                            object lowerNumber = null, upperNumber = null;
+                            J2N.Numerics.Number lowerNumber = null, upperNumber = null;
 
                             if (lowerText.Length > 0)
                             {
@@ -113,20 +112,20 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                             switch (numericConfig.Type)
                             {
                                 case NumericType.INT64:
-                                    if (upperNumber != null) upperNumber = Convert.ToInt64(upperNumber); // LUCENENET TODO: Find a way to pass culture
-                                    if (lowerNumber != null) lowerNumber = Convert.ToInt64(lowerNumber);
+                                    if (upperNumber != null) upperNumber = J2N.Numerics.Int64.GetInstance(upperNumber.ToInt64());
+                                    if (lowerNumber != null) lowerNumber = J2N.Numerics.Int64.GetInstance(lowerNumber.ToInt64());
                                     break;
                                 case NumericType.INT32:
-                                    if (upperNumber != null) upperNumber = Convert.ToInt32(upperNumber); // LUCENENET TODO: Find a way to pass culture
-                                    if (lowerNumber != null) lowerNumber = Convert.ToInt32(lowerNumber);
+                                    if (upperNumber != null) upperNumber = J2N.Numerics.Int32.GetInstance(upperNumber.ToInt32());
+                                    if (lowerNumber != null) lowerNumber = J2N.Numerics.Int32.GetInstance(lowerNumber.ToInt32());
                                     break;
                                 case NumericType.DOUBLE:
-                                    if (upperNumber != null) upperNumber = Convert.ToDouble(upperNumber); // LUCENENET TODO: Find a way to pass culture
-                                    if (lowerNumber != null) lowerNumber = Convert.ToDouble(lowerNumber);
+                                    if (upperNumber != null) upperNumber = J2N.Numerics.Double.GetInstance(upperNumber.ToDouble());
+                                    if (lowerNumber != null) lowerNumber = J2N.Numerics.Double.GetInstance(lowerNumber.ToDouble());
                                     break;
                                 case NumericType.SINGLE:
-                                    if (upperNumber != null) upperNumber = Convert.ToSingle(upperNumber); // LUCENENET TODO: Find a way to pass culture
-                                    if (lowerNumber != null) lowerNumber = Convert.ToSingle(lowerNumber);
+                                    if (upperNumber != null) upperNumber = J2N.Numerics.Single.GetInstance(upperNumber.ToSingle());
+                                    if (lowerNumber != null) lowerNumber = J2N.Numerics.Single.GetInstance(lowerNumber.ToSingle());
                                     break;
                             }
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/TermRangeQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/TermRangeQueryNodeProcessor.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
 
                     if (DateTime.TryParseExact(part1, shortDateFormat, locale, DateTimeStyles.None, out DateTime d1))
                     {
-                        part1 = DateTools.DateToString(d1, dateRes);
+                        part1 = DateTools.DateToString(d1, timeZone, dateRes);
                         lower.Text = new StringCharSequence(part1);
                     }
 
@@ -135,7 +135,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                             d2 = cal.AddMilliseconds(d2, 999);
                         }
 
-                        part2 = DateTools.DateToString(d2, dateRes);
+                        part2 = DateTools.DateToString(d2, timeZone, dateRes);
                         upper.Text = new StringCharSequence(part2);
                     }
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/TermRangeQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/TermRangeQueryNodeProcessor.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
     /// <see cref="CultureInfo.CurrentCulture"/> will be used.
     /// <para/>
     /// If a <see cref="ConfigurationKeys.DATE_RESOLUTION"/> is defined and the
-    /// <see cref="DateTools.Resolution"/> is not <c>null</c> it will also be used to parse the
+    /// <see cref="DateResolution"/> is not <c>null</c> it will also be used to parse the
     /// date value.
     /// </summary>
     /// <seealso cref="ConfigurationKeys.DATE_RESOLUTION"/>
@@ -61,7 +61,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                 FieldQueryNode lower = (FieldQueryNode)termRangeNode.LowerBound;
 
                 // LUCENENET specific - set to 0 (instead of null), since it doesn't correspond to any valid setting
-                DateTools.Resolution dateRes = 0/* = null*/;
+                DateResolution dateRes = 0/* = null*/;
                 bool inclusive = false;
                 CultureInfo locale = GetQueryConfigHandler().Get(ConfigurationKeys.LOCALE);
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/StandardQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/StandardQueryParser.cs
@@ -376,36 +376,36 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         }
 
         /// <summary>
-        /// Sets the default <see cref="DateTools.Resolution"/> used for certain field when
-        /// no <see cref="DateTools.Resolution"/> is defined for this field.
+        /// Sets the default <see cref="Documents.DateResolution"/> used for certain field when
+        /// no <see cref="Documents.DateResolution"/> is defined for this field.
         /// </summary>
-        /// <param name="dateResolution">the default <see cref="DateTools.Resolution"/></param>
+        /// <param name="dateResolution">the default <see cref="Documents.DateResolution"/></param>
         // LUCENENET NOTE: This method is required by the ICommonQueryParserConfiguration interface
-        public virtual void SetDateResolution(DateTools.Resolution dateResolution)
+        public virtual void SetDateResolution(DateResolution dateResolution)
         {
             QueryConfigHandler.Set(ConfigurationKeys.DATE_RESOLUTION, dateResolution);
         }
 
         /// <summary>
-        /// Gets the default <see cref="DateTools.Resolution"/> used for certain field when
-        /// no <see cref="DateTools.Resolution"/> is defined for this field.
+        /// Gets the default <see cref="Documents.DateResolution"/> used for certain field when
+        /// no <see cref="Documents.DateResolution"/> is defined for this field.
         /// </summary>
-        public virtual DateTools.Resolution DateResolution => QueryConfigHandler.Get(ConfigurationKeys.DATE_RESOLUTION);
+        public virtual DateResolution DateResolution => QueryConfigHandler.Get(ConfigurationKeys.DATE_RESOLUTION);
 
         /// <summary>
-        /// Sets the <see cref="DateTools.Resolution"/> used for each field
+        /// Sets the <see cref="Documents.DateResolution"/> used for each field
         /// </summary>
-        /// <param name="dateRes">a collection that maps a field to its <see cref="DateTools.Resolution"/></param>
+        /// <param name="dateRes">a collection that maps a field to its <see cref="Documents.DateResolution"/></param>
         [Obsolete("Use DateResolutionMap property instead.")]
-        public virtual void SetDateResolution(IDictionary<string, DateTools.Resolution?> dateRes)
+        public virtual void SetDateResolution(IDictionary<string, DateResolution?> dateRes)
         {
             DateResolutionMap = dateRes;
         }
 
         /// <summary>
-        /// Gets or Sets the field to <see cref="T:DateTools.Resolution?"/> map used to normalize each date field.
+        /// Gets or Sets the field to <see cref="T:DateResolution?"/> map used to normalize each date field.
         /// </summary>
-        public virtual IDictionary<string, DateTools.Resolution?> DateResolutionMap
+        public virtual IDictionary<string, DateResolution?> DateResolutionMap
         {
             get => QueryConfigHandler.Get(ConfigurationKeys.FIELD_DATE_RESOLUTION_MAP);
             set => QueryConfigHandler.Set(ConfigurationKeys.FIELD_DATE_RESOLUTION_MAP, value);

--- a/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
@@ -109,7 +109,7 @@ namespace Lucene.Net.QueryParsers.Classic
             qp.AutoGeneratePhraseQueries = value;
         }
 
-        public override void SetDateResolution(ICommonQueryParserConfiguration cqpC, string field, DateTools.Resolution value)
+        public override void SetDateResolution(ICommonQueryParserConfiguration cqpC, string field, DateResolution value)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(cqpC is QueryParser);
             QueryParser qp = (QueryParser)cqpC;

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
@@ -429,10 +429,10 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
         {
             // we use the default Locale since LuceneTestCase randomizes it
             //DateFormat df = DateFormat.getDateInstance(DateFormat.SHORT, Locale.getDefault());
-            //return DateTools.DateToString(df.parse(s), DateTools.Resolution.DAY);
+            //return DateTools.DateToString(df.parse(s), DateResolution.DAY);
 
             //DateFormat df = DateFormat.getDateInstance(DateFormat.SHORT, Locale.getDefault());
-            return DateTools.DateToString(DateTime.Parse(s), DateTools.Resolution.DAY);
+            return DateTools.DateToString(DateTime.Parse(s), DateResolution.DAY);
         }
 
         private String getLocalizedDate(int year, int month, int day,
@@ -483,18 +483,18 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
             String hourField = "hour";
             PrecedenceQueryParser qp = new PrecedenceQueryParser(new MockAnalyzer(Random));
 
-            IDictionary<string, DateTools.Resolution?> fieldMap = new JCG.Dictionary<string, DateTools.Resolution?>();
+            IDictionary<string, DateResolution?> fieldMap = new JCG.Dictionary<string, DateResolution?>();
             // set a field specific date resolution
-            fieldMap.Put(monthField, DateTools.Resolution.MONTH);
+            fieldMap.Put(monthField, DateResolution.MONTH);
 #pragma warning disable 612, 618
             qp.SetDateResolution(fieldMap);
 #pragma warning restore 612, 618
 
             // set default date resolution to MILLISECOND
-            qp.SetDateResolution(DateTools.Resolution.MILLISECOND);
+            qp.SetDateResolution(DateResolution.MILLISECOND);
 
             // set second field specific date resolution
-            fieldMap.Put(hourField, DateTools.Resolution.HOUR);
+            fieldMap.Put(hourField, DateResolution.HOUR);
 #pragma warning disable 612, 618
             qp.SetDateResolution(fieldMap);
 #pragma warning restore 612, 618
@@ -502,18 +502,18 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
             // for this field no field specific date resolution has been set,
             // so verify if the default resolution is used
             assertDateRangeQueryEquals(qp, defaultField, startDate, endDate,
-                endDateExpected, DateTools.Resolution.MILLISECOND);
+                endDateExpected, DateResolution.MILLISECOND);
 
             // verify if field specific date resolutions are used for these two fields
             assertDateRangeQueryEquals(qp, monthField, startDate, endDate,
-                endDateExpected, DateTools.Resolution.MONTH);
+                endDateExpected, DateResolution.MONTH);
 
             assertDateRangeQueryEquals(qp, hourField, startDate, endDate,
-                endDateExpected, DateTools.Resolution.HOUR);
+                endDateExpected, DateResolution.HOUR);
         }
 
         /** for testing DateTools support */
-        private String getDate(String s, DateTools.Resolution resolution)
+        private String getDate(String s, DateResolution resolution)
         {
             // we use the default Locale since LuceneTestCase randomizes it
             //DateFormat df = DateFormat.getDateInstance(DateFormat.SHORT, Locale.getDefault());
@@ -522,7 +522,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
         }
 
         /** for testing DateTools support */
-        private String getDate(DateTime d, DateTools.Resolution resolution)
+        private String getDate(DateTime d, DateResolution resolution)
         {
             return DateTools.DateToString(d, resolution);
         }
@@ -541,7 +541,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
 
         public void assertDateRangeQueryEquals(PrecedenceQueryParser qp, String field,
             String startDate, String endDate, DateTime endDateInclusive,
-            DateTools.Resolution resolution)
+            DateResolution resolution)
         {
             assertQueryEquals(qp, field, field + ":[" + escapeDateString(startDate)
                 + " TO " + escapeDateString(endDate) + "]", "["

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -253,7 +253,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             IDictionary<String, Field> numericFieldMap = new JCG.Dictionary<String, Field>();
             qp.NumericConfigMap = (numericConfigMap);
 
-            foreach (NumericType type in Enum.GetValues(typeof(NumericType)))
+            foreach (NumericType type in (NumericType[])Enum.GetValues(typeof(NumericType)))
             {
                 if (type == NumericType.NONE)
                 {
@@ -302,7 +302,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             numericFieldMap.Put(DATE_FIELD_NAME, dateField);
             doc.Add(dateField);
 
-            foreach (NumberType numberType in Enum.GetValues(typeof(NumberType)))
+            foreach (NumberType numberType in (NumberType[])Enum.GetValues(typeof(NumberType)))
             {
                 setFieldValues(numberType, numericFieldMap);
                 if (Verbose) Console.WriteLine("Indexing document: " + doc);
@@ -509,7 +509,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             String lowerInclusiveStr = (lowerInclusive ? "[" : "{");
             String upperInclusiveStr = (upperInclusive ? "]" : "}");
 
-            foreach (NumericType type in Enum.GetValues(typeof(NumericType)))
+            foreach (NumericType type in (NumericType[])Enum.GetValues(typeof(NumericType)))
             {
                 if (type == NumericType.NONE)
                 {
@@ -576,7 +576,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
             StringBuilder sb = new StringBuilder();
 
-            foreach (NumericType type in Enum.GetValues(typeof(NumericType)))
+            foreach (NumericType type in (NumericType[])Enum.GetValues(typeof(NumericType)))
             {
                 if (type == NumericType.NONE)
                 {
@@ -607,7 +607,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         {
             StringBuilder sb = new StringBuilder();
 
-            foreach (NumericType type in Enum.GetValues(typeof(NumericType)))
+            foreach (NumericType type in (NumericType[])Enum.GetValues(typeof(NumericType)))
             {
                 if (type == NumericType.NONE)
                 {

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -1,4 +1,5 @@
 ﻿using J2N.Collections.Generic.Extensions;
+using J2N.Numerics;
 using Lucene.Net.Analysis;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
@@ -51,7 +52,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         private readonly static String FIELD_NAME = "field";
         private static CultureInfo? LOCALE;
         private static TimeZoneInfo? TIMEZONE;
-        private static IDictionary<String, /*Number*/ object>? RANDOM_NUMBER_MAP;
+        private static IDictionary<String, J2N.Numerics.Number>? RANDOM_NUMBER_MAP;
         private readonly static IEscapeQuerySyntax ESCAPER = new Standard.Parser.EscapeQuerySyntax();
         private readonly static String DATE_FIELD_NAME = "date";
         private static DateFormat DATE_STYLE;
@@ -138,7 +139,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
             qp = new StandardQueryParser(ANALYZER);
 
-            IDictionary<string, /*Number*/object> randomNumberMap = new JCG.Dictionary<string, object>();
+            IDictionary<string, Number> randomNumberMap = new JCG.Dictionary<string, Number>();
 
             /*SimpleDateFormat*/
             //string dateFormat;
@@ -213,7 +214,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             //NUMBER_FORMAT.setMaximumIntegerDigits((Random().nextInt() & 20) + 1);
             //NUMBER_FORMAT.setMinimumIntegerDigits((Random().nextInt() & 20) + 1);
 
-            NUMBER_FORMAT = new NumberFormat(LOCALE);
+            NUMBER_FORMAT = new MockNumberFormat(LOCALE);
 
             double randomDouble;
             long randomLong;
@@ -233,11 +234,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                 )), LOCALE))
                 ;
 
-            randomNumberMap.Put(NumericType.INT64.ToString(), randomLong);
-            randomNumberMap.Put(NumericType.INT32.ToString(), randomInt);
-            randomNumberMap.Put(NumericType.SINGLE.ToString(), randomFloat);
-            randomNumberMap.Put(NumericType.DOUBLE.ToString(), randomDouble);
-            randomNumberMap.Put(DATE_FIELD_NAME, randomDate);
+            randomNumberMap[NumericType.INT64.ToString()] = (J2N.Numerics.Int64)randomLong;
+            randomNumberMap[NumericType.INT32.ToString()] = (J2N.Numerics.Int32)randomInt;
+            randomNumberMap[NumericType.SINGLE.ToString()] = (J2N.Numerics.Single)randomFloat;
+            randomNumberMap[NumericType.DOUBLE.ToString()] = (J2N.Numerics.Double)randomDouble;
+            randomNumberMap[DATE_FIELD_NAME] = (J2N.Numerics.Int64)randomDate;
 
             RANDOM_NUMBER_MAP = randomNumberMap.AsReadOnly();
 
@@ -314,7 +315,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
         }
 
-        private static /*Number*/ object? GetNumberType(NumberType? numberType, String fieldName)
+        private static Number? GetNumberType(NumberType? numberType, String fieldName)
         {
 
             if (numberType == null)
@@ -329,28 +330,27 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                     return RANDOM_NUMBER_MAP![fieldName];
 
                 case NumberType.NEGATIVE:
-                    /*Number*/
-                    object number = RANDOM_NUMBER_MAP![fieldName];
+                    Number number = RANDOM_NUMBER_MAP![fieldName];
 
                     if (NumericType.INT64.ToString().Equals(fieldName, StringComparison.Ordinal)
                         || DATE_FIELD_NAME.Equals(fieldName, StringComparison.Ordinal))
                     {
-                        number = -Convert.ToInt64(number);
+                        number = J2N.Numerics.Int64.GetInstance(-number.ToInt64());
 
                     }
                     else if (NumericType.DOUBLE.ToString().Equals(fieldName, StringComparison.Ordinal))
                     {
-                        number = -Convert.ToDouble(number);
+                        number = J2N.Numerics.Double.GetInstance(-number.ToDouble());
 
                     }
                     else if (NumericType.SINGLE.ToString().Equals(fieldName, StringComparison.Ordinal))
                     {
-                        number = -Convert.ToSingle(number);
+                        number = J2N.Numerics.Single.GetInstance(-number.ToSingle());
 
                     }
                     else if (NumericType.INT32.ToString().Equals(fieldName, StringComparison.Ordinal))
                     {
-                        number = -Convert.ToInt32(number);
+                        number = J2N.Numerics.Int32.GetInstance(-number.ToInt32());
 
                     }
                     else
@@ -362,7 +362,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                     return number;
 
                 default:
-                    return 0;
+                    return J2N.Numerics.Int32.GetInstance(0);
 
             }
 
@@ -372,8 +372,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             IDictionary<String, Field> numericFieldMap)
         {
 
-            /*Number*/
-            object? number = GetNumberType(numberType, NumericType.DOUBLE
+            Number? number = GetNumberType(numberType, NumericType.DOUBLE
                 .ToString());
             numericFieldMap[NumericType.DOUBLE.ToString()].SetDoubleValue(Convert.ToDouble(
                 number));
@@ -397,6 +396,19 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         private static DateFormat randomDateStyle(Random random)
         {
             return DATE_STYLES[random.nextInt(DATE_STYLES.Length)];
+        }
+
+        private class MockNumberFormat : NumberFormat
+        {
+            public MockNumberFormat(IFormatProvider? provider) : base(provider) { }
+
+            public override Number Parse(string source)
+            {
+                double dbl = J2N.Numerics.Double.Parse(source, FormatProvider);
+                if (dbl == (long)dbl)
+                    return J2N.Numerics.Int64.GetInstance((long)dbl);
+                return J2N.Numerics.Double.GetInstance(dbl);
+            }
         }
 
         [Test]
@@ -512,10 +524,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                   .append('"').append(upperInclusiveStr).append(' ');
             }
 
-            /*Number*/
-            object? lowerDateNumber = GetNumberType(lowerType, DATE_FIELD_NAME);
-            /*Number*/
-            object? upperDateNumber = GetNumberType(upperType, DATE_FIELD_NAME);
+            Number? lowerDateNumber = GetNumberType(lowerType, DATE_FIELD_NAME);
+            Number? upperDateNumber = GetNumberType(upperType, DATE_FIELD_NAME);
             String lowerDateStr;
             String upperDateStr;
 

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
@@ -734,7 +734,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         }
 
         /** for testing DateTools support */
-        private String GetDate(String s, DateTools.Resolution resolution)
+        private String GetDate(String s, DateResolution resolution)
 
         {
             // we use the default Locale since LuceneTestCase randomizes it
@@ -745,7 +745,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         }
 
         /** for testing DateTools support */
-        private String GetDate(DateTime d, DateTools.Resolution resolution)
+        private String GetDate(DateTime d, DateResolution resolution)
         {
             return DateTools.DateToString(d, resolution);
         }
@@ -799,19 +799,19 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             String hourField = "hour";
             StandardQueryParser qp = new StandardQueryParser();
 
-            IDictionary<string, DateTools.Resolution?> dateRes = new Dictionary<string, DateTools.Resolution?>();
+            IDictionary<string, DateResolution?> dateRes = new Dictionary<string, DateResolution?>();
 
             // set a field specific date resolution    
-            dateRes.Put(monthField, DateTools.Resolution.MONTH);
+            dateRes.Put(monthField, DateResolution.MONTH);
 #pragma warning disable 612, 618
             qp.SetDateResolution(dateRes);
 #pragma warning restore 612, 618
 
             // set default date resolution to MILLISECOND
-            qp.SetDateResolution(DateTools.Resolution.MILLISECOND);
+            qp.SetDateResolution(DateResolution.MILLISECOND);
 
             // set second field specific date resolution
-            dateRes.Put(hourField, DateTools.Resolution.HOUR);
+            dateRes.Put(hourField, DateResolution.HOUR);
 #pragma warning disable 612, 618
             qp.SetDateResolution(dateRes);
 #pragma warning restore 612, 618
@@ -819,20 +819,20 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             // for this field no field specific date resolution has been set,
             // so verify if the default resolution is used
             AssertDateRangeQueryEquals(qp, defaultField, startDate, endDate,
-                endDateExpected/*.getTime()*/, DateTools.Resolution.MILLISECOND);
+                endDateExpected/*.getTime()*/, DateResolution.MILLISECOND);
 
             // verify if field specific date resolutions are used for these two
             // fields
             AssertDateRangeQueryEquals(qp, monthField, startDate, endDate,
-                endDateExpected/*.getTime()*/, DateTools.Resolution.MONTH);
+                endDateExpected/*.getTime()*/, DateResolution.MONTH);
 
             AssertDateRangeQueryEquals(qp, hourField, startDate, endDate,
-                endDateExpected/*.getTime()*/, DateTools.Resolution.HOUR);
+                endDateExpected/*.getTime()*/, DateResolution.HOUR);
         }
 
         public void AssertDateRangeQueryEquals(StandardQueryParser qp,
             String field, String startDate, String endDate, DateTime endDateInclusive,
-            DateTools.Resolution resolution)
+            DateResolution resolution)
         {
             AssertQueryEquals(qp, field, field + ":[" + EscapeDateString(startDate) + " TO " + EscapeDateString(endDate)
                 + "]", "[" + GetDate(startDate, resolution) + " TO "

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestStandardQP.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestStandardQP.cs
@@ -109,7 +109,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
 
         public override void SetDateResolution(ICommonQueryParserConfiguration cqpC,
-            string field, DateTools.Resolution value)
+            string field, DateResolution value)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(cqpC is StandardQueryParser);
             StandardQueryParser qp = (StandardQueryParser)cqpC;

--- a/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
@@ -146,7 +146,7 @@ namespace Lucene.Net.QueryParsers.Util
 
         public abstract void SetAutoGeneratePhraseQueries(ICommonQueryParserConfiguration cqpC, bool value);
 
-        public abstract void SetDateResolution(ICommonQueryParserConfiguration cqpC, string field, DateTools.Resolution value);
+        public abstract void SetDateResolution(ICommonQueryParserConfiguration cqpC, string field, DateResolution value);
 
         public abstract Query GetQuery(string query, ICommonQueryParserConfiguration cqpC);
 
@@ -671,7 +671,7 @@ namespace Lucene.Net.QueryParsers.Util
         }
 
         /// <summary>for testing DateTools support</summary>
-        private string GetDate(string s, DateTools.Resolution resolution)
+        private string GetDate(string s, DateResolution resolution)
         {
             // we use the default Locale since LuceneTestCase randomizes it
             DateTime d = DateTime.ParseExact(s, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, CultureInfo.CurrentCulture);
@@ -679,7 +679,7 @@ namespace Lucene.Net.QueryParsers.Util
         }
 
         /// <summary>for testing DateTools support</summary>
-        private string GetDate(DateTime d, DateTools.Resolution resolution)
+        private string GetDate(DateTime d, DateResolution resolution)
         {
             return DateTools.DateToString(d, resolution);
         }
@@ -724,29 +724,29 @@ namespace Lucene.Net.QueryParsers.Util
             ICommonQueryParserConfiguration qp = GetParserConfig(a);
 
             // set a field specific date resolution
-            SetDateResolution(qp, monthField, DateTools.Resolution.MONTH);
+            SetDateResolution(qp, monthField, DateResolution.MONTH);
 
             // set default date resolution to MILLISECOND
-            qp.SetDateResolution(DateTools.Resolution.MILLISECOND);
+            qp.SetDateResolution(DateResolution.MILLISECOND);
 
             // set second field specific date resolution    
-            SetDateResolution(qp, hourField, DateTools.Resolution.HOUR);
+            SetDateResolution(qp, hourField, DateResolution.HOUR);
 
             // for this field no field specific date resolution has been set,
             // so verify if the default resolution is used
             AssertDateRangeQueryEquals(qp, defaultField, startDate, endDate,
-                    endDateExpected /*.getTime()*/, DateTools.Resolution.MILLISECOND);
+                    endDateExpected /*.getTime()*/, DateResolution.MILLISECOND);
 
             // verify if field specific date resolutions are used for these two fields
             AssertDateRangeQueryEquals(qp, monthField, startDate, endDate,
-                    endDateExpected /*.getTime()*/, DateTools.Resolution.MONTH);
+                    endDateExpected /*.getTime()*/, DateResolution.MONTH);
 
             AssertDateRangeQueryEquals(qp, hourField, startDate, endDate,
-                    endDateExpected /*.getTime()*/, DateTools.Resolution.HOUR);
+                    endDateExpected /*.getTime()*/, DateResolution.HOUR);
         }
 
         public void AssertDateRangeQueryEquals(ICommonQueryParserConfiguration cqpC, string field, string startDate, string endDate,
-            DateTime endDateInclusive, DateTools.Resolution resolution)
+            DateTime endDateInclusive, DateResolution resolution)
         {
             AssertQueryEquals(cqpC, field, field + ":[" + EscapeDateString(startDate) + " TO " + EscapeDateString(endDate) + "]",
                        "[" + GetDate(startDate, resolution) + " TO " + GetDate(endDateInclusive, resolution) + "]");

--- a/src/Lucene.Net.Tests._A-D/Lucene.Net.Tests._A-D.csproj
+++ b/src/Lucene.Net.Tests._A-D/Lucene.Net.Tests._A-D.csproj
@@ -27,6 +27,10 @@
     <AssemblyTitle>Lucene.Net.Tests._A-D</AssemblyTitle>
     <RootNamespace>Lucene.Net</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TimeZoneConverter" Version="$(TimeZoneConverterPackageVersion)" />
+  </ItemGroup>
   
   <ItemGroup>
     <Compile Include="..\Lucene.Net.Tests\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />

--- a/src/Lucene.Net.Tests/Document/TestDateTools.cs
+++ b/src/Lucene.Net.Tests/Document/TestDateTools.cs
@@ -1,7 +1,10 @@
+﻿using Lucene.Net.Attributes;
+using Lucene.Net.Support;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.Globalization;
+using TimeZoneConverter;
 using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Documents
@@ -74,22 +77,60 @@ namespace Lucene.Net.Documents
         }
 
         [Test]
-        public virtual void TestStringtoTime()
+        public virtual void TestStringtoTime_UnixEpoch()
         {
-            long time = DateTools.StringToTime("197001010000");
+            long time = DateTools.StringToTime("197001010000", NumericRepresentation.UNIX_TIME_MILLISECONDS);
 
             // we use default locale since LuceneTestCase randomizes it
             //Calendar cal = new GregorianCalendar(TimeZone.GetTimeZone("GMT"), Locale.Default);
             //cal.Clear();
-           
-            DateTime cal = new GregorianCalendar().ToDateTime(1970, 1, 1, 0, 0, 0, 0); // hour, minute, second -  year=1970, month=january, day=1
+
+            DateTime cal = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc); //new GregorianCalendar().ToDateTime(1970, 1, 1, 0, 0, 0, 0); // hour, minute, second -  year=1970, month=january, day=1
+            //cal.set(DateTime.MILLISECOND, 0);
+            Assert.AreEqual(DateTools.TicksToUnixTimeMilliseconds(cal.Ticks), time);
+
+            cal = new DateTime(1980, 2, 2, 11, 5, 0, 0, DateTimeKind.Utc); //new GregorianCalendar().ToDateTime(1980, 2, 2, 11, 5, 0, 0); // hour, minute, second -  year=1980, month=february, day=2
+            //cal.set(DateTime.MILLISECOND, 0);
+            time = DateTools.StringToTime("198002021105", NumericRepresentation.UNIX_TIME_MILLISECONDS);
+            Assert.AreEqual(DateTools.TicksToUnixTimeMilliseconds(cal.Ticks), time);
+        }
+
+        [Test]
+        public virtual void TestStringtoTime_Ticks()
+        {
+            long time = DateTools.StringToTime("197001010000", NumericRepresentation.TICKS);
+
+            // we use default locale since LuceneTestCase randomizes it
+            //Calendar cal = new GregorianCalendar(TimeZone.GetTimeZone("GMT"), Locale.Default);
+            //cal.Clear();
+
+            DateTime cal = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc); //new GregorianCalendar().ToDateTime(1970, 1, 1, 0, 0, 0, 0); // hour, minute, second -  year=1970, month=january, day=1
             //cal.set(DateTime.MILLISECOND, 0);
             Assert.AreEqual(cal.Ticks, time);
 
-            cal = new GregorianCalendar().ToDateTime(1980, 2, 2, 11, 5, 0, 0); // hour, minute, second -  year=1980, month=february, day=2
+            cal = new DateTime(1980, 2, 2, 11, 5, 0, 0, DateTimeKind.Utc); //new GregorianCalendar().ToDateTime(1980, 2, 2, 11, 5, 0, 0); // hour, minute, second -  year=1980, month=february, day=2
             //cal.set(DateTime.MILLISECOND, 0);
-            time = DateTools.StringToTime("198002021105");
+            time = DateTools.StringToTime("198002021105", NumericRepresentation.TICKS);
             Assert.AreEqual(cal.Ticks, time);
+        }
+
+        [Test]
+        public virtual void TestStringtoTime_TicksAsMilliseconds()
+        {
+            long time = DateTools.StringToTime("197001010000", NumericRepresentation.TICKS_AS_MILLISECONDS);
+
+            // we use default locale since LuceneTestCase randomizes it
+            //Calendar cal = new GregorianCalendar(TimeZone.GetTimeZone("GMT"), Locale.Default);
+            //cal.Clear();
+
+            DateTime cal = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc); //new GregorianCalendar().ToDateTime(1970, 1, 1, 0, 0, 0, 0); // hour, minute, second -  year=1970, month=january, day=1
+            //cal.set(DateTime.MILLISECOND, 0);
+            Assert.AreEqual(cal.Ticks / TimeSpan.TicksPerMillisecond, time);
+
+            cal = new DateTime(1980, 2, 2, 11, 5, 0, 0, DateTimeKind.Utc); //new GregorianCalendar().ToDateTime(1980, 2, 2, 11, 5, 0, 0); // hour, minute, second -  year=1980, month=february, day=2
+            //cal.set(DateTime.MILLISECOND, 0);
+            time = DateTools.StringToTime("198002021105", NumericRepresentation.TICKS_AS_MILLISECONDS);
+            Assert.AreEqual(cal.Ticks / TimeSpan.TicksPerMillisecond, time);
         }
 
         [Test]
@@ -97,60 +138,89 @@ namespace Lucene.Net.Documents
         {
             // we use default locale since LuceneTestCase randomizes it
             //Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.Default);
-            DateTime cal = new GregorianCalendar().ToDateTime(2004, 2, 3, 22, 8, 56, 333);
+            //DateTime cal = new GregorianCalendar(GregorianCalendarTypes.Localized).ToDateTime(2004, 2, 3, 22, 8, 56, 333);
+            DateTime cal = new DateTime(2004, 2, 3, 22, 8, 56, 333, DateTimeKind.Utc);
+            
 
             /*cal.clear();
             cal = new DateTime(2004, 1, 3, 22, 8, 56); // hour, minute, second -  year=2004, month=february(!), day=3
             cal.set(DateTime.MILLISECOND, 333);*/
 
-            string dateString = DateTools.DateToString(cal, DateTools.Resolution.YEAR);
+            string dateString = DateTools.DateToString(cal, DateResolution.YEAR);
             Assert.AreEqual("2004", dateString);
             Assert.AreEqual("2004-01-01 00:00:00:000", IsoFormat(DateTools.StringToDate(dateString)));
 
-            dateString = DateTools.DateToString(cal, DateTools.Resolution.MONTH);
+            dateString = DateTools.DateToString(cal, DateResolution.MONTH);
             Assert.AreEqual("200402", dateString);
             Assert.AreEqual("2004-02-01 00:00:00:000", IsoFormat(DateTools.StringToDate(dateString)));
 
-            dateString = DateTools.DateToString(cal, DateTools.Resolution.DAY);
+            dateString = DateTools.DateToString(cal, DateResolution.DAY);
             Assert.AreEqual("20040203", dateString);
             Assert.AreEqual("2004-02-03 00:00:00:000", IsoFormat(DateTools.StringToDate(dateString)));
 
-            dateString = DateTools.DateToString(cal, DateTools.Resolution.HOUR);
+            dateString = DateTools.DateToString(cal, DateResolution.HOUR);
             Assert.AreEqual("2004020322", dateString);
             Assert.AreEqual("2004-02-03 22:00:00:000", IsoFormat(DateTools.StringToDate(dateString)));
 
-            dateString = DateTools.DateToString(cal, DateTools.Resolution.MINUTE);
+            dateString = DateTools.DateToString(cal, DateResolution.MINUTE);
             Assert.AreEqual("200402032208", dateString);
             Assert.AreEqual("2004-02-03 22:08:00:000", IsoFormat(DateTools.StringToDate(dateString)));
 
-            dateString = DateTools.DateToString(cal, DateTools.Resolution.SECOND);
+            dateString = DateTools.DateToString(cal, DateResolution.SECOND);
             Assert.AreEqual("20040203220856", dateString);
             Assert.AreEqual("2004-02-03 22:08:56:000", IsoFormat(DateTools.StringToDate(dateString)));
 
-            dateString = DateTools.DateToString(cal, DateTools.Resolution.MILLISECOND);
+            dateString = DateTools.DateToString(cal, DateResolution.MILLISECOND);
             Assert.AreEqual("20040203220856333", dateString);
             Assert.AreEqual("2004-02-03 22:08:56:333", IsoFormat(DateTools.StringToDate(dateString)));
 
             // date before 1970:
-            cal = new GregorianCalendar().ToDateTime(1961, 3, 5, 23, 9, 51, 444); // hour, minute, second -  year=1961, month=march(!), day=5
+            //cal = new GregorianCalendar().ToDateTime(1961, 3, 5, 23, 9, 51, 444); // hour, minute, second -  year=1961, month=march(!), day=5
             //cal.set(DateTime.MILLISECOND, 444);
-            dateString = DateTools.DateToString(cal, DateTools.Resolution.MILLISECOND);
+            cal = new DateTime(1961, 3, 5, 23, 9, 51, 444, DateTimeKind.Utc);
+            dateString = DateTools.DateToString(cal, DateResolution.MILLISECOND);
             Assert.AreEqual("19610305230951444", dateString);
             Assert.AreEqual("1961-03-05 23:09:51:444", IsoFormat(DateTools.StringToDate(dateString)));
 
-            dateString = DateTools.DateToString(cal, DateTools.Resolution.HOUR);
+            dateString = DateTools.DateToString(cal, DateResolution.HOUR);
             Assert.AreEqual("1961030523", dateString);
             Assert.AreEqual("1961-03-05 23:00:00:000", IsoFormat(DateTools.StringToDate(dateString)));
 
             // timeToString:
-            cal = new GregorianCalendar().ToDateTime(1970, 1, 1, 0, 0, 0, 0); // hour, minute, second -  year=1970, month=january, day=1
+
+            // ticks:
+
+            //cal = new GregorianCalendar().ToDateTime(1970, 1, 1, 0, 0, 0, 0); // hour, minute, second -  year=1970, month=january, day=1
             //cal.set(DateTime.MILLISECOND, 0);
-            dateString = DateTools.TimeToString(cal.Ticks / TimeSpan.TicksPerMillisecond, DateTools.Resolution.MILLISECOND);
+            cal = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            dateString = DateTools.TimeToString(cal.Ticks, DateResolution.MILLISECOND, NumericRepresentation.TICKS);
             Assert.AreEqual("19700101000000000", dateString);
 
             cal = new GregorianCalendar().ToDateTime(1970, 1, 1, 1, 2, 3, 0); // hour, minute, second -  year=1970, month=january, day=1
             //cal.set(DateTime.MILLISECOND, 0);
-            dateString = DateTools.TimeToString(cal.Ticks / TimeSpan.TicksPerMillisecond, DateTools.Resolution.MILLISECOND);
+            dateString = DateTools.TimeToString(cal.Ticks, DateResolution.MILLISECOND, NumericRepresentation.TICKS);
+            Assert.AreEqual("19700101010203000", dateString);
+
+            // unix epoch:
+
+            cal = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            dateString = DateTools.TimeToString(DateTools.TicksToUnixTimeMilliseconds(cal.Ticks), DateResolution.MILLISECOND, NumericRepresentation.UNIX_TIME_MILLISECONDS);
+            Assert.AreEqual("19700101000000000", dateString);
+
+            cal = new GregorianCalendar().ToDateTime(1970, 1, 1, 1, 2, 3, 0); // hour, minute, second -  year=1970, month=january, day=1
+            //cal.set(DateTime.MILLISECOND, 0);
+            dateString = DateTools.TimeToString(DateTools.TicksToUnixTimeMilliseconds(cal.Ticks), DateResolution.MILLISECOND, NumericRepresentation.UNIX_TIME_MILLISECONDS);
+            Assert.AreEqual("19700101010203000", dateString);
+
+            // ticks as ms:
+
+            cal = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            dateString = DateTools.TimeToString(cal.Ticks / TimeSpan.TicksPerMillisecond, DateResolution.MILLISECOND, NumericRepresentation.TICKS_AS_MILLISECONDS);
+            Assert.AreEqual("19700101000000000", dateString);
+
+            cal = new GregorianCalendar().ToDateTime(1970, 1, 1, 1, 2, 3, 0); // hour, minute, second -  year=1970, month=january, day=1
+            //cal.set(DateTime.MILLISECOND, 0);
+            dateString = DateTools.TimeToString(cal.Ticks / TimeSpan.TicksPerMillisecond, DateResolution.MILLISECOND, NumericRepresentation.TICKS_AS_MILLISECONDS);
             Assert.AreEqual("19700101010203000", dateString);
         }
 
@@ -160,37 +230,56 @@ namespace Lucene.Net.Documents
             // we use default locale since LuceneTestCase randomizes it
             //Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.Default);
             //cal.clear();
-            DateTime cal = new GregorianCalendar().ToDateTime(2004, 2, 3, 22, 8, 56, 333); // hour, minute, second -  year=2004, month=february(!), day=3
+            //DateTime cal = new GregorianCalendar().ToDateTime(2004, 2, 3, 22, 8, 56, 333); // hour, minute, second -  year=2004, month=february(!), day=3
             //cal.set(DateTime.MILLISECOND, 333);
-            DateTime date = cal;
+            DateTime date = new DateTime(2004, 2, 3, 22, 8, 56, 333, DateTimeKind.Utc);
             Assert.AreEqual("2004-02-03 22:08:56:333", IsoFormat(date));
 
-            DateTime dateYear = DateTools.Round(date, DateTools.Resolution.YEAR);
+            DateTime dateYear = DateTools.Round(date, DateResolution.YEAR);
             Assert.AreEqual("2004-01-01 00:00:00:000", IsoFormat(dateYear));
 
-            DateTime dateMonth = DateTools.Round(date, DateTools.Resolution.MONTH);
+            DateTime dateMonth = DateTools.Round(date, DateResolution.MONTH);
             Assert.AreEqual("2004-02-01 00:00:00:000", IsoFormat(dateMonth));
 
-            DateTime dateDay = DateTools.Round(date, DateTools.Resolution.DAY);
+            DateTime dateDay = DateTools.Round(date, DateResolution.DAY);
             Assert.AreEqual("2004-02-03 00:00:00:000", IsoFormat(dateDay));
 
-            DateTime dateHour = DateTools.Round(date, DateTools.Resolution.HOUR);
+            DateTime dateHour = DateTools.Round(date, DateResolution.HOUR);
             Assert.AreEqual("2004-02-03 22:00:00:000", IsoFormat(dateHour));
 
-            DateTime dateMinute = DateTools.Round(date, DateTools.Resolution.MINUTE);
+            DateTime dateMinute = DateTools.Round(date, DateResolution.MINUTE);
             Assert.AreEqual("2004-02-03 22:08:00:000", IsoFormat(dateMinute));
 
-            DateTime dateSecond = DateTools.Round(date, DateTools.Resolution.SECOND);
+            DateTime dateSecond = DateTools.Round(date, DateResolution.SECOND);
             Assert.AreEqual("2004-02-03 22:08:56:000", IsoFormat(dateSecond));
 
-            DateTime dateMillisecond = DateTools.Round(date, DateTools.Resolution.MILLISECOND);
+            DateTime dateMillisecond = DateTools.Round(date, DateResolution.MILLISECOND);
             Assert.AreEqual("2004-02-03 22:08:56:333", IsoFormat(dateMillisecond));
 
             // long parameter:
-            long dateYearLong = DateTools.Round(date.Ticks / TimeSpan.TicksPerMillisecond, DateTools.Resolution.YEAR);
+
+            // ticks:
+
+            long dateYearLong = DateTools.Round(date.Ticks, DateResolution.YEAR, NumericRepresentation.TICKS, NumericRepresentation.TICKS);
             Assert.AreEqual("2004-01-01 00:00:00:000", IsoFormat(new DateTime(dateYearLong)));
 
-            long dateMillisecondLong = DateTools.Round(date.Ticks / TimeSpan.TicksPerMillisecond, DateTools.Resolution.MILLISECOND);
+            long dateMillisecondLong = DateTools.Round(date.Ticks, DateResolution.MILLISECOND, NumericRepresentation.TICKS, NumericRepresentation.TICKS);
+            Assert.AreEqual("2004-02-03 22:08:56:333", IsoFormat(new DateTime(dateMillisecondLong)));
+
+            // unix epoch:
+
+            dateYearLong = DateTools.Round(DateTools.TicksToUnixTimeMilliseconds(date.Ticks), DateResolution.YEAR, NumericRepresentation.UNIX_TIME_MILLISECONDS, NumericRepresentation.TICKS);
+            Assert.AreEqual("2004-01-01 00:00:00:000", IsoFormat(new DateTime(dateYearLong)));
+
+            dateMillisecondLong = DateTools.Round(DateTools.TicksToUnixTimeMilliseconds(date.Ticks), DateResolution.MILLISECOND, NumericRepresentation.UNIX_TIME_MILLISECONDS, NumericRepresentation.TICKS);
+            Assert.AreEqual("2004-02-03 22:08:56:333", IsoFormat(new DateTime(dateMillisecondLong)));
+
+            // ticks as ms:
+
+            dateYearLong = DateTools.Round(date.Ticks / TimeSpan.TicksPerMillisecond, DateResolution.YEAR, NumericRepresentation.TICKS_AS_MILLISECONDS, NumericRepresentation.TICKS);
+            Assert.AreEqual("2004-01-01 00:00:00:000", IsoFormat(new DateTime(dateYearLong)));
+
+            dateMillisecondLong = DateTools.Round(date.Ticks / TimeSpan.TicksPerMillisecond, DateResolution.MILLISECOND, NumericRepresentation.TICKS_AS_MILLISECONDS, NumericRepresentation.TICKS);
             Assert.AreEqual("2004-02-03 22:08:56:333", IsoFormat(new DateTime(dateMillisecondLong)));
         }
 
@@ -199,47 +288,301 @@ namespace Lucene.Net.Documents
             /*SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS", Locale.ROOT);
             sdf.TimeZone = TimeZone.getTimeZone("GMT");
             return sdf.Format(date);*/
-            return date.ToString("yyyy-MM-dd HH:mm:ss:fff", System.Globalization.CultureInfo.InvariantCulture);
+            return date.ToString("yyyy-MM-dd HH:mm:ss:fff", CultureInfo.InvariantCulture);
         }
 
         [Test]
-        public virtual void TestDateToolsUTC()
+        public virtual void TestDateToolsUTC_UnixEpoch()
         {
-            /*// Sun, 30 Oct 2005 00:00:00 +0000 -- the last second of 2005's DST in Europe/London
-            long time = 1130630400;
-            try
-            {
-                TimeZone.Default = TimeZone.getTimeZone("Europe/London"); // "GMT"
-                string d1 = DateTools.DateToString(new DateTime(time * 1000), DateTools.Resolution.MINUTE);
-                string d2 = DateTools.DateToString(new DateTime((time+3600) * 1000), DateTools.Resolution.MINUTE);
-                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
-                Assert.AreEqual(DateTools.StringToTime(d1), time * 1000, "midnight");
-                Assert.AreEqual(DateTools.StringToTime(d2), (time+3600) * 1000, "later");
-            }
-            finally
-            {
-                TimeZone.Default = null;
-            }*/
-
             // Sun, 30 Oct 2005 00:00:00 +0000 -- the last second of 2005's DST in Europe/London
             //long time = 1130630400;
-            DateTime time1 = new DateTime(2005, 10, 30);
+            DateTime time1 = new DateTime(2005, 10, 30, 0, 0, 0, DateTimeKind.Utc);
             DateTime time2 = time1.AddHours(1);
-            try
+
             {
-                //TimeZone.setDefault(TimeZone.getTimeZone("Europe/London")); // {{Aroush-2.0}} need porting 'java.util.TimeZone.getTimeZone'
-                System.DateTime tempAux = time1;
-                System.String d1 = DateTools.DateToString(tempAux, DateTools.Resolution.MINUTE);
-                System.DateTime tempAux2 = time2;
-                System.String d2 = DateTools.DateToString(tempAux2, DateTools.Resolution.MINUTE);
+                TimeZoneInfo timeZone = TZConvert.GetTimeZoneInfo("Europe/London");
+                string d1 = DateTools.DateToString(time1, timeZone, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, timeZone, DateResolution.MINUTE);
                 Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
-                Assert.AreEqual(DateTools.StringToTime(d1), time1.Ticks, "midnight");
-                Assert.AreEqual(DateTools.StringToTime(d2), time2.Ticks, "later");
+                Assert.AreEqual(DateTools.StringToTime(d1), DateTools.TicksToUnixTimeMilliseconds(time1.Ticks), "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2), DateTools.TicksToUnixTimeMilliseconds(time2.Ticks), "later");
             }
-            finally
+
             {
-                //TimeZone.SetDefault(null);    // {{Aroush-2.0}} need porting 'java.util.TimeZone.setDefault'
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1), DateTools.TicksToUnixTimeMilliseconds(time1.Ticks), "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2), DateTools.TicksToUnixTimeMilliseconds(time2.Ticks), "later");
             }
+
+            time1 = new DateTime(2005, 10, 30, 0, 0, 0, DateTimeKind.Utc).ToLocalTime();
+            time2 = time1.AddHours(1);
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1), DateTools.TicksToUnixTimeMilliseconds(time1.ToUniversalTime().Ticks), "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2), DateTools.TicksToUnixTimeMilliseconds(time2.ToUniversalTime().Ticks), "later");
+            }
+
+            time1 = new DateTime(2005, 10, 30, 0, 0, 0, DateTimeKind.Unspecified);
+            time2 = time1.AddHours(1);
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1), DateTools.TicksToUnixTimeMilliseconds(time1.ToUniversalTime().Ticks), "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2), DateTools.TicksToUnixTimeMilliseconds(time2.ToUniversalTime().Ticks), "later");
+            }
+        }
+
+        [Test]
+        public virtual void TestDateToolsUTC_Ticks()
+        {
+            // Sun, 30 Oct 2005 00:00:00 +0000 -- the last second of 2005's DST in Europe/London
+            //long time = 1130630400;
+            DateTime time1 = new DateTime(2005, 10, 30, 0, 0, 0, DateTimeKind.Utc);
+            DateTime time2 = time1.AddHours(1);
+
+            {
+                TimeZoneInfo timeZone = TZConvert.GetTimeZoneInfo("Europe/London");
+                string d1 = DateTools.DateToString(time1, timeZone, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, timeZone, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS), time1.Ticks, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS), time2.Ticks, "later");
+            }
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS), time1.Ticks, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS), time2.Ticks, "later");
+            }
+
+            time1 = new DateTime(2005, 10, 30, 0, 0, 0, DateTimeKind.Utc).ToLocalTime();
+            time2 = time1.AddHours(1);
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS), time1.ToUniversalTime().Ticks, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS), time2.ToUniversalTime().Ticks, "later");
+            }
+
+            time1 = new DateTime(2005, 10, 30, 0, 0, 0, DateTimeKind.Unspecified);
+            time2 = time1.AddHours(1);
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS), time1.ToUniversalTime().Ticks, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS), time2.ToUniversalTime().Ticks, "later");
+            }
+        }
+
+        [Test]
+        public virtual void TestDateToolsUTC_TicksAsMilliseconds()
+        {
+            // Sun, 30 Oct 2005 00:00:00 +0000 -- the last second of 2005's DST in Europe/London
+            //long time = 1130630400;
+            DateTime time1 = new DateTime(2005, 10, 30, 0, 0, 0, DateTimeKind.Utc);
+            DateTime time2 = time1.AddHours(1);
+
+            {
+                TimeZoneInfo timeZone = TZConvert.GetTimeZoneInfo("Europe/London");
+                string d1 = DateTools.DateToString(time1, timeZone, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, timeZone, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS_AS_MILLISECONDS), time1.Ticks / TimeSpan.TicksPerMillisecond, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS_AS_MILLISECONDS), time2.Ticks / TimeSpan.TicksPerMillisecond, "later");
+            }
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS_AS_MILLISECONDS), time1.Ticks / TimeSpan.TicksPerMillisecond, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS_AS_MILLISECONDS), time2.Ticks / TimeSpan.TicksPerMillisecond, "later");
+            }
+
+            time1 = new DateTime(2005, 10, 30, 0, 0, 0, DateTimeKind.Utc).ToLocalTime();
+            time2 = time1.AddHours(1);
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS_AS_MILLISECONDS), time1.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS_AS_MILLISECONDS), time2.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond, "later");
+            }
+
+            time1 = new DateTime(2005, 10, 30, 0, 0, 0, DateTimeKind.Unspecified);
+            time2 = time1.AddHours(1);
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS_AS_MILLISECONDS), time1.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS_AS_MILLISECONDS), time2.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond, "later");
+            }
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestDateToolsUTC_DateTimeOffset_UnixEpoch()
+        {
+            // Sun, 30 Oct 2005 00:00:00 +0000 -- the last second of 2005's DST in Europe/London
+            //long time = 1130630400;
+            DateTimeOffset time1 = new DateTimeOffset(2005, 10, 30, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset time2 = time1.AddHours(1);
+
+            {
+                TimeZoneInfo timeZone = TZConvert.GetTimeZoneInfo("Europe/London");
+                DateTimeOffset tempAux = TimeZoneInfo.ConvertTime(time1, timeZone);
+                string d1 = DateTools.DateToString(tempAux, DateResolution.MINUTE);
+                DateTimeOffset tempAux2 = TimeZoneInfo.ConvertTime(time2, timeZone);
+                string d2 = DateTools.DateToString(tempAux2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.UNIX_TIME_MILLISECONDS), DateTools.TicksToUnixTimeMilliseconds(time1.Ticks), "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.UNIX_TIME_MILLISECONDS), DateTools.TicksToUnixTimeMilliseconds(time2.Ticks), "later");
+            }
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.UNIX_TIME_MILLISECONDS), DateTools.TicksToUnixTimeMilliseconds(time1.Ticks), "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.UNIX_TIME_MILLISECONDS), DateTools.TicksToUnixTimeMilliseconds(time2.Ticks), "later");
+            }
+
+            time1 = new DateTimeOffset(2005, 10, 30, 0, 0, 0, TimeSpan.Zero).ToLocalTime();
+            time2 = time1.AddHours(1);
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.UNIX_TIME_MILLISECONDS), DateTools.TicksToUnixTimeMilliseconds(time1.ToUniversalTime().Ticks), "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.UNIX_TIME_MILLISECONDS), DateTools.TicksToUnixTimeMilliseconds(time2.ToUniversalTime().Ticks), "later");
+            }
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestDateToolsUTC_DateTimeOffset_Ticks()
+        {
+            // Sun, 30 Oct 2005 00:00:00 +0000 -- the last second of 2005's DST in Europe/London
+            //long time = 1130630400;
+            DateTimeOffset time1 = new DateTimeOffset(2005, 10, 30, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset time2 = time1.AddHours(1);
+
+            {
+                TimeZoneInfo timeZone = TZConvert.GetTimeZoneInfo("Europe/London");
+                DateTimeOffset tempAux = TimeZoneInfo.ConvertTime(time1, timeZone);
+                string d1 = DateTools.DateToString(tempAux, DateResolution.MINUTE);
+                DateTimeOffset tempAux2 = TimeZoneInfo.ConvertTime(time2, timeZone);
+                string d2 = DateTools.DateToString(tempAux2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS), time1.Ticks, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS), time2.Ticks, "later");
+            }
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS), time1.Ticks, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS), time2.Ticks, "later");
+            }
+
+            time1 = new DateTimeOffset(2005, 10, 30, 0, 0, 0, TimeSpan.Zero).ToLocalTime();
+            time2 = time1.AddHours(1);
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS), time1.ToUniversalTime().Ticks, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS), time2.ToUniversalTime().Ticks, "later");
+            }
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestDateToolsUTC_DateTimeOffset_TicksAsMilliseconds()
+        {
+            // Sun, 30 Oct 2005 00:00:00 +0000 -- the last second of 2005's DST in Europe/London
+            //long time = 1130630400;
+            DateTimeOffset time1 = new DateTimeOffset(2005, 10, 30, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset time2 = time1.AddHours(1);
+
+            {
+                TimeZoneInfo timeZone = TZConvert.GetTimeZoneInfo("Europe/London");
+                DateTimeOffset tempAux = TimeZoneInfo.ConvertTime(time1, timeZone);
+                string d1 = DateTools.DateToString(tempAux, DateResolution.MINUTE);
+                DateTimeOffset tempAux2 = TimeZoneInfo.ConvertTime(time2, timeZone);
+                string d2 = DateTools.DateToString(tempAux2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS_AS_MILLISECONDS), time1.Ticks / TimeSpan.TicksPerMillisecond, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS_AS_MILLISECONDS), time2.Ticks / TimeSpan.TicksPerMillisecond, "later");
+            }
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS_AS_MILLISECONDS), time1.Ticks / TimeSpan.TicksPerMillisecond, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS_AS_MILLISECONDS), time2.Ticks / TimeSpan.TicksPerMillisecond, "later");
+            }
+
+            time1 = new DateTimeOffset(2005, 10, 30, 0, 0, 0, TimeSpan.Zero).ToLocalTime();
+            time2 = time1.AddHours(1);
+
+            {
+                string d1 = DateTools.DateToString(time1, DateResolution.MINUTE);
+                string d2 = DateTools.DateToString(time2, DateResolution.MINUTE);
+                Assert.IsFalse(d1.Equals(d2, StringComparison.Ordinal), "different times");
+                Assert.AreEqual(DateTools.StringToTime(d1, NumericRepresentation.TICKS_AS_MILLISECONDS), time1.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond, "midnight");
+                Assert.AreEqual(DateTools.StringToTime(d2, NumericRepresentation.TICKS_AS_MILLISECONDS), time2.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond, "later");
+            }
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public void TestDocumentationComments()
+        {
+            long unixEpochDate = 1095774611000; // javadoc appears to be wrong - this is actually what changes the GMT time as below
+            long ticks = 632313714110000000; // 2004-09-21 13:50:11
+            Assert.AreEqual(ticks, DateTools.UnixTimeMillisecondsToTicks(unixEpochDate));
+
+            long ticksOut = DateTools.Round(ticks, DateResolution.MONTH, NumericRepresentation.TICKS, NumericRepresentation.TICKS);
+            long expected = 1093996800000; // javadoc appears to be wrong - this is actually what the above is converted to
+            long actual = DateTools.TicksToUnixTimeMilliseconds(ticksOut);
+            Assert.AreEqual(expected, actual);
+
+            long unixEpochDateOut = DateTools.Round(unixEpochDate, DateResolution.MONTH, NumericRepresentation.UNIX_TIME_MILLISECONDS, NumericRepresentation.UNIX_TIME_MILLISECONDS);
+            Assert.AreEqual(expected, unixEpochDateOut);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public void TestLuceneCompatibility()
+        {
+            long unixDate = 1075846136333L;
+
+            string convertedDate = DateTools.TimeToString(unixDate, DateResolution.MILLISECOND, NumericRepresentation.UNIX_TIME_MILLISECONDS);
+            string expectedDate = "20040203220856333";
+            Assert.AreEqual(expectedDate, convertedDate);
+            Assert.AreEqual("2004-02-03 22:08:56:333", IsoFormat(DateTools.StringToDate(convertedDate)));
+            Assert.AreEqual(unixDate, DateTools.StringToTime(convertedDate));
         }
     }
 }

--- a/src/Lucene.Net.Tests/Search/TestCustomSearcherSort.cs
+++ b/src/Lucene.Net.Tests/Search/TestCustomSearcherSort.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -257,7 +257,7 @@ namespace Lucene.Net.Search
 
             // Just to generate some different Lucene Date strings
             internal virtual string LuceneDate
-                => DateTools.TimeToString((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) + random.Next() - int.MinValue, DateTools.Resolution.DAY);
+                => DateTools.TimeToString((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) + random.Next() - int.MinValue, DateResolution.DAY);
         }
     }
 }

--- a/src/Lucene.Net.Tests/Search/TestDateFilter.cs
+++ b/src/Lucene.Net.Tests/Search/TestDateFilter.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Search
 
             Document doc = new Document();
             // add time that is in the past
-            doc.Add(NewStringField("datefield", DateTools.TimeToString(now - 1000, DateTools.Resolution.MILLISECOND), Field.Store.YES));
+            doc.Add(NewStringField("datefield", DateTools.TimeToString(now - 1000, DateResolution.MILLISECOND), Field.Store.YES));
             doc.Add(NewTextField("body", "Today is a very sunny day in New York City", Field.Store.YES));
             writer.AddDocument(doc);
 
@@ -68,10 +68,10 @@ namespace Lucene.Net.Search
 
             // filter that should preserve matches
             // DateFilter df1 = DateFilter.Before("datefield", now);
-            TermRangeFilter df1 = TermRangeFilter.NewStringRange("datefield", DateTools.TimeToString(now - 2000, DateTools.Resolution.MILLISECOND), DateTools.TimeToString(now, DateTools.Resolution.MILLISECOND), false, true);
+            TermRangeFilter df1 = TermRangeFilter.NewStringRange("datefield", DateTools.TimeToString(now - 2000, DateResolution.MILLISECOND), DateTools.TimeToString(now, DateResolution.MILLISECOND), false, true);
             // filter that should discard matches
             // DateFilter df2 = DateFilter.Before("datefield", now - 999999);
-            TermRangeFilter df2 = TermRangeFilter.NewStringRange("datefield", DateTools.TimeToString(0, DateTools.Resolution.MILLISECOND), DateTools.TimeToString(now - 2000, DateTools.Resolution.MILLISECOND), true, false);
+            TermRangeFilter df2 = TermRangeFilter.NewStringRange("datefield", DateTools.TimeToString(0, DateResolution.MILLISECOND), DateTools.TimeToString(now - 2000, DateResolution.MILLISECOND), true, false);
 
             // search something that doesn't exist with DateFilter
             Query query1 = new TermQuery(new Term("body", "NoMatchForthis"));
@@ -126,7 +126,7 @@ namespace Lucene.Net.Search
 
             Document doc = new Document();
             // add time that is in the future
-            doc.Add(NewStringField("datefield", DateTools.TimeToString(now + 888888, DateTools.Resolution.MILLISECOND), Field.Store.YES));
+            doc.Add(NewStringField("datefield", DateTools.TimeToString(now + 888888, DateResolution.MILLISECOND), Field.Store.YES));
             doc.Add(NewTextField("body", "Today is a very sunny day in New York City", Field.Store.YES));
             writer.AddDocument(doc);
 
@@ -136,10 +136,10 @@ namespace Lucene.Net.Search
 
             // filter that should preserve matches
             // DateFilter df1 = DateFilter.After("datefield", now);
-            TermRangeFilter df1 = TermRangeFilter.NewStringRange("datefield", DateTools.TimeToString(now, DateTools.Resolution.MILLISECOND), DateTools.TimeToString(now + 999999, DateTools.Resolution.MILLISECOND), true, false);
+            TermRangeFilter df1 = TermRangeFilter.NewStringRange("datefield", DateTools.TimeToString(now, DateResolution.MILLISECOND), DateTools.TimeToString(now + 999999, DateResolution.MILLISECOND), true, false);
             // filter that should discard matches
             // DateFilter df2 = DateFilter.After("datefield", now + 999999);
-            TermRangeFilter df2 = TermRangeFilter.NewStringRange("datefield", DateTools.TimeToString(now + 999999, DateTools.Resolution.MILLISECOND), DateTools.TimeToString(now + 999999999, DateTools.Resolution.MILLISECOND), false, true);
+            TermRangeFilter df2 = TermRangeFilter.NewStringRange("datefield", DateTools.TimeToString(now + 999999, DateResolution.MILLISECOND), DateTools.TimeToString(now + 999999999, DateResolution.MILLISECOND), false, true);
 
             // search something that doesn't exist with DateFilter
             Query query1 = new TermQuery(new Term("body", "NoMatchForthis"));

--- a/src/Lucene.Net.Tests/Search/TestDateSort.cs
+++ b/src/Lucene.Net.Tests/Search/TestDateSort.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using NUnit.Framework;
 
 namespace Lucene.Net.Search
@@ -117,7 +117,7 @@ namespace Lucene.Net.Search
             document.Add(textField);
 
             // Add the date/time field.
-            string dateTimeString = DateTools.TimeToString(time, DateTools.Resolution.SECOND);
+            string dateTimeString = DateTools.TimeToString(time, DateResolution.SECOND);
             Field dateTimeField = NewStringField(DATE_TIME_FIELD, dateTimeString, Field.Store.YES);
             document.Add(dateTimeField);
 

--- a/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net
         [TestCase(typeof(Lucene.Net.Analysis.Analyzer))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:ConcurrentHashSet|PlatformHelper)|^Lucene\.ExceptionExtensions");
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:ConcurrentHashSet|PlatformHelper|DateTimeOffsetUtil)|^Lucene\.ExceptionExtensions");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net/Document/DateTools.cs
+++ b/src/Lucene.Net/Document/DateTools.cs
@@ -42,13 +42,21 @@ namespace Lucene.Net.Documents
     /// </summary>
     public static class DateTools
     {
-        private const string YEAR_FORMAT = "yyyy";
-        private const string MONTH_FORMAT = "yyyyMM";
-        private const string DAY_FORMAT = "yyyyMMdd";
-        private const string HOUR_FORMAT = "yyyyMMddHH";
-        private const string MINUTE_FORMAT = "yyyyMMddHHmm";
-        private const string SECOND_FORMAT = "yyyyMMddHHmmss";
-        private const string MILLISECOND_FORMAT = "yyyyMMddHHmmssfff";
+        /// <summary>
+        /// Returns the date format string for the specified <paramref name="resolution"/>
+        /// or <c>null</c> if the resolution is invalid.
+        /// </summary>
+        private static string ToDateFormat(Resolution resolution) => resolution switch
+        {
+            Resolution.YEAR =>        "yyyy",
+            Resolution.MONTH =>       "yyyyMM",
+            Resolution.DAY =>         "yyyyMMdd",
+            Resolution.HOUR =>        "yyyyMMddHH",
+            Resolution.MINUTE =>      "yyyyMMddHHmm",
+            Resolution.SECOND =>      "yyyyMMddHHmmss",
+            Resolution.MILLISECOND => "yyyyMMddHHmmssfff",
+            _ => null, // Invalid option
+        };
 
         // LUCENENET - not used
         //private static readonly System.Globalization.Calendar calInstance = new System.Globalization.GregorianCalendar();
@@ -76,38 +84,12 @@ namespace Lucene.Net.Documents
         /// depending on <paramref name="resolution"/>; using GMT as timezone </returns>
         public static string TimeToString(long time, Resolution resolution)
         {
-            DateTime date = new DateTime(Round(time, resolution));
+            DateTime date = new DateTime(Round(time, resolution), DateTimeKind.Utc);
+            string format = ToDateFormat(resolution);
+            if (format is null)
+                throw new ArgumentException("unknown resolution " + resolution);
 
-            if (resolution == Resolution.YEAR)
-            {
-                return date.ToString(YEAR_FORMAT, CultureInfo.InvariantCulture);
-            }
-            else if (resolution == Resolution.MONTH)
-            {
-                return date.ToString(MONTH_FORMAT, CultureInfo.InvariantCulture);
-            }
-            else if (resolution == Resolution.DAY)
-            {
-                return date.ToString(DAY_FORMAT, CultureInfo.InvariantCulture);
-            }
-            else if (resolution == Resolution.HOUR)
-            {
-                return date.ToString(HOUR_FORMAT, CultureInfo.InvariantCulture);
-            }
-            else if (resolution == Resolution.MINUTE)
-            {
-                return date.ToString(MINUTE_FORMAT, CultureInfo.InvariantCulture);
-            }
-            else if (resolution == Resolution.SECOND)
-            {
-                return date.ToString(SECOND_FORMAT, CultureInfo.InvariantCulture);
-            }
-            else if (resolution == Resolution.MILLISECOND)
-            {
-                return date.ToString(MILLISECOND_FORMAT, CultureInfo.InvariantCulture);
-            }
-
-            throw new ArgumentException("unknown resolution " + resolution);
+            return date.ToString(format, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -135,67 +117,11 @@ namespace Lucene.Net.Documents
         /// expected format </exception>
         public static DateTime StringToDate(string dateString)
         {
-            DateTime date;
-            if (dateString.Length == 4)
-            {
-                date = new DateTime(Convert.ToInt16(dateString.Substring(0, 4), CultureInfo.InvariantCulture),
-                    1, 1, 0, 0, 0, 0);
-            }
-            else if (dateString.Length == 6)
-            {
-                date = new DateTime(Convert.ToInt16(dateString.Substring(0, 4), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(4, 2), CultureInfo.InvariantCulture),
-                    1, 0, 0, 0, 0);
-            }
-            else if (dateString.Length == 8)
-            {
-                date = new DateTime(Convert.ToInt16(dateString.Substring(0, 4), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(4, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(6, 2), CultureInfo.InvariantCulture),
-                    0, 0, 0, 0);
-            }
-            else if (dateString.Length == 10)
-            {
-                date = new DateTime(Convert.ToInt16(dateString.Substring(0, 4), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(4, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(6, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(8, 2), CultureInfo.InvariantCulture),
-                    0, 0, 0);
-            }
-            else if (dateString.Length == 12)
-            {
-                date = new DateTime(Convert.ToInt16(dateString.Substring(0, 4), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(4, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(6, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(8, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(10, 2), CultureInfo.InvariantCulture),
-                    0, 0);
-            }
-            else if (dateString.Length == 14)
-            {
-                date = new DateTime(Convert.ToInt16(dateString.Substring(0, 4), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(4, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(6, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(8, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(10, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(12, 2), CultureInfo.InvariantCulture),
-                    0);
-            }
-            else if (dateString.Length == 17)
-            {
-                date = new DateTime(Convert.ToInt16(dateString.Substring(0, 4), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(4, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(6, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(8, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(10, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(12, 2), CultureInfo.InvariantCulture),
-                    Convert.ToInt16(dateString.Substring(14, 3), CultureInfo.InvariantCulture));
-            }
-            else
-            {
+            string format = ToDateFormat((Resolution)dateString.Length);
+            if (format is null || !DateTimeOffset.TryParseExact(dateString, format, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out DateTimeOffset dateOffset))
                 throw new ParseException("Input is not valid date string: " + dateString, 0);
-            }
-            return date;
+
+            return dateOffset.DateTime;
         }
 
         /// <summary>
@@ -225,7 +151,9 @@ namespace Lucene.Net.Documents
         /// (also known as the "epoch")</returns>
         public static long Round(long time, Resolution resolution)
         {
-            DateTime dt = new DateTime(time * TimeSpan.TicksPerMillisecond);
+            DateTimeOffset dt = new DateTimeOffset(time * TimeSpan.TicksPerMillisecond, TimeSpan.Zero);
+            // Remove extra ticks beyond milliseconds
+            dt = new DateTimeOffset(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, dt.Millisecond, TimeSpan.Zero);
 
             if (resolution == Resolution.YEAR)
             {

--- a/src/Lucene.Net/Document/DateTools.cs
+++ b/src/Lucene.Net/Document/DateTools.cs
@@ -1,4 +1,5 @@
 ﻿using J2N.Text;
+using Lucene.Net.Support;
 using System;
 using System.Globalization;
 
@@ -36,79 +37,171 @@ namespace Lucene.Net.Documents
     /// a sortable binary representation (prefix encoded) of numeric values, which
     /// date/time are.
     /// 
-    /// For indexing a <see cref="DateTime"/>, just get the <see cref="DateTime.Ticks"/> and index
+    /// For indexing a <see cref="DateTime"/>, just get the <see cref="UnixTimeMillisecondsToTicks(long)"/> from <see cref="DateTime.Ticks"/> and index
     /// this as a numeric value with <see cref="Int64Field"/> and use <see cref="Search.NumericRangeQuery{T}"/>
     /// to query it.
     /// </summary>
+    // LUCENENET: This class was refactored significantly to be usable on the .NET platform, but still allows
+    // all of the same features as Java and prior versions of Lucene.NET
     public static class DateTools
     {
         /// <summary>
         /// Returns the date format string for the specified <paramref name="resolution"/>
         /// or <c>null</c> if the resolution is invalid.
         /// </summary>
-        private static string ToDateFormat(Resolution resolution) => resolution switch
+        private static string ToDateFormat(DateResolution resolution) => resolution switch
         {
-            Resolution.YEAR =>        "yyyy",
-            Resolution.MONTH =>       "yyyyMM",
-            Resolution.DAY =>         "yyyyMMdd",
-            Resolution.HOUR =>        "yyyyMMddHH",
-            Resolution.MINUTE =>      "yyyyMMddHHmm",
-            Resolution.SECOND =>      "yyyyMMddHHmmss",
-            Resolution.MILLISECOND => "yyyyMMddHHmmssfff",
+            DateResolution.YEAR =>        "yyyy",
+            DateResolution.MONTH =>       "yyyyMM",
+            DateResolution.DAY =>         "yyyyMMdd",
+            DateResolution.HOUR =>        "yyyyMMddHH",
+            DateResolution.MINUTE =>      "yyyyMMddHHmm",
+            DateResolution.SECOND =>      "yyyyMMddHHmmss",
+            DateResolution.MILLISECOND => "yyyyMMddHHmmssfff",
             _ => null, // Invalid option
         };
 
-        // LUCENENET - not used
-        //private static readonly System.Globalization.Calendar calInstance = new System.Globalization.GregorianCalendar();
-
         /// <summary>
-        /// Converts a <see cref="DateTime"/> to a string suitable for indexing.
+        /// Converts a <see cref="DateTime"/> to a string suitable for indexing using the specified 
+        /// <paramref name="resolution"/>.
+        /// <para/>
+        /// The <paramref name="date"/> is converted according to its <see cref="DateTime.Kind"/> property
+        /// to the Universal Coordinated Time (UTC) prior to rounding to the the specified
+        /// <paramref name="resolution"/>. If <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Unspecified"/>,
+        /// <see cref="DateTimeKind.Local"/> is assumed.
         /// </summary>
-        /// <param name="date"> the date to be converted </param>
-        /// <param name="resolution"> the desired resolution, see
-        /// <see cref="Round(DateTime, DateTools.Resolution)"/> </param>
-        /// <returns> a string in format <c>yyyyMMddHHmmssSSS</c> or shorter,
-        /// depending on <paramref name="resolution"/>; using GMT as timezone  </returns>
-        public static string DateToString(DateTime date, Resolution resolution)
+        /// <param name="date">The date to be converted.</param>
+        /// <param name="resolution">The desired resolution, see
+        /// <see cref="Round(DateTime, DateResolution)"/>.</param>
+        /// <returns>A string in format <c>yyyyMMddHHmmssSSS</c> or shorter,
+        /// depending on <paramref name="resolution"/>; using UTC as the timezone.</returns>
+        public static string DateToString(DateTime date, DateResolution resolution)
         {
-            return TimeToString(date.Ticks / TimeSpan.TicksPerMillisecond, resolution);
+            return DateToString(date, resolution, timeZone: null);
         }
 
         /// <summary>
-        /// Converts a millisecond time to a string suitable for indexing.
+        /// Converts a <see cref="DateTime"/> to a string suitable for indexing using the specified <paramref name="timeZone"/>
+        /// and <paramref name="resolution"/>.
+        /// <para/>
+        /// The <paramref name="date"/> is converted from the specified <paramref name="timeZone"/> to Universal Coordinated Time
+        /// (UTC) prior to rounding to the the specified <paramref name="resolution"/>.
         /// </summary>
-        /// <param name="time"> the date expressed as milliseconds since January 1, 1970, 00:00:00 GMT (also known as the "epoch") </param>
-        /// <param name="resolution"> the desired resolution, see
-        /// <see cref="Round(long, DateTools.Resolution)"/> </param>
-        /// <returns> a string in format <c>yyyyMMddHHmmssSSS</c> or shorter,
-        /// depending on <paramref name="resolution"/>; using GMT as timezone </returns>
-        public static string TimeToString(long time, Resolution resolution)
+        /// <param name="date">The date to be converted.</param>
+        /// <param name="timeZone">The time zone of the specified <paramref name="date"/>.</param>
+        /// <param name="resolution">The desired resolution, see
+        /// <see cref="Round(DateTime, DateResolution)"/>.</param>
+        /// <returns>A string in format <c>yyyyMMddHHmmssSSS</c> or shorter,
+        /// depending on <paramref name="resolution"/>; using UTC as the timezone.</returns>
+        public static string DateToString(DateTime date, TimeZoneInfo timeZone, DateResolution resolution)
         {
-            DateTime date = new DateTime(Round(time, resolution), DateTimeKind.Utc);
+            if (timeZone is null)
+                throw new ArgumentNullException(nameof(timeZone));
+
+            return DateToString(date, resolution, timeZone);
+        }
+
+        private static string DateToString(DateTime date, DateResolution resolution, TimeZoneInfo timeZone)
+        {
             string format = ToDateFormat(resolution);
             if (format is null)
-                throw new ArgumentException("unknown resolution " + resolution);
+                throw new ArgumentException($"Unknown resolution {resolution}.");
 
+            DateTimeOffset timeZoneAdjusted;
+            switch (date.Kind)
+            {
+                case DateTimeKind.Utc:
+                    if (timeZone is null || TimeZoneInfo.Utc.Equals(timeZone))
+                    {
+                        timeZoneAdjusted = new DateTimeOffset(date, TimeSpan.Zero);
+                    }
+                    else
+                    {
+                        timeZoneAdjusted = new DateTimeOffset(date, TimeSpan.Zero);
+                        timeZoneAdjusted = TimeZoneInfo.ConvertTime(timeZoneAdjusted, timeZone);
+                    }
+                    break;
+
+                case DateTimeKind.Local:
+                    timeZone = timeZone ?? TimeZoneInfo.Local;
+                    timeZoneAdjusted = new DateTimeOffset(date, timeZone.GetUtcOffset(date));
+                    break;
+
+                default: //case DateTimeKind.Unspecified:
+                    timeZone = timeZone ?? TimeZoneInfo.Local; // Assume local time zone if not specified
+                    timeZoneAdjusted = new DateTimeOffset(date, timeZone.GetUtcOffset(new DateTime(date.Ticks, DateTimeKind.Local)));
+                    break;
+            }
+
+            DateTime d = Round(timeZoneAdjusted.UtcDateTime, resolution);
+            return d.ToString(format, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="DateTimeOffset"/> to a string suitable for indexing using the specified 
+        /// <paramref name="resolution"/>.
+        /// <para/>
+        /// The <paramref name="date"/> is converted using its <see cref="DateTimeOffset.UtcDateTime"/> property.
+        /// </summary>
+        /// <param name="date">The date to be converted.</param>
+        /// <param name="resolution">The desired resolution, see <see cref="Round(DateTime, DateResolution)"/>.</param>
+        /// <returns>A string in format <c>yyyyMMddHHmmssSSS</c> or shorter,
+        /// depending on <paramref name="resolution"/>; using UTC as the timezone.</returns>
+        public static string DateToString(DateTimeOffset date, DateResolution resolution)
+        {
+            string format = ToDateFormat(resolution);
+            if (format is null)
+                throw new ArgumentException($"Unknown resolution {resolution}.");
+            DateTime d = Round(date.UtcDateTime, resolution);
+            return d.ToString(format, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts from a numeric representation of a time to a string suitable for indexing.
+        /// <para/>
+        /// <b>NOTE:</b> For compatibility with Lucene.NET 3.0.3 and Lucene.NET 4.8.0-beta00001 through 4.8.0-beta00015
+        /// specify <paramref name="inputRepresentation"/> as <see cref="NumericRepresentation.TICKS_AS_MILLISECONDS"/>.
+        /// </summary>
+        /// <param name="time">The ticks that represent the date to be converted.</param>
+        /// <param name="resolution">The desired resolution, see
+        /// <see cref="Round(long, DateResolution, NumericRepresentation, NumericRepresentation)"/>.</param>
+        /// <param name="inputRepresentation">The numeric representation of <paramref name="time"/>.</param>
+        /// <returns>A string in format <c>yyyyMMddHHmmssSSS</c> or shorter,
+        /// depending on <paramref name="resolution"/>; using GMT as timezone.</returns>
+        public static string TimeToString(long time, DateResolution resolution,
+            NumericRepresentation inputRepresentation = NumericRepresentation.UNIX_TIME_MILLISECONDS)
+        {
+            string format = ToDateFormat(resolution);
+            if (format is null)
+                throw new ArgumentException($"Unknown resolution {resolution}.");
+            DateTime date = new DateTime(Round(time, resolution, inputRepresentation, NumericRepresentation.TICKS), DateTimeKind.Utc);
             return date.ToString(format, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
-        /// Converts a string produced by <see cref="TimeToString(long, Resolution)"/> or
-        /// <see cref="DateToString(DateTime, Resolution)"/> back to a time, represented as the
-        /// number of milliseconds since January 1, 1970, 00:00:00 GMT (also known as the "epoch").
+        /// Converts a string produced by <see cref="TimeToString(long, DateResolution, NumericRepresentation)"/> or
+        /// <see cref="DateToString(DateTime, DateResolution)"/> back to a time, represented as a <see cref="long"/>.
         /// </summary>
-        /// <param name="dateString"> the date string to be converted </param>
-        /// <returns> the number of milliseconds since January 1, 1970, 00:00:00 GMT (also known as the "epoch")</returns>
-        /// <exception cref="FormatException"> if <paramref name="dateString"/> is not in the
-        /// expected format </exception>
-        public static long StringToTime(string dateString)
+        /// <param name="dateString"> The date string to be converted. </param>
+        /// <param name="outputRepresentation">The numeric representation of the return value.</param>
+        /// <returns>A numeric representation of <paramref name="dateString"/> represented as specified by
+        /// <paramref name="outputRepresentation"/>.</returns>
+        /// <exception cref="FormatException"><paramref name="dateString"/> is not in the expected format.</exception>
+        public static long StringToTime(string dateString, NumericRepresentation outputRepresentation = NumericRepresentation.UNIX_TIME_MILLISECONDS)
         {
-            return StringToDate(dateString).Ticks;
+            long ticks = StringToDate(dateString).Ticks;
+            return outputRepresentation switch
+            {
+                NumericRepresentation.UNIX_TIME_MILLISECONDS => TicksToUnixTimeMilliseconds(ticks),
+                NumericRepresentation.TICKS => ticks,
+                NumericRepresentation.TICKS_AS_MILLISECONDS => ticks / TimeSpan.TicksPerMillisecond,
+                _ => throw new ArgumentException($"'{outputRepresentation}' is not a valid {nameof(outputRepresentation)}.")
+            };
         }
 
         /// <summary>
-        /// Converts a string produced by <see cref="TimeToString(long, Resolution)"/> or
-        /// <see cref="DateToString(DateTime, Resolution)"/> back to a time, represented as a
+        /// Converts a string produced by <see cref="TimeToString(long, DateResolution, NumericRepresentation)"/> or
+        /// <see cref="DateToString(DateTime, DateResolution)"/> back to a time, represented as a
         /// <see cref="DateTime"/> object.
         /// </summary>
         /// <param name="dateString"> the date string to be converted </param>
@@ -117,9 +210,9 @@ namespace Lucene.Net.Documents
         /// expected format </exception>
         public static DateTime StringToDate(string dateString)
         {
-            string format = ToDateFormat((Resolution)dateString.Length);
+            string format = ToDateFormat((DateResolution)dateString.Length);
             if (format is null || !DateTimeOffset.TryParseExact(dateString, format, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out DateTimeOffset dateOffset))
-                throw new ParseException("Input is not valid date string: " + dateString, 0);
+                throw new ParseException($"Input is not valid date string: '{dateString}'.", 0);
 
             return dateOffset.DateTime;
         }
@@ -127,35 +220,61 @@ namespace Lucene.Net.Documents
         /// <summary>
         /// Limit a date's resolution. For example, the date <c>2004-09-21 13:50:11</c>
         /// will be changed to <c>2004-09-01 00:00:00</c> when using
-        /// <see cref="Resolution.MONTH"/>.
+        /// <see cref="DateResolution.MONTH"/>.
         /// </summary>
-        /// <param name="date"> the date to be rounded </param>
-        /// <param name="resolution"> The desired resolution of the date to be returned </param>
-        /// <returns> the date with all values more precise than <paramref name="resolution"/>
-        /// set to 0 or 1 </returns>
-        public static DateTime Round(DateTime date, Resolution resolution)
+        /// <param name="date"> The <see cref="DateTime"/> to be rounded.</param>
+        /// <param name="resolution"> The desired resolution of the <see cref="DateTime"/> to be returned. </param>
+        /// <returns> The <see cref="DateTime"/> with all values more precise than <paramref name="resolution"/>
+        /// set to their minimum value (0 or 1 depending on the field).</returns>
+        public static DateTime Round(DateTime date, DateResolution resolution)
         {
-            return new DateTime(Round(date.Ticks / TimeSpan.TicksPerMillisecond, resolution));
+            return new DateTime(Round(date.Ticks, resolution,
+                inputRepresentation: NumericRepresentation.TICKS,
+                outputRepresentation: NumericRepresentation.TICKS));
         }
 
         /// <summary>
-        /// Limit a date's resolution. For example, the date <c>1095767411000</c>
+        /// Limit a date's resolution.
+        /// <para/>
+        /// For example, the time <c>1095774611000</c>
         /// (which represents 2004-09-21 13:50:11) will be changed to
-        /// <c>1093989600000</c> (2004-09-01 00:00:00) when using
-        /// <see cref="Resolution.MONTH"/>.
+        /// <c>1093996800000</c> (2004-09-01 00:00:00) when using
+        /// <see cref="DateResolution.MONTH"/> and <see cref="NumericRepresentation.UNIX_TIME_MILLISECONDS"/>
+        /// for both <paramref name="inputRepresentation"/> and <paramref name="outputRepresentation"/>.
+        /// <para/>
+        /// The ticks <c>632313714110000000</c>
+        /// (which represents 2004-09-21 13:50:11) will be changed to
+        /// <c>632295936000000000</c> (2004-09-01 00:00:00) when using
+        /// <see cref="DateResolution.MONTH"/> and <see cref="NumericRepresentation.TICKS"/>
+        /// for both <paramref name="inputRepresentation"/> and <paramref name="outputRepresentation"/>.
+        /// <para/>
+        /// <b>NOTE:</b> For compatibility with Lucene.NET 3.0.3 and Lucene.NET 4.8.0-beta00001 through 4.8.0-beta00015
+        /// specify <paramref name="inputRepresentation"/> as <see cref="NumericRepresentation.TICKS_AS_MILLISECONDS"/> and
+        /// <paramref name="outputRepresentation"/> as <see cref="NumericRepresentation.TICKS"/>.
         /// </summary>
-        /// <param name="time"> the time to be rounded </param>
-        /// <param name="resolution"> The desired resolution of the date to be returned </param>
-        /// <returns> the date with all values more precise than <paramref name="resolution"/>
-        /// set to 0 or 1, expressed as milliseconds since January 1, 1970, 00:00:00 GMT 
-        /// (also known as the "epoch")</returns>
-        public static long Round(long time, Resolution resolution)
+        /// <param name="time">The ticks that represent the date to be rounded.</param>
+        /// <param name="resolution">The desired resolution of the date to be returned.</param>
+        /// <param name="inputRepresentation">The numeric representation of <paramref name="time"/>.</param>
+        /// <param name="outputRepresentation">The numeric representation of the return value.</param>
+        /// <returns>The date with all values more precise than <paramref name="resolution"/>
+        /// set to their minimum value (0 or 1 depending on the field). The return value is expressed in ticks.</returns>
+        public static long Round(long time, DateResolution resolution,
+            NumericRepresentation inputRepresentation = NumericRepresentation.UNIX_TIME_MILLISECONDS,
+            NumericRepresentation outputRepresentation = NumericRepresentation.UNIX_TIME_MILLISECONDS)
         {
-            DateTimeOffset dt = new DateTimeOffset(time * TimeSpan.TicksPerMillisecond, TimeSpan.Zero);
+            long ticks = inputRepresentation switch
+            {
+                NumericRepresentation.UNIX_TIME_MILLISECONDS => UnixTimeMillisecondsToTicks(time),
+                NumericRepresentation.TICKS => time,
+                NumericRepresentation.TICKS_AS_MILLISECONDS => time * TimeSpan.TicksPerMillisecond,
+                _ => throw new ArgumentException($"'{inputRepresentation}' is not a valid {nameof(inputRepresentation)}.")
+            };
+            
+            DateTimeOffset dt = new DateTimeOffset(ticks, TimeSpan.Zero);
             // Remove extra ticks beyond milliseconds
             dt = new DateTimeOffset(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, dt.Millisecond, TimeSpan.Zero);
 
-            if (resolution == Resolution.YEAR)
+            if (resolution == DateResolution.YEAR)
             {
                 dt = dt.AddMonths(1 - dt.Month);
                 dt = dt.AddDays(1 - dt.Day);
@@ -164,7 +283,7 @@ namespace Lucene.Net.Documents
                 dt = dt.AddSeconds(0 - dt.Second);
                 dt = dt.AddMilliseconds(0 - dt.Millisecond);
             }
-            else if (resolution == Resolution.MONTH)
+            else if (resolution == DateResolution.MONTH)
             {
                 dt = dt.AddDays(1 - dt.Day);
                 dt = dt.AddHours(0 - dt.Hour);
@@ -172,29 +291,29 @@ namespace Lucene.Net.Documents
                 dt = dt.AddSeconds(0 - dt.Second);
                 dt = dt.AddMilliseconds(0 - dt.Millisecond);
             }
-            else if (resolution == Resolution.DAY)
+            else if (resolution == DateResolution.DAY)
             {
                 dt = dt.AddHours(0 - dt.Hour);
                 dt = dt.AddMinutes(0 - dt.Minute);
                 dt = dt.AddSeconds(0 - dt.Second);
                 dt = dt.AddMilliseconds(0 - dt.Millisecond);
             }
-            else if (resolution == Resolution.HOUR)
+            else if (resolution == DateResolution.HOUR)
             {
                 dt = dt.AddMinutes(0 - dt.Minute);
                 dt = dt.AddSeconds(0 - dt.Second);
                 dt = dt.AddMilliseconds(0 - dt.Millisecond);
             }
-            else if (resolution == Resolution.MINUTE)
+            else if (resolution == DateResolution.MINUTE)
             {
                 dt = dt.AddSeconds(0 - dt.Second);
                 dt = dt.AddMilliseconds(0 - dt.Millisecond);
             }
-            else if (resolution == Resolution.SECOND)
+            else if (resolution == DateResolution.SECOND)
             {
                 dt = dt.AddMilliseconds(0 - dt.Millisecond);
             }
-            else if (resolution == Resolution.MILLISECOND)
+            else if (resolution == DateResolution.MILLISECOND)
             {
                 // don't cut off anything
             }
@@ -202,40 +321,102 @@ namespace Lucene.Net.Documents
             {
                 throw new ArgumentException("unknown resolution " + resolution);
             }
-            return dt.Ticks;
+            return outputRepresentation switch
+            {
+                NumericRepresentation.UNIX_TIME_MILLISECONDS => TicksToUnixTimeMilliseconds(dt.Ticks),
+                NumericRepresentation.TICKS => dt.Ticks,
+                NumericRepresentation.TICKS_AS_MILLISECONDS => dt.Ticks / TimeSpan.TicksPerMillisecond,
+                _ => throw new ArgumentException($"'{outputRepresentation}' is not a valid {nameof(outputRepresentation)}.")
+            };
         }
 
         /// <summary>
-        /// Specifies the time granularity. </summary>
-        public enum Resolution
+        /// Converts from .NET ticks to the number of milliseconds since January 1, 1970, 00:00:00
+        /// UTC (also known as the "epoch").
+        /// <para/>
+        /// This is the value that is stored in Java Lucene indexes and can be used for storing values
+        /// that can be read by Java Lucene.
+        /// </summary>
+        /// <param name="ticks">The .NET ticks to be converted.</param>
+        /// <returns>The converted ticks to number of milliseconds since January 1, 1970, 00:00:00
+        /// UTC (also known as the "epoch").</returns>
+        public static long TicksToUnixTimeMilliseconds(long ticks)
         {
-            /// <summary>
-            /// Limit a date's resolution to year granularity. </summary>
-            YEAR = 4,
-
-            /// <summary>
-            /// Limit a date's resolution to month granularity. </summary>
-            MONTH = 6,
-
-            /// <summary>
-            /// Limit a date's resolution to day granularity. </summary>
-            DAY = 8,
-
-            /// <summary>
-            /// Limit a date's resolution to hour granularity. </summary>
-            HOUR = 10,
-
-            /// <summary>
-            /// Limit a date's resolution to minute granularity. </summary>
-            MINUTE = 12,
-
-            /// <summary>
-            /// Limit a date's resolution to second granularity. </summary>
-            SECOND = 14,
-
-            /// <summary>
-            /// Limit a date's resolution to millisecond granularity. </summary>
-            MILLISECOND = 17
+            return DateTimeOffsetUtil.ToUnixTimeMilliseconds(ticks);
         }
+
+        /// <summary>
+        /// Converts from the number of milliseconds since January 1, 1970, 00:00:00 UTC
+        /// (also known as the "epoch") to .NET ticks.
+        /// </summary>
+        /// <param name="unixTimeMilliseconds">The number of milliseconds since January 1, 1970, 00:00:00
+        /// UTC (also known as the "epoch") to be converted.</param>
+        /// <returns>The converted .NET ticks that can be used to create a <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.</returns>
+        public static long UnixTimeMillisecondsToTicks(long unixTimeMilliseconds)
+        {
+            return DateTimeOffsetUtil.GetTicksFromUnixTimeMilliseconds(unixTimeMilliseconds);
+        }
+    }
+
+    /// <summary>
+    /// Specifies the time granularity. </summary>
+    public enum DateResolution
+    {
+        /// <summary>
+        /// Limit a date's resolution to year granularity. </summary>
+        YEAR = 4,
+
+        /// <summary>
+        /// Limit a date's resolution to month granularity. </summary>
+        MONTH = 6,
+
+        /// <summary>
+        /// Limit a date's resolution to day granularity. </summary>
+        DAY = 8,
+
+        /// <summary>
+        /// Limit a date's resolution to hour granularity. </summary>
+        HOUR = 10,
+
+        /// <summary>
+        /// Limit a date's resolution to minute granularity. </summary>
+        MINUTE = 12,
+
+        /// <summary>
+        /// Limit a date's resolution to second granularity. </summary>
+        SECOND = 14,
+
+        /// <summary>
+        /// Limit a date's resolution to millisecond granularity. </summary>
+        MILLISECOND = 17
+    }
+
+    /// <summary>
+    /// Specifies how a time will be represented as a <see cref="long"/>.
+    /// </summary>
+    public enum NumericRepresentation
+    {
+        /// <summary>
+        /// The number of milliseconds since January 1, 1970, 00:00:00
+        /// UTC (also known as the "epoch"). This is the format that Lucene
+        /// uses, and it is recommended to store this value in the index for compatibility.
+        /// </summary>
+        UNIX_TIME_MILLISECONDS,
+
+        /// <summary>
+        /// The .NET ticks representing a date. Specify this to pass the raw ticks from <see cref="DateTime.Ticks"/>
+        /// or to instantiate a new <see cref="DateTime"/> from the result.
+        /// </summary>
+        TICKS,
+
+        /// <summary>
+        /// .NET ticks as total milliseconds.
+        /// Input values must be converted using the formula <c>ticks / <see cref="TimeSpan.TicksPerMillisecond"/></c>.
+        /// Output values can be converted to ticks using <c>ticks * <see cref="TimeSpan.TicksPerMillisecond"/></c>.
+        /// <para/>
+        /// This option is provided for compatibility with Lucene.NET 3.0.3 and Lucene.NET 4.8.0-beta00001 through 4.8.0-beta00015,
+        /// since it was the only option for input representation.
+        /// </summary>
+        TICKS_AS_MILLISECONDS,
     }
 }

--- a/src/Lucene.Net/Support/DateTimeOffsetUtil.cs
+++ b/src/Lucene.Net/Support/DateTimeOffsetUtil.cs
@@ -74,5 +74,13 @@ namespace Lucene.Net.Support
             long milliseconds = offset.UtcDateTime.Ticks / TimeSpan.TicksPerMillisecond;
             return milliseconds - UnixEpochMilliseconds;
         }
+
+        public static long ToUnixTimeMilliseconds(long ticks)
+        {
+            // Truncate sub-millisecond precision before offsetting by the Unix Epoch to avoid
+            // the last digit being off by one for dates that result in negative Unix times
+            long milliseconds = ticks / TimeSpan.TicksPerMillisecond;
+            return milliseconds - UnixEpochMilliseconds;
+        }
     }
 }

--- a/src/Lucene.Net/Support/DateTimeOffsetUtil.cs
+++ b/src/Lucene.Net/Support/DateTimeOffsetUtil.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Lucene.Net.Support
+{
+    // Source: https://github.com/dotnet/runtime/blob/af4efb1936b407ca5f4576e81484cf5687b79a26/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+    internal static class DateTimeOffsetUtil
+    {
+        /// <summary>
+        /// The .NET ticks representing January 1, 1970 0:00:00, also known as the "epoch".
+        /// </summary>
+        private const long UnixEpochTicks = 621355968000000000L;
+
+        private const long UnixEpochMilliseconds = UnixEpochTicks / TimeSpan.TicksPerMillisecond; // 62,135,596,800,000
+
+        public const long MinMilliseconds = /*DateTime.*/MinTicks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
+        public const long MaxMilliseconds = /*DateTime.*/MaxTicks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
+
+        // From System.DateTime
+
+        // Number of 100ns ticks per time unit
+        private const long TicksPerMillisecond = 10000;
+        private const long TicksPerSecond = TicksPerMillisecond * 1000;
+        private const long TicksPerMinute = TicksPerSecond * 60;
+        private const long TicksPerHour = TicksPerMinute * 60;
+        private const long TicksPerDay = TicksPerHour * 24;
+
+        // Number of days in a non-leap year
+        private const int DaysPerYear = 365;
+        // Number of days in 4 years
+        private const int DaysPer4Years = DaysPerYear * 4 + 1;       // 1461
+        // Number of days in 100 years
+        private const int DaysPer100Years = DaysPer4Years * 25 - 1;  // 36524
+        // Number of days in 400 years
+        private const int DaysPer400Years = DaysPer100Years * 4 + 1; // 146097
+
+        // Number of days from 1/1/0001 to 12/31/9999
+        private const int DaysTo10000 = DaysPer400Years * 25 - 366;  // 3652059
+
+        internal const long MinTicks = 0;
+        internal const long MaxTicks = DaysTo10000 * TicksPerDay - 1;
+
+
+        public static long GetTicksFromUnixTimeMilliseconds(long milliseconds)
+        {
+            if (milliseconds < MinMilliseconds || milliseconds > MaxMilliseconds)
+            {
+                throw new ArgumentOutOfRangeException(nameof(milliseconds),
+                    string.Format("Valid values are between {0} and {1}, inclusive.", MinMilliseconds, MaxMilliseconds));
+            }
+
+            long ticks = milliseconds * TimeSpan.TicksPerMillisecond + UnixEpochTicks;
+            return ticks;
+        }
+
+        public static DateTimeOffset FromUnixTimeMilliseconds(long milliseconds)
+        {
+            if (milliseconds < MinMilliseconds || milliseconds > MaxMilliseconds)
+            {
+                throw new ArgumentOutOfRangeException(nameof(milliseconds),
+                    string.Format("Valid values are between {0} and {1}, inclusive.", MinMilliseconds, MaxMilliseconds));
+            }
+
+            long ticks = milliseconds * TimeSpan.TicksPerMillisecond + UnixEpochTicks;
+            return new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+
+        public static long ToUnixTimeMilliseconds(DateTimeOffset offset)
+        {
+            // Truncate sub-millisecond precision before offsetting by the Unix Epoch to avoid
+            // the last digit being off by one for dates that result in negative Unix times
+            long milliseconds = offset.UtcDateTime.Ticks / TimeSpan.TicksPerMillisecond;
+            return milliseconds - UnixEpochMilliseconds;
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Util/NumberFormat.cs
+++ b/src/Lucene.Net/Support/Util/NumberFormat.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Util
     // and passing this class around to different methods, that would require some major refactoring.
     // We should probably look into doing that in vNext. We should also look into supporting all of .NET's numeric
     // types instead of just the ones that Java supports, as well.
-    public class NumberFormat
+    public abstract class NumberFormat
     {
         private readonly IFormatProvider formatProvider;
 
@@ -51,7 +51,11 @@ namespace Lucene.Net.Util
         {
             string format = GetNumberFormat();
 
-            if (number is int i)
+            if (number is J2N.Numerics.Number num)
+            {
+                return num.ToString(format, formatProvider);
+            }
+            else if (number is int i)
             {
                 return i.ToString(format, formatProvider);
             }
@@ -65,11 +69,11 @@ namespace Lucene.Net.Util
             }
             else if (number is float f)
             {
-                return f.ToString(format, formatProvider);
+                return J2N.Numerics.Single.ToString(f, format, formatProvider);
             }
             else if (number is double d)
             {
-                return d.ToString(format, formatProvider);
+                return J2N.Numerics.Double.ToString(d, format, formatProvider);
             }
             else if (number is decimal dec)
             {
@@ -82,7 +86,7 @@ namespace Lucene.Net.Util
         public virtual string Format(double number)
         {
             string format = GetNumberFormat();
-            return number.ToString(format, formatProvider);
+            return J2N.Numerics.Double.ToString(number, format, formatProvider);
         }
 
         public virtual string Format(long number)
@@ -102,10 +106,7 @@ namespace Lucene.Net.Util
             return null;
         }
 
-        public virtual /*Number*/ object Parse(string source)
-        {
-            return decimal.Parse(source, formatProvider);
-        }
+        public abstract J2N.Numerics.Number Parse(string source);
 
         public override string ToString()
         {


### PR DESCRIPTION
### DateTools

- Added support for `TimeZoneInfo` when converting to/from string
- BREAKING: Added `NumericRepresentation` enum to allow converting to/from long in the following formats:
  - Unix Epoch (default): Milliseconds since Jan 1, 1970 12:00:00 AM UTC.
  - Ticks: The raw ticks from `DateTime` or `DateTimeOffset`.
  - Ticks as Milliseconds: This is for compatibility with prior versions of Lucene.NET (3.0.3 and 4.8.0-beta00001 - 4.8.0-beta00015). The conversion done on input values is `time * TimeSpan.TicksPerMillisecond` and the conversion to output values is `time / TimeSpan.TicksPerMillisecond`.
- BREAKING: De-nested `Resolution` enum and renamed `DateResolution`.

### QueryParser

- `Lucene.Net.QueryParsers.Flexible.Standard.Config.NumberDateFormat`: Added constructor overload to format a date without a time.
- `Lucene.Net.QueryParsers.Flexible.Standard.Config.NumberDateFormat`: Added `NumericRepresentation` property to set the representation to use for both `Format()` and `Parse()`.
- Added support for `TimeZoneInfo` when converting to/from string (Classic and Flexible query parsers)
- BREAKING: `Lucene.Net.QueryParsers.Flexible.Standard`: Changed numeric nodes to accept and return `J2N.Numerics` types instead of `object`.
- `Lucene.Net.QueryParsers.Classic.QueryParserBase: Use `TryParse()` instead of `Parse()` to parse numeric values. Use the current culture, but fall back to invariant culture.