### PR TITLE
BREAKING: Lucene.Net.Util.Fst: Added class constraint on all generics

### DIFF
--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/TokenInfoDictionary.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/TokenInfoDictionary.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Util.Fst;
 using System;
 using System.IO;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Analysis.Ja.Dict
 {
@@ -34,10 +35,10 @@ namespace Lucene.Net.Analysis.Ja.Dict
 
         private TokenInfoDictionary()
         {
-            FST<long?> fst = null;
+            FST<Int64> fst = null;
             using (Stream @is = GetResource(FST_FILENAME_SUFFIX))
             {
-                fst = new FST<long?>(new InputStreamDataInput(@is), PositiveInt32Outputs.Singleton);
+                fst = new FST<Int64>(new InputStreamDataInput(@is), PositiveInt32Outputs.Singleton);
             }
             // TODO: some way to configure?
             this.fst = new TokenInfoFST(fst, true);

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/TokenInfoFST.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/TokenInfoFST.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Util.Fst;
 using System.Diagnostics;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Analysis.Ja.Dict
 {
@@ -30,22 +31,22 @@ namespace Lucene.Net.Analysis.Ja.Dict
     /// </summary>
     public sealed class TokenInfoFST
     {
-        private readonly FST<long?> fst;
+        private readonly FST<Int64> fst;
 
         // depending upon fasterButMoreRam, we cache root arcs for either 
         // kana (0x3040-0x30FF) or kana + han (0x3040-0x9FFF)
         // false: 191 arcs
         // true:  28,607 arcs (costs ~1.5MB)
         private readonly int cacheCeiling;
-        private readonly FST.Arc<long?>[] rootCache;
+        private readonly FST.Arc<Int64>[] rootCache;
 
-        private readonly long? NO_OUTPUT;
+        private readonly Int64 NO_OUTPUT;
 
         // LUCENENET specific - made field private
         // and added public property for reading it.
-        public long? NoOutput => NO_OUTPUT;
+        public Int64 NoOutput => NO_OUTPUT;
 
-        public TokenInfoFST(FST<long?> fst, bool fasterButMoreRam)
+        public TokenInfoFST(FST<Int64> fst, bool fasterButMoreRam)
         {
             this.fst = fst;
             this.cacheCeiling = fasterButMoreRam ? 0x9FFF : 0x30FF;
@@ -53,30 +54,30 @@ namespace Lucene.Net.Analysis.Ja.Dict
             rootCache = CacheRootArcs();
         }
 
-        private FST.Arc<long?>[] CacheRootArcs()
+        private FST.Arc<Int64>[] CacheRootArcs()
         {
-            FST.Arc<long?>[] rootCache = new FST.Arc<long?>[1 + (cacheCeiling - 0x3040)];
-            FST.Arc<long?> firstArc = new FST.Arc<long?>();
+            FST.Arc<Int64>[] rootCache = new FST.Arc<Int64>[1 + (cacheCeiling - 0x3040)];
+            FST.Arc<Int64> firstArc = new FST.Arc<Int64>();
             fst.GetFirstArc(firstArc);
-            FST.Arc<long?> arc = new FST.Arc<long?>();
+            FST.Arc<Int64> arc = new FST.Arc<Int64>();
             FST.BytesReader fstReader = fst.GetBytesReader();
             // TODO: jump to 3040, readNextRealArc to ceiling? (just be careful we don't add bugs)
             for (int i = 0; i < rootCache.Length; i++)
             {
                 if (fst.FindTargetArc(0x3040 + i, firstArc, arc, fstReader) != null)
                 {
-                    rootCache[i] = new FST.Arc<long?>().CopyFrom(arc);
+                    rootCache[i] = new FST.Arc<Int64>().CopyFrom(arc);
                 }
             }
             return rootCache;
         }
 
-        public FST.Arc<long?> FindTargetArc(int ch, FST.Arc<long?> follow, FST.Arc<long?> arc, bool useCache, FST.BytesReader fstReader)
+        public FST.Arc<Int64> FindTargetArc(int ch, FST.Arc<Int64> follow, FST.Arc<Int64> arc, bool useCache, FST.BytesReader fstReader)
         {
             if (useCache && ch >= 0x3040 && ch <= cacheCeiling)
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(ch != FST.END_LABEL);
-                FST.Arc<long?> result = rootCache[ch - 0x3040];
+                FST.Arc<Int64> result = rootCache[ch - 0x3040];
                 if (result == null)
                 {
                     return null;
@@ -93,7 +94,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
             }
         }
 
-        public FST.Arc<long?> GetFirstArc(FST.Arc<long?> arc)
+        public FST.Arc<Int64> GetFirstArc(FST.Arc<Int64> arc)
         {
             return fst.GetFirstArc(arc);
         }
@@ -108,6 +109,6 @@ namespace Lucene.Net.Analysis.Ja.Dict
         /// <para/>
         /// @lucene.internal 
         /// </summary>
-        internal FST<long?> InternalFST => fst;
+        internal FST<Int64> InternalFST => fst;
     }
 }

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/UserDictionary.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/UserDictionary.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Analysis.Ja.Dict
 {
@@ -84,7 +85,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
             JCG.List<int[]> segmentations = new JCG.List<int[]>(featureEntries.Count);
 
             PositiveInt32Outputs fstOutput = PositiveInt32Outputs.Singleton;
-            Builder<long?> fstBuilder = new Builder<long?>(Lucene.Net.Util.Fst.FST.INPUT_TYPE.BYTE2, fstOutput);
+            Builder<Int64> fstBuilder = new Builder<Int64>(Lucene.Net.Util.Fst.FST.INPUT_TYPE.BYTE2, fstOutput);
             Int32sRef scratch = new Int32sRef();
             long ord = 0;
 
@@ -141,7 +142,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
 
             FST.BytesReader fstReader = fst.GetBytesReader();
 
-            FST.Arc<long?> arc = new FST.Arc<long?>();
+            FST.Arc<Int64> arc = new FST.Arc<Int64>();
             int end = off + len;
             for (int startOffset = off; startOffset < end; startOffset++)
             {

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Threading;
 using Console = Lucene.Net.Util.SystemConsole;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -91,7 +92,7 @@ namespace Lucene.Net.Analysis.Ja
         private readonly UserDictionary userDictionary;
         private readonly CharacterDefinition characterDefinition;
 
-        private readonly FST.Arc<long?> arc = new FST.Arc<long?>();
+        private readonly FST.Arc<Int64> arc = new FST.Arc<Int64>();
         private readonly FST.BytesReader fstReader;
         private readonly Int32sRef wordIdRef = new Int32sRef();
 

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text;
 using Console = Lucene.Net.Util.SystemConsole;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Analysis.Ja.Util
 {
@@ -116,7 +117,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             Console.WriteLine("  encode...");
 
             PositiveInt32Outputs fstOutput = PositiveInt32Outputs.Singleton;
-            Builder<long?> fstBuilder = new Builder<long?>(Lucene.Net.Util.Fst.FST.INPUT_TYPE.BYTE2, 0, 0, true, true, int.MaxValue, fstOutput, null, true, PackedInt32s.DEFAULT, true, 15);
+            Builder<Int64> fstBuilder = new Builder<Int64>(FST.INPUT_TYPE.BYTE2, 0, 0, true, true, int.MaxValue, fstOutput, null, true, PackedInt32s.DEFAULT, true, 15);
             Int32sRef scratch = new Int32sRef();
             long ord = -1; // first ord will be 0
             string lastValue = null;
@@ -150,7 +151,7 @@ namespace Lucene.Net.Analysis.Ja.Util
                 offset = next;
             }
 
-            FST<long?> fst = fstBuilder.Finish();
+            FST<Int64> fst = fstBuilder.Finish();
 
             Console.WriteLine("  " + fst.NodeCount + " nodes, " + fst.ArcCount + " arcs, " + fst.GetSizeInBytes() + " bytes...  ");
             dictionary.SetFST(fst);

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryWriter.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Analysis.Ja.Dict;
 using Lucene.Net.Util.Fst;
 using System.IO;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Analysis.Ja.Util
 {
@@ -23,14 +24,14 @@ namespace Lucene.Net.Analysis.Ja.Util
 
     public class TokenInfoDictionaryWriter : BinaryDictionaryWriter
     {
-        private FST<long?> fst;
+        private FST<Int64> fst;
 
         public TokenInfoDictionaryWriter(int size)
             : base(typeof(TokenInfoDictionary), size)
         {
         }
 
-        public virtual void SetFST(FST<long?> fst)
+        public virtual void SetFST(FST<Int64> fst)
         {
             this.fst = fst;
         }

--- a/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexReader.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Util;
 using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Codecs.BlockTerms
 {
@@ -118,12 +119,12 @@ namespace Lucene.Net.Codecs.BlockTerms
 
         private class IndexEnum : FieldIndexEnum
         {
-            private readonly BytesRefFSTEnum<long?> fstEnum;
-            private BytesRefFSTEnum.InputOutput<long?> current;
+            private readonly BytesRefFSTEnum<Int64> fstEnum;
+            private BytesRefFSTEnum.InputOutput<Int64> current;
 
-            public IndexEnum(FST<long?> fst)
+            public IndexEnum(FST<Int64> fst)
             {
-                fstEnum = new BytesRefFSTEnum<long?>(fst);
+                fstEnum = new BytesRefFSTEnum<Int64>(fst);
             }
 
             public override BytesRef Term
@@ -146,14 +147,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 //System.out.println("VGR: seek field=" + fieldInfo.name + " target=" + target);
                 current = fstEnum.SeekFloor(target);
                 //System.out.println("  got input=" + current.input + " output=" + current.output);
-                if (current.Output.HasValue)
-                {
-                    return current.Output.Value;
-                }
-                else
-                {
-                    throw new NullReferenceException("current.Output is null"); // LUCENENET NOTE: NullReferenceException would be thrown in Java, so doing it here
-                }
+                return current.Output;
             }
 
             public override long Next()
@@ -168,14 +162,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 else
                 {
                     current = fstEnum.Current;
-                    if (current.Output.HasValue)
-                    {
-                        return current.Output.Value;
-                    }
-                    else
-                    {
-                        throw new NullReferenceException("current.Output is null"); // LUCENENET NOTE: NullReferenceException would be thrown in Java, so doing it here
-                    }
+                    return current.Output;
                 }
             }
 
@@ -195,7 +182,7 @@ namespace Lucene.Net.Codecs.BlockTerms
 
             private readonly long indexStart;
             // Set only if terms index is loaded:
-            internal volatile FST<long?> fst;
+            internal volatile FST<Int64> fst;
 
             public FieldIndexData(VariableGapTermsIndexReader outerInstance, /*FieldInfo fieldInfo, // LUCENENET: Not referenced */ long indexStart)
             {
@@ -216,7 +203,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                     using (IndexInput clone = (IndexInput)outerInstance.input.Clone())
                     {
                         clone.Seek(indexStart);
-                        fst = new FST<long?>(clone, outerInstance.fstOutputs);
+                        fst = new FST<Int64>(clone, outerInstance.fstOutputs);
                     } // clone.Dispose();
 
                     /*
@@ -232,9 +219,9 @@ namespace Lucene.Net.Codecs.BlockTerms
                         // subsample
                         Int32sRef scratchIntsRef = new Int32sRef();
                         PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-                        Builder<long?> builder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, outputs);
-                        BytesRefFSTEnum<long?> fstEnum = new BytesRefFSTEnum<long?>(fst);
-                        BytesRefFSTEnum.InputOutput<long?> result;
+                        Builder<Int64> builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, outputs);
+                        BytesRefFSTEnum<Int64> fstEnum = new BytesRefFSTEnum<Int64>(fst);
+                        BytesRefFSTEnum.InputOutput<Int64> result;
                         int count = outerInstance.indexDivisor;
                         while (fstEnum.MoveNext())
                         {

--- a/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexWriter.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Codecs.BlockTerms
 {
@@ -242,12 +243,12 @@ namespace Lucene.Net.Codecs.BlockTerms
         {
             private readonly VariableGapTermsIndexWriter outerInstance;
 
-            private readonly Builder<long?> fstBuilder;
+            private readonly Builder<Int64> fstBuilder;
             private readonly PositiveInt32Outputs fstOutputs;
             private readonly long startTermsFilePointer;
 
             internal readonly FieldInfo fieldInfo;
-            internal FST<long?> fst;
+            internal FST<Int64> fst;
             internal readonly long indexStart;
 
             private readonly BytesRef lastTerm = new BytesRef();
@@ -259,7 +260,7 @@ namespace Lucene.Net.Codecs.BlockTerms
 
                 this.fieldInfo = fieldInfo;
                 fstOutputs = PositiveInt32Outputs.Singleton;
-                fstBuilder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, fstOutputs);
+                fstBuilder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, fstOutputs);
                 indexStart = outerInstance.m_output.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 ////System.out.println("VGW: field=" + fieldInfo.name);
 

--- a/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using BitSet = Lucene.Net.Util.OpenBitSet;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Codecs.Memory
 {
@@ -84,7 +85,7 @@ namespace Lucene.Net.Codecs.Memory
                     long sumDocFreq = blockIn.ReadVInt64();
                     int docCount = blockIn.ReadVInt32();
                     int longsSize = blockIn.ReadVInt32();
-                    var index = new FST<long?>(indexIn, PositiveInt32Outputs.Singleton);
+                    var index = new FST<Int64>(indexIn, PositiveInt32Outputs.Singleton);
 
                     var current = new TermsReader(this, fieldInfo, blockIn, numTerms, sumTotalTermFreq, sumDocFreq, docCount, longsSize, index);
                     // LUCENENET NOTE: This simulates a put operation in Java,
@@ -198,7 +199,7 @@ namespace Lucene.Net.Codecs.Memory
             internal readonly long sumDocFreq;
             internal readonly int docCount;
             private readonly int longsSize;
-            internal readonly FST<long?> index;
+            internal readonly FST<Int64> index;
 
             private readonly int numSkipInfo;
             internal readonly long[] skipInfo;
@@ -206,7 +207,7 @@ namespace Lucene.Net.Codecs.Memory
             internal readonly byte[] metaLongsBlock;
             internal readonly byte[] metaBytesBlock;
 
-            internal TermsReader(FSTOrdTermsReader outerInstance, FieldInfo fieldInfo, IndexInput blockIn, long numTerms, long sumTotalTermFreq, long sumDocFreq, int docCount, int longsSize, FST<long?> index)
+            internal TermsReader(FSTOrdTermsReader outerInstance, FieldInfo fieldInfo, IndexInput blockIn, long numTerms, long sumTotalTermFreq, long sumDocFreq, int docCount, int longsSize, FST<Int64> index)
             {
                 this.outerInstance = outerInstance;
                 this.fieldInfo = fieldInfo;
@@ -450,7 +451,7 @@ namespace Lucene.Net.Codecs.Memory
             // Iterates through all terms in this field
             private sealed class SegmentTermsEnum : BaseTermsEnum
             {
-                private readonly BytesRefFSTEnum<long?> fstEnum;
+                private readonly BytesRefFSTEnum<Int64> fstEnum;
 
                 /* True when current term's metadata is decoded */
                 private bool decoded;
@@ -460,7 +461,7 @@ namespace Lucene.Net.Codecs.Memory
 
                 internal SegmentTermsEnum(FSTOrdTermsReader.TermsReader outerInstance) : base(outerInstance)
                 {
-                    this.fstEnum = new BytesRefFSTEnum<long?>(outerInstance.index);
+                    this.fstEnum = new BytesRefFSTEnum<Int64>(outerInstance.index);
                     this.decoded = false;
                     this.seekPending = false;
                 }
@@ -475,7 +476,7 @@ namespace Lucene.Net.Codecs.Memory
                 }
 
                 // Update current enum according to FSTEnum
-                private void UpdateEnum(BytesRefFSTEnum.InputOutput<long?> pair)
+                private void UpdateEnum(BytesRefFSTEnum.InputOutput<Int64> pair)
                 {
                     if (pair == null)
                     {
@@ -484,7 +485,7 @@ namespace Lucene.Net.Codecs.Memory
                     else
                     {
                         term = pair.Input;
-                        ord = pair.Output.Value;
+                        ord = pair.Output;
                         DecodeStats();
                     }
                     decoded = false;
@@ -505,7 +506,7 @@ namespace Lucene.Net.Codecs.Memory
                     {
                         var pair = fstEnum.Current;
                         term = pair.Input;
-                        ord = pair.Output.Value;
+                        ord = pair.Output;
                         DecodeStats();
                     }
                     else
@@ -574,9 +575,9 @@ namespace Lucene.Net.Codecs.Memory
                 private int level;
 
                 /// <summary>term dict fst</summary>
-                private readonly FST<long?> fst;
+                private readonly FST<Int64> fst;
                 private readonly FST.BytesReader fstReader;
-                private readonly Outputs<long?> fstOutputs;
+                private readonly Outputs<Int64> fstOutputs;
 
                 /// <summary>Query automaton to intersect with.</summary>
                 private readonly ByteRunAutomaton fsa;
@@ -584,14 +585,14 @@ namespace Lucene.Net.Codecs.Memory
                 private sealed class Frame
                 {
                     /// <summary>fst stats</summary>
-                    internal FST.Arc<long?> arc;
+                    internal FST.Arc<Int64> arc;
 
                     /// <summary>automaton stats</summary>
                     internal int state;
 
                     internal Frame()
                     {
-                        this.arc = new FST.Arc<long?>();
+                        this.arc = new FST.Arc<Int64>();
                         this.state = -1;
                     }
 
@@ -648,7 +649,7 @@ namespace Lucene.Net.Codecs.Memory
                 {
                     var arc = TopFrame().arc;
                     if (Debugging.AssertsEnabled) Debugging.Assert(arc.NextFinalOutput == fstOutputs.NoOutput);
-                    ord = arc.Output.Value;
+                    ord = arc.Output;
                     base.DecodeStats();
                 }
 
@@ -850,7 +851,7 @@ namespace Lucene.Net.Codecs.Memory
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 private static bool CanGrow(Frame frame) // can walk forward on both fst&fsa // LUCENENET: CA1822: Mark members as static
                 {
-                    return frame.state != -1 && FST<long?>.TargetHasArcs(frame.arc);
+                    return frame.state != -1 && FST<Int64>.TargetHasArcs(frame.arc);
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lucene.Net.Codecs/Memory/FSTOrdTermsWriter.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTOrdTermsWriter.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Codecs.Memory
 {
@@ -259,7 +260,7 @@ namespace Lucene.Net.Codecs.Memory
             /// NOTE: This was longsSize (field) in Lucene.
             /// </summary>
             public int Int64sSize { get; set; }
-            public FST<long?> Dict { get; set; }
+            public FST<Int64> Dict { get; set; }
 
             // TODO: block encode each part 
 
@@ -280,7 +281,7 @@ namespace Lucene.Net.Codecs.Memory
         {
             private readonly FSTOrdTermsWriter _outerInstance;
 
-            private readonly Builder<long?> _builder;
+            private readonly Builder<Int64> _builder;
             private readonly PositiveInt32Outputs _outputs;
             private readonly FieldInfo _fieldInfo;
             private readonly int _longsSize;
@@ -307,7 +308,7 @@ namespace Lucene.Net.Codecs.Memory
                 _fieldInfo = fieldInfo;
                 _longsSize = outerInstance.postingsWriter.SetField(fieldInfo);
                 _outputs = PositiveInt32Outputs.Singleton;
-                _builder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, _outputs);
+                _builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, _outputs);
 
                 _lastBlockStatsFp = 0;
                 _lastBlockMetaLongsFp = 0;

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Codecs.Memory
 {
@@ -346,7 +347,7 @@ namespace Lucene.Net.Codecs.Memory
             meta.WriteByte(MemoryDocValuesProducer.FST);
             meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-            var builder = new Builder<long?>(INPUT_TYPE.BYTE1, outputs);
+            var builder = new Builder<Int64>(INPUT_TYPE.BYTE1, outputs);
             var scratch = new Int32sRef();
             long ord = 0;
             foreach (BytesRef v in values)
@@ -354,7 +355,7 @@ namespace Lucene.Net.Codecs.Memory
                 builder.Add(Util.ToInt32sRef(v, scratch), ord);
                 ord++;
             }
-            FST<long?> fst = builder.Finish();
+            FST<Int64> fst = builder.Finish();
             if (fst != null)
             {
                 fst.Save(data);

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Codecs.Memory
 {
@@ -46,7 +47,7 @@ namespace Lucene.Net.Codecs.Memory
         // ram instances we have already loaded
         private readonly IDictionary<int, NumericDocValues> numericInstances = new Dictionary<int, NumericDocValues>();
         private readonly IDictionary<int, BinaryDocValues> binaryInstances = new Dictionary<int, BinaryDocValues>();
-        private readonly IDictionary<int, FST<long?>> fstInstances = new Dictionary<int, FST<long?>>();
+        private readonly IDictionary<int, FST<Int64>> fstInstances = new Dictionary<int, FST<Int64>>();
         private readonly IDictionary<int, IBits> docsWithFieldInstances = new Dictionary<int, IBits>();
 
         private readonly int maxDoc;
@@ -419,14 +420,14 @@ namespace Lucene.Net.Codecs.Memory
             {
                 return DocValues.EMPTY_SORTED;
             }
-            FST<long?> instance;
+            FST<Int64> instance;
             UninterruptableMonitor.Enter(this);
             try
             {
                 if (!fstInstances.TryGetValue(field.Number, out instance))
                 {
                     data.Seek(entry.offset);
-                    instance = new FST<long?>(data, PositiveInt32Outputs.Singleton);
+                    instance = new FST<Int64>(data, PositiveInt32Outputs.Singleton);
                     ramBytesUsed.AddAndGet(instance.GetSizeInBytes());
                     fstInstances[field.Number] = instance;
                 }
@@ -440,10 +441,10 @@ namespace Lucene.Net.Codecs.Memory
 
             // per-thread resources
             var @in = fst.GetBytesReader();
-            var firstArc = new FST.Arc<long?>();
-            var scratchArc = new FST.Arc<long?>();
+            var firstArc = new FST.Arc<Int64>();
+            var scratchArc = new FST.Arc<Int64>();
             var scratchInts = new Int32sRef();
-            var fstEnum = new BytesRefFSTEnum<long?>(fst);
+            var fstEnum = new BytesRefFSTEnum<Int64>(fst);
 
             return new SortedDocValuesAnonymousClass(entry, docToOrd, fst, @in, firstArc, scratchArc,
                 scratchInts, fstEnum);
@@ -453,16 +454,16 @@ namespace Lucene.Net.Codecs.Memory
         {
             private readonly MemoryDocValuesProducer.FSTEntry entry;
             private readonly NumericDocValues docToOrd;
-            private readonly FST<long?> fst;
+            private readonly FST<Int64> fst;
             private readonly FST.BytesReader @in;
-            private readonly FST.Arc<long?> firstArc;
-            private readonly FST.Arc<long?> scratchArc;
+            private readonly FST.Arc<Int64> firstArc;
+            private readonly FST.Arc<Int64> scratchArc;
             private readonly Int32sRef scratchInts;
-            private readonly BytesRefFSTEnum<long?> fstEnum;
+            private readonly BytesRefFSTEnum<Int64> fstEnum;
 
             public SortedDocValuesAnonymousClass(FSTEntry fstEntry,
-                NumericDocValues numericDocValues, FST<long?> fst1, FST.BytesReader @in, FST.Arc<long?> arc, FST.Arc<long?> scratchArc1,
-                Int32sRef intsRef, BytesRefFSTEnum<long?> bytesRefFstEnum)
+                NumericDocValues numericDocValues, FST<Int64> fst1, FST.BytesReader @in, FST.Arc<Int64> arc, FST.Arc<Int64> scratchArc1,
+                Int32sRef intsRef, BytesRefFSTEnum<Int64> bytesRefFstEnum)
             {
                 entry = fstEntry;
                 docToOrd = numericDocValues;
@@ -536,14 +537,14 @@ namespace Lucene.Net.Codecs.Memory
             {
                 return DocValues.EMPTY_SORTED_SET; // empty FST!
             }
-            FST<long?> instance;
+            FST<Int64> instance;
             UninterruptableMonitor.Enter(this);
             try
             {
                 if (!fstInstances.TryGetValue(field.Number, out instance))
                 {
                     data.Seek(entry.offset);
-                    instance = new FST<long?>(data, PositiveInt32Outputs.Singleton);
+                    instance = new FST<Int64>(data, PositiveInt32Outputs.Singleton);
                     ramBytesUsed.AddAndGet(instance.GetSizeInBytes());
                     fstInstances[field.Number] = instance;
                 }
@@ -557,10 +558,10 @@ namespace Lucene.Net.Codecs.Memory
 
             // per-thread resources
             var @in = fst.GetBytesReader();
-            var firstArc = new FST.Arc<long?>();
-            var scratchArc = new FST.Arc<long?>();
+            var firstArc = new FST.Arc<Int64>();
+            var scratchArc = new FST.Arc<Int64>();
             var scratchInts = new Int32sRef();
-            var fstEnum = new BytesRefFSTEnum<long?>(fst);
+            var fstEnum = new BytesRefFSTEnum<Int64>(fst);
             var @ref = new BytesRef();
             var input = new ByteArrayDataInput();
             return new SortedSetDocValuesAnonymousClass(entry, docToOrds, fst, @in, firstArc,
@@ -571,19 +572,19 @@ namespace Lucene.Net.Codecs.Memory
         {
             private readonly MemoryDocValuesProducer.FSTEntry entry;
             private readonly BinaryDocValues docToOrds;
-            private readonly FST<long?> fst;
+            private readonly FST<Int64> fst;
             private readonly FST.BytesReader @in;
-            private readonly FST.Arc<long?> firstArc;
-            private readonly FST.Arc<long?> scratchArc;
+            private readonly FST.Arc<Int64> firstArc;
+            private readonly FST.Arc<Int64> scratchArc;
             private readonly Int32sRef scratchInts;
-            private readonly BytesRefFSTEnum<long?> fstEnum;
+            private readonly BytesRefFSTEnum<Int64> fstEnum;
             private readonly BytesRef @ref;
             private readonly ByteArrayDataInput input;
 
             private long currentOrd;
 
-            public SortedSetDocValuesAnonymousClass(FSTEntry fstEntry, BinaryDocValues binaryDocValues, FST<long?> fst1,
-                FST.BytesReader @in, FST.Arc<long?> arc, FST.Arc<long?> scratchArc1, Int32sRef intsRef, BytesRefFSTEnum<long?> bytesRefFstEnum,
+            public SortedSetDocValuesAnonymousClass(FSTEntry fstEntry, BinaryDocValues binaryDocValues, FST<Int64> fst1,
+                FST.BytesReader @in, FST.Arc<Int64> arc, FST.Arc<Int64> scratchArc1, Int32sRef intsRef, BytesRefFSTEnum<Int64> bytesRefFstEnum,
                 BytesRef @ref, ByteArrayDataInput byteArrayDataInput)
             {
                 entry = fstEntry;
@@ -647,11 +648,11 @@ namespace Lucene.Net.Codecs.Memory
                     }
                     else if (o.Input.Equals(key))
                     {
-                        return o.Output.Value;
+                        return o.Output;
                     }
                     else
                     {
-                        return -o.Output.Value - 1;
+                        return -o.Output - 1;
                     }
                 }
                 catch (Exception bogus) when (bogus.IsIOException())
@@ -759,21 +760,21 @@ namespace Lucene.Net.Codecs.Memory
         // exposes FSTEnum directly as a TermsEnum: avoids binary-search next()
         internal class FSTTermsEnum : TermsEnum
         {
-            private readonly BytesRefFSTEnum<long?> input;
+            private readonly BytesRefFSTEnum<Int64> input;
 
             // this is all for the complicated seek(ord)...
             // maybe we should add a FSTEnum that supports this operation?
-            private readonly FST<long?> fst;
+            private readonly FST<Int64> fst;
             private readonly FST.BytesReader bytesReader;
-            private readonly FST.Arc<long?> firstArc = new FST.Arc<long?>();
-            private readonly FST.Arc<long?> scratchArc = new FST.Arc<long?>();
+            private readonly FST.Arc<Int64> firstArc = new FST.Arc<Int64>();
+            private readonly FST.Arc<Int64> scratchArc = new FST.Arc<Int64>();
             private readonly Int32sRef scratchInts = new Int32sRef();
             private readonly BytesRef scratchBytes = new BytesRef();
 
-            internal FSTTermsEnum(FST<long?> fst)
+            internal FSTTermsEnum(FST<Int64> fst)
             {
                 this.fst = fst;
-                input = new BytesRefFSTEnum<long?>(fst);
+                input = new BytesRefFSTEnum<Int64>(fst);
                 bytesReader = fst.GetBytesReader();
             }
 
@@ -832,7 +833,7 @@ namespace Lucene.Net.Codecs.Memory
 
             public override BytesRef Term => input.Current.Input;
 
-            public override long Ord => input.Current.Output.Value;
+            public override long Ord => input.Current.Output;
 
             public override int DocFreq => throw UnsupportedOperationException.Create();
 

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Codecs.SimpleText
 {
@@ -110,13 +111,13 @@ namespace Lucene.Net.Codecs.SimpleText
             private long totalTermFreq;
             private long docsStart;
             //private bool ended; // LUCENENET: Never read
-            private readonly BytesRefFSTEnum<PairOutputs<long?, PairOutputs<long?, long?>.Pair>.Pair> fstEnum;
+            private readonly BytesRefFSTEnum<PairOutputs<Int64, PairOutputs<Int64, Int64>.Pair>.Pair> fstEnum;
 
-            public SimpleTextTermsEnum(SimpleTextFieldsReader outerInstance, FST<PairOutputs<long?, PairOutputs<long?, long?>.Pair>.Pair> fst, IndexOptions indexOptions)
+            public SimpleTextTermsEnum(SimpleTextFieldsReader outerInstance, FST<PairOutputs<Int64, PairOutputs<Int64, Int64>.Pair>.Pair> fst, IndexOptions indexOptions)
             {
                 this.outerInstance = outerInstance;
                 this.indexOptions = indexOptions;
-                fstEnum = new BytesRefFSTEnum<PairOutputs<long?, PairOutputs<long?, long?>.Pair>.Pair>(fst);
+                fstEnum = new BytesRefFSTEnum<PairOutputs<Int64, PairOutputs<Int64, Int64>.Pair>.Pair>(fst);
             }
 
             public override bool SeekExact(BytesRef text)
@@ -126,9 +127,9 @@ namespace Lucene.Net.Codecs.SimpleText
                 {
                     var pair1 = result.Output;
                     var pair2 = pair1.Output2;
-                    docsStart = pair1.Output1.Value;
+                    docsStart = pair1.Output1;
                     docFreq = (int)pair2.Output1;
-                    totalTermFreq = pair2.Output2.Value;
+                    totalTermFreq = pair2.Output2;
                     return true;
                 }
                 else
@@ -151,9 +152,9 @@ namespace Lucene.Net.Codecs.SimpleText
                     //System.out.println("  got text=" + term.utf8ToString());
                     var pair1 = result.Output;
                     var pair2 = pair1.Output2;
-                    docsStart = pair1.Output1.Value;
+                    docsStart = pair1.Output1;
                     docFreq = (int)pair2.Output1;
-                    totalTermFreq = pair2.Output2.Value;
+                    totalTermFreq = pair2.Output2;
 
                     if (result.Input.Equals(text))
                     {
@@ -175,9 +176,9 @@ namespace Lucene.Net.Codecs.SimpleText
                 {
                     var pair1 = fstEnum.Current.Output;
                     var pair2 = pair1.Output2;
-                    docsStart = pair1.Output1.Value;
+                    docsStart = pair1.Output1;
                     docFreq = (int)pair2.Output1;
-                    totalTermFreq = pair2.Output2.Value;
+                    totalTermFreq = pair2.Output2;
                     return fstEnum.Current.Input != null;
                 }
                 else
@@ -550,12 +551,12 @@ namespace Lucene.Net.Codecs.SimpleText
             private long sumTotalTermFreq;
             private long sumDocFreq;
             private int docCount;
-            private FST<PairOutputs<long?, PairOutputs<long?, long?>.Pair>.Pair> fst;
+            private FST<PairOutputs<Int64, PairOutputs<Int64, Int64>.Pair>.Pair> fst;
             private int termCount;
             private readonly BytesRef scratch = new BytesRef(10);
             private readonly CharsRef scratchUTF16 = new CharsRef(10);
 
-            public SimpleTextTerms(SimpleTextFieldsReader outerInstance, String field, long termsStart, int maxDoc)
+            public SimpleTextTerms(SimpleTextFieldsReader outerInstance, string field, long termsStart, int maxDoc)
             {
                 this.outerInstance = outerInstance;
                 this.maxDoc = maxDoc;
@@ -567,11 +568,10 @@ namespace Lucene.Net.Codecs.SimpleText
             private void LoadTerms()
             {
                 PositiveInt32Outputs posIntOutputs = PositiveInt32Outputs.Singleton;
-                Builder<PairOutputs<long?, PairOutputs<long?, long?>.Pair>.Pair> b;
-                PairOutputs<long?, long?> outputsInner = new PairOutputs<long?, long?>(posIntOutputs, posIntOutputs);
-                PairOutputs<long?, PairOutputs<long?, long?>.Pair> outputs = new PairOutputs<long?, PairOutputs<long?, long?>.Pair>(posIntOutputs,
+                var outputsInner = new PairOutputs<Int64, Int64>(posIntOutputs, posIntOutputs);
+                var outputs = new PairOutputs<Int64, PairOutputs<Int64, Int64>.Pair>(posIntOutputs,
                     outputsInner);
-                b = new Builder<PairOutputs<long?, PairOutputs<long?, long?>.Pair>.Pair>(FST.INPUT_TYPE.BYTE1, outputs);
+                var b = new Builder<PairOutputs<Int64, PairOutputs<Int64, Int64>.Pair>.Pair>(FST.INPUT_TYPE.BYTE1, outputs);
                 IndexInput @in = (IndexInput)outerInstance.input.Clone();
                 @in.Seek(termsStart);
                 BytesRef lastTerm = new BytesRef(10);

--- a/src/Lucene.Net.Misc/Util/Fst/ListOfOutputs.cs
+++ b/src/Lucene.Net.Misc/Util/Fst/ListOfOutputs.cs
@@ -180,26 +180,26 @@ namespace Lucene.Net.Util.Fst
         public override object Merge(object first, object second)
         {
             IList<T> outputList = new JCG.List<T>();
-            if (!(first is IList<T> firstList))
+            if (!(first is IList firstList))
             {
                 outputList.Add((T)first);
             }
             else
             {
-                foreach (T value in firstList)
+                foreach (object value in firstList)
                 {
-                    outputList.Add(value);
+                    outputList.Add((T)value);
                 }
             }
-            if (!(second is IList<T> secondList))
+            if (!(second is IList secondList))
             {
                 outputList.Add((T)second);
             }
             else
             {
-                foreach (T value in secondList)
+                foreach (object value in secondList)
                 {
-                    outputList.Add(value);
+                    outputList.Add((T)value);
                 }
             }
             //System.out.println("MERGE: now " + outputList.size() + " first=" + outputToString(first) + " second=" + outputToString(second));

--- a/src/Lucene.Net.Misc/Util/Fst/UpToTwoPositiveIntOutputs.cs
+++ b/src/Lucene.Net.Misc/Util/Fst/UpToTwoPositiveIntOutputs.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Diagnostics;
 using Lucene.Net.Store;
 using System;
 using System.Runtime.CompilerServices;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Util.Fst
 {
@@ -100,7 +101,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private static readonly long? NO_OUTPUT = new long?(0);
+        private static readonly Int64 NO_OUTPUT = Int64.GetInstance(0);
 
         private readonly bool doShare;
 
@@ -120,7 +121,7 @@ namespace Lucene.Net.Util.Fst
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "This is a shipped public API")]
-        public long? Get(long v)
+        public Int64 Get(long v)
         {
             return v == 0 ? NO_OUTPUT : v;
         }
@@ -139,8 +140,8 @@ namespace Lucene.Net.Util.Fst
                 Debugging.Assert(Valid(output1, false));
                 Debugging.Assert(Valid(output2, false));
             }
-            long? output1_ = (long?)output1;
-            long? output2_ = (long?)output2;
+            Int64 output1_ = (Int64)output1;
+            Int64 output2_ = (Int64)output2;
             if (output1_ == NO_OUTPUT || output2_ == NO_OUTPUT)
             {
                 return NO_OUTPUT;
@@ -152,7 +153,7 @@ namespace Lucene.Net.Util.Fst
                     Debugging.Assert(output1_ > 0);
                     Debugging.Assert(output2_ > 0);
                 }
-                return Math.Min(output1_.GetValueOrDefault(), output2_.GetValueOrDefault());
+                return Int64.GetInstance(Math.Min(output1_, output2_));
             }
             else if (output1_.Equals(output2_))
             {
@@ -171,8 +172,8 @@ namespace Lucene.Net.Util.Fst
                 Debugging.Assert(Valid(output, false));
                 Debugging.Assert(Valid(inc, false));
             }
-            long? output2 = (long?)output;
-            long? inc2 = (long?)inc;
+            Int64 output2 = (Int64)output;
+            Int64 inc2 = (Int64)inc;
             if (Debugging.AssertsEnabled) Debugging.Assert(output2 >= inc2);
 
             if (inc2 == NO_OUTPUT)
@@ -185,7 +186,7 @@ namespace Lucene.Net.Util.Fst
             }
             else
             {
-                return output2 - inc2;
+                return Int64.GetInstance(output2 - inc2);
             }
         }
 
@@ -193,10 +194,9 @@ namespace Lucene.Net.Util.Fst
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(Valid(prefix, false));
             if (Debugging.AssertsEnabled) Debugging.Assert(Valid(output, true));
-            long? prefix2 = (long?)prefix;
-            if (output is long?)
+            Int64 prefix2 = (Int64)prefix;
+            if (output is Int64 output2)
             {
-                long? output2 = (long?)output;
                 if (prefix2 == NO_OUTPUT)
                 {
                     return output2;
@@ -207,13 +207,13 @@ namespace Lucene.Net.Util.Fst
                 }
                 else
                 {
-                    return prefix2 + output2;
+                    return Int64.GetInstance(prefix2 + output2);
                 }
             }
             else
             {
                 TwoInt64s output3 = (TwoInt64s)output;
-                long v = prefix2.Value;
+                long v = prefix2;
                 return new TwoInt64s(output3.First + v, output3.Second + v);
             }
         }
@@ -221,10 +221,9 @@ namespace Lucene.Net.Util.Fst
         public override void Write(object output, DataOutput @out)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(Valid(output, true));
-            if (output is long?)
+            if (output is Int64 output2)
             {
-                long? output2 = (long?)output;
-                @out.WriteVInt64(output2.GetValueOrDefault() << 1);
+                @out.WriteVInt64(output2 << 1);
             }
             else
             {
@@ -247,7 +246,7 @@ namespace Lucene.Net.Util.Fst
                 }
                 else
                 {
-                    return v;
+                    return Int64.GetInstance(v);
                 }
             }
             else
@@ -260,10 +259,10 @@ namespace Lucene.Net.Util.Fst
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool Valid(long? o) // LUCENENET: CA1822: Mark members as static
+        private static bool Valid(Int64 o) // LUCENENET: CA1822: Mark members as static
         {
             Debugging.Assert(o != null);
-            Debugging.Assert(o is long?);
+            Debugging.Assert(o is Int64);
             Debugging.Assert(o == NO_OUTPUT || o > 0);
             return true;
         }
@@ -274,8 +273,8 @@ namespace Lucene.Net.Util.Fst
         {
             if (!allowDouble)
             {
-                Debugging.Assert(o is long?);
-                return Valid((long?)o);
+                Debugging.Assert(o is Int64);
+                return Valid((Int64)o);
             }
             else if (o is TwoInt64s)
             {
@@ -283,7 +282,7 @@ namespace Lucene.Net.Util.Fst
             }
             else
             {
-                return Valid((long?)o);
+                return Valid((Int64)o);
             }
         }
 
@@ -302,7 +301,7 @@ namespace Lucene.Net.Util.Fst
                 Debugging.Assert(Valid(first, false));
                 Debugging.Assert(Valid(second, false));
             }
-            return new TwoInt64s(((long?)first).GetValueOrDefault(), ((long?)second).GetValueOrDefault());
+            return new TwoInt64s((Int64)first, (Int64)second);
         }
     }
 }

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FSTUtil.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FSTUtil.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
     {
         /// <summary>
         /// Holds a pair (automaton, fst) of states and accumulated output in the intersected machine. </summary>
-        public sealed class Path<T>
+        public sealed class Path<T> where T : class // LUCENENET specific - added class constraint because we are comparing reference equality
         {
             /// <summary>
             /// Node in the automaton where path ends: </summary>
@@ -67,7 +67,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// Enumerates all minimal prefix paths in the automaton that also intersect the <see cref="FST"/>,
         /// accumulating the <see cref="FST"/> end node and output for each path.
         /// </summary>
-        public static IList<Path<T>> IntersectPrefixPaths<T>(Automaton a, FST<T> fst)
+        public static IList<Path<T>> IntersectPrefixPaths<T>(Automaton a, FST<T> fst) where T : class // LUCENENET specific - added class constraint because we are comparing reference equality
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(a.IsDeterministic);
             IList<Path<T>> queue = new JCG.List<Path<T>>();

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
@@ -16,6 +16,7 @@ using System.Diagnostics;
 using System.IO;
 using Directory = Lucene.Net.Store.Directory;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Search.Suggest.Analyzing
 {
@@ -105,7 +106,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
         /// <summary>
         /// Holds 1gram, 2gram, 3gram models as a single FST. </summary>
-        private FST<long?> fst;
+        private FST<Int64> fst;
 
         /// <summary>
         /// Analyzer that will be used for analyzing suggestions at
@@ -373,8 +374,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     // Move all ngrams into an FST:
                     TermsEnum termsEnum = terms.GetEnumerator(null);
 
-                    Outputs<long?> outputs = PositiveInt32Outputs.Singleton;
-                    Builder<long?> builder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, outputs);
+                    Outputs<Int64> outputs = PositiveInt32Outputs.Singleton;
+                    Builder<Int64> builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, outputs);
 
                     Int32sRef scratchInts = new Int32sRef();
                     while (termsEnum.MoveNext())
@@ -471,7 +472,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
             totTokens = input.ReadVInt64();
 
-            fst = new FST<long?>(input, PositiveInt32Outputs.Singleton);
+            fst = new FST<Int64>(input, PositiveInt32Outputs.Singleton);
 
             return true;
         }
@@ -609,7 +610,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     lastTokens[0] = new BytesRef();
                 }
 
-                var arc = new FST.Arc<long?>();
+                var arc = new FST.Arc<Int64>();
 
                 var bytesReader = fst.GetBytesReader();
 
@@ -649,7 +650,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     // TODO: we could add fuzziness here
                     // match the prefix portion exactly
                     //Pair<Long,BytesRef> prefixOutput = null;
-                    long? prefixOutput = null;
+                    Int64 prefixOutput = null;
                     try
                     {
                         prefixOutput = LookupPrefix(fst, bytesReader, token, arc);
@@ -660,7 +661,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     }
                     //System.out.println("  prefixOutput=" + prefixOutput);
 
-                    if (prefixOutput == null)
+                    if (prefixOutput is null)
                     {
                         // This model never saw this prefix, e.g. the
                         // trigram model never saw context "purple mushroom"
@@ -705,7 +706,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     CharsRef spare = new CharsRef();
 
                     // complete top-N
-                    Util.Fst.Util.TopResults<long?> completions = null;
+                    Util.Fst.Util.TopResults<Int64> completions = null;
                     try
                     {
 
@@ -720,7 +721,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                         // Must do num+seen.size() for queue depth because we may
                         // reject up to seen.size() paths in acceptResult():
-                        Util.Fst.Util.TopNSearcher<long?> searcher = new TopNSearcherAnonymousClass(this, fst, num, num + seen.Count, weightComparer, seen, finalLastToken);
+                        Util.Fst.Util.TopNSearcher<Int64> searcher = new TopNSearcherAnonymousClass(this, fst, num, num + seen.Count, weightComparer, seen, finalLastToken);
 
                         // since this search is initialized with a single start node 
                         // it is okay to start with an empty input path here
@@ -739,7 +740,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     BytesRef suffix = new BytesRef(8);
                     //System.out.println("    " + completions.length + " completions");
 
-                    foreach (Util.Fst.Util.Result<long?> completion in completions)
+                    foreach (Util.Fst.Util.Result<Int64> completion in completions)
                     {
                         token.Length = prefixLength;
                         // append suffix
@@ -810,7 +811,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
         }
 
-        private class TopNSearcherAnonymousClass : Util.Fst.Util.TopNSearcher<long?>
+        private class TopNSearcherAnonymousClass : Util.Fst.Util.TopNSearcher<Int64>
         {
             private readonly FreeTextSuggester outerInstance;
 
@@ -819,10 +820,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             public TopNSearcherAnonymousClass(
                 FreeTextSuggester outerInstance,
-                FST<long?> fst,
+                FST<Int64> fst,
                 int num,
                 int size,
-                IComparer<long?> weightComparer,
+                IComparer<Int64> weightComparer,
                 ISet<BytesRef> seen,
                 BytesRef finalLastToken)
                 : base(fst, num, size, weightComparer)
@@ -836,7 +837,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             private readonly BytesRef scratchBytes;
 
-            protected override void AddIfCompetitive(Util.Fst.Util.FSTPath<long?> path)
+            protected override void AddIfCompetitive(Util.Fst.Util.FSTPath<Int64> path)
             {
                 if (path.Arc.Label != outerInstance.separator)
                 {
@@ -849,7 +850,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 }
             }
 
-            protected override bool AcceptResult(Int32sRef input, long? output)
+            protected override bool AcceptResult(Int32sRef input, Int64 output)
             {
                 Util.Fst.Util.ToBytesRef(input, scratchBytes);
                 finalLastToken.Grow(finalLastToken.Length + scratchBytes.Length);
@@ -880,10 +881,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         }
 
         // NOTE: copied from WFSTCompletionLookup & tweaked
-        private long? LookupPrefix(FST<long?> fst, FST.BytesReader bytesReader, BytesRef scratch, FST.Arc<long?> arc)
+        private Int64 LookupPrefix(FST<Int64> fst, FST.BytesReader bytesReader, BytesRef scratch, FST.Arc<Int64> arc)
         {
 
-            long? output = fst.Outputs.NoOutput;
+            Int64 output = fst.Outputs.NoOutput;
 
             fst.GetFirstArc(arc);
 
@@ -905,7 +906,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             return output;
         }
 
-        internal static readonly IComparer<long?> weightComparer =  Comparer<long?>.Default;
+        internal static readonly IComparer<Int64> weightComparer =  Comparer<Int64>.Default;
 
         /// <summary>
         /// Returns the weight associated with an input string,

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FuzzySuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FuzzySuggester.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Util.Automaton;
 using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Search.Suggest.Analyzing
 {
@@ -171,10 +172,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             this.unicodeAware = unicodeAware;
         }
 
-        protected internal override IList<FSTUtil.Path<PairOutputs<long?, BytesRef>.Pair>> GetFullPrefixPaths(
-            IList<FSTUtil.Path<PairOutputs<long?, BytesRef>.Pair>> prefixPaths, 
+        protected override IList<FSTUtil.Path<PairOutputs<Int64, BytesRef>.Pair>> GetFullPrefixPaths(
+            IList<FSTUtil.Path<PairOutputs<Int64, BytesRef>.Pair>> prefixPaths, 
             Automaton lookupAutomaton, 
-            FST<PairOutputs<long?, BytesRef>.Pair> fst)
+            FST<PairOutputs<Int64, BytesRef>.Pair> fst)
         {
 
             // TODO: right now there's no penalty for fuzzy/edits,

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 using static Lucene.Net.Util.Fst.FST;
 using static Lucene.Net.Util.Packed.PackedInt32s;
 
@@ -280,7 +281,7 @@ namespace Lucene.Net.Codecs.Lucene42
             meta.WriteByte((byte)Lucene42DocValuesProducer.FST);
             meta.WriteInt64(data.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-            Builder<long?> builder = new Builder<long?>(INPUT_TYPE.BYTE1, outputs);
+            Builder<Int64> builder = new Builder<Int64>(INPUT_TYPE.BYTE1, outputs);
             Int32sRef scratch = new Int32sRef();
             long ord = 0;
             foreach (BytesRef v in values)

--- a/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
+++ b/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
@@ -493,12 +493,13 @@ namespace Lucene.Net.Util.Fst
                     Assert.IsTrue(OutputsEqual(pair.Output, output));
 
                     // verify enum's next
-                    Int32sRefFSTEnum.InputOutput<T> t = fstEnum.Next();
+                    Assert.IsTrue(fstEnum.MoveNext());
+                    Int32sRefFSTEnum.InputOutput<T> t = fstEnum.Current;
                     Assert.IsNotNull(t);
                     Assert.AreEqual(term, t.Input, "expected input=" + InputToString(inputMode, term) + " but fstEnum returned " + InputToString(inputMode, t.Input));
                     Assert.IsTrue(OutputsEqual(pair.Output, t.Output));
                 }
-                Assert.IsNull(fstEnum.Next());
+                Assert.IsFalse(fstEnum.MoveNext());
             }
 
             IDictionary<Int32sRef, T> termsMap = new Dictionary<Int32sRef, T>();
@@ -687,7 +688,7 @@ namespace Lucene.Net.Util.Fst
                         {
                             Console.WriteLine("  do next");
                         }
-                        isDone = fstEnum_.Next() == null;
+                        isDone = fstEnum_.MoveNext() == false;
                     }
                     else if (upto != -1 && upto < 0.75 * pairs.Count && random.NextBoolean())
                     {
@@ -975,8 +976,9 @@ namespace Lucene.Net.Util.Fst
             }
             Int32sRefFSTEnum<T> fstEnum = new Int32sRefFSTEnum<T>(fst);
             Int32sRefFSTEnum.InputOutput<T> current;
-            while ((current = fstEnum.Next()) != null)
+            while (fstEnum.MoveNext())
             {
+                current = fstEnum.Current;
                 if (LuceneTestCase.Verbose)
                 {
                     Console.WriteLine("  fstEnum.next prefix=" + InputToString(inputMode, current.Input, false) + " output=" + outputs.OutputToString(current.Output));

--- a/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
+++ b/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
@@ -15,6 +15,7 @@ using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 using Directory = Lucene.Net.Store.Directory;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Util.Fst
 {
@@ -37,7 +38,7 @@ namespace Lucene.Net.Util.Fst
 
     /// <summary>
     /// Holds one input/output pair. </summary>
-    public class InputOutput<T> : IComparable<InputOutput<T>>
+    public class InputOutput<T> : IComparable<InputOutput<T>> where T : class // LUCENENET specific - added class constraint because we compare reference equality
     {
         public Int32sRef Input { get; private set; }
         public T Output { get; private set; }
@@ -56,7 +57,7 @@ namespace Lucene.Net.Util.Fst
 
     /// <summary>
     /// Helper class to test FSTs. </summary>
-    public class FSTTester<T>
+    public class FSTTester<T> where T : class // LUCENENET specific - added class constraint because we compare reference equality
     {
         internal readonly Random random;
         internal readonly IList<InputOutput<T>> pairs;
@@ -341,11 +342,17 @@ namespace Lucene.Net.Util.Fst
 
             foreach (InputOutput<T> pair in pairs)
             {
-                if (pair.Output is IEnumerable)
+                if (pair.Output is IEnumerable<T> values)
+                {
+                    foreach (T value in values)
+                    {
+                        builder.Add(pair.Input, value);
+                    }
+                }
+                else if (pair.Output is IEnumerable objectValues)
                 {
                     Builder<object> builderObject = builder as Builder<object>;
-                    var values = pair.Output as IEnumerable;
-                    foreach (object value in values)
+                    foreach (object value in objectValues)
                     {
                         builderObject.Add(pair.Input, value);
                     }
@@ -421,22 +428,22 @@ namespace Lucene.Net.Util.Fst
         // FST is complete
         private void VerifyUnPruned(int inputMode, FST<T> fst)
         {
-            FST<long?> fstLong;
-            ISet<long?> validOutputs;
+            FST<Int64> fstLong;
+            ISet<Int64> validOutputs;
             long minLong = long.MaxValue;
             long maxLong = long.MinValue;
 
             if (doReverseLookup)
             {
-                FST<long?> fstLong0 = fst as FST<long?>;
+                FST<Int64> fstLong0 = fst as FST<Int64>;
                 fstLong = fstLong0;
-                validOutputs = new JCG.HashSet<long?>();
+                validOutputs = new JCG.HashSet<Int64>();
                 foreach (InputOutput<T> pair in pairs)
                 {
-                    long? output = pair.Output as long?;
-                    maxLong = Math.Max(maxLong, output.Value);
-                    minLong = Math.Min(minLong, output.Value);
-                    validOutputs.Add(output.Value);
+                    Int64 output = (Int64)(object)pair.Output;
+                    maxLong = Math.Max(maxLong, output);
+                    minLong = Math.Min(minLong, output);
+                    validOutputs.Add(output);
                 }
             }
             else
@@ -532,7 +539,7 @@ namespace Lucene.Net.Util.Fst
                 if (doReverseLookup)
                 {
                     //System.out.println("lookup output=" + output + " outs=" + fst.Outputs);
-                    Int32sRef input = Util.GetByOutput(fstLong, (output as long?).Value);
+                    Int32sRef input = Util.GetByOutput(fstLong, (Int64)(object)output);
                     Assert.IsNotNull(input);
                     //System.out.println("  got " + Util.toBytesRef(input, new BytesRef()).utf8ToString());
                     Assert.AreEqual(scratch, input);

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/Dict/TestTokenInfoDictionary.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/Dict/TestTokenInfoDictionary.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Util.Fst;
 using NUnit.Framework;
 using System;
 using Console = Lucene.Net.Util.SystemConsole;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Analysis.Ja.Dict
 {
@@ -37,9 +38,9 @@ namespace Lucene.Net.Analysis.Ja.Dict
             int lastSourceId = -1;
             TokenInfoDictionary tid = TokenInfoDictionary.Instance;
             ConnectionCosts matrix = ConnectionCosts.Instance;
-            FST<long?> fst = tid.FST.InternalFST;
-            Int32sRefFSTEnum<long?> fstEnum = new Int32sRefFSTEnum<long?>(fst);
-            Int32sRefFSTEnum.InputOutput<long?> mapping;
+            FST<Int64> fst = tid.FST.InternalFST;
+            Int32sRefFSTEnum<Int64> fstEnum = new Int32sRefFSTEnum<Int64>(fst);
+            Int32sRefFSTEnum.InputOutput<Int64> mapping;
             Int32sRef scratch = new Int32sRef();
             while ((mapping = fstEnum.Next()) != null)
             {

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/Dict/TestTokenInfoDictionary.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/Dict/TestTokenInfoDictionary.cs
@@ -42,8 +42,9 @@ namespace Lucene.Net.Analysis.Ja.Dict
             Int32sRefFSTEnum<Int64> fstEnum = new Int32sRefFSTEnum<Int64>(fst);
             Int32sRefFSTEnum.InputOutput<Int64> mapping;
             Int32sRef scratch = new Int32sRef();
-            while ((mapping = fstEnum.Next()) != null)
+            while (fstEnum.MoveNext())
             {
+                mapping = fstEnum.Current;
                 numTerms++;
                 Int32sRef input = mapping.Input;
                 char[] chars = new char[input.Length];

--- a/src/Lucene.Net.Tests.Misc/Util/Fst/TestFSTsMisc.cs
+++ b/src/Lucene.Net.Tests.Misc/Util/Fst/TestFSTsMisc.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Console = Lucene.Net.Util.SystemConsole;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Util.Fst
 {
@@ -107,7 +108,7 @@ namespace Lucene.Net.Util.Fst
                         {
                             value2 = lastOutput + TestUtil.NextInt32(Random, -100, 1000);
                         }
-                        IList<long> values = new JCG.List<long>();
+                        IList<Int64> values = new JCG.List<Int64>();
                         values.Add(value);
                         values.Add(value2);
                         output = values;
@@ -128,14 +129,14 @@ namespace Lucene.Net.Util.Fst
                         Console.WriteLine("TEST: now test OneOrMoreOutputs");
                     }
                     PositiveInt32Outputs _outputs = PositiveInt32Outputs.Singleton; 
-                    ListOfOutputs<long?> outputs2 = new ListOfOutputs<long?>(_outputs);
+                    ListOfOutputs<Int64> outputs2 = new ListOfOutputs<Int64>(_outputs);
                     IList<InputOutput<object>> pairs2 = new JCG.List<InputOutput<object>>(terms.Length);
                     long lastOutput2 = 0;
                     for (int idx = 0; idx < terms.Length; idx++)
                     {
 
                         int outputCount = TestUtil.NextInt32(Random, 1, 7);
-                        IList<long?> values = new JCG.List<long?>();
+                        IList<Int64> values = new JCG.List<Int64>();
                         for (int i = 0; i < outputCount; i++)
                         {
                             // Sometimes go backwards
@@ -149,7 +150,7 @@ namespace Lucene.Net.Util.Fst
                         }
 
                         object output;
-                        if (values.size() == 1)
+                        if (values.Count == 1)
                         {
                             output = values[0];
                         }
@@ -165,7 +166,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private class FSTTesterHelper<T> : FSTTester<T>
+        private class FSTTesterHelper<T> : FSTTester<T> where T : class // LUCENENET specific - added class constraint, since we compare reference equality
         {
             public FSTTesterHelper(Random random, Directory dir, int inputMode, IList<InputOutput<T>> pairs, Outputs<T> outputs, bool doReverseLookup)
                 : base(random, dir, inputMode, pairs, outputs, doReverseLookup)
@@ -174,13 +175,13 @@ namespace Lucene.Net.Util.Fst
 
             protected override bool OutputsEqual(T output1, T output2)
             {
-                if (output1 is UpToTwoPositiveInt64Outputs.TwoInt64s twoLongs1 && output2 is IEnumerable<long> output2Enumerable)
+                if (output1 is UpToTwoPositiveInt64Outputs.TwoInt64s twoLongs1 && output2 is JCG.List<Int64> output2List)
                 {
-                    return (new long[] { twoLongs1.First, twoLongs1.Second }).SequenceEqual(output2Enumerable);
+                    return output2List.Equals(new Int64[] { twoLongs1.First, twoLongs1.Second });
                 }
-                else if (output2 is UpToTwoPositiveInt64Outputs.TwoInt64s twoLongs2 && output1 is IEnumerable<long> output1Enumerable)
+                else if (output2 is UpToTwoPositiveInt64Outputs.TwoInt64s twoLongs2 && output1 is JCG.List<Int64> output1List)
                 {
-                    return (new long[] { twoLongs2.First, twoLongs2.Second }).SequenceEqual(output1Enumerable);
+                    return output1List.Equals(new Int64[] { twoLongs2.First, twoLongs2.Second });
                 }
 
                 return output1.Equals(output2);
@@ -192,21 +193,21 @@ namespace Lucene.Net.Util.Fst
         public void TestListOfOutputs()
         {
             PositiveInt32Outputs _outputs = PositiveInt32Outputs.Singleton;
-            ListOfOutputs<long?> outputs = new ListOfOutputs<long?>(_outputs);
-            Builder<object> builder = new Builder<object>(Lucene.Net.Util.Fst.FST.INPUT_TYPE.BYTE1, outputs);
+            ListOfOutputs<Int64> outputs = new ListOfOutputs<Int64>(_outputs);
+            Builder<object> builder = new Builder<object>(FST.INPUT_TYPE.BYTE1, outputs);
 
             Int32sRef scratch = new Int32sRef();
             // Add the same input more than once and the outputs
             // are merged:
-            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), 1L);
-            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), 3L);
-            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), 0L);
-            builder.Add(Util.ToInt32sRef(new BytesRef("b"), scratch), 17L);
+            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), (Int64)1L);
+            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), (Int64)3L);
+            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), (Int64)0L);
+            builder.Add(Util.ToInt32sRef(new BytesRef("b"), scratch), (Int64)17L);
             FST<object> fst = builder.Finish();
 
             object output = Util.Get(fst, new BytesRef("a"));
             assertNotNull(output);
-            IList<long?> outputList = outputs.AsList(output);
+            IList<Int64> outputList = outputs.AsList(output);
             assertEquals(3, outputList.size());
             assertEquals(1L, outputList[0]);
             assertEquals(3L, outputList[1]);
@@ -223,25 +224,25 @@ namespace Lucene.Net.Util.Fst
         public void TestListOfOutputsEmptyString()
         {
             PositiveInt32Outputs _outputs = PositiveInt32Outputs.Singleton;
-            ListOfOutputs<long?> outputs = new ListOfOutputs<long?>(_outputs);
+            ListOfOutputs<Int64> outputs = new ListOfOutputs<Int64>(_outputs);
             Builder<object> builder = new Builder<object>(FST.INPUT_TYPE.BYTE1, outputs);
 
             Int32sRef scratch = new Int32sRef();
-            builder.Add(scratch, 0L);
-            builder.Add(scratch, 1L);
-            builder.Add(scratch, 17L);
-            builder.Add(scratch, 1L);
+            builder.Add(scratch, (Int64)0L);
+            builder.Add(scratch, (Int64)1L);
+            builder.Add(scratch, (Int64)17L);
+            builder.Add(scratch, (Int64)1L);
 
-            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), 1L);
-            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), 3L);
-            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), 0L);
-            builder.Add(Util.ToInt32sRef(new BytesRef("b"), scratch), 0L);
+            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), (Int64)1L);
+            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), (Int64)3L);
+            builder.Add(Util.ToInt32sRef(new BytesRef("a"), scratch), (Int64)0L);
+            builder.Add(Util.ToInt32sRef(new BytesRef("b"), scratch), (Int64)0L);
 
             FST<object> fst = builder.Finish();
 
             object output = Util.Get(fst, new BytesRef(""));
             assertNotNull(output);
-            IList<long?> outputList = outputs.AsList(output);
+            IList<Int64> outputList = outputs.AsList(output);
             assertEquals(4, outputList.size());
             assertEquals(0L, outputList[0]);
             assertEquals(1L, outputList[1]);

--- a/src/Lucene.Net.Tests/Util/Fst/Test2BFST.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/Test2BFST.cs
@@ -113,13 +113,9 @@ namespace Lucene.Net.Util.Fst
                         Arrays.Fill(ints2, 0);
                         r = new J2N.Randomizer(seed);
                         int upto = 0;
-                        while (true)
+                        while (fstEnum.MoveNext())
                         {
-                            Int32sRefFSTEnum.InputOutput<object> pair = fstEnum.Next();
-                            if (pair == null)
-                            {
-                                break;
-                            }
+                            Int32sRefFSTEnum.InputOutput<object> pair = fstEnum.Current;
                             for (int j = 10; j < ints2.Length; j++)
                             {
                                 ints2[j] = r.Next(256);
@@ -202,13 +198,9 @@ namespace Lucene.Net.Util.Fst
                         Arrays.Fill(ints, 0);
                         r = new J2N.Randomizer(seed);
                         int upto = 0;
-                        while (true)
+                        while (fstEnum.MoveNext())
                         {
-                            Int32sRefFSTEnum.InputOutput<BytesRef> pair = fstEnum.Next();
-                            if (pair == null)
-                            {
-                                break;
-                            }
+                            Int32sRefFSTEnum.InputOutput<BytesRef> pair = fstEnum.Current;
                             Assert.AreEqual(input, pair.Input);
                             r.NextBytes(outputBytes);
                             Assert.AreEqual(output, pair.Output);
@@ -295,13 +287,9 @@ namespace Lucene.Net.Util.Fst
                         r = new J2N.Randomizer(seed);
                         int upto = 0;
                         output = 1;
-                        while (true)
+                        while (fstEnum.MoveNext())
                         {
-                            Int32sRefFSTEnum.InputOutput<Int64> pair = fstEnum.Next();
-                            if (pair == null)
-                            {
-                                break;
-                            }
+                            Int32sRefFSTEnum.InputOutput<J2N.Numerics.Int64> pair = fstEnum.Current;
                             Assert.AreEqual(input, pair.Input);
                             Assert.AreEqual(output, pair.Output);
                             output += 1 + r.Next(10);

--- a/src/Lucene.Net.Tests/Util/Fst/Test2BFST.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/Test2BFST.cs
@@ -4,6 +4,7 @@ using RandomizedTesting.Generators;
 using System;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Util.Fst
 {
@@ -237,8 +238,8 @@ namespace Lucene.Net.Util.Fst
                 // size = 3GB
                 {
                     Console.WriteLine("\nTEST: 3 GB size; doPack=" + doPack + " outputs=long");
-                    Outputs<long?> outputs = PositiveInt32Outputs.Singleton;
-                    Builder<long?> b = new Builder<long?>(FST.INPUT_TYPE.BYTE1, 0, 0, true, true, int.MaxValue, outputs, null, doPack, PackedInt32s.COMPACT, true, 15);
+                    Outputs<Int64> outputs = PositiveInt32Outputs.Singleton;
+                    Builder<Int64> b = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, 0, 0, true, true, int.MaxValue, outputs, null, doPack, PackedInt32s.COMPACT, true, 15);
 
                     long output = 1;
 
@@ -262,7 +263,7 @@ namespace Lucene.Net.Util.Fst
                         NextInput(r, ints);
                     }
 
-                    FST<long?> fst = b.Finish();
+                    FST<Int64> fst = b.Finish();
 
                     for (int verify = 0; verify < 2; verify++)
                     {
@@ -288,7 +289,7 @@ namespace Lucene.Net.Util.Fst
                         }
 
                         Console.WriteLine("\nTEST: enum all input/outputs");
-                        Int32sRefFSTEnum<long?> fstEnum = new Int32sRefFSTEnum<long?>(fst);
+                        Int32sRefFSTEnum<Int64> fstEnum = new Int32sRefFSTEnum<Int64>(fst);
 
                         Arrays.Fill(ints, 0);
                         r = new J2N.Randomizer(seed);
@@ -296,13 +297,13 @@ namespace Lucene.Net.Util.Fst
                         output = 1;
                         while (true)
                         {
-                            Int32sRefFSTEnum.InputOutput<long?> pair = fstEnum.Next();
+                            Int32sRefFSTEnum.InputOutput<Int64> pair = fstEnum.Next();
                             if (pair == null)
                             {
                                 break;
                             }
                             Assert.AreEqual(input, pair.Input);
-                            Assert.AreEqual(output, pair.Output.Value);
+                            Assert.AreEqual(output, pair.Output);
                             output += 1 + r.Next(10);
                             upto++;
                             NextInput(r, ints);
@@ -316,7 +317,7 @@ namespace Lucene.Net.Util.Fst
                             fst.Save(@out);
                             @out.Dispose();
                             IndexInput @in = dir.OpenInput("fst", IOContext.DEFAULT);
-                            fst = new FST<long?>(@in, outputs);
+                            fst = new FST<Int64>(@in, outputs);
                             @in.Dispose();
                         }
                         else

--- a/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
@@ -15,6 +15,7 @@ using System.Text;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 using JCG = J2N.Collections.Generic;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Util.Fst
 {
@@ -55,7 +56,7 @@ namespace Lucene.Net.Util.Fst
     using MultiFields = Lucene.Net.Index.MultiFields;
     using OpenMode = Lucene.Net.Index.OpenMode;
     using PackedInt32s = Lucene.Net.Util.Packed.PackedInt32s;
-    using Pair = Lucene.Net.Util.Fst.PairOutputs<long?, long?>.Pair;
+    using Pair = Lucene.Net.Util.Fst.PairOutputs<Int64, Int64>.Pair;
     using RandomIndexWriter = Lucene.Net.Index.RandomIndexWriter;
     using RegExp = Lucene.Net.Util.Automaton.RegExp;
     using Term = Lucene.Net.Index.Term;
@@ -136,12 +137,12 @@ namespace Lucene.Net.Util.Fst
                 // FST ord pos int
                 {
                     PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-                    IList<InputOutput<long?>> pairs = new JCG.List<InputOutput<long?>>(terms2.Length);
+                    IList<InputOutput<Int64>> pairs = new JCG.List<InputOutput<Int64>>(terms2.Length);
                     for (int idx = 0; idx < terms2.Length; idx++)
                     {
-                        pairs.Add(new InputOutput<long?>(terms2[idx], (long?)idx));
+                        pairs.Add(new InputOutput<Int64>(terms2[idx], idx));
                     }
-                    FST<long?> fst = (new FSTTester<long?>(Random, dir, inputMode, pairs, outputs, true)).DoTest(0, 0, false);
+                    FST<Int64> fst = (new FSTTester<Int64>(Random, dir, inputMode, pairs, outputs, true)).DoTest(0, 0, false);
                     Assert.IsNotNull(fst);
                     Assert.AreEqual(22, fst.NodeCount);
                     Assert.AreEqual(27, fst.ArcCount);
@@ -185,51 +186,51 @@ namespace Lucene.Net.Util.Fst
             // PositiveIntOutput (ord)
             {
                 PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-                IList<InputOutput<long?>> pairs = new JCG.List<InputOutput<long?>>(terms.Length);
+                IList<InputOutput<Int64>> pairs = new JCG.List<InputOutput<Int64>>(terms.Length);
                 for (int idx = 0; idx < terms.Length; idx++)
                 {
-                    pairs.Add(new InputOutput<long?>(terms[idx], (long?)idx));
+                    pairs.Add(new InputOutput<Int64>(terms[idx], idx));
                 }
-                (new FSTTester<long?>(Random, dir, inputMode, pairs, outputs, true)).DoTest(true);
+                (new FSTTester<Int64>(Random, dir, inputMode, pairs, outputs, true)).DoTest(true);
             }
 
             // PositiveIntOutput (random monotonically increasing positive number)
             {
                 PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-                IList<InputOutput<long?>> pairs = new JCG.List<InputOutput<long?>>(terms.Length);
+                IList<InputOutput<Int64>> pairs = new JCG.List<InputOutput<Int64>>(terms.Length);
                 long lastOutput = 0;
                 for (int idx = 0; idx < terms.Length; idx++)
                 {
                     long value = lastOutput + TestUtil.NextInt32(Random, 1, 1000);
                     lastOutput = value;
-                    pairs.Add(new InputOutput<long?>(terms[idx], value));
+                    pairs.Add(new InputOutput<Int64>(terms[idx], value));
                 }
-                (new FSTTester<long?>(Random, dir, inputMode, pairs, outputs, true)).DoTest(true);
+                (new FSTTester<Int64>(Random, dir, inputMode, pairs, outputs, true)).DoTest(true);
             }
 
             // PositiveIntOutput (random positive number)
             {
                 PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-                IList<InputOutput<long?>> pairs = new JCG.List<InputOutput<long?>>(terms.Length);
+                IList<InputOutput<Int64>> pairs = new JCG.List<InputOutput<Int64>>(terms.Length);
                 for (int idx = 0; idx < terms.Length; idx++)
                 {
-                    pairs.Add(new InputOutput<long?>(terms[idx], TestUtil.NextInt64(Random, 0, long.MaxValue)));
+                    pairs.Add(new InputOutput<Int64>(terms[idx], TestUtil.NextInt64(Random, 0, long.MaxValue)));
                 }
-                (new FSTTester<long?>(Random, dir, inputMode, pairs, outputs, false)).DoTest(true);
+                (new FSTTester<Int64>(Random, dir, inputMode, pairs, outputs, false)).DoTest(true);
             }
 
             // Pair<ord, (random monotonically increasing positive number>
             {
                 PositiveInt32Outputs o1 = PositiveInt32Outputs.Singleton;
                 PositiveInt32Outputs o2 = PositiveInt32Outputs.Singleton;
-                PairOutputs<long?, long?> outputs = new PairOutputs<long?, long?>(o1, o2);
+                PairOutputs<Int64, Int64> outputs = new PairOutputs<Int64, Int64>(o1, o2);
                 IList<InputOutput<Pair>> pairs = new JCG.List<InputOutput<Pair>>(terms.Length);
                 long lastOutput = 0;
                 for (int idx = 0; idx < terms.Length; idx++)
                 {
                     long value = lastOutput + TestUtil.NextInt32(Random, 1, 1000);
                     lastOutput = value;
-                    pairs.Add(new InputOutput<Pair>(terms[idx], outputs.NewPair((long?)idx, value)));
+                    pairs.Add(new InputOutput<Pair>(terms[idx], outputs.NewPair(idx, value)));
                 }
                 (new FSTTester<Pair>(Random, dir, inputMode, pairs, outputs, false)).DoTest(true);
             }
@@ -349,7 +350,7 @@ namespace Lucene.Net.Util.Fst
 
             bool doRewrite = Random.NextBoolean();
 
-            Builder<long?> builder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, 0, 0, true, true, int.MaxValue, outputs, null, doRewrite, PackedInt32s.DEFAULT, true, 15);
+            Builder<Int64> builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, 0, 0, true, true, int.MaxValue, outputs, null, doRewrite, PackedInt32s.DEFAULT, true, 15);
 
             bool storeOrd = Random.NextBoolean();
             if (Verbose)
@@ -418,7 +419,7 @@ namespace Lucene.Net.Util.Fst
                         Console.WriteLine(ord + " terms...");
                     }
                 }
-                FST<long?> fst = builder.Finish();
+                FST<Int64> fst = builder.Finish();
                 if (Verbose)
                 {
                     Console.WriteLine("FST: " + docCount + " docs; " + ord + " terms; " + fst.NodeCount + " nodes; " + fst.ArcCount + " arcs;" + " " + fst.GetSizeInBytes() + " bytes");
@@ -429,7 +430,7 @@ namespace Lucene.Net.Util.Fst
                     Random random = new J2N.Randomizer(Random.NextInt64());
                     // Now confirm BytesRefFSTEnum and TermsEnum act the
                     // same:
-                    BytesRefFSTEnum<long?> fstEnum = new BytesRefFSTEnum<long?>(fst);
+                    BytesRefFSTEnum<Int64> fstEnum = new BytesRefFSTEnum<Int64>(fst);
                     int num = AtLeast(1000);
                     for (int iter = 0; iter < num; iter++)
                     {
@@ -441,7 +442,7 @@ namespace Lucene.Net.Util.Fst
                         }
 
                         TermsEnum.SeekStatus seekResult = termsEnum.SeekCeil(randomTerm);
-                        BytesRefFSTEnum.InputOutput<long?> fstSeekResult = fstEnum.SeekCeil(randomTerm);
+                        BytesRefFSTEnum.InputOutput<Int64> fstSeekResult = fstEnum.SeekCeil(randomTerm);
 
                         if (seekResult == TermsEnum.SeekStatus.END)
                         {
@@ -475,7 +476,7 @@ namespace Lucene.Net.Util.Fst
                                     {
                                         Console.WriteLine("  end!");
                                     }
-                                    BytesRefFSTEnum.InputOutput<long?> nextResult;
+                                    BytesRefFSTEnum.InputOutput<Int64> nextResult;
                                     if (fstEnum.MoveNext())
                                     {
                                         nextResult = fstEnum.Current;
@@ -495,7 +496,7 @@ namespace Lucene.Net.Util.Fst
             dir.Dispose();
         }
 
-        private void AssertSame(TermsEnum termsEnum, BytesRefFSTEnum<long?> fstEnum, bool storeOrd) // LUCENENET specific - changed to long? so we don't need a cast
+        private void AssertSame(TermsEnum termsEnum, BytesRefFSTEnum<Int64> fstEnum, bool storeOrd)
         {
             if (termsEnum.Term == null)
             {
@@ -518,7 +519,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private abstract class VisitTerms<T>
+        private abstract class VisitTerms<T> where T : class // LUCENENET specific - added class constraint, since we compare reference equality
         {
             private readonly string dirOut;
             private readonly string wordsFileIn;
@@ -648,8 +649,8 @@ namespace Lucene.Net.Util.Fst
                                 else
                                 {
                                     // Get by output
-                                    long? output = GetOutput(intsRef, ord) as long?;
-                                    Int32sRef actual = Util.GetByOutput(fst as FST<long?>, output.GetValueOrDefault());
+                                    Int64 output = (Int64)(object)GetOutput(intsRef, ord);
+                                    Int32sRef actual = Util.GetByOutput(fst as FST<Int64>, output);
                                     if (actual == null)
                                     {
                                         throw RuntimeException.Create("unexpected null input from output=" + output);
@@ -816,9 +817,9 @@ namespace Lucene.Net.Util.Fst
 
         private class VisitTermsAnonymousClass : VisitTerms<Pair>
         {
-            private readonly PairOutputs<long?, long?> outputs;
+            private readonly PairOutputs<Int64, Int64> outputs;
 
-            public VisitTermsAnonymousClass(string dirOut, string wordsFileIn, int inputMode, int prune, PairOutputs<long?, long?> outputs, bool doPack, bool noArcArrays)
+            public VisitTermsAnonymousClass(string dirOut, string wordsFileIn, int inputMode, int prune, PairOutputs<Int64, Int64> outputs, bool doPack, bool noArcArrays)
                 : base(dirOut, wordsFileIn, inputMode, prune, outputs, doPack, noArcArrays)
             {
                 this.outputs = outputs;
@@ -835,20 +836,20 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private class VisitTermsAnonymousClass2 : VisitTerms<long?>
+        private class VisitTermsAnonymousClass2 : VisitTerms<Int64>
         {
             public VisitTermsAnonymousClass2(string dirOut, string wordsFileIn, int inputMode, int prune, PositiveInt32Outputs outputs, bool doPack, bool noArcArrays)
                 : base(dirOut, wordsFileIn, inputMode, prune, outputs, doPack, noArcArrays)
             {
             }
 
-            protected internal override long? GetOutput(Int32sRef input, int ord)
+            protected internal override Int64 GetOutput(Int32sRef input, int ord)
             {
                 return ord;
             }
         }
 
-        private class VisitTermsAnonymousClass3 : VisitTerms<long?>
+        private class VisitTermsAnonymousClass3 : VisitTerms<Int64>
         {
             public VisitTermsAnonymousClass3(string dirOut, string wordsFileIn, int inputMode, int prune, PositiveInt32Outputs outputs, bool doPack, bool noArcArrays)
                 : base(dirOut, wordsFileIn, inputMode, prune, outputs, doPack, noArcArrays)
@@ -856,7 +857,7 @@ namespace Lucene.Net.Util.Fst
             }
 
             internal Random rand;
-            protected internal override long? GetOutput(Int32sRef input, int ord)
+            protected internal override Int64 GetOutput(Int32sRef input, int ord)
             {
                 if (ord == 0)
                 {
@@ -972,7 +973,7 @@ namespace Lucene.Net.Util.Fst
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
 
             // Build an FST mapping BytesRef -> Long
-            Builder<long?> builder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, outputs);
+            Builder<Int64> builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, outputs);
 
             BytesRef a = new BytesRef("a");
             BytesRef b = new BytesRef("b");
@@ -982,14 +983,14 @@ namespace Lucene.Net.Util.Fst
             builder.Add(Util.ToInt32sRef(b, new Int32sRef()), 42L);
             builder.Add(Util.ToInt32sRef(c, new Int32sRef()), 13824324872317238L);
 
-            FST<long?> fst = builder.Finish();
+            FST<Int64> fst = builder.Finish();
 
             Assert.AreEqual(13824324872317238L, Util.Get(fst, c));
             Assert.AreEqual(42, Util.Get(fst, b));
             Assert.AreEqual(17, Util.Get(fst, a));
 
-            BytesRefFSTEnum<long?> fstEnum = new BytesRefFSTEnum<long?>(fst);
-            BytesRefFSTEnum.InputOutput<long?> seekResult;
+            BytesRefFSTEnum<Int64> fstEnum = new BytesRefFSTEnum<Int64>(fst);
+            BytesRefFSTEnum.InputOutput<Int64> seekResult;
             seekResult = fstEnum.SeekFloor(a);
             Assert.IsNotNull(seekResult);
             Assert.AreEqual(17, seekResult.Output);
@@ -1339,10 +1340,10 @@ namespace Lucene.Net.Util.Fst
         {
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
 
-            Builder<long?> builder = new Builder<long?>(FST.INPUT_TYPE.BYTE4, 2, 0, true, true, int.MaxValue, outputs, null, Random.NextBoolean(), PackedInt32s.DEFAULT, true, 15);
+            Builder<Int64> builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE4, 2, 0, true, true, int.MaxValue, outputs, null, Random.NextBoolean(), PackedInt32s.DEFAULT, true, 15);
             builder.Add(Util.ToUTF32("stat", new Int32sRef()), 17L);
             builder.Add(Util.ToUTF32("station", new Int32sRef()), 10L);
-            FST<long?> fst = builder.Finish();
+            FST<Int64> fst = builder.Finish();
             //Writer w = new OutputStreamWriter(new FileOutputStream("/x/tmp3/out.dot"));
             StringWriter w = new StringWriter();
             Util.ToDot(fst, w, false, false);
@@ -1356,10 +1357,10 @@ namespace Lucene.Net.Util.Fst
         {
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
             bool willRewrite = Random.NextBoolean();
-            Builder<long?> builder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, 0, 0, true, true, int.MaxValue, outputs, null, willRewrite, PackedInt32s.DEFAULT, true, 15);
+            Builder<Int64> builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, 0, 0, true, true, int.MaxValue, outputs, null, willRewrite, PackedInt32s.DEFAULT, true, 15);
             builder.Add(Util.ToInt32sRef(new BytesRef("stat"), new Int32sRef()), outputs.NoOutput);
             builder.Add(Util.ToInt32sRef(new BytesRef("station"), new Int32sRef()), outputs.NoOutput);
-            FST<long?> fst = builder.Finish();
+            FST<Int64> fst = builder.Finish();
             StringWriter w = new StringWriter();
             //Writer w = new OutputStreamWriter(new FileOutputStream("/x/tmp/out.dot"));
             Util.ToDot(fst, w, false, false);
@@ -1378,16 +1379,16 @@ namespace Lucene.Net.Util.Fst
         public virtual void TestNonFinalStopNode()
         {
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-            long? nothing = outputs.NoOutput;
-            Builder<long?> b = new Builder<long?>(FST.INPUT_TYPE.BYTE1, outputs);
+            long nothing = outputs.NoOutput;
+            Builder<Int64> b = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, outputs);
 
-            FST<long?> fst = new FST<long?>(FST.INPUT_TYPE.BYTE1, outputs, false, PackedInt32s.COMPACT, true, 15);
+            FST<Int64> fst = new FST<Int64>(FST.INPUT_TYPE.BYTE1, outputs, false, PackedInt32s.COMPACT, true, 15);
 
-            Builder.UnCompiledNode<long?> rootNode = new Builder.UnCompiledNode<long?>(b, 0);
+            Builder.UnCompiledNode<Int64> rootNode = new Builder.UnCompiledNode<Int64>(b, 0);
 
             // Add final stop node
             {
-                Builder.UnCompiledNode<long?> node = new Builder.UnCompiledNode<long?>(b, 0);
+                Builder.UnCompiledNode<Int64> node = new Builder.UnCompiledNode<Int64>(b, 0);
                 node.IsFinal = true;
                 rootNode.AddArc('a', node);
                 Builder.CompiledNode frozen = new Builder.CompiledNode();
@@ -1400,7 +1401,7 @@ namespace Lucene.Net.Util.Fst
 
             // Add non-final stop node
             {
-                Builder.UnCompiledNode<long?> node = new Builder.UnCompiledNode<long?>(b, 0);
+                Builder.UnCompiledNode<Int64> node = new Builder.UnCompiledNode<Int64>(b, 0);
                 rootNode.AddArc('b', node);
                 Builder.CompiledNode frozen = new Builder.CompiledNode();
                 frozen.Node = fst.AddNode(node);
@@ -1425,20 +1426,20 @@ namespace Lucene.Net.Util.Fst
             @out.Dispose();
 
             IndexInput @in = dir.OpenInput("fst", IOContext.DEFAULT);
-            FST<long?> fst2 = new FST<long?>(@in, outputs);
+            FST<Int64> fst2 = new FST<Int64>(@in, outputs);
             CheckStopNodes(fst2, outputs);
             @in.Dispose();
             dir.Dispose();
         }
 
-        private void CheckStopNodes(FST<long?> fst, PositiveInt32Outputs outputs)
+        private void CheckStopNodes(FST<Int64> fst, PositiveInt32Outputs outputs)
         {
-            long? nothing = outputs.NoOutput;
-            FST.Arc<long?> startArc = fst.GetFirstArc(new FST.Arc<long?>());
+            Int64 nothing = outputs.NoOutput;
+            FST.Arc<Int64> startArc = fst.GetFirstArc(new FST.Arc<Int64>());
             Assert.AreEqual(nothing, startArc.Output);
             Assert.AreEqual(nothing, startArc.NextFinalOutput);
 
-            FST.Arc<long?> arc = fst.ReadFirstTargetArc(startArc, new FST.Arc<long?>(), fst.GetBytesReader());
+            FST.Arc<Int64> arc = fst.ReadFirstTargetArc(startArc, new FST.Arc<Int64>(), fst.GetBytesReader());
             Assert.AreEqual('a', arc.Label);
             Assert.AreEqual(17, arc.NextFinalOutput);
             Assert.IsTrue(arc.IsFinal);
@@ -1449,24 +1450,24 @@ namespace Lucene.Net.Util.Fst
             Assert.AreEqual(42, arc.Output);
         }
 
-        internal static readonly IComparer<long?> minLongComparer = Comparer<long?>.Create((left, right)=> left.Value.CompareTo(right.Value));
+        internal static readonly IComparer<Int64> minLongComparer = Comparer<Int64>.Create((left, right)=> left.CompareTo(right));
         
         [Test]
         public virtual void TestShortestPaths()
         {
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-            Builder<long?> builder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, outputs);
+            Builder<Int64> builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, outputs);
 
             Int32sRef scratch = new Int32sRef();
             builder.Add(Util.ToInt32sRef(new BytesRef("aab"), scratch), 22L);
             builder.Add(Util.ToInt32sRef(new BytesRef("aac"), scratch), 7L);
             builder.Add(Util.ToInt32sRef(new BytesRef("ax"), scratch), 17L);
-            FST<long?> fst = builder.Finish();
+            FST<Int64> fst = builder.Finish();
             //Writer w = new OutputStreamWriter(new FileOutputStream("out.dot"));
             //Util.toDot(fst, w, false, false);
             //w.Dispose();
 
-            Util.TopResults<long?> res = Util.ShortestPaths(fst, fst.GetFirstArc(new FST.Arc<long?>()), outputs.NoOutput, minLongComparer, 3, true);
+            Util.TopResults<Int64> res = Util.ShortestPaths(fst, fst.GetFirstArc(new FST.Arc<Int64>()), outputs.NoOutput, minLongComparer, 3, true);
             Assert.IsTrue(res.IsComplete);
             Assert.AreEqual(3, res.TopN.Count);
             Assert.AreEqual(Util.ToInt32sRef(new BytesRef("aac"), scratch), res.TopN[0].Input);
@@ -1483,7 +1484,7 @@ namespace Lucene.Net.Util.Fst
         public virtual void TestRejectNoLimits()
         {
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-            Builder<long?> builder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, outputs);
+            Builder<Int64> builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, outputs);
 
             Int32sRef scratch = new Int32sRef();
             builder.Add(Util.ToInt32sRef(new BytesRef("aab"), scratch), 22L);
@@ -1492,12 +1493,12 @@ namespace Lucene.Net.Util.Fst
             builder.Add(Util.ToInt32sRef(new BytesRef("adcde"), scratch), 17L);
 
             builder.Add(Util.ToInt32sRef(new BytesRef("ax"), scratch), 17L);
-            FST<long?> fst = builder.Finish();
+            FST<Int64> fst = builder.Finish();
             AtomicInt32 rejectCount = new AtomicInt32();
-            Util.TopNSearcher<long?> searcher = new TopNSearcherAnonymousClass(fst, minLongComparer, rejectCount);
+            Util.TopNSearcher<Int64> searcher = new TopNSearcherAnonymousClass(fst, minLongComparer, rejectCount);
 
-            searcher.AddStartPaths(fst.GetFirstArc(new FST.Arc<long?>()), outputs.NoOutput, true, new Int32sRef());
-            Util.TopResults<long?> res = searcher.Search();
+            searcher.AddStartPaths(fst.GetFirstArc(new FST.Arc<Int64>()), outputs.NoOutput, true, new Int32sRef());
+            Util.TopResults<Int64> res = searcher.Search();
             Assert.AreEqual(rejectCount, 4);
             Assert.IsTrue(res.IsComplete); // rejected(4) + topN(2) <= maxQueueSize(6)
 
@@ -1507,25 +1508,25 @@ namespace Lucene.Net.Util.Fst
             rejectCount.Value = (0);
             searcher = new TopNSearcherAnonymousClass2(fst, minLongComparer, rejectCount);
 
-            searcher.AddStartPaths(fst.GetFirstArc(new FST.Arc<long?>()), outputs.NoOutput, true, new Int32sRef());
+            searcher.AddStartPaths(fst.GetFirstArc(new FST.Arc<Int64>()), outputs.NoOutput, true, new Int32sRef());
             res = searcher.Search();
             Assert.AreEqual(rejectCount, 4);
             Assert.IsFalse(res.IsComplete); // rejected(4) + topN(2) > maxQueueSize(5)
         }
 
-        private class TopNSearcherAnonymousClass : Util.TopNSearcher<long?>
+        private class TopNSearcherAnonymousClass : Util.TopNSearcher<Int64>
         {
             private readonly AtomicInt32 rejectCount;
 
-            public TopNSearcherAnonymousClass(FST<long?> fst, IComparer<long?> minLongComparer, AtomicInt32 rejectCount)
+            public TopNSearcherAnonymousClass(FST<Int64> fst, IComparer<Int64> minLongComparer, AtomicInt32 rejectCount)
                 : base(fst, 2, 6, minLongComparer)
             {
                 this.rejectCount = rejectCount;
             }
 
-            protected override bool AcceptResult(Int32sRef input, long? output)
+            protected override bool AcceptResult(Int32sRef input, Int64 output)
             {
-                bool accept = (int)output == 7;
+                bool accept = output == 7;
                 if (!accept)
                 {
                     rejectCount.IncrementAndGet();
@@ -1534,19 +1535,19 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private class TopNSearcherAnonymousClass2 : Util.TopNSearcher<long?>
+        private class TopNSearcherAnonymousClass2 : Util.TopNSearcher<Int64>
         {
             private readonly AtomicInt32 rejectCount;
 
-            public TopNSearcherAnonymousClass2(FST<long?> fst, IComparer<long?> minLongComparer, AtomicInt32 rejectCount)
+            public TopNSearcherAnonymousClass2(FST<Int64> fst, IComparer<Int64> minLongComparer, AtomicInt32 rejectCount)
                 : base(fst, 2, 5, minLongComparer)
             {
                 this.rejectCount = rejectCount;
             }
 
-            protected override bool AcceptResult(Int32sRef input, long? output)
+            protected override bool AcceptResult(Int32sRef input, Int64 output)
             {
-                bool accept = (int)output == 7;
+                bool accept = output == 7;
                 if (!accept)
                 {
                     rejectCount.IncrementAndGet();
@@ -1556,7 +1557,7 @@ namespace Lucene.Net.Util.Fst
         }
 
         // compares just the weight side of the pair
-        internal static readonly IComparer<Pair> minPairWeightComparer = Comparer<Pair>.Create((left, right)=> left.Output1.GetValueOrDefault().CompareTo(right.Output1.GetValueOrDefault()));
+        internal static readonly IComparer<Pair> minPairWeightComparer = Comparer<Pair>.Create((left, right)=> left.Output1.CompareTo(right.Output1));
              
         /// <summary>
         /// like testShortestPaths, but uses pairoutputs so we have both a weight and an output </summary>
@@ -1564,7 +1565,7 @@ namespace Lucene.Net.Util.Fst
         public virtual void TestShortestPathsWFST()
         {
 
-            PairOutputs<long?, long?> outputs = new PairOutputs<long?, long?>(PositiveInt32Outputs.Singleton, PositiveInt32Outputs.Singleton); // output -  weight
+            PairOutputs<Int64, Int64> outputs = new PairOutputs<Int64, Int64>(PositiveInt32Outputs.Singleton, PositiveInt32Outputs.Singleton); // output -  weight
 
             Builder<Pair> builder = new Builder<Pair>(FST.INPUT_TYPE.BYTE1, outputs);
 
@@ -1604,7 +1605,7 @@ namespace Lucene.Net.Util.Fst
             JCG.SortedSet<string> allPrefixes = new JCG.SortedSet<string>(StringComparer.Ordinal);
 
             PositiveInt32Outputs outputs = PositiveInt32Outputs.Singleton;
-            Builder<long?> builder = new Builder<long?>(FST.INPUT_TYPE.BYTE1, outputs);
+            Builder<Int64> builder = new Builder<Int64>(FST.INPUT_TYPE.BYTE1, outputs);
             Int32sRef scratch = new Int32sRef();
 
             for (int i = 0; i < numWords; i++)
@@ -1633,7 +1634,7 @@ namespace Lucene.Net.Util.Fst
                 builder.Add(Util.ToInt32sRef(new BytesRef(e.Key), scratch), e.Value);
             }
 
-            FST<long?> fst = builder.Finish();
+            FST<Int64> fst = builder.Finish();
             //System.out.println("SAVE out.dot");
             //Writer w = new OutputStreamWriter(new FileOutputStream("out.dot"));
             //Util.toDot(fst, w, false, false);
@@ -1647,8 +1648,8 @@ namespace Lucene.Net.Util.Fst
                 // 1. run prefix against fst, then complete by value
                 //System.out.println("TEST: " + prefix);
 
-                long? prefixOutput = 0;
-                FST.Arc<long?> arc = fst.GetFirstArc(new FST.Arc<long?>());
+                long prefixOutput = 0;
+                FST.Arc<Int64> arc = fst.GetFirstArc(new FST.Arc<Int64>());
                 for (int idx = 0; idx < prefix.Length; idx++)
                 {
                     if (fst.FindTargetArc((int)prefix[idx], arc, arc, reader) == null)
@@ -1660,11 +1661,11 @@ namespace Lucene.Net.Util.Fst
 
                 int topN = TestUtil.NextInt32(random, 1, 10);
 
-                Util.TopResults<long?> r = Util.ShortestPaths(fst, arc, fst.Outputs.NoOutput, minLongComparer, topN, true);
+                Util.TopResults<Int64> r = Util.ShortestPaths(fst, arc, fst.Outputs.NoOutput, minLongComparer, topN, true);
                 Assert.IsTrue(r.IsComplete);
 
                 // 2. go thru whole treemap (slowCompletor) and check its actually the best suggestion
-                JCG.List<Util.Result<long?>> matches = new JCG.List<Util.Result<long?>>();
+                JCG.List<Util.Result<Int64>> matches = new JCG.List<Util.Result<Int64>>();
 
                 // TODO: could be faster... but its slowCompletor for a reason
                 foreach (KeyValuePair<string, long> e in slowCompletor)
@@ -1672,12 +1673,12 @@ namespace Lucene.Net.Util.Fst
                     if (e.Key.StartsWith(prefix, StringComparison.Ordinal))
                     {
                         //System.out.println("  consider " + e.getKey());
-                        matches.Add(new Util.Result<long?>(Util.ToInt32sRef(new BytesRef(e.Key.Substring(prefix.Length)), new Int32sRef()), e.Value - prefixOutput));
+                        matches.Add(new Util.Result<Int64>(Util.ToInt32sRef(new BytesRef(e.Key.Substring(prefix.Length)), new Int32sRef()), e.Value - prefixOutput));
                     }
                 }
 
                 Assert.IsTrue(matches.Count > 0);
-                matches.Sort(new TieBreakByInputComparer<long?>(minLongComparer));
+                matches.Sort(new TieBreakByInputComparer<Int64>(minLongComparer));
                 if (matches.Count > topN)
                 {
                     matches.RemoveRange(topN, matches.Count - topN); // LUCENENET: Converted end index to length
@@ -1694,7 +1695,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private class TieBreakByInputComparer<T> : IComparer<Util.Result<T>>
+        private class TieBreakByInputComparer<T> : IComparer<Util.Result<T>> where T : class // LUCENENET specific - added class constraint, since we compare reference equality
         {
             private readonly IComparer<T> comparer;
             public TieBreakByInputComparer(IComparer<T> comparer)
@@ -1719,10 +1720,10 @@ namespace Lucene.Net.Util.Fst
         // used by slowcompletor
         internal class TwoLongs
         {
-            internal long a;
-            internal long b;
+            internal Int64 a;
+            internal Int64 b;
 
-            internal TwoLongs(long a, long b)
+            internal TwoLongs(Int64 a, Int64 b)
             {
                 this.a = a;
                 this.b = b;
@@ -1739,7 +1740,7 @@ namespace Lucene.Net.Util.Fst
             JCG.SortedDictionary<string, TwoLongs> slowCompletor = new JCG.SortedDictionary<string, TwoLongs>(StringComparer.Ordinal);
             JCG.SortedSet<string> allPrefixes = new JCG.SortedSet<string>(StringComparer.Ordinal);
 
-            PairOutputs<long?, long?> outputs = new PairOutputs<long?, long?>(PositiveInt32Outputs.Singleton, PositiveInt32Outputs.Singleton); // output -  weight
+            PairOutputs<Int64, Int64> outputs = new PairOutputs<Int64, Int64>(PositiveInt32Outputs.Singleton, PositiveInt32Outputs.Singleton); // output -  weight
             Builder<Pair> builder = new Builder<Pair>(FST.INPUT_TYPE.BYTE1, outputs);
             Int32sRef scratch = new Int32sRef();
 

--- a/src/Lucene.Net/Util/Fst/Builder.cs
+++ b/src/Lucene.Net/Util/Fst/Builder.cs
@@ -451,7 +451,7 @@ namespace Lucene.Net.Util.Fst
                 T commonOutputPrefix;
                 T wordSuffix;
 
-                if (!lastOutput.Equals(NO_OUTPUT))
+                if (lastOutput != NO_OUTPUT)
                 {
                     commonOutputPrefix = fst.Outputs.Common(output, lastOutput);
                     if (Debugging.AssertsEnabled) Debugging.Assert(ValidOutput(commonOutputPrefix));
@@ -490,7 +490,7 @@ namespace Lucene.Net.Util.Fst
 
         internal bool ValidOutput(T output) // Only called from assert
         {
-            return output.Equals(NO_OUTPUT) || !output.Equals(NO_OUTPUT);
+            return output == NO_OUTPUT || !output.Equals(NO_OUTPUT);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/Fst/Builder.cs
+++ b/src/Lucene.Net/Util/Fst/Builder.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -50,6 +50,7 @@ namespace Lucene.Net.Util.Fst
     /// @lucene.experimental
     /// </summary>
     public class Builder<T> : Builder
+        where T : class // LUCENENET specific - added class constraint, since we compare reference equality
     {
         private readonly NodeHash<T> dedupHash;
         private readonly FST<T> fst;
@@ -583,7 +584,7 @@ namespace Lucene.Net.Util.Fst
         /// Expert: this is invoked by Builder whenever a suffix
         ///  is serialized.
         /// </summary>
-        public abstract class FreezeTail<S>
+        public abstract class FreezeTail<S> where S : class // LUCNENET specific - added class constraint because we compare reference equality
         {
             public abstract void Freeze(UnCompiledNode<S>[] frontier, int prefixLenPlus1, Int32sRef prevInput);
         }
@@ -595,7 +596,7 @@ namespace Lucene.Net.Util.Fst
 
         /// <summary>
         /// Expert: holds a pending (seen but not yet serialized) arc. </summary>
-        public class Arc<S>
+        public class Arc<S> where S : class // LUCENENET specific - added class constraint because we compare reference equality
         {
             public int Label { get; set; } // really an "unsigned" byte
             public INode Target { get; set; }
@@ -613,7 +614,7 @@ namespace Lucene.Net.Util.Fst
 
         /// <summary>
         /// Expert: holds a pending (seen but not yet serialized) Node. </summary>
-        public sealed class UnCompiledNode<S> : INode
+        public sealed class UnCompiledNode<S> : INode where S : class // LUCENENET specific - added class constraint, since we compare reference equality
         {
             internal Builder<S> Owner { get; private set; }
             public int NumArcs { get; set; }

--- a/src/Lucene.Net/Util/Fst/BytesRefFSTEnum.cs
+++ b/src/Lucene.Net/Util/Fst/BytesRefFSTEnum.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Runtime.CompilerServices;
 
@@ -27,7 +27,7 @@ namespace Lucene.Net.Util.Fst
     ///
     /// @lucene.experimental
     /// </summary>
-    public sealed class BytesRefFSTEnum<T> : FSTEnum<T>
+    public sealed class BytesRefFSTEnum<T> : FSTEnum<T> where T : class // LUCENENET specific - added class constraint, since we compare reference equality
     {
         private readonly BytesRef current = new BytesRef(10);
         private readonly BytesRefFSTEnum.InputOutput<T> result = new BytesRefFSTEnum.InputOutput<T>();

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -699,14 +699,14 @@ namespace Lucene.Net.Util.Fst
                 if (arc.IsFinal)
                 {
                     flags += FST.BIT_FINAL_ARC;
-                    if (!arc.NextFinalOutput.Equals(NO_OUTPUT))
+                    if (arc.NextFinalOutput != NO_OUTPUT)
                     {
                         flags += FST.BIT_ARC_HAS_FINAL_OUTPUT;
                     }
                 }
-                else
+                else if (Debugging.AssertsEnabled)
                 {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(arc.NextFinalOutput.Equals(NO_OUTPUT));
+                    Debugging.Assert(arc.NextFinalOutput == NO_OUTPUT);
                 }
 
                 bool targetHasArcs = target.Node > 0;
@@ -720,7 +720,7 @@ namespace Lucene.Net.Util.Fst
                     inCounts.Set((int)target.Node, inCounts.Get((int)target.Node) + 1);
                 }
 
-                if (!arc.Output.Equals(NO_OUTPUT))
+                if (arc.Output != NO_OUTPUT)
                 {
                     flags += FST.BIT_ARC_HAS_OUTPUT;
                 }
@@ -730,14 +730,14 @@ namespace Lucene.Net.Util.Fst
 
                 // System.out.println("  write arc: label=" + (char) arc.Label + " flags=" + flags + " target=" + target.Node + " pos=" + bytes.getPosition() + " output=" + outputs.outputToString(arc.Output));
 
-                if (!arc.Output.Equals(NO_OUTPUT))
+                if (arc.Output != NO_OUTPUT)
                 {
                     Outputs.Write(arc.Output, bytes);
                     //System.out.println("    write output");
                     arcWithOutputCount++;
                 }
 
-                if (!arc.NextFinalOutput.Equals(NO_OUTPUT))
+                if (arc.NextFinalOutput != NO_OUTPUT)
                 {
                     //System.out.println("    write final output");
                     Outputs.WriteFinalOutput(arc.NextFinalOutput, bytes);
@@ -868,11 +868,11 @@ namespace Lucene.Net.Util.Fst
         /// </summary>
         public FST.Arc<T> GetFirstArc(FST.Arc<T> arc)
         {
-            if (!EqualityComparer<T>.Default.Equals(emptyOutput, default))
+            if (null != emptyOutput) // LUCENENET: intentionally putting null on the left to avoid custom equality overrides
             {
                 arc.Flags = FST.BIT_FINAL_ARC | FST.BIT_LAST_ARC;
                 arc.NextFinalOutput = emptyOutput;
-                if (!emptyOutput.Equals(NO_OUTPUT))
+                if (emptyOutput != NO_OUTPUT)
                 {
                     arc.Flags |= FST.BIT_ARC_HAS_FINAL_OUTPUT;
                 }
@@ -1837,21 +1837,21 @@ namespace Lucene.Net.Util.Fst
                             if (arc.IsFinal)
                             {
                                 flags += (sbyte)FST.BIT_FINAL_ARC;
-                                if (!arc.NextFinalOutput.Equals(NO_OUTPUT))
+                                if (arc.NextFinalOutput != NO_OUTPUT)
                                 {
                                     flags += (sbyte)FST.BIT_ARC_HAS_FINAL_OUTPUT;
                                 }
                             }
                             else
                             {
-                                if (Debugging.AssertsEnabled) Debugging.Assert(arc.NextFinalOutput.Equals(NO_OUTPUT));
+                                if (Debugging.AssertsEnabled) Debugging.Assert(arc.NextFinalOutput == NO_OUTPUT);
                             }
                             if (!TargetHasArcs(arc))
                             {
                                 flags += (sbyte)FST.BIT_STOP_NODE;
                             }
 
-                            if (!arc.Output.Equals(NO_OUTPUT))
+                            if (arc.Output != NO_OUTPUT)
                             {
                                 flags += (sbyte)FST.BIT_ARC_HAS_OUTPUT;
                             }
@@ -1892,7 +1892,7 @@ namespace Lucene.Net.Util.Fst
 
                             fst.WriteLabel(writer, arc.Label);
 
-                            if (!arc.Output.Equals(NO_OUTPUT))
+                            if (arc.Output != NO_OUTPUT)
                             {
                                 Outputs.Write(arc.Output, writer);
                                 if (!retry)
@@ -1900,7 +1900,7 @@ namespace Lucene.Net.Util.Fst
                                     fst.arcWithOutputCount++;
                                 }
                             }
-                            if (!arc.NextFinalOutput.Equals(NO_OUTPUT))
+                            if (arc.NextFinalOutput != NO_OUTPUT)
                             {
                                 Outputs.WriteFinalOutput(arc.NextFinalOutput, writer);
                             }

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -63,6 +63,7 @@ namespace Lucene.Net.Util.Fst
     /// @lucene.experimental
     /// </summary>
     public sealed class FST<T>
+        where T : class // LUCENENET specific - added class constraint, since we compare reference equality
     {
         /*/// <summary>
         /// Specifies allowed range of each int input label for
@@ -2155,7 +2156,7 @@ namespace Lucene.Net.Util.Fst
         /// returns <c>true</c> if the node at this address has any
         /// outgoing arcs
         /// </summary>
-        public static bool TargetHasArcs<T>(Arc<T> arc)
+        public static bool TargetHasArcs<T>(Arc<T> arc) where T : class // LUCENENET specific - added class constraint, since we compare reference equality
         {
             return arc.Target > 0;
         }
@@ -2163,7 +2164,7 @@ namespace Lucene.Net.Util.Fst
         /// <summary>
         /// Reads an automaton from a file.
         /// </summary>
-        public static FST<T> Read<T>(FileInfo file, Outputs<T> outputs)
+        public static FST<T> Read<T>(FileInfo file, Outputs<T> outputs) where T : class // LUCENENET specific - added class constraint, since we compare reference equality
         {
             var bs = new BufferedStream(file.OpenRead());
             bool success = false;
@@ -2220,6 +2221,7 @@ namespace Lucene.Net.Util.Fst
         /// </summary>
         /// <typeparam name="T"></typeparam>
         public class Arc<T>
+            where T : class // LUCENENET specific - added class constraint, since we compare reference equality
         {
             public int Label { get; set; }
 
@@ -2307,7 +2309,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        internal class ArcAndState<T>
+        internal class ArcAndState<T> where T : class // LUCENENET specific - added class constraint, since we compare reference equality
         {
             internal Arc<T> Arc { get; private set; }
             internal Int32sRef Chain { get; private set; }

--- a/src/Lucene.Net/Util/Fst/FSTEnum.cs
+++ b/src/Lucene.Net/Util/Fst/FSTEnum.cs
@@ -28,6 +28,7 @@ namespace Lucene.Net.Util.Fst
     /// @lucene.experimental
     /// </summary>
     public abstract class FSTEnum<T> // LUCENENET NOTE: changed from internal to public because has public subclasses
+        where T : class // LUCENENET specific - added class constraint, since we compare reference equality
     {
         protected readonly FST<T> m_fst;
 

--- a/src/Lucene.Net/Util/Fst/IntsRefFSTEnum.cs
+++ b/src/Lucene.Net/Util/Fst/IntsRefFSTEnum.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Diagnostics;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util.Fst
@@ -50,6 +51,24 @@ namespace Lucene.Net.Util.Fst
 
         public Int32sRefFSTEnum.InputOutput<T> Current => result;
 
+        public bool MoveNext() // LUCENENET specific - replaced Next() with MoveNext()
+        {
+            //System.out.println("  enum.next");
+            DoNext();
+
+            if (m_upto == 0)
+            {
+                return false;
+            }
+            else
+            {
+                current.Length = m_upto - 1;
+                result.Output = m_output[m_upto];
+                return true;
+            }
+        }
+
+        [Obsolete("Use MoveNext() and Current instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public Int32sRefFSTEnum.InputOutput<T> Next()
         {
             //System.out.println("  enum.next");

--- a/src/Lucene.Net/Util/Fst/IntsRefFSTEnum.cs
+++ b/src/Lucene.Net/Util/Fst/IntsRefFSTEnum.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util.Fst
@@ -28,7 +28,7 @@ namespace Lucene.Net.Util.Fst
     /// <para/>
     /// @lucene.experimental
     /// </summary>
-    public sealed class Int32sRefFSTEnum<T> : FSTEnum<T>
+    public sealed class Int32sRefFSTEnum<T> : FSTEnum<T> where T : class // LUCENENET specific - added class constraint, since we compare reference equality
     {
         private readonly Int32sRef current = new Int32sRef(10);
         private readonly Int32sRefFSTEnum.InputOutput<T> result = new Int32sRefFSTEnum.InputOutput<T>();
@@ -154,7 +154,7 @@ namespace Lucene.Net.Util.Fst
 
         /// <summary>
         /// Holds a single input (<see cref="Int32sRef"/>) + output pair. </summary>
-        public class InputOutput<T>
+        public class InputOutput<T> where T : class // LUCENENET specific - added class constraint, since we compare reference equality
         {
             public Int32sRef Input { get; set; }
             public T Output { get; set; }

--- a/src/Lucene.Net/Util/Fst/NodeHash.cs
+++ b/src/Lucene.Net/Util/Fst/NodeHash.cs
@@ -1,4 +1,4 @@
-using J2N.Collections;
+﻿using J2N.Collections;
 using Lucene.Net.Diagnostics;
 using System.Runtime.CompilerServices;
 using JCG = J2N.Collections.Generic;
@@ -29,6 +29,7 @@ namespace Lucene.Net.Util.Fst
     /// Used to dedup states (lookup already-frozen states)
     /// </summary>
     internal sealed class NodeHash<T>
+        where T : class // LUCENENET specific - added class constraint, since we compare reference equality
     {
         private PagedGrowableWriter table;
         private long count;

--- a/src/Lucene.Net/Util/Fst/PairOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/PairOutputs.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util.Fst
@@ -29,6 +29,8 @@ namespace Lucene.Net.Util.Fst
     /// @lucene.experimental
     /// </summary>
     public class PairOutputs<A, B> : Outputs<PairOutputs<A, B>.Pair>
+        where A : class // LUCENENET specific - added class constraints because we compare reference equality
+        where B : class
     {
         private readonly Pair NO_OUTPUT;
         private readonly Outputs<A> outputs1;
@@ -80,7 +82,7 @@ namespace Lucene.Net.Util.Fst
                 b = outputs2.NoOutput;
             }
 
-            if (a.Equals(outputs1.NoOutput) && b.Equals(outputs2.NoOutput))
+            if (a == outputs1.NoOutput && b == outputs2.NoOutput)
             {
                 return NO_OUTPUT;
             }
@@ -98,26 +100,22 @@ namespace Lucene.Net.Util.Fst
             bool noOutput1 = pair.Output1.Equals(outputs1.NoOutput);
             bool noOutput2 = pair.Output2.Equals(outputs2.NoOutput);
 
-            if (noOutput1 && !pair.Output1.Equals(outputs1.NoOutput))
+            if (noOutput1 && pair.Output1 != outputs1.NoOutput)
             {
                 return false;
             }
 
-            if (noOutput2 && !pair.Output2.Equals(outputs2.NoOutput))
+            if (noOutput2 && pair.Output2 != outputs2.NoOutput)
             {
                 return false;
             }
 
             if (noOutput1 && noOutput2)
             {
-                if (!pair.Equals(NO_OUTPUT))
-                {
+                if (pair != NO_OUTPUT)
                     return false;
-                }
-                else
-                {
-                    return true;
-                }
+
+                return true;
             }
             else
             {
@@ -132,7 +130,8 @@ namespace Lucene.Net.Util.Fst
                 Debugging.Assert(Valid(pair1));
                 Debugging.Assert(Valid(pair2));
             }
-            return NewPair(outputs1.Common(pair1.Output1, pair2.Output1), outputs2.Common(pair1.Output2, pair2.Output2));
+            return NewPair(outputs1.Common(pair1.Output1, pair2.Output1),
+                           outputs2.Common(pair1.Output2, pair2.Output2));
         }
 
         public override Pair Subtract(Pair output, Pair inc)
@@ -142,7 +141,8 @@ namespace Lucene.Net.Util.Fst
                 Debugging.Assert(Valid(output));
                 Debugging.Assert(Valid(inc));
             }
-            return NewPair(outputs1.Subtract(output.Output1, inc.Output1), outputs2.Subtract(output.Output2, inc.Output2));
+            return NewPair(outputs1.Subtract(output.Output1, inc.Output1),
+                           outputs2.Subtract(output.Output2, inc.Output2));
         }
 
         public override Pair Add(Pair prefix, Pair output)
@@ -152,7 +152,8 @@ namespace Lucene.Net.Util.Fst
                 Debugging.Assert(Valid(prefix));
                 Debugging.Assert(Valid(output));
             }
-            return NewPair(outputs1.Add(prefix.Output1, output.Output1), outputs2.Add(prefix.Output2, output.Output2));
+            return NewPair(outputs1.Add(prefix.Output1, output.Output1),
+                           outputs2.Add(prefix.Output2, output.Output2));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lucene.Net/Util/Fst/PositiveIntOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/PositiveIntOutputs.cs
@@ -1,6 +1,8 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
+using Int64 = J2N.Numerics.Int64;
 
 namespace Lucene.Net.Util.Fst
 {
@@ -26,15 +28,15 @@ namespace Lucene.Net.Util.Fst
 
     /// <summary>
     /// An FST <see cref="Outputs{T}"/> implementation where each output
-    /// is a non-negative <see cref="T:long?"/> value.
+    /// is a non-negative <see cref="Int64"/> value.
     /// <para/>
     /// NOTE: This was PositiveIntOutputs in Lucene
     /// <para/>
     /// @lucene.experimental
     /// </summary>
-    public sealed class PositiveInt32Outputs : Outputs<long?>
+    public sealed class PositiveInt32Outputs : Outputs<Int64>
     {
-        private const long NO_OUTPUT = new long();
+        private static readonly Int64 NO_OUTPUT = Int64.GetInstance(0);
 
         private static readonly PositiveInt32Outputs singleton = new PositiveInt32Outputs();
 
@@ -44,7 +46,7 @@ namespace Lucene.Net.Util.Fst
 
         public static PositiveInt32Outputs Singleton => singleton;
 
-        public override long? Common(long? output1, long? output2)
+        public override Int64 Common(Int64 output1, Int64 output2)
         {
             if (Debugging.AssertsEnabled)
             {
@@ -62,11 +64,11 @@ namespace Lucene.Net.Util.Fst
                     Debugging.Assert(output1 > 0);
                     Debugging.Assert(output2 > 0);
                 }
-                return Math.Min(output1.Value, output2.Value);
+                return Math.Min(output1, output2);
             }
         }
 
-        public override long? Subtract(long? output, long? inc)
+        public override Int64 Subtract(Int64 output, Int64 inc)
         {
             if (Debugging.AssertsEnabled)
             {
@@ -89,7 +91,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        public override long? Add(long? prefix, long? output)
+        public override Int64 Add(Int64 prefix, Int64 output)
         {
             if (Debugging.AssertsEnabled)
             {
@@ -111,14 +113,14 @@ namespace Lucene.Net.Util.Fst
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override void Write(long? output, DataOutput @out)
+        public override void Write(Int64 output, DataOutput @out)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(Valid(output));
-            @out.WriteVInt64(output.Value);
+            @out.WriteVInt64(output);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override long? Read(DataInput @in)
+        public override Int64 Read(DataInput @in)
         {
             long v = @in.ReadVInt64();
             if (v == 0)
@@ -131,19 +133,19 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private bool Valid(long? o)
+        private bool Valid(Int64 o)
         {
             Debugging.Assert(o != null, "PositiveIntOutput precondition fail");
             Debugging.Assert(o == NO_OUTPUT || o > 0,"o={0}", o);
             return true;
         }
 
-        public override long? NoOutput => NO_OUTPUT;
+        public override Int64 NoOutput => NO_OUTPUT;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string OutputToString(long? output)
+        public override string OutputToString(Int64 output)
         {
-            return output.ToString(); // LUCENENET TODO: Invariant Culture?
+            return output.ToString(NumberFormatInfo.InvariantInfo);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This reverts `Lucene.Net.Util.Fst` to be more like the original design, using reference types as the generic closing type for generic classes and methods. It reverts to the original reference equality checking that Lucene uses. It also adds a class constraint on all of the generic types to enforce this, as using value types is incompatible with the reference equality checks.

The original design of FST uses reference equality to compare output values. There are also extensions to FST in `Lucene.Net.Misc` that declare the generic type as `object` so either a long integer type or another reference type can be returned.

This had been changed to use `long?` as the generic closing type and the reference equality checking was changed to value equality checking. This of course meant that boxing would take place in the `Lucene.Net.Misc` extensions and also made it impossible to use `long` instead of `long?` as the generic closing type because of how equality was being compared, which made the API confusing to use.

> NOTE: There are numeric reference type wrappers in the `J2N.Numerics` namespace that can be used with this API. The built-in implementation uses `J2N.Numerics.Int64`.

This PR also adds a `MoveNext()` method to the `Lucene.Net.Util.Fst.Int32sRefFSTEnum` and deprecates the `Next()` method (see #279).

