### PR TITLE
Lucene.Net.TestFramework: Changed RandomSeedAttribute parameter to string to allow for compound seeds

### DIFF
--- a/src/Lucene.Net.TestFramework/Support/Util/RandomSeedAttribute.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/RandomSeedAttribute.cs
@@ -28,25 +28,18 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Construct a <see cref="RandomSeedAttribute"/> with a specific random seed value.
         /// </summary>
-        /// <param name="randomSeed">A <see cref="long"/> value that represents the initial random seed to use to run the tests.</param>
-        public RandomSeedAttribute(long randomSeed)
+        /// <param name="randomSeed">A <see cref="string"/> value that represents the initial random seed to use to run the tests.
+        /// The seed is a hexadecimal string representation of a <see cref="long"/> value.
+        /// <para/>
+        /// <b>NOTE:</b> For future expansion, the string may include other values as well using ":" as delimiters.</param>
+        public RandomSeedAttribute(string randomSeed)
         {
             RandomSeed = randomSeed;
         }
 
         /// <summary>
-        /// Construct a <see cref="RandomSeedAttribute"/> with a specific random seed value.
-        /// </summary>
-        /// <param name="randomSeed">A <see cref="ulong"/> value that represents the initial random seed to use to run the tests.</param>
-        [CLSCompliant(false)]
-        public RandomSeedAttribute(ulong randomSeed)
-        {
-            RandomSeed = unchecked((long)randomSeed);
-        }
-
-        /// <summary>
         /// The random seed value.
         /// </summary>
-        public long RandomSeed { get; private set; }
+        public string RandomSeed { get; private set; }
     }
 }

--- a/src/Lucene.Net.TestFramework/Support/Util/RandomizedContext.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/RandomizedContext.cs
@@ -27,7 +27,8 @@ namespace Lucene.Net.Util
     /// </summary>
     internal class RandomizedContext
     {
-        internal const string RandomizedContextPropertyName = "RandomizedContext";
+        // LUCENENET NOTE: Using an underscore to prefix the name hides it from "traits" in Test Explorer
+        internal const string RandomizedContextPropertyName = "_RandomizedContext";
 
         private Random randomGenerator;
         private readonly Test currentTest;

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1032,7 +1032,7 @@ namespace Lucene.Net.Util
                 message = result.Message + $"\n\nTo reproduce this test result:\n\n" +
                     $"Option 1:\n\n" +
                     $" Apply the following assembly-level attributes:\n\n" +
-                    $"[assembly: Lucene.Net.Util.RandomSeed({RandomizedContext.CurrentContext.RandomSeedAsHex}L)]\n" +
+                    $"[assembly: Lucene.Net.Util.RandomSeed(\"{RandomizedContext.CurrentContext.RandomSeedAsHex}\")]\n" +
                     $"[assembly: NUnit.Framework.SetCulture(\"{Thread.CurrentThread.CurrentCulture.Name}\")]\n\n" +
                     $"Option 2:\n\n" +
                     $" Use the following .runsettings file:\n\n" +


### PR DESCRIPTION
Lucene uses a compound seed that contains multiple seeds delimited by a colon. It is unclear what the purpose of this is, but this patch changes the datatype of the `RandomSeedAttribute` from long/ulong to string and changes the parsing to ignore everything after a colon so we can expand later without a breaking change.

This also prefixes the `RandomizedContext` property with an underscore, which hides it from displaying in Visual Studio Test Explorer.