### PR TITLE
Test Framework Updates

### DIFF
--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -651,7 +651,7 @@ namespace Lucene.Net.Analysis
                     CheckRandomData(new J2N.Randomizer(seed), a, iterations, maxWordLength, useCharFilter, simple, offsetsAreCorrect, iw);
                     success = true;
                 }
-                catch (Exception e) when (e.IsException()) // LUCENENET TODO: This catch block can be removed because Rethrow.rethrow() simply does what its name says, but need to get rid of the FirstException functionality and fix ThreadJob so it re-throws ThreadInterruptedExcepetion first.
+                catch (Exception e) when (e.IsException())
                 {
                     //Console.WriteLine("Exception in Thread: " + e);
                     //throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)

--- a/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
@@ -324,7 +324,7 @@ namespace Lucene.Net.Index
 
                 foreach (AtomicReaderContext ctx in r.Leaves)
                 {
-                    AtomicReader sub = ctx.AtomicReader; // LUCENENET TODO: Dispose() ?
+                    AtomicReader sub = ctx.AtomicReader;
                     FieldCache.Int32s ids = FieldCache.DEFAULT.GetInt32s(sub, "id", false);
                     for (int docID = 0; docID < sub.NumDocs; docID++)
                     {

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -896,7 +896,7 @@ namespace Lucene.Net.Store
         // NOTE: this is off by default; see LUCENE-5574
         private bool assertNoUnreferencedFilesOnClose;
 
-        public virtual bool AssertNoUnreferencedFilesOnClose // LUCENENET TODO: Rename AssertNoUnreferencedFilesOnDispose ?
+        public virtual bool AssertNoUnreferencedFilesOnDispose // LUCENENET specific: Renamed from AssertNoUnreferencedFilesOnClose
         {
             get => assertNoUnreferencedFilesOnClose; // LUCENENET specific - added getter (to follow MSDN property guidelines)
             set => assertNoUnreferencedFilesOnClose = value;

--- a/src/Lucene.Net.TestFramework/Store/MockIndexOutputWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockIndexOutputWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Lucene.Net.Util;
+using System;
 using System.IO;
 using System.Threading;
 using Console = Lucene.Net.Util.SystemConsole;
@@ -93,12 +94,11 @@ namespace Lucene.Net.Store
                     message += "; wrote " + freeSpace + " of " + len + " bytes";
                 }
                 message += ")";
-                // LUCENENET TODO: Finish implementation
-                /*if (LuceneTestCase.VERBOSE)
+                if (LuceneTestCase.Verbose)
                 {
-                  Console.WriteLine(Thread.CurrentThread.Name + ": MDW: now throw fake disk full");
-                  (new Exception()).printStackTrace(System.out);
-                }*/
+                    Console.WriteLine(Thread.CurrentThread.Name + ": MDW: now throw fake disk full");
+                    Console.WriteLine(Environment.StackTrace);
+                }
                 throw new IOException(message);
             }
         }

--- a/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Support/JavaCompatibility/LuceneTestCase.cs
@@ -25,10 +25,10 @@ namespace Lucene.Net.Util
      * limitations under the License.
      */
 
-    /// <summary>
-    /// LUCENENET specific extensions to <see cref="LuceneTestCase"/> to make it easier to port tests
-    /// from Java with fewer changes.
-    /// </summary>
+
+    // LUCENENET specific extensions to <see cref="LuceneTestCase"/> to make it easier to port tests
+    // from Java with fewer changes.
+    // LUCENENET NOTE: Don't add xml doc comments here, they must be applied only to the main LuceneTestCase class
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "These methods are for making porting tests from Java simpler")]
     public abstract partial class LuceneTestCase
     {

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Util
     /// static methods annotated with <see cref="OneTimeSetUp"/> and <see cref="OneTimeTearDown"/>. Any
     /// code in these methods is executed within the test framework's control and
     /// ensure proper setup has been made. <b>Try not to use static initializers
-    /// (including complex final field initializers).</b> Static initializers are
+    /// (including complex readonly field initializers).</b> Static initializers are
     /// executed before any setup rules are fired and may cause you (or somebody
     /// else) headaches.
     /// </para>
@@ -87,42 +87,81 @@ namespace Lucene.Net.Util
     /// <para>
     /// Any test method annotated with <see cref="Test"/> is considered a test case.
     /// </para>
+    ///
+    /// <h3>Randomized execution and test facilities</h3>
+    ///
+    /// <para>
+    /// <see cref="LuceneTestCase"/> uses a custom <see cref="TestFixtureAttribute"/> to execute test cases.
+    /// The custom <see cref="TestFixtureAttribute"/> has built-in support for test randomization
+    /// including access to a repeatable <see cref="Random"/> instance. See
+    /// <see cref="Random"/> property. Any test using <see cref="Random"/> acquired from
+    /// <see cref="Random"/> should be fully reproducible (assuming no race conditions
+    /// between threads etc.). The initial seed for a test case is reported in the failure
+    /// test message.
+    /// </para>
+    /// <para>
+    /// The seed can be configured with a RunSettings file, a <c>lucene.testSettings.config</c> JSON file,
+    /// an environment variable, or using <see cref="RandomSeedAttribute"/> at the assembly level.
+    /// It is recommended to configure the culture also, since they are randomly picked from a list
+    /// of cultures installed on a given machine, so the culture will vary from one machine to the next.
+    /// </para>
+    /// 
+    /// <h4><i>.runsettings</i> File Configuration Example</h4>
+    /// 
+    /// <code>
+    /// &lt;RunSettings&gt;
+    ///   &lt;TestRunParameters&gt;
+    ///     &lt;Parameter name="tests:seed" value="0x1ffa1d067056b0e6" /&gt;
+    ///     &lt;Parameter name="tests:culture" value="sw-TZ" /&gt;
+    ///   &lt;/TestRunParameters&gt;
+    /// &lt;/RunSettings&gt;
+    /// </code>
+    /// <para>
+    /// See the <i>.runsettings</i> documentation at: <a href="https://docs.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file">
+    /// https://docs.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file</a>.
+    /// </para>
+    /// 
+    /// <h4>Attribute Configuration Example</h4>
+    /// 
+    /// <code>
+    /// [assembly: Lucene.Net.Util.RandomSeed("0x1ffa1d067056b0e6")]
+    /// [assembly: NUnit.Framework.SetCulture("sw-TZ")]
+    /// </code>
+    ///
+    /// <h4><i>lucene.testSettings.config</i> File Configuration Example</h4>
+    ///
+    /// <para>
+    /// Add a file named <i>lucene.testSettings.config</i> to the executable directory or
+    /// any directory between the executable and the root of the drive with the following contents.
+    /// </para>
+    /// 
+    /// <code>
+    /// {
+    ///	  "tests": {
+    ///     "seed": "0x1ffa1d067056b0e6",
+    ///     "culture": "sw-TZ"
+    ///	  }
+    /// }
+    /// </code>
+    ///
+    /// <h4>Environment Variable Configuration Example</h4>
+    ///
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Variable</term>
+    ///         <term>Value</term>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>lucene:tests:seed</term>
+    ///         <term>0x1ffa1d067056b0e6</term>
+    ///     </item>
+    ///     <item>
+    ///         <term>lucene:tests:culture</term>
+    ///         <term>sw-TZ</term>
+    ///     </item>
+    /// </list>
+    /// 
     /// </summary>
-
-    // LUCENENET TODO: Randomized seed
-    ///// <h3>Randomized execution and test facilities</h3>
-    /////
-    ///// <para>
-    ///// <see cref="LuceneTestCase"/> uses <see cref="RandomizedRunner"/> to execute test cases.
-    ///// <see cref="RandomizedRunner"/> has built-in support for tests randomization
-    ///// including access to a repeatable <see cref="Random"/> instance. See
-    ///// <see cref="Random"/> property. Any test using <see cref="Random"/> acquired from
-    ///// <see cref="Random"/> should be fully reproducible (assuming no race conditions
-    ///// between threads etc.). The initial seed for a test case is reported in many
-    ///// ways:
-    ///// <list type="bullet">
-    /////     <item>
-    /////         <description>
-    /////             as part of any exception thrown from its body (inserted as a dummy stack
-    /////             trace entry),
-    /////         </description>
-    /////     </item>
-    /////     <item>
-    /////         <description>
-    /////             as part of the main thread executing the test case (if your test hangs,
-    /////             just dump the stack trace of all threads and you'll see the seed),
-    /////         </description>
-    /////     </item>
-    /////     <item>
-    /////         <description>
-    /////             the master seed can also be accessed manually by getting the current
-    /////             context (<see cref="RandomizedContext.Current"/>) and then calling
-    /////             <see cref="RandomizedContext.RunnerSeed"/>.
-    /////         </description>
-    /////     </item>
-    ///// </list>
-    ///// </para>
-    ///// </summary>
     [TestFixture]
     public abstract partial class LuceneTestCase //: Assert // Wait long for leaked threads to complete before failure. zk needs this. -  See LUCENE-3995 for rationale.
     {

--- a/src/Lucene.Net.Tests.Misc/Index/TestIndexSplitter.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/TestIndexSplitter.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Index
             // so the unreferenced files are expected.
             if (fsDir is MockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)fsDir).AssertNoUnreferencedFilesOnClose = (false);
+                ((MockDirectoryWrapper)fsDir).AssertNoUnreferencedFilesOnDispose = (false);
             }
 
             MergePolicy mergePolicy = new LogByteSizeMergePolicy();

--- a/src/Lucene.Net.Tests/Index/TestCrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestCrash.cs
@@ -92,7 +92,7 @@ namespace Lucene.Net.Index
 
             // We create leftover files because merging could be
             // running when we crash:
-            dir.AssertNoUnreferencedFilesOnClose = false;
+            dir.AssertNoUnreferencedFilesOnDispose = false;
 
             Crash(writer);
 
@@ -123,7 +123,7 @@ namespace Lucene.Net.Index
 
             // We create leftover files because merging could be
             // running / store files could be open when we crash:
-            dir.AssertNoUnreferencedFilesOnClose = false;
+            dir.AssertNoUnreferencedFilesOnDispose = false;
 
             dir.PreventDoubleWrite = false;
             Console.WriteLine("TEST: now crash");
@@ -153,7 +153,7 @@ namespace Lucene.Net.Index
 
             // We create leftover files because merging could be
             // running when we crash:
-            dir.AssertNoUnreferencedFilesOnClose = false;
+            dir.AssertNoUnreferencedFilesOnDispose = false;
 
             writer.Dispose();
             writer = InitIndex(Random, dir, false);

--- a/src/Lucene.Net.Tests/Index/TestDoc.cs
+++ b/src/Lucene.Net.Tests/Index/TestDoc.cs
@@ -127,7 +127,7 @@ namespace Lucene.Net.Index
             {
                 // We create unreferenced files (we don't even write
                 // a segments file):
-                wrapper.AssertNoUnreferencedFilesOnClose = false;
+                wrapper.AssertNoUnreferencedFilesOnDispose = false;
             }
 
             IndexWriter writer = new IndexWriter(directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(-1).SetMergePolicy(NewLogMergePolicy(10)));
@@ -165,7 +165,7 @@ namespace Lucene.Net.Index
             {
                 // We create unreferenced files (we don't even write
                 // a segments file):
-                wrapper.AssertNoUnreferencedFilesOnClose = false;
+                wrapper.AssertNoUnreferencedFilesOnDispose = false;
             }
 
             writer = new IndexWriter(directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(-1).SetMergePolicy(NewLogMergePolicy(10)));

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
@@ -437,7 +437,7 @@ namespace Lucene.Net.Index
                 // Since we throw exc during abort, eg when IW is
                 // attempting to delete files, we will leave
                 // leftovers:
-                dir.AssertNoUnreferencedFilesOnClose = false;
+                dir.AssertNoUnreferencedFilesOnDispose = false;
 
                 if (m_doFail)
                 {

--- a/src/Lucene.Net.Tests/Index/TestStressIndexing.cs
+++ b/src/Lucene.Net.Tests/Index/TestStressIndexing.cs
@@ -229,7 +229,7 @@ namespace Lucene.Net.Index
             MockDirectoryWrapper wrapper = directory as MockDirectoryWrapper;
             if (wrapper != null)
             {
-                wrapper.AssertNoUnreferencedFilesOnClose = true;
+                wrapper.AssertNoUnreferencedFilesOnDispose = true;
             }
 
             RunStressTest(directory, new ConcurrentMergeScheduler());

--- a/src/Lucene.Net.Tests/Index/TestTransactions.cs
+++ b/src/Lucene.Net.Tests/Index/TestTransactions.cs
@@ -304,8 +304,8 @@ namespace Lucene.Net.Index
 
             // We throw exceptions in deleteFile, which creates
             // leftover files:
-            dir1.AssertNoUnreferencedFilesOnClose = false;
-            dir2.AssertNoUnreferencedFilesOnClose = false;
+            dir1.AssertNoUnreferencedFilesOnDispose = false;
+            dir2.AssertNoUnreferencedFilesOnDispose = false;
 
             InitIndex(dir1);
             InitIndex(dir2);


### PR DESCRIPTION
- Fixed the documentation comments for `LuceneTestCase`
- Adds some documentation for random seed configuration
- Implements some missing console logging
- **BREAKING:** `Lucene.Net.TestFramework.Store.MockDirectoryWrapper:` Renamed `AssertNoUnreferencedFilesOnClose` to `AssertNoUnreferencedFilesOnDispose`