### PR TITLE
NuGet Readme, documentation, and release notes links

### DIFF
--- a/build/NuGet.props
+++ b/build/NuGet.props
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
@@ -24,10 +24,25 @@
     <PackageTags>lucene.net;core;text;search;information;retrieval;lucene;apache;analysis;index;query</PackageTags>
     <Authors>The Apache Software Foundation</Authors>
     <RepositoryUrl>https://github.com/apache/lucenenet</RepositoryUrl>
-    <PackageProjectUrl>http://lucenenet.apache.org/</PackageProjectUrl>
+    <PackageProjectUrl>https://lucenenet.apache.org</PackageProjectUrl>
     <PackageIcon>lucene-net-icon-128x128.png</PackageIcon>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageNoticeFile>NOTICE.txt</PackageNoticeFile>
+
+    <!-- This git tag convention was used for legacy packages rather than using PackageVersion, so we are following suit -->
+    <VCSLabelPrefix>Lucene.Net_</VCSLabelPrefix>
+    <VCSLabel>$(VCSLabelPrefix)$(PackageVersion.Replace('.', '_').Replace('-', '_'))</VCSLabel>
+    <ReleaseNotesUrl>$(RepositoryUrl)/releases/tag/$(VCSLabel)</ReleaseNotesUrl>
+    <PackageReleaseNotes>$(ReleaseNotesUrl)</PackageReleaseNotes>
+
+    <!-- Build a compound description that links to the release notes and package documentation home page. -->
+    <Description>
+      $(Description)
+
+Documentation: $(PackageProjectUrl)/docs/$(PackageVersion)/api/$(PackageDocumentationRelativeUrl)
+
+This package is part of the Lucene.NET project: https://www.nuget.org/packages/Lucene.Net/$(PackageVersion)
+    </Description>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(SolutionDir)LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>

--- a/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
+++ b/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Analyzers for indexing content in different languages and domains for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>analysis-common/overview.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+  
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.Common</AssemblyTitle>
-    <Description>Analyzers for indexing content in different languages and domains for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);analysis</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Analysis.Kuromoji/Lucene.Net.Analysis.Kuromoji.csproj
+++ b/src/Lucene.Net.Analysis.Kuromoji/Lucene.Net.Analysis.Kuromoji.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Japanese Morphological Analyzer for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>analysis-kuromoji/Lucene.Net.Analysis.Ja.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.Kuromoji</AssemblyTitle>
-    <Description>Japanese Morphological Analyzer for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);analysis;japanese</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Analysis.Morfologik/Lucene.Net.Analysis.Morfologik.csproj
+++ b/src/Lucene.Net.Analysis.Morfologik/Lucene.Net.Analysis.Morfologik.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Analyzer for dictionary stemming, built-in Polish dictionary for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>analysis-morfologik/Lucene.Net.Analysis.Morfologik.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+  
   <Import Project="$(SolutionDir)build/NuGet.props" />
 
   <PropertyGroup>
@@ -29,8 +35,7 @@
 
     <AssemblyTitle>Lucene.Net.Analysis.Morfologik</AssemblyTitle>
     <RootNamespace>Lucene.Net.Analysis</RootNamespace>
-    <Description>Japanese Morphological Analyzer for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
-    <PackageTags>$(PackageTags);analysis;japanese</PackageTags>
+    <PackageTags>$(PackageTags);analysis;polish;ukrainian</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>OpenNLP library integration for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>analysis-opennlp/Lucene.Net.Analysis.OpenNlp.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
 
   <PropertyGroup>
@@ -28,8 +34,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net451</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>
-    <Description>Analyzer for indexing phonetic signatures (for sounds-alike search) for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
-    <PackageTags>$(PackageTags);analysis;soundex;double;metaphone;sounds;like;beider;morse;cologne;caverphone;nysiis;match;rating</PackageTags>
+    <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
     <RootNamespace>Lucene.Net.Analysis.OpenNlp</RootNamespace>

--- a/src/Lucene.Net.Analysis.Phonetic/Lucene.Net.Analysis.Phonetic.csproj
+++ b/src/Lucene.Net.Analysis.Phonetic/Lucene.Net.Analysis.Phonetic.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Analyzer for indexing phonetic signatures (for sounds-alike search) for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>analysis-phonetic/Lucene.Net.Analysis.Phonetic.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
 
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.Phonetic</AssemblyTitle>
-    <Description>Analyzer for indexing phonetic signatures (for sounds-alike search) for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);analysis;soundex;double;metaphone;sounds;like;beider;morse;cologne;caverphone;nysiis;match;rating</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Analysis.SmartCn/Lucene.Net.Analysis.SmartCn.csproj
+++ b/src/Lucene.Net.Analysis.SmartCn/Lucene.Net.Analysis.SmartCn.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Analyzer for indexing Chinese for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>analysis-smartcn/Lucene.Net.Analysis.Cn.Smart.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,8 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net451</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.SmartCn</AssemblyTitle>
-    <Description>Analyzer for indexing Chinese for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
-    
     <PackageTags>$(PackageTags);analysis;chinese;smart</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Analysis.Stempel/Lucene.Net.Analysis.Stempel.csproj
+++ b/src/Lucene.Net.Analysis.Stempel/Lucene.Net.Analysis.Stempel.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Analyzer for indexing Polish for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>analysis-stempel/Lucene.Net.Analysis.Stempel.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.Stempel</AssemblyTitle>
-    <Description>Analyzer for indexing Polish for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);analysis;polish</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Benchmark/Lucene.Net.Benchmark.csproj
+++ b/src/Lucene.Net.Benchmark/Lucene.Net.Benchmark.csproj
@@ -20,6 +20,12 @@
 
 -->
 <Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>System for benchmarking the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>benchmark/Lucene.Net.Benchmarks.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
   
   <Import Project="$(SolutionDir)build/NuGet.props" />
 
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net451</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Benchmark</AssemblyTitle>
-    <Description>System for benchmarking the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);benchmark</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Classification/Lucene.Net.Classification.csproj
+++ b/src/Lucene.Net.Classification/Lucene.Net.Classification.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Classification module for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>classification/Lucene.Net.Classification.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Classification</AssemblyTitle>
-    <Description>Classification module for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);classification</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Codecs/Lucene.Net.Codecs.csproj
+++ b/src/Lucene.Net.Codecs/Lucene.Net.Codecs.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Specialized codecs and postings formats for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>codecs/overview.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Codecs</AssemblyTitle>
-    <Description>Specialized codecs and postings formats for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);codec</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Expressions/Lucene.Net.Expressions.csproj
+++ b/src/Lucene.Net.Expressions/Lucene.Net.Expressions.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Dynamically computed values to sort/facet/search on based on a pluggable grammar for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>expressions/overview.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Expressions</AssemblyTitle>
-    <Description>Dynamically computed values to sort/facet/search on based on a pluggable grammar for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);expression</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Facet/Lucene.Net.Facet.csproj
+++ b/src/Lucene.Net.Facet/Lucene.Net.Facet.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Faceted indexing and search capabilities for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>facet/package.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Facet</AssemblyTitle>
-    <Description>Faceted indexing and search capabilities for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);facet;faceted</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Grouping/Lucene.Net.Grouping.csproj
+++ b/src/Lucene.Net.Grouping/Lucene.Net.Grouping.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Collectors for grouping search results for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>grouping/package.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Grouping</AssemblyTitle>
-    <Description>Collectors for grouping search results for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);grouping;group</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Highlighter/Lucene.Net.Highlighter.csproj
+++ b/src/Lucene.Net.Highlighter/Lucene.Net.Highlighter.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Highlights search keywords in results from the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>highlighter/overview.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Highlighter</AssemblyTitle>
-    <Description>Highlights search keywords in results from the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);highlight;highlighter</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Join/Lucene.Net.Join.csproj
+++ b/src/Lucene.Net.Join/Lucene.Net.Join.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Index-time and Query-time joins for normalized content of the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>join/package.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,9 +34,8 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <RootNamespace>Lucene.Net.Search.Join</RootNamespace>
-
+    
     <AssemblyTitle>Lucene.Net.Join</AssemblyTitle>
-    <Description>Index-time and Query-time joins for normalized content of the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);join</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Memory/Lucene.Net.Memory.csproj
+++ b/src/Lucene.Net.Memory/Lucene.Net.Memory.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Single-document in-memory index implementation for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>memory/Lucene.Net.Index.Memory.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
     
     <AssemblyTitle>Lucene.Net.Memory</AssemblyTitle>
-    <Description>Single-document in-memory index implementation for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);memory</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Misc/Lucene.Net.Misc.csproj
+++ b/src/Lucene.Net.Misc/Lucene.Net.Misc.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Index tools and other miscellaneous functionality for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>misc/Lucene.Net.Misc.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Misc</AssemblyTitle>
-    <Description>Index tools and other miscellaneous functionality for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);miscellaneous</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Queries/Lucene.Net.Queries.csproj
+++ b/src/Lucene.Net.Queries/Lucene.Net.Queries.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Extended Filters and Queries for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>queries/Lucene.Net.Queries.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Queries</AssemblyTitle>
-    <Description>Extended Filters and Queries for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);query;queries</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.QueryParser/Lucene.Net.QueryParser.csproj
+++ b/src/Lucene.Net.QueryParser/Lucene.Net.QueryParser.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Query parsers and parsing framework for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>queryparser/overview.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -30,7 +36,6 @@
     <RootNamespace>Lucene.Net.QueryParsers</RootNamespace>
     
     <AssemblyTitle>Lucene.Net.QueryParser</AssemblyTitle>
-    <Description>Query parsers and parsing framework for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);query;queryparser</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     

--- a/src/Lucene.Net.Replicator/Lucene.Net.Replicator.csproj
+++ b/src/Lucene.Net.Replicator/Lucene.Net.Replicator.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Replicator that allows replication of files between a server and client(s) for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>replicator/Lucene.Net.Replicator.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Replicator</AssemblyTitle>
-    <Description>Replicator that allows replication of files between a server and client(s) for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);files;replication;replicate</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Sandbox/Lucene.Net.Sandbox.csproj
+++ b/src/Lucene.Net.Sandbox/Lucene.Net.Sandbox.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Various third party contributions and new ideas extensions for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>sandbox/overview.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Sandbox</AssemblyTitle>
-    <Description>Various third party contributions and new ideas extensions for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);sandbox</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Spatial/Lucene.Net.Spatial.csproj
+++ b/src/Lucene.Net.Spatial/Lucene.Net.Spatial.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Geospatial search for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>spatial/Lucene.Net.Spatial.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Spatial</AssemblyTitle>
-    <Description>Geospatial search for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);spatial;geo;geospatial;2d</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.Suggest/Lucene.Net.Suggest.csproj
+++ b/src/Lucene.Net.Suggest/Lucene.Net.Suggest.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Auto-suggest and Spellchecking support for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>suggest/overview.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
   
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net45</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Suggest</AssemblyTitle>
-    <Description>Auto-suggest and Spellchecking support for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);suggest;suggestion</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>

--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>Framework for testing Lucene.NET-based applications using NUnit.</Description>
+    <PackageDocumentationRelativeUrl>test-framework/overview.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
 
   <PropertyGroup>
@@ -29,7 +35,6 @@
 
     <AssemblyTitle>Lucene.Net.TestFramework</AssemblyTitle>
     <RootNamespace>Lucene.Net</RootNamespace>
-    <Description>Framework for testing third-party code that uses the Lucene.Net API using NUnit.</Description>
     <PackageTags>$(PackageTags);testframework;test;framework;nunit</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -29,6 +29,7 @@
 
     <AssemblyTitle>Lucene.Net</AssemblyTitle>
     <Description>Lucene.Net is a full-text search engine library capable of advanced text analysis, indexing, and searching. It can be used to easily add search capabilities to applications. Lucene.Net is a C# port of the popular Java Lucene search engine framework from The Apache Software Foundation, targeted at .NET Framework and .NET Core users.</Description>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
@@ -43,6 +44,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet Package Files">
+    <None Include="readme-nuget.md" Pack="true" PackagePath="\readme.md"/>
     <None Include="$(LuceneNetCodeAnalysisToolsDir)*.ps1" Pack="true" PackagePath="tools" />
     <None Include="$(LuceneNetCodeAnalysisCSAssemblyFile)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(LuceneNetCodeAnalysisVBAssemblyFile)" Pack="true" PackagePath="analyzers/dotnet/vb" Visible="false" />

--- a/src/Lucene.Net/readme-nuget.md
+++ b/src/Lucene.Net/readme-nuget.md
@@ -1,0 +1,146 @@
+﻿Lucene.NET is a full-text search engine library capable of advanced text analysis, indexing, and searching. It can be used to easily add search capabilities to applications. Lucene.NET is a C# port of the popular Java Lucene search engine framework from The Apache Software Foundation, targeting the .NET platform.
+
+## Quick Start
+
+### Prerequisites
+
+- [Lucene.Net](https://www.nuget.org/packages/Lucene.Net/absoluteLatest)
+- [Lucene.Net.Analysis.Common](https://www.nuget.org/packages/Lucene.Net.Analysis.Common/absoluteLatest)
+
+#### Imports
+
+```c#
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Documents;
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using Lucene.Net.Store;
+using Lucene.Net.Util;
+```
+
+### Create an Index and Define a Text Analyzer
+
+```c#
+// Ensures index backward compatibility
+const LuceneVersion AppLuceneVersion = LuceneVersion.LUCENE_48;
+
+// Construct a machine-independent path for the index
+var basePath = Environment.GetFolderPath(
+    Environment.SpecialFolder.CommonApplicationData);
+var indexPath = Path.Combine(basePath, "index");
+
+using var dir = FSDirectory.Open(indexPath);
+
+// Create an analyzer to process the text
+var analyzer = new StandardAnalyzer(AppLuceneVersion);
+
+// Create an index writer
+var indexConfig = new IndexWriterConfig(AppLuceneVersion, analyzer);
+using var writer = new IndexWriter(dir, indexConfig);
+```
+
+### Add to the Index
+
+```c#
+var source = new
+{
+    Name = "Kermit the Frog",
+    FavoritePhrase = "The quick brown fox jumps over the lazy dog"
+};
+var doc = new Document
+{
+    // StringField indexes but doesn't tokenize
+    new StringField("name",
+        source.Name,
+        Field.Store.YES),
+    new TextField("favoritePhrase",
+        source.FavoritePhrase,
+        Field.Store.YES)
+};
+
+writer.AddDocument(doc);
+writer.Flush(triggerMerge: false, applyAllDeletes: false);
+```
+
+### Construct a Query
+
+```c#
+// Search with a phrase
+var phrase = new MultiPhraseQuery
+{
+    new Term("favoritePhrase", "brown"),
+    new Term("favoritePhrase", "fox")
+};
+```
+
+### Fetch the Results
+
+```c#
+// Re-use the writer to get real-time updates
+using var reader = writer.GetReader(applyAllDeletes: true);
+var searcher = new IndexSearcher(reader);
+var hits = searcher.Search(phrase, 20 /* top 20 */).ScoreDocs;
+
+// Display the output in a table
+Console.WriteLine($"{"Score",10}" +
+    $" {"Name",-15}" +
+    $" {"Favorite Phrase",-40}");
+foreach (var hit in hits)
+{
+    var foundDoc = searcher.Doc(hit.Doc);
+    Console.WriteLine($"{hit.Score:f8}" +
+        $" {foundDoc.Get("name"),-15}" +
+        $" {foundDoc.Get("favoritePhrase"),-40}");
+}
+```
+
+## Documentation
+
+See the [API documentation for Lucene.NET 4.8.0](https://lucenenet.apache.org/docs/4.8.0-beta00015/).
+
+## All Packages
+
+- [Lucene.Net](https://www.nuget.org/packages/Lucene.Net/absoluteLatest) - Core library
+- [Lucene.Net.Analysis.Common](https://www.nuget.org/packages/Lucene.Net.Analysis.Common/absoluteLatest) - Analyzers for indexing content in different languages and domains
+- [Lucene.Net.Analysis.Kuromoji](https://www.nuget.org/packages/Lucene.Net.Analysis.Kuromoji/absoluteLatest) - Japanese Morphological Analyzer
+- [Lucene.Net.Analysis.Morfologik](https://www.nuget.org/packages/Lucene.Net.Analysis.Morfologik/absoluteLatest) - Analyzer for dictionary stemming, built-in Polish dictionary
+- [Lucene.Net.Analysis.OpenNLP](https://www.nuget.org/packages/Lucene.Net.Analysis.OpenNLP/absoluteLatest) - OpenNLP Library Integration
+- [Lucene.Net.Analysis.Phonetic](https://www.nuget.org/packages/Lucene.Net.Analysis.Phonetic/absoluteLatest) - Analyzer for indexing phonetic signatures (for sounds-alike search)
+- [Lucene.Net.Analysis.SmartCn](https://www.nuget.org/packages/Lucene.Net.Analysis.SmartCn/absoluteLatest) - Analyzer for indexing Chinese
+- [Lucene.Net.Analysis.Stempel](https://www.nuget.org/packages/Lucene.Net.Analysis.Stempel/absoluteLatest) - Analyzer for indexing Polish
+- [Lucene.Net.Benchmark](https://www.nuget.org/packages/Lucene.Net.Benchmark/) - System for benchmarking Lucene
+- [Lucene.Net.Classification](https://www.nuget.org/packages/Lucene.Net.Classification/absoluteLatest) - Classification module for Lucene
+- [Lucene.Net.Codecs](https://www.nuget.org/packages/Lucene.Net.Codecs/absoluteLatest) - Lucene codecs and postings formats
+- [Lucene.Net.Expressions](https://www.nuget.org/packages/Lucene.Net.Expressions/absoluteLatest) - Dynamically computed values to sort/facet/search on based on a pluggable grammar
+- [Lucene.Net.Facet](https://www.nuget.org/packages/Lucene.Net.Facet/absoluteLatest) - Faceted indexing and search capabilities
+- [Lucene.Net.Grouping](https://www.nuget.org/packages/Lucene.Net.Grouping/absoluteLatest) - Collectors for grouping search results
+- [Lucene.Net.Highlighter](https://www.nuget.org/packages/Lucene.Net.Highlighter/absoluteLatest) - Highlights search keywords in results
+- [Lucene.Net.ICU](https://www.nuget.org/packages/Lucene.Net.ICU/absoluteLatest) - Specialized ICU (International Components for Unicode) Analyzers and Highlighters
+- [Lucene.Net.Join](https://www.nuget.org/packages/Lucene.Net.Join/absoluteLatest) - Index-time and Query-time joins for normalized content
+- [Lucene.Net.Memory](https://www.nuget.org/packages/Lucene.Net.Memory/absoluteLatest) - Single-document in-memory index implementation
+- [Lucene.Net.Misc](https://www.nuget.org/packages/Lucene.Net.Misc/absoluteLatest) - Index tools and other miscellaneous code
+- [Lucene.Net.Queries](https://www.nuget.org/packages/Lucene.Net.Queries/absoluteLatest) - Filters and Queries that add to core Lucene
+- [Lucene.Net.QueryParser](https://www.nuget.org/packages/Lucene.Net.QueryParser/absoluteLatest) - Text to Query parsers and parsing framework
+- [Lucene.Net.Replicator](https://www.nuget.org/packages/Lucene.Net.Replicator/absoluteLatest)  Files replication utility
+- [Lucene.Net.Sandbox](https://www.nuget.org/packages/Lucene.Net.Sandbox/absoluteLatest) - Various third party contributions and new ideas
+- [Lucene.Net.Spatial](https://www.nuget.org/packages/Lucene.Net.Spatial/absoluteLatest) - Geospatial search
+- [Lucene.Net.Suggest](https://www.nuget.org/packages/Lucene.Net.Suggest/absoluteLatest) - Auto-suggest and Spell-checking support
+- [Lucene.Net.TestFramework](https://www.nuget.org/packages/Lucene.Net.TestFramework/absoluteLatest) - Framework for testing Lucene-based applications
+
+## Demos & Tools
+
+There are several demos implemented as simple console applications that can be copied and pasted into Visual Studio or compiled on the command line in the [Lucene.Net.Demo project](https://github.com/apache/lucenenet/tree/master/src/Lucene.Net.Demo).
+
+There is also a dotnet command line tool available on NuGet. It contains all of the demos as well as tools maintaining your Lucene.NET index, featuring operations such as splitting, merging, listing segment info, fixing, deleting segments, upgrading, etc. Always be sure to back up your index before running any commands against it!
+
+- [Prerequisite: .NET 6.0 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+
+```
+dotnet tool install lucene-cli -g --version 4.8.0-beta00015
+```
+
+> NOTE: The version of the CLI you install should match the version of Lucene.NET you use.
+
+Once installed, you can explore the commands and options that are available by entering the command `lucene`.
+
+[lucene-cli Documentation](https://lucenenet.apache.org/docs/4.8.0-beta00015/cli/)

--- a/src/dotnet/Lucene.Net.ICU/Lucene.Net.ICU.csproj
+++ b/src/dotnet/Lucene.Net.ICU/Lucene.Net.ICU.csproj
@@ -21,6 +21,12 @@
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- These properties must be set prior to importing NuGet.props -->
+  <PropertyGroup>
+    <Description>International Components for Unicode-based features including Thai analyzer support, an international postings highlighter, and BreakIterator support for the vector highlighter for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
+    <PackageDocumentationRelativeUrl>icu/overview.html</PackageDocumentationRelativeUrl>
+  </PropertyGroup>
+
   <Import Project="$(SolutionDir)build/NuGet.props" />
 
   <PropertyGroup>
@@ -28,7 +34,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net451</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.ICU</AssemblyTitle>
-    <Description>International Components for Unicode-based features including Thai analyzer support, an international postings highlighter, and BreakIterator support for the vector highlighter for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);icu;international;unicode</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>


### PR DESCRIPTION
- Added a `readme.md` file for the Lucene.Net NuGet package.
- Added a link to the documentation mini-site below the description for each NuGet package (except Lucene.Net and lucene-cli, which each have a readme.md)
- Added a link to the release notes in the NuGet package (`<PackageReleaseNotes>`).
- Corrected the description of several of the packages, which had copy-paste errors.

