### PR TITLE
Fixed broken book link for Instant Lucene.NET

### DIFF
--- a/websites/site/lucenetemplate/index.html.tmpl
+++ b/websites/site/lucenetemplate/index.html.tmpl
@@ -1,4 +1,4 @@
-{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+﻿{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 {{!include(/^styles/.*/)}}
 {{!include(/^fonts/.*/)}}
 {{!include(favicon.ico)}}
@@ -56,7 +56,7 @@
 
             <div class="row">
               <div class="col-xs-12 col-md-6">
-                <a href="https://www.amazon.com/Instant-Lucene-NET-Michael-Heydt-ebook/dp/B00E7NC9EG" target="_blank"><img src="https://images-na.ssl-images-amazon.com/images/I/51ovFeqMwBL.jpg" /></a>
+                <a href="https://www.amazon.com/Instant-Lucene-NET-Michael-Heydt/dp/1782165940" target="_blank"><img src="https://images-na.ssl-images-amazon.com/images/I/51ovFeqMwBL.jpg" /></a>
               </div>
               <div class="col-xs-12 col-md-6">
                 <a href="https://www.amazon.com/Lucene-4-Cookbook-Edwood-Ng-ebook/dp/B00ZPJWC9S" target="_blank"><img src="https://images-na.ssl-images-amazon.com/images/I/51uIsUPhaeL.jpg"></a>


### PR DESCRIPTION
The prior link was broken and went to a 404 page at Amazon.com