### PR TITLE
Upgraded build tools for LuceneDocsPlugins and moved docs/website build to windows-latest (fixes #601)

### DIFF
--- a/.github/workflows/Lucene-Net-Documentation.yml
+++ b/.github/workflows/Lucene-Net-Documentation.yml
@@ -118,6 +118,11 @@ jobs:
           git --git-dir "$Env:GIT_MAIN_REPO" checkout -b "docs/${{ env.RELEASE_VERSION }}"
         shell: powershell
 
+      - name: Setup .NET 6 SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.101'
+
       - name: Build docs
         run: ./main-repo/websites/apidocs/docs.ps1 -Clean -LuceneNetVersion ${{ env.RELEASE_VERSION }}
         shell: powershell

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,7 +20,7 @@
 -->
 <Project>
 
-  <Import Project="$(SolutionDir).build/dependencies.props" />
+  <Import Project=".build/dependencies.props" Condition="Exists('.build/dependencies.props')" />
 
   <!-- Features in .NET 5.x and .NET 6.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
@@ -163,6 +163,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageReferenceVersion)" PrivateAssets="All"/>
   </ItemGroup>
 
-  <Import Project=".build\release.targets" Condition="Exists('.build\release.targets')" />
+  <Import Project=".build/release.targets" Condition="Exists('.build/release.targets')" />
 
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -267,9 +267,13 @@ stages:
   - job: Docs
     condition: and(succeeded(), eq(variables['GenerateDocs'], 'true'))
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
 
     steps:
+    - template: '.build/azure-templates/install-dotnet-sdk.yml'
+      parameters:
+        sdkVersion: '$(DotNetSDKVersion)'
+
     - pwsh: |
          $(Build.SourcesDirectory)/websites/apidocs/docs.ps1 -LuceneNetVersion $(PackageVersion) -Clean -BaseUrl https://lucenenet.apache.org/docs/
       errorActionPreference: 'continue'
@@ -293,7 +297,7 @@ stages:
   - job: Website
     condition: and(succeeded(), eq(variables['GenerateWebsite'], 'true'))
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
 
     steps:
     - pwsh: |

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,23 @@
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/src/docs/Directory.Build.props
+++ b/src/docs/Directory.Build.props
@@ -1,0 +1,35 @@
+﻿<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- According to the docs (https://docs.microsoft.com/en-us/cpp/build/reference/common-macros-for-build-commands-and-properties?view=vs-2019), the 
+      SolutionDir is only available when running in the IDE, so we patch to ensure it also works when using dotnet.exe -->
+    <SolutionDir>$(MSBuildThisFileDirectory)../../</SolutionDir>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Assembly Signing">
+    <!-- This is the default location of Lucene.Net.snk relative to the project directory.
+      If the project is further nested from the repo root, override this value in the csproj. -->
+    <AssemblyOriginatorKeyFile>$(SolutionDir)Lucene.Net.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+</Project>

--- a/src/docs/Directory.Build.targets
+++ b/src/docs/Directory.Build.targets
@@ -1,0 +1,23 @@
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/src/docs/DocumentationTools.sln
+++ b/src/docs/DocumentationTools.sln
@@ -18,11 +18,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # under the License.
 VisualStudioVersion = 16.0.29521.150
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LuceneDocsPlugins", "LuceneDocsPlugins\LuceneDocsPlugins.csproj", "{D5D1C256-4A5A-4C57-949D-E9A1FFB6A5D1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LuceneDocsPlugins", "LuceneDocsPlugins\LuceneDocsPlugins.csproj", "{D5D1C256-4A5A-4C57-949D-E9A1FFB6A5D1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Info", "Info", "{D0D177C8-D797-4850-AB75-E91E3126761C}"
 	ProjectSection(SolutionItems) = preProject
 		convert.ps1 = convert.ps1
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		readme.md = readme.md
 	EndProjectSection
 EndProject

--- a/src/docs/LuceneDocsPlugins/LuceneDocsPlugins.csproj
+++ b/src/docs/LuceneDocsPlugins/LuceneDocsPlugins.csproj
@@ -17,72 +17,54 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup Label="Assembly Signing">
-    <!-- Ensure this doesn't inherit the strong naming since this tool will no work with a signed assembly due to it's references -->
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyTitle>LuceneDocsPlugins</AssemblyTitle>
+    <Product>LuceneDocsPlugins</Product>
   </PropertyGroup>
+  
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D5D1C256-4A5A-4C57-949D-E9A1FFB6A5D1}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LuceneDocsPlugins</RootNamespace>
-    <AssemblyName>LuceneDocsPlugins</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+
+  <PropertyGroup Label="Version Info">
+    <Version>1.0.0.0</Version>
+    <FileVersion>$(Version)</FileVersion>
+    <InformationalVersion>$(Version)</InformationalVersion>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\..\..\..\websites\apidocs\lucenetemplate\plugins\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup Label="Assembly Publishing">
+    <IsPublishable>true</IsPublishable>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  
+  <PropertyGroup Label="Assembly Signing">
+    <!-- Ensure this doesn't inherit the strong naming since this tool will no work with a signed assembly due to it's references -->
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Remove="packages\**" />
+    <EmbeddedResource Remove="packages\**" />
+    <None Remove="packages\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
+    <PackageReference Include="Microsoft.DocAsCode.Dfm" Version="2.58.0" />
+    <PackageReference Include="YamlDotNet" Version="6.0.0" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="EnvironmentVariableInlineRule.cs" />
-    <Compile Include="EnvironmentVariableRendererPart.cs" />
-    <Compile Include="LuceneDfmEngineCustomizer.cs" />
-    <Compile Include="LuceneNoteBlockRule.cs" />
-    <Compile Include="LuceneNoteBlockToken.cs" />
-    <Compile Include="RendererPartProvider.cs" />
-    <Compile Include="LuceneNoteTokenRendererPart.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Composition">
-      <Version>1.0.31</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.DocAsCode.Dfm">
-      <Version>2.58.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>

--- a/src/docs/LuceneDocsPlugins/Properties/AssemblyInfo.cs
+++ b/src/docs/LuceneDocsPlugins/Properties/AssemblyInfo.cs
@@ -21,18 +21,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("LuceneDocsPlugins")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("LuceneDocsPlugins")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
@@ -40,16 +28,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d5d1c256-4a5a-4c57-949d-e9a1ffb6a5d1")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Fixes #601.

- Upgraded `LuceneDocsPlugins.csproj` to use new .csproj format
- Upgraded `docs.ps1` to use `dotnet publish` rather than NuGet restore and MSBuild
- Upgraded Azure Pipelines to use `windows-latest` instead of `vs2017-win2016` for docs and website