### PR TITLE
BUG: Lucene.Net.Search.FieldCacheImpl.Cache<TKey, TValue>::Put(): Inverted cache logic

### DIFF
--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -312,7 +312,7 @@ namespace Lucene.Net.Search
                         wrapper.InitReader(reader);
                     }
 #endif
-                    if (innerCache.TryGetValue(key, out object temp) || temp is null)
+                    if (!innerCache.TryGetValue(key, out object temp) || temp is null)
                         innerCache[key] = value;
                     // else if another thread beat us to it, leave the current value
                 }


### PR DESCRIPTION
Logic was inverted on `innerCache` so the value was being updated if exists, when it should not be updated in this case