### PR TITLE
PERFORMANCE: Lucene.Net.Index.BaseCompositeReader: Removed unnecessary list allocation

### DIFF
--- a/src/Lucene.Net/Index/BaseCompositeReader.cs
+++ b/src/Lucene.Net/Index/BaseCompositeReader.cs
@@ -1,7 +1,6 @@
 ﻿using J2N.Collections.Generic.Extensions;
 using System;
 using System.Collections.Generic;
-using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -72,13 +71,7 @@ namespace Lucene.Net.Index
         protected BaseCompositeReader(R[] subReaders)
         {
             this.subReaders = subReaders;
-
-            // LUCENENET: To eliminate casting, we create the list explicitly
-            var subReadersList = new JCG.List<IndexReader>(subReaders.Length);
-            for (int i = 0; i < subReaders.Length; i++)
-                subReadersList.Add(subReaders[i]);
-            this.subReadersList = subReadersList.AsReadOnly();
-
+            this.subReadersList = ((IndexReader[])subReaders).AsReadOnly(); // LUCENENET: Work around generic casting from R to IndexWriter
             starts = new int[subReaders.Length + 1]; // build starts array
             int maxDoc = 0, numDocs = 0;
             for (int i = 0; i < subReaders.Length; i++)


### PR DESCRIPTION
Removed allocation of new `List<T>` that was added during the port to handle generic casting. Lucene [didn't have this extra allocation](https://github.com/apache/lucene/blob/releases/lucene-solr/4.8.0/lucene/core/src/java/org/apache/lucene/index/BaseCompositeReader.java#L69).