### PR TITLE
Add DebuggerDisplay for SegToken

### DIFF
--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegToken.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegToken.cs
@@ -26,6 +26,7 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
     /// <para/>
     /// @lucene.experimental
     /// </summary>
+    [System.Diagnostics.DebuggerDisplay("{new string(CharArray)}"]
     public class SegToken
     {
         /// <summary>

--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegToken.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegToken.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
     /// <para/>
     /// @lucene.experimental
     /// </summary>
-    [System.Diagnostics.DebuggerDisplay("{new string(CharArray)}"]
+    [System.Diagnostics.DebuggerDisplay("{new string(CharArray)}")]
     public class SegToken
     {
         /// <summary>


### PR DESCRIPTION
It is so hard to debug without a friendly display. I just add a `DebuggerDisplay` for `SegToken`, you can also add one for `SegTokenPair` and others.
In C# 10, the attribute should be 
```csharp
[System.Diagnostics.DebuggerDisplay($"\{new string({nameof(CharArray)})\}")]
```

You can also override the `ToString` method instead.