### PR TITLE
Lucene.Net.Analysis.Fa/PersianAnalyzer: Removed PersianStemmer as per apache/lucene#904

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Fa/PersianAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Fa/PersianAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿// Lucene version compatibility level 4.8.1
 using Lucene.Net.Analysis.Ar;
 using Lucene.Net.Analysis.Core;
-using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Util;
@@ -81,14 +80,12 @@ namespace Lucene.Net.Analysis.Fa
             }
         }
 
-        private readonly CharArraySet stemExclusionSet;
-
         /// <summary>
         /// Builds an analyzer with the default stop words:
         /// <see cref="DEFAULT_STOPWORD_FILE"/>.
         /// </summary>
         public PersianAnalyzer(LuceneVersion matchVersion)
-              : this(matchVersion, DefaultSetHolder.DEFAULT_STOP_SET)
+            : this(matchVersion, DefaultSetHolder.DEFAULT_STOP_SET)
         {
         }
 
@@ -100,25 +97,8 @@ namespace Lucene.Net.Analysis.Fa
         /// <param name="stopwords">
         ///          a stopword set </param>
         public PersianAnalyzer(LuceneVersion matchVersion, CharArraySet stopwords)
-              : this(matchVersion, stopwords, CharArraySet.EMPTY_SET)
+            : base(matchVersion, stopwords)
         {
-        }
-
-        /// <summary>
-        /// Builds an analyzer with the given stop word. If a none-empty stem exclusion set is
-        /// provided this analyzer will add a <see cref="SetKeywordMarkerFilter"/> before
-        /// <see cref="PersianStemFilter"/>.
-        /// </summary>
-        /// <param name="matchVersion">
-        ///          lucene compatibility version </param>
-        /// <param name="stopwords">
-        ///          a stopword set </param>
-        /// <param name="stemExclusionSet">
-        ///          a set of terms not to be stemmed </param>
-        public PersianAnalyzer(LuceneVersion matchVersion, CharArraySet stopwords, CharArraySet stemExclusionSet)
-              : base(matchVersion, stopwords)
-        {
-            this.stemExclusionSet = CharArraySet.UnmodifiableSet(CharArraySet.Copy(matchVersion, stemExclusionSet));
         }
 
         /// <summary>
@@ -153,12 +133,7 @@ namespace Lucene.Net.Analysis.Fa
              * the order here is important: the stopword list is normalized with the
              * above!
              */
-            result = new StopFilter(m_matchVersion, result, m_stopwords);
-            if (stemExclusionSet.Count > 0)
-            {
-                result = new SetKeywordMarkerFilter(result, stemExclusionSet);
-            }
-            return new TokenStreamComponents(source, new PersianStemFilter(result));
+            return new TokenStreamComponents(source, new StopFilter(m_matchVersion, result, m_stopwords));
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fa/TestPersianStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Fa/TestPersianStemFilter.cs
@@ -1,7 +1,6 @@
 ﻿// Lucene version compatibility level 9.2
 using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.Miscellaneous;
-using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
 using System.IO;
@@ -25,14 +24,20 @@ namespace Lucene.Net.Analysis.Fa
      * limitations under the License.
      */
 
-    /// <summary>
-    /// Test the Persian Normalization Filter
-    /// 
-    /// </summary>
-
+    /// <summary>Test the Persian Normalization Filter</summary>
     public class TestPersianStemFilter : BaseTokenStreamTestCase
     {
-        internal PersianAnalyzer a = new PersianAnalyzer(TEST_VERSION_CURRENT);
+        private Analyzer a;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer source = new MockTokenizer(reader);
+                return new TokenStreamComponents(source, new PersianStemFilter(source));
+            });
+        }
 
         [Test]
         public virtual void TestAnSuffix()
@@ -94,9 +99,7 @@ namespace Lucene.Net.Analysis.Fa
         {
             CharArraySet set = new CharArraySet(TEST_VERSION_CURRENT, 1, true);
             set.Add("ساهدهات");
-#pragma warning disable 612, 618
-            StandardTokenizer tokenStream = new StandardTokenizer(TEST_VERSION_CURRENT, new StringReader("ساهدهات"));
-#pragma warning restore 612, 618
+            MockTokenizer tokenStream = new MockTokenizer(new StringReader("ساهدهات"));
 
             PersianStemFilter filter = new PersianStemFilter(new SetKeywordMarkerFilter(tokenStream, set));
             AssertTokenStreamContents(filter, new string[] { "ساهدهات" });


### PR DESCRIPTION
Reverted changes from #571 as was done in apache/lucene#904. Changed `TestPersianStemFilter` to use mocks.