### PR TITLE
Build: Fix for x86 tests

### DIFF
--- a/.build/azure-templates/install-dotnet-sdk.yml
+++ b/.build/azure-templates/install-dotnet-sdk.yml
@@ -19,6 +19,7 @@
 
 parameters:
   sdkVersion: '' # The .NET SDK version to install
+  performMultiLevelLookup: 'false' # Whether to check for x86 when running commands
 
 steps:
 - pwsh: |
@@ -40,3 +41,4 @@ steps:
   inputs:
     packageType: 'sdk'
     version: '${{ parameters.sdkVersion }}'
+    performMultiLevelLookup: '${{ parameters.performMultiLevelLookup }}'

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -75,20 +75,33 @@ steps:
 
 #- pwsh: Get-ChildItem -Path $(System.DefaultWorkingDirectory) # Uncomment for debugging
 
+- pwsh: |
+    $testPlatform = '${{ parameters.vsTestPlatform }}'
+    if ($IsWindows -eq $null) {
+        $IsWindows = $env:OS.StartsWith('Win')
+    }
+    $performMulitLevelLookup = if ($IsWindows -and $testPlatform.Equals('x86')) { 'true' } else { 'false' }
+    Write-Host "##vso[task.setvariable variable=PerformMultiLevelLookup;]$performMulitLevelLookup"
+
 - template: 'install-dotnet-sdk.yml'
   parameters:
     sdkVersion: '${{ parameters.dotNetSdkVersion }}'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
 
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 3.1.412'
   inputs:
-    version: 3.1.412
+    packageType: 'sdk'
+    version: '3.1.412'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
   condition: and(succeeded(), contains('${{ parameters.framework }}', 'netcoreapp3.'))
 
 - task: UseDotNet@2
   displayName: 'Use .NET sdk 5.0.400'
   inputs:
-    version: 5.0.400
+    packageType: 'sdk'
+    version: '5.0.400'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
   condition: and(succeeded(), contains('${{ parameters.framework }}', 'net5.'))
 
 #- template: 'show-all-files.yml' # Uncomment for debugging

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -369,16 +369,6 @@ stages:
           imageName: 'windows-2019'
           maximumParallelJobs: 8
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        Linux:
-          osName: 'Linux'
-          imageName: 'ubuntu-latest'
-          maximumParallelJobs: 7
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        macOS:
-          osName: 'macOS'
-          imageName: 'macOS-latest'
-          maximumParallelJobs: 7
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
     displayName: 'Test net6.0,x86 on'
     pool:
       vmImage: $(imageName)
@@ -439,16 +429,6 @@ stages:
           imageName: 'windows-2019'
           maximumParallelJobs: 8
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        Linux:
-          osName: 'Linux'
-          imageName: 'ubuntu-latest'
-          maximumParallelJobs: 7
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        macOS:
-          osName: 'macOS'
-          imageName: 'macOS-latest'
-          maximumParallelJobs: 7
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
     displayName: 'Test net5.0,x86 on'
     pool:
       vmImage: $(imageName)
@@ -508,16 +488,6 @@ stages:
           osName: 'Windows'
           imageName: 'windows-2019'
           maximumParallelJobs: 8
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        Linux:
-          osName: 'Linux'
-          imageName: 'ubuntu-latest'
-          maximumParallelJobs: 7
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        macOS:
-          osName: 'macOS'
-          imageName: 'macOS-10.15' # macOS-latest should not be used here because we may get OS Darwin 19.6.0, which isn't supported fully (we get PlatformNotSupportedException).
-          maximumParallelJobs: 7
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
     displayName: 'Test netcoreapp3.1,x86 on'
     pool:


### PR DESCRIPTION
There were a couple of issues with the testing strategy for x86:

1. x86 is not supported on Linux or macOS on .NET Core.
2. The .NET Core x86 tests were failing to run.

The Azure DevOps agents [require a `performMultiLevelLookup` parameter set to `true` to run x86](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops), which we weren't providing.

This fixes the build to pass the parameter in case of x86 on Windows, and removes all of the test configs for x86 on macOS/Linux.