### PR TITLE
chore(deps): Update Newtonsoft.Json to 13.0.1 to avoid vulnerability

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -67,7 +67,7 @@
     <MorfologikPolishPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikPolishPackageVersion>
     <MorfologikStemmingPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikStemmingPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
-    <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
+    <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
     <NUnit3TestAdapterPackageVersion>3.17.0</NUnit3TestAdapterPackageVersion>
     <NUnitPackageVersion>3.13.1</NUnitPackageVersion>
     <OpenNLPNETPackageVersion>1.9.1.1</OpenNLPNETPackageVersion>


### PR DESCRIPTION
fixes #640

https://github.com/advisories/GHSA-5crp-9r3c-p9vr

Updated Newtonsoft.Json to 13.0.1. I ran the unit tests locally and can't see that this change breaks anything.