### PR TITLE
fix: Fixed throw statement in BinaryDictionary

### DIFF
--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/BinaryDictionary.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/BinaryDictionary.cs
@@ -199,7 +199,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
             {
                 throw new FileNotFoundException(string.Format("Expected file '{0}' not found. " +
                     "If the '{1}' directory exists, this file is required. " +
-                    "Either remove the '{3}' directory or generate the required dictionary files using the lucene-cli tool.",
+                    "Either remove the '{2}' directory or generate the required dictionary files using the lucene-cli tool.",
                     fileName, DATA_DIR, DATA_SUBDIR));
             }
 


### PR DESCRIPTION
The `string.Format` statement would result in the following exception:

```
Unhandled exception. System.FormatException: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
   at System.Text.ValueStringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(String format, Object arg0, Object arg1, Object arg2)
```