### PR TITLE
fix: Aligned FrenchStemmer.cs with Java code

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
@@ -483,21 +483,21 @@ namespace Lucene.Net.Analysis.Fr
                 {
                     if (source.EndsWith(prefix + search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length);
+                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length - (sb.Length - (prefix.Length + search[i].Length)));
                         modified = true;
                         SetStrings();
                         break;
                     }
                     else if (from != null && from.EndsWith(prefix + search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length).Insert(sb.Length, replace);
+                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length - (sb.Length - (prefix.Length + search[i].Length))).Insert(sb.Length - (prefix.Length + search[i].Length), replace);
                         modified = true;
                         SetStrings();
                         break;
                     }
                     else if (without && source.EndsWith(search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - search[i].Length, sb.Length);
+                        sb.Remove(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length));
                         modified = true;
                         SetStrings();
                         break;
@@ -521,7 +521,7 @@ namespace Lucene.Net.Analysis.Fr
                 {
                     if (source.EndsWith(search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - search[i].Length, sb.Length - sb.Length - search[i].Length).Insert(sb.Length - search[i].Length, replace);
+                        sb.Remove(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length)).Insert(sb.Length - search[i].Length, replace);
                         modified = true;
                         found = true;
                         SetStrings();

--- a/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using System;
 using System.Globalization;
 using System.Text;
@@ -483,21 +483,21 @@ namespace Lucene.Net.Analysis.Fr
                 {
                     if (source.EndsWith(prefix + search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length - sb.Length - (prefix.Length + search[i].Length));
+                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length);
                         modified = true;
                         SetStrings();
                         break;
                     }
                     else if (from != null && from.EndsWith(prefix + search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length - sb.Length - (prefix.Length + search[i].Length)).Insert(sb.Length - (prefix.Length + search[i].Length), replace);
+                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length).Insert(sb.Length, replace);
                         modified = true;
                         SetStrings();
                         break;
                     }
                     else if (without && source.EndsWith(search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - search[i].Length, sb.Length - sb.Length - search[i].Length);
+                        sb.Remove(sb.Length - search[i].Length, sb.Length);
                         modified = true;
                         SetStrings();
                         break;


### PR DESCRIPTION
[File: FrenchStemmer.cs]

Java reference: https://github.com/apache/lucene/blob/f01152a5909fa6059f4f1d4aeb4e14968ef1d8c2/lucene/analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchStemmer.java#L450-L477

I'm unsure if this is covered by and unit tests.

Detected on 3 issues here: https://sonarcloud.io/project/issues?fileUuids=AYPAuMLmhbfJOGLOoZHT&resolved=false&severities=MAJOR&types=BUG&id=nikcio_lucenenet&open=AYPAuPYNhbfJOGLOobEI