### PR TITLE
fix: Aligned ReplaceFrom with the Java code (FrenchStemmer.cs)

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
@@ -521,7 +521,7 @@ namespace Lucene.Net.Analysis.Fr
                 {
                     if (source.EndsWith(search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - search[i].Length, sb.Length - sb.Length - search[i].Length).Insert(sb.Length - search[i].Length, replace);
+                        sb.Remove(sb.Length - search[i].Length, sb.Length).Insert(sb.Length, replace);
                         modified = true;
                         found = true;
                         SetStrings();


### PR DESCRIPTION
[File: FrenchStemmer.cs]

Java reference: https://github.com/apache/lucene/blob/f01152a5909fa6059f4f1d4aeb4e14968ef1d8c2/lucene/analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchStemmer.java#L486-L502

I'm unsure if this is covered by unit tests.