### PR TITLE
.editorconfig: Added suppression for CA2249: Consider using String.Contains instead of String.IndexOf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -164,6 +164,10 @@ dotnet_diagnostic.CA1031.severity = none
 # CA1034: Do not nest types
 dotnet_diagnostic.CA1034.severity = none
 
+#### Usage ####
+# CA2249: Consider using String.Contains instead of String.IndexOf
+dotnet_diagnostic.CA2249.severity=none
+
 
 # Features that require .NET Standard 2.1+
 


### PR DESCRIPTION
As per https://github.com/apache/lucenenet/issues/648#issuecomment-1279823136