### PR TITLE
SWEEP: Fixed ArgumentOutOfRange parameters so the message is passed into the 2nd parameter.

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
@@ -312,8 +312,8 @@ namespace Lucene.Net.Analysis.Util
                 // LUCENENET specific - Added guard clause for null
                 if (buffer is null)
                     throw new ArgumentNullException(nameof(buffer));
-                if (offset > buffer.Length - length)
-                    throw new ArgumentOutOfRangeException(nameof(offset) + " + " + nameof(length), $"offset + length may not be greater than the size of {nameof(buffer)}");
+                if (offset > buffer.Length - length) // LUCENENET: Checks for int overflow
+                    throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(offset)} + {nameof(length)} may not be greater than the size of {nameof(buffer)}");
                 if (length < 0)
                     throw new ArgumentOutOfRangeException(nameof(length), length, $"{nameof(length)} must not be negative.");
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
@@ -162,7 +162,7 @@ namespace Lucene.Net.Analysis.Util
         {
             if (bufferSize < 2)
             {
-                // LUCENENET: Changed from InvalidArgumentException to ArgumentOutOfRangeException
+                // LUCENENET: Changed from IllegalArgumentException to ArgumentOutOfRangeException
                 throw new ArgumentOutOfRangeException(nameof(bufferSize), "buffersize must be >= 2");
             }
             return new CharacterBuffer(new char[bufferSize], 0, 0);
@@ -244,7 +244,7 @@ namespace Lucene.Net.Analysis.Util
         {
             if (srcLen < 0)
             {
-                // LUCENENET: Changed from InvalidArgumentException to ArgumentOutOfRangeException
+                // LUCENENET: Changed from IllegalArgumentException to ArgumentOutOfRangeException
                 throw new ArgumentOutOfRangeException(nameof(srcLen), "srcLen must be >= 0");
             }
             int codePointCount = 0;
@@ -265,7 +265,7 @@ namespace Lucene.Net.Analysis.Util
         {
             if (srcLen < 0)
             {
-                // LUCENENET: Changed from InvalidArgumentException to ArgumentOutOfRangeException
+                // LUCENENET: Changed from IllegalArgumentException to ArgumentOutOfRangeException
                 throw new ArgumentOutOfRangeException(nameof(srcLen), "srcLen must be >= 0");
             }
             int written = 0;
@@ -361,7 +361,7 @@ namespace Lucene.Net.Analysis.Util
                 if (Debugging.AssertsEnabled) Debugging.Assert(buffer.Buffer.Length >= 2);
                 if (numChars < 2 || numChars > buffer.Buffer.Length)
                 {
-                    // LUCENENET: Changed from InvalidArgumentException to ArgumentOutOfRangeException
+                    // LUCENENET: Changed from IllegalArgumentException to ArgumentOutOfRangeException
                     throw new ArgumentOutOfRangeException(nameof(numChars), "numChars must be >= 2 and <= the buffer size");
                 }
                 char[] charBuffer = buffer.Buffer;
@@ -469,11 +469,11 @@ namespace Lucene.Net.Analysis.Util
                     throw new ArgumentNullException(nameof(chars)); // LUCENENET specific - added null guard clause
                 if (offset >= limit)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(offset), "offset must be less than limit");
+                    throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(offset)} must be less than limit.");
                 }
                 // LUCENENET specific - added array bound check
                 if (offset < 0  || offset >= chars.Length)
-                    throw new ArgumentOutOfRangeException(nameof(offset));
+                    throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(offset)} must not be negative and be less than chars.Length.");
 
                 return chars[offset];
             }
@@ -483,7 +483,7 @@ namespace Lucene.Net.Analysis.Util
                 if (Debugging.AssertsEnabled) Debugging.Assert(buffer.Buffer.Length >= 1);
                 if (numChars < 1 || numChars > buffer.Buffer.Length)
                 {
-                    // LUCENENET: Changed from InvalidArgumentException to ArgumentOutOfRangeException
+                    // LUCENENET: Changed from IllegalArgumentException to ArgumentOutOfRangeException
                     throw new ArgumentOutOfRangeException(nameof(numChars), "numChars must be >= 1 and <= the buffer size");
                 }
                 buffer.offset = 0;
@@ -527,12 +527,13 @@ namespace Lucene.Net.Analysis.Util
 
             public override int OffsetByCodePoints(char[] buf, int start, int count, int index, int offset)
             {
-                int result = index + offset;
+                // LUCENENET: Checks for int overflow
+                uint result = (uint)index + (uint)offset;
                 if (result < 0 || result > count)
                 {
                     throw new ArgumentOutOfRangeException(nameof(index) + " + " + nameof(offset), "index + offset must be >= 0 and <= count");
                 }
-                return result;
+                return (int)result;
             }
         }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using J2N.Text;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -176,9 +176,9 @@ namespace Lucene.Net.Analysis.Util
             if (startIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(startIndex));
             if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length));
-            if (startIndex + length > m_buf.Length)
-                throw new ArgumentOutOfRangeException("", $"{nameof(startIndex)} + {nameof(length)} > {nameof(Length)}");
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} may not be negative.");
+            if (startIndex > m_buf.Length - length) // LUCENENET: Checks for int overflow
+                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
 
             char[] result = new char[length];
             for (int i = 0, j = startIndex; i < length; i++, j++)

--- a/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/MultiTrie2.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/MultiTrie2.cs
@@ -265,7 +265,7 @@ namespace Egothor.Stemmer
                             // LUCENENET: Should never happen, but since we don't
                             // have a catch block here who knows what might happen if
                             // we don't do this.
-                            throw new ArgumentOutOfRangeException();
+                            throw IndexOutOfBoundsException.Create(nameof(cmd));
                         }
                     }
                     if (!TrySkip(key, LengthPP(p[i]), out key))
@@ -273,7 +273,7 @@ namespace Egothor.Stemmer
                         // LUCENENET: Should never happen, but since we don't
                         // have a catch block here who knows what might happen if
                         // we don't do this.
-                        throw new ArgumentOutOfRangeException();
+                        throw IndexOutOfBoundsException.Create(nameof(cmd));
                     }
                 }
                 // System.err.println("--->"+key);

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/RandomFacetSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/RandomFacetSource.cs
@@ -101,7 +101,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             maxFacetDepth = config.Get("max.facet.depth", 3);
             if (maxFacetDepth < 2)
             {
-                throw new ArgumentOutOfRangeException("max.facet.depth", "max.facet.depth must be at least 2; got: " + maxFacetDepth);
+                throw new ArgumentOutOfRangeException(nameof(config), "max.facet.depth must be at least 2; got: " + maxFacetDepth);
             }
             maxValue = maxDocFacets * maxFacetDepth;
         }

--- a/src/Lucene.Net.Facet/Taxonomy/LRUHashMap.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/LRUHashMap.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Facet.Taxonomy
             {
                 if (value < 1)
                 {
-                    throw new ArgumentOutOfRangeException("Limit must be at least 1"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentOutOfRangeException(nameof(Limit), "Limit must be at least 1"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
                 }
                 cache.Limit = value;
             }

--- a/src/Lucene.Net.Grouping/AbstractFirstPassGroupingCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractFirstPassGroupingCollector.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Search.Grouping
         {
             if (topNGroups < 1)
             {
-                throw new ArgumentOutOfRangeException("topNGroups must be >= 1 (got " + topNGroups + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(topNGroups), "topNGroups must be >= 1 (got " + topNGroups + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
 
             // TODO: allow null groupSort to mean "by relevance",
@@ -113,7 +113,7 @@ namespace Lucene.Net.Search.Grouping
 
             if (groupOffset < 0)
             {
-                throw new ArgumentOutOfRangeException("groupOffset must be >= 0 (got " + groupOffset + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(groupOffset), "groupOffset must be >= 0 (got " + groupOffset + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
 
             if (groupMap.Count <= groupOffset)

--- a/src/Lucene.Net.Spatial/Prefix/Tree/Cell.cs
+++ b/src/Lucene.Net.Spatial/Prefix/Tree/Cell.cs
@@ -118,11 +118,11 @@ namespace Lucene.Net.Spatial.Prefix.Tree
             // LUCENENET specific - check that the offset and length are in bounds
             int len = bytes.Length;
             if (offset < 0)
-                throw new ArgumentOutOfRangeException(nameof(offset));
+                throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(offset)} must not be negative.");
             if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length));
-            if (offset + length > len)
-                throw new ArgumentException($"{nameof(offset)} and {nameof(length)} must refer to a location within the array.");
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
+            if (offset > len - length) // Checks for int overflow
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(offset)} and {nameof(length)} must refer to a location within the array.");
 
             b_off = offset;
             b_len = length;
@@ -139,7 +139,7 @@ namespace Lucene.Net.Spatial.Prefix.Tree
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (length < 0)
                 throw new ArgumentOutOfRangeException(nameof(length));
-            if (offset + length > len)
+            if (offset > len - length) // Checks for int overflow
                 throw new ArgumentOutOfRangeException(nameof(length), "Offset and length must refer to a location within the array.");
 
             if (Debugging.AssertsEnabled) Debugging.Assert(Level != 0);

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -166,7 +166,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         {
             if (minPrefixChars < 0)
             {
-                throw new ArgumentOutOfRangeException("minPrefixChars must be >= 0; got: " + minPrefixChars);// LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(minPrefixChars), "minPrefixChars must be >= 0; got: " + minPrefixChars);// LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
 
             this.m_queryAnalyzer = queryAnalyzer;

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
@@ -163,8 +163,8 @@ namespace Lucene.Net.Analysis.TokenAttributes
                 throw new ArgumentOutOfRangeException(nameof(startIndex));
             if (length < 0)
                 throw new ArgumentOutOfRangeException(nameof(length));
-            if (startIndex + length > Length)
-                throw new ArgumentOutOfRangeException("", $"{nameof(startIndex)} + {nameof(length)} > {nameof(Length)}");
+            if (startIndex > Length - length) // Checks for int overflow
+                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
 
             char[] result = new char[length];
             for (int i = 0, j = startIndex; i < length; i++, j++)

--- a/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
@@ -179,7 +179,7 @@ namespace Lucene.Net.Index
             {
                 if (priority > (int)ThreadPriority.Highest || priority < (int)ThreadPriority.Lowest)
                 {
-                    throw new ArgumentOutOfRangeException("priority must be in range " + (int)ThreadPriority.Highest + " .. " + (int)ThreadPriority.Lowest + " inclusive"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentOutOfRangeException(nameof(priority), "priority must be in range " + (int)ThreadPriority.Lowest + " .. " + (int)ThreadPriority.Highest + " inclusive"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
                 }
                 mergeThreadPriority = priority;
                 UpdateMergeThreads();

--- a/src/Lucene.Net/Search/BooleanClause.cs
+++ b/src/Lucene.Net/Search/BooleanClause.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Search
                     return "-";
 
                 default:
-                    throw new ArgumentOutOfRangeException("Invalid Occur value"); // LUCENENET specific
+                    throw new ArgumentOutOfRangeException(nameof(occur), "Invalid Occur value"); // LUCENENET specific
             }
         }
 

--- a/src/Lucene.Net/Search/SearcherLifetimeManager.cs
+++ b/src/Lucene.Net/Search/SearcherLifetimeManager.cs
@@ -249,7 +249,7 @@ namespace Lucene.Net.Search
             {
                 if (maxAgeSec < 0)
                 {
-                    throw new ArgumentOutOfRangeException("maxAgeSec must be > 0 (got " + maxAgeSec + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentOutOfRangeException(nameof(maxAgeSec), "maxAgeSec must be > 0 (got " + maxAgeSec + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
                 }
                 this.maxAgeSec = maxAgeSec;
             }

--- a/src/Lucene.Net/Store/BufferedIndexInput.cs
+++ b/src/Lucene.Net/Store/BufferedIndexInput.cs
@@ -129,7 +129,7 @@ namespace Lucene.Net.Store
         {
             if (bufferSize <= 0)
             {
-                throw new ArgumentOutOfRangeException("bufferSize must be greater than 0 (got " + bufferSize + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), "bufferSize must be greater than 0 (got " + bufferSize + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
         }
 

--- a/src/Lucene.Net/Store/BufferedIndexOutput.cs
+++ b/src/Lucene.Net/Store/BufferedIndexOutput.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Store
         {
             if (bufferSize <= 0)
             {
-                throw new ArgumentOutOfRangeException("bufferSize must be greater than 0 (got " + bufferSize + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), "bufferSize must be greater than 0 (got " + bufferSize + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
             this.bufferSize = bufferSize;
             // LUCENENET: We lazy-load the buffer, so we don't force all subclasses to allocate it

--- a/src/Lucene.Net/Store/ByteBufferIndexInput.cs
+++ b/src/Lucene.Net/Store/ByteBufferIndexInput.cs
@@ -225,7 +225,7 @@ namespace Lucene.Net.Store
             // necessary in case offset != 0 and pos < 0, but pos >= -offset
             if (pos < 0L)
             {
-                throw new ArgumentOutOfRangeException("Seeking to negative position: " + this); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(pos), "Seeking to negative position: " + this); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
             pos += offset;
             // we use >> here to preserve negative, so we will catch AIOOBE,
@@ -307,7 +307,7 @@ namespace Lucene.Net.Store
                 throw new ArgumentOutOfRangeException(nameof(offset), "offset may not be negative.");
             if (length < 0)
                 throw new ArgumentOutOfRangeException(nameof(length), "length may not be negative.");
-            if (offset + length > this.length)
+            if (offset > this.length - length) // LUCENENET: Checks for int overflow
             {
                 throw new ArgumentException("slice() " + sliceDescription + " out of bounds: offset=" + offset + ",length=" + length + ",fileLength=" + this.length + ": " + this);
             }

--- a/src/Lucene.Net/Store/DataInput.cs
+++ b/src/Lucene.Net/Store/DataInput.cs
@@ -315,7 +315,7 @@ namespace Lucene.Net.Store
         {
             if (numBytes < 0)
             {
-                throw new ArgumentOutOfRangeException("numBytes must be >= 0, got " + numBytes); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(numBytes), "numBytes must be >= 0, got " + numBytes); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
             if (skipBuffer is null)
             {

--- a/src/Lucene.Net/Store/Lock.cs
+++ b/src/Lucene.Net/Store/Lock.cs
@@ -117,7 +117,7 @@ namespace Lucene.Net.Store
             bool locked = Obtain();
             if (lockWaitTimeout < 0 && lockWaitTimeout != LOCK_OBTAIN_WAIT_FOREVER)
             {
-                throw new ArgumentOutOfRangeException("lockWaitTimeout should be LOCK_OBTAIN_WAIT_FOREVER or a non-negative number (got " + lockWaitTimeout + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(lockWaitTimeout), "lockWaitTimeout should be LOCK_OBTAIN_WAIT_FOREVER or a non-negative number (got " + lockWaitTimeout + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
 
             long maxSleepCount = lockWaitTimeout / LOCK_POLL_INTERVAL;

--- a/src/Lucene.Net/Store/LockStressTest.cs
+++ b/src/Lucene.Net/Store/LockStressTest.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Store
         {
             if (args.Length != 7)
             {
-                // LUCENENET specific - our wrapper console shows the correct usage
+                // LUCENENET specific - our lucene-cli wrapper console shows the correct usage
                 throw new ArgumentException();
                 //Console.WriteLine("Usage: java Lucene.Net.Store.LockStressTest myID verifierHost verifierPort lockFactoryClassName lockDirName sleepTimeMS count\n" + 
                 //    "\n" + 
@@ -64,7 +64,7 @@ namespace Lucene.Net.Store
 
             if (myID < 0 || myID > 255)
             {
-                throw new ArgumentOutOfRangeException("ID", "ID must be a unique int 0..255"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(args), "ID must be a unique int 0..255"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
                 //Console.WriteLine("myID must be a unique int 0..255");
                 //Environment.Exit(1);
             }

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -307,8 +307,8 @@ namespace Lucene.Net.Util
                 throw new ArgumentOutOfRangeException(nameof(startIndex));
             if (length < 0)
                 throw new ArgumentOutOfRangeException(nameof(length));
-            if (startIndex + length > Length)
-                throw new ArgumentOutOfRangeException("", $"{nameof(startIndex)} + {nameof(length)} > {nameof(Length)}");
+            if (startIndex > Length - length) // LUCENENET: Checks for int overflow
+                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
 
             return new CharsRef(chars, Offset + startIndex, length);
         }


### PR DESCRIPTION
Fixes #665.

Also addressed potential int overflow issues when checking for "index + length must be <= array length".