### PR TITLE
Lucene.Net.Analysis.Cn.Smart.Utility: Changed SPACES to use an encoded character for '\u3000' so it is visible in the designer.

### DIFF
--- a/src/Lucene.Net.Analysis.SmartCn/Utility.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Utility.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
         /// <summary>
         /// Space-like characters that need to be skipped: such as space, tab, newline, carriage return.
         /// </summary>
-        public static readonly string SPACES = " 　\t\r\n";
+        public static readonly string SPACES = " \u3000\t\r\n"; // LUCENENET specific - made the U+3000 character explicitly visible: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS2479&id=nikcio_lucenenet
 
         /// <summary>
         /// Maximum bigram frequency (used in the smoothing function).


### PR DESCRIPTION
Fixes #680.