### PR TITLE
Review for CA1822: Mark members as static

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Bg/BulgarianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Bg/BulgarianStemmer.cs
@@ -89,7 +89,7 @@ namespace Lucene.Net.Analysis.Bg
         /// <param name="s"> input buffer </param>
         /// <param name="len"> length of input buffer </param>
         /// <returns> new stemmed length </returns>
-        private int RemoveArticle(char[] s, int len)
+        private static int RemoveArticle(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 6 && StemmerUtil.EndsWith(s, len, "ият"))
             {
@@ -112,7 +112,7 @@ namespace Lucene.Net.Analysis.Bg
             return len;
         }
 
-        private int RemovePlural(char[] s, int len)
+        private static int RemovePlural(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 6)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Br/BrazilianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Br/BrazilianStemmer.cs
@@ -92,7 +92,7 @@ namespace Lucene.Net.Analysis.Br
         /// Checks a term if it can be processed correctly.
         /// </summary>
         /// <returns>  true if, and only if, the given term consists in letters. </returns>
-        private bool IsStemmable(string term)
+        private static bool IsStemmable(string term) // LUCENENET: CA1822: Mark members as static
         {
             for (int c = 0; c < term.Length; c++)
             {
@@ -109,7 +109,7 @@ namespace Lucene.Net.Analysis.Br
         /// Checks a term if it can be processed indexed.
         /// </summary>
         /// <returns> true if it can be indexed </returns>
-        private bool IsIndexable(string term)
+        private static bool IsIndexable(string term) // LUCENENET: CA1822: Mark members as static
         {
             return (term.Length < 30) && (term.Length > 2);
         }
@@ -118,7 +118,7 @@ namespace Lucene.Net.Analysis.Br
         /// See if string is 'a','e','i','o','u'
         /// </summary>
         /// <returns> true if is vowel </returns>
-        private bool IsVowel(char value)
+        private static bool IsVowel(char value) // LUCENENET: CA1822: Mark members as static
         {
             return (value == 'a') || (value == 'e') || (value == 'i') || (value == 'o') || (value == 'u');
         }
@@ -259,7 +259,7 @@ namespace Lucene.Net.Analysis.Br
         /// 4) ç -> c
         /// </summary>
         /// <returns> null or a string transformed </returns>
-        private string ChangeTerm(string value)
+        private static string ChangeTerm(string value) // LUCENENET: CA1822: Mark members as static
         {
             int j;
             string r = "";
@@ -319,7 +319,7 @@ namespace Lucene.Net.Analysis.Br
         /// Check if a string ends with a suffix
         /// </summary>
         /// <returns> true if the string ends with the specified suffix </returns>
-        private bool Suffix(string value, string suffix)
+        private static bool Suffix(string value, string suffix) // LUCENENET: CA1822: Mark members as static
         {
 
             // be-safe !!!

--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
@@ -31134,7 +31134,7 @@ namespace Lucene.Net.Analysis.CharFilters
         /// in error fallback rules.
         /// </summary>
         /// <param name="errorCode">the code of the errormessage to display</param>
-        private void ZzScanError(int errorCode)
+        private static void ZzScanError(int errorCode) // LUCENENET: CA1822: Mark members as static
         {
             string message;
             // LUCENENET specific: Defensive check so we don't have to catch IndexOutOfRangeException

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
@@ -191,7 +191,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
             }
         }
 
-        private XmlReaderSettings GetXmlReaderSettings()
+        private static XmlReaderSettings GetXmlReaderSettings() // LUCENENET: CA1822: Mark members as static
         {
             return
 
@@ -202,7 +202,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
                 };
         }
 
-        private IDictionary<string, string> GetAttributes(XmlReader node)
+        private static IDictionary<string, string> GetAttributes(XmlReader node) // LUCENENET: CA1822: Mark members as static
         {
             var result = new Dictionary<string, string>();
             if (node.HasAttributes)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Cz/CzechStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Cz/CzechStemmer.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Analysis.Cz
             return len;
         }
 
-        private int RemoveCase(char[] s, int len)
+        private static int RemoveCase(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 7 && StemmerUtil.EndsWith(s, len, "atech"))
             {
@@ -96,7 +96,7 @@ namespace Lucene.Net.Analysis.Cz
             return len;
         }
 
-        private int RemovePossessives(char[] s, int len)
+        private static int RemovePossessives(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 5 && (StemmerUtil.EndsWith(s, len, "ov") || StemmerUtil.EndsWith(s, len, "in") || StemmerUtil.EndsWith(s, len, "ův")))
             {
@@ -106,7 +106,7 @@ namespace Lucene.Net.Analysis.Cz
             return len;
         }
 
-        private int Normalize(char[] s, int len)
+        private static int Normalize(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (StemmerUtil.EndsWith(s, len, "čt")) // čt -> ck
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/De/GermanLightStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/De/GermanLightStemmer.cs
@@ -100,7 +100,7 @@ namespace Lucene.Net.Analysis.De
             return Step2(s, len);
         }
 
-        private bool StEnding(char ch)
+        private static bool StEnding(char ch) // LUCENENET: CA1822: Mark members as static
         {
             switch (ch)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/De/GermanStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/De/GermanStemmer.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Analysis.De
         /// Checks if a term could be stemmed.
         /// </summary>
         /// <returns>  true if, and only if, the given term consists in letters. </returns>
-        private bool IsStemmable(string term)
+        private static bool IsStemmable(string term) // LUCENENET: CA1822: Mark members as static
         {
             for (int c = 0; c < term.Length; c++)
             {
@@ -159,7 +159,7 @@ namespace Lucene.Net.Analysis.De
         /// <summary>
         /// Removes a particle denotion ("ge") from a term.
         /// </summary>
-        private void RemoveParticleDenotion(StringBuilder buffer)
+        private static void RemoveParticleDenotion(StringBuilder buffer) // LUCENENET: CA1822: Mark members as static
         {
             if (buffer.Length > 4)
             {
@@ -265,7 +265,7 @@ namespace Lucene.Net.Analysis.De
         /// character combinations. Umlauts will remain as their corresponding vowel,
         /// as "ß" remains as "ss".
         /// </summary>
-        private void Resubstitute(StringBuilder buffer)
+        private static void Resubstitute(StringBuilder buffer) // LUCENENET: CA1822: Mark members as static
         {
             for (int c = 0; c < buffer.Length; c++)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/El/GreekLowerCaseFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/El/GreekLowerCaseFilter.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Analysis.El
             }
         }
 
-        private int LowerCase(int codepoint)
+        private static int LowerCase(int codepoint) // LUCENENET: CA1822: Mark members as static
         {
             switch (codepoint)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
@@ -79,7 +79,7 @@ namespace Lucene.Net.Analysis.El
             return Rule22(s, len);
         }
 
-        private int Rule0(char[] s, int len)
+        private static int Rule0(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 9 && (StemmerUtil.EndsWith(s, len, "καθεστωτοσ") || 
                 StemmerUtil.EndsWith(s, len, "καθεστωτων")))
@@ -183,7 +183,7 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        private int Rule1(char[] s, int len)
+        private static int Rule1(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 4 && (StemmerUtil.EndsWith(s, len, "αδεσ") || 
                 StemmerUtil.EndsWith(s, len, "αδων")))
@@ -206,7 +206,7 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        private int Rule2(char[] s, int len)
+        private static int Rule2(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 4 && (StemmerUtil.EndsWith(s, len, "εδεσ") || 
                 StemmerUtil.EndsWith(s, len, "εδων")))
@@ -227,7 +227,7 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        private int Rule3(char[] s, int len)
+        private static int Rule3(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 5 && (StemmerUtil.EndsWith(s, len, "ουδεσ") || 
                 StemmerUtil.EndsWith(s, len, "ουδων")))
@@ -259,7 +259,7 @@ namespace Lucene.Net.Analysis.El
         private static readonly CharArraySet exc4 = new CharArraySet(LuceneVersion.LUCENE_CURRENT, new string[] { "θ", "δ", "ελ", "γαλ", "ν", "π", "ιδ", "παρ" }, false);
 #pragma warning restore 612, 618
 
-        private int Rule4(char[] s, int len)
+        private static int Rule4(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 3 && (StemmerUtil.EndsWith(s, len, "εωσ") || 
                 StemmerUtil.EndsWith(s, len, "εων")))
@@ -273,7 +273,7 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        private int Rule5(char[] s, int len)
+        private static int Rule5(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 2 && StemmerUtil.EndsWith(s, len, "ια"))
             {
@@ -305,7 +305,7 @@ namespace Lucene.Net.Analysis.El
                 "πετσ", "πιτσ", "πικαντ", "πλιατσ", "ποστελν", "πρωτοδ", "σερτ",
                 "συναδ", "τσαμ", "υποδ", "φιλον", "φυλοδ", "χασ" }, false);
 
-        private int Rule6(char[] s, int len)
+        private static int Rule6(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
             if (len > 3 && (StemmerUtil.EndsWith(s, len, "ικα") || 
@@ -338,7 +338,7 @@ namespace Lucene.Net.Analysis.El
             new string[] { "αναπ", "αποθ", "αποκ", "αποστ", "βουβ", "ξεθ", "ουλ",
                 "πεθ", "πικρ", "ποτ", "σιχ", "χ" }, false);
 
-        private int Rule7(char[] s, int len)
+        private static int Rule7(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len == 5 && StemmerUtil.EndsWith(s, len, "αγαμε"))
             {
@@ -396,7 +396,7 @@ namespace Lucene.Net.Analysis.El
                 "ολογαλ", "πενταρφ", "περηφ", "περιτρ", "πλατ", "πολυδαπ", "πολυμηχ",
                 "στεφ", "ταβ", "τετ", "υπερηφ", "υποκοπ", "χαμηλοδαπ", "ψηλοταβ" }, false);
 
-        private int Rule8(char[] s, int len)
+        private static int Rule8(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
 
@@ -458,7 +458,7 @@ namespace Lucene.Net.Analysis.El
                 "βαρον", "ντρ", "σκ", "κοπ", "μπορ", "νιφ", "παγ", "παρακαλ", "σερπ",
                 "σκελ", "συρφ", "τοκ", "υ", "δ", "εμ", "θαρρ", "θ" }, false);
 
-        private int Rule9(char[] s, int len)
+        private static int Rule9(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 5 && StemmerUtil.EndsWith(s, len, "ησετε"))
             {
@@ -509,7 +509,7 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        private int Rule10(char[] s, int len)
+        private static int Rule10(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 5 && (StemmerUtil.EndsWith(s, len, "οντασ") || StemmerUtil.EndsWith(s, len, "ωντασ")))
             {
@@ -529,7 +529,7 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        private int Rule11(char[] s, int len)
+        private static int Rule11(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 6 && StemmerUtil.EndsWith(s, len, "ομαστε"))
             {
@@ -563,7 +563,7 @@ namespace Lucene.Net.Analysis.El
             new string[] { "αλ", "αρ", "εκτελ", "ζ", "μ", "ξ", "παρακαλ", "αρ", "προ", "νισ" }, false);
 #pragma warning restore 612, 618
 
-        private int Rule12(char[] s, int len)
+        private static int Rule12(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 5 && StemmerUtil.EndsWith(s, len, "ιεστε"))
             {
@@ -592,7 +592,7 @@ namespace Lucene.Net.Analysis.El
 #pragma warning restore 612, 618
             new string[] { "διαθ", "θ", "παρακαταθ", "προσθ", "συνθ" }, false);
 
-        private int Rule13(char[] s, int len)
+        private static int Rule13(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 6 && StemmerUtil.EndsWith(s, len, "ηθηκεσ"))
             {
@@ -638,7 +638,7 @@ namespace Lucene.Net.Analysis.El
                 "λεχ", "μ", "πατ", "ρ", "λ", "μεδ", "μεσαζ", "υποτειν", "αμ", "αιθ",
                 "ανηκ", "δεσποζ", "ενδιαφερ", "δε", "δευτερευ", "καθαρευ", "πλε", "τσα" }, false);
 
-        private int Rule14(char[] s, int len)
+        private static int Rule14(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
 
@@ -692,7 +692,7 @@ namespace Lucene.Net.Analysis.El
 #pragma warning restore 612, 618
             new string[] { "ψοφ", "ναυλοχ" }, false);
 
-        private int Rule15(char[] s, int len)
+        private static int Rule15(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
             if (len > 4 && StemmerUtil.EndsWith(s, len, "αγεσ"))
@@ -737,7 +737,7 @@ namespace Lucene.Net.Analysis.El
 #pragma warning restore 612, 618
             new string[] { "ν", "χερσον", "δωδεκαν", "ερημον", "μεγαλον", "επταν" }, false);
 
-        private int Rule16(char[] s, int len)
+        private static int Rule16(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
             if (len > 4 && StemmerUtil.EndsWith(s, len, "ησου"))
@@ -765,7 +765,7 @@ namespace Lucene.Net.Analysis.El
 #pragma warning restore 612, 618
             new string[] { "ασβ", "σβ", "αχρ", "χρ", "απλ", "αειμν", "δυσχρ", "ευχρ", "κοινοχρ", "παλιμψ" }, false);
 
-        private int Rule17(char[] s, int len)
+        private static int Rule17(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 4 && StemmerUtil.EndsWith(s, len, "ηστε"))
             {
@@ -785,7 +785,7 @@ namespace Lucene.Net.Analysis.El
 #pragma warning restore 612, 618
             new string[] { "ν", "ρ", "σπι", "στραβομουτσ", "κακομουτσ", "εξων" }, false);
 
-        private int Rule18(char[] s, int len)
+        private static int Rule18(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
 
@@ -816,7 +816,7 @@ namespace Lucene.Net.Analysis.El
 #pragma warning restore 612, 618
             new string[] { "παρασουσ", "φ", "χ", "ωριοπλ", "αζ", "αλλοσουσ", "ασουσ" }, false);
 
-        private int Rule19(char[] s, int len)
+        private static int Rule19(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
 
@@ -841,7 +841,7 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        private int Rule20(char[] s, int len)
+        private static int Rule20(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 5 && (StemmerUtil.EndsWith(s, len, "ματων") || StemmerUtil.EndsWith(s, len, "ματοσ")))
             {
@@ -854,7 +854,7 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        private int Rule21(char[] s, int len)
+        private static int Rule21(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 9 && StemmerUtil.EndsWith(s, len, "ιοντουσαν"))
             {
@@ -973,7 +973,7 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        private int Rule22(char[] s, int len)
+        private static int Rule22(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (StemmerUtil.EndsWith(s, len, "εστερ") || 
                 StemmerUtil.EndsWith(s, len, "εστατ"))
@@ -1002,7 +1002,7 @@ namespace Lucene.Net.Analysis.El
         /// <param name="len"> The length of the char[] array. </param>
         /// <param name="suffix"> A <see cref="string"/> object to check if the word given ends with these characters. </param>
         /// <returns> True if the word ends with the suffix given , false otherwise. </returns>
-        private bool EndsWith(char[] s, int len, string suffix)
+        private static bool EndsWith(char[] s, int len, string suffix) // LUCENENET: CA1822: Mark members as static
         {
             int suffixLen = suffix.Length;
             if (suffixLen > len)
@@ -1028,7 +1028,7 @@ namespace Lucene.Net.Analysis.El
         /// <param name="len"> The length of the <see cref="T:char[]"/> array. </param>
         /// <returns> True if the word contained in the leading portion of <see cref="T:char[]"/> array , 
         /// ends with a vowel , false otherwise. </returns>
-        private bool EndsWithVowel(char[] s, int len)
+        private static bool EndsWithVowel(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len == 0)
             {
@@ -1057,7 +1057,7 @@ namespace Lucene.Net.Analysis.El
         /// <param name="len"> The length of the <see cref="T:char[]"/> array. </param>
         /// <returns> True if the word contained in the leading portion of <see cref="T:char[]"/> array , 
         /// ends with a vowel , false otherwise. </returns>
-        private bool EndsWithVowelNoY(char[] s, int len)
+        private static bool EndsWithVowelNoY(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len == 0)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/En/KStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/En/KStemmer.cs
@@ -569,7 +569,7 @@ namespace Lucene.Net.Analysis.En
             return d;
         }
 
-        private bool IsAlpha(char ch)
+        private static bool IsAlpha(char ch) // LUCENENET: CA1822: Mark members as static
         {
             return ch >= 'a' && ch <= 'z'; // terms must be lowercased already
         }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Fi/FinnishLightStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Fi/FinnishLightStemmer.cs
@@ -122,7 +122,7 @@ namespace Lucene.Net.Analysis.Fi
             return len;
         }
 
-        private int Step2(char[] s, int len)
+        private static int Step2(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 5)
             {
@@ -241,7 +241,7 @@ namespace Lucene.Net.Analysis.Fi
             return len;
         }
 
-        private int Norm1(char[] s, int len)
+        private static int Norm1(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 5 && StemmerUtil.EndsWith(s, len, "hde"))
             {
@@ -275,7 +275,7 @@ namespace Lucene.Net.Analysis.Fi
             return len;
         }
 
-        private int Norm2(char[] s, int len)
+        private static int Norm2(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 8)
             {
@@ -312,7 +312,7 @@ namespace Lucene.Net.Analysis.Fi
             return len;
         }
 
-        private bool IsVowel(char ch)
+        private static bool IsVowel(char ch) // LUCENENET: CA1822: Mark members as static
         {
             switch (ch)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchLightStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchLightStemmer.cs
@@ -275,7 +275,7 @@ namespace Lucene.Net.Analysis.Fr
             return Norm(s, len);
         }
 
-        private int Norm(char[] s, int len)
+        private static int Norm(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 4)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Ga/IrishLowerCaseFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Ga/IrishLowerCaseFilter.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Analysis.Ga
             }
         }
 
-        private bool IsUpperVowel(int v)
+        private static bool IsUpperVowel(int v) // LUCENENET: CA1822: Mark members as static
         {
             switch (v)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hu/HungarianLightStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hu/HungarianLightStemmer.cs
@@ -233,7 +233,7 @@ namespace Lucene.Net.Analysis.Hu
             return len;
         }
 
-        private int RemovePlural(char[] s, int len)
+        private static int RemovePlural(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 3 && s[len - 1] == 'k')
             {
@@ -254,7 +254,7 @@ namespace Lucene.Net.Analysis.Hu
             return len;
         }
 
-        private int Normalize(char[] s, int len)
+        private static int Normalize(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 3)
             {
@@ -270,7 +270,7 @@ namespace Lucene.Net.Analysis.Hu
             return len;
         }
 
-        private bool IsVowel(char ch)
+        private static bool IsVowel(char ch) // LUCENENET: CA1822: Mark members as static
         {
             switch (ch)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -449,7 +449,7 @@ namespace Lucene.Net.Analysis.Hunspell
             stripOffsets[currentIndex] = currentOffset;
         }
 
-        private FST<Int32sRef> AffixFST(JCG.SortedDictionary<string, IList<int>> affixes)
+        private static FST<Int32sRef> AffixFST(JCG.SortedDictionary<string, IList<int>> affixes) // LUCENENET: CA1822: Mark members as static
         {
             Int32SequenceOutputs outputs = Int32SequenceOutputs.Singleton;
             Builder<Int32sRef> builder = new Builder<Int32sRef>(FST.INPUT_TYPE.BYTE4, outputs);
@@ -660,7 +660,7 @@ namespace Lucene.Net.Analysis.Hunspell
             }
         }
 
-        private FST<CharsRef> ParseConversions(TextReader reader, int num, int lineNumber)
+        private static FST<CharsRef> ParseConversions(TextReader reader, int num, int lineNumber) // LUCENENET: CA1822: Mark members as static
         {
             IDictionary<string, string> mappings = new JCG.SortedDictionary<string, string>(StringComparer.Ordinal);
 
@@ -754,7 +754,7 @@ namespace Lucene.Net.Analysis.Hunspell
         /// <param name="encoding"> Encoding to retrieve the <see cref="Encoding"/> instance for </param>
         /// <returns> <see cref="Encoding"/> for the given encoding <see cref="string"/> </returns>
         // LUCENENET NOTE: This was getJavaEncoding in Lucene
-        private Encoding GetSystemEncoding(string encoding)
+        private static Encoding GetSystemEncoding(string encoding) // LUCENENET: CA1822: Mark members as static
         {
             if (string.IsNullOrEmpty(encoding))
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Stemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Stemmer.cs
@@ -724,7 +724,7 @@ namespace Lucene.Net.Analysis.Hunspell
         /// <param name="flags"> Array of flags to cross check against.  Can be <c>null</c> </param>
         /// <param name="matchEmpty"> If true, will match a zero length flags array. </param>
         /// <returns> <c>true</c> if the flag is found in the array or the array is <c>null</c>, <c>false</c> otherwise </returns>
-        private bool HasCrossCheckedFlag(char flag, char[] flags, bool matchEmpty)
+        private static bool HasCrossCheckedFlag(char flag, char[] flags, bool matchEmpty) // LUCENENET: CA1822: Mark members as static
         {
             return (flags.Length == 0 && matchEmpty) || Array.BinarySearch(flags, flag) >= 0;
         }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Id/IndonesianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Id/IndonesianStemmer.cs
@@ -112,7 +112,7 @@ namespace Lucene.Net.Analysis.Id
             return length;
         }
 
-        private bool IsVowel(char ch)
+        private static bool IsVowel(char ch) // LUCENENET: CA1822: Mark members as static
         {
             switch (ch)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/In/IndicNormalizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/In/IndicNormalizer.cs
@@ -340,7 +340,7 @@ namespace Lucene.Net.Analysis.In
         /// <summary>
         /// LUCENENET: Returns the unicode block for the specified character
         /// </summary>
-        private Regex GetBlockForChar(char c)
+        private static Regex GetBlockForChar(char c) // LUCENENET: CA1822: Mark members as static
         {
             string charAsString = c.ToString();
             foreach (var block in scripts.Keys)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Lv/LatvianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Lv/LatvianStemmer.cs
@@ -101,7 +101,7 @@ namespace Lucene.Net.Analysis.Lv
         ///     <item><description> z -> ž</description></item>
         /// </list>
         /// </summary>
-        private int Unpalatalize(char[] s, int len)
+        private static int Unpalatalize(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             // we check the character removed: if its -u then 
             // its 2,5, or 6 gen pl., and these two can only apply then.
@@ -189,7 +189,7 @@ namespace Lucene.Net.Analysis.Lv
         /// Count the vowels in the string, we always require at least
         /// one in the remaining stem to accept it.
         /// </summary>
-        private int NumVowels(char[] s, int len)
+        private static int NumVowels(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             int n = 0;
             for (int i = 0; i < len; i++)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/WordDelimiterFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/WordDelimiterFilterFactory.cs
@@ -179,7 +179,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
             return types;
         }
 
-        private byte ParseType(string s)
+        private static byte ParseType(string s) // LUCENENET: CA1822: Mark members as static
         {
             if (s.Equals("LOWER", StringComparison.Ordinal))
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Pt/PortugueseLightStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Pt/PortugueseLightStemmer.cs
@@ -136,7 +136,7 @@ namespace Lucene.Net.Analysis.Pt
             return len;
         }
 
-        private int RemoveSuffix(char[] s, int len)
+        private static int RemoveSuffix(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 4 && StemmerUtil.EndsWith(s, len, "es"))
             {
@@ -202,7 +202,7 @@ namespace Lucene.Net.Analysis.Pt
             return len;
         }
 
-        private int NormFeminine(char[] s, int len)
+        private static int NormFeminine(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 7 && (StemmerUtil.EndsWith(s, len, "inha") || StemmerUtil.EndsWith(s, len, "iaca") || StemmerUtil.EndsWith(s, len, "eira")))
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Ru/RussianLightStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Ru/RussianLightStemmer.cs
@@ -71,7 +71,7 @@ namespace Lucene.Net.Analysis.Ru
             return Normalize(s, len);
         }
 
-        private int Normalize(char[] s, int len)
+        private static int Normalize(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 3)
             {
@@ -91,7 +91,7 @@ namespace Lucene.Net.Analysis.Ru
             return len;
         }
 
-        private int RemoveCase(char[] s, int len)
+        private static int RemoveCase(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (len > 6 && (StemmerUtil.EndsWith(s, len, "иями") || StemmerUtil.EndsWith(s, len, "оями")))
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailTokenizerImpl.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailTokenizerImpl.cs
@@ -9343,7 +9343,7 @@ namespace Lucene.Net.Analysis.Standard
         /// in error fallback rules.
         /// </summary>
         /// <param name="errorCode">the code of the errormessage to display</param>
-        private void ZzScanError(int errorCode)
+        private static void ZzScanError(int errorCode) // LUCENENET: CA1822: Mark members as static
         {
             string message;
             // LUCENENET specific: Defensive check so we don't have to catch IndexOutOfRangeException

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SolrSynonymParser.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SolrSynonymParser.cs
@@ -188,7 +188,7 @@ namespace Lucene.Net.Analysis.Synonym
             return list.ToArray();
         }
 
-        private string Unescape(string s)
+        private static string Unescape(string s) // LUCENENET: CA1822: Mark members as static
         {
             if (s.IndexOf("\\", StringComparison.Ordinal) >= 0)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Tr/TurkishLowerCaseFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Tr/TurkishLowerCaseFilter.cs
@@ -111,7 +111,7 @@ namespace Lucene.Net.Analysis.Tr
         /// lookahead for a combining dot above.
         /// other NSMs may be in between.
         /// </summary>
-        private bool IsBeforeDot(char[] s, int pos, int len)
+        private static bool IsBeforeDot(char[] s, int pos, int len) // LUCENENET: CA1822: Mark members as static
         {
             for (int i = pos; i < len;)
             {
@@ -134,7 +134,7 @@ namespace Lucene.Net.Analysis.Tr
         /// delete a character in-place.
         /// rarely happens, only if <see cref="COMBINING_DOT_ABOVE"/> is found after an i
         /// </summary>
-        private int Delete(char[] s, int pos, int len)
+        private static int Delete(char[] s, int pos, int len) // LUCENENET: CA1822: Mark members as static
         {
             if (pos < len)
                 Array.Copy(s, pos + 1, s, pos, len - pos - 1);

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
@@ -177,7 +177,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// NOTE: This was requireInt() in Lucene
         /// </summary>
-        protected virtual int RequireInt32(IDictionary<string, string> args, string name)
+        protected int RequireInt32(IDictionary<string, string> args, string name)
         {
             return int.Parse(Require(args, name), CultureInfo.InvariantCulture);
         }
@@ -185,7 +185,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// NOTE: This was getInt() in Lucene
         /// </summary>
-        protected virtual int GetInt32(IDictionary<string, string> args, string name, int defaultVal)
+        protected int GetInt32(IDictionary<string, string> args, string name, int defaultVal)
         {
             if (args.TryGetValue(name, out string s))
             {
@@ -195,12 +195,12 @@ namespace Lucene.Net.Analysis.Util
             return defaultVal;
         }
 
-        protected virtual bool RequireBoolean(IDictionary<string, string> args, string name)
+        protected bool RequireBoolean(IDictionary<string, string> args, string name)
         {
             return bool.Parse(Require(args, name));
         }
 
-        protected virtual bool GetBoolean(IDictionary<string, string> args, string name, bool defaultVal)
+        protected bool GetBoolean(IDictionary<string, string> args, string name, bool defaultVal)
         {
             if (args.TryGetValue(name, out string s))
             {
@@ -213,7 +213,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// NOTE: This was requireFloat() in Lucene
         /// </summary>
-        protected virtual float RequireSingle(IDictionary<string, string> args, string name)
+        protected float RequireSingle(IDictionary<string, string> args, string name)
         {
             return float.Parse(Require(args, name), CultureInfo.InvariantCulture);
         }
@@ -221,7 +221,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// NOTE: This was getFloat() in Lucene
         /// </summary>
-        protected virtual float GetSingle(IDictionary<string, string> args, string name, float defaultVal)
+        protected float GetSingle(IDictionary<string, string> args, string name, float defaultVal)
         {
             if (args.TryGetValue(name, out string s))
             {
@@ -285,7 +285,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// Compiles a pattern for the value of the specified argument key <paramref name="name"/> 
         /// </summary>
-        protected virtual Regex GetPattern(IDictionary<string, string> args, string name)
+        protected Regex GetPattern(IDictionary<string, string> args, string name)
         {
             try
             {
@@ -329,7 +329,7 @@ namespace Lucene.Net.Analysis.Util
         /// Returns as <see cref="CharArraySet"/> from wordFiles, which
         /// can be a comma-separated list of filenames
         /// </summary>
-        protected virtual CharArraySet GetWordSet(IResourceLoader loader, string wordFiles, bool ignoreCase)
+        protected CharArraySet GetWordSet(IResourceLoader loader, string wordFiles, bool ignoreCase)
         {
             AssureMatchVersion();
             IList<string> files = SplitFileNames(wordFiles);
@@ -351,7 +351,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// Returns the resource's lines (with content treated as UTF-8)
         /// </summary>
-        protected virtual IList<string> GetLines(IResourceLoader loader, string resource)
+        protected IList<string> GetLines(IResourceLoader loader, string resource)
         {
             return WordlistLoader.GetLines(loader.OpenResource(resource), Encoding.UTF8);
         }
@@ -360,7 +360,7 @@ namespace Lucene.Net.Analysis.Util
         /// Same as <see cref="GetWordSet(IResourceLoader, string, bool)"/>,
         /// except the input is in snowball format. 
         /// </summary>
-        protected virtual CharArraySet GetSnowballWordSet(IResourceLoader loader, string wordFiles, bool ignoreCase)
+        protected CharArraySet GetSnowballWordSet(IResourceLoader loader, string wordFiles, bool ignoreCase)
         {
             AssureMatchVersion();
             IList<string> files = SplitFileNames(wordFiles);
@@ -388,7 +388,7 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="fileNames"> the string containing file names </param>
         /// <returns> a list of file names with the escaping backslashed removed </returns>
-        protected virtual IList<string> SplitFileNames(string fileNames)
+        protected IList<string> SplitFileNames(string fileNames)
         {
             if (fileNames is null)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
@@ -177,7 +177,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// NOTE: This was requireInt() in Lucene
         /// </summary>
-        protected int RequireInt32(IDictionary<string, string> args, string name)
+        protected virtual int RequireInt32(IDictionary<string, string> args, string name)
         {
             return int.Parse(Require(args, name), CultureInfo.InvariantCulture);
         }
@@ -185,7 +185,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// NOTE: This was getInt() in Lucene
         /// </summary>
-        protected int GetInt32(IDictionary<string, string> args, string name, int defaultVal)
+        protected virtual int GetInt32(IDictionary<string, string> args, string name, int defaultVal)
         {
             if (args.TryGetValue(name, out string s))
             {
@@ -195,12 +195,12 @@ namespace Lucene.Net.Analysis.Util
             return defaultVal;
         }
 
-        protected bool RequireBoolean(IDictionary<string, string> args, string name)
+        protected virtual bool RequireBoolean(IDictionary<string, string> args, string name)
         {
             return bool.Parse(Require(args, name));
         }
 
-        protected bool GetBoolean(IDictionary<string, string> args, string name, bool defaultVal)
+        protected virtual bool GetBoolean(IDictionary<string, string> args, string name, bool defaultVal)
         {
             if (args.TryGetValue(name, out string s))
             {
@@ -213,7 +213,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// NOTE: This was requireFloat() in Lucene
         /// </summary>
-        protected float RequireSingle(IDictionary<string, string> args, string name)
+        protected virtual float RequireSingle(IDictionary<string, string> args, string name)
         {
             return float.Parse(Require(args, name), CultureInfo.InvariantCulture);
         }
@@ -221,7 +221,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// NOTE: This was getFloat() in Lucene
         /// </summary>
-        protected float GetSingle(IDictionary<string, string> args, string name, float defaultVal)
+        protected virtual float GetSingle(IDictionary<string, string> args, string name, float defaultVal)
         {
             if (args.TryGetValue(name, out string s))
             {
@@ -285,7 +285,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// Compiles a pattern for the value of the specified argument key <paramref name="name"/> 
         /// </summary>
-        protected Regex GetPattern(IDictionary<string, string> args, string name)
+        protected virtual Regex GetPattern(IDictionary<string, string> args, string name)
         {
             try
             {
@@ -329,7 +329,7 @@ namespace Lucene.Net.Analysis.Util
         /// Returns as <see cref="CharArraySet"/> from wordFiles, which
         /// can be a comma-separated list of filenames
         /// </summary>
-        protected CharArraySet GetWordSet(IResourceLoader loader, string wordFiles, bool ignoreCase)
+        protected virtual CharArraySet GetWordSet(IResourceLoader loader, string wordFiles, bool ignoreCase)
         {
             AssureMatchVersion();
             IList<string> files = SplitFileNames(wordFiles);
@@ -351,7 +351,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// Returns the resource's lines (with content treated as UTF-8)
         /// </summary>
-        protected IList<string> GetLines(IResourceLoader loader, string resource)
+        protected virtual IList<string> GetLines(IResourceLoader loader, string resource)
         {
             return WordlistLoader.GetLines(loader.OpenResource(resource), Encoding.UTF8);
         }
@@ -360,7 +360,7 @@ namespace Lucene.Net.Analysis.Util
         /// Same as <see cref="GetWordSet(IResourceLoader, string, bool)"/>,
         /// except the input is in snowball format. 
         /// </summary>
-        protected CharArraySet GetSnowballWordSet(IResourceLoader loader, string wordFiles, bool ignoreCase)
+        protected virtual CharArraySet GetSnowballWordSet(IResourceLoader loader, string wordFiles, bool ignoreCase)
         {
             AssureMatchVersion();
             IList<string> files = SplitFileNames(wordFiles);
@@ -388,7 +388,7 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="fileNames"> the string containing file names </param>
         /// <returns> a list of file names with the escaping backslashed removed </returns>
-        protected IList<string> SplitFileNames(string fileNames)
+        protected virtual IList<string> SplitFileNames(string fileNames)
         {
             if (fileNames is null)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
@@ -261,7 +261,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// Converts a sequence of unicode code points to a sequence of .NET characters. </summary>
         ///  <returns> the number of chars written to the destination buffer  </returns>
-        public virtual int ToChars(int[] src, int srcOff, int srcLen, char[] dest, int destOff)
+        public int ToChars(int[] src, int srcOff, int srcLen, char[] dest, int destOff)
         {
             if (srcLen < 0)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
@@ -261,7 +261,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// Converts a sequence of unicode code points to a sequence of .NET characters. </summary>
         ///  <returns> the number of chars written to the destination buffer  </returns>
-        public int ToChars(int[] src, int srcOff, int srcLen, char[] dest, int destOff)
+        public virtual int ToChars(int[] src, int srcOff, int srcLen, char[] dest, int destOff)
         {
             if (srcLen < 0)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizerImpl.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizerImpl.cs
@@ -703,7 +703,7 @@ namespace Lucene.Net.Analysis.Wikipedia
         /// in error fallback rules.
         /// </summary>
         /// <param name="errorCode">the code of the errormessage to display</param>
-        private void ZzScanError(int errorCode)
+        private static void ZzScanError(int errorCode) // LUCENENET: CA1822: Mark members as static
         {
             string message;
             // LUCENENET specific: Defensive check so we don't have to catch IndexOutOfRangeException

--- a/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizerFactory.cs
+++ b/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizerFactory.cs
@@ -143,7 +143,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
                 }
             }
 
-            private BreakIterator ParseRules(string filename, IResourceLoader loader)
+            private static BreakIterator ParseRules(string filename, IResourceLoader loader) // LUCENENET: CA1822: Mark members as static
             {
                 StringBuilder rules = new StringBuilder();
                 Stream rulesStream = loader.OpenResource(filename);

--- a/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
@@ -172,7 +172,7 @@ namespace Lucene.Net.Analysis.Ja
             return sb.ToString();
         }
 
-        private string FormatHeader()
+        private static string FormatHeader() // LUCENENET: CA1822: Mark members as static
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("digraph viterbi {\n");
@@ -187,7 +187,7 @@ namespace Lucene.Net.Analysis.Ja
             return sb.ToString();
         }
 
-        private string FormatTrailer()
+        private static string FormatTrailer() // LUCENENET: CA1822: Mark members as static
         {
             return "}";
         }

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/BinaryDictionaryWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/BinaryDictionaryWriter.cs
@@ -191,7 +191,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             return m_buffer.Position;
         }
 
-        private bool IsKatakana(string s)
+        private static bool IsKatakana(string s) // LUCENENET: CA1822: Mark members as static
         {
             for (int i = 0; i < s.Length; i++)
             {
@@ -212,7 +212,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             }
         }
 
-        private string ToKatakana(string s)
+        private static string ToKatakana(string s) // LUCENENET: CA1822: Mark members as static
         {
             char[] text = new char[s.Length];
             for (int i = 0; i < s.Length; i++)

--- a/src/Lucene.Net.Analysis.Morfologik/Morfologik/TokenAttributes/MorphosyntacticTagsAttribute.cs
+++ b/src/Lucene.Net.Analysis.Morfologik/Morfologik/TokenAttributes/MorphosyntacticTagsAttribute.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Analysis.Morfologik.TokenAttributes
             return false;
         }
 
-        private bool Equal(object l1, object l2)
+        private static bool Equal(object l1, object l2) // LUCENENET: CA1822: Mark members as static
         {
             return l1 is null ? (l2 is null) : (l1.Equals(l2));
         }

--- a/src/Lucene.Net.Analysis.Phonetic/Language/ColognePhonetic.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/ColognePhonetic.cs
@@ -475,7 +475,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// <summary>
         /// Converts the string to upper case and replaces germanic characters as defined in <see cref="PREPROCESS_MAP"/>.
         /// </summary>
-        private string Preprocess(string text)
+        private static string Preprocess(string text) // LUCENENET: CA1822: Mark members as static
         {
             text = LOCALE_GERMAN.TextInfo.ToUpper(text);
 

--- a/src/Lucene.Net.Analysis.Phonetic/Language/DoubleMetaphone.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/DoubleMetaphone.cs
@@ -251,7 +251,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// Handles 'A', 'E', 'I', 'O', 'U', and 'Y' cases.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int HandleAEIOUY(DoubleMetaphoneResult result, int index)
+        private static int HandleAEIOUY(DoubleMetaphoneResult result, int index) // LUCENENET: CA1822: Mark members as static
         {
             if (index == 0)
             {
@@ -415,7 +415,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// <summary>
         /// Handles 'D' cases.
         /// </summary>
-        private int HandleD(string value, DoubleMetaphoneResult result, int index)
+        private static int HandleD(string value, DoubleMetaphoneResult result, int index) // LUCENENET: CA1822: Mark members as static
         {
             if (Contains(value, index, 2, "DG"))
             {
@@ -830,7 +830,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// <summary>
         /// Handles 'T' cases.
         /// </summary>
-        private int HandleT(string value, DoubleMetaphoneResult result, int index)
+        private static int HandleT(string value, DoubleMetaphoneResult result, int index) // LUCENENET: CA1822: Mark members as static
         {
             if (Contains(value, index, 4, "TION"))
             {
@@ -918,7 +918,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// <summary>
         /// Handles 'X' cases.
         /// </summary>
-        private int HandleX(string value, DoubleMetaphoneResult result, int index)
+        private static int HandleX(string value, DoubleMetaphoneResult result, int index) // LUCENENET: CA1822: Mark members as static
         {
             if (index == 0)
             {
@@ -1076,7 +1076,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// of slavo-germanic origin if it contians any of 'W', 'K', 'CZ', or 'WITZ'.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool IsSlavoGermanic(string value)
+        private static bool IsSlavoGermanic(string value) // LUCENENET: CA1822: Mark members as static
         {
             return value.IndexOf('W') > -1 || value.IndexOf('K') > -1 ||
                 value.IndexOf("CZ", StringComparison.Ordinal) > -1 || value.IndexOf("WITZ", StringComparison.Ordinal) > -1;
@@ -1096,7 +1096,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// return <c>true</c> if the value starts with any of 'GN', 'KN',
         /// 'PN', 'WR' or 'PS'.
         /// </summary>
-        private bool IsSilentStart(string value)
+        private static bool IsSilentStart(string value) // LUCENENET: CA1822: Mark members as static
         {
             bool result = false;
             foreach (string element in SILENT_START)
@@ -1115,7 +1115,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// <summary>
         /// Cleans the input.
         /// </summary>
-        private string CleanInput(string input)
+        private static string CleanInput(string input) // LUCENENET: CA1822: Mark members as static
         {
             if (input is null)
             {

--- a/src/Lucene.Net.Analysis.Phonetic/Language/MatchRatingApproachEncoder.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/MatchRatingApproachEncoder.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">The name to be cleaned.</param>
         /// <returns>The cleaned name.</returns>
-        internal string CleanName(string name)
+        internal static string CleanName(string name) // LUCENENET: CA1822: Mark members as static
         {
             string upperName = LOCALE_ENGLISH.TextInfo.ToUpper(name);
 
@@ -135,7 +135,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">The string to get the substrings from.</param>
         /// <returns>Annexed first &amp; last 3 letters of input word.</returns>
-        internal string GetFirst3Last3(string name)
+        internal static string GetFirst3Last3(string name) // LUCENENET: CA1822: Mark members as static
         {
             int nameLength = name.Length;
 
@@ -157,7 +157,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="sumLength">The length of 2 strings sent down.</param>
         /// <returns>The min rating value.</returns>
-        internal int GetMinRating(int sumLength)
+        internal static int GetMinRating(int sumLength) // LUCENENET: CA1822: Mark members as static
         {
             int minRating; // LUCENENET: IDE0059: Remove unnecessary value assignment
 
@@ -271,7 +271,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// <param name="name1"></param>
         /// <param name="name2"></param>
         /// <returns></returns>
-        internal int LeftToRightThenRightToLeftProcessing(string name1, string name2)
+        internal static int LeftToRightThenRightToLeftProcessing(string name1, string name2) // LUCENENET: CA1822: Mark members as static
         {
             char[] name1Char = name1.ToCharArray();
             char[] name2Char = name2.ToCharArray();
@@ -366,7 +366,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">String to have double consonants removed.</param>
         /// <returns>Single consonant word.</returns>
-        internal string RemoveDoubleConsonants(string name)
+        internal static string RemoveDoubleConsonants(string name) // LUCENENET: CA1822: Mark members as static
         {
             string replacedName = name.ToUpperInvariant();
             foreach (string dc in DOUBLE_CONSONANT)
@@ -385,7 +385,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">The name to have vowels removed.</param>
         /// <returns>De-voweled word.</returns>
-        internal string RemoveVowels(string name)
+        internal static string RemoveVowels(string name) // LUCENENET: CA1822: Mark members as static
         {
             // Extract first letter
             string firstLetter = name.Substring(0, 1 - 0);

--- a/src/Lucene.Net.Analysis.Phonetic/Language/MatchRatingApproachEncoder.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/MatchRatingApproachEncoder.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">The name to be cleaned.</param>
         /// <returns>The cleaned name.</returns>
-        internal static string CleanName(string name) // LUCENENET: CA1822: Mark members as static
+        internal string CleanName(string name)
         {
             string upperName = LOCALE_ENGLISH.TextInfo.ToUpper(name);
 
@@ -135,7 +135,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">The string to get the substrings from.</param>
         /// <returns>Annexed first &amp; last 3 letters of input word.</returns>
-        internal static string GetFirst3Last3(string name) // LUCENENET: CA1822: Mark members as static
+        internal string GetFirst3Last3(string name)
         {
             int nameLength = name.Length;
 
@@ -157,7 +157,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="sumLength">The length of 2 strings sent down.</param>
         /// <returns>The min rating value.</returns>
-        internal static int GetMinRating(int sumLength) // LUCENENET: CA1822: Mark members as static
+        internal int GetMinRating(int sumLength)
         {
             int minRating; // LUCENENET: IDE0059: Remove unnecessary value assignment
 
@@ -271,7 +271,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// <param name="name1"></param>
         /// <param name="name2"></param>
         /// <returns></returns>
-        internal static int LeftToRightThenRightToLeftProcessing(string name1, string name2) // LUCENENET: CA1822: Mark members as static
+        internal int LeftToRightThenRightToLeftProcessing(string name1, string name2)
         {
             char[] name1Char = name1.ToCharArray();
             char[] name2Char = name2.ToCharArray();
@@ -366,7 +366,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">String to have double consonants removed.</param>
         /// <returns>Single consonant word.</returns>
-        internal static string RemoveDoubleConsonants(string name) // LUCENENET: CA1822: Mark members as static
+        internal string RemoveDoubleConsonants(string name)
         {
             string replacedName = name.ToUpperInvariant();
             foreach (string dc in DOUBLE_CONSONANT)
@@ -385,7 +385,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">The name to have vowels removed.</param>
         /// <returns>De-voweled word.</returns>
-        internal static string RemoveVowels(string name) // LUCENENET: CA1822: Mark members as static
+        internal string RemoveVowels(string name)
         {
             // Extract first letter
             string firstLetter = name.Substring(0, 1 - 0);

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Metaphone.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Metaphone.cs
@@ -398,12 +398,12 @@ namespace Lucene.Net.Analysis.Phonetic.Language
             return code.ToString();
         }
 
-        private bool IsVowel(StringBuilder sb, int index)
+        private static bool IsVowel(StringBuilder sb, int index) // LUCENENET: CA1822: Mark members as static
         {
             return VOWELS.IndexOf(sb[index]) >= 0;
         }
 
-        private bool IsPreviousChar(StringBuilder sb, int index, char c)
+        private static bool IsPreviousChar(StringBuilder sb, int index, char c) // LUCENENET: CA1822: Mark members as static
         {
             bool matches = false;
             if (index > 0 &&
@@ -414,7 +414,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
             return matches;
         }
 
-        private bool IsNextChar(StringBuilder sb, int index, char c)
+        private static bool IsNextChar(StringBuilder sb, int index, char c) // LUCENENET: CA1822: Mark members as static
         {
             bool matches = false;
             if (index >= 0 &&
@@ -425,7 +425,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
             return matches;
         }
 
-        private bool RegionMatch(StringBuilder sb, int index, string test)
+        private static bool RegionMatch(StringBuilder sb, int index, string test) // LUCENENET: CA1822: Mark members as static
         {
             bool matches = false;
             if (index >= 0 &&
@@ -437,7 +437,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
             return matches;
         }
 
-        private bool IsLastChar(int wdsz, int n)
+        private static bool IsLastChar(int wdsz, int n) // LUCENENET: CA1822: Mark members as static
         {
             return n + 1 == wdsz;
         }

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Soundex.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Soundex.cs
@@ -153,7 +153,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
             this.specialCaseHW = !HasMarker(this.soundexMapping);
         }
 
-        private bool HasMarker(char[] mapping)
+        private static bool HasMarker(char[] mapping) // LUCENENET: CA1822: Mark members as static
         {
             foreach (char ch in mapping)
             {

--- a/src/Lucene.Net.Analysis.Phonetic/PhoneticFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/PhoneticFilterFactory.cs
@@ -138,7 +138,7 @@ namespace Lucene.Net.Analysis.Phonetic
             GetEncoder();//trigger initialization for potential problems to be thrown now
         }
 
-        private Type ResolveEncoder(string name, IResourceLoader loader)
+        private static Type ResolveEncoder(string name, IResourceLoader loader) // LUCENENET: CA1822: Mark members as static
         {
             string lookupName = name;
             if (name.IndexOf('.') == -1)

--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/HHMMSegmenter.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/HHMMSegmenter.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
         /// </summary>
         /// <param name="sentence">input sentence, without start and end markers</param>
         /// <returns><see cref="SegGraph"/> corresponding to the input sentence.</returns>
-        private SegGraph CreateSegGraph(string sentence)
+        private static SegGraph CreateSegGraph(string sentence) // LUCENENET: CA1822: Mark members as static
         {
             int i = 0, j;
             int length = sentence.Length;

--- a/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/MultiTrie2.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/MultiTrie2.cs
@@ -349,7 +349,7 @@ namespace Egothor.Stemmer
             return m;
         }
 
-        private bool CannotFollow(char after, char goes)
+        private static bool CannotFollow(char after, char goes) // LUCENENET: CA1822: Mark members as static
         {
             switch (after)
             {
@@ -383,7 +383,7 @@ namespace Egothor.Stemmer
             return true;
         }
 
-        private int DashEven(string @in, int from)
+        private static int DashEven(string @in, int from) // LUCENENET: CA1822: Mark members as static
         {
             while (from < @in.Length)
             {
@@ -400,7 +400,7 @@ namespace Egothor.Stemmer
         }
 
 
-        private int LengthPP(string cmd)
+        private static int LengthPP(string cmd) // LUCENENET: CA1822: Mark members as static
         {
             int len = 0;
             for (int i = 0; i < cmd.Length; i++)

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/DirContentSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/DirContentSource.cs
@@ -154,7 +154,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         private int iteration = 0;
         private Enumerator inputFiles = null;
 
-        private DateTime? ParseDate(string dateStr)
+        private static DateTime? ParseDate(string dateStr) // LUCENENET: CA1822: Mark members as static
         {
             if (DateTime.TryParseExact(dateStr, "dd-MMM-yyyy hh:mm:ss.fff", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime temp))
             {

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
                 }
             }
 
-            internal string Time(string original)
+            internal static string Time(string original) // LUCENENET: CA1822: Mark members as static
             {
                 StringBuilder buffer = new StringBuilder();
 

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/ReutersContentSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/ReutersContentSource.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
 
         // LUCENENET specific: DateFormatInfo not used
 
-        private DateTime? ParseDate(string dateStr)
+        private static DateTime? ParseDate(string dateStr) // LUCENENET: CA1822: Mark members as static
         {
             if (DateTime.TryParseExact(dateStr, "dd-MMM-yyyy hh:mm:ss.fff", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime temp))
             {

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/Algorithm.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/Algorithm.cs
@@ -356,7 +356,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
             }
         }
 
-        private string[] InitTasksPackages(Config config)
+        private static string[] InitTasksPackages(Config config) // LUCENENET: CA1822: Mark members as static
         {
             // LUCENENET specific - changing the logic a bit
             // to add all referenced assemblies by default.

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/Config.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/Config.cs
@@ -375,7 +375,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
             return roundNumber;
         }
 
-        private string[] PropToStringArray(string s)
+        private static string[] PropToStringArray(string s) // LUCENENET: CA1822: Mark members as static
         {
             if (s.IndexOf(':') < 0)
             {
@@ -393,7 +393,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
         }
 
         // extract properties to array, e.g. for "10:100:5" return int[]{10,100,5}. 
-        private int[] PropToInt32Array(string s)
+        private static int[] PropToInt32Array(string s) // LUCENENET: CA1822: Mark members as static
         {
             if (s.IndexOf(':') < 0)
             {
@@ -416,7 +416,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
         }
 
         // extract properties to array, e.g. for "10.7:100.4:-2.3" return int[]{10.7,100.4,-2.3}. 
-        private double[] PropToDoubleArray(string s)
+        private static double[] PropToDoubleArray(string s) // LUCENENET: CA1822: Mark members as static
         {
             if (s.IndexOf(':') < 0)
             {
@@ -439,7 +439,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
         }
 
         // extract properties to array, e.g. for "true:true:false" return boolean[]{true,false,false}. 
-        private bool[] PropToBooleanArray(string s)
+        private static bool[] PropToBooleanArray(string s) // LUCENENET: CA1822: Mark members as static
         {
             if (s.IndexOf(':') < 0)
             {

--- a/src/Lucene.Net.Benchmark/Quality/QualityStats.cs
+++ b/src/Lucene.Net.Benchmark/Quality/QualityStats.cs
@@ -193,13 +193,13 @@ namespace Lucene.Net.Benchmarks.Quality
         }
 
         private const string padd = "                                    ";
-        private string Format(string s, int minLen)
+        private static string Format(string s, int minLen) // LUCENENET: CA1822: Mark members as static
         {
             s = (s ?? "");
             int n = Math.Max(minLen, s.Length);
             return (s + padd).Substring(0, n-0);
         }
-        private string FracFormat(string frac)
+        private static string FracFormat(string frac) // LUCENENET: CA1822: Mark members as static
         {
             int k = frac.IndexOf('.');
             string s1 = padd + frac.Substring(0, k-0);

--- a/src/Lucene.Net.Benchmark/Quality/Trec/TrecTopicsReader.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/TrecTopicsReader.cs
@@ -122,7 +122,7 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
         }
 
         // read until finding a line that starts with the specified prefix
-        private StringBuilder Read(TextReader reader, string prefix, StringBuilder sb, bool collectMatchLine, bool collectAll)
+        private static StringBuilder Read(TextReader reader, string prefix, StringBuilder sb, bool collectMatchLine, bool collectAll) // LUCENENET: CA1822: Mark members as static
         {
             sb = sb ?? new StringBuilder();
             string sep = "";

--- a/src/Lucene.Net.Benchmark/Quality/Utils/SubmissionReport.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Utils/SubmissionReport.cs
@@ -88,7 +88,7 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
         }
 
         private const string padd = "                                    ";
-        private string Format(string s, int minLen)
+        private static string Format(string s, int minLen) // LUCENENET: CA1822: Mark members as static
         {
             s = (s ?? "");
             int n = Math.Max(minLen, s.Length);

--- a/src/Lucene.Net.Benchmark/Support/Sax/Helpers/AttributesImpl.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/Helpers/AttributesImpl.cs
@@ -594,7 +594,7 @@ namespace Sax.Helpers
         /// </summary>
         /// <param name="index">The index to report.</param>
         /// <exception cref="IndexOutOfRangeException">Always.</exception>
-        private void BadIndex(int index)
+        private static void BadIndex(int index) // LUCENENET: CA1822: Mark members as static
         {
             string msg =
                 "Attempt to modify attribute at illegal index: " + index;

--- a/src/Lucene.Net.Benchmark/Support/TagSoup/Parser.cs
+++ b/src/Lucene.Net.Benchmark/Support/TagSoup/Parser.cs
@@ -1147,7 +1147,7 @@ namespace TagSoup
         /// </summary>
         /// <param name="src"></param>
         /// <returns></returns>
-        private string CleanPublicId(string src)
+        private static string CleanPublicId(string src) // LUCENENET: CA1822: Mark members as static
         {
             if (src is null)
             {

--- a/src/Lucene.Net.Codecs/BlockTerms/BlockTermsWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/BlockTermsWriter.cs
@@ -118,7 +118,7 @@ namespace Lucene.Net.Codecs.BlockTerms
             }
         }
 
-        private void WriteHeader(IndexOutput output)
+        private static void WriteHeader(IndexOutput output) // LUCENENET: CA1822: Mark members as static
         {
             CodecUtil.WriteHeader(output, CODEC_NAME, VERSION_CURRENT);
         }

--- a/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexWriter.cs
@@ -77,7 +77,7 @@ namespace Lucene.Net.Codecs.BlockTerms
             }
         }
 
-        private void WriteHeader(IndexOutput output)
+        private static void WriteHeader(IndexOutput output) // LUCENENET: CA1822: Mark members as static
         {
             CodecUtil.WriteHeader(output, CODEC_NAME, VERSION_CURRENT);
         }

--- a/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexWriter.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexWriter.cs
@@ -203,7 +203,7 @@ namespace Lucene.Net.Codecs.BlockTerms
             }
         }
 
-        private void WriteHeader(IndexOutput output)
+        private static void WriteHeader(IndexOutput output) // LUCENENET: CA1822: Mark members as static
         {
             CodecUtil.WriteHeader(output, CODEC_NAME, VERSION_CURRENT);
         }

--- a/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
@@ -119,7 +119,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private int ReadHeader(IndexInput @in)
+        private static int ReadHeader(IndexInput @in) // LUCENENET: CA1822: Mark members as static
         {
             return CodecUtil.CheckHeader(@in, FSTOrdTermsWriter.TERMS_CODEC_NAME, FSTOrdTermsWriter.TERMS_VERSION_START, FSTOrdTermsWriter.TERMS_VERSION_CURRENT);
         }
@@ -137,7 +137,7 @@ namespace Lucene.Net.Codecs.Memory
             @in.Seek(@in.ReadInt64());
         }
 
-        private void CheckFieldSummary(SegmentInfo info, IndexInput indexIn, IndexInput blockIn, TermsReader field, TermsReader previous)
+        private static void CheckFieldSummary(SegmentInfo info, IndexInput indexIn, IndexInput blockIn, TermsReader field, TermsReader previous) // LUCENENET: CA1822: Mark members as static
         {
             // #docs with field must be <= #docs
             if (field.docCount < 0 || field.docCount > info.DocCount)

--- a/src/Lucene.Net.Codecs/Memory/FSTOrdTermsWriter.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTOrdTermsWriter.cs
@@ -239,12 +239,12 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private void WriteHeader(IndexOutput @out)
+        private static void WriteHeader(IndexOutput @out) // LUCENENET: CA1822: Mark members as static
         {
             CodecUtil.WriteHeader(@out, TERMS_CODEC_NAME, TERMS_VERSION_CURRENT);
         }
 
-        private void WriteTrailer(IndexOutput output, long dirStart)
+        private static void WriteTrailer(IndexOutput output, long dirStart) // LUCENENET: CA1822: Mark members as static
         {
             output.WriteInt64(dirStart);
         }

--- a/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
@@ -116,7 +116,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private int ReadHeader(IndexInput @in)
+        private static int ReadHeader(IndexInput @in) // LUCENENET: CA1822: Mark members as static
         {
             return CodecUtil.CheckHeader(@in, FSTTermsWriter.TERMS_CODEC_NAME, FSTTermsWriter.TERMS_VERSION_START, FSTTermsWriter.TERMS_VERSION_CURRENT);
         }
@@ -135,7 +135,7 @@ namespace Lucene.Net.Codecs.Memory
         }
 
 
-        private void CheckFieldSummary(SegmentInfo info, IndexInput @in, TermsReader field, TermsReader previous)
+        private static void CheckFieldSummary(SegmentInfo info, IndexInput @in, TermsReader field, TermsReader previous) // LUCENENET: CA1822: Mark members as static
         {
             // #docs with field must be <= #docs
             if (field.docCount < 0 || field.docCount > info.DocCount)

--- a/src/Lucene.Net.Codecs/Memory/FSTTermsWriter.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermsWriter.cs
@@ -152,12 +152,12 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private void WriteHeader(IndexOutput output)
+        private static void WriteHeader(IndexOutput output) // LUCENENET: CA1822: Mark members as static
         {
             CodecUtil.WriteHeader(output, TERMS_CODEC_NAME, TERMS_VERSION_CURRENT);
         }
 
-        private void WriteTrailer(IndexOutput output, long dirStart)
+        private static void WriteTrailer(IndexOutput output, long dirStart) // LUCENENET: CA1822: Mark members as static
         {
             output.WriteInt64(dirStart);
         }

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldInfosReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldInfosReader.cs
@@ -164,7 +164,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return "false".Equals(dvType, StringComparison.Ordinal) ? Index.DocValuesType.NONE : (Index.DocValuesType)Enum.Parse(typeof(Index.DocValuesType), dvType, true);
         }
 
-        private string ReadString(int offset, BytesRef scratch)
+        private static string ReadString(int offset, BytesRef scratch) // LUCENENET: CA1822: Mark members as static
         {
             return Encoding.UTF8.GetString(scratch.Bytes, scratch.Offset + offset, scratch.Length - offset);
         }

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextLiveDocsFormat.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextLiveDocsFormat.cs
@@ -115,7 +115,7 @@ namespace Lucene.Net.Codecs.SimpleText
         /// <summary>
         /// NOTE: This was parseIntAt() in Lucene.
         /// </summary>
-        private int ParseInt32At(BytesRef bytes, int offset, CharsRef scratch)
+        private static int ParseInt32At(BytesRef bytes, int offset, CharsRef scratch) // LUCENENET: CA1822: Mark members as static
         {
             UnicodeUtil.UTF8toUTF16(bytes.Bytes, bytes.Offset + offset, bytes.Length - offset, scratch);
             return ArrayUtil.ParseInt32(scratch.Chars, 0, scratch.Length);

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextSegmentInfoReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextSegmentInfoReader.cs
@@ -115,7 +115,7 @@ namespace Lucene.Net.Codecs.SimpleText
             }
         }
 
-        private string ReadString(int offset, BytesRef scratch)
+        private static string ReadString(int offset, BytesRef scratch) // LUCENENET: CA1822: Mark members as static
         {
             return Encoding.UTF8.GetString(scratch.Bytes, scratch.Offset + offset, scratch.Length - offset);
         }

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextStoredFieldsReader.cs
@@ -260,7 +260,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return ArrayUtil.ParseInt32(_scratchUtf16.Chars, 0, _scratchUtf16.Length);
         }
 
-        private bool EqualsAt(BytesRef a, BytesRef b, int bOffset)
+        private static bool EqualsAt(BytesRef a, BytesRef b, int bOffset) // LUCENENET: CA1822: Mark members as static
         {
             return a.Length == b.Length - bOffset &&
                    ArrayUtil.Equals(a.Bytes, a.Offset, b.Bytes, b.Offset + bOffset, b.Length - bOffset);

--- a/src/Lucene.Net.Facet/FacetsConfig.cs
+++ b/src/Lucene.Net.Facet/FacetsConfig.cs
@@ -488,7 +488,7 @@ namespace Lucene.Net.Facet
             }
         }
 
-        private void ProcessSSDVFacetFields(IDictionary<string, IList<SortedSetDocValuesFacetField>> byField, Document doc)
+        private static void ProcessSSDVFacetFields(IDictionary<string, IList<SortedSetDocValuesFacetField>> byField, Document doc) // LUCENENET: CA1822: Mark members as static
         {
             //System.out.println("process SSDV: " + byField);
             foreach (KeyValuePair<string, IList<SortedSetDocValuesFacetField>> ent in byField)
@@ -513,7 +513,7 @@ namespace Lucene.Net.Facet
             }
         }
 
-        private void ProcessAssocFacetFields(ITaxonomyWriter taxoWriter, IDictionary<string, IList<AssociationFacetField>> byField, Document doc)
+        private static void ProcessAssocFacetFields(ITaxonomyWriter taxoWriter, IDictionary<string, IList<AssociationFacetField>> byField, Document doc) // LUCENENET: CA1822: Mark members as static
         {
             foreach (KeyValuePair<string, IList<AssociationFacetField>> ent in byField)
             {

--- a/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
@@ -170,7 +170,7 @@ namespace Lucene.Net.Facet.Taxonomy
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void NoDelimiter(char[] buf, int offset, int len, char delimiter)
+        private static void NoDelimiter(char[] buf, int offset, int len, char delimiter) // LUCENENET: CA1822: Mark members as static
         {
             for (int idx = 0; idx < len; idx++)
             {

--- a/src/Lucene.Net.Grouping/Term/TermDistinctValuesCollector.cs
+++ b/src/Lucene.Net.Grouping/Term/TermDistinctValuesCollector.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Search.Grouping.Terms
             }
         }
 
-        private bool DoesNotContainOrd(int ord, int[] ords)
+        private static bool DoesNotContainOrd(int ord, int[] ords) // LUCENENET: CA1822: Mark members as static
         {
             if (ords.Length == 0)
             {

--- a/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
@@ -231,7 +231,7 @@ namespace Lucene.Net.Index.Memory
                     info.SortTerms();
                 }
 
-                internal int BinarySearch(BytesRef b, BytesRef bytesRef, int low, int high, BytesRefHash hash, int[] ords, IComparer<BytesRef> comparer)
+                internal static int BinarySearch(BytesRef b, BytesRef bytesRef, int low, int high, BytesRefHash hash, int[] ords, IComparer<BytesRef> comparer) // LUCENENET: CA1822: Mark members as static
                 {
                     int mid; // LUCENENET: IDE0059: Remove unnecessary value assignment
                     while (low <= high)

--- a/src/Lucene.Net.Misc/Index/PKIndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/PKIndexSplitter.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void CreateIndex(IndexWriterConfig config, Directory target, IndexReader reader, Filter preserveFilter, bool negateFilter)
+        private static void CreateIndex(IndexWriterConfig config, Directory target, IndexReader reader, Filter preserveFilter, bool negateFilter) // LUCENENET: CA1822: Mark members as static
         {
             bool success = false;
             IndexWriter w = new IndexWriter(target, config);

--- a/src/Lucene.Net.Queries/CommonTermsQuery.cs
+++ b/src/Lucene.Net.Queries/CommonTermsQuery.cs
@@ -180,7 +180,7 @@ namespace Lucene.Net.Queries
             return MinNrShouldMatch(m_highFreqMinNrShouldMatch, numOptional);
         }
 
-        private int MinNrShouldMatch(float minNrShouldMatch, int numOptional)
+        private static int MinNrShouldMatch(float minNrShouldMatch, int numOptional) // LUCENENET: CA1822: Mark members as static
         {
             if (minNrShouldMatch >= 1.0f || minNrShouldMatch == 0.0f)
             {

--- a/src/Lucene.Net.QueryParser/Classic/MultiFieldQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Classic/MultiFieldQueryParser.cs
@@ -137,7 +137,7 @@ namespace Lucene.Net.QueryParsers.Classic
             return q2;
         }
 
-        private void ApplySlop(Query q, int slop)
+        private static void ApplySlop(Query q, int slop) // LUCENENET: CA1822: Mark members as static
         {
             if (q is PhraseQuery phraseQuery)
             {

--- a/src/Lucene.Net.QueryParser/Flexible/Precedence/Processors/BooleanModifiersQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Precedence/Processors/BooleanModifiersQueryNodeProcessor.cs
@@ -93,7 +93,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence.Processors
             return node;
         }
 
-        private IQueryNode ApplyModifier(IQueryNode node, Modifier mod)
+        private static IQueryNode ApplyModifier(IQueryNode node, Modifier mod) // LUCENENET: CA1822: Mark members as static
         {
             // check if modifier is not already defined and is default
             if (!(node is ModifierQueryNode modNode))

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/EscapeQuerySyntaxImpl.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/EscapeQuerySyntaxImpl.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
             return buffer;
         }
 
-        private ICharSequence EscapeQuoted(ICharSequence str, CultureInfo locale)
+        private static ICharSequence EscapeQuoted(ICharSequence str, CultureInfo locale) // LUCENENET: CA1822: Mark members as static
         {
             if (str is null || str.Length == 0)
                 return str;

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/BooleanQuery2ModifierNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/BooleanQuery2ModifierNodeProcessor.cs
@@ -167,7 +167,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
             return toTest != null && typeof(BooleanQueryNode).Equals(toTest.GetType());
         }
 
-        private IQueryNode ApplyModifier(IQueryNode node, Modifier mod)
+        private static IQueryNode ApplyModifier(IQueryNode node, Modifier mod) // LUCENENET: CA1822: Mark members as static
         {
             // check if modifier is not already defined and is default
             if (!(node is ModifierQueryNode modNode))

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/WildcardQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/WildcardQueryNodeProcessor.cs
@@ -93,7 +93,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
             return false;
         }
 
-        private bool IsPrefixWildcard(string text)
+        private static bool IsPrefixWildcard(string text) // LUCENENET: CA1822: Mark members as static
         {
             if (text is null || text.Length <= 0 || !IsWildcard(text)) return false;
 

--- a/src/Lucene.Net.Suggest/Spell/JaroWinklerDistance.cs
+++ b/src/Lucene.Net.Suggest/Spell/JaroWinklerDistance.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Search.Spell
         {
         }
 
-        private int[] Matches(string s1, string s2)
+        private static int[] Matches(string s1, string s2) // LUCENENET: CA1822: Mark members as static
         {
             string max, min;
             if (s1.Length > s2.Length)

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
@@ -866,7 +866,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
         /// <summary>
         /// weight -> cost </summary>
-        private long EncodeWeight(long ngramCount)
+        private static long EncodeWeight(long ngramCount) // LUCENENET: CA1822: Mark members as static
         {
             return long.MaxValue - ngramCount;
         }
@@ -881,7 +881,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         }
 
         // NOTE: copied from WFSTCompletionLookup & tweaked
-        private Int64 LookupPrefix(FST<Int64> fst, FST.BytesReader bytesReader, BytesRef scratch, FST.Arc<Int64> arc)
+        private static Int64 LookupPrefix(FST<Int64> fst, FST.BytesReader bytesReader, BytesRef scratch, FST.Arc<Int64> arc) // LUCENENET: CA1822: Mark members as static
         {
 
             Int64 output = fst.Outputs.NoOutput;

--- a/src/Lucene.Net.Suggest/Suggest/DocumentDictionary.cs
+++ b/src/Lucene.Net.Suggest/Suggest/DocumentDictionary.cs
@@ -229,7 +229,7 @@ namespace Lucene.Net.Search.Suggest
                 }
             }
 
-            private ISet<string> GetRelevantFields(params string[] fields)
+            private static ISet<string> GetRelevantFields(params string[] fields) // LUCENENET: CA1822: Mark members as static
             {
                 var relevantFields = new JCG.HashSet<string>();
                 foreach (string relevantField in fields)

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
@@ -343,7 +343,7 @@ namespace Lucene.Net.Search.Suggest.Fst
         /// Returns <c>true</c> if and only if <paramref name="list"/> contained
         /// <paramref name="key"/>.
         /// </returns>
-        private bool CheckExistingAndReorder(IList<Completion> list, BytesRef key)
+        private static bool CheckExistingAndReorder(IList<Completion> list, BytesRef key) // LUCENENET: CA1822: Mark members as static
         {
             // We assume list does not have duplicates (because of how the FST is created).
             for (int i = list.Count; --i >= 0; )

--- a/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
@@ -206,23 +206,23 @@ namespace Lucene.Net.Analysis
             Search.Query queryY = new TermQuery(new Term("contents", "y"));
 
             sort.SetSort(new SortField("US", SortFieldType.STRING));
-            this.AssertMatches(searcher, queryY, sort, usResult);
+            AssertMatches(searcher, queryY, sort, usResult);
 
             sort.SetSort(new SortField("France", SortFieldType.STRING));
-            this.AssertMatches(searcher, queryX, sort, frResult);
+            AssertMatches(searcher, queryX, sort, frResult);
 
             sort.SetSort(new SortField("Sweden", SortFieldType.STRING));
-            this.AssertMatches(searcher, queryY, sort, svResult);
+            AssertMatches(searcher, queryY, sort, svResult);
 
             sort.SetSort(new SortField("Denmark", SortFieldType.STRING));
-            this.AssertMatches(searcher, queryY, sort, dkResult);
+            AssertMatches(searcher, queryY, sort, dkResult);
         }
 
         /// <summary>
         /// Make sure the documents returned by the search match the expected list
         /// </summary>
         // Copied from TestSort.java
-        private void AssertMatches(IndexSearcher searcher, Search.Query query, Sort sort, string expectedResult)
+        private static void AssertMatches(IndexSearcher searcher, Search.Query query, Sort sort, string expectedResult) // LUCENENET: CA1822: Mark members as static
         {
             ScoreDoc[] result = searcher.Search(query, null, 1000, sort).ScoreDocs;
             StringBuilder buff = new StringBuilder(10);

--- a/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
@@ -1262,7 +1262,7 @@ namespace Lucene.Net.Index
             internal abstract long Next();
         }
 
-        private void DoTestNumericsVsStoredFields(long minValue, long maxValue)
+        private static void DoTestNumericsVsStoredFields(long minValue, long maxValue) // LUCENENET: CA1822: Mark members as static
         {
             DoTestNumericsVsStoredFields(new Int64ProducerAnonymousClass(minValue, maxValue));
         }
@@ -1344,7 +1344,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void DoTestMissingVsFieldCache(long minValue, long maxValue)
+        private static void DoTestMissingVsFieldCache(long minValue, long maxValue) // LUCENENET: CA1822: Mark members as static
         {
             DoTestMissingVsFieldCache(new Int64ProducerAnonymousClass2(minValue, maxValue));
         }
@@ -1518,7 +1518,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void DoTestBinaryVsStoredFields(int minLength, int maxLength)
+        private static void DoTestBinaryVsStoredFields(int minLength, int maxLength) // LUCENENET: CA1822: Mark members as static
         {
             using Directory dir = NewDirectory();
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));
@@ -1604,7 +1604,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void DoTestSortedVsStoredFields(int minLength, int maxLength)
+        private static void DoTestSortedVsStoredFields(int minLength, int maxLength) // LUCENENET: CA1822: Mark members as static
         {
             using Directory dir = NewDirectory();
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));
@@ -1669,7 +1669,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void DoTestSortedVsFieldCache(int minLength, int maxLength)
+        private static void DoTestSortedVsFieldCache(int minLength, int maxLength) // LUCENENET: CA1822: Mark members as static
         {
             using Directory dir = NewDirectory();
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));
@@ -2316,7 +2316,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void DoTestSortedSetVsStoredFields(int minLength, int maxLength, int maxValuesPerDoc)
+        private static void DoTestSortedSetVsStoredFields(int minLength, int maxLength, int maxValuesPerDoc) // LUCENENET: CA1822: Mark members as static
         {
             using Directory dir = NewDirectory();
             IndexWriterConfig conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));
@@ -2575,7 +2575,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void DoTestSortedSetVsUninvertedField(int minLength, int maxLength)
+        private static void DoTestSortedSetVsUninvertedField(int minLength, int maxLength) // LUCENENET: CA1822: Mark members as static
         {
             using Directory dir = NewDirectory();
             IndexWriterConfig conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));

--- a/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
@@ -520,7 +520,7 @@ namespace Lucene.Net.Index
                                         //if (VERBOSE) {
                                         //System.out.println(Thread.currentThread().getName() + " now search body:" + term.Utf8ToString());
                                         //}
-                                        totHits.AddAndGet(outerInstance.RunQuery(s, new TermQuery(new Term("body", termsEnum.Term))));
+                                        totHits.AddAndGet(RunQuery(s, new TermQuery(new Term("body", termsEnum.Term))));
                                     }
                                 }
                                 //if (VERBOSE) {
@@ -906,7 +906,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private int RunQuery(IndexSearcher s, Query q)
+        private static int RunQuery(IndexSearcher s, Query q) // LUCENENET: CA1822: Mark members as static
         {
             s.Search(q, 10);
             int hitCount = s.Search(q, null, 10, new Sort(new SortField("title", SortFieldType.STRING))).TotalHits;

--- a/src/Lucene.Net.TestFramework/Support/Util/LuceneRandomSeedInitializer.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LuceneRandomSeedInitializer.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Util
         /// <param name="seed">The random seed for a new <see cref="Random"/> instance.
         /// Note this is a subclass of <see cref="Random"/>, since the default doesn't produce consistent results across platforms.</param>
         /// <returns><c>true</c> if the seed was found in context; <c>false</c> if the seed was generated.</returns>
-        private bool TryGetRandomSeedsFromContext(Test test, out long seed, out long? testSeed)
+        private static bool TryGetRandomSeedsFromContext(Test test, out long seed, out long? testSeed) // LUCENENET: CA1822: Mark members as static
         {
             //bool generate;
             seed = default;

--- a/src/Lucene.Net.TestFramework/Support/Util/LuceneRandomSeedInitializer.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LuceneRandomSeedInitializer.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Util
         /// <param name="seed">The random seed for a new <see cref="Random"/> instance.
         /// Note this is a subclass of <see cref="Random"/>, since the default doesn't produce consistent results across platforms.</param>
         /// <returns><c>true</c> if the seed was found in context; <c>false</c> if the seed was generated.</returns>
-        private static bool TryGetRandomSeedsFromContext(Test test, out long seed, out long? testSeed) // LUCENENET: CA1822: Mark members as static
+        private static bool TryGetRandomSeedsFromContext(Test test, out long seed, out long? testSeed)
         {
             //bool generate;
             seed = default;

--- a/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
@@ -276,7 +276,7 @@ namespace Lucene.Net.Util
         /// // tight loop with many invocations.
         /// </code>
         /// </summary>
-        protected static Random Random => LuceneTestCase.Random; // LUCENENET: CA1822: Mark members as static
+        protected Random Random => LuceneTestCase.Random;
 
         /// <summary>
         /// Overridden in a derived class, provides a way to set <see cref="CodecFactory"/>,

--- a/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
@@ -276,7 +276,7 @@ namespace Lucene.Net.Util
         /// // tight loop with many invocations.
         /// </code>
         /// </summary>
-        protected Random Random => LuceneTestCase.Random;
+        protected static Random Random => LuceneTestCase.Random; // LUCENENET: CA1822: Mark members as static
 
         /// <summary>
         /// Overridden in a derived class, provides a way to set <see cref="CodecFactory"/>,

--- a/src/Lucene.Net.TestFramework/Support/Util/UseTempLineDocsFileRule.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/UseTempLineDocsFileRule.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Util
     {
         private bool lineFileDocsExtracted;
 
-        private bool IsEnabled()
+        private static bool IsEnabled() // LUCENENET: CA1822: Mark members as static
         {
             bool enabled = false;
             Assembly assembly = RandomizedContext.CurrentContext.CurrentTestAssembly;

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -3166,7 +3166,7 @@ namespace Lucene.Net.Util
         // LUCENENET specific - moved this here so we can reference it more readily (similar to how Spatial does it).
         // However, this is also available as an extension method of the System.Random class in RandomizedTesting.Generators.
         // This method was originally in carrotsearch.randomizedtesting.RandomizedTest.
-        public double RandomGaussian()
+        public static double RandomGaussian() // LUCENENET: CA1822: Mark members as static
         {
             return Random.NextGaussian();
         }

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/Language/MatchRatingApproachEncoderTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/Language/MatchRatingApproachEncoderTest.cs
@@ -90,19 +90,19 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         [Test]
         public void TestRemoveSingleDoubleConsonants_BUBLE_RemovedSuccessfully()
         {
-            Assert.AreEqual("BUBLE", this.StringEncoder.RemoveDoubleConsonants("BUBBLE"));
+            Assert.AreEqual("BUBLE", MatchRatingApproachEncoder.RemoveDoubleConsonants("BUBBLE"));
         }
 
         [Test]
         public void TestRemoveDoubleConsonants_MISSISSIPPI_RemovedSuccessfully()
         {
-            Assert.AreEqual("MISISIPI", this.StringEncoder.RemoveDoubleConsonants("MISSISSIPPI"));
+            Assert.AreEqual("MISISIPI", MatchRatingApproachEncoder.RemoveDoubleConsonants("MISSISSIPPI"));
         }
 
         [Test]
         public void TestRemoveDoubleDoubleVowel_BEETLE_NotRemoved()
         {
-            Assert.AreEqual("BEETLE", this.StringEncoder.RemoveDoubleConsonants("BEETLE"));
+            Assert.AreEqual("BEETLE", MatchRatingApproachEncoder.RemoveDoubleConsonants("BEETLE"));
         }
 
         [Test]
@@ -120,115 +120,115 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         [Test]
         public void TestRemoveVowel_ALESSANDRA_Returns_ALSSNDR()
         {
-            Assert.AreEqual("ALSSNDR", this.StringEncoder.RemoveVowels("ALESSANDRA"));
+            Assert.AreEqual("ALSSNDR", MatchRatingApproachEncoder.RemoveVowels("ALESSANDRA"));
         }
 
         [Test]
         public void TestRemoveVowel__AIDAN_Returns_ADN()
         {
-            Assert.AreEqual("ADN", this.StringEncoder.RemoveVowels("AIDAN"));
+            Assert.AreEqual("ADN", MatchRatingApproachEncoder.RemoveVowels("AIDAN"));
         }
 
         [Test]
         public void TestRemoveVowel__DECLAN_Returns_DCLN()
         {
-            Assert.AreEqual("DCLN", this.StringEncoder.RemoveVowels("DECLAN"));
+            Assert.AreEqual("DCLN", MatchRatingApproachEncoder.RemoveVowels("DECLAN"));
         }
 
         [Test]
         public void TestGetFirstLast3__ALEXANDER_Returns_Aleder()
         {
-            Assert.AreEqual("Aleder", this.StringEncoder.GetFirst3Last3("Alexzander"));
+            Assert.AreEqual("Aleder", MatchRatingApproachEncoder.GetFirst3Last3("Alexzander"));
         }
 
         [Test]
         public void TestGetFirstLast3_PETE_Returns_PETE()
         {
-            Assert.AreEqual("PETE", this.StringEncoder.GetFirst3Last3("PETE"));
+            Assert.AreEqual("PETE", MatchRatingApproachEncoder.GetFirst3Last3("PETE"));
         }
 
         [Test]
         public void TestleftTorightThenRightToLeft_ALEXANDER_ALEXANDRA_Returns4()
         {
-            Assert.AreEqual(4, this.StringEncoder.LeftToRightThenRightToLeftProcessing("ALEXANDER", "ALEXANDRA"));
+            Assert.AreEqual(4, MatchRatingApproachEncoder.LeftToRightThenRightToLeftProcessing("ALEXANDER", "ALEXANDRA"));
         }
 
         [Test]
         public void TestleftTorightThenRightToLeft_EINSTEIN_MICHAELA_Returns0()
         {
-            Assert.AreEqual(0, this.StringEncoder.LeftToRightThenRightToLeftProcessing("EINSTEIN", "MICHAELA"));
+            Assert.AreEqual(0, MatchRatingApproachEncoder.LeftToRightThenRightToLeftProcessing("EINSTEIN", "MICHAELA"));
         }
 
         [Test]
         public void TestGetMinRating_7_Return4_Successfully()
         {
-            Assert.AreEqual(4, this.StringEncoder.GetMinRating(7));
+            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(7));
         }
 
         [Test]
         public void TestGetMinRating_1_Returns5_Successfully()
         {
-            Assert.AreEqual(5, this.StringEncoder.GetMinRating(1));
+            Assert.AreEqual(5, MatchRatingApproachEncoder.GetMinRating(1));
         }
 
         [Test]
         public void TestGetMinRating_2_Returns5_Successfully()
         {
-            Assert.AreEqual(5, this.StringEncoder.GetMinRating(2));
+            Assert.AreEqual(5, MatchRatingApproachEncoder.GetMinRating(2));
         }
 
         [Test]
         public void TestGetMinRating_5_Returns4_Successfully()
         {
-            Assert.AreEqual(4, this.StringEncoder.GetMinRating(5));
+            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(5));
         }
 
         [Test]
         public void TestGetMinRating_5_Returns4_Successfully2()
         {
-            Assert.AreEqual(4, this.StringEncoder.GetMinRating(5));
+            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(5));
         }
 
         [Test]
         public void TestGetMinRating_6_Returns4_Successfully()
         {
-            Assert.AreEqual(4, this.StringEncoder.GetMinRating(6));
+            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(6));
         }
 
         [Test]
         public void TestGetMinRating_7_Returns4_Successfully()
         {
-            Assert.AreEqual(4, this.StringEncoder.GetMinRating(7));
+            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(7));
         }
 
         [Test]
         public void TestGetMinRating_8_Returns3_Successfully()
         {
-            Assert.AreEqual(3, this.StringEncoder.GetMinRating(8));
+            Assert.AreEqual(3, MatchRatingApproachEncoder.GetMinRating(8));
         }
 
         [Test]
         public void TestGetMinRating_10_Returns3_Successfully()
         {
-            Assert.AreEqual(3, this.StringEncoder.GetMinRating(10));
+            Assert.AreEqual(3, MatchRatingApproachEncoder.GetMinRating(10));
         }
 
         [Test]
         public void TestGetMinRating_11_Returns_3_Successfully()
         {
-            Assert.AreEqual(3, this.StringEncoder.GetMinRating(11));
+            Assert.AreEqual(3, MatchRatingApproachEncoder.GetMinRating(11));
         }
 
         [Test]
         public void TestGetMinRating_13_Returns_1_Successfully()
         {
-            Assert.AreEqual(1, this.StringEncoder.GetMinRating(13));
+            Assert.AreEqual(1, MatchRatingApproachEncoder.GetMinRating(13));
         }
 
         [Test]
         public void TestCleanName_SuccessfullyClean()
         {
-            Assert.AreEqual("THISISATEST", this.StringEncoder.CleanName("This-ís   a t.,es &t"));
+            Assert.AreEqual("THISISATEST", MatchRatingApproachEncoder.CleanName("This-ís   a t.,es &t"));
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/Language/MatchRatingApproachEncoderTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/Language/MatchRatingApproachEncoderTest.cs
@@ -90,19 +90,19 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         [Test]
         public void TestRemoveSingleDoubleConsonants_BUBLE_RemovedSuccessfully()
         {
-            Assert.AreEqual("BUBLE", MatchRatingApproachEncoder.RemoveDoubleConsonants("BUBBLE"));
+            Assert.AreEqual("BUBLE", this.StringEncoder.RemoveDoubleConsonants("BUBBLE"));
         }
 
         [Test]
         public void TestRemoveDoubleConsonants_MISSISSIPPI_RemovedSuccessfully()
         {
-            Assert.AreEqual("MISISIPI", MatchRatingApproachEncoder.RemoveDoubleConsonants("MISSISSIPPI"));
+            Assert.AreEqual("MISISIPI", this.StringEncoder.RemoveDoubleConsonants("MISSISSIPPI"));
         }
 
         [Test]
         public void TestRemoveDoubleDoubleVowel_BEETLE_NotRemoved()
         {
-            Assert.AreEqual("BEETLE", MatchRatingApproachEncoder.RemoveDoubleConsonants("BEETLE"));
+            Assert.AreEqual("BEETLE", this.StringEncoder.RemoveDoubleConsonants("BEETLE"));
         }
 
         [Test]
@@ -120,115 +120,115 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         [Test]
         public void TestRemoveVowel_ALESSANDRA_Returns_ALSSNDR()
         {
-            Assert.AreEqual("ALSSNDR", MatchRatingApproachEncoder.RemoveVowels("ALESSANDRA"));
+            Assert.AreEqual("ALSSNDR", this.StringEncoder.RemoveVowels("ALESSANDRA"));
         }
 
         [Test]
         public void TestRemoveVowel__AIDAN_Returns_ADN()
         {
-            Assert.AreEqual("ADN", MatchRatingApproachEncoder.RemoveVowels("AIDAN"));
+            Assert.AreEqual("ADN", this.StringEncoder.RemoveVowels("AIDAN"));
         }
 
         [Test]
         public void TestRemoveVowel__DECLAN_Returns_DCLN()
         {
-            Assert.AreEqual("DCLN", MatchRatingApproachEncoder.RemoveVowels("DECLAN"));
+            Assert.AreEqual("DCLN", this.StringEncoder.RemoveVowels("DECLAN"));
         }
 
         [Test]
         public void TestGetFirstLast3__ALEXANDER_Returns_Aleder()
         {
-            Assert.AreEqual("Aleder", MatchRatingApproachEncoder.GetFirst3Last3("Alexzander"));
+            Assert.AreEqual("Aleder", this.StringEncoder.GetFirst3Last3("Alexzander"));
         }
 
         [Test]
         public void TestGetFirstLast3_PETE_Returns_PETE()
         {
-            Assert.AreEqual("PETE", MatchRatingApproachEncoder.GetFirst3Last3("PETE"));
+            Assert.AreEqual("PETE", this.StringEncoder.GetFirst3Last3("PETE"));
         }
 
         [Test]
         public void TestleftTorightThenRightToLeft_ALEXANDER_ALEXANDRA_Returns4()
         {
-            Assert.AreEqual(4, MatchRatingApproachEncoder.LeftToRightThenRightToLeftProcessing("ALEXANDER", "ALEXANDRA"));
+            Assert.AreEqual(4, this.StringEncoder.LeftToRightThenRightToLeftProcessing("ALEXANDER", "ALEXANDRA"));
         }
 
         [Test]
         public void TestleftTorightThenRightToLeft_EINSTEIN_MICHAELA_Returns0()
         {
-            Assert.AreEqual(0, MatchRatingApproachEncoder.LeftToRightThenRightToLeftProcessing("EINSTEIN", "MICHAELA"));
+            Assert.AreEqual(0, this.StringEncoder.LeftToRightThenRightToLeftProcessing("EINSTEIN", "MICHAELA"));
         }
 
         [Test]
         public void TestGetMinRating_7_Return4_Successfully()
         {
-            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(7));
+            Assert.AreEqual(4, this.StringEncoder.GetMinRating(7));
         }
 
         [Test]
         public void TestGetMinRating_1_Returns5_Successfully()
         {
-            Assert.AreEqual(5, MatchRatingApproachEncoder.GetMinRating(1));
+            Assert.AreEqual(5, this.StringEncoder.GetMinRating(1));
         }
 
         [Test]
         public void TestGetMinRating_2_Returns5_Successfully()
         {
-            Assert.AreEqual(5, MatchRatingApproachEncoder.GetMinRating(2));
+            Assert.AreEqual(5, this.StringEncoder.GetMinRating(2));
         }
 
         [Test]
         public void TestGetMinRating_5_Returns4_Successfully()
         {
-            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(5));
+            Assert.AreEqual(4, this.StringEncoder.GetMinRating(5));
         }
 
         [Test]
         public void TestGetMinRating_5_Returns4_Successfully2()
         {
-            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(5));
+            Assert.AreEqual(4, this.StringEncoder.GetMinRating(5));
         }
 
         [Test]
         public void TestGetMinRating_6_Returns4_Successfully()
         {
-            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(6));
+            Assert.AreEqual(4, this.StringEncoder.GetMinRating(6));
         }
 
         [Test]
         public void TestGetMinRating_7_Returns4_Successfully()
         {
-            Assert.AreEqual(4, MatchRatingApproachEncoder.GetMinRating(7));
+            Assert.AreEqual(4, this.StringEncoder.GetMinRating(7));
         }
 
         [Test]
         public void TestGetMinRating_8_Returns3_Successfully()
         {
-            Assert.AreEqual(3, MatchRatingApproachEncoder.GetMinRating(8));
+            Assert.AreEqual(3, this.StringEncoder.GetMinRating(8));
         }
 
         [Test]
         public void TestGetMinRating_10_Returns3_Successfully()
         {
-            Assert.AreEqual(3, MatchRatingApproachEncoder.GetMinRating(10));
+            Assert.AreEqual(3, this.StringEncoder.GetMinRating(10));
         }
 
         [Test]
         public void TestGetMinRating_11_Returns_3_Successfully()
         {
-            Assert.AreEqual(3, MatchRatingApproachEncoder.GetMinRating(11));
+            Assert.AreEqual(3, this.StringEncoder.GetMinRating(11));
         }
 
         [Test]
         public void TestGetMinRating_13_Returns_1_Successfully()
         {
-            Assert.AreEqual(1, MatchRatingApproachEncoder.GetMinRating(13));
+            Assert.AreEqual(1, this.StringEncoder.GetMinRating(13));
         }
 
         [Test]
         public void TestCleanName_SuccessfullyClean()
         {
-            Assert.AreEqual("THISISATEST", MatchRatingApproachEncoder.CleanName("This-ís   a t.,es &t"));
+            Assert.AreEqual("THISISATEST", this.StringEncoder.CleanName("This-ís   a t.,es &t"));
         }
 
         [Test]

--- a/src/Lucene.Net/Analysis/Token.cs
+++ b/src/Lucene.Net/Analysis/Token.cs
@@ -628,7 +628,7 @@ namespace Lucene.Net.Analysis
             reflector.Reflect(typeof(ITypeAttribute), "type", type);
         }
 
-        private void CheckOffsets(int startOffset, int endOffset)
+        private static void CheckOffsets(int startOffset, int endOffset) // LUCENENET: CA1822: Mark members as static
         {
             if (startOffset < 0 || endOffset < startOffset)
             {

--- a/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
@@ -936,7 +936,7 @@ namespace Lucene.Net.Codecs
 
             // for debugging
 #pragma warning disable IDE0051 // Remove unused private members
-            private string ToString(BytesRef b)
+            private static string ToString(BytesRef b) // LUCENENET: CA1822: Mark members as static
 #pragma warning restore IDE0051 // Remove unused private members
             {
                 try

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
@@ -590,7 +590,7 @@ namespace Lucene.Net.Codecs.Compressing
         }
 
         // field -> term index -> position index
-        private int[][] PositionIndex(int skip, int numFields, PackedInt32s.Reader numTerms, int[] termFreqs)
+        private static int[][] PositionIndex(int skip, int numFields, PackedInt32s.Reader numTerms, int[] termFreqs) // LUCENENET: CA1822: Mark members as static
         {
             int[][] positionIndex = new int[numFields][];
             int termIndex = 0;

--- a/src/Lucene.Net/Codecs/DocValuesConsumer.cs
+++ b/src/Lucene.Net/Codecs/DocValuesConsumer.cs
@@ -116,7 +116,7 @@ namespace Lucene.Net.Codecs
             AddNumericField(fieldInfo, GetMergeNumericFieldEnumerable(/* fieldInfo, // LUCENENET: Never read */ mergeState, toMerge, docsWithField));
         }
 
-        private IEnumerable<long?> GetMergeNumericFieldEnumerable(/*FieldInfo fieldinfo, // LUCENENET: Never read */ MergeState mergeState, IList<NumericDocValues> toMerge, IList<IBits> docsWithField)
+        private static IEnumerable<long?> GetMergeNumericFieldEnumerable(/*FieldInfo fieldinfo, // LUCENENET: Never read */ MergeState mergeState, IList<NumericDocValues> toMerge, IList<IBits> docsWithField) // LUCENENET: CA1822: Mark members as static
         {
             int readerUpto = -1;
             int docIDUpto = 0;
@@ -178,7 +178,7 @@ namespace Lucene.Net.Codecs
             AddBinaryField(fieldInfo, GetMergeBinaryFieldEnumerable(/*fieldInfo, // LUCENENET: Never read */ mergeState, toMerge, docsWithField));
         }
 
-        private IEnumerable<BytesRef> GetMergeBinaryFieldEnumerable(/*FieldInfo fieldInfo, // LUCENENET: Never read */ MergeState mergeState, IList<BinaryDocValues> toMerge, IList<IBits> docsWithField)
+        private static IEnumerable<BytesRef> GetMergeBinaryFieldEnumerable(/*FieldInfo fieldInfo, // LUCENENET: Never read */ MergeState mergeState, IList<BinaryDocValues> toMerge, IList<IBits> docsWithField) // LUCENENET: CA1822: Mark members as static
         {
             int readerUpto = -1;
             int docIDUpto = 0;
@@ -281,7 +281,7 @@ namespace Lucene.Net.Codecs
            );
         }
 
-        private IEnumerable<BytesRef> GetMergeSortValuesEnumerable(OrdinalMap map, SortedDocValues[] dvs)
+        private static IEnumerable<BytesRef> GetMergeSortValuesEnumerable(OrdinalMap map, SortedDocValues[] dvs) // LUCENENET: CA1822: Mark members as static
         {
             var scratch = new BytesRef();
             int currentOrd = 0;
@@ -296,7 +296,7 @@ namespace Lucene.Net.Codecs
             }
         }
 
-        private IEnumerable<long?> GetMergeSortedFieldDocToOrdEnumerable(AtomicReader[] readers, SortedDocValues[] dvs, OrdinalMap map)
+        private static IEnumerable<long?> GetMergeSortedFieldDocToOrdEnumerable(AtomicReader[] readers, SortedDocValues[] dvs, OrdinalMap map) // LUCENENET: CA1822: Mark members as static
         {
             int readerUpTo = -1;
             int docIDUpTo = 0;
@@ -387,7 +387,7 @@ namespace Lucene.Net.Codecs
             );
         }
 
-        private IEnumerable<BytesRef> GetMergeSortedSetValuesEnumerable(OrdinalMap map, SortedSetDocValues[] dvs)
+        private static IEnumerable<BytesRef> GetMergeSortedSetValuesEnumerable(OrdinalMap map, SortedSetDocValues[] dvs) // LUCENENET: CA1822: Mark members as static
         {
             var scratch = new BytesRef();
             long currentOrd = 0;
@@ -402,7 +402,7 @@ namespace Lucene.Net.Codecs
             }
         }
 
-        private IEnumerable<long?> GetMergeSortedSetDocToOrdCountEnumerable(AtomicReader[] readers, SortedSetDocValues[] dvs)
+        private static IEnumerable<long?> GetMergeSortedSetDocToOrdCountEnumerable(AtomicReader[] readers, SortedSetDocValues[] dvs) // LUCENENET: CA1822: Mark members as static
         {
             int readerUpto = -1;
             int docIDUpto = 0;
@@ -446,7 +446,7 @@ namespace Lucene.Net.Codecs
             }
         }
 
-        private IEnumerable<long?> GetMergeSortedSetOrdsEnumerable(AtomicReader[] readers, SortedSetDocValues[] dvs, OrdinalMap map)
+        private static IEnumerable<long?> GetMergeSortedSetOrdsEnumerable(AtomicReader[] readers, SortedSetDocValues[] dvs, OrdinalMap map) // LUCENENET: CA1822: Mark members as static
         {
             int readerUpto = -1;
             int docIDUpto = 0;

--- a/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsReader.cs
@@ -200,7 +200,7 @@ namespace Lucene.Net.Codecs.Lucene41
             }
         }
 
-        private void DecodeTerm(DataInput @in, FieldInfo fieldInfo, Lucene41PostingsWriter.Int32BlockTermState termState)
+        private static void DecodeTerm(DataInput @in, FieldInfo fieldInfo, Lucene41PostingsWriter.Int32BlockTermState termState) // LUCENENET: CA1822: Mark members as static
         {
             // LUCENENET specific - to avoid boxing, changed from CompareTo() to IndexOptionsComparer.Compare()
             bool fieldHasPositions = IndexOptionsComparer.Default.Compare(fieldInfo.IndexOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
@@ -482,7 +482,7 @@ namespace Lucene.Net.Codecs.Lucene45
             writer.Finish();
         }
 
-        private IEnumerable<long?> GetSortedSetEnumerable(IEnumerable<long?> docToOrdCount, IEnumerable<long?> ords)
+        private static IEnumerable<long?> GetSortedSetEnumerable(IEnumerable<long?> docToOrdCount, IEnumerable<long?> ords) // LUCENENET: CA1822: Mark members as static
         {
             IEnumerator<long?> docToOrdCountIter = docToOrdCount.GetEnumerator();
             IEnumerator<long?> ordsIter = ords.GetEnumerator();

--- a/src/Lucene.Net/Index/DocumentsWriterFlushQueue.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterFlushQueue.cs
@@ -299,7 +299,7 @@ namespace Lucene.Net.Index
                 indexWriter.PublishFlushedSegment(newSegment.segmentInfo, segmentUpdates, globalPacket);
             }
 
-            protected virtual void FinishFlush(IndexWriter indexWriter, FlushedSegment newSegment, FrozenBufferedUpdates bufferedUpdates)
+            protected void FinishFlush(IndexWriter indexWriter, FlushedSegment newSegment, FrozenBufferedUpdates bufferedUpdates)
             {
                 // Finish the flushed segment and publish it to IndexWriter
                 if (newSegment is null)

--- a/src/Lucene.Net/Index/DocumentsWriterFlushQueue.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterFlushQueue.cs
@@ -299,7 +299,7 @@ namespace Lucene.Net.Index
                 indexWriter.PublishFlushedSegment(newSegment.segmentInfo, segmentUpdates, globalPacket);
             }
 
-            protected void FinishFlush(IndexWriter indexWriter, FlushedSegment newSegment, FrozenBufferedUpdates bufferedUpdates)
+            protected virtual void FinishFlush(IndexWriter indexWriter, FlushedSegment newSegment, FrozenBufferedUpdates bufferedUpdates)
             {
                 // Finish the flushed segment and publish it to IndexWriter
                 if (newSegment is null)

--- a/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
+++ b/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
@@ -386,10 +386,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public void Abort()
-        {
-        }
+        // LUCENENET: Removed Abort() method because it is not in use.
 
         internal BytesRef payload;
 

--- a/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
+++ b/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
@@ -387,7 +387,7 @@ namespace Lucene.Net.Index
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void Abort()
+        public static void Abort()
         {
         }
 

--- a/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
+++ b/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
@@ -387,7 +387,7 @@ namespace Lucene.Net.Index
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void Abort()
+        public void Abort()
         {
         }
 

--- a/src/Lucene.Net/Index/PrefixCodedTerms.cs
+++ b/src/Lucene.Net/Index/PrefixCodedTerms.cs
@@ -195,7 +195,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            private int SharedPrefix(BytesRef term1, BytesRef term2)
+            private static int SharedPrefix(BytesRef term1, BytesRef term2) // LUCENENET: CA1822: Mark members as static
             {
                 int pos1 = 0;
                 int pos1End = pos1 + Math.Min(term1.Length, term2.Length);

--- a/src/Lucene.Net/Index/ReadersAndUpdates.cs
+++ b/src/Lucene.Net/Index/ReadersAndUpdates.cs
@@ -749,7 +749,7 @@ namespace Lucene.Net.Index
         /// <summary>
         /// NOTE: This was getLongEnumerable() in Lucene
         /// </summary>
-        private IEnumerable<long?> GetInt64Enumerable(SegmentReader reader, string field, NumericDocValuesFieldUpdates fieldUpdates)
+        private static IEnumerable<long?> GetInt64Enumerable(SegmentReader reader, string field, NumericDocValuesFieldUpdates fieldUpdates) // LUCENENET: CA1822: Mark members as static
         {
             int maxDoc = reader.MaxDoc;
             IBits DocsWithField = reader.GetDocsWithField(field);
@@ -781,7 +781,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private IEnumerable<BytesRef> GetBytesRefEnumerable(SegmentReader reader, string field, BinaryDocValuesFieldUpdates fieldUpdates)
+        private static IEnumerable<BytesRef> GetBytesRefEnumerable(SegmentReader reader, string field, BinaryDocValuesFieldUpdates fieldUpdates) // LUCENENET: CA1822: Mark members as static
         {
             BinaryDocValues currentValues = reader.GetBinaryDocValues(field);
             IBits DocsWithField = reader.GetDocsWithField(field);

--- a/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
+++ b/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
@@ -140,10 +140,7 @@ namespace Lucene.Net.Index
             return doVectors;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public void Abort()
-        {
-        }
+        // LUCENENET: Removed Abort() method because it is not in use.
 
         /// <summary>
         /// Called once per field per document if term vectors

--- a/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
+++ b/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Index
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void Abort() // LUCENENET: CA1822: Mark members as static
+        public void Abort()
         {
         }
 

--- a/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
+++ b/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Index
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void Abort()
+        public static void Abort() // LUCENENET: CA1822: Mark members as static
         {
         }
 

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -163,7 +163,7 @@ namespace Lucene.Net.Search
             return result.ToArray();
         }
 
-        private void AddCacheEntries<TKey, TValue>(IList<FieldCache.CacheEntry> result, Type cacheType, Cache<TKey, TValue> cache) where TKey : CacheKey
+        private void AddCacheEntries<TKey, TValue>(IList<FieldCache.CacheEntry> result, Type cacheType, Cache<TKey, TValue> cache) where TKey : CacheKey // LUCENENET: CA1822: Mark members as static
         {
             UninterruptableMonitor.Enter(cache.readerCache);
             try

--- a/src/Lucene.Net/Search/FuzzyTermsEnum.cs
+++ b/src/Lucene.Net/Search/FuzzyTermsEnum.cs
@@ -259,7 +259,7 @@ namespace Lucene.Net.Search
         }
 
         // for some raw min similarity and input term length, the maximum # of edits
-        private int InitialMaxDistance(float minimumSimilarity, int termLen)
+        private static int InitialMaxDistance(float minimumSimilarity, int termLen) // LUCENENET: CA1822: Mark members as static
         {
             return (int)((1D - minimumSimilarity) * termLen);
         }

--- a/src/Lucene.Net/Search/MultiPhraseQuery.cs
+++ b/src/Lucene.Net/Search/MultiPhraseQuery.cs
@@ -477,7 +477,7 @@ namespace Lucene.Net.Search
         }
 
         // Breakout calculation of the termArrays equals
-        private bool TermArraysEquals(IList<Term[]> termArrays1, IList<Term[]> termArrays2)
+        private static bool TermArraysEquals(IList<Term[]> termArrays1, IList<Term[]> termArrays2) // LUCENENET: CA1822: Mark members as static
         {
             if (termArrays1.Count != termArrays2.Count)
             {

--- a/src/Lucene.Net/Search/PhraseQuery.cs
+++ b/src/Lucene.Net/Search/PhraseQuery.cs
@@ -400,7 +400,7 @@ namespace Lucene.Net.Search
             }
 
             // only called from assert
-            private bool TermNotInReader(AtomicReader reader, Term term)
+            private static bool TermNotInReader(AtomicReader reader, Term term) // LUCENENET: CA1822: Mark members as static
             {
                 return reader.DocFreq(term) == 0;
             }

--- a/src/Lucene.Net/Store/CompoundFileWriter.cs
+++ b/src/Lucene.Net/Store/CompoundFileWriter.cs
@@ -236,7 +236,7 @@ namespace Lucene.Net.Store
             }
         }
 
-        private void WriteEntryTable(ICollection<FileEntry> entries, IndexOutput entryOut)
+        private static void WriteEntryTable(ICollection<FileEntry> entries, IndexOutput entryOut) // LUCENENET: CA1822: Mark members as static
         {
             CodecUtil.WriteHeader(entryOut, ENTRY_CODEC, VERSION_CURRENT);
             entryOut.WriteVInt32(entries.Count);

--- a/src/Lucene.Net/Store/NativeFSLockFactory.cs
+++ b/src/Lucene.Net/Store/NativeFSLockFactory.cs
@@ -463,7 +463,7 @@ namespace Lucene.Net.Store
         /// <summary>
         /// Return true if the <see cref="IOException"/> is the result of a share violation
         /// </summary>
-        private bool IsShareViolation(IOException e)
+        private static bool IsShareViolation(IOException e) // LUCENENET: CA1822: Mark members as static
         {
             return e.HResult == NativeFSLockFactory.HRESULT_FILE_SHARE_VIOLATION;
         }
@@ -645,7 +645,7 @@ namespace Lucene.Net.Store
         /// <summary>
         /// Return true if the <see cref="IOException"/> is the result of a lock violation
         /// </summary>
-        private bool IsLockViolation(IOException e)
+        private static bool IsLockViolation(IOException e) // LUCENENET: CA1822: Mark members as static
         {
             return e.HResult == NativeFSLockFactory.HRESULT_FILE_LOCK_VIOLATION;
         }

--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Util
                 }
 
                 // LUCENENET: optimize known creation of built-in types
-                private Attribute CreateInstance(Type attributeType)
+                private static Attribute CreateInstance(Type attributeType) // LUCENENET: CA1822: Mark members as static
                 {
                     if (ReferenceEquals(typeof(CharTermAttribute), attributeType))
                         return new CharTermAttribute();

--- a/src/Lucene.Net/Util/Fst/PositiveIntOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/PositiveIntOutputs.cs
@@ -133,7 +133,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private bool Valid(Int64 o)
+        private static bool Valid(Int64 o) // LUCENENET: CA1822: Mark members as static
         {
             Debugging.Assert(o != null, "PositiveIntOutput precondition fail");
             Debugging.Assert(o == NO_OUTPUT || o > 0,"o={0}", o);

--- a/src/Lucene.Net/Util/RamUsageEstimator.cs
+++ b/src/Lucene.Net/Util/RamUsageEstimator.cs
@@ -947,7 +947,7 @@ namespace Lucene.Net.Util
             /// <summary>
             /// Round the capacity to the next allowed value.
             /// </summary>
-            private int RoundCapacity(int requestedCapacity) // LUCENENET NOTE: made private, since protected is not valid in a sealed class
+            private static int RoundCapacity(int requestedCapacity) // LUCENENET NOTE: made private, since protected is not valid in a sealed class // LUCENENET: CA1822: Mark members as static
             {
                 // Maximum positive integer that is a power of two.
                 if (requestedCapacity > ((int)(0x80000000 >> 1))) // LUCENENET: No need to cast to uint because it already is

--- a/src/dotnet/tools/lucene-cli/CommandLine/CommandLineApplication.cs
+++ b/src/dotnet/tools/lucene-cli/CommandLine/CommandLineApplication.cs
@@ -516,7 +516,7 @@ namespace Lucene.Net.Cli.CommandLine
             Out.WriteLine();
         }
 
-        private void HandleUnexpectedArg(CommandLineApplication command, string[] args, int index, string argTypeName)
+        private static void HandleUnexpectedArg(CommandLineApplication command, string[] args, int index, string argTypeName) // LUCENENET: CA1822: Mark members as static
         {
             if (command._throwOnUnexpectedArg)
             {

--- a/src/dotnet/tools/lucene-cli/CommandLine/CommandOption.cs
+++ b/src/dotnet/tools/lucene-cli/CommandLine/CommandOption.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Cli.CommandLine
             return HasValue() ? Values[0] : null;
         }
 
-        private bool IsEnglishLetter(char c)
+        private static bool IsEnglishLetter(char c) // LUCENENET: CA1822: Mark members as static
         {
             return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
         }


### PR DESCRIPTION
#663 

This should target almost all of the issues currently reported in #663 but I think there will come more of the same issues after this is merged and scanned due to all the new methods now being static. So don't close the issue just yet.

It's mostly just adding `static` and a comment. But some places I've also changed the code to work with the new static methods. I should only have changed the code in some tests.

I've also added `virtual` to methods that I found had the `final` keyword in the Java source code.