### PR TITLE
SWEEP: Prefer 'AsSpan' over 'Substring' when span-based overloads are available

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -34,6 +34,7 @@
 
     <DefineConstants>$(DefineConstants);FEATURE_ARGITERATOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRING_CONCAT_READONLYSPAN</DefineConstants>
 
   </PropertyGroup>
   
@@ -53,8 +54,10 @@
 
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ADDORUPDATE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
-    
+    <DefineConstants>$(DefineConstants);FEATURE_NUMBER_PARSE_READONLYSPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STREAM_READ_SPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_READONLYSPAN</DefineConstants>
+
   </PropertyGroup>
 
   <!-- Features in .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, and .NET 6.x -->

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -967,7 +967,11 @@ namespace Lucene.Net.Analysis.Hunspell
                                     sb.Length = 0;
                                     sb.Append(cleansed);
                                 }
+#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
+                                sb.Append(line.AsSpan(flagSep));
+#else
                                 sb.Append(line.Substring(flagSep));
+#endif
                                 writer.Write(sb.ToString().GetBytes(Encoding.UTF8));
                             }
                         }

--- a/src/Lucene.Net.Analysis.Phonetic/Language/DoubleMetaphone.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/DoubleMetaphone.cs
@@ -1240,7 +1240,11 @@ namespace Lucene.Net.Analysis.Phonetic.Language
                 }
                 else
                 {
+#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
+                    this.primary.Append(value.AsSpan(0, addChars - 0));
+#else
                     this.primary.Append(value.Substring(0, addChars - 0));
+#endif
                 }
             }
 
@@ -1253,7 +1257,11 @@ namespace Lucene.Net.Analysis.Phonetic.Language
                 }
                 else
                 {
+#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
+                    this.alternate.Append(value.AsSpan(0, addChars - 0));
+#else
                     this.alternate.Append(value.Substring(0, addChars - 0));
+#endif
                 }
             }
 

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
@@ -116,16 +116,27 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
 
             internal string Time(string original)
             {
-                StringBuilder buffer = new StringBuilder();
+                StringBuilder buffer = new StringBuilder(24); // LUCENENET: We always have 24 chars, so allocate it up front
 
+#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
+                buffer.Append(original.AsSpan(8, 10 - 8));
+                buffer.Append('-');
+                buffer.Append(months[int.Parse(original.AsSpan(5, 7 - 5), NumberStyles.Integer, CultureInfo.InvariantCulture) - 1]);
+                buffer.Append('-');
+                buffer.Append(original.AsSpan(0, 4 - 0));
+                buffer.Append(' ');
+                buffer.Append(original.AsSpan(11, 19 - 11));
+                buffer.Append(".000");
+#else
                 buffer.Append(original.Substring(8, 10 - 8));
                 buffer.Append('-');
-                buffer.Append(months[Convert.ToInt32(original.Substring(5, 7 - 5), CultureInfo.InvariantCulture) - 1]);
+                buffer.Append(months[int.Parse(original.Substring(5, 7 - 5), NumberStyles.Integer, CultureInfo.InvariantCulture) - 1]);
                 buffer.Append('-');
                 buffer.Append(original.Substring(0, 4 - 0));
                 buffer.Append(' ');
                 buffer.Append(original.Substring(11, 19 - 11));
                 buffer.Append(".000");
+#endif
 
                 return buffer.ToString();
             }

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/SearchTravRetHighlightTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/SearchTravRetHighlightTask.cs
@@ -157,7 +157,11 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 else if (splits[i].StartsWith("mergeContiguous[", StringComparison.Ordinal) == true)
                 {
                     int len = "mergeContiguous[".Length;
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
+                    m_mergeContiguous = bool.Parse(splits[i].AsSpan(len, (splits[i].Length - 1) - len));
+#else
                     m_mergeContiguous = bool.Parse(splits[i].Substring(len, (splits[i].Length - 1) - len));
+#endif
                 }
                 else if (splits[i].StartsWith("fields[", StringComparison.Ordinal) == true)
                 {

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/EscapeQuerySyntaxImpl.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/EscapeQuerySyntaxImpl.cs
@@ -170,10 +170,17 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
                 }
                 if (found)
                 {
+#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
+                    result.Append(@string.ToString().AsSpan(copyStart, firstIndex - copyStart));
+                    result.Append(escapeChar);
+                    result.Append(@string.ToString().AsSpan(firstIndex,
+                        (firstIndex + sequence1Length) - firstIndex));
+#else
                     result.Append(@string.ToString().Substring(copyStart, firstIndex - copyStart));
                     result.Append(escapeChar);
                     result.Append(@string.ToString().Substring(firstIndex,
                         (firstIndex + sequence1Length) - firstIndex));
+#endif
                     copyStart = start = firstIndex + sequence1Length;
                 }
                 else
@@ -184,7 +191,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
             
             if (result.Length == 0 && copyStart == 0)
                 return @string;
+#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
+            result.Append(@string.ToString().AsSpan(copyStart));
+#else
             result.Append(@string.ToString().Substring(copyStart));
+#endif
             return result.ToString().AsCharSequence();
         }
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParser.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParser.cs
@@ -633,7 +633,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
                     if (fuzzy)
                     {
                         // LUCENENET specific: parse without throwing exceptions
-                        float fms = float.TryParse(fuzzySlop.Image.Substring(1), NumberStyles.Float, CultureInfo.InvariantCulture, out float temp) ? temp : defaultMinSimilarity;
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
+                        float fms = float.TryParse(fuzzySlop.Image.AsSpan(1), NumberStyles.Float, CultureInfo.InvariantCulture, out float temp) ? temp : defaultMinSimilarity;
+#else
+                        float fms = float.TryParse(fuzzySlop.Image.Substring(1), NumberStyles.Float, CultureInfo.InvariantCulture, out float temp) ? temp: defaultMinSimilarity;
+#endif
                         if (fms < 0.0f)
                         {
                             { if (true) throw new ParseException(QueryParserMessages.INVALID_SYNTAX_FUZZY_LIMITS); }
@@ -766,8 +770,12 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
 
                     if (fuzzySlop != null)
                     {
-                        // LUCENENET: don't let parsing throw exceptions
+                        // LUCENENET specific: parse without throwing exceptions
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
+                        if (float.TryParse(fuzzySlop.Image.AsSpan(1), NumberStyles.Float, CultureInfo.InvariantCulture, out float temp))
+#else
                         if (float.TryParse(fuzzySlop.Image.Substring(1), NumberStyles.Float, CultureInfo.InvariantCulture, out float temp))
+#endif
                         {
                             try
                             {

--- a/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
@@ -440,7 +440,7 @@ namespace Lucene.Net.Replicator.Http
                 return res;
             }
 
-#if FEATURE_SPAN
+#if FEATURE_STREAM_READ_SPAN
             public override int Read(Span<byte> buffer)
             {
                 int res = input.Read(buffer);

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -783,11 +783,19 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             // TODO: apps can try to invert their analysis logic
             // here, e.g. downcase the two before checking prefix:
             sb.Append("<b>");
+#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
+            sb.Append(surface.AsSpan(0, prefixToken.Length - 0));
+#else
             sb.Append(surface.Substring(0, prefixToken.Length - 0));
+#endif
             sb.Append("</b>");
             if (prefixToken.Length < surface.Length)
             {
+#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
+                sb.Append(surface.AsSpan(prefixToken.Length));
+#else
                 sb.Append(surface.Substring(prefixToken.Length));
+#endif
             }
         }
 

--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -152,16 +152,29 @@ namespace Lucene.Net.Util
                     int lastPlus = attributeInterfaceType.FullName.LastIndexOf('+');
                     if (lastPlus == -1)
                     {
+#if FEATURE_STRING_CONCAT_READONLYSPAN
+                        return string.Concat(
+                            attributeInterfaceType.Namespace,
+                            ".",
+                            attributeInterfaceType.Name.AsSpan(1));
+#else
                         return string.Concat(
                             attributeInterfaceType.Namespace,
                             ".",
                             attributeInterfaceType.Name.Substring(1));
+#endif
                     }
                     else
                     {
+#if FEATURE_STRING_CONCAT_READONLYSPAN
+                        return string.Concat(
+                            attributeInterfaceType.FullName.AsSpan(0, lastPlus + 1),
+                            attributeInterfaceType.Name.AsSpan(1));
+#else
                         return string.Concat(
                             attributeInterfaceType.FullName.Substring(0, lastPlus + 1),
                             attributeInterfaceType.Name.Substring(1));
+#endif
                     }
                 }
             }


### PR DESCRIPTION
Fixes #675.

While the System.Memory package allows the use of `ReadOnlySpan<T>` in all target frameworks, the methods overloads that accept `ReadOnlySpan<T>` parameters are only available in `net6.0` and in most cases, `netstandard2.1`. Therefore, at least for this use case, it was impractical to use System.Memory and we have new conditional compilation features to enable the `AsSpan()` calls when the APIs exist to utilize them.

- FEATURE_STRING_CONCAT_READONLYSPAN (`net6.0` only)
- FEATURE_NUMBER_PARSE_READONLYSPAN (`net6.0` and `netstandard2.1` only)
- FEATURE_STREAM_READ_SPAN (`net6.0` and `netstandard2.1` only)
- FEATURE_STRINGBUILDER_APPEND_READONLYSPAN (`net6.0` and `netstandard2.1` only)
