### PR TITLE
chore: Added suppression attributes to CA1822

### DIFF
--- a/src/Lucene.Net.Analysis.Phonetic/Language/MatchRatingApproachEncoder.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/MatchRatingApproachEncoder.cs
@@ -1,5 +1,6 @@
 ﻿// commons-codec version compatibility level: 1.9
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 
@@ -84,6 +85,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">The name to be cleaned.</param>
         /// <returns>The cleaned name.</returns>
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         internal string CleanName(string name)
         {
             string upperName = LOCALE_ENGLISH.TextInfo.ToUpper(name);
@@ -135,6 +137,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">The string to get the substrings from.</param>
         /// <returns>Annexed first &amp; last 3 letters of input word.</returns>
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         internal string GetFirst3Last3(string name)
         {
             int nameLength = name.Length;
@@ -157,6 +160,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="sumLength">The length of 2 strings sent down.</param>
         /// <returns>The min rating value.</returns>
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         internal int GetMinRating(int sumLength)
         {
             int minRating; // LUCENENET: IDE0059: Remove unnecessary value assignment
@@ -271,6 +275,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// <param name="name1"></param>
         /// <param name="name2"></param>
         /// <returns></returns>
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         internal int LeftToRightThenRightToLeftProcessing(string name1, string name2)
         {
             char[] name1Char = name1.ToCharArray();
@@ -366,6 +371,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">String to have double consonants removed.</param>
         /// <returns>Single consonant word.</returns>
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         internal string RemoveDoubleConsonants(string name)
         {
             string replacedName = name.ToUpperInvariant();
@@ -385,6 +391,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         /// </summary>
         /// <param name="name">The name to have vowels removed.</param>
         /// <returns>De-voweled word.</returns>
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         internal string RemoveVowels(string name)
         {
             // Extract first letter

--- a/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Configuration;
 using NUnit.Framework;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace Lucene.Net.Util
@@ -276,6 +277,7 @@ namespace Lucene.Net.Util
         /// // tight loop with many invocations.
         /// </code>
         /// </summary>
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         protected Random Random => LuceneTestCase.Random;
 
         /// <summary>

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -165,7 +165,7 @@ namespace Lucene.Net.Search
         }
 
         [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "False positive")]
-        private void AddCacheEntries<TKey, TValue>(IList<FieldCache.CacheEntry> result, Type cacheType, Cache<TKey, TValue> cache) where TKey : CacheKey // LUCENENET: CA1822: Mark members as static
+        private void AddCacheEntries<TKey, TValue>(IList<FieldCache.CacheEntry> result, Type cacheType, Cache<TKey, TValue> cache) where TKey : CacheKey
         {
             UninterruptableMonitor.Enter(cache.readerCache);
             try

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -11,6 +11,7 @@ using Prism.Events;
 #endif
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using JCG = J2N.Collections.Generic;
@@ -163,6 +164,7 @@ namespace Lucene.Net.Search
             return result.ToArray();
         }
 
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "False positive")]
         private void AddCacheEntries<TKey, TValue>(IList<FieldCache.CacheEntry> result, Type cacheType, Cache<TKey, TValue> cache) where TKey : CacheKey // LUCENENET: CA1822: Mark members as static
         {
             UninterruptableMonitor.Enter(cache.readerCache);

--- a/src/Lucene.Net/Search/Similarities/BasicModelBE.cs
+++ b/src/Lucene.Net/Search/Similarities/BasicModelBE.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Search.Similarities
 {
@@ -49,6 +51,8 @@ namespace Lucene.Net.Search.Similarities
 
         /// <summary>
         /// The <em>f</em> helper function defined for <em>B<sub>E</sub></em>. </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         private double F(double n, double m)
         {
             return (m + 0.5) * SimilarityBase.Log2(n / m) + (n - m) * SimilarityBase.Log2(n);


### PR DESCRIPTION
Following #690 I've now added suppression attributes to the methods we decided not to make static.

Adds to #663 

I also had another look at [This issue](https://sonarcloud.io/project/issues?issues=AYPAuN5xhbfJOGLOoaDV&open=AYPAuN5xhbfJOGLOoaDV&id=nikcio_lucenenet) and found that the reason this caused problems is because I forgot to change the `this.` to `BasicModelBE.` in the `Score` method. But I don't know if this is moving too far away from the original code?

The change would be:

```csharp
public override sealed float Score(BasicStats stats, float tfn)
{
    double F = stats.TotalTermFreq + 1 + tfn;
    // approximation only holds true when F << N, so we use N += F
    double N = F + stats.NumberOfDocuments;
    return (float)(-SimilarityBase.Log2((N - 1) * Math.E) + BasicModelBE.F(N + F - 1, N + F - tfn - 2) - BasicModelBE.F(F, F - tfn));
}
/// <summary>
/// The <em>f</em> helper function defined for <em>B<sub>E</sub></em>. </summary>
private static double F(double n, double m) // LUCENENET: CA1822: Mark members as static
{
    return (m + 0.5) * SimilarityBase.Log2(n / m) + (n - m) * SimilarityBase.Log2(n);
}
```