### PR TITLE
SWEEP: Add a nested comment explaining why this method is empty.

### DIFF
--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTokensTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTokensTask.cs
@@ -152,7 +152,10 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 }
             }
 
-            protected override void Dispose(bool disposing) { }
+            protected override void Dispose(bool disposing)
+            {
+                // LUCENENET: Intentionally blank
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net.Benchmark/Support/TagSoup/PYXScanner.cs
+++ b/src/Lucene.Net.Benchmark/Support/TagSoup/PYXScanner.cs
@@ -133,6 +133,7 @@ namespace TagSoup
 
         public virtual void StartCDATA()
         {
+            // LUCENENET: Intentionally blank
         }
 
         //public static void main(string[] argv)  {

--- a/src/Lucene.Net.Benchmark/Support/TagSoup/PYXWriter.cs
+++ b/src/Lucene.Net.Benchmark/Support/TagSoup/PYXWriter.cs
@@ -71,6 +71,7 @@ namespace TagSoup
 
         public virtual void Entity(char[] buffer, int startIndex, int length)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual int GetEntity()
@@ -95,6 +96,7 @@ namespace TagSoup
 
         public virtual void Decl(char[] buffer, int startIndex, int length)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void GI(char[] buffer, int startIndex, int length)
@@ -220,6 +222,7 @@ namespace TagSoup
 
         public virtual void EndPrefixMapping(string prefix)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void IgnorableWhitespace(char[] buffer, int startIndex, int length)
@@ -240,14 +243,17 @@ namespace TagSoup
 
         public virtual void SetDocumentLocator(ILocator locator)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void SkippedEntity(string name)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void StartDocument()
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void StartElement(string uri, string localname, string qname, IAttributes atts)
@@ -283,6 +289,7 @@ namespace TagSoup
 
         public virtual void StartPrefixMapping(string prefix, string uri)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void Comment(char[] ch, int start, int length)
@@ -292,26 +299,32 @@ namespace TagSoup
 
         public virtual void EndCDATA()
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void EndDTD()
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void EndEntity(string name)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void StartCDATA()
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void StartDTD(string name, string publicId, string systemId)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public virtual void StartEntity(string name)
         {
+            // LUCENENET: Intentionally blank
         }
 
         // Constructor

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -1085,8 +1085,9 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                 }
             }
 
-            public void AddDone() // nothing to do
+            public void AddDone()
             {
+                // nothing to do
             }
 
             public int[] GetMap()

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
@@ -266,6 +266,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
 
             public void Dispose()
             {
+                // LUCENENET: Intentionally blank
             }
 
             public bool MoveNext()

--- a/src/Lucene.Net.Queries/Function/FunctionQuery.cs
+++ b/src/Lucene.Net.Queries/Function/FunctionQuery.cs
@@ -51,6 +51,7 @@ namespace Lucene.Net.Queries.Function
 
         public override void ExtractTerms(ISet<Term> terms)
         {
+            // LUCENENET: Intentionally blank
         }
 
         protected internal class FunctionWeight : Weight

--- a/src/Lucene.Net.QueryParser/Classic/QueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParser.cs
@@ -896,11 +896,13 @@ namespace Lucene.Net.QueryParsers.Classic
         /// <summary>Enable tracing. </summary>
         public void Enable_tracing()
         {
+            // LUCENENET: Intentionally blank
         }
 
         /// <summary>Disable tracing. </summary>
         public void Disable_tracing()
         {
+            // LUCENENET: Intentionally blank
         }
 
         private void Jj_rescan_token()

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParser.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParser.cs
@@ -1260,11 +1260,13 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
         /// <summary>Enable tracing.</summary>
         public void Enable_tracing()
         {
+            // LUCENENET: Intentionally blank
         }
 
         /// <summary>Disable tracing.</summary>
         public void Disable_tracing()
         {
+            // LUCENENET: Intentionally blank
         }
 
         private void Jj_rescan_token()

--- a/src/Lucene.Net.QueryParser/Surround/Parser/QueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Parser/QueryParser.cs
@@ -871,11 +871,13 @@ namespace Lucene.Net.QueryParsers.Surround.Parser
         /// <summary>Enable tracing. </summary>
         public void Enable_tracing()
         {
+            // LUCENENET: Intentionally blank
         }
 
         /// <summary>Disable tracing. </summary>
         public void Disable_tracing()
         {
+            // LUCENENET: Intentionally blank
         }
 
         private void Jj_rescan_token()

--- a/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
@@ -200,6 +200,7 @@ namespace Lucene.Net.Index
 
                 public void Dispose()
                 {
+                    // LUCENENET: Intentionally blank
                 }
             }
         }
@@ -300,6 +301,7 @@ namespace Lucene.Net.Index
 
                 public void Dispose()
                 {
+                    // LUCENENET: Intentionally blank
                 }
             }
         }

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -137,6 +137,7 @@ namespace Lucene.Net.Analysis
 
             protected override void Dispose(bool disposing)
             {
+                // LUCENENET: Intentionally blank
             }
         }
     }

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -316,6 +316,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                 public void Dispose()
                 {
+                    // LUCENENET: Intentionally blank
                 }
             }
 

--- a/src/Lucene.Net/Index/DocumentsWriterFlushControl.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterFlushControl.cs
@@ -563,17 +563,17 @@ namespace Lucene.Net.Index
 
         private IEnumerator<ThreadState> GetPerThreadsIterator(int upto)
         {
-            return new IteratorAnonymousClass(this, upto);
+            return new EnumeratorAnonymousClass(this, upto);
         }
 
-        private class IteratorAnonymousClass : IEnumerator<ThreadState>
+        private class EnumeratorAnonymousClass : IEnumerator<ThreadState>
         {
             private readonly DocumentsWriterFlushControl outerInstance;
             private ThreadState current;
             private readonly int upto;
             private int i;
 
-            public IteratorAnonymousClass(DocumentsWriterFlushControl outerInstance, int upto)
+            public EnumeratorAnonymousClass(DocumentsWriterFlushControl outerInstance, int upto)
             {
                 this.outerInstance = outerInstance;
                 this.upto = upto;
@@ -584,6 +584,7 @@ namespace Lucene.Net.Index
 
             public void Dispose()
             {
+                // LUCENENET: Intentionally blank
             }
 
             object System.Collections.IEnumerator.Current => Current;

--- a/src/Lucene.Net/Index/FrozenBufferedUpdates.cs
+++ b/src/Lucene.Net/Index/FrozenBufferedUpdates.cs
@@ -223,6 +223,7 @@ namespace Lucene.Net.Index
 
                 public void Dispose()
                 {
+                    // LUCENENET: Intentionally blank
                 }
             }
         }

--- a/src/Lucene.Net/Index/NoMergePolicy.cs
+++ b/src/Lucene.Net/Index/NoMergePolicy.cs
@@ -53,6 +53,7 @@ namespace Lucene.Net.Index
 
         protected override void Dispose(bool disposing)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public override MergeSpecification FindMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos)
@@ -77,6 +78,7 @@ namespace Lucene.Net.Index
 
         public override void SetIndexWriter(IndexWriter writer)
         {
+            // LUCENENET: Intentionally blank
         }
 
         protected override long Size(SegmentCommitInfo info)

--- a/src/Lucene.Net/Index/ParallelCompositeReader.cs
+++ b/src/Lucene.Net/Index/ParallelCompositeReader.cs
@@ -169,25 +169,27 @@ namespace Lucene.Net.Index
 
         private class ParallelAtomicReaderAnonymousClass : ParallelAtomicReader
         {
-            public ParallelAtomicReaderAnonymousClass(Lucene.Net.Index.AtomicReader[] atomicSubs, Lucene.Net.Index.AtomicReader[] storedSubs)
+            public ParallelAtomicReaderAnonymousClass(AtomicReader[] atomicSubs, AtomicReader[] storedSubs)
                 : base(true, atomicSubs, storedSubs)
             {
             }
 
             protected internal override void DoClose()
             {
+                // LUCENENET: Intentionally blank
             }
         }
 
         private class ParallelCompositeReaderAnonymousClass : ParallelCompositeReader
         {
-            public ParallelCompositeReaderAnonymousClass(Lucene.Net.Index.CompositeReader[] compositeSubs, Lucene.Net.Index.CompositeReader[] storedSubs)
+            public ParallelCompositeReaderAnonymousClass(CompositeReader[] compositeSubs, CompositeReader[] storedSubs)
                 : base(true, compositeSubs, storedSubs)
             {
             }
 
             protected internal override void DoClose()
             {
+                // LUCENENET: Intentionally blank
             }
         }
 

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -857,6 +857,7 @@ namespace Lucene.Net.Search
 
             public void Dispose()
             {
+                // LUCENENET: Intentionally blank
             }
 
             public void Submit(Func<T> task)

--- a/src/Lucene.Net/Search/MatchAllDocsQuery.cs
+++ b/src/Lucene.Net/Search/MatchAllDocsQuery.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Util;
+﻿using Lucene.Net.Util;
 using System.Collections.Generic;
 using System.Text;
 
@@ -139,6 +139,7 @@ namespace Lucene.Net.Search
 
         public override void ExtractTerms(ISet<Term> terms)
         {
+            // LUCENENET: Intentionally blank
         }
 
         public override string ToString(string field)

--- a/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
@@ -121,6 +121,7 @@ namespace Lucene.Net.Index
         /// </summary>
         public void SetMergeThreadPriority(int priority)
         {
+            // LUCENENET: Intentionally blank
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -298,6 +298,7 @@ namespace Lucene.Net.Util
 
             public void Dispose()
             {
+                // LUCENENET: Intentionally blank
             }
 
             public bool MoveNext()

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -1,6 +1,7 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -91,7 +92,7 @@ namespace Lucene.Net.Util.Automaton
                 return new TransitionsEnumerator(this);
             }
 
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
             }
@@ -123,7 +124,7 @@ namespace Lucene.Net.Util.Automaton
 
                 public Transition Current => current;
 
-                object System.Collections.IEnumerator.Current => Current;
+                object IEnumerator.Current => Current;
 
                 public void Reset()
                 {
@@ -132,6 +133,7 @@ namespace Lucene.Net.Util.Automaton
 
                 public void Dispose()
                 {
+                    // LUCENENET: Intentionally blank
                 }
             }
         }

--- a/src/Lucene.Net/Util/InfoStream.cs
+++ b/src/Lucene.Net/Util/InfoStream.cs
@@ -50,6 +50,7 @@ namespace Lucene.Net.Util
 
             protected override void Dispose(bool disposing)
             {
+                // LUCENENET: Intentionally blank
             }
         }
 

--- a/src/Lucene.Net/Util/MergedIterator.cs
+++ b/src/Lucene.Net/Util/MergedIterator.cs
@@ -114,6 +114,7 @@ namespace Lucene.Net.Util
 
         public void Dispose()
         {
+            // LUCENENET: Intentionally blank
         }
 
         private void PullTop()
@@ -276,6 +277,7 @@ namespace Lucene.Net.Util
 
         public void Dispose()
         {
+            // LUCENENET: Intentionally blank
         }
 
         private void PullTop()

--- a/src/Lucene.Net/Util/RamUsageEstimator.cs
+++ b/src/Lucene.Net/Util/RamUsageEstimator.cs
@@ -1042,6 +1042,7 @@ namespace Lucene.Net.Util
 
                 public void Dispose()
                 {
+                    // LUCENENET: Intentionally blank
                 }
             }
         }


### PR DESCRIPTION
Fixes #681.