### PR TITLE
Feature: build dependency conflict messaging

### DIFF
--- a/.build/azure-templates/publish-test-results.yml
+++ b/.build/azure-templates/publish-test-results.yml
@@ -1,4 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
+﻿# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -73,12 +73,16 @@ steps:
                     if ($reader.Name -eq 'RunInfos') {
                         $inRunInfos = $true
                     }
-                    if ($inRunInfos -and !$crashed -and $reader.Name -eq 'Text' -and $reader.ReadInnerXml().Contains('Test host process crashed')) {
-                        Write-Host "##vso[task.setvariable variable=HostCrashed;]true"
-                        # Report all of the test projects that crashed
-                        $crashedRuns = "$env:CRASHEDRUNS,$testProjectName".TrimStart(',')
-                        Write-Host "##vso[task.setvariable variable=CrashedRuns;]$crashedRuns"
-                        $crashed = $true
+                    if ($inRunInfos -and !$crashed -and $reader.Name -eq 'Text') {
+                        $innerXml = $reader.ReadInnerXml()
+                        # Test for specific error messages - we may need to adjust this, as needed
+                        if ($innerXml -and ($innerXml.Contains('Test host process crashed') -or $innerXml.Contains('Could not load file or assembly'))) {
+                            Write-Host "##vso[task.setvariable variable=HostCrashed;]true"
+                            # Report all of the test projects that crashed
+                            $crashedRuns = "$env:CRASHEDRUNS,$testProjectName".TrimStart(',')
+                            Write-Host "##vso[task.setvariable variable=CrashedRuns;]$crashedRuns"
+                            $crashed = $true
+                        }
                     }
                 }
                 if ($reader.NodeType -eq [System.Xml.XmlNodeType]::EndElement -and $reader.Name -eq 'RunInfos') {

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -251,7 +251,8 @@ steps:
 - pwsh: |
     $failed = $false
     if ($env:HOSTCRASHED -eq 'true') {
-        Write-Host "##vso[task.logissue type=error;]Test host process(es) crashed:  $($env:CRASHEDRUNS)."
+        $runsExpanded = "$($env:CRASHEDRUNS)" -replace ',',"`r`n"
+        Write-Host "##vso[task.logissue type=error;]Test host process(es) crashed, hung, or failed to load assemblies. Review the testresults artifacts for details. (click here to view the projects that failed)`r`n$runsExpanded"
         $failed = $true
     }
     $maximumAllowedFailures = '${{ parameters.maximumAllowedFailures }}'

--- a/.github/workflows/Lucene-Net-Dependency-Conflict-Warning.yml
+++ b/.github/workflows/Lucene-Net-Dependency-Conflict-Warning.yml
@@ -1,0 +1,45 @@
+﻿# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# References:
+# https://stackoverflow.com/a/58704739
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+
+name: 'Lucene.Net Dependency Conflict Warning'
+
+on:
+  pull_request:
+    paths:
+    - '.build/dependencies.props'
+    - 'src/**/*.csproj'
+
+jobs:
+
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add warning comment to PR
+        env:
+          URL: ${{ github.event.pull_request.comments_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl \
+            -X POST \
+            $URL \
+            -H "Content-Type: application/json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            --data '{ "body": ":warning: **IMPORTANT:** This PR may contain changes to dependency versions. The GitHub Actions test runner is not set up to detect dependency version conflicts between projects. To ensure the changes do not cause dependency conflicts, [run the tests for these changes in Azure DevOps](https://github.com/apache/lucenenet#azure-devops) before accepting this pull request. :warning:" }'


### PR DESCRIPTION
See #699.

- Added a GitHub workflow that posts a message to a PR to run tests in Azure DevOps if they have dependency version changes ([example](https://github.com/NightOwl888/lucenenet/pull/12)).
- Added detection of assembly load failures to Azure DevOps to fail the build ([example](https://dev.azure.com/LuceneNET-Temp/Lucene.NET/_build/results?buildId=2009&view=results)).

![image](https://user-images.githubusercontent.com/1538288/196540031-5759470d-ca79-4a8a-af59-7b0497424adb.png)
