### PR TITLE
Fix/gh 666

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/NGram/NGramTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/NGram/NGramTokenFilter.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Analysis.NGram
             offsetAtt = AddAttribute<IOffsetAttribute>();
         }
 
-        private class PositionIncrementAttributeAnonymousClass : PositionIncrementAttribute
+        private sealed class PositionIncrementAttributeAnonymousClass : PositionIncrementAttribute
         {
             public override int PositionIncrement
             {
@@ -123,7 +123,7 @@ namespace Lucene.Net.Analysis.NGram
             }
         }
 
-        private class PositionLengthAttributeAnonymousClass : PositionLengthAttribute
+        private sealed class PositionLengthAttributeAnonymousClass : PositionLengthAttribute
         {
             public override int PositionLength
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Sinks/TeeSinkTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Sinks/TeeSinkTokenFilter.cs
@@ -263,7 +263,7 @@ namespace Lucene.Net.Analysis.Sinks
 
         private static readonly SinkFilter ACCEPT_ALL_FILTER = new SinkFilterAnonymousClass();
 
-        private class SinkFilterAnonymousClass : SinkFilter
+        private sealed class SinkFilterAnonymousClass : SinkFilter
         {
             public override bool Accept(AttributeSource source)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/ClassicAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/ClassicAnalyzer.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Analysis.Standard
             return new TokenStreamComponentsAnonymousClass(this, src, tok);
         }
 
-        private class TokenStreamComponentsAnonymousClass : TokenStreamComponents
+        private sealed class TokenStreamComponentsAnonymousClass : TokenStreamComponents
         {
             private readonly ClassicAnalyzer outerInstance;
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/StandardAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/StandardAnalyzer.cs
@@ -109,7 +109,7 @@ namespace Lucene.Net.Analysis.Standard
             return new TokenStreamComponentsAnonymousClass(this, src, tok);
         }
 
-        private class TokenStreamComponentsAnonymousClass : TokenStreamComponents
+        private sealed class TokenStreamComponentsAnonymousClass : TokenStreamComponents
         {
             private readonly StandardAnalyzer outerInstance;
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailAnalyzer.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Analysis.Standard
             return new TokenStreamComponentsAnonymousClass(this, src, tok);
         }
 
-        private class TokenStreamComponentsAnonymousClass : TokenStreamComponents
+        private sealed class TokenStreamComponentsAnonymousClass : TokenStreamComponents
         {
             private readonly UAX29URLEmailAnalyzer outerInstance;
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayIterator.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayIterator.cs
@@ -133,7 +133,7 @@ namespace Lucene.Net.Analysis.Util
             return new CharArrayIteratorAnonymousClass2();
         }
 
-        private class CharArrayIteratorAnonymousClass2 : CharArrayIterator
+        private sealed class CharArrayIteratorAnonymousClass2 : CharArrayIterator
         {
             // no bugs
             protected override char JreBugWorkaround(char ch)
@@ -151,7 +151,7 @@ namespace Lucene.Net.Analysis.Util
             return new CharArrayIteratorAnonymousClass4();
         }
 
-        private class CharArrayIteratorAnonymousClass4 : CharArrayIterator
+        private sealed class CharArrayIteratorAnonymousClass4 : CharArrayIterator
         {
             // no bugs
             protected override char JreBugWorkaround(char ch)

--- a/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizerFactory.cs
+++ b/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizerFactory.cs
@@ -116,7 +116,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
             }
         }
 
-        private class DefaultICUTokenizerConfigAnonymousClass : DefaultICUTokenizerConfig
+        private sealed class DefaultICUTokenizerConfigAnonymousClass : DefaultICUTokenizerConfig
         {
             private readonly BreakIterator[] breakers;
             public DefaultICUTokenizerConfigAnonymousClass(bool cjkAsWords, bool myanmarAsWords, IDictionary<int, string> tailored, IResourceLoader loader)

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
@@ -398,7 +398,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             }
         }
 
-        private class RuleAnonymousClass : Rule
+        private sealed class RuleAnonymousClass : Rule
         {
             private readonly int myLine;
             private readonly string loc;

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/DemoHTMLParser.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/DemoHTMLParser.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
                 this.body = body.ToString();
             }
 
-            private class DefaultHandlerAnonymousClass : DefaultHandler
+            private sealed class DefaultHandlerAnonymousClass : DefaultHandler
             {
                 private int inBODY = 0, inHEAD = 0, inTITLE = 0, suppressed = 0;
 

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/SpatialDocMaker.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/SpatialDocMaker.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
 
         // LUCENENET specific: since this[string] is not virtual in .NET, this full implementation
         // of IDictionary<string, string> is required to override methods to get a value by key
-        private class DictionaryAnonymousClass : IDictionary<string, string>
+        private sealed class DictionaryAnonymousClass : IDictionary<string, string>
         {
             private readonly Config config;
             public DictionaryAnonymousClass(Config config)
@@ -155,7 +155,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             return strategy;
         }
 
-        private class RecursivePrefixTreeStrategyAnonymousClass : RecursivePrefixTreeStrategy
+        private sealed class RecursivePrefixTreeStrategyAnonymousClass : RecursivePrefixTreeStrategy
         {
             public RecursivePrefixTreeStrategyAnonymousClass(SpatialPrefixTree grid, string fieldName, Config config)
                 : base(grid, fieldName)
@@ -192,7 +192,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             return new ShapeConverterAnonymousClass(spatialStrategy, radiusDegrees, plusMinus, bbox);
         }
 
-        private class ShapeConverterAnonymousClass : IShapeConverter
+        private sealed class ShapeConverterAnonymousClass : IShapeConverter
         {
             private readonly SpatialStrategy spatialStrategy;
             private readonly double radiusDegrees;

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/SearchTravRetHighlightTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/SearchTravRetHighlightTask.cs
@@ -97,7 +97,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             return new BenchmarkHighlighterAnonymousClass(this, m_highlighter);
         }
 
-        private class BenchmarkHighlighterAnonymousClass : BenchmarkHighlighter
+        private sealed class BenchmarkHighlighterAnonymousClass : BenchmarkHighlighter
         {
             private readonly SearchTravRetHighlightTask outerInstance;
             private readonly Highlighter highlighter;

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/SearchTravRetVectorHighlightTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/SearchTravRetVectorHighlightTask.cs
@@ -101,7 +101,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             return new BenchmarkHighlighterAnonymousClass(this, m_highlighter, myq);
         }
 
-        private class BenchmarkHighlighterAnonymousClass : BenchmarkHighlighter
+        private sealed class BenchmarkHighlighterAnonymousClass : BenchmarkHighlighter
         {
             private readonly SearchTravRetVectorHighlightTask outerInstance;
             private readonly FastVectorHighlighter highlighter;

--- a/src/Lucene.Net.Benchmark/Quality/Utils/DocNameExtractor.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Utils/DocNameExtractor.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
             return name.Count > 0 ? name[0] : null;
         }
 
-        private class StoredFieldVisitorAnonymousClass : StoredFieldVisitor
+        private sealed class StoredFieldVisitorAnonymousClass : StoredFieldVisitor
         {
             private readonly DocNameExtractor outerInstance;
             private readonly IList<string> name;

--- a/src/Lucene.Net.Codecs/DiskDV/DiskDocValuesFormat.cs
+++ b/src/Lucene.Net.Codecs/DiskDV/DiskDocValuesFormat.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Codecs.DiskDV
             return new Lucene45DocValuesConsumerAnonymousClass(state);
         }
 
-        private class Lucene45DocValuesConsumerAnonymousClass : Lucene45DocValuesConsumer
+        private sealed class Lucene45DocValuesConsumerAnonymousClass : Lucene45DocValuesConsumer
         {
             public Lucene45DocValuesConsumerAnonymousClass(SegmentWriteState state)
                 : base(state, DATA_CODEC, DATA_EXTENSION, META_CODEC, META_EXTENSION)

--- a/src/Lucene.Net.Codecs/Memory/DirectDocValuesConsumer.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectDocValuesConsumer.cs
@@ -305,7 +305,7 @@ namespace Lucene.Net.Codecs.Memory
             AddBinaryFieldValues(field, values);
         }
 
-        private class EnumerableAnonymousClass : IEnumerable<long?>
+        private sealed class EnumerableAnonymousClass : IEnumerable<long?>
         {
             private readonly IEnumerable<long?> _docToOrdCount;
 
@@ -317,7 +317,7 @@ namespace Lucene.Net.Codecs.Memory
             // Just aggregates the count values so they become
             // "addresses", and adds one more value in the end
             // (the final sum):
-            public virtual IEnumerator<long?> GetEnumerator()
+            public IEnumerator<long?> GetEnumerator()
             {
                 return new Enumerator( _docToOrdCount);
             }

--- a/src/Lucene.Net.Codecs/Memory/DirectDocValuesProducer.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectDocValuesProducer.cs
@@ -281,7 +281,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class NumericDocValuesAnonymousClass : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass : NumericDocValues
         {
             private readonly sbyte[] values;
 
@@ -296,7 +296,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class NumericDocValuesAnonymousClass2 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass2 : NumericDocValues
         {
             private readonly short[] values;
 
@@ -311,7 +311,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class NumericDocValuesAnonymousClass3 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass3 : NumericDocValues
         {
             private readonly int[] values;
 
@@ -326,7 +326,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class NumericDocValuesAnonymousClass4 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass4 : NumericDocValues
         {
             private readonly long[] values;
 
@@ -379,7 +379,7 @@ namespace Lucene.Net.Codecs.Memory
             return new BinaryDocValuesAnonymousClass(bytes, address);
         }
 
-        private class BinaryDocValuesAnonymousClass : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass : BinaryDocValues
         {
             private readonly byte[] bytes;
             private readonly int[] address;
@@ -426,7 +426,7 @@ namespace Lucene.Net.Codecs.Memory
             return new SortedDocValuesAnonymousClass(entry, docToOrd, values);
         }
 
-        private class SortedDocValuesAnonymousClass : SortedDocValues
+        private sealed class SortedDocValuesAnonymousClass : SortedDocValues
         {
             private readonly SortedEntry entry;
             private readonly NumericDocValues docToOrd;
@@ -483,7 +483,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class RandomAccessOrdsAnonymousClass : RandomAccessOrds
+        private sealed class RandomAccessOrdsAnonymousClass : RandomAccessOrds
         {
             private readonly SortedSetEntry entry;
             private readonly NumericDocValues docToOrdAddress;

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
@@ -410,7 +410,7 @@ namespace Lucene.Net.Codecs.Memory
             WriteFST(field, values);
         }
 
-        private class EnumerableAnonymousClass : IEnumerable<BytesRef>
+        private sealed class EnumerableAnonymousClass : IEnumerable<BytesRef>
         {
             private readonly IEnumerable<long?> _docToOrdCount;
             private readonly IEnumerable<long?> _ords;

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
@@ -284,7 +284,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class NumericDocValuesAnonymousClass : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass : NumericDocValues
         {
             private readonly long[] decode;
             private readonly PackedInt32s.Reader ordsReader;
@@ -301,7 +301,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class NumericDocValuesAnonymousClass2 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass2 : NumericDocValues
         {
             private readonly sbyte[] bytes;
 
@@ -316,7 +316,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class NumericDocValuesAnonymousClass3 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass3 : NumericDocValues
         {
             private readonly long min;
             private readonly long mult;
@@ -377,7 +377,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class BinaryDocValuesAnonymousClass : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass : BinaryDocValues
         {
             private readonly PagedBytes.Reader bytesReader;
             private readonly int fixedLength;
@@ -394,7 +394,7 @@ namespace Lucene.Net.Codecs.Memory
             }
         }
 
-        private class BinaryDocValuesAnonymousClass2 : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass2 : BinaryDocValues
         {
             private readonly PagedBytes.Reader bytesReader;
             private readonly MonotonicBlockPackedReader addresses;
@@ -450,7 +450,7 @@ namespace Lucene.Net.Codecs.Memory
                 scratchInts, fstEnum);
         }
 
-        private class SortedDocValuesAnonymousClass : SortedDocValues
+        private sealed class SortedDocValuesAnonymousClass : SortedDocValues
         {
             private readonly MemoryDocValuesProducer.FSTEntry entry;
             private readonly NumericDocValues docToOrd;
@@ -568,7 +568,7 @@ namespace Lucene.Net.Codecs.Memory
                 scratchArc, scratchInts, fstEnum, @ref, input);
         }
 
-        private class SortedSetDocValuesAnonymousClass : SortedSetDocValues
+        private sealed class SortedSetDocValuesAnonymousClass : SortedSetDocValues
         {
             private readonly MemoryDocValuesProducer.FSTEntry entry;
             private readonly BinaryDocValues docToOrds;

--- a/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
@@ -338,7 +338,7 @@ namespace Lucene.Net.Codecs.Memory
             return new FieldsConsumerAnonymousClass(this, @out);
         }
 
-        private class FieldsConsumerAnonymousClass : FieldsConsumer
+        private sealed class FieldsConsumerAnonymousClass : FieldsConsumer
         {
             private readonly MemoryPostingsFormat outerInstance;
 
@@ -979,7 +979,7 @@ namespace Lucene.Net.Codecs.Memory
             return new FieldsProducerAnonymousClass(fields);
         }
 
-        private class FieldsProducerAnonymousClass : FieldsProducer
+        private sealed class FieldsProducerAnonymousClass : FieldsProducer
         {
             private readonly IDictionary<string, TermsReader> _fields;
 

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
@@ -157,7 +157,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return new NumericDocValuesAnonymousClass(this, field, @in, scratch);
         }
 
-        private class NumericDocValuesAnonymousClass : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass : NumericDocValues
         {
             private readonly SimpleTextDocValuesReader _outerInstance;
 
@@ -207,7 +207,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return new BitsAnonymousClass(this, field, input, scratch);
         }
 
-        private class BitsAnonymousClass : IBits
+        private sealed class BitsAnonymousClass : IBits
         {
             private readonly SimpleTextDocValuesReader _outerInstance;
 
@@ -252,7 +252,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return new BinaryDocValuesAnonymousClass(this, field, input, scratch);
         }
 
-        private class BinaryDocValuesAnonymousClass : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass : BinaryDocValues
         {
             private readonly SimpleTextDocValuesReader _outerInstance;
 
@@ -313,7 +313,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return new BitsAnonymousClass2(this, field, input, scratch);
         }
 
-        private class BitsAnonymousClass2 : IBits
+        private sealed class BitsAnonymousClass2 : IBits
         {
             private readonly SimpleTextDocValuesReader _outerInstance;
 
@@ -376,7 +376,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return new SortedDocValuesAnonymousClass(this, field, input, scratch);
         }
 
-        private class SortedDocValuesAnonymousClass : SortedDocValues
+        private sealed class SortedDocValuesAnonymousClass : SortedDocValues
         {
             private readonly SimpleTextDocValuesReader _outerInstance;
 
@@ -476,7 +476,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return new SortedSetDocValuesAnonymousClass(this, field, input, scratch);
         }
 
-        private class SortedSetDocValuesAnonymousClass : SortedSetDocValues
+        private sealed class SortedSetDocValuesAnonymousClass : SortedSetDocValues
         {
             private readonly SimpleTextDocValuesReader _outerInstance;
 

--- a/src/Lucene.Net.Facet/DrillSidewaysQuery.cs
+++ b/src/Lucene.Net.Facet/DrillSidewaysQuery.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Facet
             return new WeightAnonymousClass(this, baseWeight, drillDowns);
         }
 
-        private class WeightAnonymousClass : Weight
+        private sealed class WeightAnonymousClass : Weight
         {
             private readonly DrillSidewaysQuery outerInstance;
 

--- a/src/Lucene.Net.Facet/FacetsCollector.cs
+++ b/src/Lucene.Net.Facet/FacetsCollector.cs
@@ -133,7 +133,7 @@ namespace Lucene.Net.Facet
             return new DocsAnonymousClass(maxDoc);
         }
 
-        private class DocsAnonymousClass : Docs
+        private sealed class DocsAnonymousClass : Docs
         {
             public DocsAnonymousClass(int maxDoc)
             {

--- a/src/Lucene.Net.Facet/Range/DoubleRange.cs
+++ b/src/Lucene.Net.Facet/Range/DoubleRange.cs
@@ -126,7 +126,7 @@ namespace Lucene.Net.Facet.Range
             return new FilterAnonymousClass(this, fastMatchFilter, valueSource);
         }
 
-        private class FilterAnonymousClass : Filter
+        private sealed class FilterAnonymousClass : Filter
         {
             private readonly DoubleRange outerInstance;
 
@@ -180,7 +180,7 @@ namespace Lucene.Net.Facet.Range
                 return new DocIdSetAnonymousClass(this, acceptDocs, values, maxDoc, fastMatchBits);
             }
 
-            private class DocIdSetAnonymousClass : DocIdSet
+            private sealed class DocIdSetAnonymousClass : DocIdSet
             {
                 private readonly FilterAnonymousClass outerInstance;
 
@@ -200,7 +200,7 @@ namespace Lucene.Net.Facet.Range
 
                 public override IBits Bits => new BitsAnonymousClass(this);
 
-                private class BitsAnonymousClass : IBits
+                private sealed class BitsAnonymousClass : IBits
                 {
                     private readonly DocIdSetAnonymousClass outerInstance;
 
@@ -209,7 +209,7 @@ namespace Lucene.Net.Facet.Range
                         this.outerInstance = outerInstance;
                     }
 
-                    public virtual bool Get(int docID)
+                    public bool Get(int docID)
                     {
                         if (outerInstance.acceptDocs != null && outerInstance.acceptDocs.Get(docID) == false)
                         {
@@ -222,7 +222,7 @@ namespace Lucene.Net.Facet.Range
                         return outerInstance.outerInstance.outerInstance.Accept(outerInstance.values.DoubleVal(docID));
                     }
 
-                    public virtual int Length => outerInstance.maxDoc;
+                    public int Length => outerInstance.maxDoc;
                 }
 
                 public override DocIdSetIterator GetIterator()

--- a/src/Lucene.Net.Facet/Range/LongRange.cs
+++ b/src/Lucene.Net.Facet/Range/LongRange.cs
@@ -120,7 +120,7 @@ namespace Lucene.Net.Facet.Range
             return new FilterAnonymousClass(this, fastMatchFilter, valueSource);
         }
 
-        private class FilterAnonymousClass : Filter
+        private sealed class FilterAnonymousClass : Filter
         {
             private readonly Int64Range outerInstance;
 
@@ -175,7 +175,7 @@ namespace Lucene.Net.Facet.Range
                 return new DocIdSetAnonymousClass(this, acceptDocs, values, maxDoc, fastMatchBits);
             }
 
-            private class DocIdSetAnonymousClass : DocIdSet
+            private sealed class DocIdSetAnonymousClass : DocIdSet
             {
                 private readonly FilterAnonymousClass outerInstance;
 
@@ -196,7 +196,7 @@ namespace Lucene.Net.Facet.Range
 
                 public override IBits Bits => new BitsAnonymousClass(this);
 
-                private class BitsAnonymousClass : IBits
+                private sealed class BitsAnonymousClass : IBits
                 {
                     private readonly DocIdSetAnonymousClass outerInstance;
 
@@ -205,7 +205,7 @@ namespace Lucene.Net.Facet.Range
                         this.outerInstance = outerInstance;
                     }
 
-                    public virtual bool Get(int docID)
+                    public bool Get(int docID)
                     {
                         if (outerInstance.acceptDocs != null && outerInstance.acceptDocs.Get(docID) == false)
                         {
@@ -219,7 +219,7 @@ namespace Lucene.Net.Facet.Range
                     }
 
 
-                    public virtual int Length => outerInstance.maxDoc;
+                    public int Length => outerInstance.maxDoc;
                 }
 
                 public override DocIdSetIterator GetIterator()

--- a/src/Lucene.Net.Facet/Taxonomy/CachedOrdinalsReader.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/CachedOrdinalsReader.cs
@@ -122,7 +122,7 @@ namespace Lucene.Net.Facet.Taxonomy
             return new OrdinalsSegmentReaderAnonymousClass(cachedOrds);
         }
 
-        private class OrdinalsSegmentReaderAnonymousClass : OrdinalsSegmentReader
+        private sealed class OrdinalsSegmentReaderAnonymousClass : OrdinalsSegmentReader
         {
             private readonly CachedOrds cachedOrds;
 

--- a/src/Lucene.Net.Facet/Taxonomy/DocValuesOrdinalsReader.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/DocValuesOrdinalsReader.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Facet.Taxonomy
             return new OrdinalsSegmentReaderAnonymousClass(this, values);
         }
 
-        private class OrdinalsSegmentReaderAnonymousClass : OrdinalsSegmentReader
+        private sealed class OrdinalsSegmentReaderAnonymousClass : OrdinalsSegmentReader
         {
             private readonly DocValuesOrdinalsReader outerInstance;
 

--- a/src/Lucene.Net.Facet/Taxonomy/TaxonomyFacetSumValueSource.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/TaxonomyFacetSumValueSource.cs
@@ -170,7 +170,7 @@ namespace Lucene.Net.Facet.Taxonomy
                 return new DoubleDocValuesAnonymousClass(this, scorer);
             }
 
-            private class DoubleDocValuesAnonymousClass : DoubleDocValues
+            private sealed class DoubleDocValuesAnonymousClass : DoubleDocValues
             {
                 private readonly Scorer scorer;
 

--- a/src/Lucene.Net.Highlighter/PostingsHighlight/MultiTermHighlighting.cs
+++ b/src/Lucene.Net.Highlighter/PostingsHighlight/MultiTermHighlighting.cs
@@ -137,7 +137,7 @@ namespace Lucene.Net.Search.PostingsHighlight
             return list.ToArray(/*new CharacterRunAutomaton[list.size()]*/);
         }
 
-        private class CharacterRunAutomatonToStringAnonymousClass : CharacterRunAutomaton
+        private sealed class CharacterRunAutomatonToStringAnonymousClass : CharacterRunAutomaton
         {
             private readonly Func<string> toStringMethod;
 
@@ -153,7 +153,7 @@ namespace Lucene.Net.Search.PostingsHighlight
             }
         }
 
-        private class SimpleCharacterRunAutomatonAnonymousClass : CharacterRunAutomaton
+        private sealed class SimpleCharacterRunAutomatonAnonymousClass : CharacterRunAutomaton
         {
             private readonly CharsRef lowerBound;
             private readonly CharsRef upperBound;
@@ -234,7 +234,7 @@ namespace Lucene.Net.Search.PostingsHighlight
             return new DocsAndPositionsEnumAnonymousClass(ts, matchers, charTermAtt, offsetAtt);
         }
 
-        private class DocsAndPositionsEnumAnonymousClass : DocsAndPositionsEnum
+        private sealed class DocsAndPositionsEnumAnonymousClass : DocsAndPositionsEnum
         {
             private readonly CharacterRunAutomaton[] matchers;
             private readonly ICharTermAttribute charTermAtt;

--- a/src/Lucene.Net.Highlighter/PostingsHighlight/Passage.cs
+++ b/src/Lucene.Net.Highlighter/PostingsHighlight/Passage.cs
@@ -64,7 +64,7 @@ namespace Lucene.Net.Search.PostingsHighlight
             numMatches++;
         }
 
-        private class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
+        private sealed class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
         {
             private readonly int[] starts;
             private readonly int[] ends;

--- a/src/Lucene.Net.Highlighter/PostingsHighlight/PostingsHighlighter.cs
+++ b/src/Lucene.Net.Highlighter/PostingsHighlight/PostingsHighlighter.cs
@@ -337,7 +337,7 @@ namespace Lucene.Net.Search.PostingsHighlight
             return snippets;
         }
 
-        private class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
+        private sealed class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
         {
             private readonly string[] fields;
             private readonly int[] maxPassages;
@@ -843,7 +843,7 @@ namespace Lucene.Net.Search.PostingsHighlight
         /// we rewrite against an empty indexreader: as we don't want things like
         /// rangeQueries that don't summarize the document
         /// </summary>
-        private class DocsAndPositionsEnumAnonymousClass : DocsAndPositionsEnum
+        private sealed class DocsAndPositionsEnumAnonymousClass : DocsAndPositionsEnum
         {
             public override int NextPosition()
             {

--- a/src/Lucene.Net.Highlighter/VectorHighlight/BaseFragmentsBuilder.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/BaseFragmentsBuilder.cs
@@ -170,7 +170,7 @@ namespace Lucene.Net.Search.VectorHighlight
             return fields.ToArray(/*new Field[fields.size()]*/);
         }
 
-        private class GetFieldsStoredFieldsVisitorAnonymousClass : StoredFieldVisitor
+        private sealed class GetFieldsStoredFieldsVisitorAnonymousClass : StoredFieldVisitor
         {
             private readonly IList<Field> fields;
             private readonly string fieldName;

--- a/src/Lucene.Net.Join/TermsIncludingScoreQuery.cs
+++ b/src/Lucene.Net.Join/TermsIncludingScoreQuery.cs
@@ -119,7 +119,7 @@ namespace Lucene.Net.Search.Join
             return new WeightAnonymousClass(this, originalWeight);
         }
 
-        private class WeightAnonymousClass : Weight
+        private sealed class WeightAnonymousClass : Weight
         {
             private readonly TermsIncludingScoreQuery outerInstance;
 

--- a/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Index.Memory
                     return new IteratorAnonymousClass(this);
                 }
 
-                private class IteratorAnonymousClass : IEnumerator<string>
+                private sealed class IteratorAnonymousClass : IEnumerator<string>
                 {
                     private readonly MemoryFields outerInstance;
 
@@ -166,7 +166,7 @@ namespace Lucene.Net.Index.Memory
                     }
                 }
 
-                private class TermsAnonymousClass : Terms
+                private sealed class TermsAnonymousClass : Terms
                 {
                     private readonly MemoryFields outerInstance;
 

--- a/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
@@ -107,14 +107,14 @@ namespace Lucene.Net.Index.Memory
 
                 public override IEnumerator<string> GetEnumerator()
                 {
-                    return new IteratorAnonymousClass(this);
+                    return new EnumeratorAnonymousClass(this);
                 }
 
-                private sealed class IteratorAnonymousClass : IEnumerator<string>
+                private sealed class EnumeratorAnonymousClass : IEnumerator<string>
                 {
                     private readonly MemoryFields outerInstance;
 
-                    public IteratorAnonymousClass(MemoryFields outerInstance)
+                    public EnumeratorAnonymousClass(MemoryFields outerInstance)
                     {
                         this.outerInstance = outerInstance;
                         upto = -1;

--- a/src/Lucene.Net.Memory/MemoryIndex.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.cs
@@ -578,7 +578,7 @@ namespace Lucene.Net.Index.Memory
             }
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly float[] scores;
 
@@ -589,19 +589,19 @@ namespace Lucene.Net.Index.Memory
 
             private Scorer scorer;
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 scores[0] = scorer.GetScore();
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
         }

--- a/src/Lucene.Net.Misc/Index/Sorter/BlockJoinComparatorSource.cs
+++ b/src/Lucene.Net.Misc/Index/Sorter/BlockJoinComparatorSource.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Index.Sorter
                 childSlots, parentReverseMul, parentComparers, childReverseMul, childComparers);
         }
 
-        private class FieldComparerAnonymousClass : FieldComparer<J2N.Numerics.Int32>
+        private sealed class FieldComparerAnonymousClass : FieldComparer<J2N.Numerics.Int32>
         {
             private readonly BlockJoinComparerSource outerInstance;
 
@@ -210,12 +210,12 @@ namespace Lucene.Net.Index.Sorter
                 }
             }
 
-            internal virtual int Parent(int doc)
+            internal int Parent(int doc)
             {
                 return parentBits.NextSetBit(doc);
             }
 
-            internal virtual int Compare(int docID1, int parent1, int docID2, int parent2)
+            internal int Compare(int docID1, int parent1, int docID2, int parent2)
             {
                 if (parent1 == parent2) // both are in the same block
                 {
@@ -243,7 +243,7 @@ namespace Lucene.Net.Index.Sorter
                 }
             }
 
-            internal virtual int Compare(int docID1, int docID2, FieldComparer[] comparers, int[] reverseMul)
+            internal int Compare(int docID1, int docID2, FieldComparer[] comparers, int[] reverseMul)
             {
                 for (int i = 0; i < comparers.Length; i++)
                 {

--- a/src/Lucene.Net.Misc/Index/Sorter/Sorter.cs
+++ b/src/Lucene.Net.Misc/Index/Sorter/Sorter.cs
@@ -212,7 +212,7 @@ namespace Lucene.Net.Index.Sorter
             return new DocMapAnonymousClass(maxDoc, newToOld, oldToNew);
         }
 
-        private class DocMapAnonymousClass : Sorter.DocMap
+        private sealed class DocMapAnonymousClass : Sorter.DocMap
         {
             private readonly int maxDoc;
             private readonly MonotonicAppendingInt64Buffer newToOld;
@@ -270,7 +270,7 @@ namespace Lucene.Net.Index.Sorter
             return Sort(reader.MaxDoc, comparer);
         }
 
-        private class DocComparerAnonymousClass : DocComparer
+        private sealed class DocComparerAnonymousClass : DocComparer
         {
             private readonly int[] reverseMul;
             private readonly FieldComparer[] comparers;
@@ -323,7 +323,7 @@ namespace Lucene.Net.Index.Sorter
 
         internal static readonly Scorer FAKESCORER = new ScorerAnonymousClass();
 
-        private class ScorerAnonymousClass : Scorer
+        private sealed class ScorerAnonymousClass : Scorer
         {
             public ScorerAnonymousClass() 
                 : base(null)

--- a/src/Lucene.Net.Misc/Index/Sorter/SortingAtomicReader.cs
+++ b/src/Lucene.Net.Misc/Index/Sorter/SortingAtomicReader.cs
@@ -120,7 +120,7 @@ namespace Lucene.Net.Index.Sorter
                 return new BitsAnonymousClass(this, liveDocs);
             }
 
-            private class BitsAnonymousClass : IBits
+            private sealed class BitsAnonymousClass : IBits
             {
                 private readonly SortingTermsEnum outerInstance;
 

--- a/src/Lucene.Net.Misc/Index/Sorter/SortingMergePolicy.cs
+++ b/src/Lucene.Net.Misc/Index/Sorter/SortingMergePolicy.cs
@@ -140,7 +140,7 @@ namespace Lucene.Net.Index.Sorter
                 return new DocMapAnonymousClass(this, mergeState, deletes);
             }
 
-            private class DocMapAnonymousClass : MergePolicy.DocMap
+            private sealed class DocMapAnonymousClass : MergePolicy.DocMap
             {
                 private readonly SortingOneMerge outerInstance;
 

--- a/src/Lucene.Net.Queries/BoostingQuery.cs
+++ b/src/Lucene.Net.Queries/BoostingQuery.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Queries
             };
         }
 
-        private class BooleanQueryAnonymousClass : BooleanQuery
+        private sealed class BooleanQueryAnonymousClass : BooleanQuery
         {
             private readonly BoostingQuery outerInstance;
 
@@ -75,7 +75,7 @@ namespace Lucene.Net.Queries
                 return new BooleanWeightAnonymousClass(this, searcher);
             }
 
-            private class BooleanWeightAnonymousClass : BooleanWeight
+            private sealed class BooleanWeightAnonymousClass : BooleanWeight
             {
                 private readonly BooleanQueryAnonymousClass outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/ByteFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ByteFieldSource.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new FunctionValuesAnonymousClass(this, arr);
         }
 
-        private class FunctionValuesAnonymousClass : FunctionValues
+        private sealed class FunctionValuesAnonymousClass : FunctionValues
         {
             private readonly ByteFieldSource outerInstance;
             private readonly FieldCache.Bytes arr;

--- a/src/Lucene.Net.Queries/Function/ValueSources/BytesRefFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/BytesRefFieldSource.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             }
         }
 
-        private class FunctionValuesAnonymousClass : FunctionValues
+        private sealed class FunctionValuesAnonymousClass : FunctionValues
         {
             private readonly BytesRefFieldSource outerInstance;
 
@@ -94,7 +94,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             }
         }
 
-        private class DocTermsIndexDocValuesAnonymousClass : DocTermsIndexDocValues
+        private sealed class DocTermsIndexDocValuesAnonymousClass : DocTermsIndexDocValues
         {
             private readonly BytesRefFieldSource outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/ConstValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ConstValueSource.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, this);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly ConstValueSource outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/DefFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DefFunction.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new ValuesAnonymousClass(this, ValsArr(m_sources, fcontext, readerContext));
         }
 
-        private class ValuesAnonymousClass : Values
+        private sealed class ValuesAnonymousClass : Values
         {
             public ValuesAnonymousClass(DefFunction outerInstance, FunctionValues[] valsArr)
                 : base(outerInstance, valsArr)

--- a/src/Lucene.Net.Queries/Function/ValueSources/DoubleConstValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DoubleConstValueSource.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new DoubleDocValuesAnonymousClass(this, this);
         }
 
-        private class DoubleDocValuesAnonymousClass : DoubleDocValues
+        private sealed class DoubleDocValuesAnonymousClass : DoubleDocValues
         {
             private readonly DoubleConstValueSource outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/DoubleFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DoubleFieldSource.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new DoubleDocValuesAnonymousClass(this, arr, valid);
         }
 
-        private class DoubleDocValuesAnonymousClass : DoubleDocValues
+        private sealed class DoubleDocValuesAnonymousClass : DoubleDocValues
         {
             private readonly FieldCache.Doubles arr;
             private readonly IBits valid;

--- a/src/Lucene.Net.Queries/Function/ValueSources/DualFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DualFloatFunction.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, this, aVals, bVals);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly DualSingleFunction outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/EnumFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/EnumFieldSource.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new Int32DocValuesAnonymousClass(this, this, arr, valid);
         }
 
-        private class Int32DocValuesAnonymousClass : Int32DocValues
+        private sealed class Int32DocValuesAnonymousClass : Int32DocValues
         {
             private readonly EnumFieldSource outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/FloatFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/FloatFieldSource.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, arr, valid);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly FieldCache.Singles arr;
             private readonly IBits valid;

--- a/src/Lucene.Net.Queries/Function/ValueSources/IfFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/IfFunction.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new FunctionValuesAnonymousClass(ifVals, trueVals, falseVals);
         }
 
-        private class FunctionValuesAnonymousClass : FunctionValues
+        private sealed class FunctionValuesAnonymousClass : FunctionValues
         {
             private readonly FunctionValues ifVals;
             private readonly FunctionValues trueVals;

--- a/src/Lucene.Net.Queries/Function/ValueSources/IntFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/IntFieldSource.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new Int32DocValuesAnonymousClass(this, this, arr, valid);
         }
 
-        private class Int32DocValuesAnonymousClass : Int32DocValues
+        private sealed class Int32DocValuesAnonymousClass : Int32DocValues
         {
             private readonly Int32FieldSource outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/JoinDocFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/JoinDocFreqValueSource.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new Int32DocValuesAnonymousClass(this, this, terms, termsEnum);
         }
 
-        private class Int32DocValuesAnonymousClass : Int32DocValues
+        private sealed class Int32DocValuesAnonymousClass : Int32DocValues
         {
             private readonly JoinDocFreqValueSource outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/LinearFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LinearFloatFunction.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, this, vals);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly LinearSingleFunction outerInstance;
             private readonly FunctionValues vals;

--- a/src/Lucene.Net.Queries/Function/ValueSources/LiteralValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LiteralValueSource.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new StrDocValuesAnonymousClass(this, this);
         }
 
-        private class StrDocValuesAnonymousClass : StrDocValues
+        private sealed class StrDocValuesAnonymousClass : StrDocValues
         {
             private readonly LiteralValueSource outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/LongFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LongFieldSource.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new Int64DocValuesAnonymousClass(this, this, arr, valid);
         }
 
-        private class Int64DocValuesAnonymousClass : Int64DocValues
+        private sealed class Int64DocValuesAnonymousClass : Int64DocValues
         {
             private readonly Int64FieldSource outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/MultiBoolFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/MultiBoolFunction.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new BoolDocValuesAnonymousClass(this, this, vals);
         }
 
-        private class BoolDocValuesAnonymousClass : BoolDocValues
+        private sealed class BoolDocValuesAnonymousClass : BoolDocValues
         {
             private readonly MultiBoolFunction outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/MultiFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/MultiFloatFunction.cs
@@ -77,7 +77,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, this, valsArr);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly MultiSingleFunction outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/NormValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/NormValueSource.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, similarity, norms);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly TFIDFSimilarity similarity;
             private readonly NumericDocValues norms;

--- a/src/Lucene.Net.Queries/Function/ValueSources/RangeMapFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/RangeMapFloatFunction.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, this, vals, targets, defaults);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly RangeMapSingleFunction outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/ReciprocalFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ReciprocalFloatFunction.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, this, vals);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly ReciprocalSingleFunction outerInstance;
             private readonly FunctionValues vals;

--- a/src/Lucene.Net.Queries/Function/ValueSources/ReverseOrdFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ReverseOrdFieldSource.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new Int32DocValuesAnonymousClass(this, off, sindex, end);
         }
 
-        private class Int32DocValuesAnonymousClass : Int32DocValues
+        private sealed class Int32DocValuesAnonymousClass : Int32DocValues
         {
             private readonly int off;
             private readonly SortedDocValues sindex;

--- a/src/Lucene.Net.Queries/Function/ValueSources/ScaleFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ScaleFloatFunction.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, this, scale, minSource, maxSource, vals);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly ScaleSingleFunction outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/ShortFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ShortFieldSource.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new FunctionValuesAnonymousClass(this, arr);
         }
 
-        private class FunctionValuesAnonymousClass : FunctionValues
+        private sealed class FunctionValuesAnonymousClass : FunctionValues
         {
             private readonly Int16FieldSource outerInstance;
             private readonly FieldCache.Int16s arr;

--- a/src/Lucene.Net.Queries/Function/ValueSources/SimpleBoolFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/SimpleBoolFunction.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new BoolDocValuesAnonymousClass(this, this, vals);
         }
 
-        private class BoolDocValuesAnonymousClass : BoolDocValues
+        private sealed class BoolDocValuesAnonymousClass : BoolDocValues
         {
             private readonly SimpleBoolFunction outerInstance;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/SimpleFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/SimpleFloatFunction.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, this, vals);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly SimpleSingleFunction outerInstance;
             private readonly FunctionValues vals;

--- a/src/Lucene.Net.Queries/Function/ValueSources/SumTotalTermFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/SumTotalTermFreqValueSource.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             context[this] = new Int64DocValuesAnonymousClass(this, ttf);
         }
 
-        private class Int64DocValuesAnonymousClass : Int64DocValues
+        private sealed class Int64DocValuesAnonymousClass : Int64DocValues
         {
             private readonly long ttf;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/TFValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/TFValueSource.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new SingleDocValuesAnonymousClass(this, this, terms, similarity);
         }
 
-        private class SingleDocValuesAnonymousClass : SingleDocValues
+        private sealed class SingleDocValuesAnonymousClass : SingleDocValues
         {
             private readonly TFValueSource outerInstance;
 
@@ -79,7 +79,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             private int atDoc;
             private int lastDocRequested;
 
-            public virtual void Reset()
+            public void Reset()
             {
                 // no one should call us for deleted docs?
 
@@ -107,7 +107,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
                 atDoc = -1;
             }
 
-            private class DocsEnumAnonymousClass : DocsEnum
+            private sealed class DocsEnumAnonymousClass : DocsEnum
             {
                 public override int Freq => 0;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/TermFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/TermFreqValueSource.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new Int32DocValuesAnonymousClass(this, this, terms);
         }
 
-        private class Int32DocValuesAnonymousClass : Int32DocValues
+        private sealed class Int32DocValuesAnonymousClass : Int32DocValues
         {
             private readonly TermFreqValueSource outerInstance;
 
@@ -69,7 +69,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             private int atDoc;
             private int lastDocRequested;
 
-            public virtual void Reset()
+            public void Reset()
             {
                 // no one should call us for deleted docs?
 
@@ -97,7 +97,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
                 atDoc = -1;
             }
 
-            private class DocsEnumAnonymousClass : DocsEnum
+            private sealed class DocsEnumAnonymousClass : DocsEnum
             {
                 public override int Freq => 0;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/TotalTermFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/TotalTermFreqValueSource.cs
@@ -79,7 +79,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             context[this] = new Int64DocValuesAnonymousClass(this, ttf);
         }
 
-        private class Int64DocValuesAnonymousClass : Int64DocValues
+        private sealed class Int64DocValuesAnonymousClass : Int64DocValues
         {
             private readonly long ttf;
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/VectorValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/VectorValueSource.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             return new FunctionValuesAnonymousClass2(this, valsArr);
         }
 
-        private class FunctionValuesAnonymousClass : FunctionValues
+        private sealed class FunctionValuesAnonymousClass : FunctionValues
         {
             private readonly VectorValueSource outerInstance;
 
@@ -137,7 +137,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             }
         }
 
-        private class FunctionValuesAnonymousClass2 : FunctionValues
+        private sealed class FunctionValuesAnonymousClass2 : FunctionValues
         {
             private readonly VectorValueSource outerInstance;
             private readonly FunctionValues[] valsArr;

--- a/src/Lucene.Net.Queries/TermFilter.cs
+++ b/src/Lucene.Net.Queries/TermFilter.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Queries
             return new DocIdSetAnonymousClass(acceptDocs, termsEnum);
         }
 
-        private class DocIdSetAnonymousClass : DocIdSet
+        private sealed class DocIdSetAnonymousClass : DocIdSet
         {
             private readonly IBits acceptDocs;
             private readonly TermsEnum termsEnum;

--- a/src/Lucene.Net.Queries/TermsFilter.cs
+++ b/src/Lucene.Net.Queries/TermsFilter.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Queries
         {
         }
 
-        private class FieldAndTermEnumAnonymousClass : FieldAndTermEnum
+        private sealed class FieldAndTermEnumAnonymousClass : FieldAndTermEnum
         {            
             public FieldAndTermEnumAnonymousClass(IList<Term> terms)
             {
@@ -103,7 +103,7 @@ namespace Lucene.Net.Queries
         {
         }
 
-        private class FieldAndTermEnumAnonymousClass2 : FieldAndTermEnum
+        private sealed class FieldAndTermEnumAnonymousClass2 : FieldAndTermEnum
         {
             public FieldAndTermEnumAnonymousClass2(string field, IList<BytesRef> terms)
                 : base(field)

--- a/src/Lucene.Net.Sandbox/Queries/SortedSetSortField.cs
+++ b/src/Lucene.Net.Sandbox/Queries/SortedSetSortField.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Sandbox.Queries
             base.m_missingValue = value;
         }
 
-        private class TermOrdValComparerAnonymousClass : FieldComparer.TermOrdValComparer
+        private sealed class TermOrdValComparerAnonymousClass : FieldComparer.TermOrdValComparer
         {
             private readonly SortedSetSortField outerInstance;
 

--- a/src/Lucene.Net.Spatial/Serialized/SerializedDVStrategy.cs
+++ b/src/Lucene.Net.Spatial/Serialized/SerializedDVStrategy.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Spatial.Serialized
             return new Field[] { new BinaryDocValuesField(FieldName, bytesRef) };
         }
 
-        private class OutputStreamAnonymousClass : MemoryStream
+        private sealed class OutputStreamAnonymousClass : MemoryStream
         {
             private readonly BytesRef bytesRef;
 
@@ -158,7 +158,7 @@ namespace Lucene.Net.Spatial.Serialized
                 return new DocIdSetAnonymousClass(this, context, acceptDocs);
             }
 
-            private class DocIdSetAnonymousClass : DocIdSet
+            private sealed class DocIdSetAnonymousClass : DocIdSet
             {
                 private readonly PredicateValueSourceFilter outerInstance;
                 private readonly AtomicReaderContext context;
@@ -190,7 +190,7 @@ namespace Lucene.Net.Spatial.Serialized
                     }
                 }
 
-                private class BitsAnonymousClass : IBits
+                private sealed class BitsAnonymousClass : IBits
                 {
                     private readonly FunctionValues predFuncValues;
                     private readonly AtomicReaderContext context;
@@ -204,14 +204,14 @@ namespace Lucene.Net.Spatial.Serialized
                         this.acceptDocs = acceptDocs;
                     }
 
-                    public virtual bool Get(int index)
+                    public bool Get(int index)
                     {
                         if (acceptDocs != null && !acceptDocs.Get(index))
                             return false;
                         return predFuncValues.BoolVal(index);
                     }
 
-                    public virtual int Length => context.Reader.MaxDoc;
+                    public int Length => context.Reader.MaxDoc;
                 }
             }
 
@@ -261,7 +261,7 @@ namespace Lucene.Net.Spatial.Serialized
                 return new FuctionValuesAnonymousClass(this, docValues);
             }
 
-            private class FuctionValuesAnonymousClass : FunctionValues
+            private sealed class FuctionValuesAnonymousClass : FunctionValues
             {
                 private readonly ShapeDocValueSource outerInstance;
                 private readonly BinaryDocValues docValues;

--- a/src/Lucene.Net.Spatial/Util/DistanceToShapeValueSource.cs
+++ b/src/Lucene.Net.Spatial/Util/DistanceToShapeValueSource.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Spatial.Util
             return new DoubleDocValuesAnonymousClass(this, shapeValues);
         }
 
-        private class DoubleDocValuesAnonymousClass : DoubleDocValues
+        private sealed class DoubleDocValuesAnonymousClass : DoubleDocValues
         {
             private readonly DistanceToShapeValueSource outerInstance;
             private readonly FunctionValues shapeValues;

--- a/src/Lucene.Net.Spatial/Util/ShapePredicateValueSource.cs
+++ b/src/Lucene.Net.Spatial/Util/ShapePredicateValueSource.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Spatial.Util
             return new BoolDocValuesAnonymousClass(this, shapeValues);
         }
 
-        private class BoolDocValuesAnonymousClass : BoolDocValues
+        private sealed class BoolDocValuesAnonymousClass : BoolDocValues
         {
             private readonly ShapePredicateValueSource outerInstance;
             private readonly FunctionValues shapeValues;

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -290,7 +290,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         private Analyzer GetGramAnalyzer()
             => new AnalyzerWrapperAnonymousClass(this, Analyzer.PER_FIELD_REUSE_STRATEGY);
 
-        private class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
+        private sealed class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
         {
             private readonly AnalyzingInfixSuggester outerInstance;
 

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
@@ -884,7 +884,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
         }
 
-        private class TopNSearcherAnonymousClass : Util.Fst.Util.TopNSearcher<PairOutputs<Int64, BytesRef>.Pair>
+        private sealed class TopNSearcherAnonymousClass : Util.Fst.Util.TopNSearcher<PairOutputs<Int64, BytesRef>.Pair>
         {
             private readonly AnalyzingSuggester outerInstance;
 

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
@@ -263,7 +263,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
         }
 
-        private class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
+        private sealed class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
         {
             private readonly FreeTextSuggester outerInstance;
             private readonly Analyzer other;
@@ -811,7 +811,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
         }
 
-        private class TopNSearcherAnonymousClass : Util.Fst.Util.TopNSearcher<Int64>
+        private sealed class TopNSearcherAnonymousClass : Util.Fst.Util.TopNSearcher<Int64>
         {
             private readonly FreeTextSuggester outerInstance;
 

--- a/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
@@ -291,7 +291,7 @@ namespace Lucene.Net.Analysis
             }
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly Analyzer analyzer;
             private readonly IDictionary<string, BytesRef> map;

--- a/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
@@ -161,7 +161,7 @@ namespace Lucene.Net.Analysis
 
         protected readonly RollingBuffer<T> m_positions;
 
-        private class RollingBufferAnonymousClass : RollingBuffer<T>
+        private sealed class RollingBufferAnonymousClass : RollingBuffer<T>
         {
             private readonly LookaheadTokenFilter<T> outerInstance;
 

--- a/src/Lucene.Net.TestFramework/Codecs/Compressing/Dummy/DummyCompressingCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Compressing/Dummy/DummyCompressingCodec.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Codecs.Compressing.Dummy
     {
         public static readonly CompressionMode DUMMY = new CompressionModeAnonymousClass();
 
-        private class CompressionModeAnonymousClass : CompressionMode
+        private sealed class CompressionModeAnonymousClass : CompressionMode
         {
             public CompressionModeAnonymousClass()
             { }
@@ -53,7 +53,7 @@ namespace Lucene.Net.Codecs.Compressing.Dummy
 
         private static readonly Decompressor DUMMY_DECOMPRESSOR = new DecompressorAnonymousClass();
 
-        private class DecompressorAnonymousClass : Decompressor
+        private sealed class DecompressorAnonymousClass : Decompressor
         {
             public override void Decompress(DataInput @in, int originalLength, int offset, int length, BytesRef bytes)
             {
@@ -75,7 +75,7 @@ namespace Lucene.Net.Codecs.Compressing.Dummy
 
         private static readonly Compressor DUMMY_COMPRESSOR = new CompressorAnonymousClass();
 
-        private class CompressorAnonymousClass : Compressor
+        private sealed class CompressorAnonymousClass : Compressor
         {
             public override void Compress(byte[] bytes, int off, int len, DataOutput @out)
             {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWPostingsFormat.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             return new Lucene3xFieldsAnonymousClass(state.Directory, state.FieldInfos, state.SegmentInfo, state.Context, state.TermsIndexDivisor);
         }
 
-        private class Lucene3xFieldsAnonymousClass : Lucene3xFields
+        private sealed class Lucene3xFieldsAnonymousClass : Lucene3xFields
         {
             public Lucene3xFieldsAnonymousClass(Store.Directory directory, FieldInfos fieldInfos, SegmentInfo segmentInfo, Store.IOContext context, int termsIndexDivisor)
                 : base(directory, fieldInfos, segmentInfo, context, termsIndexDivisor)

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsFormat.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             return new Lucene3xTermVectorsReaderAnonymousClass(directory, segmentInfo, fieldInfos, context);
         }
 
-        private class Lucene3xTermVectorsReaderAnonymousClass : Lucene3xTermVectorsReader
+        private sealed class Lucene3xTermVectorsReaderAnonymousClass : Lucene3xTermVectorsReader
         {
             public Lucene3xTermVectorsReaderAnonymousClass(Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext context)
                 : base(directory, segmentInfo, fieldInfos, context)

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40RWCodec.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Codecs.Lucene40
     {
         private readonly FieldInfosFormat fieldInfos = new Lucene40FieldInfosFormatAnonymousClass();
 
-        private class Lucene40FieldInfosFormatAnonymousClass : Lucene40FieldInfosFormat
+        private sealed class Lucene40FieldInfosFormatAnonymousClass : Lucene40FieldInfosFormat
         {
             public override FieldInfosWriter FieldInfosWriter
             {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene41/Lucene41RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene41/Lucene41RWCodec.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Codecs.Lucene41
         private readonly StoredFieldsFormat fieldsFormat = new Lucene41StoredFieldsFormat();
         private readonly FieldInfosFormat fieldInfos = new Lucene40FieldInfosFormatAnonymousClass();
 
-        private class Lucene40FieldInfosFormatAnonymousClass : Lucene40FieldInfosFormat
+        private sealed class Lucene40FieldInfosFormatAnonymousClass : Lucene40FieldInfosFormat
         {
             public override FieldInfosWriter FieldInfosWriter
             {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
@@ -353,7 +353,7 @@ namespace Lucene.Net.Codecs.Lucene42
             WriteFST(field, values);
         }
 
-        private class EnumerableAnonymousClass : IEnumerable<BytesRef>
+        private sealed class EnumerableAnonymousClass : IEnumerable<BytesRef>
         {
             private readonly IEnumerable<long?> docToOrdCount;
             private readonly IEnumerable<long?> ords;

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42RWCodec.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Codecs.Lucene42
 
         private readonly FieldInfosFormat fieldInfosFormat = new Lucene42FieldInfosFormatAnonymousClass();
 
-        private class Lucene42FieldInfosFormatAnonymousClass : Lucene42FieldInfosFormat
+        private sealed class Lucene42FieldInfosFormatAnonymousClass : Lucene42FieldInfosFormat
         {
             public override FieldInfosWriter FieldInfosWriter
             {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene45/Lucene45RWCodec.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene45/Lucene45RWCodec.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Codecs.Lucene45
     {
         private readonly FieldInfosFormat fieldInfosFormat = new Lucene42FieldInfosFormatAnonymousClass();
 
-        private class Lucene42FieldInfosFormatAnonymousClass : Lucene42FieldInfosFormat
+        private sealed class Lucene42FieldInfosFormatAnonymousClass : Lucene42FieldInfosFormat
         {
             public override FieldInfosWriter FieldInfosWriter
             {

--- a/src/Lucene.Net.TestFramework/Codecs/MissingOrdRemapper.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MissingOrdRemapper.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Codecs
             return new EnumerableAnonymousClass(iterable);
         }
 
-        private class EnumerableAnonymousClass : IEnumerable<BytesRef>
+        private sealed class EnumerableAnonymousClass : IEnumerable<BytesRef>
         {
             private readonly IEnumerable<BytesRef> iterable;
 
@@ -54,7 +54,7 @@ namespace Lucene.Net.Codecs
                 return GetEnumerator();
             }
 
-            private class EnumeratorAnonymousClass : IEnumerator<BytesRef>
+            private sealed class EnumeratorAnonymousClass : IEnumerator<BytesRef>
             {
                 public EnumeratorAnonymousClass(EnumerableAnonymousClass outerInstance)
                 {
@@ -103,7 +103,7 @@ namespace Lucene.Net.Codecs
             return new EnumerableAnonymousClass2(iterable);
         }
 
-        private class EnumerableAnonymousClass2 : IEnumerable<long?>
+        private sealed class EnumerableAnonymousClass2 : IEnumerable<long?>
         {
             private readonly IEnumerable<long?> iterable;
 
@@ -120,7 +120,7 @@ namespace Lucene.Net.Codecs
             IEnumerator IEnumerable.GetEnumerator()
                 => GetEnumerator();
 
-            private class EnumeratorAnonymousClass2 : IEnumerator<long?>
+            private sealed class EnumeratorAnonymousClass2 : IEnumerator<long?>
             {
                 public EnumeratorAnonymousClass2(EnumerableAnonymousClass2 outerInstance)
                 {
@@ -163,7 +163,7 @@ namespace Lucene.Net.Codecs
             return new EnumerableAnonymousClass3(iterable);
         }
 
-        private class EnumerableAnonymousClass3 : IEnumerable<long?>
+        private sealed class EnumerableAnonymousClass3 : IEnumerable<long?>
         {
             private readonly IEnumerable<long?> iterable;
 
@@ -180,7 +180,7 @@ namespace Lucene.Net.Codecs
             IEnumerator IEnumerable.GetEnumerator()
                 => GetEnumerator();
 
-            private class EnumeratorAnonymousClass3 : IEnumerator<long?>
+            private sealed class EnumeratorAnonymousClass3 : IEnumerator<long?>
             {
                 public EnumeratorAnonymousClass3(EnumerableAnonymousClass3 outerInstance)
                 {

--- a/src/Lucene.Net.TestFramework/Codecs/MockIntBlock/MockFixedIntBlockPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MockIntBlock/MockFixedIntBlockPostingsFormat.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Codecs.MockIntBlock
                 return new FixedInt32BlockIndexInputAnonymousClass(dir.OpenInput(fileName, context));
             }
 
-            private class FixedInt32BlockIndexInputAnonymousClass : FixedInt32BlockIndexInput
+            private sealed class FixedInt32BlockIndexInputAnonymousClass : FixedInt32BlockIndexInput
             {
                 public FixedInt32BlockIndexInputAnonymousClass(IndexInput input)
                     : base(input)
@@ -84,7 +84,7 @@ namespace Lucene.Net.Codecs.MockIntBlock
                     return new BlockReaderAnonymousClass(@in, buffer);
                 }
 
-                private class BlockReaderAnonymousClass : FixedInt32BlockIndexInput.IBlockReader
+                private sealed class BlockReaderAnonymousClass : FixedInt32BlockIndexInput.IBlockReader
                 {
                     private readonly IndexInput @in;
                     private readonly int[] buffer;
@@ -129,7 +129,7 @@ namespace Lucene.Net.Codecs.MockIntBlock
                 }
             }
 
-            private class FixedInt32BlockIndexOutputAnonymousClass : FixedInt32BlockIndexOutput
+            private sealed class FixedInt32BlockIndexOutputAnonymousClass : FixedInt32BlockIndexOutput
             {
                 public FixedInt32BlockIndexOutputAnonymousClass(IndexOutput output, int blockSize)
                     : base(output, blockSize)

--- a/src/Lucene.Net.TestFramework/Codecs/MockIntBlock/MockVariableIntBlockPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MockIntBlock/MockVariableIntBlockPostingsFormat.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Codecs.MockIntBlock
                 return new VariableInt32BlockIndexInputAnonymousClass(input, baseBlockSize);
             }
 
-            private class VariableInt32BlockIndexInputAnonymousClass : VariableInt32BlockIndexInput
+            private sealed class VariableInt32BlockIndexInputAnonymousClass : VariableInt32BlockIndexInput
             {
                 private readonly int baseBlockSize;
 
@@ -86,7 +86,7 @@ namespace Lucene.Net.Codecs.MockIntBlock
                     return new BlockReaderAnonymousClass(@in, buffer, baseBlockSize);
                 }
 
-                private class BlockReaderAnonymousClass : IBlockReader
+                private sealed class BlockReaderAnonymousClass : IBlockReader
                 {
                     private readonly IndexInput input;
                     private readonly int[] buffer;
@@ -99,11 +99,11 @@ namespace Lucene.Net.Codecs.MockIntBlock
                         this.baseBlockSize = baseBlockSize;
                     }
 
-                    public virtual void Seek(long pos)
+                    public void Seek(long pos)
                     {
                     }
 
-                    public virtual int ReadBlock()
+                    public int ReadBlock()
                     {
                         buffer[0] = input.ReadVInt32();
                         int count = buffer[0] <= 3 ? baseBlockSize - 1 : 2 * baseBlockSize - 1;
@@ -137,7 +137,7 @@ namespace Lucene.Net.Codecs.MockIntBlock
                 }
             }
 
-            private class VariableInt32BlockIndexOutputAnonymousClass : VariableInt32BlockIndexOutput
+            private sealed class VariableInt32BlockIndexOutputAnonymousClass : VariableInt32BlockIndexOutput
             {
                 private readonly int baseBlockSize;
                 private readonly IndexOutput output;

--- a/src/Lucene.Net.TestFramework/Codecs/MockRandom/MockRandomPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/MockRandom/MockRandomPostingsFormat.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Codecs.MockRandom
         private readonly Random seedRandom;
         private const string SEED_EXT = "sd";
 
-        private class RandomAnonymousClassHelper : J2N.Randomizer
+        private sealed class RandomAnonymousClassHelper : J2N.Randomizer
         {
             public RandomAnonymousClassHelper()
                 : base(0)
@@ -117,7 +117,7 @@ namespace Lucene.Net.Codecs.MockRandom
             }
         }
 
-        private class IndexTermSelectorAnonymousClass : VariableGapTermsIndexWriter.IndexTermSelector
+        private sealed class IndexTermSelectorAnonymousClass : VariableGapTermsIndexWriter.IndexTermSelector
         {
             private readonly Random rand;
             private readonly int gap;

--- a/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
@@ -45,13 +45,13 @@ namespace Lucene.Net.Codecs.RAMOnly
         private static readonly IComparer<BytesRef> reverseUnicodeComparer = new ComparerAnonymousClass();
 
 #pragma warning disable 659 // LUCENENET: Overrides Equals but not GetHashCode
-        private class ComparerAnonymousClass : IComparer<BytesRef>
+        private sealed class ComparerAnonymousClass : IComparer<BytesRef>
 #pragma warning restore 659
         {
             public ComparerAnonymousClass()
             { }
 
-            public virtual int Compare(BytesRef t1, BytesRef t2)
+            public int Compare(BytesRef t1, BytesRef t2)
             {
                 var b1 = t1.Bytes;
                 var b2 = t2.Bytes;

--- a/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
@@ -1267,7 +1267,7 @@ namespace Lucene.Net.Index
             DoTestNumericsVsStoredFields(new Int64ProducerAnonymousClass(minValue, maxValue));
         }
 
-        private class Int64ProducerAnonymousClass : Int64Producer
+        private sealed class Int64ProducerAnonymousClass : Int64Producer
         {
             private readonly long minValue;
             private readonly long maxValue;
@@ -1349,7 +1349,7 @@ namespace Lucene.Net.Index
             DoTestMissingVsFieldCache(new Int64ProducerAnonymousClass2(minValue, maxValue));
         }
 
-        private class Int64ProducerAnonymousClass2 : Int64Producer
+        private sealed class Int64ProducerAnonymousClass2 : Int64Producer
         {
             private readonly long minValue;
             private readonly long maxValue;
@@ -2696,7 +2696,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class Int64ProducerAnonymousClass3 : Int64Producer
+        private sealed class Int64ProducerAnonymousClass3 : Int64Producer
         {
             private readonly long min;
             private readonly long mul;
@@ -2732,7 +2732,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class Int64ProducerAnonymousClass4 : Int64Producer
+        private sealed class Int64ProducerAnonymousClass4 : Int64Producer
         {
             internal override long Next()
             {
@@ -3256,7 +3256,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly DirectoryReader ir;
             private readonly CountdownEvent startingGun;
@@ -3392,7 +3392,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly DirectoryReader ir;
             private readonly CountdownEvent startingGun;

--- a/src/Lucene.Net.TestFramework/Index/BaseMergePolicyTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseMergePolicyTestCase.cs
@@ -64,7 +64,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class SerialMergeSchedulerAnonymousClass : SerialMergeScheduler
+        private sealed class SerialMergeSchedulerAnonymousClass : SerialMergeScheduler
         {
             private readonly AtomicBoolean mayMerge;
 

--- a/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
@@ -501,7 +501,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly int numDocs;
             private readonly DirectoryReader rd;

--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -877,7 +877,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly BaseTermVectorsFormatTestCase outerInstance;
 

--- a/src/Lucene.Net.TestFramework/Index/FieldFilterAtomicReader.cs
+++ b/src/Lucene.Net.TestFramework/Index/FieldFilterAtomicReader.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Index
             base.Document(docID, new StoredFieldVisitorAnonymousClass(this, visitor));
         }
 
-        private class StoredFieldVisitorAnonymousClass : StoredFieldVisitor
+        private sealed class StoredFieldVisitorAnonymousClass : StoredFieldVisitor
         {
             private readonly FieldFilterAtomicReader outerInstance;
 

--- a/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Index
             return MockIndexWriter(dir, conf, new TestPointAnonymousClass(random));
         }
 
-        private class TestPointAnonymousClass : ITestPoint
+        private sealed class TestPointAnonymousClass : ITestPoint
         {
             private readonly Random random;
 
@@ -62,7 +62,7 @@ namespace Lucene.Net.Index
                 this.random = random;
             }
 
-            public virtual void Apply(string message)
+            public void Apply(string message)
             {
                 if (random.Next(4) == 2)
                 {
@@ -148,7 +148,7 @@ namespace Lucene.Net.Index
             MaybeCommit();
         }
 
-        private class EnumerableAnonymousClass<IndexableField> : IEnumerable<IEnumerable<IndexableField>>
+        private sealed class EnumerableAnonymousClass<IndexableField> : IEnumerable<IEnumerable<IndexableField>>
         {
             private readonly IEnumerable<IndexableField> doc;
 
@@ -167,7 +167,7 @@ namespace Lucene.Net.Index
                 return GetEnumerator();
             }
 
-            private class EnumeratorAnonymousClass : IEnumerator<IEnumerable<IndexableField>>
+            private sealed class EnumeratorAnonymousClass : IEnumerator<IEnumerable<IndexableField>>
             {
                 private readonly EnumerableAnonymousClass<IndexableField> outerInstance;
 
@@ -251,7 +251,7 @@ namespace Lucene.Net.Index
             MaybeCommit();
         }
 
-        private class EnumerableAnonymousClass2 : IEnumerable<IEnumerable<IIndexableField>>
+        private sealed class EnumerableAnonymousClass2 : IEnumerable<IEnumerable<IIndexableField>>
         {
             private readonly IEnumerable<IIndexableField> doc;
 
@@ -268,7 +268,7 @@ namespace Lucene.Net.Index
             IEnumerator IEnumerable.GetEnumerator() 
                 => GetEnumerator();
 
-            private class EnumeratorAnonymousClass2 : IEnumerator<IEnumerable<IIndexableField>>
+            private sealed class EnumeratorAnonymousClass2 : IEnumerator<IEnumerable<IIndexableField>>
             {
                 private readonly EnumerableAnonymousClass2 outerInstance;
 
@@ -296,7 +296,7 @@ namespace Lucene.Net.Index
 
                 object IEnumerator.Current => Current;
 
-                public virtual void Reset()
+                public void Reset()
                     => throw new NotImplementedException();
 
                 public void Dispose()

--- a/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/ThreadedIndexingAndSearchingTestCase.cs
@@ -139,7 +139,7 @@ namespace Lucene.Net.Index
             return threads;
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly ThreadedIndexingAndSearchingTestCase outerInstance;
 
@@ -421,7 +421,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly ThreadedIndexingAndSearchingTestCase outerInstance;
 
@@ -796,7 +796,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class IndexReaderWarmerAnonymousClass : IndexWriter.IndexReaderWarmer
+        private sealed class IndexReaderWarmerAnonymousClass : IndexWriter.IndexReaderWarmer
         {
             private readonly ThreadedIndexingAndSearchingTestCase outerInstance;
 
@@ -847,7 +847,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class PrintStreamInfoStreamAnonymousClass : TextWriterInfoStream
+        private sealed class PrintStreamInfoStreamAnonymousClass : TextWriterInfoStream
         {
             public PrintStreamInfoStreamAnonymousClass(TextWriter @out)
                 : base(@out)

--- a/src/Lucene.Net.TestFramework/Search/AssertingIndexSearcher.cs
+++ b/src/Lucene.Net.TestFramework/Search/AssertingIndexSearcher.cs
@@ -64,7 +64,7 @@ namespace Lucene.Net.Search
             return new AssertingWeightAnonymousClass(random, w);
         }
 
-        private class AssertingWeightAnonymousClass : AssertingWeight
+        private sealed class AssertingWeightAnonymousClass : AssertingWeight
         {
             public AssertingWeightAnonymousClass(Random random, Weight w)
                 : base(random, w)

--- a/src/Lucene.Net.TestFramework/Search/QueryUtils.cs
+++ b/src/Lucene.Net.TestFramework/Search/QueryUtils.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Search
             Assert.IsFalse(q.Equals(null));
         }
 
-        private class QueryAnonymousClass : Query
+        private sealed class QueryAnonymousClass : Query
         {
             public QueryAnonymousClass()
             {
@@ -288,7 +288,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly Query q;
             private readonly IndexSearcher s;
@@ -318,12 +318,12 @@ namespace Lucene.Net.Search
             private Scorer scorer;
             private int leafPtr;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.sc = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 float score = sc.GetScore();
                 lastDoc[0] = doc;
@@ -361,7 +361,7 @@ namespace Lucene.Net.Search
                 }
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 // confirm that skipping beyond the last doc, on the
                 // previous reader, hits NO_MORE_DOCS
@@ -386,7 +386,7 @@ namespace Lucene.Net.Search
                 lastDoc[0] = -1;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class CollectorAnonymousClass2 : ICollector
+        private sealed class CollectorAnonymousClass2 : ICollector
         {
             private readonly Query q;
             private readonly IndexSearcher s;
@@ -440,12 +440,12 @@ namespace Lucene.Net.Search
             private int leafPtr;
             private IBits liveDocs;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 float score = scorer.GetScore();
                 try
@@ -476,7 +476,7 @@ namespace Lucene.Net.Search
                 }
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 // confirm that skipping beyond the last doc, on the
                 // previous reader, hits NO_MORE_DOCS
@@ -500,7 +500,7 @@ namespace Lucene.Net.Search
                 liveDocs = ((AtomicReader)context.Reader).LiveDocs;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
         }
     }
 }

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -1375,7 +1375,7 @@ namespace Lucene.Net.Store
             return handle;
         }
 
-        private class IndexInputSlicerAnonymousClass : IndexInputSlicer
+        private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly MockDirectoryWrapper outerInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -3171,7 +3171,7 @@ namespace Lucene.Net.Util
             return Random.NextGaussian();
         }
 
-        private class ReaderClosedListenerAnonymousClass : IndexReader.IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass : IndexReader.IReaderClosedListener
         {
             private readonly LimitedConcurrencyLevelTaskScheduler ex;
 

--- a/src/Lucene.Net.TestFramework/Util/TestRuleAssertionsRequired.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleAssertionsRequired.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Util
         return new StatementAnonymousClass(this, @base, description);
       }
 
-      private class StatementAnonymousClass : Statement
+      private sealed class StatementAnonymousClass : Statement
       {
           private readonly TestRuleAssertionsRequired OuterInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/TestRuleFieldCacheSanity.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleFieldCacheSanity.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Util
         return new StatementAnonymousClass(this, s, d);
       }
 
-      private class StatementAnonymousClass : Statement
+      private sealed class StatementAnonymousClass : Statement
       {
           private readonly TestRuleFieldCacheSanity OuterInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/TestRuleIgnoreAfterMaxFailures.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleIgnoreAfterMaxFailures.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Util
         return new StatementAnonymousClass(this, s);
       }
 
-      private class StatementAnonymousClass : Statement
+      private sealed class StatementAnonymousClass : Statement
       {
           private readonly TestRuleIgnoreAfterMaxFailures OuterInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/TestRuleIgnoreTestSuites.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleIgnoreTestSuites.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Util
         return new StatementAnonymousClass(this, s, d);
       }
 
-      private class StatementAnonymousClass : Statement
+      private sealed class StatementAnonymousClass : Statement
       {
           private readonly TestRuleIgnoreTestSuites OuterInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/TestRuleMarkFailure.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleMarkFailure.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Util
         return new StatementAnonymousClass(this, s);
       }
 
-      private class StatementAnonymousClass : Statement
+      private sealed class StatementAnonymousClass : Statement
       {
           private readonly TestRuleMarkFailure OuterInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/TestRuleSetupAndRestoreClassEnv.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleSetupAndRestoreClassEnv.cs
@@ -323,7 +323,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        private class Lucene46CodecAnonymousClass : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass : Lucene46Codec
         {
             private readonly PostingsFormat format;
             private readonly DocValuesFormat dvFormat;

--- a/src/Lucene.Net.TestFramework/Util/TestRuleSetupTeardownChained.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleSetupTeardownChained.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Util
         return new StatementAnonymousClass(this, @base);
       }
 
-      private class StatementAnonymousClass : Statement
+      private sealed class StatementAnonymousClass : Statement
       {
           private readonly TestRuleSetupTeardownChained OuterInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/TestRuleStoreClassName.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleStoreClassName.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Util
         return new StatementAnonymousClass(this, s, d);
       }
 
-      private class StatementAnonymousClass : Statement
+      private sealed class StatementAnonymousClass : Statement
       {
           private readonly TestRuleStoreClassName OuterInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/TestRuleThreadAndTestName.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleThreadAndTestName.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Util
         return new StatementAnonymousClass(this, @base, description);
       }
 
-      private class StatementAnonymousClass : Statement
+      private sealed class StatementAnonymousClass : Statement
       {
           private readonly TestRuleThreadAndTestName OuterInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/TestSecurityManager.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestSecurityManager.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Util
         base.CheckExit(status);
       }
 
-      private class PrivilegedActionAnonymousClass : PrivilegedAction<Void>
+      private sealed class PrivilegedActionAnonymousClass : PrivilegedAction<Void>
       {
           private readonly TestSecurityManager OuterInstance;
 

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -502,7 +502,7 @@ namespace Lucene.Net.Util
             return new Lucene46CodecAnonymousClass(format);
         }
 
-        private class Lucene46CodecAnonymousClass : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass : Lucene46Codec
         {
             private readonly PostingsFormat format;
 
@@ -534,7 +534,7 @@ namespace Lucene.Net.Util
             return new Lucene46CodecAnonymousClass2(format);
         }
 
-        private class Lucene46CodecAnonymousClass2 : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass2 : Lucene46Codec
         {
             private readonly DocValuesFormat format;
 
@@ -651,7 +651,7 @@ namespace Lucene.Net.Util
             Assert.AreEqual(reflectedValues, map, aggressive: false, "Reflection does not produce same map");
         }
 
-        private class AttributeReflectorAnonymousClass : IAttributeReflector
+        private sealed class AttributeReflectorAnonymousClass : IAttributeReflector
         {
             private readonly IDictionary<string, object> map;
 
@@ -899,7 +899,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        private class RandomAccessFilterStrategyAnonymousClass : FilteredQuery.RandomAccessFilterStrategy
+        private sealed class RandomAccessFilterStrategyAnonymousClass : FilteredQuery.RandomAccessFilterStrategy
         {
             protected override bool UseRandomAccess(IBits bits, int firstFilterDoc)
             {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -73,13 +73,13 @@ namespace Lucene.Net.Analysis.Core
 
         private static readonly IPredicate<object[]> ALWAYS = new PredicateAnonymousClass();
 
-        private class PredicateAnonymousClass : IPredicate<object[]>
+        private sealed class PredicateAnonymousClass : IPredicate<object[]>
         {
             public PredicateAnonymousClass()
             {
             }
 
-            public virtual bool Apply(object[] args)
+            public bool Apply(object[] args)
             {
                 return true;
             }
@@ -169,26 +169,26 @@ namespace Lucene.Net.Analysis.Core
             allowedCharFilterArgs.Add(typeof(TextReader));
         }
 
-        private class PredicateAnonymousClass2 : IPredicate<object[]>
+        private sealed class PredicateAnonymousClass2 : IPredicate<object[]>
         {
             public PredicateAnonymousClass2()
             {
             }
 
-            public virtual bool Apply(object[] args)
+            public bool Apply(object[] args)
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(args.Length == 3);
                 return !((bool)args[2]); // args are broken if consumeAllTokens is false
             }
         }
 
-        private class PredicateAnonymousClass3 : IPredicate<object[]>
+        private sealed class PredicateAnonymousClass3 : IPredicate<object[]>
         {
             public PredicateAnonymousClass3()
             {
             }
 
-            public virtual bool Apply(object[] args)
+            public bool Apply(object[] args)
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(args.Length == 3);
                 return !((bool)args[2]); // args are broken if consumeAllTokens is false

--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/Segmentation/TestICUTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/Segmentation/TestICUTokenizer.cs
@@ -352,7 +352,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
             ts.End();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly CountdownEvent startingGun;
 

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/CountingHighlighterTestTask.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/CountingHighlighterTestTask.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             return document;
         }
 
-        private class BenchmarkHighlighterAnonymousClass : BenchmarkHighlighter
+        private sealed class BenchmarkHighlighterAnonymousClass : BenchmarkHighlighter
         {
             private readonly CountingHighlighterTestTask outerInstance;
             private readonly Highlighter highlighter;

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/WriteLineDocTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/WriteLineDocTaskTest.cs
@@ -368,7 +368,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 br.Dispose();
             }
         }
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly WriteLineDocTask wldt;
             public ThreadAnonymousClass(string name, WriteLineDocTask wldt)

--- a/src/Lucene.Net.Tests.Facet/Range/TestRangeFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Range/TestRangeFacetCounts.cs
@@ -301,7 +301,7 @@ namespace Lucene.Net.Facet.Range
             IOUtils.Dispose(tw, tr, td, w, r, d);
         }
 
-        private class DrillSidewaysAnonymousClass : DrillSideways
+        private sealed class DrillSidewaysAnonymousClass : DrillSideways
         {
             private readonly TestRangeFacetCounts outerInstance;
 
@@ -1112,7 +1112,7 @@ namespace Lucene.Net.Facet.Range
             IOUtils.Dispose(r, writer, dir);
         }
 
-        private class ValueSourceAnonymousClass : ValueSource
+        private sealed class ValueSourceAnonymousClass : ValueSource
         {
             private readonly TestRangeFacetCounts outerInstance;
 
@@ -1129,7 +1129,7 @@ namespace Lucene.Net.Facet.Range
                 return new DoubleDocValuesAnonymousClass(this);
             }
 
-            private class DoubleDocValuesAnonymousClass : DoubleDocValues
+            private sealed class DoubleDocValuesAnonymousClass : DoubleDocValues
             {
                 private readonly ValueSourceAnonymousClass outerInstance;
 
@@ -1162,7 +1162,7 @@ namespace Lucene.Net.Facet.Range
 
         }
 
-        private class CachingWrapperFilterAnonymousClass : CachingWrapperFilter
+        private sealed class CachingWrapperFilterAnonymousClass : CachingWrapperFilter
         {
             private readonly TestRangeFacetCounts outerInstance;
 
@@ -1184,7 +1184,7 @@ namespace Lucene.Net.Facet.Range
             }
         }
 
-        private class DrillSidewaysAnonymousClass2 : DrillSideways
+        private sealed class DrillSidewaysAnonymousClass2 : DrillSideways
         {
             private readonly TestRangeFacetCounts outerInstance;
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestAddTaxonomy.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestAddTaxonomy.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             IOUtils.Dispose(dirs);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestAddTaxonomy outerInstance;
 
@@ -275,7 +275,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             IOUtils.Dispose(src, dest);
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly TestAddTaxonomy outerInstance;
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestConcurrentFacetedIndexing.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestConcurrentFacetedIndexing.cs
@@ -43,27 +43,27 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         // always returns true in put(), to indicate some cache entries were cleared.
         private static ITaxonomyWriterCache NO_OP_CACHE = new TaxonomyWriterCacheAnonymousClass();
 
-        private class TaxonomyWriterCacheAnonymousClass : ITaxonomyWriterCache
+        private sealed class TaxonomyWriterCacheAnonymousClass : ITaxonomyWriterCache
         {
             public TaxonomyWriterCacheAnonymousClass()
             {
             }
 
 
-            public virtual void Dispose()
+            public void Dispose()
             {
             }
-            public virtual int Get(FacetLabel categoryPath)
+            public int Get(FacetLabel categoryPath)
             {
                 return -1;
             }
-            public virtual bool Put(FacetLabel categoryPath, int ordinal)
+            public bool Put(FacetLabel categoryPath, int ordinal)
             {
                 return true;
             }
-            public virtual bool IsFull => true;
+            public bool IsFull => true;
 
-            public virtual void Clear()
+            public void Clear()
             {
             }
 
@@ -165,7 +165,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             IOUtils.Dispose(tw, iw, tr, taxoDir, indexDir);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestConcurrentFacetedIndexing outerInstance;
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyReader.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyReader.cs
@@ -266,7 +266,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             dir.Dispose();
         }
 
-        private class DirectoryTaxonomyWriterAnonymousClass : DirectoryTaxonomyWriter
+        private sealed class DirectoryTaxonomyWriterAnonymousClass : DirectoryTaxonomyWriter
         {
             private readonly TestDirectoryTaxonomyReader outerInstance;
 
@@ -326,7 +326,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             dir.Dispose();
         }
 
-        private class DirectoryTaxonomyWriterAnonymousClass2 : DirectoryTaxonomyWriter
+        private sealed class DirectoryTaxonomyWriterAnonymousClass2 : DirectoryTaxonomyWriter
         {
             internal static IndexWriter iw = null;
 
@@ -385,7 +385,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             dir.Dispose();
         }
 
-        private class DirectoryTaxonomyWriterAnonymousClass3 : DirectoryTaxonomyWriter
+        private sealed class DirectoryTaxonomyWriterAnonymousClass3 : DirectoryTaxonomyWriter
         {
             internal static IndexWriter iw;
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
@@ -54,22 +54,22 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         // always returns true in put(), to indicate some cache entries were cleared.
         private static readonly ITaxonomyWriterCache NO_OP_CACHE = new TaxonomyWriterCacheAnonymousClass();
 
-        private class TaxonomyWriterCacheAnonymousClass : ITaxonomyWriterCache
+        private sealed class TaxonomyWriterCacheAnonymousClass : ITaxonomyWriterCache
         {
-            public virtual void Dispose()
+            public void Dispose()
             {
             }
-            public virtual int Get(FacetLabel categoryPath)
+            public int Get(FacetLabel categoryPath)
             {
                 return -1;
             }
-            public virtual bool Put(FacetLabel categoryPath, int ordinal)
+            public bool Put(FacetLabel categoryPath, int ordinal)
             {
                 return true;
             }
-            public virtual bool IsFull => true;
+            public bool IsFull => true;
 
-            public virtual void Clear()
+            public void Clear()
             {
             }
 
@@ -343,7 +343,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             IOUtils.Dispose(dtr, dir);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly int range;
             private readonly AtomicInt32 numCats;

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestCachedOrdinalsReader.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestCachedOrdinalsReader.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Facet.Taxonomy
             IOUtils.Dispose(writer, taxoWriter, reader, indexDir, taxoDir);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestCachedOrdinalsReader outerInstance;
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestSearcherTaxonomyManager.cs
@@ -216,7 +216,7 @@ namespace Lucene.Net.Facet.Taxonomy
             IOUtils.Dispose(mgr, tw, w, taxoDir, dir);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly AtomicBoolean stop;
             private readonly SearcherTaxonomyManager mgr;

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyCombined.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyCombined.cs
@@ -865,7 +865,7 @@ namespace Lucene.Net.Facet.Taxonomy
             tr.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestTaxonomyCombined outerInstance;
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
@@ -299,7 +299,7 @@ namespace Lucene.Net.Facet.Taxonomy
             IOUtils.Dispose(writer, taxoWriter, dir, taxoDir);
         }
 
-        private class PerFieldSimilarityWrapperAnonymousClass : PerFieldSimilarityWrapper
+        private sealed class PerFieldSimilarityWrapperAnonymousClass : PerFieldSimilarityWrapper
         {
             private readonly TestTaxonomyFacetCounts outerInstance;
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
@@ -363,7 +363,7 @@ namespace Lucene.Net.Facet.Taxonomy
             IOUtils.Dispose(taxoWriter, iw, taxoReader, taxoDir, r, indexDir);
         }
 
-        private class ValueSourceAnonymousClass : ValueSource
+        private sealed class ValueSourceAnonymousClass : ValueSource
         {
             private readonly TestTaxonomyFacetSumValueSource outerInstance;
 
@@ -379,7 +379,7 @@ namespace Lucene.Net.Facet.Taxonomy
                 return new DoubleDocValuesAnonymousClass(this, scorer);
             }
 
-            private class DoubleDocValuesAnonymousClass : DoubleDocValues
+            private sealed class DoubleDocValuesAnonymousClass : DoubleDocValues
             {
                 private readonly ValueSourceAnonymousClass outerInstance;
 

--- a/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
@@ -808,7 +808,7 @@ namespace Lucene.Net.Facet
             IOUtils.Dispose(r, tr, w, tw, d, td);
         }
 
-        private class FilterAnonymousClass : Filter
+        private sealed class FilterAnonymousClass : Filter
         {
             private readonly TestDrillSideways outerInstance;
 
@@ -833,7 +833,7 @@ namespace Lucene.Net.Facet
             }
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestDrillSideways outerInstance;
 
@@ -844,25 +844,25 @@ namespace Lucene.Net.Facet
 
             internal int lastDocID;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(doc > lastDocID);
                 lastDocID = doc;
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 lastDocID = -1;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
         }
 
-        private class DrillSidewaysAnonymousClass : DrillSideways
+        private sealed class DrillSidewaysAnonymousClass : DrillSideways
         {
             private readonly TestDrillSideways outerInstance;
 
@@ -875,7 +875,7 @@ namespace Lucene.Net.Facet
             protected override bool ScoreSubDocsAtOnce => true;
         }
 
-        private class DrillSidewaysAnonymousClass2 : DrillSideways
+        private sealed class DrillSidewaysAnonymousClass2 : DrillSideways
         {
             private readonly TestDrillSideways outerInstance;
 
@@ -989,7 +989,7 @@ namespace Lucene.Net.Facet
             return topNIDs;
         }
 
-        private class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
+        private sealed class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
         {
             private readonly TestDrillSideways outerInstance;
 

--- a/src/Lucene.Net.Tests.Facet/TestFacetsConfig.cs
+++ b/src/Lucene.Net.Tests.Facet/TestFacetsConfig.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Facet
             Assert.IsTrue(config.GetDimConfig("foobar").IsHierarchical);
         }
 
-        private class FacetsConfigAnonymousClass : FacetsConfig
+        private sealed class FacetsConfigAnonymousClass : FacetsConfig
         {
             private readonly TestFacetsConfig outerInstance;
 

--- a/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterPhraseTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterPhraseTest.cs
@@ -135,7 +135,7 @@ namespace Lucene.Net.Search.Highlight
             }
         }
 
-        private class ConcurrentSpanCollectorAnonymousClass : ICollector
+        private sealed class ConcurrentSpanCollectorAnonymousClass : ICollector
         {
             private readonly HighlighterPhraseTest outerInstance;
             private readonly FixedBitSet bitset;
@@ -147,19 +147,19 @@ namespace Lucene.Net.Search.Highlight
 
             private int baseDoc;
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
 
-            public virtual void Collect(int i)
+            public void Collect(int i)
             {
                 bitset.Set(this.baseDoc + i);
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 this.baseDoc = context.DocBase;
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 // Do Nothing
             }

--- a/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
@@ -131,7 +131,7 @@ namespace Lucene.Net.Search.Highlight
             assertEquals("<B>This</B> piece of text refers to Kennedy at the beginning then has a longer piece of text that is <B>very</B>", fragment);
         }
 
-        private class TestHighlightUnknowQueryAnonymousClass : Query
+        private sealed class TestHighlightUnknowQueryAnonymousClass : Query
         {
             public override Query Rewrite(IndexReader reader)
             {
@@ -1543,7 +1543,7 @@ namespace Lucene.Net.Search.Highlight
             assertEquals("XHTML Encoding should have worked:", rawDocContent, decodedSnippet);
         }
 
-        private class TestEncodingScorerAnonymousClass : IScorer
+        private sealed class TestEncodingScorerAnonymousClass : IScorer
         {
             private readonly HighlighterTest outerInstance;
 

--- a/src/Lucene.Net.Tests.Highlighter/Highlight/OffsetLimitTokenFilterTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Highlight/OffsetLimitTokenFilterTest.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Search.Highlight
             CheckOneTerm(new AnalyzerAnonymousClass(), "llenges", "llenges");
         }
 
-        private class AnalyzerAnonymousClass : Analyzer
+        private sealed class AnalyzerAnonymousClass : Analyzer
         {
             protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
             {

--- a/src/Lucene.Net.Tests.Highlighter/VectorHighlight/FastVectorHighlighterTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/VectorHighlight/FastVectorHighlighterTest.cs
@@ -642,7 +642,7 @@ namespace Lucene.Net.Search.VectorHighlight
             dir.Dispose();
         }
 
-        private class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
+        private sealed class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
         {
             IDictionary<String, Analyzer> fieldAnalyzers = new JCG.SortedDictionary<String, Analyzer>(StringComparer.Ordinal);
 

--- a/src/Lucene.Net.Tests.Highlighter/VectorHighlight/FieldQueryTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/VectorHighlight/FieldQueryTest.cs
@@ -990,7 +990,7 @@ namespace Lucene.Net.Search.VectorHighlight
             phraseCandidate.Add(new TermInfo("defg", 0, 12, 0, 1));
             assertNotNull(fq.SearchPhrase(F, phraseCandidate));
         }
-        private class TestStopRewriteQueryAnonymousClass : Query
+        private sealed class TestStopRewriteQueryAnonymousClass : Query
         {
             public override string ToString(string field)
             {
@@ -1007,7 +1007,7 @@ namespace Lucene.Net.Search.VectorHighlight
             new FieldQuery(q, reader, true, true);
         }
 
-        private class TestFlattenFilteredQueryFilterAnonymousClass : Filter
+        private sealed class TestFlattenFilteredQueryFilterAnonymousClass : Filter
         {
             public override DocIdSet GetDocIdSet(AtomicReaderContext context, IBits acceptDocs)
             {

--- a/src/Lucene.Net.Tests.Join/Support/TestJoinUtil.cs
+++ b/src/Lucene.Net.Tests.Join/Support/TestJoinUtil.cs
@@ -259,15 +259,15 @@ namespace Lucene.Net.Tests.Join
             dir.Dispose();
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             internal bool sawFive;
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
 
-            public virtual void Collect(int docID)
+            public void Collect(int docID)
             {
                 // Hairy / evil (depends on how BooleanScorer
                 // stores temporarily collected docIDs by
@@ -282,11 +282,11 @@ namespace Lucene.Net.Tests.Join
                 }
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
         [Test]
@@ -520,7 +520,7 @@ namespace Lucene.Net.Tests.Join
             }
         }
 
-        private class CollectorAnonymousClass2 : ICollector
+        private sealed class CollectorAnonymousClass2 : ICollector
         {
             private bool scoreDocsInOrder;
             private FixedBitSet actualResult;
@@ -538,24 +538,24 @@ namespace Lucene.Net.Tests.Join
 
             private int _docBase;
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 actualResult.Set(doc + _docBase);
                 topScoreDocCollector.Collect(doc);
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 _docBase = context.DocBase;
                 topScoreDocCollector.SetNextReader(context);
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 topScoreDocCollector.SetScorer(scorer);
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => scoreDocsInOrder;
+            public bool AcceptsDocsOutOfOrder => scoreDocsInOrder;
         }
 
         private IndexIterationContext CreateContext(int nDocs, RandomIndexWriter writer, bool multipleValuesPerDocument, bool scoreDocsInOrder)
@@ -746,7 +746,7 @@ namespace Lucene.Net.Tests.Join
             return context;
         }
 
-        private class CollectorAnonymousClass3 : ICollector
+        private sealed class CollectorAnonymousClass3 : ICollector
         {
             private readonly string fromField;
             private readonly IDictionary<BytesRef, JoinScore> joinValueToJoinScores;
@@ -764,7 +764,7 @@ namespace Lucene.Net.Tests.Join
             private SortedSetDocValues docTermOrds;
             internal readonly BytesRef joinValue;
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 docTermOrds.SetDocument(doc);
                 long ord;
@@ -779,20 +779,20 @@ namespace Lucene.Net.Tests.Join
                 }
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 docTermOrds = FieldCache.DEFAULT.GetDocTermOrds(context.AtomicReader, fromField);
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
         }
 
-        private class CollectorAnonymousClass4 : ICollector
+        private sealed class CollectorAnonymousClass4 : ICollector
         {
             private readonly string fromField;
             private readonly IDictionary<BytesRef, JoinScore> joinValueToJoinScores;
@@ -811,7 +811,7 @@ namespace Lucene.Net.Tests.Join
             private IBits docsWithField;
             private readonly BytesRef spare;
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 terms.Get(doc, spare);
                 BytesRef joinValue = spare;
@@ -827,21 +827,21 @@ namespace Lucene.Net.Tests.Join
                 joinScore.AddScore(scorer.GetScore());
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 terms = FieldCache.DEFAULT.GetTerms(context.AtomicReader, fromField, true);
                 docsWithField = FieldCache.DEFAULT.GetDocsWithField(context.AtomicReader, fromField);
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
         }
 
-        private class CollectorAnonymousClass5 : ICollector
+        private sealed class CollectorAnonymousClass5 : ICollector
         {
             private readonly string toField;
             private readonly IDictionary<BytesRef, JoinScore> joinValueToJoinScores;
@@ -860,7 +860,7 @@ namespace Lucene.Net.Tests.Join
                 this.docToJoinScore = docToJoinScore;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 docTermOrds.SetDocument(doc);
                 long ord;
@@ -881,20 +881,20 @@ namespace Lucene.Net.Tests.Join
                 }
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 docBase = context.DocBase;
                 docTermOrds = FieldCache.DEFAULT.GetDocTermOrds(context.AtomicReader, toField);
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
         }
 
-        private class CollectorAnonymousClass6 : ICollector
+        private sealed class CollectorAnonymousClass6 : ICollector
         {
             private readonly string toField;
             private readonly IDictionary<BytesRef, JoinScore> joinValueToJoinScores;
@@ -914,7 +914,7 @@ namespace Lucene.Net.Tests.Join
                 this.docToJoinScore = docToJoinScore;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 terms.Get(doc, spare);
                 if (!joinValueToJoinScores.TryGetValue(spare, out JoinScore joinScore) || joinScore is null)
@@ -924,15 +924,15 @@ namespace Lucene.Net.Tests.Join
                 docToJoinScore[docBase + doc] = joinScore;
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 terms = FieldCache.DEFAULT.GetTerms(context.AtomicReader, toField, false);
                 docBase = context.DocBase;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
         }

--- a/src/Lucene.Net.Tests.Join/TestJoinUtil.cs
+++ b/src/Lucene.Net.Tests.Join/TestJoinUtil.cs
@@ -256,15 +256,15 @@ namespace Lucene.Net.Search.Join
             dir.Dispose();
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             internal bool sawFive;
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
 
-            public virtual void Collect(int docID)
+            public void Collect(int docID)
             {
                 // Hairy / evil (depends on how BooleanScorer
                 // stores temporarily collected docIDs by
@@ -279,11 +279,11 @@ namespace Lucene.Net.Search.Join
                 }
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
         [Test]
@@ -517,7 +517,7 @@ namespace Lucene.Net.Search.Join
             }
         }
 
-        private class CollectorAnonymousClass2 : ICollector
+        private sealed class CollectorAnonymousClass2 : ICollector
         {
             private bool scoreDocsInOrder;
             private FixedBitSet actualResult;
@@ -535,24 +535,24 @@ namespace Lucene.Net.Search.Join
 
             private int _docBase;
             
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 actualResult.Set(doc + _docBase);
                 topScoreDocCollector.Collect(doc);
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 _docBase = context.DocBase;
                 topScoreDocCollector.SetNextReader(context);
             }
             
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 topScoreDocCollector.SetScorer(scorer);
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => scoreDocsInOrder;
+            public bool AcceptsDocsOutOfOrder => scoreDocsInOrder;
         }
         
         private IndexIterationContext CreateContext(int nDocs, RandomIndexWriter writer, bool multipleValuesPerDocument, bool scoreDocsInOrder)
@@ -743,7 +743,7 @@ namespace Lucene.Net.Search.Join
             return context;
         }
 
-        private class CollectorAnonymousClass3 : ICollector
+        private sealed class CollectorAnonymousClass3 : ICollector
         {
             private readonly string fromField;
             private readonly IDictionary<BytesRef, JoinScore> joinValueToJoinScores;
@@ -761,7 +761,7 @@ namespace Lucene.Net.Search.Join
             private SortedSetDocValues docTermOrds;
             internal readonly BytesRef joinValue;
             
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 docTermOrds.SetDocument(doc);
                 long ord;
@@ -776,20 +776,20 @@ namespace Lucene.Net.Search.Join
                 }
             }
             
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 docTermOrds = FieldCache.DEFAULT.GetDocTermOrds(context.AtomicReader, fromField);
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
         }
 
-        private class CollectorAnonymousClass4 : ICollector
+        private sealed class CollectorAnonymousClass4 : ICollector
         {
             private readonly string fromField;
             private readonly IDictionary<BytesRef, JoinScore> joinValueToJoinScores;
@@ -808,7 +808,7 @@ namespace Lucene.Net.Search.Join
             private IBits docsWithField;
             private readonly BytesRef spare;
             
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 terms.Get(doc, spare);
                 BytesRef joinValue = spare;
@@ -824,21 +824,21 @@ namespace Lucene.Net.Search.Join
                 joinScore.AddScore(scorer.GetScore());
             }
             
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 terms = FieldCache.DEFAULT.GetTerms(context.AtomicReader, fromField, true);
                 docsWithField = FieldCache.DEFAULT.GetDocsWithField(context.AtomicReader, fromField);
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
         }
 
-        private class CollectorAnonymousClass5 : ICollector
+        private sealed class CollectorAnonymousClass5 : ICollector
         {
             private readonly string toField;
             private readonly IDictionary<BytesRef, JoinScore> joinValueToJoinScores;
@@ -857,7 +857,7 @@ namespace Lucene.Net.Search.Join
                 this.docToJoinScore = docToJoinScore;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 docTermOrds.SetDocument(doc);
                 long ord;
@@ -878,20 +878,20 @@ namespace Lucene.Net.Search.Join
                 }
             }
             
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 docBase = context.DocBase;
                 docTermOrds = FieldCache.DEFAULT.GetDocTermOrds(context.AtomicReader, toField);
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
         }
 
-        private class CollectorAnonymousClass6 : ICollector
+        private sealed class CollectorAnonymousClass6 : ICollector
         {
             private readonly string toField;
             private readonly IDictionary<BytesRef, JoinScore> joinValueToJoinScores;
@@ -911,7 +911,7 @@ namespace Lucene.Net.Search.Join
                 this.docToJoinScore = docToJoinScore;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 terms.Get(doc, spare);
                 if (!joinValueToJoinScores.TryGetValue(spare, out JoinScore joinScore) || joinScore is null)
@@ -921,15 +921,15 @@ namespace Lucene.Net.Search.Join
                 docToJoinScore[docBase + doc] = joinScore;
             }
             
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 terms = FieldCache.DEFAULT.GetTerms(context.AtomicReader, toField, false);
                 docBase = context.DocBase;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
         }

--- a/src/Lucene.Net.Tests.Queries/TestCustomScoreQuery.cs
+++ b/src/Lucene.Net.Tests.Queries/TestCustomScoreQuery.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Tests.Queries
                 return new CustomScoreProviderAnonymousClass(context);
             }
 
-            private class CustomScoreProviderAnonymousClass : CustomScoreProvider
+            private sealed class CustomScoreProviderAnonymousClass : CustomScoreProvider
             {
                 public CustomScoreProviderAnonymousClass(AtomicReaderContext context) : base(context)
                 {
@@ -143,7 +143,7 @@ namespace Lucene.Net.Tests.Queries
                 return new CustomScoreProviderAnonymousClass(context);
             }
 
-            private class CustomScoreProviderAnonymousClass : CustomScoreProvider
+            private sealed class CustomScoreProviderAnonymousClass : CustomScoreProvider
             {
                 public CustomScoreProviderAnonymousClass(AtomicReaderContext context) : base(context)
                 {
@@ -194,7 +194,7 @@ namespace Lucene.Net.Tests.Queries
                 return new CustomScoreProviderAnonymousClass(context, values);
             }
             
-            private class CustomScoreProviderAnonymousClass : CustomScoreProvider
+            private sealed class CustomScoreProviderAnonymousClass : CustomScoreProvider
             {
                 private FieldCache.Int32s values;
 

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -351,7 +351,7 @@ namespace Lucene.Net.Replicator
             handlerTaxoDir.RandomIOExceptionRateOnOpen = (0.0);
         }
 
-        private class SourceDirectoryFactoryAnonymousClass : ISourceDirectoryFactory
+        private sealed class SourceDirectoryFactoryAnonymousClass : ISourceDirectoryFactory
         {
             private long clientMaxSize = 100, handlerIndexMaxSize = 100, handlerTaxoMaxSize = 100;
             private double clientExRate = 1.0, handlerIndexExRate = 1.0, handlerTaxoExRate = 1.0;
@@ -423,7 +423,7 @@ namespace Lucene.Net.Replicator
 
 
 
-        private class ReplicationClientAnonymousClass : ReplicationClient
+        private sealed class ReplicationClientAnonymousClass : ReplicationClient
         {
             private readonly IndexAndTaxonomyReplicationClientTest test;
             private readonly AtomicInt32 failures;

--- a/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
@@ -279,7 +279,7 @@ namespace Lucene.Net.Replicator
             handlerDir.RandomIOExceptionRateOnOpen = 0.0;
         }
 
-        private class SourceDirectoryFactoryAnonymousClass : ISourceDirectoryFactory
+        private sealed class SourceDirectoryFactoryAnonymousClass : ISourceDirectoryFactory
         {
             private long clientMaxSize = 100, handlerMaxSize = 100;
             private double clientExRate = 1.0, handlerExRate = 1.0;
@@ -334,7 +334,7 @@ namespace Lucene.Net.Replicator
             }
         }
 
-        private class ReplicationClientAnonymousClass : ReplicationClient
+        private sealed class ReplicationClientAnonymousClass : ReplicationClient
         {
             private readonly IndexReplicationClientTest test;
             private readonly AtomicInt32 failures;

--- a/src/Lucene.Net.Tests.Spatial/QueryEqualsHashCodeTest.cs
+++ b/src/Lucene.Net.Tests.Spatial/QueryEqualsHashCodeTest.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Spatial
             }
         }
 
-        private class ObjGeneratorQueryAnonymousClass : ObjGenerator
+        private sealed class ObjGeneratorQueryAnonymousClass : ObjGenerator
         {
             private readonly SpatialStrategy strategy;
 
@@ -68,7 +68,7 @@ namespace Lucene.Net.Spatial
             }
         }
 
-        private class ObjGeneratorFilterAnonymousClass : ObjGenerator
+        private sealed class ObjGeneratorFilterAnonymousClass : ObjGenerator
         {
             private readonly SpatialStrategy strategy;
 
@@ -83,7 +83,7 @@ namespace Lucene.Net.Spatial
             }
         }
 
-        private class ObjGeneratorDistanceValueSourceAnonymousClass : ObjGenerator
+        private sealed class ObjGeneratorDistanceValueSourceAnonymousClass : ObjGenerator
         {
             private readonly SpatialStrategy strategy;
 

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TestMockAnalyzer.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TestMockAnalyzer.cs
@@ -279,7 +279,7 @@ namespace Lucene.Net.Analysis
             }
         }
 
-        private class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
+        private sealed class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
         {
             private readonly Analyzer @delegate;
             public AnalyzerWrapperAnonymousClass(Analyzer @delegate)

--- a/src/Lucene.Net.Tests/Analysis/TestCachingTokenFilter.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestCachingTokenFilter.cs
@@ -83,7 +83,7 @@ namespace Lucene.Net.Analysis
             dir.Dispose();
         }
 
-        private class TokenStreamAnonymousClass : TokenStream
+        private sealed class TokenStreamAnonymousClass : TokenStream
         {
             private TestCachingTokenFilter outerInstance;
 

--- a/src/Lucene.Net.Tests/Analysis/TestMockAnalyzer.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestMockAnalyzer.cs
@@ -279,7 +279,7 @@ namespace Lucene.Net.Analysis
             CheckOneTerm(a, "abc", "aabc");
         }
 
-        private class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
+        private sealed class AnalyzerWrapperAnonymousClass : AnalyzerWrapper
         {
             private readonly TestMockAnalyzer outerInstance;
 
@@ -349,7 +349,7 @@ namespace Lucene.Net.Analysis
             writer.IndexWriter.Directory.Dispose();
         }
 
-        private class AnalyzerWrapperAnonymousClass2 : AnalyzerWrapper
+        private sealed class AnalyzerWrapperAnonymousClass2 : AnalyzerWrapper
         {
             private readonly TestMockAnalyzer outerInstance;
 

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -343,7 +343,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
             Assert.AreEqual("4567890123456" + longTestString, t.ToString());
         }
 
-        private class CharSequenceAnonymousClass : ICharSequence
+        private sealed class CharSequenceAnonymousClass : ICharSequence
         {
             private readonly TestCharTermAttributeImpl outerInstance;
 

--- a/src/Lucene.Net.Tests/Codecs/Compressing/TestCompressingStoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/Codecs/Compressing/TestCompressingStoredFieldsFormat.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Codecs.Compressing
             }
         }
 
-        private class FieldAnonymousClass : Field
+        private sealed class FieldAnonymousClass : Field
         {
             private readonly TestCompressingStoredFieldsFormat outerInstance;
 

--- a/src/Lucene.Net.Tests/Codecs/PerField/TestPerFieldDocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/Codecs/PerField/TestPerFieldDocValuesFormat.cs
@@ -126,7 +126,7 @@ namespace Lucene.Net.Codecs.PerField
             directory.Dispose();
         }
 
-        private class Lucene46CodecAnonymousClass : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass : Lucene46Codec
         {
             private readonly TestPerFieldDocValuesFormat outerInstance;
 

--- a/src/Lucene.Net.Tests/Codecs/PerField/TestPerFieldPostingsFormat2.cs
+++ b/src/Lucene.Net.Tests/Codecs/PerField/TestPerFieldPostingsFormat2.cs
@@ -288,7 +288,7 @@ namespace Lucene.Net.Codecs.PerField
             DoTestMixedPostings(codec);
         }
 
-        private class Lucene46CodecAnonymousClass : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass : Lucene46Codec
         {
             private readonly TestPerFieldPostingsFormat2 outerInstance;
 
@@ -321,7 +321,7 @@ namespace Lucene.Net.Codecs.PerField
           DoTestMixedPostings(codec);
         }
 
-        private class Lucene46CodecAnonymousClass2 : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass2 : Lucene46Codec
         {
             private readonly TestPerFieldPostingsFormat2 outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -678,7 +678,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            private class ThreadAnonymousClass : ThreadJob
+            private sealed class ThreadAnonymousClass : ThreadJob
             {
                 private readonly RunAddIndexesThreads outerInstance;
                 private readonly int numIter;

--- a/src/Lucene.Net.Tests/Index/TestBagOfPositions.cs
+++ b/src/Lucene.Net.Tests/Index/TestBagOfPositions.cs
@@ -158,7 +158,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestBagOfPositions outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestBagOfPostings.cs
+++ b/src/Lucene.Net.Tests/Index/TestBagOfPostings.cs
@@ -138,7 +138,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestBagOfPostings outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestBinaryDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/Index/TestBinaryDocValuesUpdates.cs
@@ -701,7 +701,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class Lucene46CodecAnonymousClass : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass : Lucene46Codec
         {
             private readonly TestBinaryDocValuesUpdates outerInstance;
 
@@ -1280,7 +1280,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestBinaryDocValuesUpdates outerInstance;
 
@@ -1488,7 +1488,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class Lucene46CodecAnonymousClass2 : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass2 : Lucene46Codec
         {
             private readonly TestBinaryDocValuesUpdates outerInstance;
 
@@ -1503,7 +1503,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class Lucene46CodecAnonymousClass3 : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass3 : Lucene46Codec
         {
             private readonly TestBinaryDocValuesUpdates outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestCodecs.cs
+++ b/src/Lucene.Net.Tests/Index/TestCodecs.cs
@@ -127,7 +127,7 @@ namespace Lucene.Net.Index
                 Array.Sort(terms);
             }
 
-            private class IndexableFieldTypeAnonymousClass : IIndexableFieldType
+            private sealed class IndexableFieldTypeAnonymousClass : IIndexableFieldType
             {
                 private readonly FieldData outerInstance;
                 private readonly bool omitTF;

--- a/src/Lucene.Net.Tests/Index/TestConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net.Tests/Index/TestConcurrentMergeScheduler.cs
@@ -322,7 +322,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ConcurrentMergeSchedulerAnonymousClass : ConcurrentMergeScheduler
+        private sealed class ConcurrentMergeSchedulerAnonymousClass : ConcurrentMergeScheduler
         {
             private readonly TestConcurrentMergeScheduler outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
@@ -1108,7 +1108,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ReaderClosedListenerAnonymousClass : IndexReader.IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass : IndexReader.IReaderClosedListener
         {
             private readonly TestDirectoryReader outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Index
             dir2.Dispose();
         }
 
-        private class TestReopenAnonymousClass : TestReopen
+        private sealed class TestReopenAnonymousClass : TestReopen
         {
             private readonly TestDirectoryReaderReopen outerInstance;
 
@@ -85,7 +85,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class TestReopenAnonymousClass2 : TestReopen
+        private sealed class TestReopenAnonymousClass2 : TestReopen
         {
             private readonly TestDirectoryReaderReopen outerInstance;
 
@@ -338,7 +338,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class TestReopenAnonymousClass3 : TestReopen
+        private sealed class TestReopenAnonymousClass3 : TestReopen
         {
             private readonly TestDirectoryReaderReopen outerInstance;
 
@@ -365,7 +365,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ReaderThreadTaskAnonymousClass : ReaderThreadTask
+        private sealed class ReaderThreadTaskAnonymousClass : ReaderThreadTask
         {
             private readonly TestDirectoryReaderReopen outerInstance;
 
@@ -433,7 +433,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ReaderThreadTaskAnonymousClass2 : ReaderThreadTask
+        private sealed class ReaderThreadTaskAnonymousClass2 : ReaderThreadTask
         {
             private readonly TestDirectoryReaderReopen outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestDocInverterPerFieldErrorInfo.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocInverterPerFieldErrorInfo.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            private class TokenFilterAnonymousClass : TokenFilter
+            private sealed class TokenFilterAnonymousClass : TokenFilter
             {
                 private readonly ThrowingAnalyzer outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestDocValuesIndexing.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocValuesIndexing.cs
@@ -549,7 +549,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestDocValuesIndexing outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestDocValuesWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocValuesWithThreads.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestDocValuesWithThreads outerInstance;
 
@@ -265,7 +265,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly Random random;
             private readonly IList<BytesRef> docValues;

--- a/src/Lucene.Net.Tests/Index/TestDocumentWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentWriter.cs
@@ -140,7 +140,7 @@ namespace Lucene.Net.Index
             reader.Dispose();
         }
 
-        private class AnalyzerAnonymousClass : Analyzer
+        private sealed class AnalyzerAnonymousClass : Analyzer
         {
             protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
             {
@@ -182,7 +182,7 @@ namespace Lucene.Net.Index
             reader.Dispose();
         }
 
-        private class AnalyzerAnonymousClass2 : Analyzer
+        private sealed class AnalyzerAnonymousClass2 : Analyzer
         {
             private readonly TestDocumentWriter outerInstance;
 
@@ -197,7 +197,7 @@ namespace Lucene.Net.Index
                 return new TokenStreamComponents(tokenizer, new TokenFilterAnonymousClass(this, tokenizer));
             }
 
-            private class TokenFilterAnonymousClass : TokenFilter
+            private sealed class TokenFilterAnonymousClass : TokenFilter
             {
                 private readonly AnalyzerAnonymousClass2 outerInstance;
 
@@ -292,7 +292,7 @@ namespace Lucene.Net.Index
             reader.Dispose();
         }
 
-        private class TokenStreamAnonymousClass : TokenStream
+        private sealed class TokenStreamAnonymousClass : TokenStream
         {
             private readonly TestDocumentWriter outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestDocumentsWriterDeleteQueue.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentsWriterDeleteQueue.cs
@@ -230,7 +230,7 @@ namespace Lucene.Net.Index
             Assert.IsFalse(queue.AnyChanges(), "all changes applied");
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestDocumentsWriterDeleteQueue outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Index
             Join(stallThreads);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly DocumentsWriterStallControl ctrl;
             private readonly int stallProbability;
@@ -402,7 +402,7 @@ namespace Lucene.Net.Index
             return array;
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly DocumentsWriterStallControl ctrl;
 

--- a/src/Lucene.Net.Tests/Index/TestForceMergeForever.cs
+++ b/src/Lucene.Net.Tests/Index/TestForceMergeForever.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Index
             docs.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestForceMergeForever outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestIndexCommit.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexCommit.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class IndexCommitAnonymousClass : IndexCommit
+        private sealed class IndexCommitAnonymousClass : IndexCommit
         {
             private readonly TestIndexCommit outerInstance;
 
@@ -73,7 +73,7 @@ namespace Lucene.Net.Index
             public override int SegmentCount => 2;
         }
 
-        private class IndexCommitAnonymousClass2 : IndexCommit
+        private sealed class IndexCommitAnonymousClass2 : IndexCommit
         {
             private readonly TestIndexCommit outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestIndexReaderClose.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexReaderClose.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class FilterAtomicReaderAnonymousClass : FilterAtomicReader
+        private sealed class FilterAtomicReaderAnonymousClass : FilterAtomicReader
         {
             private readonly TestIndexReaderClose outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
@@ -1038,7 +1038,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class TokenStreamAnonymousClass : TokenStream
+        private sealed class TokenStreamAnonymousClass : TokenStream
         {
             private readonly TestIndexWriter outerInstance;
 
@@ -2319,7 +2319,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class AnalyzerAnonymousClass : Analyzer
+        private sealed class AnalyzerAnonymousClass : Analyzer
         {
             private readonly TestIndexWriter outerInstance;
 
@@ -2664,7 +2664,7 @@ namespace Lucene.Net.Index
             }
 
             /*
-          private class EnumeratorAnonymousClass : IEnumerator<IEnumerable<IndexableField>>
+          private sealed class EnumeratorAnonymousClass : IEnumerator<IEnumerable<IndexableField>>
           {
               private readonly RandomFailingFieldEnumerable outerInstance;
 
@@ -2838,7 +2838,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class TestPointAnonymousClass : ITestPoint
+        private sealed class TestPointAnonymousClass : ITestPoint
         {
             private readonly TestIndexWriter outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterCommit.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterCommit.cs
@@ -359,7 +359,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly Func<string, string, Field.Store, Field> newStringField;
             private Directory dir;

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterDelete.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterDelete.cs
@@ -377,7 +377,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestIndexWriterDelete outerInstance;
 
@@ -939,7 +939,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class FailureAnonymousClass : Failure
+        private sealed class FailureAnonymousClass : Failure
         {
             private readonly TestIndexWriterDelete outerInstance;
 
@@ -1054,7 +1054,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class FailureAnonymousClass2 : Failure
+        private sealed class FailureAnonymousClass2 : Failure
         {
             private readonly TestIndexWriterDelete outerInstance;
 
@@ -1339,7 +1339,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class IndexWriterAnonymousClass : IndexWriter
+        private sealed class IndexWriterAnonymousClass : IndexWriter
         {
             private readonly TestIndexWriterDelete outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -122,7 +122,7 @@ namespace Lucene.Net.Index
                 return GetEnumerator();
             }
 
-            private class IteratorAnonymousClass : IEnumerator<Document>
+            private sealed class IteratorAnonymousClass : IEnumerator<Document>
             {
                 private readonly DocCopyIterator outerInstance;
 
@@ -647,7 +647,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class TokenFilterAnonymousClass : TokenFilter
+        private sealed class TokenFilterAnonymousClass : TokenFilter
         {
             public TokenFilterAnonymousClass(MockTokenizer tokenizer)
                 : base(tokenizer)
@@ -938,7 +938,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly int NUM_ITER;
             private readonly IndexWriter writer;
@@ -1223,7 +1223,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class TOOMInfoStreamAnonymousClass : InfoStream
+        private sealed class TOOMInfoStreamAnonymousClass : InfoStream
         {
             private readonly AtomicBoolean thrown;
 
@@ -1904,7 +1904,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class IndexableFieldAnonymousClass : IIndexableField
+        private sealed class IndexableFieldAnonymousClass : IIndexableField
         {
             public string Name => "foo";
 
@@ -1923,19 +1923,19 @@ namespace Lucene.Net.Index
             }
 
             // LUCENENET specific - created overload so we can format an underlying numeric type using specified provider
-            public virtual string GetStringValue(IFormatProvider provider)
+            public string GetStringValue(IFormatProvider provider)
             {
                 return GetStringValue();
             }
 
             // LUCENENET specific - created overload so we can format an underlying numeric type using specified format
-            public virtual string GetStringValue(string format)
+            public string GetStringValue(string format)
             {
                 return GetStringValue();
             }
 
             // LUCENENET specific - created overload so we can format an underlying numeric type using specified format and provider
-            public virtual string GetStringValue(string format, IFormatProvider provider)
+            public string GetStringValue(string format, IFormatProvider provider)
             {
                 return GetStringValue();
             }
@@ -1952,40 +1952,40 @@ namespace Lucene.Net.Index
 
             // LUCENENET specific - Since we have no numeric reference types in .NET, this method was added to check
             // the numeric type of the inner field without boxing/unboxing.
-            public virtual NumericFieldType NumericType => NumericFieldType.NONE;
+            public NumericFieldType NumericType => NumericFieldType.NONE;
 
             // LUCENENET specific - created overload for Byte, since we have no Number class in .NET
-            public virtual byte? GetByteValue()
+            public byte? GetByteValue()
             {
                 return null;
             }
 
             // LUCENENET specific - created overload for Short, since we have no Number class in .NET
-            public virtual short? GetInt16Value()
+            public short? GetInt16Value()
             {
                 return null;
             }
 
             // LUCENENET specific - created overload for Int32, since we have no Number class in .NET
-            public virtual int? GetInt32Value()
+            public int? GetInt32Value()
             {
                 return null;
             }
 
             // LUCENENET specific - created overload for Int64, since we have no Number class in .NET
-            public virtual long? GetInt64Value()
+            public long? GetInt64Value()
             {
                 return null;
             }
 
             // LUCENENET specific - created overload for Single, since we have no Number class in .NET
-            public virtual float? GetSingleValue()
+            public float? GetSingleValue()
             {
                 return null;
             }
 
             // LUCENENET specific - created overload for Double, since we have no Number class in .NET
-            public virtual double? GetDoubleValue()
+            public double? GetDoubleValue()
             {
                 return null;
             }
@@ -2057,7 +2057,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class FailureAnonymousClass : Failure
+        private sealed class FailureAnonymousClass : Failure
         {
 
             public override Failure Reset()
@@ -2319,7 +2319,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class FailureAnonymousClass2 : Failure
+        private sealed class FailureAnonymousClass2 : Failure
         {
             private readonly AtomicBoolean shouldFail;
 
@@ -2359,7 +2359,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ConcurrentMergeSchedulerAnonymousClass : ConcurrentMergeScheduler
+        private sealed class ConcurrentMergeSchedulerAnonymousClass : ConcurrentMergeScheduler
         {
             protected override void HandleMergeException(Exception exc)
             {
@@ -2429,7 +2429,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class TEDRInfoStreamAnonymousClass : InfoStream
+        private sealed class TEDRInfoStreamAnonymousClass : InfoStream
         {
             private readonly string messageToFailOn;
 
@@ -2511,7 +2511,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class FailureAnonymousClass3 : Failure
+        private sealed class FailureAnonymousClass3 : Failure
         {
             public override void Eval(MockDirectoryWrapper dir)
             {

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Index
 
             public virtual IEnumerator<Document> GetEnumerator()
             {
-                return new IteratorAnonymousClass(this);
+                return new EnumeratorAnonymousClass(this);
             }
 
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
@@ -122,11 +122,11 @@ namespace Lucene.Net.Index
                 return GetEnumerator();
             }
 
-            private sealed class IteratorAnonymousClass : IEnumerator<Document>
+            private sealed class EnumeratorAnonymousClass : IEnumerator<Document>
             {
                 private readonly DocCopyIterator outerInstance;
 
-                public IteratorAnonymousClass(DocCopyIterator outerInstance)
+                public EnumeratorAnonymousClass(DocCopyIterator outerInstance)
                 {
                     this.outerInstance = outerInstance;
                 }

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterMerging.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterMerging.cs
@@ -438,7 +438,7 @@ namespace Lucene.Net.Index
             directory.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestIndexWriterMerging outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
@@ -90,7 +90,7 @@
 //            }
 //        }
 
-//        private class ThreadAnonymousClass : ThreadJob
+//        private sealed class ThreadAnonymousClass : ThreadJob
 //        {
 //            private readonly TestIndexWriterOnJRECrash outerInstance;
 
@@ -165,7 +165,7 @@
 //                return t;
 //            }
 
-//            private class ThreadAnonymousClass2 : ThreadJob
+//            private sealed class ThreadAnonymousClass2 : ThreadJob
 //            {
 //                private InputStream From;
 //                private OutputStream To;

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
@@ -565,7 +565,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            private class ThreadAnonymousClass : ThreadJob
+            private sealed class ThreadAnonymousClass : ThreadJob
             {
                 private readonly AddDirectoriesThreads outerInstance;
 
@@ -949,7 +949,7 @@ namespace Lucene.Net.Index
             dir1.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly IndexWriter writer;
             private readonly Directory[] dirs;
@@ -1055,7 +1055,7 @@ namespace Lucene.Net.Index
             dir1.Dispose();
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly IndexWriter writer;
             private readonly long endTime;
@@ -1189,7 +1189,7 @@ namespace Lucene.Net.Index
             Assert.IsTrue(didWarm);
         }
 
-        private class IndexReaderWarmerAnonymousClass : IndexWriter.IndexReaderWarmer
+        private sealed class IndexReaderWarmerAnonymousClass : IndexWriter.IndexReaderWarmer
         {
             private readonly AtomicBoolean didWarm;
 
@@ -1227,7 +1227,7 @@ namespace Lucene.Net.Index
             Assert.IsTrue(didWarm);
         }
 
-        private class InfoStreamAnonymousClass : InfoStream
+        private sealed class InfoStreamAnonymousClass : InfoStream
         {
             private readonly AtomicBoolean didWarm;
 
@@ -1380,7 +1380,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class FailureAnonymousClass : Failure
+        private sealed class FailureAnonymousClass : Failure
         {
             private readonly AtomicBoolean shouldFail;
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
@@ -688,7 +688,7 @@ namespace Lucene.Net.Index
             d.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly BaseDirectoryWrapper d;
             private readonly AtomicReference<IndexWriter> writerRef;

--- a/src/Lucene.Net.Tests/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexableField.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Index
                 fieldType = new IndexableFieldTypeAnonymousClass(this);
             }
 
-            private class IndexableFieldTypeAnonymousClass : IIndexableFieldType
+            private sealed class IndexableFieldTypeAnonymousClass : IIndexableFieldType
             {
                 private MyField outerInstance;
 
@@ -375,7 +375,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class EnumerableAnonymousClass : IEnumerable<IIndexableField>
+        private sealed class EnumerableAnonymousClass : IEnumerable<IIndexableField>
         {
             private readonly TestIndexableField outerInstance;
 
@@ -391,7 +391,7 @@ namespace Lucene.Net.Index
                 this.finalBaseCount = finalBaseCount;
             }
 
-            public virtual IEnumerator<IIndexableField> GetEnumerator()
+            public IEnumerator<IIndexableField> GetEnumerator()
             {
                 return new IteratorAnonymousClass(this, outerInstance);
             }
@@ -401,7 +401,7 @@ namespace Lucene.Net.Index
                 return GetEnumerator();
             }
 
-            private class IteratorAnonymousClass : IEnumerator<IIndexableField>
+            private sealed class IteratorAnonymousClass : IEnumerator<IIndexableField>
             {
                 private readonly EnumerableAnonymousClass outerInstance;
                 private readonly TestIndexableField outerTextIndexableField;

--- a/src/Lucene.Net.Tests/Index/TestIndexableField.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexableField.cs
@@ -393,7 +393,7 @@ namespace Lucene.Net.Index
 
             public IEnumerator<IIndexableField> GetEnumerator()
             {
-                return new IteratorAnonymousClass(this, outerInstance);
+                return new EnumeratorAnonymousClass(this, outerInstance);
             }
 
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
@@ -401,12 +401,12 @@ namespace Lucene.Net.Index
                 return GetEnumerator();
             }
 
-            private sealed class IteratorAnonymousClass : IEnumerator<IIndexableField>
+            private sealed class EnumeratorAnonymousClass : IEnumerator<IIndexableField>
             {
                 private readonly EnumerableAnonymousClass outerInstance;
                 private readonly TestIndexableField outerTextIndexableField;
 
-                public IteratorAnonymousClass(EnumerableAnonymousClass outerInstance, TestIndexableField outerTextIndexableField)
+                public EnumeratorAnonymousClass(EnumerableAnonymousClass outerInstance, TestIndexableField outerTextIndexableField)
                 {
                     this.outerInstance = outerInstance;
                     this.outerTextIndexableField = outerTextIndexableField;

--- a/src/Lucene.Net.Tests/Index/TestMixedDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/Index/TestMixedDocValuesUpdates.cs
@@ -323,7 +323,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestMixedDocValuesUpdates outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestNeverDelete.cs
+++ b/src/Lucene.Net.Tests/Index/TestNeverDelete.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Index
             System.IO.Directory.Delete(tmpDir.FullName, true);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly Func<string, string, Field.Store, Field> newStringField;
             private readonly Func<string, string, Field.Store, Field> newTextField;

--- a/src/Lucene.Net.Tests/Index/TestNumericDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/Index/TestNumericDocValuesUpdates.cs
@@ -650,7 +650,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class Lucene46CodecAnonymousClass : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass : Lucene46Codec
         {
             private readonly TestNumericDocValuesUpdates outerInstance;
 
@@ -1194,7 +1194,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestNumericDocValuesUpdates outerInstance;
 
@@ -1400,7 +1400,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class Lucene46CodecAnonymousClass2 : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass2 : Lucene46Codec
         {
             private readonly TestNumericDocValuesUpdates outerInstance;
 
@@ -1415,7 +1415,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class Lucene46CodecAnonymousClass3 : Lucene46Codec
+        private sealed class Lucene46CodecAnonymousClass3 : Lucene46Codec
         {
             private readonly TestNumericDocValuesUpdates outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestOmitTf.cs
+++ b/src/Lucene.Net.Tests/Index/TestOmitTf.cs
@@ -397,7 +397,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class CountingHitCollectorAnonymousClass : CountingHitCollector
+        private sealed class CountingHitCollectorAnonymousClass : CountingHitCollector
         {
             private readonly TestOmitTf outerInstance;
 
@@ -422,7 +422,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class CountingHitCollectorAnonymousClass2 : CountingHitCollector
+        private sealed class CountingHitCollectorAnonymousClass2 : CountingHitCollector
         {
             private readonly TestOmitTf outerInstance;
 
@@ -447,7 +447,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class CountingHitCollectorAnonymousClass3 : CountingHitCollector
+        private sealed class CountingHitCollectorAnonymousClass3 : CountingHitCollector
         {
             private readonly TestOmitTf outerInstance;
 
@@ -473,7 +473,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class CountingHitCollectorAnonymousClass4 : CountingHitCollector
+        private sealed class CountingHitCollectorAnonymousClass4 : CountingHitCollector
         {
             private readonly TestOmitTf outerInstance;
 
@@ -499,7 +499,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class CountingHitCollectorAnonymousClass5 : CountingHitCollector
+        private sealed class CountingHitCollectorAnonymousClass5 : CountingHitCollector
         {
             private readonly TestOmitTf outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestParallelCompositeReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestParallelCompositeReader.cs
@@ -169,7 +169,7 @@ namespace Lucene.Net.Index
             dir1.Dispose();
         }
 
-        private class ReaderClosedListenerAnonymousClass : IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass : IReaderClosedListener
         {
             private readonly TestParallelCompositeReader outerInstance;
 
@@ -210,7 +210,7 @@ namespace Lucene.Net.Index
             dir1.Dispose();
         }
 
-        private class ReaderClosedListenerAnonymousClass2 : IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass2 : IReaderClosedListener
         {
             private readonly TestParallelCompositeReader outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestPayloads.cs
+++ b/src/Lucene.Net.Tests/Index/TestPayloads.cs
@@ -521,7 +521,7 @@ namespace Lucene.Net.Index
             Assert.AreEqual(pool.Count, numThreads);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestPayloads outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestPersistentSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestPersistentSnapshotDeletionPolicy.cs
@@ -151,7 +151,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class FailureAnonymousClass : Failure
+        private sealed class FailureAnonymousClass : Failure
         {
             private readonly TestPersistentSnapshotDeletionPolicy outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestSnapshotDeletionPolicy.cs
@@ -176,7 +176,7 @@ namespace Lucene.Net.Index
             TestIndexWriter.AssertNoUnreferencedFiles(dir, "some files were not deleted but should have been");
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly long stopTime;
             private readonly IndexWriter writer;
@@ -385,7 +385,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly TestSnapshotDeletionPolicy outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestStressNRT.cs
+++ b/src/Lucene.Net.Tests/Index/TestStressNRT.cs
@@ -156,7 +156,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestStressNRT outerInstance;
 
@@ -424,7 +424,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly TestStressNRT outerInstance;
 

--- a/src/Lucene.Net.Tests/Index/TestTermdocPerf.cs
+++ b/src/Lucene.Net.Tests/Index/TestTermdocPerf.cs
@@ -103,7 +103,7 @@ namespace Lucene.Net.Index
             writer.Dispose();
         }
 
-        private class AnalyzerAnonymousClass : Analyzer
+        private sealed class AnalyzerAnonymousClass : Analyzer
         {
             private readonly Random random;
             private readonly string val;

--- a/src/Lucene.Net.Tests/Index/TestThreadedForceMerge.cs
+++ b/src/Lucene.Net.Tests/Index/TestThreadedForceMerge.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Index
             writer.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestThreadedForceMerge outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/Payloads/TestPayloadExplanations.cs
+++ b/src/Lucene.Net.Tests/Search/Payloads/TestPayloadExplanations.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Search.Payloads
             searcher.Similarity = new DefaultSimilarityAnonymousClass(this);
         }
 
-        private class DefaultSimilarityAnonymousClass : DefaultSimilarity
+        private sealed class DefaultSimilarityAnonymousClass : DefaultSimilarity
         {
             private readonly TestPayloadExplanations outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/Spans/TestFieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net.Tests/Search/Spans/TestFieldMaskingSpanQuery.cs
@@ -127,7 +127,7 @@ namespace Lucene.Net.Search.Spans
             Assert.AreEqual(2, terms.Count);
         }
 
-        private class SpanTermQueryAnonymousClass : SpanTermQuery
+        private sealed class SpanTermQueryAnonymousClass : SpanTermQuery
         {
             private readonly TestFieldMaskingSpanQuery outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/Spans/TestSpans.cs
+++ b/src/Lucene.Net.Tests/Search/Spans/TestSpans.cs
@@ -442,7 +442,7 @@ namespace Lucene.Net.Search.Spans
             }
         }
 
-        private class DefaultSimilarityAnonymousClass : DefaultSimilarity
+        private sealed class DefaultSimilarityAnonymousClass : DefaultSimilarity
         {
             private readonly TestSpans outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestAutomatonQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestAutomatonQuery.cs
@@ -246,7 +246,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestAutomatonQuery outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestBoolean2.cs
+++ b/src/Lucene.Net.Tests/Search/TestBoolean2.cs
@@ -274,7 +274,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class DefaultSimilarityAnonymousClass : DefaultSimilarity
+        private sealed class DefaultSimilarityAnonymousClass : DefaultSimilarity
         {
             private readonly TestBoolean2 outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestBooleanMinShouldMatch.cs
+++ b/src/Lucene.Net.Tests/Search/TestBooleanMinShouldMatch.cs
@@ -368,7 +368,7 @@ namespace Lucene.Net.Search
             // System.out.println("Total hits:"+tot);
         }
 
-        private class CallbackAnonymousClass : TestBoolean2.ICallback
+        private sealed class CallbackAnonymousClass : TestBoolean2.ICallback
         {
             private readonly TestBooleanMinShouldMatch outerInstance;
 
@@ -382,7 +382,7 @@ namespace Lucene.Net.Search
                 this.vals = vals;
             }
 
-            public virtual void PostCreate(BooleanQuery q)
+            public void PostCreate(BooleanQuery q)
             {
                 BooleanClause[] c = q.GetClauses();
                 int opt = 0;
@@ -459,7 +459,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class DefaultSimilarityAnonymousClass : DefaultSimilarity
+        private sealed class DefaultSimilarityAnonymousClass : DefaultSimilarity
         {
             private readonly TestBooleanMinShouldMatch outerInstance;
 
@@ -496,7 +496,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class DefaultSimilarityAnonymousClass2 : DefaultSimilarity
+        private sealed class DefaultSimilarityAnonymousClass2 : DefaultSimilarity
         {
             private readonly TestBooleanMinShouldMatch outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestBooleanOr.cs
+++ b/src/Lucene.Net.Tests/Search/TestBooleanOr.cs
@@ -214,7 +214,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestBooleanOr outerInstance;
 
@@ -230,21 +230,21 @@ namespace Lucene.Net.Search
                 this.end = end;
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 Assert.IsTrue(doc < end, "collected doc=" + doc + " beyond max=" + end);
                 hits.Set(doc);
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
     }
 }

--- a/src/Lucene.Net.Tests/Search/TestBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestBooleanQuery.cs
@@ -392,7 +392,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class IndexSearcherAnonymousClass : IndexSearcher
+        private sealed class IndexSearcherAnonymousClass : IndexSearcher
         {
             private readonly TestBooleanQuery outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestBooleanScorer.cs
+++ b/src/Lucene.Net.Tests/Search/TestBooleanScorer.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Search
             directory.Dispose();
         }
 
-        private class BulkScorerAnonymousClass : BulkScorer
+        private sealed class BulkScorerAnonymousClass : BulkScorer
         {
             private int doc = -1;
 
@@ -123,7 +123,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestBooleanScorer outerInstance;
 
@@ -137,21 +137,21 @@ namespace Lucene.Net.Search
 
             internal int docBase;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 hits.Add(docBase + doc);
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 docBase = context.DocBase;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
         [Test]
@@ -186,7 +186,7 @@ namespace Lucene.Net.Search
             d.Dispose();
         }
 
-        private class CollectorAnonymousClass2 : ICollector
+        private sealed class CollectorAnonymousClass2 : ICollector
         {
             private readonly TestBooleanScorer outerInstance;
 
@@ -200,23 +200,23 @@ namespace Lucene.Net.Search
                 this.count = count;
             }
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 // Make sure we got BooleanScorer:
                 Type clazz = scorer.GetType();
                 Assert.AreEqual(typeof(FakeScorer).Name, clazz.Name, "Scorer is implemented by wrong class");
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 count[0]++;
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Lucene.Net.Search
                 return new WeightAnonymousClass(this);
             }
 
-            private class WeightAnonymousClass : Weight
+            private sealed class WeightAnonymousClass : Weight
             {
                 private readonly CrazyMustUseBulkScorerQuery outerInstance;
 
@@ -268,7 +268,7 @@ namespace Lucene.Net.Search
                     return new BulkScorerAnonymousClass(this);
                 }
 
-                private class BulkScorerAnonymousClass : BulkScorer
+                private sealed class BulkScorerAnonymousClass : BulkScorer
                 {
                     private readonly WeightAnonymousClass outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestCachingCollector.cs
+++ b/src/Lucene.Net.Tests/Search/TestCachingCollector.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestCachingCollector outerInstance;
 
@@ -116,21 +116,21 @@ namespace Lucene.Net.Search
 
             internal int prevDocID;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 Assert.AreEqual(prevDocID + 1, doc);
                 prevDocID = doc;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/TestCachingWrapperFilter.cs
+++ b/src/Lucene.Net.Tests/Search/TestCachingWrapperFilter.cs
@@ -218,7 +218,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class FilterAnonymousClass : Filter
+        private sealed class FilterAnonymousClass : Filter
         {
             private readonly TestCachingWrapperFilter outerInstance;
 
@@ -256,7 +256,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class FilterAnonymousClass2 : Filter
+        private sealed class FilterAnonymousClass2 : Filter
         {
             private readonly TestCachingWrapperFilter outerInstance;
 
@@ -273,7 +273,7 @@ namespace Lucene.Net.Search
                 return new DocIdSetAnonymousClass(this);
             }
 
-            private class DocIdSetAnonymousClass : DocIdSet
+            private sealed class DocIdSetAnonymousClass : DocIdSet
             {
                 private readonly FilterAnonymousClass2 outerInstance;
 
@@ -343,7 +343,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class FilterAnonymousClass3 : Filter
+        private sealed class FilterAnonymousClass3 : Filter
         {
             private readonly TestCachingWrapperFilter outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestComplexExplanations.cs
+++ b/src/Lucene.Net.Tests/Search/TestComplexExplanations.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Search
             return new DefaultSimilarityAnonymousClass();
         }
 
-        private class DefaultSimilarityAnonymousClass : DefaultSimilarity
+        private sealed class DefaultSimilarityAnonymousClass : DefaultSimilarity
         {
             public DefaultSimilarityAnonymousClass()
             {

--- a/src/Lucene.Net.Tests/Search/TestConjunctions.cs
+++ b/src/Lucene.Net.Tests/Search/TestConjunctions.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Search
                 return new SimWeightAnonymousClass(this);
             }
 
-            private class SimWeightAnonymousClass : SimWeight
+            private sealed class SimWeightAnonymousClass : SimWeight
             {
                 private readonly TFSimilarity outerInstance;
 
@@ -133,7 +133,7 @@ namespace Lucene.Net.Search
                 return new SimScorerAnonymousClass(this);
             }
 
-            private class SimScorerAnonymousClass : SimScorer
+            private sealed class SimScorerAnonymousClass : SimScorer
             {
                 private readonly TFSimilarity outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestConstantScoreQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestConstantScoreQuery.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, count[0], "invalid number of results");
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestConstantScoreQuery outerInstance;
 
@@ -83,7 +83,7 @@ namespace Lucene.Net.Search
 
             private Scorer scorer;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
                 Assert.AreEqual(scorerClassName, scorer.GetType().Name, "Scorer is implemented by wrong class");
@@ -94,17 +94,17 @@ namespace Lucene.Net.Search
                 }
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 Assert.AreEqual(expectedScore, this.scorer.GetScore(), 0, "Score differs from expected");
                 count[0]++;
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
         [Test]
@@ -163,7 +163,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class DefaultSimilarityAnonymousClass : DefaultSimilarity
+        private sealed class DefaultSimilarityAnonymousClass : DefaultSimilarity
         {
             private readonly TestConstantScoreQuery outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
+++ b/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
@@ -299,7 +299,7 @@ namespace Lucene.Net.Search
             nrtNoDeletesThread.Start();
         }
 
-        private class SearcherFactoryAnonymousClass : SearcherFactory
+        private sealed class SearcherFactoryAnonymousClass : SearcherFactory
         {
             private readonly TestControlledRealTimeReopenThread outerInstance;
 
@@ -449,7 +449,7 @@ namespace Lucene.Net.Search
             IOUtils.Dispose(manager, _writer, d);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestControlledRealTimeReopenThread outerInstance;
 
@@ -487,7 +487,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly TestControlledRealTimeReopenThread outerInstance;
 
@@ -576,7 +576,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class SearcherFactoryAnonymousClass2 : SearcherFactory
+        private sealed class SearcherFactoryAnonymousClass2 : SearcherFactory
         {
             private readonly TestControlledRealTimeReopenThread outerInstance;
 
@@ -612,7 +612,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class RefreshListenerAnonymousClass : ReferenceManager.IRefreshListener
+        private sealed class RefreshListenerAnonymousClass : ReferenceManager.IRefreshListener
         {
             private readonly TestControlledRealTimeReopenThread outerInstance;
 
@@ -708,7 +708,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class RunnableAnonymousClass : ThreadJob
+        private sealed class RunnableAnonymousClass : ThreadJob
         {
             private readonly TestControlledRealTimeReopenThread outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestDocBoost.cs
+++ b/src/Lucene.Net.Tests/Search/TestDocBoost.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using Assert = Lucene.Net.TestFramework.Assert;
@@ -82,7 +82,7 @@ namespace Lucene.Net.Search
             store.Dispose();
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestDocBoost outerInstance;
 
@@ -98,22 +98,22 @@ namespace Lucene.Net.Search
             private int @base;
             private Scorer scorer;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 scores[doc + @base] = scorer.GetScore();
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 @base = context.DocBase;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
     }
 }

--- a/src/Lucene.Net.Tests/Search/TestDocIdSet.cs
+++ b/src/Lucene.Net.Tests/Search/TestDocIdSet.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class DocIdSetAnonymousClass : DocIdSet
+        private sealed class DocIdSetAnonymousClass : DocIdSet
         {
             private readonly TestDocIdSet outerInstance;
 
@@ -92,7 +92,7 @@ namespace Lucene.Net.Search
                 return new DocIdSetIteratorAnonymousClass(this);
             }
 
-            private class DocIdSetIteratorAnonymousClass : DocIdSetIterator
+            private sealed class DocIdSetIteratorAnonymousClass : DocIdSetIterator
             {
                 private readonly DocIdSetAnonymousClass outerInstance;
 
@@ -124,7 +124,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class FilteredDocIdSetAnonymousClass : FilteredDocIdSet
+        private sealed class FilteredDocIdSetAnonymousClass : FilteredDocIdSet
         {
             private readonly TestDocIdSet outerInstance;
 
@@ -165,7 +165,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class FilterAnonymousClass : Filter
+        private sealed class FilterAnonymousClass : Filter
         {
             private readonly TestDocIdSet outerInstance;
 
@@ -203,7 +203,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class FilterAnonymousClass2 : Filter
+        private sealed class FilterAnonymousClass2 : Filter
         {
             private readonly TestDocIdSet outerInstance;
 
@@ -218,7 +218,7 @@ namespace Lucene.Net.Search
                 return new FilteredDocIdSetAnonymousClass2(this, innerNullIteratorSet);
             }
 
-            private class DocIdSetAnonymousClass2 : DocIdSet
+            private sealed class DocIdSetAnonymousClass2 : DocIdSet
             {
                 private readonly FilterAnonymousClass2 outerInstance;
 
@@ -233,7 +233,7 @@ namespace Lucene.Net.Search
                 }
             }
 
-            private class FilteredDocIdSetAnonymousClass2 : FilteredDocIdSet
+            private sealed class FilteredDocIdSetAnonymousClass2 : FilteredDocIdSet
             {
                 private readonly FilterAnonymousClass2 outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestDocValuesScoring.cs
+++ b/src/Lucene.Net.Tests/Search/TestDocValuesScoring.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class PerFieldSimilarityWrapperAnonymousClass : PerFieldSimilarityWrapper
+        private sealed class PerFieldSimilarityWrapperAnonymousClass : PerFieldSimilarityWrapper
         {
             private readonly TestDocValuesScoring outerInstance;
 
@@ -189,7 +189,7 @@ namespace Lucene.Net.Search
                 return new SimScorerAnonymousClass(this, sub, values);
             }
 
-            private class SimScorerAnonymousClass : SimScorer
+            private sealed class SimScorerAnonymousClass : SimScorer
             {
                 private readonly BoostingSimilarity outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestEarlyTermination.cs
+++ b/src/Lucene.Net.Tests/Search/TestEarlyTermination.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Search
             reader.Dispose();
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestEarlyTermination outerInstance;
 
@@ -89,11 +89,11 @@ namespace Lucene.Net.Search
             internal readonly bool outOfOrder;
             internal bool collectionTerminated;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 Assert.IsFalse(collectionTerminated);
                 if (Rarely())
@@ -103,7 +103,7 @@ namespace Lucene.Net.Search
                 }
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 if (Random.NextBoolean())
                 {
@@ -116,7 +116,7 @@ namespace Lucene.Net.Search
                 }
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => outOfOrder;
+            public bool AcceptsDocsOutOfOrder => outOfOrder;
         }
     }
 }

--- a/src/Lucene.Net.Tests/Search/TestElevationComparator.cs
+++ b/src/Lucene.Net.Tests/Search/TestElevationComparator.cs
@@ -151,7 +151,7 @@ namespace Lucene.Net.Search
             return new FieldComparerAnonymousClass(this, fieldname, numHits);
         }
 
-        private class FieldComparerAnonymousClass : FieldComparer<J2N.Numerics.Int32>
+        private sealed class FieldComparerAnonymousClass : FieldComparer<J2N.Numerics.Int32>
         {
             private readonly ElevationComparerSource outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestFieldCache.cs
+++ b/src/Lucene.Net.Tests/Search/TestFieldCache.cs
@@ -502,7 +502,7 @@ namespace Lucene.Net.Search
             Assert.IsFalse(failed);
         }
 
-        private class RunnableAnonymousClass //: IThreadRunnable
+        private sealed class RunnableAnonymousClass //: IThreadRunnable
         {
             private readonly TestFieldCache outerInstance;
 
@@ -523,7 +523,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestFieldCache outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestFilteredQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestFilteredQuery.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Search
             return new FilterAnonymousClass();
         }
 
-        private class FilterAnonymousClass : Filter
+        private sealed class FilterAnonymousClass : Filter
         {
             public FilterAnonymousClass()
             {
@@ -210,7 +210,7 @@ namespace Lucene.Net.Search
             return new FilterAnonymousClass2();
         }
 
-        private class FilterAnonymousClass2 : Filter
+        private sealed class FilterAnonymousClass2 : Filter
         {
             public FilterAnonymousClass2()
             {
@@ -456,7 +456,7 @@ namespace Lucene.Net.Search
             return TestUtil.RandomFilterStrategy(random);
         }
 
-        private class RandomAccessFilterStrategyAnonymousClass : FilteredQuery.RandomAccessFilterStrategy
+        private sealed class RandomAccessFilterStrategyAnonymousClass : FilteredQuery.RandomAccessFilterStrategy
         {
             public RandomAccessFilterStrategyAnonymousClass()
             {
@@ -502,7 +502,7 @@ namespace Lucene.Net.Search
             IOUtils.Dispose(reader, writer, directory);
         }
 
-        private class FilterAnonymousClass3 : Filter
+        private sealed class FilterAnonymousClass3 : Filter
         {
             private readonly TestFilteredQuery outerInstance;
 
@@ -532,7 +532,7 @@ namespace Lucene.Net.Search
                 return new DocIdSetAnonymousClass(this, nullBitset, reader, bitSet);
             }
 
-            private class DocIdSetAnonymousClass : DocIdSet
+            private sealed class DocIdSetAnonymousClass : DocIdSet
             {
                 private readonly FilterAnonymousClass3 outerInstance;
 
@@ -560,7 +560,7 @@ namespace Lucene.Net.Search
                     }
                 }
 
-                private class BitsAnonymousClass : IBits
+                private sealed class BitsAnonymousClass : IBits
                 {
                     private readonly DocIdSetAnonymousClass outerInstance;
 
@@ -621,7 +621,7 @@ namespace Lucene.Net.Search
             IOUtils.Dispose(reader, writer, directory);
         }
 
-        private class FilterAnonymousClass4 : Filter
+        private sealed class FilterAnonymousClass4 : Filter
         {
             private readonly TestFilteredQuery outerInstance;
 
@@ -638,7 +638,7 @@ namespace Lucene.Net.Search
                 return new DocIdSetAnonymousClass2(this, context);
             }
 
-            private class DocIdSetAnonymousClass2 : DocIdSet
+            private sealed class DocIdSetAnonymousClass2 : DocIdSet
             {
                 private readonly FilterAnonymousClass4 outerInstance;
 
@@ -662,7 +662,7 @@ namespace Lucene.Net.Search
                     return new DocIdSetIteratorAnonymousClass(this, termDocsEnum);
                 }
 
-                private class DocIdSetIteratorAnonymousClass : DocIdSetIterator
+                private sealed class DocIdSetIteratorAnonymousClass : DocIdSetIterator
                 {
                     private readonly DocIdSetAnonymousClass2 outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestLiveFieldValues.cs
+++ b/src/Lucene.Net.Tests/Search/TestLiveFieldValues.cs
@@ -100,7 +100,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class SearcherFactoryAnonymousClass : SearcherFactory
+        private sealed class SearcherFactoryAnonymousClass : SearcherFactory
         {
             public override IndexSearcher NewSearcher(IndexReader r)
             {
@@ -108,7 +108,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class LiveFieldValuesAnonymousClass : LiveFieldValues<IndexSearcher, int?>
+        private sealed class LiveFieldValuesAnonymousClass : LiveFieldValues<IndexSearcher, int?>
         {
             public LiveFieldValuesAnonymousClass(SearcherManager mgr, int missing)
                 : base(mgr, missing)
@@ -132,7 +132,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly IndexWriter w;
             private readonly SearcherManager mgr;

--- a/src/Lucene.Net.Tests/Search/TestMinShouldMatch2.cs
+++ b/src/Lucene.Net.Tests/Search/TestMinShouldMatch2.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Search
             searcher.Similarity = new DefaultSimilarityAnonymousClass();
         }
 
-        private class DefaultSimilarityAnonymousClass : DefaultSimilarity
+        private sealed class DefaultSimilarityAnonymousClass : DefaultSimilarity
         {
             public DefaultSimilarityAnonymousClass()
             {

--- a/src/Lucene.Net.Tests/Search/TestMultiPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiPhraseQuery.cs
@@ -380,7 +380,7 @@ namespace Lucene.Net.Search
             indexStore.Dispose();
         }
 
-        private class DefaultSimilarityAnonymousClass : DefaultSimilarity
+        private sealed class DefaultSimilarityAnonymousClass : DefaultSimilarity
         {
             private readonly TestMultiPhraseQuery outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestMultiTermConstantScore.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiTermConstantScore.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
@@ -285,7 +285,7 @@ namespace Lucene.Net.Search
             Assert.IsTrue(hits[0].Score > hits[1].Score);
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestMultiTermConstantScore outerInstance;
 
@@ -298,22 +298,22 @@ namespace Lucene.Net.Search
             private int @base;
             private Scorer scorer;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 Assert.AreEqual(1.0f, scorer.GetScore(), SCORE_COMP_THRESH, "score for doc " + (doc + @base) + " was not correct");
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 @base = context.DocBase;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
@@ -203,7 +203,7 @@ namespace Lucene.Net.Search
             CheckBooleanQueryBoosts((BooleanQuery)q3);
         }
 
-        private class MultiTermQueryAnonymousClass : MultiTermQuery
+        private sealed class MultiTermQueryAnonymousClass : MultiTermQuery
         {
             private readonly TestMultiTermQueryRewrites outerInstance;
 
@@ -218,7 +218,7 @@ namespace Lucene.Net.Search
                 return new TermRangeTermsEnumAnonymousClass(this, terms.GetEnumerator(), new BytesRef("2"), new BytesRef("7"));
             }
 
-            private class TermRangeTermsEnumAnonymousClass : TermRangeTermsEnum
+            private sealed class TermRangeTermsEnumAnonymousClass : TermRangeTermsEnum
             {
                 private readonly MultiTermQueryAnonymousClass outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestPhraseQuery.cs
@@ -88,7 +88,7 @@ namespace Lucene.Net.Search
             searcher = NewSearcher(reader);
         }
 
-        private class AnalyzerAnonymousClass : Analyzer
+        private sealed class AnalyzerAnonymousClass : Analyzer
         {
             public AnalyzerAnonymousClass()
             {

--- a/src/Lucene.Net.Tests/Search/TestPositionIncrement.cs
+++ b/src/Lucene.Net.Tests/Search/TestPositionIncrement.cs
@@ -166,7 +166,7 @@ namespace Lucene.Net.Search
             store.Dispose();
         }
 
-        private class AnalyzerAnonymousClass : Analyzer
+        private sealed class AnalyzerAnonymousClass : Analyzer
         {
             private readonly TestPositionIncrement outerInstance;
 
@@ -180,7 +180,7 @@ namespace Lucene.Net.Search
                 return new TokenStreamComponents(new TokenizerAnonymousClass(reader));
             }
 
-            private class TokenizerAnonymousClass : Tokenizer
+            private sealed class TokenizerAnonymousClass : Tokenizer
             {
                 public TokenizerAnonymousClass(TextReader reader)
                     : base(reader)

--- a/src/Lucene.Net.Tests/Search/TestQueryRescorer.cs
+++ b/src/Lucene.Net.Tests/Search/TestQueryRescorer.cs
@@ -163,7 +163,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class QueryRescorerAnonymousClass : QueryRescorer
+        private sealed class QueryRescorerAnonymousClass : QueryRescorer
         {
             private readonly TestQueryRescorer outerInstance;
 
@@ -251,7 +251,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class QueryRescorerAnonymousClass2 : QueryRescorer
+        private sealed class QueryRescorerAnonymousClass2 : QueryRescorer
         {
             private readonly TestQueryRescorer outerInstance;
 
@@ -418,7 +418,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class QueryRescorerAnonymousClass3 : QueryRescorer
+        private sealed class QueryRescorerAnonymousClass3 : QueryRescorer
         {
             private readonly TestQueryRescorer outerInstance;
 
@@ -452,7 +452,7 @@ namespace Lucene.Net.Search
                 return new WeightAnonymousClass(this);
             }
 
-            private class WeightAnonymousClass : Weight
+            private sealed class WeightAnonymousClass : Weight
             {
                 private readonly FixedScoreQuery outerInstance;
 
@@ -477,7 +477,7 @@ namespace Lucene.Net.Search
                     return new ScorerAnonymousClass(this, context);
                 }
 
-                private class ScorerAnonymousClass : Scorer
+                private sealed class ScorerAnonymousClass : Scorer
                 {
                     private readonly WeightAnonymousClass outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestRegexpQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestRegexpQuery.cs
@@ -120,7 +120,7 @@ namespace Lucene.Net.Search
             Assert.AreEqual(1, searcher.Search(query, 5).TotalHits);
         }
 
-        private class AutomatonProviderAnonymousClass : IAutomatonProvider
+        private sealed class AutomatonProviderAnonymousClass : IAutomatonProvider
         {
             private readonly TestRegexpQuery outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestSameScoresWithThreads.cs
+++ b/src/Lucene.Net.Tests/Search/TestSameScoresWithThreads.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestSameScoresWithThreads outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestScorerPerf.cs
+++ b/src/Lucene.Net.Tests/Search/TestScorerPerf.cs
@@ -180,7 +180,7 @@ namespace Lucene.Net.Search
             return result;
         }
 
-        private class FilterAnonymousClass : Filter
+        private sealed class FilterAnonymousClass : Filter
         {
             private readonly BitSet rnd;
 

--- a/src/Lucene.Net.Tests/Search/TestSearchWithThreads.cs
+++ b/src/Lucene.Net.Tests/Search/TestSearchWithThreads.cs
@@ -117,7 +117,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestSearchWithThreads outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestSearcherManager.cs
+++ b/src/Lucene.Net.Tests/Search/TestSearcherManager.cs
@@ -98,7 +98,7 @@ namespace Lucene.Net.Search
             lifetimeMGR = new SearcherLifetimeManager();
         }
 
-        private class SearcherFactoryAnonymousClass : SearcherFactory
+        private sealed class SearcherFactoryAnonymousClass : SearcherFactory
         {
             private readonly TestSearcherManager outerInstance;
 
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search
             reopenThread.Join();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestSearcherManager outerInstance;
 
@@ -331,7 +331,7 @@ namespace Lucene.Net.Search
             //}
         }
 
-        private class SearcherFactoryAnonymousClass2 : SearcherFactory
+        private sealed class SearcherFactoryAnonymousClass2 : SearcherFactory
         {
             private readonly TestSearcherManager outerInstance;
 
@@ -367,7 +367,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class RunnableAnonymousClass //: IThreadRunnable
+        private sealed class RunnableAnonymousClass //: IThreadRunnable
         {
             private readonly TestSearcherManager outerInstance;
 
@@ -515,7 +515,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class RefreshListenerAnonymousClass : ReferenceManager.IRefreshListener
+        private sealed class RefreshListenerAnonymousClass : ReferenceManager.IRefreshListener
         {
             private readonly TestSearcherManager outerInstance;
 
@@ -573,7 +573,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class SearcherFactoryAnonymousClass3 : SearcherFactory
+        private sealed class SearcherFactoryAnonymousClass3 : SearcherFactory
         {
             private readonly TestSearcherManager outerInstance;
 
@@ -613,7 +613,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly TestSearcherManager outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestSimilarity.cs
+++ b/src/Lucene.Net.Tests/Search/TestSimilarity.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Documents;
+﻿using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using Assert = Lucene.Net.TestFramework.Assert;
@@ -126,7 +126,7 @@ namespace Lucene.Net.Search
             store.Dispose();
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestSimilarity outerInstance;
 
@@ -137,24 +137,24 @@ namespace Lucene.Net.Search
 
             private Scorer scorer;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 Assert.AreEqual(1.0f, scorer.GetScore(), 0);
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
-        private class CollectorAnonymousClass2 : ICollector
+        private sealed class CollectorAnonymousClass2 : ICollector
         {
             private readonly TestSimilarity outerInstance;
 
@@ -167,26 +167,26 @@ namespace Lucene.Net.Search
             private int @base;
             private Scorer scorer;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 //System.out.println("Doc=" + doc + " score=" + score);
                 Assert.AreEqual((float)doc + @base + 1, scorer.GetScore(), 0);
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 @base = context.DocBase;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
-        private class CollectorAnonymousClass3 : ICollector
+        private sealed class CollectorAnonymousClass3 : ICollector
         {
             private readonly TestSimilarity outerInstance;
 
@@ -197,25 +197,25 @@ namespace Lucene.Net.Search
 
             private Scorer scorer;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 //System.out.println("Doc=" + doc + " score=" + score);
                 Assert.AreEqual(1.0f, scorer.GetScore(), 0);
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
-        private class CollectorAnonymousClass4 : ICollector
+        private sealed class CollectorAnonymousClass4 : ICollector
         {
             private readonly TestSimilarity outerInstance;
 
@@ -226,22 +226,22 @@ namespace Lucene.Net.Search
 
             private Scorer scorer;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 //System.out.println("Doc=" + doc + " score=" + score);
                 Assert.AreEqual(2.0f, scorer.GetScore(), 0);
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
     }
 }

--- a/src/Lucene.Net.Tests/Search/TestSloppyPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestSloppyPhraseQuery.cs
@@ -243,7 +243,7 @@ namespace Lucene.Net.Search
             QueryUtils.Check(Random, pq, searcher);
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestSloppyPhraseQuery outerInstance;
 
@@ -254,23 +254,23 @@ namespace Lucene.Net.Search
 
             internal Scorer scorer;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 Assert.IsFalse(float.IsInfinity(scorer.Freq));
                 Assert.IsFalse(float.IsInfinity(scorer.GetScore()));
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 // do nothing
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => false;
+            public bool AcceptsDocsOutOfOrder => false;
         }
 
         // LUCENE-3215

--- a/src/Lucene.Net.Tests/Search/TestSort.cs
+++ b/src/Lucene.Net.Tests/Search/TestSort.cs
@@ -1581,7 +1581,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class IntParserAnonymousClass : FieldCache.IInt32Parser
+        private sealed class IntParserAnonymousClass : FieldCache.IInt32Parser
         {
             private readonly TestSort outerInstance;
 
@@ -1643,7 +1643,7 @@ namespace Lucene.Net.Search
         }
 
 #pragma warning disable 612, 618
-        private class ByteParserAnonymousClass : FieldCache.IByteParser
+        private sealed class ByteParserAnonymousClass : FieldCache.IByteParser
 #pragma warning restore 612, 618
         {
             private readonly TestSort outerInstance;
@@ -1703,7 +1703,7 @@ namespace Lucene.Net.Search
         }
 
 #pragma warning disable 612, 618
-        private class ShortParserAnonymousClass : FieldCache.IInt16Parser
+        private sealed class ShortParserAnonymousClass : FieldCache.IInt16Parser
 #pragma warning restore 612, 618
         {
             private readonly TestSort outerInstance;
@@ -1765,7 +1765,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class LongParserAnonymousClass : FieldCache.IInt64Parser
+        private sealed class LongParserAnonymousClass : FieldCache.IInt64Parser
         {
             private readonly TestSort outerInstance;
 
@@ -1826,7 +1826,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class FloatParserAnonymousClass : FieldCache.ISingleParser
+        private sealed class FloatParserAnonymousClass : FieldCache.ISingleParser
         {
             private readonly TestSort outerInstance;
 
@@ -1887,7 +1887,7 @@ namespace Lucene.Net.Search
             dir.Dispose();
         }
 
-        private class DoubleParserAnonymousClass : FieldCache.IDoubleParser
+        private sealed class DoubleParserAnonymousClass : FieldCache.IDoubleParser
         {
             private readonly TestSort outerInstance;
 

--- a/src/Lucene.Net.Tests/Search/TestTermScorer.cs
+++ b/src/Lucene.Net.Tests/Search/TestTermScorer.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Search
             Assert.IsTrue(doc0.Score == 1.6931472f, doc0.Score + " does not equal: " + 1.6931472f);
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly TestTermScorer outerInstance;
 
@@ -124,12 +124,12 @@ namespace Lucene.Net.Search
             private int @base;
             private Scorer scorer;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
                 this.scorer = scorer;
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
                 float score = scorer.GetScore();
                 doc = doc + @base;
@@ -138,12 +138,12 @@ namespace Lucene.Net.Search
                 Assert.IsTrue(doc == 0 || doc == 5, "Doc: " + doc + " does not equal 0 or doc does not equal 5");
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
                 @base = context.DocBase;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => true;
+            public bool AcceptsDocsOutOfOrder => true;
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/TestTimeLimitingCollector.cs
+++ b/src/Lucene.Net.Tests/Search/TestTimeLimitingCollector.cs
@@ -339,7 +339,7 @@ namespace Lucene.Net.Search
             assertEquals("some threads failed!", N_THREADS, success.Cardinality);
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestTimeLimitingCollector outerInstance;
             private readonly OpenBitSet success;

--- a/src/Lucene.Net.Tests/Store/TestRAMDirectory.cs
+++ b/src/Lucene.Net.Tests/Store/TestRAMDirectory.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Store
             writer.Dispose();
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestRAMDirectory outerInstance;
 

--- a/src/Lucene.Net.Tests/TestWorstCaseTestBehavior.cs
+++ b/src/Lucene.Net.Tests/TestWorstCaseTestBehavior.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net
             // once alive, leave it to run outside of the test scope.
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly TestWorstCaseTestBehavior outerInstance;
 
@@ -106,7 +106,7 @@ namespace Lucene.Net
             t.Join();
         }
 
-        private class ThreadAnonymousClass2 : ThreadJob
+        private sealed class ThreadAnonymousClass2 : ThreadJob
         {
             private readonly TestWorstCaseTestBehavior outerInstance;
 

--- a/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
@@ -815,7 +815,7 @@ namespace Lucene.Net.Util.Fst
             }
         }*/
 
-        private class VisitTermsAnonymousClass : VisitTerms<Pair>
+        private sealed class VisitTermsAnonymousClass : VisitTerms<Pair>
         {
             private readonly PairOutputs<Int64, Int64> outputs;
 
@@ -836,7 +836,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private class VisitTermsAnonymousClass2 : VisitTerms<Int64>
+        private sealed class VisitTermsAnonymousClass2 : VisitTerms<Int64>
         {
             public VisitTermsAnonymousClass2(string dirOut, string wordsFileIn, int inputMode, int prune, PositiveInt32Outputs outputs, bool doPack, bool noArcArrays)
                 : base(dirOut, wordsFileIn, inputMode, prune, outputs, doPack, noArcArrays)
@@ -849,7 +849,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private class VisitTermsAnonymousClass3 : VisitTerms<Int64>
+        private sealed class VisitTermsAnonymousClass3 : VisitTerms<Int64>
         {
             public VisitTermsAnonymousClass3(string dirOut, string wordsFileIn, int inputMode, int prune, PositiveInt32Outputs outputs, bool doPack, bool noArcArrays)
                 : base(dirOut, wordsFileIn, inputMode, prune, outputs, doPack, noArcArrays)
@@ -867,7 +867,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private class VisitTermsAnonymousClass4 : VisitTerms<object>
+        private sealed class VisitTermsAnonymousClass4 : VisitTerms<object>
         {
             private readonly object NO_OUTPUT;
 
@@ -1514,7 +1514,7 @@ namespace Lucene.Net.Util.Fst
             Assert.IsFalse(res.IsComplete); // rejected(4) + topN(2) > maxQueueSize(5)
         }
 
-        private class TopNSearcherAnonymousClass : Util.TopNSearcher<Int64>
+        private sealed class TopNSearcherAnonymousClass : Util.TopNSearcher<Int64>
         {
             private readonly AtomicInt32 rejectCount;
 
@@ -1535,7 +1535,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        private class TopNSearcherAnonymousClass2 : Util.TopNSearcher<Int64>
+        private sealed class TopNSearcherAnonymousClass2 : Util.TopNSearcher<Int64>
         {
             private readonly AtomicInt32 rejectCount;
 

--- a/src/Lucene.Net.Tests/Util/Packed/TestEliasFanoDocIdSet.cs
+++ b/src/Lucene.Net.Tests/Util/Packed/TestEliasFanoDocIdSet.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Util.Packed
             return set;
         }
 
-        private class DocIdSetIteratorAnonymousClass : DocIdSetIterator
+        private sealed class DocIdSetIteratorAnonymousClass : DocIdSetIterator
         {
             private readonly BitSet bs;
             private readonly int numBits;

--- a/src/Lucene.Net.Tests/Util/TestFilterIterator.cs
+++ b/src/Lucene.Net.Tests/Util/TestFilterIterator.cs
@@ -136,7 +136,7 @@ namespace Lucene.Net.Util
         }
 
         [Obsolete("This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        private class FilterIteratorAnonymousClass : FilterIterator<string>
+        private sealed class FilterIteratorAnonymousClass : FilterIterator<string>
         {
             public FilterIteratorAnonymousClass(IEnumerator<string> iterator)
                 : base(iterator)
@@ -160,7 +160,7 @@ namespace Lucene.Net.Util
         }
 
         [Obsolete("This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        private class FilterIteratorAnonymousClass2 : FilterIterator<string>
+        private sealed class FilterIteratorAnonymousClass2 : FilterIterator<string>
         {
             public FilterIteratorAnonymousClass2(IEnumerator<string> iterator)
                 : base(iterator)
@@ -185,7 +185,7 @@ namespace Lucene.Net.Util
         }
 
         [Obsolete("This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        private class FilterIteratorAnonymousClass3 : FilterIterator<string>
+        private sealed class FilterIteratorAnonymousClass3 : FilterIterator<string>
         {
             public FilterIteratorAnonymousClass3(IEnumerator<string> iterator)
                 : base(iterator)
@@ -209,7 +209,7 @@ namespace Lucene.Net.Util
         }
 
         [Obsolete("This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        private class FilterIteratorAnonymousClass4 : FilterIterator<string>
+        private sealed class FilterIteratorAnonymousClass4 : FilterIterator<string>
         {
             public FilterIteratorAnonymousClass4(IEnumerator<string> iterator)
                 : base(iterator)
@@ -234,7 +234,7 @@ namespace Lucene.Net.Util
         }
 
         [Obsolete("This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        private class FilterIteratorAnonymousClass5 : FilterIterator<string>
+        private sealed class FilterIteratorAnonymousClass5 : FilterIterator<string>
         {
             public FilterIteratorAnonymousClass5(IEnumerator<string> iterator)
                 : base(iterator)
@@ -262,7 +262,7 @@ namespace Lucene.Net.Util
         }
 
         [Obsolete("This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        private class FilterIteratorAnonymousClass6 : FilterIterator<string>
+        private sealed class FilterIteratorAnonymousClass6 : FilterIterator<string>
         {
             public FilterIteratorAnonymousClass6(IEnumerator<string> iterator)
                 : base(iterator)
@@ -290,7 +290,7 @@ namespace Lucene.Net.Util
         }
 
         [Obsolete("This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        private class FilterIteratorAnonymousClass7 : FilterIterator<string>
+        private sealed class FilterIteratorAnonymousClass7 : FilterIterator<string>
         {
             public FilterIteratorAnonymousClass7(IEnumerator<string> iterator)
                 : base(iterator)

--- a/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
+++ b/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
@@ -276,7 +276,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        private class LongRangeBuilderAnonymousClass : NumericUtils.Int64RangeBuilder
+        private sealed class LongRangeBuilderAnonymousClass : NumericUtils.Int64RangeBuilder
         {
             private readonly long lower;
             private readonly long upper;
@@ -469,7 +469,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        private class IntRangeBuilderAnonymousClass : NumericUtils.Int32RangeBuilder
+        private sealed class IntRangeBuilderAnonymousClass : NumericUtils.Int32RangeBuilder
         {
             private readonly int lower;
             private readonly int upper;

--- a/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
+++ b/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
@@ -88,7 +88,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        private class RollingBufferAnonymousClass : RollingBuffer<Position>
+        private sealed class RollingBufferAnonymousClass : RollingBuffer<Position>
         {
             public RollingBufferAnonymousClass()
                 : base(NewInstanceFunc)

--- a/src/Lucene.Net.Tests/Util/TestWeakIdentityMap.cs
+++ b/src/Lucene.Net.Tests/Util/TestWeakIdentityMap.cs
@@ -273,7 +273,7 @@
 //            }
 //        }
 
-//        private class RunnableAnonymousClass : ThreadJob
+//        private sealed class RunnableAnonymousClass : ThreadJob
 //        {
 //            private readonly TestWeakIdentityMap outerInstance;
 

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -126,7 +126,7 @@ namespace Lucene.Net.Analysis
 
         private static readonly TextReader ILLEGAL_STATE_READER = new ReaderAnonymousClass();
 
-        private class ReaderAnonymousClass : TextReader
+        private sealed class ReaderAnonymousClass : TextReader
         {
             public override int Read(char[] cbuf, int off, int len)
             {

--- a/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsReader.cs
@@ -380,7 +380,7 @@ namespace Lucene.Net.Codecs.Compressing
             }
         }
 
-        private class DataInputAnonymousClass : DataInput
+        private sealed class DataInputAnonymousClass : DataInput
         {
             private readonly CompressingStoredFieldsReader outerInstance;
 
@@ -395,7 +395,7 @@ namespace Lucene.Net.Codecs.Compressing
 
             internal int decompressed;
 
-            internal virtual void FillBuffer()
+            internal void FillBuffer()
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(decompressed <= length);
                 if (decompressed == length)

--- a/src/Lucene.Net/Codecs/Compressing/CompressionMode.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressionMode.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Codecs.Compressing
         /// </summary>
         public static readonly CompressionMode FAST = new CompressionModeAnonymousClass();
 
-        private class CompressionModeAnonymousClass : CompressionMode
+        private sealed class CompressionModeAnonymousClass : CompressionMode
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override Compressor NewCompressor()
@@ -73,7 +73,7 @@ namespace Lucene.Net.Codecs.Compressing
         /// </summary>
         public static readonly CompressionMode HIGH_COMPRESSION = new CompressionModeAnonymousClass2();
 
-        private class CompressionModeAnonymousClass2 : CompressionMode
+        private sealed class CompressionModeAnonymousClass2 : CompressionMode
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override Compressor NewCompressor()
@@ -102,7 +102,7 @@ namespace Lucene.Net.Codecs.Compressing
         /// </summary>
         public static readonly CompressionMode FAST_DECOMPRESSION = new CompressionModeAnonymousClass3();
 
-        private class CompressionModeAnonymousClass3 : CompressionMode
+        private sealed class CompressionModeAnonymousClass3 : CompressionMode
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override Compressor NewCompressor()
@@ -141,7 +141,7 @@ namespace Lucene.Net.Codecs.Compressing
 
         private static readonly Decompressor LZ4_DECOMPRESSOR = new DecompressorAnonymousClass();
 
-        private class DecompressorAnonymousClass : Decompressor
+        private sealed class DecompressorAnonymousClass : Decompressor
         {
             public override void Decompress(DataInput @in, int originalLength, int offset, int length, BytesRef bytes)
             {

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xCodec.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xCodec.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         // 3.x doesn't support docvalues
         private readonly DocValuesFormat docValuesFormat = new DocValuesFormatAnonymousClass();
 
-        private class DocValuesFormatAnonymousClass : DocValuesFormat
+        private sealed class DocValuesFormatAnonymousClass : DocValuesFormat
         {
             public DocValuesFormatAnonymousClass()
                 : base()

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xNormsProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xNormsProducer.cs
@@ -253,7 +253,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                 }
             }
 
-            private class NumericDocValuesAnonymousClass : NumericDocValues
+            private sealed class NumericDocValuesAnonymousClass : NumericDocValues
             {
                 private readonly byte[] bytes;
 

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -280,7 +280,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                 return new EnumeratorAnonymousClass(this);
             }
 
-            private class EnumeratorAnonymousClass : IEnumerator<string>
+            private sealed class EnumeratorAnonymousClass : IEnumerator<string>
             {
                 private readonly TVFields outerInstance;
                 private string current;

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40Codec.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40Codec.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
         private readonly PostingsFormat postingsFormat;
 
-        private class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
+        private sealed class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
         {
             private readonly Lucene40Codec outerInstance;
 

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40DocValuesReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40DocValuesReader.cs
@@ -178,7 +178,7 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        private class NumericDocValuesAnonymousClass : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass : NumericDocValues
         {
             private readonly long[] values;
 
@@ -194,7 +194,7 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        private class NumericDocValuesAnonymousClass2 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass2 : NumericDocValues
         {
             private readonly long minValue;
             private readonly long defaultValue;
@@ -237,7 +237,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return new NumericDocValuesAnonymousClass3(values);
         }
 
-        private class NumericDocValuesAnonymousClass3 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass3 : NumericDocValues
         {
             private readonly byte[] values;
 
@@ -274,7 +274,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return new NumericDocValuesAnonymousClass4(values);
         }
 
-        private class NumericDocValuesAnonymousClass4 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass4 : NumericDocValues
         {
             private readonly short[] values;
 
@@ -311,7 +311,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return new NumericDocValuesAnonymousClass5(values);
         }
 
-        private class NumericDocValuesAnonymousClass5 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass5 : NumericDocValues
         {
             private readonly int[] values;
 
@@ -348,7 +348,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return new NumericDocValuesAnonymousClass6(values);
         }
 
-        private class NumericDocValuesAnonymousClass6 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass6 : NumericDocValues
         {
             private readonly long[] values;
 
@@ -385,7 +385,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return new NumericDocValuesAnonymousClass7(values);
         }
 
-        private class NumericDocValuesAnonymousClass7 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass7 : NumericDocValues
         {
             private readonly int[] values;
 
@@ -419,7 +419,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return new NumericDocValuesAnonymousClass8(values);
         }
 
-        private class NumericDocValuesAnonymousClass8 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass8 : NumericDocValues
         {
             private readonly long[] values;
 
@@ -504,7 +504,7 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        private class BinaryDocValuesAnonymousClass : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass : BinaryDocValues
         {
             private readonly int fixedLength;
             private readonly PagedBytes.Reader bytesReader;
@@ -559,7 +559,7 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        private class BinaryDocValuesAnonymousClass2 : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass2 : BinaryDocValues
         {
             private readonly PagedBytes.Reader bytesReader;
             private readonly PackedInt32s.Reader reader;
@@ -618,7 +618,7 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        private class BinaryDocValuesAnonymousClass3 : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass3 : BinaryDocValues
         {
             private readonly int fixedLength;
             private readonly PagedBytes.Reader bytesReader;
@@ -677,7 +677,7 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        private class BinaryDocValuesAnonymousClass4 : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass4 : BinaryDocValues
         {
             private readonly PagedBytes.Reader bytesReader;
             private readonly PackedInt32s.Reader reader;
@@ -782,7 +782,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return CorrectBuggyOrds(new SortedDocValuesAnonymousClass(fixedLength, valueCount, bytesReader, reader));
         }
 
-        private class SortedDocValuesAnonymousClass : SortedDocValues
+        private sealed class SortedDocValuesAnonymousClass : SortedDocValues
         {
             private readonly int fixedLength;
             private readonly int valueCount;
@@ -830,7 +830,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return CorrectBuggyOrds(new SortedDocValuesAnonymousClass2(bytesReader, addressReader, ordsReader, valueCount));
         }
 
-        private class SortedDocValuesAnonymousClass2 : SortedDocValues
+        private sealed class SortedDocValuesAnonymousClass2 : SortedDocValues
         {
             private readonly PagedBytes.Reader bytesReader;
             private readonly PackedInt32s.Reader addressReader;
@@ -878,7 +878,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return new SortedDocValuesAnonymousClass3(@in);
         }
 
-        private class SortedDocValuesAnonymousClass3 : SortedDocValues
+        private sealed class SortedDocValuesAnonymousClass3 : SortedDocValues
         {
             private readonly SortedDocValues @in;
 

--- a/src/Lucene.Net/Codecs/Lucene41/Lucene41Codec.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/Lucene41Codec.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Codecs.Lucene41
         // TODO: slightly evil
         private readonly StoredFieldsFormat fieldsFormat = new CompressingStoredFieldsFormatAnonymousClass("Lucene41StoredFields", CompressionMode.FAST, 1 << 14);
 
-        private class CompressingStoredFieldsFormatAnonymousClass : CompressingStoredFieldsFormat
+        private sealed class CompressingStoredFieldsFormatAnonymousClass : CompressingStoredFieldsFormat
         {
             public CompressingStoredFieldsFormatAnonymousClass(string formatName, CompressionMode compressionMode, int chunkSize)
                 : base(formatName, compressionMode, chunkSize)
@@ -70,7 +70,7 @@ namespace Lucene.Net.Codecs.Lucene41
 
         private readonly PostingsFormat postingsFormat;
 
-        private class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
+        private sealed class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
         {
             private readonly Lucene41Codec outerInstance;
 

--- a/src/Lucene.Net/Codecs/Lucene42/Lucene42Codec.cs
+++ b/src/Lucene.Net/Codecs/Lucene42/Lucene42Codec.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Codecs.Lucene42
 
         private readonly PostingsFormat postingsFormat;
 
-        private class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
+        private sealed class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
         {
             private readonly Lucene42Codec outerInstance;
 
@@ -71,7 +71,7 @@ namespace Lucene.Net.Codecs.Lucene42
 
         private readonly DocValuesFormat docValuesFormat;
 
-        private class PerFieldDocValuesFormatAnonymousClass : PerFieldDocValuesFormat
+        private sealed class PerFieldDocValuesFormatAnonymousClass : PerFieldDocValuesFormat
         {
             private readonly Lucene42Codec outerInstance;
 
@@ -150,7 +150,7 @@ namespace Lucene.Net.Codecs.Lucene42
 
         private readonly NormsFormat normsFormat = new Lucene42NormsFormatAnonymousClass();
 
-        private class Lucene42NormsFormatAnonymousClass : Lucene42NormsFormat
+        private sealed class Lucene42NormsFormatAnonymousClass : Lucene42NormsFormat
         {
             public override DocValuesConsumer NormsConsumer(SegmentWriteState state)
             {

--- a/src/Lucene.Net/Codecs/Lucene42/Lucene42DocValuesProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene42/Lucene42DocValuesProducer.cs
@@ -299,7 +299,7 @@ namespace Lucene.Net.Codecs.Lucene42
             }
         }
 
-        private class NumericDocValuesAnonymousClass : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass : NumericDocValues
         {
             private readonly long[] decode;
             private readonly PackedInt32s.Reader ordsReader;
@@ -317,7 +317,7 @@ namespace Lucene.Net.Codecs.Lucene42
             }
         }
 
-        private class NumericDocValuesAnonymousClass2 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass2 : NumericDocValues
         {
             private readonly byte[] bytes;
 
@@ -333,7 +333,7 @@ namespace Lucene.Net.Codecs.Lucene42
             }
         }
 
-        private class NumericDocValuesAnonymousClass3 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass3 : NumericDocValues
         {
             private readonly long min;
             private readonly long mult;
@@ -392,7 +392,7 @@ namespace Lucene.Net.Codecs.Lucene42
             }
         }
 
-        private class BinaryDocValuesAnonymousClass : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass : BinaryDocValues
         {
             private readonly PagedBytes.Reader bytesReader;
             private readonly int fixedLength;
@@ -410,7 +410,7 @@ namespace Lucene.Net.Codecs.Lucene42
             }
         }
 
-        private class BinaryDocValuesAnonymousClass2 : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass2 : BinaryDocValues
         {
             private readonly PagedBytes.Reader bytesReader;
             private readonly MonotonicBlockPackedReader addresses;
@@ -462,7 +462,7 @@ namespace Lucene.Net.Codecs.Lucene42
             return new SortedDocValuesAnonymousClass(entry, docToOrd, fst, @in, firstArc, scratchArc, scratchInts, fstEnum);
         }
 
-        private class SortedDocValuesAnonymousClass : SortedDocValues
+        private sealed class SortedDocValuesAnonymousClass : SortedDocValues
         {
             private readonly FSTEntry entry;
             private readonly NumericDocValues docToOrd;
@@ -579,7 +579,7 @@ namespace Lucene.Net.Codecs.Lucene42
             return new SortedSetDocValuesAnonymousClass(entry, docToOrds, fst, @in, firstArc, scratchArc, scratchInts, fstEnum, @ref, input);
         }
 
-        private class SortedSetDocValuesAnonymousClass : SortedSetDocValues
+        private sealed class SortedSetDocValuesAnonymousClass : SortedSetDocValues
         {
             private readonly FSTEntry entry;
             private readonly BinaryDocValues docToOrds;

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45Codec.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45Codec.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Codecs.Lucene45
 
         private readonly PostingsFormat postingsFormat;
 
-        private class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
+        private sealed class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
         {
             private readonly Lucene45Codec outerInstance;
 
@@ -73,7 +73,7 @@ namespace Lucene.Net.Codecs.Lucene45
 
         private readonly DocValuesFormat docValuesFormat;
 
-        private class PerFieldDocValuesFormatAnonymousClass : PerFieldDocValuesFormat
+        private sealed class PerFieldDocValuesFormatAnonymousClass : PerFieldDocValuesFormat
         {
             private readonly Lucene45Codec outerInstance;
 

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesProducer.cs
@@ -403,7 +403,7 @@ namespace Lucene.Net.Codecs.Lucene45
             }
         }
 
-        private class Int64ValuesAnonymousClass : Int64Values
+        private sealed class Int64ValuesAnonymousClass : Int64Values
         {
             private readonly long min;
             private readonly long mult;
@@ -423,7 +423,7 @@ namespace Lucene.Net.Codecs.Lucene45
             }
         }
 
-        private class Int64ValuesAnonymousClass2 : Int64Values
+        private sealed class Int64ValuesAnonymousClass2 : Int64Values
         {
             private readonly long[] table;
             private readonly PackedInt32s.Reader ords;
@@ -468,7 +468,7 @@ namespace Lucene.Net.Codecs.Lucene45
             return new Int64BinaryDocValuesAnonymousClass(bytes, data);
         }
 
-        private class Int64BinaryDocValuesAnonymousClass : Int64BinaryDocValues
+        private sealed class Int64BinaryDocValuesAnonymousClass : Int64BinaryDocValues
         {
             private readonly Lucene45DocValuesProducer.BinaryEntry bytes;
             private readonly IndexInput data;
@@ -537,7 +537,7 @@ namespace Lucene.Net.Codecs.Lucene45
             return new Int64BinaryDocValuesAnonymousClass2(bytes, data, addresses);
         }
 
-        private class Int64BinaryDocValuesAnonymousClass2 : Int64BinaryDocValues
+        private sealed class Int64BinaryDocValuesAnonymousClass2 : Int64BinaryDocValues
         {
             private readonly Lucene45DocValuesProducer.BinaryEntry bytes;
             private readonly IndexInput data;
@@ -632,7 +632,7 @@ namespace Lucene.Net.Codecs.Lucene45
             return new SortedDocValuesAnonymousClass(valueCount, binary, ordinals);
         }
 
-        private class SortedDocValuesAnonymousClass : SortedDocValues
+        private sealed class SortedDocValuesAnonymousClass : SortedDocValues
         {
             private readonly int valueCount;
             private readonly BinaryDocValues binary;
@@ -737,7 +737,7 @@ namespace Lucene.Net.Codecs.Lucene45
             return new RandomAccessOrdsAnonymousClass(valueCount, binary, ordinals, ordIndex);
         }
 
-        private class RandomAccessOrdsAnonymousClass : RandomAccessOrds
+        private sealed class RandomAccessOrdsAnonymousClass : RandomAccessOrds
         {
             private readonly long valueCount;
             private readonly Lucene45DocValuesProducer.Int64BinaryDocValues binary;
@@ -835,7 +835,7 @@ namespace Lucene.Net.Codecs.Lucene45
             }
         }
 
-        private class BitsAnonymousClass : IBits
+        private sealed class BitsAnonymousClass : IBits
         {
             private readonly Lucene45DocValuesProducer outerInstance;
 
@@ -849,7 +849,7 @@ namespace Lucene.Net.Codecs.Lucene45
                 this.@in = @in;
             }
 
-            public virtual bool Get(int index)
+            public bool Get(int index)
             {
                 try
                 {
@@ -862,7 +862,7 @@ namespace Lucene.Net.Codecs.Lucene45
                 }
             }
 
-            public virtual int Length => outerInstance.maxDoc;
+            public int Length => outerInstance.maxDoc;
         }
 
         public override IBits GetDocsWithField(FieldInfo field)
@@ -1087,7 +1087,7 @@ namespace Lucene.Net.Codecs.Lucene45
                 return new TermsEnumAnonymousClass(this, input);
             }
 
-            private class TermsEnumAnonymousClass : TermsEnum
+            private sealed class TermsEnumAnonymousClass : TermsEnum
             {
                 private readonly CompressedBinaryDocValues outerInstance;
 

--- a/src/Lucene.Net/Codecs/Lucene46/Lucene46Codec.cs
+++ b/src/Lucene.Net/Codecs/Lucene46/Lucene46Codec.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Codecs.Lucene46
 
         private readonly PostingsFormat postingsFormat;
 
-        private class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
+        private sealed class PerFieldPostingsFormatAnonymousClass : PerFieldPostingsFormat
         {
             private readonly Lucene46Codec outerInstance;
 
@@ -69,7 +69,7 @@ namespace Lucene.Net.Codecs.Lucene46
 
         private readonly DocValuesFormat docValuesFormat;
 
-        private class PerFieldDocValuesFormatAnonymousClass : PerFieldDocValuesFormat
+        private sealed class PerFieldDocValuesFormatAnonymousClass : PerFieldDocValuesFormat
         {
             private readonly Lucene46Codec outerInstance;
 

--- a/src/Lucene.Net/Index/BinaryDocValuesFieldUpdates.cs
+++ b/src/Lucene.Net/Index/BinaryDocValuesFieldUpdates.cs
@@ -194,7 +194,7 @@ namespace Lucene.Net.Index
             return new Iterator(size, offsets, lengths, docs, values, docsWithField);
         }
 
-        private class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
+        private sealed class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
         {
             private readonly PagedMutable docs;
             private readonly PagedGrowableWriter offsets;

--- a/src/Lucene.Net/Index/CoalescedUpdates.cs
+++ b/src/Lucene.Net/Index/CoalescedUpdates.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Index
             return new EnumerableAnonymousClass(this);
         }
 
-        private class EnumerableAnonymousClass : IEnumerable<Term>
+        private sealed class EnumerableAnonymousClass : IEnumerable<Term>
         {
             private readonly CoalescedUpdates outerInstance;
 
@@ -81,7 +81,7 @@ namespace Lucene.Net.Index
                 this.outerInstance = outerInstance;
             }
 
-            public virtual IEnumerator<Term> GetEnumerator()
+            public IEnumerator<Term> GetEnumerator()
             {
                 IEnumerator<Term>[] subs = new IEnumerator<Term>[outerInstance.iterables.Count];
                 for (int i = 0; i < outerInstance.iterables.Count; i++)
@@ -105,7 +105,7 @@ namespace Lucene.Net.Index
             return new EnumerableAnonymousClass2(this);
         }
 
-        private class EnumerableAnonymousClass2 : IEnumerable<QueryAndLimit>
+        private sealed class EnumerableAnonymousClass2 : IEnumerable<QueryAndLimit>
         {
             private readonly CoalescedUpdates outerInstance;
 
@@ -114,7 +114,7 @@ namespace Lucene.Net.Index
                 this.outerInstance = outerInstance;
             }
 
-            public virtual IEnumerator<QueryAndLimit> GetEnumerator()
+            public IEnumerator<QueryAndLimit> GetEnumerator()
             {
                 return new EnumeratorAnonymousClass(this);
             }
@@ -124,7 +124,7 @@ namespace Lucene.Net.Index
                 return GetEnumerator();
             }
 
-            private class EnumeratorAnonymousClass : IEnumerator<QueryAndLimit>
+            private sealed class EnumeratorAnonymousClass : IEnumerator<QueryAndLimit>
             {
                 private readonly EnumerableAnonymousClass2 outerInstance;
                 private readonly IEnumerator<KeyValuePair<Query, int>> iter;

--- a/src/Lucene.Net/Index/DocValues.cs
+++ b/src/Lucene.Net/Index/DocValues.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Index
         /// </summary>
         public static readonly BinaryDocValues EMPTY_BINARY = new BinaryDocValuesAnonymousClass();
 
-        private class BinaryDocValuesAnonymousClass : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass : BinaryDocValues
         {
             public BinaryDocValuesAnonymousClass()
             {
@@ -57,7 +57,7 @@ namespace Lucene.Net.Index
         /// </summary>
         public static readonly NumericDocValues EMPTY_NUMERIC = new NumericDocValuesAnonymousClass();
 
-        private class NumericDocValuesAnonymousClass : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass : NumericDocValues
         {
             public NumericDocValuesAnonymousClass()
             {
@@ -74,7 +74,7 @@ namespace Lucene.Net.Index
         /// </summary>
         public static readonly SortedDocValues EMPTY_SORTED = new SortedDocValuesAnonymousClass();
 
-        private class SortedDocValuesAnonymousClass : SortedDocValues
+        private sealed class SortedDocValuesAnonymousClass : SortedDocValues
         {
             public SortedDocValuesAnonymousClass()
             {
@@ -100,7 +100,7 @@ namespace Lucene.Net.Index
         /// </summary>
         public static readonly SortedSetDocValues EMPTY_SORTED_SET = new RandomAccessOrdsAnonymousClass();
 
-        private class RandomAccessOrdsAnonymousClass : RandomAccessOrds
+        private sealed class RandomAccessOrdsAnonymousClass : RandomAccessOrds
         {
             public RandomAccessOrdsAnonymousClass()
             {
@@ -162,7 +162,7 @@ namespace Lucene.Net.Index
             return new BitsAnonymousClass(dv, maxDoc);
         }
 
-        private class BitsAnonymousClass : IBits
+        private sealed class BitsAnonymousClass : IBits
         {
             private readonly SortedDocValues dv;
             private readonly int maxDoc;
@@ -173,12 +173,12 @@ namespace Lucene.Net.Index
                 this.maxDoc = maxDoc;
             }
 
-            public virtual bool Get(int index)
+            public bool Get(int index)
             {
                 return dv.GetOrd(index) >= 0;
             }
 
-            public virtual int Length => maxDoc;
+            public int Length => maxDoc;
         }
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace Lucene.Net.Index
             return new BitsAnonymousClass2(dv, maxDoc);
         }
 
-        private class BitsAnonymousClass2 : IBits
+        private sealed class BitsAnonymousClass2 : IBits
         {
             private readonly SortedSetDocValues dv;
             private readonly int maxDoc;
@@ -200,13 +200,13 @@ namespace Lucene.Net.Index
                 this.maxDoc = maxDoc;
             }
 
-            public virtual bool Get(int index)
+            public bool Get(int index)
             {
                 dv.SetDocument(index);
                 return dv.NextOrd() != SortedSetDocValues.NO_MORE_ORDS;
             }
 
-            public virtual int Length => maxDoc;
+            public int Length => maxDoc;
         }
     }
 }

--- a/src/Lucene.Net/Index/DocumentsWriterFlushControl.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterFlushControl.cs
@@ -566,7 +566,7 @@ namespace Lucene.Net.Index
             return new EnumeratorAnonymousClass(this, upto);
         }
 
-        private class EnumeratorAnonymousClass : IEnumerator<ThreadState>
+        private sealed class EnumeratorAnonymousClass : IEnumerator<ThreadState>
         {
             private readonly DocumentsWriterFlushControl outerInstance;
             private ThreadState current;

--- a/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Index
 
         public static IndexingChain DefaultIndexingChain => defaultIndexingChain;
 
-        private class IndexingChainAnonymousClass : IndexingChain
+        private sealed class IndexingChainAnonymousClass : IndexingChain
         {
             public IndexingChainAnonymousClass()
             {

--- a/src/Lucene.Net/Index/FrozenBufferedUpdates.cs
+++ b/src/Lucene.Net/Index/FrozenBufferedUpdates.cs
@@ -142,7 +142,7 @@ namespace Lucene.Net.Index
             return new EnumerableAnonymousClass(this);
         }
 
-        private class EnumerableAnonymousClass : IEnumerable<Term>
+        private sealed class EnumerableAnonymousClass : IEnumerable<Term>
         {
             private readonly FrozenBufferedUpdates outerInstance;
 
@@ -151,7 +151,7 @@ namespace Lucene.Net.Index
                 this.outerInstance = outerInstance;
             }
 
-            public virtual IEnumerator<Term> GetEnumerator()
+            public IEnumerator<Term> GetEnumerator()
             {
                 return outerInstance.terms.GetEnumerator();
             }
@@ -168,7 +168,7 @@ namespace Lucene.Net.Index
             return new EnumerableAnonymousClass2(this);
         }
 
-        private class EnumerableAnonymousClass2 : IEnumerable<QueryAndLimit>
+        private sealed class EnumerableAnonymousClass2 : IEnumerable<QueryAndLimit>
         {
             private readonly FrozenBufferedUpdates outerInstance;
 
@@ -177,7 +177,7 @@ namespace Lucene.Net.Index
                 this.outerInstance = outerInstance;
             }
 
-            public virtual IEnumerator<QueryAndLimit> GetEnumerator()
+            public IEnumerator<QueryAndLimit> GetEnumerator()
             {
                 return new EnumeratorAnonymousClass(this);
             }
@@ -187,7 +187,7 @@ namespace Lucene.Net.Index
                 return GetEnumerator();
             }
 
-            private class EnumeratorAnonymousClass : IEnumerator<QueryAndLimit>
+            private sealed class EnumeratorAnonymousClass : IEnumerator<QueryAndLimit>
             {
                 private readonly EnumerableAnonymousClass2 outerInstance;
                 private readonly int upto;
@@ -201,7 +201,7 @@ namespace Lucene.Net.Index
                     i = 0;
                 }
 
-                public virtual bool MoveNext()
+                public bool MoveNext()
                 {
                     if (i < upto)
                     {
@@ -212,11 +212,11 @@ namespace Lucene.Net.Index
                     return false;
                 }
 
-                public virtual QueryAndLimit Current => current;
+                public QueryAndLimit Current => current;
 
                 object IEnumerator.Current => Current;
 
-                public virtual void Reset()
+                public void Reset()
                 {
                     throw UnsupportedOperationException.Create();
                 }

--- a/src/Lucene.Net/Index/MergePolicy.cs
+++ b/src/Lucene.Net/Index/MergePolicy.cs
@@ -215,7 +215,7 @@ namespace Lucene.Net.Index
                 return new DocMapAnonymousClass();
             }
 
-            private class DocMapAnonymousClass : DocMap
+            private sealed class DocMapAnonymousClass : DocMap
             {
                 public override int Map(int docID)
                 {

--- a/src/Lucene.Net/Index/MergeState.cs
+++ b/src/Lucene.Net/Index/MergeState.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Index
                 return new DocMapAnonymousClass(maxDoc, liveDocs, docMap, numDeletedDocs);
             }
 
-            private class DocMapAnonymousClass : DocMap
+            private sealed class DocMapAnonymousClass : DocMap
             {
                 private readonly int maxDoc;
                 private readonly IBits liveDocs;
@@ -251,7 +251,7 @@ namespace Lucene.Net.Index
         /// </summary>
         public static readonly CheckAbort NONE = new CheckAbortAnonymousClass();
 
-        private class CheckAbortAnonymousClass : CheckAbort
+        private sealed class CheckAbortAnonymousClass : CheckAbort
         {
             public CheckAbortAnonymousClass()
                 : base(null, null)

--- a/src/Lucene.Net/Index/MultiDocValues.cs
+++ b/src/Lucene.Net/Index/MultiDocValues.cs
@@ -98,7 +98,7 @@ namespace Lucene.Net.Index
             return new NumericDocValuesAnonymousClass(values, starts);
         }
 
-        private class NumericDocValuesAnonymousClass : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass : NumericDocValues
         {
             private readonly NumericDocValues[] values;
             private readonly int[] starts;
@@ -166,7 +166,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class NumericDocValuesAnonymousClass2 : NumericDocValues
+        private sealed class NumericDocValuesAnonymousClass2 : NumericDocValues
         {
             private readonly NumericDocValues[] values;
             private readonly int[] starts;
@@ -295,7 +295,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class BinaryDocValuesAnonymousClass : BinaryDocValues
+        private sealed class BinaryDocValuesAnonymousClass : BinaryDocValues
         {
             private readonly BinaryDocValues[] values;
             private readonly int[] starts;

--- a/src/Lucene.Net/Index/NumericDocValuesFieldUpdates.cs
+++ b/src/Lucene.Net/Index/NumericDocValuesFieldUpdates.cs
@@ -156,7 +156,7 @@ namespace Lucene.Net.Index
             return new Iterator(size, values, docsWithField, docs);
         }
 
-        private class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
+        private sealed class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
         {
             private readonly PagedMutable docs;
             private readonly PagedGrowableWriter values;

--- a/src/Lucene.Net/Index/ParallelCompositeReader.cs
+++ b/src/Lucene.Net/Index/ParallelCompositeReader.cs
@@ -167,7 +167,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ParallelAtomicReaderAnonymousClass : ParallelAtomicReader
+        private sealed class ParallelAtomicReaderAnonymousClass : ParallelAtomicReader
         {
             public ParallelAtomicReaderAnonymousClass(AtomicReader[] atomicSubs, AtomicReader[] storedSubs)
                 : base(true, atomicSubs, storedSubs)
@@ -180,7 +180,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class ParallelCompositeReaderAnonymousClass : ParallelCompositeReader
+        private sealed class ParallelCompositeReaderAnonymousClass : ParallelCompositeReader
         {
             public ParallelCompositeReaderAnonymousClass(CompositeReader[] compositeSubs, CompositeReader[] storedSubs)
                 : base(true, compositeSubs, storedSubs)

--- a/src/Lucene.Net/Index/SegmentInfos.cs
+++ b/src/Lucene.Net/Index/SegmentInfos.cs
@@ -625,7 +625,7 @@ namespace Lucene.Net.Index
             new FindSegmentsFileAnonymousClass(this, directory).Run();
         }
 
-        private class FindSegmentsFileAnonymousClass : FindSegmentsFile
+        private sealed class FindSegmentsFileAnonymousClass : FindSegmentsFile
         {
             private readonly SegmentInfos outerInstance;
 

--- a/src/Lucene.Net/Index/StandardDirectoryReader.cs
+++ b/src/Lucene.Net/Index/StandardDirectoryReader.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Index
             return (DirectoryReader)new FindSegmentsFileAnonymousClass(directory, termInfosIndexDivisor).Run(commit);
         }
 
-        private class FindSegmentsFileAnonymousClass : SegmentInfos.FindSegmentsFile
+        private sealed class FindSegmentsFileAnonymousClass : SegmentInfos.FindSegmentsFile
         {
             private readonly int termInfosIndexDivisor;
 
@@ -402,7 +402,7 @@ namespace Lucene.Net.Index
             return (DirectoryReader)new FindSegmentsFileAnonymousClass2(this, m_directory).Run(commit);
         }
 
-        private class FindSegmentsFileAnonymousClass2 : SegmentInfos.FindSegmentsFile
+        private sealed class FindSegmentsFileAnonymousClass2 : SegmentInfos.FindSegmentsFile
         {
             private readonly StandardDirectoryReader outerInstance;
 

--- a/src/Lucene.Net/Index/Terms.cs
+++ b/src/Lucene.Net/Index/Terms.cs
@@ -97,7 +97,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private class AutomatonTermsEnumAnonymousClass : AutomatonTermsEnum
+        private sealed class AutomatonTermsEnumAnonymousClass : AutomatonTermsEnum
         {
             private readonly BytesRef startTerm;
 

--- a/src/Lucene.Net/Index/TermsEnum.cs
+++ b/src/Lucene.Net/Index/TermsEnum.cs
@@ -272,7 +272,7 @@ namespace Lucene.Net.Index
             return new TermStateAnonymousClass();
         }
 
-        private class TermStateAnonymousClass : TermState
+        private sealed class TermStateAnonymousClass : TermState
         {
             public override void CopyFrom(TermState other)
             {
@@ -290,7 +290,7 @@ namespace Lucene.Net.Index
         /// </summary>
         public static readonly TermsEnum EMPTY = new TermsEnumAnonymousClass();
 
-        private class TermsEnumAnonymousClass : TermsEnum
+        private sealed class TermsEnumAnonymousClass : TermsEnum
         {
             public override SeekStatus SeekCeil(BytesRef term)
             {

--- a/src/Lucene.Net/Index/TieredMergePolicy.cs
+++ b/src/Lucene.Net/Index/TieredMergePolicy.cs
@@ -548,7 +548,7 @@ namespace Lucene.Net.Index
             return new MergeScoreAnonymousClass(skew, nonDelRatio, finalMergeScore);
         }
 
-        private class MergeScoreAnonymousClass : MergeScore
+        private sealed class MergeScoreAnonymousClass : MergeScore
         {
             private readonly double skew;
             private readonly double nonDelRatio;

--- a/src/Lucene.Net/Search/BooleanScorer2.cs
+++ b/src/Lucene.Net/Search/BooleanScorer2.cs
@@ -177,7 +177,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class MinShouldMatchSumScorerAnonymousClass : MinShouldMatchSumScorer
+        private sealed class MinShouldMatchSumScorerAnonymousClass : MinShouldMatchSumScorer
         {
             private readonly BooleanScorer2 outerInstance;
 
@@ -194,7 +194,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class DisjunctionSumScorerAnonymousClass : DisjunctionSumScorer
+        private sealed class DisjunctionSumScorerAnonymousClass : DisjunctionSumScorer
         {
             private readonly BooleanScorer2 outerInstance;
 
@@ -218,7 +218,7 @@ namespace Lucene.Net.Search
             return new ConjunctionScorerAnonymousClass(this, m_weight, requiredScorers.ToArray(), requiredNrMatchers);
         }
 
-        private class ConjunctionScorerAnonymousClass : ConjunctionScorer
+        private sealed class ConjunctionScorerAnonymousClass : ConjunctionScorer
         {
             private readonly BooleanScorer2 outerInstance;
 

--- a/src/Lucene.Net/Search/CachingCollector.cs
+++ b/src/Lucene.Net/Search/CachingCollector.cs
@@ -379,7 +379,7 @@ namespace Lucene.Net.Search
             return Create(other, cacheScores, maxRAMMB);
         }
 
-        private class CollectorAnonymousClass : ICollector
+        private sealed class CollectorAnonymousClass : ICollector
         {
             private readonly bool acceptDocsOutOfOrder;
 
@@ -388,17 +388,17 @@ namespace Lucene.Net.Search
                 this.acceptDocsOutOfOrder = acceptDocsOutOfOrder;
             }
 
-            public virtual bool AcceptsDocsOutOfOrder => acceptDocsOutOfOrder;
+            public bool AcceptsDocsOutOfOrder => acceptDocsOutOfOrder;
 
-            public virtual void SetScorer(Scorer scorer)
+            public void SetScorer(Scorer scorer)
             {
             }
 
-            public virtual void Collect(int doc)
+            public void Collect(int doc)
             {
             }
 
-            public virtual void SetNextReader(AtomicReaderContext context)
+            public void SetNextReader(AtomicReaderContext context)
             {
             }
         }

--- a/src/Lucene.Net/Search/CachingWrapperFilter.cs
+++ b/src/Lucene.Net/Search/CachingWrapperFilter.cs
@@ -169,7 +169,7 @@ namespace Lucene.Net.Search
         /// An empty <see cref="DocIdSet"/> instance </summary>
         protected static readonly DocIdSet EMPTY_DOCIDSET = new DocIdSetAnonymousClass();
 
-        private class DocIdSetAnonymousClass : DocIdSet
+        private sealed class DocIdSetAnonymousClass : DocIdSet
         {
             public override DocIdSetIterator GetIterator()
             {

--- a/src/Lucene.Net/Search/ConstantScoreQuery.cs
+++ b/src/Lucene.Net/Search/ConstantScoreQuery.cs
@@ -256,7 +256,7 @@ namespace Lucene.Net.Search
                 return new CollectorAnonymousClass(this, collector);
             }
 
-            private class CollectorAnonymousClass : ICollector
+            private sealed class CollectorAnonymousClass : ICollector
             {
                 private readonly ConstantBulkScorer outerInstance;
 
@@ -268,23 +268,23 @@ namespace Lucene.Net.Search
                     this.collector = collector;
                 }
                 
-                public virtual void SetScorer(Scorer scorer)
+                public void SetScorer(Scorer scorer)
                 {
                     // we must wrap again here, but using the value passed in as parameter:
                     collector.SetScorer(new ConstantScorer(outerInstance.outerInstance, scorer, outerInstance.weight, outerInstance.theScore));
                 }
 
-                public virtual void Collect(int doc)
+                public void Collect(int doc)
                 {
                     collector.Collect(doc);
                 }
 
-                public virtual void SetNextReader(AtomicReaderContext context)
+                public void SetNextReader(AtomicReaderContext context)
                 {
                     collector.SetNextReader(context);
                 }
 
-                public virtual bool AcceptsDocsOutOfOrder => collector.AcceptsDocsOutOfOrder;
+                public bool AcceptsDocsOutOfOrder => collector.AcceptsDocsOutOfOrder;
             }
         }
 

--- a/src/Lucene.Net/Search/DocIdSetIterator.cs
+++ b/src/Lucene.Net/Search/DocIdSetIterator.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Search
             return new DocIdSetIteratorAnonymousClass();
         }
 
-        private class DocIdSetIteratorAnonymousClass : DocIdSetIterator
+        private sealed class DocIdSetIteratorAnonymousClass : DocIdSetIterator
         {
             public DocIdSetIteratorAnonymousClass()
             {

--- a/src/Lucene.Net/Search/DocTermOrdsRangeFilter.cs
+++ b/src/Lucene.Net/Search/DocTermOrdsRangeFilter.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Search
             return new DocTermOrdsRangeFilterAnonymousClass(field, lowerVal, upperVal, includeLower, includeUpper);
         }
 
-        private class DocTermOrdsRangeFilterAnonymousClass : DocTermOrdsRangeFilter
+        private sealed class DocTermOrdsRangeFilterAnonymousClass : DocTermOrdsRangeFilter
         {
             public DocTermOrdsRangeFilterAnonymousClass(string field, BytesRef lowerVal, BytesRef upperVal, bool includeLower, bool includeUpper)
                 : base(field, lowerVal, upperVal, includeLower, includeUpper)

--- a/src/Lucene.Net/Search/DocTermOrdsRewriteMethod.cs
+++ b/src/Lucene.Net/Search/DocTermOrdsRewriteMethod.cs
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search
                 });
             }
 
-            private class TermsAnonymousClass : Terms
+            private sealed class TermsAnonymousClass : Terms
             {
                 private readonly SortedSetDocValues docTermOrds;
 

--- a/src/Lucene.Net/Search/FieldCacheDocIdSet.cs
+++ b/src/Lucene.Net/Search/FieldCacheDocIdSet.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Lucene.Net.Search
 {
@@ -69,7 +69,7 @@ namespace Lucene.Net.Search
 
         public override sealed IBits Bits => (m_acceptDocs is null) ? (IBits)new BitsAnonymousClass(this) : new BitsAnonymousClass2(this);
 
-        private class BitsAnonymousClass : IBits
+        private sealed class BitsAnonymousClass : IBits
         {
             private readonly FieldCacheDocIdSet outerInstance;
 
@@ -78,15 +78,15 @@ namespace Lucene.Net.Search
                 this.outerInstance = outerInstance;
             }
 
-            public virtual bool Get(int docid)
+            public bool Get(int docid)
             {
                 return outerInstance.MatchDoc(docid);
             }
 
-            public virtual int Length => outerInstance.m_maxDoc;
+            public int Length => outerInstance.m_maxDoc;
         }
 
-        private class BitsAnonymousClass2 : IBits
+        private sealed class BitsAnonymousClass2 : IBits
         {
             private readonly FieldCacheDocIdSet outerInstance;
 
@@ -95,12 +95,12 @@ namespace Lucene.Net.Search
                 this.outerInstance = outerInstance;
             }
 
-            public virtual bool Get(int docid)
+            public bool Get(int docid)
             {
                 return outerInstance.MatchDoc(docid) && outerInstance.m_acceptDocs.Get(docid);
             }
 
-            public virtual int Length => outerInstance.m_maxDoc;
+            public int Length => outerInstance.m_maxDoc;
         }
 
         public override sealed DocIdSetIterator GetIterator()
@@ -123,7 +123,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class DocIdSetIteratorAnonymousClass : DocIdSetIterator
+        private sealed class DocIdSetIteratorAnonymousClass : DocIdSetIterator
         {
             private readonly FieldCacheDocIdSet outerInstance;
 
@@ -168,7 +168,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class FilteredDocIdSetIteratorAnonymousClass : FilteredDocIdSetIterator
+        private sealed class FilteredDocIdSetIteratorAnonymousClass : FilteredDocIdSetIterator
         {
             private readonly FieldCacheDocIdSet outerInstance;
 
@@ -184,7 +184,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class DocIdSetIteratorAnonymousClass2 : DocIdSetIterator
+        private sealed class DocIdSetIteratorAnonymousClass2 : DocIdSetIterator
         {
             private readonly FieldCacheDocIdSet outerInstance;
 

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -210,7 +210,7 @@ namespace Lucene.Net.Search
         // per-segment fieldcaches don't purge until the shared core closes.
         internal readonly SegmentReader.ICoreDisposedListener purgeCore;
 
-        private class CoreClosedListenerAnonymousClass : SegmentReader.ICoreDisposedListener
+        private sealed class CoreClosedListenerAnonymousClass : SegmentReader.ICoreDisposedListener
         {
             private readonly FieldCacheImpl outerInstance;
 
@@ -228,7 +228,7 @@ namespace Lucene.Net.Search
         // composite/SlowMultiReaderWrapper fieldcaches don't purge until composite reader is closed.
         internal readonly IndexReader.IReaderClosedListener purgeReader;
 
-        private class ReaderClosedListenerAnonymousClass : IndexReader.IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass : IndexReader.IReaderClosedListener
         {
             private readonly FieldCacheImpl outerInstance;
 
@@ -665,7 +665,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class FieldCache_BytesAnonymousClass : FieldCache.Bytes
+        private sealed class FieldCache_BytesAnonymousClass : FieldCache.Bytes
         {
             private readonly NumericDocValues valuesIn;
 
@@ -737,7 +737,7 @@ namespace Lucene.Net.Search
                 return new BytesFromArray(values);
             }
 
-            private class UninvertAnonymousClass : Uninvert
+            private sealed class UninvertAnonymousClass : Uninvert
             {
                 private readonly sbyte[] values;
 #pragma warning disable 612, 618
@@ -836,7 +836,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class FieldCache_Int16sAnonymousClass : FieldCache.Int16s
+        private sealed class FieldCache_Int16sAnonymousClass : FieldCache.Int16s
         {
             private readonly NumericDocValues valuesIn;
 
@@ -910,7 +910,7 @@ namespace Lucene.Net.Search
                 return new Int16sFromArray(values);
             }
 
-            private class UninvertAnonymousClass : Uninvert
+            private sealed class UninvertAnonymousClass : Uninvert
             {
                 private readonly short[] values;
 #pragma warning disable 612, 618
@@ -1008,7 +1008,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class FieldCache_Int32sAnonymousClass : FieldCache.Int32s
+        private sealed class FieldCache_Int32sAnonymousClass : FieldCache.Int32s
         {
             private readonly NumericDocValues valuesIn;
 
@@ -1122,7 +1122,7 @@ namespace Lucene.Net.Search
                 return new Int32sFromArray(values.Writer.Mutable, (int)values.MinValue);
             }
 
-            private class UninvertAnonymousClass : Uninvert
+            private sealed class UninvertAnonymousClass : Uninvert
             {
                 private readonly AtomicReader reader;
                 private readonly FieldCache.IInt32Parser parser;
@@ -1303,7 +1303,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class FieldCache_SinglesAnonymousClass : FieldCache.Singles
+        private sealed class FieldCache_SinglesAnonymousClass : FieldCache.Singles
         {
             private readonly NumericDocValues valuesIn;
 
@@ -1387,7 +1387,7 @@ namespace Lucene.Net.Search
                 return new SinglesFromArray(values);
             }
 
-            private class UninvertAnonymousClass : Uninvert
+            private sealed class UninvertAnonymousClass : Uninvert
             {
                 private readonly AtomicReader reader;
                 private readonly FieldCache.ISingleParser parser;
@@ -1469,7 +1469,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class FieldCache_Int64sAnonymousClass : FieldCache.Int64s
+        private sealed class FieldCache_Int64sAnonymousClass : FieldCache.Int64s
         {
             private readonly NumericDocValues valuesIn;
 
@@ -1554,7 +1554,7 @@ namespace Lucene.Net.Search
                 return new Int64sFromArray(values.Writer.Mutable, values.MinValue);
             }
 
-            private class UninvertAnonymousClass : Uninvert
+            private sealed class UninvertAnonymousClass : Uninvert
             {
                 private readonly AtomicReader reader;
                 private readonly FieldCache.IInt64Parser parser;
@@ -1647,7 +1647,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class FieldCache_DoublesAnonymousClass : FieldCache.Doubles
+        private sealed class FieldCache_DoublesAnonymousClass : FieldCache.Doubles
         {
             private readonly NumericDocValues valuesIn;
 
@@ -1724,7 +1724,7 @@ namespace Lucene.Net.Search
                 return new DoublesFromArray(values);
             }
 
-            private class UninvertAnonymousClass : Uninvert
+            private sealed class UninvertAnonymousClass : Uninvert
             {
                 private readonly AtomicReader reader;
                 private readonly FieldCache.IDoubleParser parser;
@@ -2099,7 +2099,7 @@ namespace Lucene.Net.Search
                 return new BinaryDocValuesImpl(bytes.Freeze(true), offsetReader);
             }
 
-            private class BitsAnonymousClass : IBits
+            private sealed class BitsAnonymousClass : IBits
             {
                 private readonly int maxDoc;
                 private readonly PackedInt32s.Reader offsetReader;
@@ -2110,12 +2110,12 @@ namespace Lucene.Net.Search
                     this.offsetReader = offsetReader;
                 }
 
-                public virtual bool Get(int index)
+                public bool Get(int index)
                 {
                     return offsetReader.Get(index) != 0;
                 }
 
-                public virtual int Length => maxDoc;
+                public int Length => maxDoc;
             }
         }
 

--- a/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
+++ b/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Search
 
     public static class FieldCacheRangeFilter
     {
-        private class StringFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<string>
+        private sealed class StringFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<string>
         {
             internal StringFieldCacheRangeFilterAnonymousClass(string field, string lowerVal, string upperVal, bool includeLower, bool includeUpper)
                 : base(field, null, lowerVal, upperVal, includeLower, includeUpper)
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class BytesRefFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<BytesRef>
+        private sealed class BytesRefFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<BytesRef>
         {
             internal BytesRefFieldCacheRangeFilterAnonymousClass(string field, BytesRef lowerVal, BytesRef upperVal, bool includeLower, bool includeUpper)
                 : base(field, null, lowerVal, upperVal, includeLower, includeUpper)
@@ -198,7 +198,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class SByteFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<sbyte?>
+        private sealed class SByteFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<sbyte?>
         {
             internal SByteFieldCacheRangeFilterAnonymousClass(string field, FieldCache.IParser parser, sbyte? lowerVal, sbyte? upperVal, bool includeLower, bool includeUpper)
                 : base(field, parser, lowerVal, upperVal, includeLower, includeUpper)
@@ -255,7 +255,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class Int16FieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<short?>
+        private sealed class Int16FieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<short?>
         {
             internal Int16FieldCacheRangeFilterAnonymousClass(string field, FieldCache.IParser parser, short? lowerVal, short? upperVal, bool includeLower, bool includeUpper)
                 : base(field, parser, lowerVal, upperVal, includeLower, includeUpper)
@@ -313,7 +313,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class Int32FieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<int?>
+        private sealed class Int32FieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<int?>
         {
             internal Int32FieldCacheRangeFilterAnonymousClass(string field, FieldCache.IParser parser, int? lowerVal, int? upperVal, bool includeLower, bool includeUpper)
                 : base(field, parser, lowerVal, upperVal, includeLower, includeUpper)
@@ -368,7 +368,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class Int64FieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<long?>
+        private sealed class Int64FieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<long?>
         {
             internal Int64FieldCacheRangeFilterAnonymousClass(string field, FieldCache.IParser parser, long? lowerVal, long? upperVal, bool includeLower, bool includeUpper)
                 : base(field, parser, lowerVal, upperVal, includeLower, includeUpper)
@@ -423,7 +423,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class SingleFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<float?>
+        private sealed class SingleFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<float?>
         {
             internal SingleFieldCacheRangeFilterAnonymousClass(string field, FieldCache.IParser parser, float? lowerVal, float? upperVal, bool includeLower, bool includeUpper)
                 : base(field, parser, lowerVal, upperVal, includeLower, includeUpper)
@@ -483,7 +483,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class DoubleFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<double?>
+        private sealed class DoubleFieldCacheRangeFilterAnonymousClass : FieldCacheRangeFilter<double?>
         {
             internal DoubleFieldCacheRangeFilterAnonymousClass(string field, FieldCache.IParser parser, double? lowerVal, double? upperVal, bool includeLower, bool includeUpper)
                 : base(field, parser, lowerVal, upperVal, includeLower, includeUpper)

--- a/src/Lucene.Net/Search/FieldCacheRewriteMethod.cs
+++ b/src/Lucene.Net/Search/FieldCacheRewriteMethod.cs
@@ -130,7 +130,7 @@ namespace Lucene.Net.Search
                 });
             }
 
-            private class TermsAnonymousClass : Terms
+            private sealed class TermsAnonymousClass : Terms
             {
                 private readonly SortedDocValues fcsi;
 

--- a/src/Lucene.Net/Search/FilteredDocIdSet.cs
+++ b/src/Lucene.Net/Search/FilteredDocIdSet.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Search
+﻿namespace Lucene.Net.Search
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -61,7 +61,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        private class BitsAnonymousClass : IBits
+        private sealed class BitsAnonymousClass : IBits
         {
             private readonly FilteredDocIdSet outerInstance;
 
@@ -73,12 +73,12 @@ namespace Lucene.Net.Search
                 this.bits = bits;
             }
 
-            public virtual bool Get(int docid)
+            public bool Get(int docid)
             {
                 return bits.Get(docid) && outerInstance.Match(docid);
             }
 
-            public virtual int Length => bits.Length;
+            public int Length => bits.Length;
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Lucene.Net.Search
             return new FilteredDocIdSetIteratorAnonymousClass(this, iterator);
         }
 
-        private class FilteredDocIdSetIteratorAnonymousClass : FilteredDocIdSetIterator
+        private sealed class FilteredDocIdSetIteratorAnonymousClass : FilteredDocIdSetIterator
         {
             private readonly FilteredDocIdSet outerInstance;
 

--- a/src/Lucene.Net/Search/FilteredQuery.cs
+++ b/src/Lucene.Net/Search/FilteredQuery.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Search
             return new WeightAnonymousClass(this, weight);
         }
 
-        private class WeightAnonymousClass : Weight
+        private sealed class WeightAnonymousClass : Weight
         {
             private readonly FilteredQuery outerInstance;
 

--- a/src/Lucene.Net/Search/MultiTermQuery.cs
+++ b/src/Lucene.Net/Search/MultiTermQuery.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Search
         /// <seealso cref="MultiTermRewriteMethod"/>
         public static readonly RewriteMethod CONSTANT_SCORE_FILTER_REWRITE = new RewriteMethodAnonymousClass();
 
-        private class RewriteMethodAnonymousClass : RewriteMethod
+        private sealed class RewriteMethodAnonymousClass : RewriteMethod
         {
             public RewriteMethodAnonymousClass()
             {
@@ -244,7 +244,7 @@ namespace Lucene.Net.Search
         /// </summary>
         public static readonly RewriteMethod CONSTANT_SCORE_AUTO_REWRITE_DEFAULT = new ConstantScoreAutoRewriteAnonymousClass();
 
-        private class ConstantScoreAutoRewriteAnonymousClass : ConstantScoreAutoRewrite
+        private sealed class ConstantScoreAutoRewriteAnonymousClass : ConstantScoreAutoRewrite
         {
             public ConstantScoreAutoRewriteAnonymousClass()
             {

--- a/src/Lucene.Net/Search/NumericRangeQuery.cs
+++ b/src/Lucene.Net/Search/NumericRangeQuery.cs
@@ -420,7 +420,7 @@ namespace Lucene.Net.Search
                 termComp = Comparer;
             }
 
-            private class Int64RangeBuilderAnonymousClass : NumericUtils.Int64RangeBuilder
+            private sealed class Int64RangeBuilderAnonymousClass : NumericUtils.Int64RangeBuilder
             {
                 private readonly NumericRangeTermsEnum outerInstance;
 
@@ -436,7 +436,7 @@ namespace Lucene.Net.Search
                 }
             }
 
-            private class Int32RangeBuilderAnonymousClass : NumericUtils.Int32RangeBuilder
+            private sealed class Int32RangeBuilderAnonymousClass : NumericUtils.Int32RangeBuilder
             {
                 private readonly NumericRangeTermsEnum outerInstance;
 

--- a/src/Lucene.Net/Search/QueryRescorer.cs
+++ b/src/Lucene.Net/Search/QueryRescorer.cs
@@ -188,7 +188,7 @@ namespace Lucene.Net.Search
             return new QueryRescorerAnonymousClass(query, weight).Rescore(searcher, topDocs, topN);
         }
 
-        private class QueryRescorerAnonymousClass : QueryRescorer
+        private sealed class QueryRescorerAnonymousClass : QueryRescorer
         {
             private readonly double weight;
 

--- a/src/Lucene.Net/Search/QueryWrapperFilter.cs
+++ b/src/Lucene.Net/Search/QueryWrapperFilter.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Search
             return new DocIdSetAnonymousClass(acceptDocs, privateContext, weight);
         }
 
-        private class DocIdSetAnonymousClass : DocIdSet
+        private sealed class DocIdSetAnonymousClass : DocIdSet
         {
             private readonly IBits acceptDocs;
             private readonly AtomicReaderContext privateContext;

--- a/src/Lucene.Net/Search/RegexpQuery.cs
+++ b/src/Lucene.Net/Search/RegexpQuery.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Search
         /// </summary>
         private static readonly IAutomatonProvider defaultProvider = new AutomatonProviderAnonymousClass();
 
-        private class AutomatonProviderAnonymousClass : IAutomatonProvider
+        private sealed class AutomatonProviderAnonymousClass : IAutomatonProvider
         {
             public Automaton GetAutomaton(string name)
             {

--- a/src/Lucene.Net/Search/ScoringRewrite.cs
+++ b/src/Lucene.Net/Search/ScoringRewrite.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Search
         ///  <seealso cref="MultiTermQuery.MultiTermRewriteMethod"/>
         public static readonly ScoringRewrite<BooleanQuery> SCORING_BOOLEAN_QUERY_REWRITE = new ScoringRewriteAnonymousClass();
 
-        private class ScoringRewriteAnonymousClass : ScoringRewrite<BooleanQuery>
+        private sealed class ScoringRewriteAnonymousClass : ScoringRewrite<BooleanQuery>
         {
             public ScoringRewriteAnonymousClass()
             {
@@ -97,7 +97,7 @@ namespace Lucene.Net.Search
         /// <seealso cref="MultiTermQuery.MultiTermRewriteMethod"/>
         public static readonly RewriteMethod CONSTANT_SCORE_BOOLEAN_QUERY_REWRITE = new RewriteMethodAnonymousClass();
 
-        private class RewriteMethodAnonymousClass : RewriteMethod
+        private sealed class RewriteMethodAnonymousClass : RewriteMethod
         {
             public RewriteMethodAnonymousClass()
             {

--- a/src/Lucene.Net/Search/SortField.cs
+++ b/src/Lucene.Net/Search/SortField.cs
@@ -152,7 +152,7 @@ namespace Lucene.Net.Search
         /// </summary>
         public static readonly object STRING_FIRST = new ObjectAnonymousClass();
 
-        private class ObjectAnonymousClass : object
+        private sealed class ObjectAnonymousClass : object
         {
             public ObjectAnonymousClass()
             {
@@ -170,7 +170,7 @@ namespace Lucene.Net.Search
         /// </summary>
         public static readonly object STRING_LAST = new ObjectAnonymousClass2();
 
-        private class ObjectAnonymousClass2 : object
+        private sealed class ObjectAnonymousClass2 : object
         {
             public ObjectAnonymousClass2()
             {

--- a/src/Lucene.Net/Search/Spans/NearSpansOrdered.cs
+++ b/src/Lucene.Net/Search/Spans/NearSpansOrdered.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Search.Spans
         // perform better since it has a lower overhead than TimSorter for small arrays
         private readonly InPlaceMergeSorter sorter;
 
-        private class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
+        private sealed class InPlaceMergeSorterAnonymousClass : InPlaceMergeSorter
         {
             private readonly NearSpansOrdered outerInstance;
 

--- a/src/Lucene.Net/Search/Spans/SpanMultiTermQueryWrapper.cs
+++ b/src/Lucene.Net/Search/Spans/SpanMultiTermQueryWrapper.cs
@@ -163,7 +163,7 @@ namespace Lucene.Net.Search.Spans
         /// <seealso cref="MultiTermRewriteMethod"/>
         public static readonly SpanRewriteMethod SCORING_SPAN_QUERY_REWRITE = new SpanRewriteMethodAnonymousClass();
 
-        private class SpanRewriteMethodAnonymousClass : SpanRewriteMethod
+        private sealed class SpanRewriteMethodAnonymousClass : SpanRewriteMethod
         {
             public SpanRewriteMethodAnonymousClass()
             {
@@ -171,7 +171,7 @@ namespace Lucene.Net.Search.Spans
 
             private readonly ScoringRewrite<SpanOrQuery> @delegate = new ScoringRewriteAnonymousClass();
 
-            private class ScoringRewriteAnonymousClass : ScoringRewrite<SpanOrQuery>
+            private sealed class ScoringRewriteAnonymousClass : ScoringRewrite<SpanOrQuery>
             {
                 public ScoringRewriteAnonymousClass()
                 {
@@ -227,7 +227,7 @@ namespace Lucene.Net.Search.Spans
                 @delegate = new TopTermsRewriteAnonymousClass(size);
             }
 
-            private class TopTermsRewriteAnonymousClass : TopTermsRewrite<SpanOrQuery>
+            private sealed class TopTermsRewriteAnonymousClass : TopTermsRewrite<SpanOrQuery>
             {
                 public TopTermsRewriteAnonymousClass(int size)
                     : base(size)

--- a/src/Lucene.Net/Search/Spans/SpanNotQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanNotQuery.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Search.Spans
             return new SpansAnonymousClass(this, context, acceptDocs, termContexts);
         }
 
-        private class SpansAnonymousClass : Spans
+        private sealed class SpansAnonymousClass : Spans
         {
             private readonly SpanNotQuery outerInstance;
 

--- a/src/Lucene.Net/Search/Spans/SpanOrQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanOrQuery.cs
@@ -214,7 +214,7 @@ namespace Lucene.Net.Search.Spans
             return new SpansAnonymousClass(this, context, acceptDocs, termContexts);
         }
 
-        private class SpansAnonymousClass : Spans
+        private sealed class SpansAnonymousClass : Spans
         {
             private readonly SpanOrQuery outerInstance;
 

--- a/src/Lucene.Net/Search/TopTermsRewrite.cs
+++ b/src/Lucene.Net/Search/TopTermsRewrite.cs
@@ -91,7 +91,7 @@ namespace Lucene.Net.Search
             return q;
         }
 
-        private class TermCollectorAnonymousClass : TermCollector
+        private sealed class TermCollectorAnonymousClass : TermCollector
         {
             private readonly int maxSize;
             private readonly JCG.PriorityQueue<ScoreTerm> stQueue;

--- a/src/Lucene.Net/Store/CompoundFileDirectory.cs
+++ b/src/Lucene.Net/Store/CompoundFileDirectory.cs
@@ -441,7 +441,7 @@ namespace Lucene.Net.Store
             return new IndexInputSlicerAnonymousClass(this, entry);
         }
 
-        private class IndexInputSlicerAnonymousClass : IndexInputSlicer
+        private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly CompoundFileDirectory outerInstance;
 

--- a/src/Lucene.Net/Store/Directory.cs
+++ b/src/Lucene.Net/Store/Directory.cs
@@ -250,7 +250,7 @@ namespace Lucene.Net.Store
             return new IndexInputSlicerAnonymousClass(OpenInput(name, context));
         }
 
-        private class IndexInputSlicerAnonymousClass : IndexInputSlicer
+        private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly IndexInput @base;
 

--- a/src/Lucene.Net/Store/LockVerifyServer.cs
+++ b/src/Lucene.Net/Store/LockVerifyServer.cs
@@ -97,7 +97,7 @@ namespace Lucene.Net.Store
             Console.WriteLine("Server terminated.");
         }
 
-        private class ThreadAnonymousClass : ThreadJob
+        private sealed class ThreadAnonymousClass : ThreadJob
         {
             private readonly object localLock;
             private readonly int[] lockedID;

--- a/src/Lucene.Net/Store/MMapDirectory.cs
+++ b/src/Lucene.Net/Store/MMapDirectory.cs
@@ -193,7 +193,7 @@ namespace Lucene.Net.Store
             return new IndexInputSlicerAnonymousClass(this, full);
         }
 
-        private class IndexInputSlicerAnonymousClass : IndexInputSlicer
+        private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly MMapDirectory outerInstance;
 

--- a/src/Lucene.Net/Store/NIOFSDirectory.cs
+++ b/src/Lucene.Net/Store/NIOFSDirectory.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Store
             return new IndexInputSlicerAnonymousClass(context, path, fc);
         }
 
-        private class IndexInputSlicerAnonymousClass : IndexInputSlicer
+        private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly IOContext context;
             private readonly FileInfo path;

--- a/src/Lucene.Net/Store/SimpleFSDirectory.cs
+++ b/src/Lucene.Net/Store/SimpleFSDirectory.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Store
             return new IndexInputSlicerAnonymousClass(context, file, descriptor);
         }
 
-        private class IndexInputSlicerAnonymousClass : IndexInputSlicer
+        private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly IOContext context;
             private readonly FileInfo file;

--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -281,7 +281,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        private class EnumeratorAnonymousClass : IEnumerator<Attribute>
+        private sealed class EnumeratorAnonymousClass : IEnumerator<Attribute>
         {
             public EnumeratorAnonymousClass(AttributeSource.State initState)
             {
@@ -604,7 +604,7 @@ namespace Lucene.Net.Util
             return buffer.ToString();
         }
 
-        private class AttributeReflectorAnonymousClass : IAttributeReflector
+        private sealed class AttributeReflectorAnonymousClass : IAttributeReflector
         {
             private readonly bool prependAttClass;
             private readonly StringBuilder buffer;

--- a/src/Lucene.Net/Util/BytesRefArray.cs
+++ b/src/Lucene.Net/Util/BytesRefArray.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -118,7 +118,7 @@ namespace Lucene.Net.Util
             return orderedEntries;
         }
 
-        private class IntroSorterAnonymousClass : IntroSorter
+        private sealed class IntroSorterAnonymousClass : IntroSorter
         {
             private readonly BytesRefArray outerInstance;
 
@@ -202,7 +202,7 @@ namespace Lucene.Net.Util
         }
 
         [Obsolete("This class will be removed in 4.8.0 release candidate"), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        private class BytesRefIteratorAnonymousClass : IBytesRefIterator
+        private sealed class BytesRefIteratorAnonymousClass : IBytesRefIterator
         {
             private readonly BytesRefArray outerInstance;
 
@@ -223,7 +223,7 @@ namespace Lucene.Net.Util
 
             internal int pos;
 
-            public virtual BytesRef Next()
+            public BytesRef Next()
             {
                 if (pos < size)
                 {
@@ -232,7 +232,7 @@ namespace Lucene.Net.Util
                 return null;
             }
 
-            public virtual IComparer<BytesRef> Comparer => comp;
+            public IComparer<BytesRef> Comparer => comp;
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/BytesRefHash.cs
+++ b/src/Lucene.Net/Util/BytesRefHash.cs
@@ -178,7 +178,7 @@ namespace Lucene.Net.Util
             return compact;
         }
 
-        private class IntroSorterAnonymousClass : IntroSorter
+        private sealed class IntroSorterAnonymousClass : IntroSorter
         {
             private readonly BytesRefHash outerInstance;
 

--- a/src/Lucene.Net/Util/Fst/BytesStore.cs
+++ b/src/Lucene.Net/Util/Fst/BytesStore.cs
@@ -410,14 +410,14 @@ namespace Lucene.Net.Util.Fst
             {
                 return new ForwardBytesReader(blocks[0]);
             }
-            return new ForwardBytesReaderAnonymousInner(this);
+            return new ForwardBytesReaderAnonymousClass(this);
         }
 
-        private class ForwardBytesReaderAnonymousInner : FST.BytesReader
+        private class ForwardBytesReaderAnonymousClass : FST.BytesReader
         {
             private readonly BytesStore outerInstance;
 
-            public ForwardBytesReaderAnonymousInner(BytesStore outerInstance)
+            public ForwardBytesReaderAnonymousClass(BytesStore outerInstance)
             {
                 this.outerInstance = outerInstance;
                 nextRead = outerInstance.blockSize;
@@ -498,14 +498,14 @@ namespace Lucene.Net.Util.Fst
             {
                 return new ReverseBytesReader(blocks[0]);
             }
-            return new ReverseBytesReaderAnonymousInner(this);
+            return new ReverseBytesReaderAnonymousClass(this);
         }
 
-        private class ReverseBytesReaderAnonymousInner : FST.BytesReader
+        private class ReverseBytesReaderAnonymousClass : FST.BytesReader
         {
             private readonly BytesStore outerInstance;
 
-            public ReverseBytesReaderAnonymousInner(BytesStore outerInstance)
+            public ReverseBytesReaderAnonymousClass(BytesStore outerInstance)
             {
                 this.outerInstance = outerInstance;
                 current = outerInstance.blocks.Count == 0 ? null : outerInstance.blocks[0];

--- a/src/Lucene.Net/Util/Fst/BytesStore.cs
+++ b/src/Lucene.Net/Util/Fst/BytesStore.cs
@@ -413,7 +413,7 @@ namespace Lucene.Net.Util.Fst
             return new ForwardBytesReaderAnonymousClass(this);
         }
 
-        private class ForwardBytesReaderAnonymousClass : FST.BytesReader
+        private sealed class ForwardBytesReaderAnonymousClass : FST.BytesReader
         {
             private readonly BytesStore outerInstance;
 
@@ -501,7 +501,7 @@ namespace Lucene.Net.Util.Fst
             return new ReverseBytesReaderAnonymousClass(this);
         }
 
-        private class ReverseBytesReaderAnonymousClass : FST.BytesReader
+        private sealed class ReverseBytesReaderAnonymousClass : FST.BytesReader
         {
             private readonly BytesStore outerInstance;
 

--- a/src/Lucene.Net/Util/Fst/NoOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/NoOutputs.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util.Fst
@@ -33,7 +33,7 @@ namespace Lucene.Net.Util.Fst
     {
         internal static readonly object NO_OUTPUT = new ObjectAnonymousClass();
 
-        private class ObjectAnonymousClass : object
+        private sealed class ObjectAnonymousClass : object
         {
             public ObjectAnonymousClass()
             {

--- a/src/Lucene.Net/Util/NumericUtils.cs
+++ b/src/Lucene.Net/Util/NumericUtils.cs
@@ -555,7 +555,7 @@ namespace Lucene.Net.Util
             return new FilteredTermsEnumAnonymousClass(termsEnum);
         }
 
-        private class FilteredTermsEnumAnonymousClass : FilteredTermsEnum
+        private sealed class FilteredTermsEnumAnonymousClass : FilteredTermsEnum
         {
             public FilteredTermsEnumAnonymousClass(TermsEnum termsEnum)
                 : base(termsEnum, false)
@@ -585,7 +585,7 @@ namespace Lucene.Net.Util
             return new FilteredTermsEnumAnonymousClass2(termsEnum);
         }
 
-        private class FilteredTermsEnumAnonymousClass2 : FilteredTermsEnum
+        private sealed class FilteredTermsEnumAnonymousClass2 : FilteredTermsEnum
         {
             public FilteredTermsEnumAnonymousClass2(TermsEnum termsEnum)
                 : base(termsEnum, false)

--- a/src/Lucene.Net/Util/OfflineSorter.cs
+++ b/src/Lucene.Net/Util/OfflineSorter.cs
@@ -441,7 +441,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        private class PriorityQueueAnonymousClass : PriorityQueue<FileAndTop>
+        private sealed class PriorityQueueAnonymousClass : PriorityQueue<FileAndTop>
         {
             private readonly OfflineSorter outerInstance;
 

--- a/src/Lucene.Net/Util/Packed/EliasFanoDocIdSet.cs
+++ b/src/Lucene.Net/Util/Packed/EliasFanoDocIdSet.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Util.Packed
             return new DocIdSetIteratorAnonymousClass(this);
         }
 
-        private class DocIdSetIteratorAnonymousClass : DocIdSetIterator
+        private sealed class DocIdSetIteratorAnonymousClass : DocIdSetIterator
         {
             public DocIdSetIteratorAnonymousClass(EliasFanoDocIdSet outerInstance)
             {

--- a/src/Lucene.Net/Util/Packed/PackedInts.cs
+++ b/src/Lucene.Net/Util/Packed/PackedInts.cs
@@ -1099,7 +1099,7 @@ namespace Lucene.Net.Util.Packed
             }
         }
 
-        private class DirectPackedReaderAnonymousClass : DirectPackedReader
+        private sealed class DirectPackedReaderAnonymousClass : DirectPackedReader
         {
             private readonly IndexInput @in;
             private readonly int valueCount;

--- a/src/Lucene.Net/Util/RamUsageEstimator.cs
+++ b/src/Lucene.Net/Util/RamUsageEstimator.cs
@@ -993,7 +993,7 @@ namespace Lucene.Net.Util
                 return GetEnumerator();
             }
 
-            private class EnumeratorAnonymousClass : IEnumerator<KType>
+            private sealed class EnumeratorAnonymousClass : IEnumerator<KType>
             {
                 private readonly IdentityHashSet<KType> outerInstance;
 

--- a/src/Lucene.Net/Util/WAH8DocIdSet.cs
+++ b/src/Lucene.Net/Util/WAH8DocIdSet.cs
@@ -244,7 +244,7 @@ namespace Lucene.Net.Util
             return builder.Build();
         }
 
-        private class PriorityQueueAnonymousClass : PriorityQueue<WAH8DocIdSet.Iterator>
+        private sealed class PriorityQueueAnonymousClass : PriorityQueue<WAH8DocIdSet.Iterator>
         {
             public PriorityQueueAnonymousClass(int numSets)
                 : base(numSets)

--- a/src/Lucene.Net/Util/WeakIdentityMap.cs
+++ b/src/Lucene.Net/Util/WeakIdentityMap.cs
@@ -259,7 +259,7 @@
 //            }
 //        }
 
-//        private class EnumeratorAnonymousClass : IEnumerator<TKey>
+//        private sealed class EnumeratorAnonymousClass : IEnumerator<TKey>
 //        {
 //            private readonly WeakIdentityMap<TKey, TValue> outerInstance;
 //            private readonly IEnumerator<KeyValuePair<IdentityWeakReference, TValue>> enumerator;


### PR DESCRIPTION
Fixes #666.

This marks all anonymous classes sealed and removes the virtual members. Also suffixes all anonymous classes with `AnonymousClass` (only found 2 that contained the word `Anon`).