### PR TITLE
BREAKING: Lucene.Net.Analysis.Cjk.CJKBigramFilter: Changed the value of CJKScript.ALL

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Cjk/CJKBigramFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Cjk/CJKBigramFilter.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using J2N;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Analysis.TokenAttributes;
@@ -42,7 +42,7 @@ namespace Lucene.Net.Analysis.Cjk
         HANGUL = 8,
         /// <summary>
         /// bigram flag for all scripts </summary>
-        ALL = 0xff
+        ALL = 0xffff,
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #657.

Changed the value of ALL to set all flags. The value was 0xff instead of 0xffff, which wasn't valid.

Reviewed all other `[Flags]` enums to ensure they are valid. Closes #658.