### PR TITLE
Fix: Remove the ToString call in order to use a strongly-typed StringBuilder overload

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
@@ -270,7 +270,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
                 token.Length = 0;
                 return word;
             }
-            token.Append(chars.ToString());
+            token.Append(chars); // LUCENENET: CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
             return null;
         }
 

--- a/src/Lucene.Net.Tests/Analysis/TestToken.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestToken.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Analysis.TokenAttributes;
+﻿using Lucene.Net.Analysis.TokenAttributes;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
@@ -99,7 +99,7 @@ namespace Lucene.Net.Analysis
                 t.CopyBuffer(content, 0, content.Length);
                 Assert.AreEqual(buf.Length, t.Length);
                 Assert.AreEqual(buf.ToString(), t.ToString());
-                buf.Append(buf.ToString());
+                buf.Append(buf); // LUCENENET: CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
             }
             Assert.AreEqual(1048576, t.Length);
 

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -1,4 +1,4 @@
-using J2N.Text;
+﻿using J2N.Text;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -57,7 +57,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
                 t.CopyBuffer(content, 0, content.Length);
                 Assert.AreEqual(buf.Length, t.Length);
                 Assert.AreEqual(buf.ToString(), t.ToString());
-                buf.Append(buf.ToString());
+                buf.Append(buf); // LUCENENET: CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
             }
             Assert.AreEqual(1048576, t.Length);
 

--- a/src/Lucene.Net.Tests/Search/TestCustomSearcherSort.cs
+++ b/src/Lucene.Net.Tests/Search/TestCustomSearcherSort.cs
@@ -181,7 +181,7 @@ namespace Lucene.Net.Search
                         message.Append("Duplicate key for hit index = ");
                         message.Append(docnum);
                         message.Append(", previous index = ");
-                        message.Append(value.ToString());
+                        message.Append(value); // LUCENENET: CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
                         message.Append(", Lucene ID = ");
                         message.Append(luceneId);
                         Log(message.ToString());


### PR DESCRIPTION
Removed call to `ToString()` for `StringBuilder.Append()` methods so strongly typed `StringBuilder` overloads can be used on target frameworks that support it. Fixes #668.