### PR TITLE
PERFORMANCE: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string.

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SlowSynonymMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SlowSynonymMap.cs
@@ -119,7 +119,7 @@ namespace Lucene.Net.Analysis.Synonym
             var sb = new StringBuilder("<");
             if (synonyms != null)
             {
-                sb.Append("[");
+                sb.Append('[');
                 for (int i = 0; i < synonyms.Length; i++)
                 {
                     if (i != 0)
@@ -135,7 +135,7 @@ namespace Lucene.Net.Analysis.Synonym
                 sb.Append("],");
             }
             sb.Append(submap);
-            sb.Append(">");
+            sb.Append('>');
             return sb.ToString();
         }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -1370,7 +1370,7 @@ namespace Lucene.Net.Analysis.Util
                         sb.Append(", ");
                     }
                     sb.Append(entry.Key);
-                    sb.Append("=");
+                    sb.Append('=');
                     sb.Append(entry.Value);
                 }
             }
@@ -1681,7 +1681,7 @@ namespace Lucene.Net.Analysis.Util
                         sb.Append(", ");
                     }
                     sb.Append(entry.Key);
-                    sb.Append("=");
+                    sb.Append('=');
                     sb.Append(entry.Value);
                 }
 

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/UserDictionary.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/UserDictionary.cs
@@ -270,18 +270,18 @@ namespace Lucene.Net.Analysis.Ja.Dict
             { // All features
                 foreach (string feature in allFeatures)
                 {
-                    sb.Append(CSVUtil.QuoteEscape(feature)).Append(",");
+                    sb.Append(CSVUtil.QuoteEscape(feature)).Append(',');
                 }
             }
             else if (fields.Length == 1)
             { // One feature doesn't need to escape value
-                sb.Append(allFeatures[fields[0]]).Append(",");
+                sb.Append(allFeatures[fields[0]]).Append(',');
             }
             else
             {
                 foreach (int field in fields)
                 {
-                    sb.Append(CSVUtil.QuoteEscape(allFeatures[field])).Append(",");
+                    sb.Append(CSVUtil.QuoteEscape(allFeatures[field])).Append(',');
                 }
             }
             return sb.Remove(sb.Length - 1, 1).ToString();

--- a/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
@@ -164,7 +164,7 @@ namespace Lucene.Net.Analysis.Ja
                         sb.Append('+');
                     }
                     sb.Append(bgCost);
-                    sb.Append("\"");
+                    sb.Append('\"');
                     sb.Append(attrs);
                     sb.Append("]\n");
                 }

--- a/src/Lucene.Net.Analysis.Kuromoji/Util/ToStringUtil.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Util/ToStringUtil.cs
@@ -961,13 +961,13 @@ namespace Lucene.Net.Analysis.Ja.Util
                         builder.Append("wa");
                         break;
                     case 'ヰ':
-                        builder.Append("i");
+                        builder.Append('i');
                         break;
                     case 'ヱ':
-                        builder.Append("e");
+                        builder.Append('e');
                         break;
                     case 'ヲ':
-                        builder.Append("o");
+                        builder.Append('o');
                         break;
                     case 'ン':
                         switch (ch2)
@@ -1000,7 +1000,7 @@ namespace Lucene.Net.Analysis.Ja.Util
                                 builder.Append("n'");
                                 goto break_main;
                             default:
-                                builder.Append("n");
+                                builder.Append('n');
                                 goto break_main;
                         }
                     case 'ガ':

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
@@ -179,7 +179,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                 {
                     if (sb.Length > 0)
                     {
-                        sb.Append("|");
+                        sb.Append('|');
                     }
                     sb.Append(ph.GetPhonemeText());
                 }
@@ -487,7 +487,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                 StringBuilder result = new StringBuilder();
                 foreach (string word in words2)
                 {
-                    result.Append("-").Append(Encode(word));
+                    result.Append('-').Append(Encode(word));
                 }
                 // return the result without the leading "-"
                 return result.ToString(1, result.Length - 1);

--- a/src/Lucene.Net.Benchmark/ByTask/Stats/TaskStats.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Stats/TaskStats.cs
@@ -127,9 +127,9 @@ namespace Lucene.Net.Benchmarks.ByTask.Stats
         public override string ToString()
         {
             StringBuilder res = new StringBuilder(task.GetName());
-            res.Append(" ");
+            res.Append(' ');
             res.Append(count);
-            res.Append(" ");
+            res.Append(' ');
             res.Append(elapsed);
             return res.ToString();
         }

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/Config.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/Config.cs
@@ -344,26 +344,26 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
                     {
                         int n1 = (roundNumber - 1) % ai.Length;
                         int n2 = roundNumber % ai.Length;
-                        sb.Append("  ").Append(name).Append(":").Append(ai[n1]).Append("-->").Append(ai[n2]);
+                        sb.Append("  ").Append(name).Append(':').Append(ai[n1]).Append("-->").Append(ai[n2]);
                     }
                     else if (a is double[] ad)
                     {
                         int n1 = (roundNumber - 1) % ad.Length;
                         int n2 = roundNumber % ad.Length;
-                        sb.Append("  ").Append(name).Append(":").Append(ad[n1]).Append("-->").Append(ad[n2]);
+                        sb.Append("  ").Append(name).Append(':').Append(ad[n1]).Append("-->").Append(ad[n2]);
                     }
                     else if (a is string[] astr)
                     {
                         int n1 = (roundNumber - 1) % astr.Length;
                         int n2 = roundNumber % astr.Length;
-                        sb.Append("  ").Append(name).Append(":").Append(astr[n1]).Append("-->").Append(astr[n2]);
+                        sb.Append("  ").Append(name).Append(':').Append(astr[n1]).Append("-->").Append(astr[n2]);
                     }
                     else
                     {
                         bool[] ab = (bool[])a;
                         int n1 = (roundNumber - 1) % ab.Length;
                         int n2 = roundNumber % ab.Length;
-                        sb.Append("  ").Append(name).Append(":").Append(ab[n1]).Append("-->").Append(ab[n2]);
+                        sb.Append("  ").Append(name).Append(':').Append(ab[n1]).Append("-->").Append(ab[n2]);
                     }
                 }
             }
@@ -474,7 +474,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
             foreach (string name in colForValByRound.Keys)
             {
                 string colName = colForValByRound[name];
-                sb.Append(" ").Append(colName);
+                sb.Append(' ').Append(colName);
             }
             return sb.ToString();
         }

--- a/src/Lucene.Net.Benchmark/Support/Util/EnglishNumberFormatExtensions.cs
+++ b/src/Lucene.Net.Benchmark/Support/Util/EnglishNumberFormatExtensions.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Util
 
                 ToWords(unit, builder);
                 builder.Append(" quadrillion");
-                if (value > 0) builder.Append(" ");
+                if (value > 0) builder.Append(' ');
             }
 
             if (value >= TRILLION)
@@ -78,7 +78,7 @@ namespace Lucene.Net.Util
 
                 ToWords(unit, builder);
                 builder.Append(" trillion");
-                if (value > 0) builder.Append(" ");
+                if (value > 0) builder.Append(' ');
             }
 
             if (value >= BILLION)
@@ -88,7 +88,7 @@ namespace Lucene.Net.Util
 
                 ToWords(unit, builder);
                 builder.Append(" billion");
-                if (value > 0) builder.Append(" ");
+                if (value > 0) builder.Append(' ');
             }
 
             if (value >= MILLION)
@@ -98,7 +98,7 @@ namespace Lucene.Net.Util
 
                 ToWords(unit, builder);
                 builder.Append(" million");
-                if (value > 0) builder.Append(" ");
+                if (value > 0) builder.Append(' ');
             }
 
             if (value >= THOUSAND)
@@ -108,7 +108,7 @@ namespace Lucene.Net.Util
 
                 ToWords(unit, builder);
                 builder.Append(" thousand");
-                if (value > 0) builder.Append(" ");
+                if (value > 0) builder.Append(' ');
             }
 
             if (value >= HUNDRED)
@@ -118,63 +118,63 @@ namespace Lucene.Net.Util
 
                 ToWords(unit, builder);
                 builder.Append(" hundred");
-                if (value > 0) builder.Append(" ");
+                if (value > 0) builder.Append(' ');
             }
 
             if (value >= 90)
             {
                 value -= 90;
                 builder.Append("ninety");
-                if (value > 0) builder.Append("-");
+                if (value > 0) builder.Append('-');
             }
 
             if (value >= 80)
             {
                 value -= 80;
                 builder.Append("eighty");
-                if (value > 0) builder.Append("-");
+                if (value > 0) builder.Append('-');
             }
 
             if (value >= 70)
             {
                 value -= 70;
                 builder.Append("seventy");
-                if (value > 0) builder.Append("-");
+                if (value > 0) builder.Append('-');
             }
 
             if (value >= 60)
             {
                 value -= 60;
                 builder.Append("sixty");
-                if (value > 0) builder.Append("-");
+                if (value > 0) builder.Append('-');
             }
 
             if (value >= 50)
             {
                 value -= 50;
                 builder.Append("fifty");
-                if (value > 0) builder.Append("-");
+                if (value > 0) builder.Append('-');
             }
 
             if (value >= 40)
             {
                 value -= 40;
                 builder.Append("forty");
-                if (value > 0) builder.Append("-");
+                if (value > 0) builder.Append('-');
             }
 
             if (value >= 30)
             {
                 value -= 30;
                 builder.Append("thirty");
-                if (value > 0) builder.Append("-");
+                if (value > 0) builder.Append('-');
             }
 
             if (value >= 20)
             {
                 value -= 20;
                 builder.Append("twenty");
-                if (value > 0) builder.Append("-");
+                if (value > 0) builder.Append('-');
             }
 
             if (value == 19) builder.Append("nineteen");

--- a/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
+++ b/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Benchmarks.Utils
             contents.Append(title);
             contents.Append("\n\n");
             contents.Append(body);
-            contents.Append("\n");
+            contents.Append('\n');
 
             try
             {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesWriter.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesWriter.cs
@@ -349,7 +349,7 @@ namespace Lucene.Net.Codecs.SimpleText
                         var ord = ordStream.Current;
                         if (sb2.Length > 0)
                         {
-                            sb2.Append(",");
+                            sb2.Append(',');
                         }
                         sb2.Append(ord.GetValueOrDefault().ToString(CultureInfo.InvariantCulture));
                     }
@@ -406,7 +406,7 @@ namespace Lucene.Net.Codecs.SimpleText
                         ordStream.MoveNext();
                         var ord = ordStream.Current;
                         if (sb2.Length > 0)
-                            sb2.Append(",");
+                            sb2.Append(',');
 
                         sb2.Append(ord);
                     }

--- a/src/Lucene.Net.Highlighter/Highlight/GradientFormatter.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/GradientFormatter.cs
@@ -134,7 +134,7 @@ namespace Lucene.Net.Search.Highlight
                 sb.Append(GetBackgroundColorString(score));
                 sb.Append("\" ");
             }
-            sb.Append(">");
+            sb.Append('>');
             sb.Append(originalText);
             sb.Append("</font>");
             return sb.ToString();
@@ -146,7 +146,7 @@ namespace Lucene.Net.Search.Highlight
             int gVal = GetColorVal(m_fgGMin, m_fgGMax, score);
             int bVal = GetColorVal(m_fgBMin, m_fgBMax, score);
             var sb = new StringBuilder();
-            sb.Append("#");
+            sb.Append('#');
             sb.Append(Int32ToHex(rVal));
             sb.Append(Int32ToHex(gVal));
             sb.Append(Int32ToHex(bVal));
@@ -159,7 +159,7 @@ namespace Lucene.Net.Search.Highlight
             int gVal = GetColorVal(m_bgGMin, m_bgGMax, score);
             int bVal = GetColorVal(m_bgBMin, m_bgBMax, score);
             var sb = new StringBuilder();
-            sb.Append("#");
+            sb.Append('#');
             sb.Append(Int32ToHex(rVal));
             sb.Append(Int32ToHex(gVal));
             sb.Append(Int32ToHex(bVal));

--- a/src/Lucene.Net.Highlighter/Highlight/SimpleHTMLEncoder.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/SimpleHTMLEncoder.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Search.Highlight
                         }
                         else
                         {
-                            result.Append("&#").Append((int)ch).Append(";");
+                            result.Append("&#").Append((int)ch).Append(';');
                         }
                         break;
                 }

--- a/src/Lucene.Net.Highlighter/PostingsHighlight/DefaultPassageFormatter.cs
+++ b/src/Lucene.Net.Highlighter/PostingsHighlight/DefaultPassageFormatter.cs
@@ -142,7 +142,7 @@ namespace Lucene.Net.Search.PostingsHighlight
                             {
                                 dest.Append("&#");
                                 dest.Append((int)ch);
-                                dest.Append(";");
+                                dest.Append(';');
                             }
                             else
                             {

--- a/src/Lucene.Net.Memory/MemoryIndex.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.cs
@@ -682,7 +682,7 @@ namespace Lucene.Net.Index.Memory
                     int iters = storeOffsets ? 3 : 1;
                     while (!postingsReader.IsEndOfSlice)
                     {
-                        result.Append("(");
+                        result.Append('(');
 
                         for (int k = 0; k < iters; k++)
                         {
@@ -692,22 +692,22 @@ namespace Lucene.Net.Index.Memory
                                 result.Append(", ");
                             }
                         }
-                        result.Append(")");
+                        result.Append(')');
                         if (!postingsReader.IsEndOfSlice)
                         {
-                            result.Append(",");
+                            result.Append(',');
                         }
 
                     }
-                    result.Append("]");
-                    result.Append("\n");
+                    result.Append(']');
+                    result.Append('\n');
                     numPositions += freq;
                 }
 
                 result.Append("\tterms=" + info.terms.Count);
                 result.Append(", positions=" + numPositions);
                 result.Append(", memory=" + RamUsageEstimator.HumanReadableUnits(RamUsageEstimator.SizeOf(info)));
-                result.Append("\n");
+                result.Append('\n');
                 sumPositions += numPositions;
                 sumTerms += info.terms.Count;
             }

--- a/src/Lucene.Net.Queries/CommonTermsQuery.cs
+++ b/src/Lucene.Net.Queries/CommonTermsQuery.cs
@@ -361,7 +361,7 @@ namespace Lucene.Net.Queries
             bool needParens = (Boost != 1.0) || (LowFreqMinimumNumberShouldMatch > 0);
             if (needParens)
             {
-                buffer.Append("(");
+                buffer.Append('(');
             }
             for (int i = 0; i < m_terms.Count; i++)
             {
@@ -375,15 +375,15 @@ namespace Lucene.Net.Queries
             }
             if (needParens)
             {
-                buffer.Append(")");
+                buffer.Append(')');
             }
             if (LowFreqMinimumNumberShouldMatch > 0 || HighFreqMinimumNumberShouldMatch > 0)
             {
                 buffer.Append('~');
-                buffer.Append("(");
+                buffer.Append('(');
                 buffer.AppendFormat(CultureInfo.InvariantCulture, "{0:0.0#######}", LowFreqMinimumNumberShouldMatch);
                 buffer.AppendFormat(CultureInfo.InvariantCulture, "{0:0.0#######}", HighFreqMinimumNumberShouldMatch);
-                buffer.Append(")");
+                buffer.Append(')');
             }
             if (Boost != 1.0f)
             {

--- a/src/Lucene.Net.Queries/CustomScoreQuery.cs
+++ b/src/Lucene.Net.Queries/CustomScoreQuery.cs
@@ -141,13 +141,13 @@ namespace Lucene.Net.Queries
         /// </summary>
         public override string ToString(string field)
         {
-            StringBuilder sb = (new StringBuilder(Name)).Append("(");
+            StringBuilder sb = (new StringBuilder(Name)).Append('(');
             sb.Append(subQuery.ToString(field));
             foreach (Query scoringQuery in scoringQueries)
             {
                 sb.Append(", ").Append(scoringQuery.ToString(field));
             }
-            sb.Append(")");
+            sb.Append(')');
             sb.Append(strict ? " STRICT" : "");
             return sb.ToString() + ToStringUtils.Boost(Boost);
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/VectorValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/VectorValueSource.cs
@@ -264,7 +264,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
                 }
                 sb.Append(source);
             }
-            sb.Append(")");
+            sb.Append(')');
             return sb.ToString();
         }
 

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/PathQueryNode.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/PathQueryNode.cs
@@ -171,7 +171,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
 
             foreach (QueryText pathelement in values)
             {
-                path.Append("/").Append(pathelement.Value);
+                path.Append('/').Append(pathelement.Value);
             }
             return path.ToString();
         }
@@ -180,7 +180,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
         public override string ToQueryString(IEscapeQuerySyntax escaper)
         {
             StringBuilder path = new StringBuilder();
-            path.Append("/").Append(GetFirstPathElement());
+            path.Append('/').Append(GetFirstPathElement());
 
             foreach (QueryText pathelement in GetPathElements(1))
             {

--- a/src/Lucene.Net.QueryParser/Surround/Query/ComposedQuery.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/ComposedQuery.cs
@@ -101,9 +101,9 @@ namespace Lucene.Net.QueryParsers.Surround.Query
                 r.Append(sqi.Current.ToString());
                 while (sqi.MoveNext())
                 {
-                    r.Append(" ");
+                    r.Append(' ');
                     r.Append(OperatorName); /* infix operator */
-                    r.Append(" ");
+                    r.Append(' ');
                     r.Append(sqi.Current.ToString());
                 }
             }

--- a/src/Lucene.Net.QueryParser/Surround/Query/FieldsQuery.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/FieldsQuery.cs
@@ -85,10 +85,10 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         public override string ToString()
         {
             StringBuilder r = new StringBuilder();
-            r.Append("(");
+            r.Append('(');
             FieldNamesToString(r);
             r.Append(q.ToString());
-            r.Append(")");
+            r.Append(')');
             return r.ToString();
         }
 

--- a/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.QueryParsers.Surround.Query
             if (c == unlimited)
                 re.Append(".*");
             else if (c == mask)
-                re.Append(".");
+                re.Append('.');
             else
                 re.Append(c);
         }

--- a/src/Lucene.Net.Sandbox/Queries/SlowFuzzyQuery.cs
+++ b/src/Lucene.Net.Sandbox/Queries/SlowFuzzyQuery.cs
@@ -162,7 +162,7 @@ namespace Lucene.Net.Sandbox.Queries
             if (!m_term.Field.Equals(field, StringComparison.Ordinal))
             {
                 buffer.Append(m_term.Field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
             buffer.Append(m_term.Text);
             buffer.Append('~');

--- a/src/Lucene.Net.TestFramework/Index/DocHelper.cs
+++ b/src/Lucene.Net.TestFramework/Index/DocHelper.cs
@@ -222,7 +222,7 @@ namespace Lucene.Net.Index
             Document doc = new Document();
             doc.Add(new Field("id", Convert.ToString(n, CultureInfo.InvariantCulture), customType1));
             doc.Add(new Field("indexname", indexName, customType1));
-            sb.Append("a");
+            sb.Append('a');
             sb.Append(n);
             doc.Add(new Field("field1", sb.ToString(), customType));
             sb.Append(" b");

--- a/src/Lucene.Net.TestFramework/Util/English.cs
+++ b/src/Lucene.Net.TestFramework/Util/English.cs
@@ -152,11 +152,11 @@ namespace Lucene.Net.Util
                 i = i % 10;
                 if (i == 0)
                 {
-                    result.Append(" ");
+                    result.Append(' ');
                 }
                 else
                 {
-                    result.Append("-");
+                    result.Append('-');
                 }
             }
             switch ((int)i)

--- a/src/Lucene.Net.TestFramework/Util/RunListenerPrintReproduceInfo.cs
+++ b/src/Lucene.Net.TestFramework/Util/RunListenerPrintReproduceInfo.cs
@@ -233,7 +233,7 @@ namespace Lucene.Net.Util
             return;
         }
 
-        b.Append(" -D").Append(key).Append("=");
+        b.Append(" -D").Append(key).Append('=');
         string v = value.ToString();
         // Add simplistic quoting. this varies a lot from system to system and between
         // shells... ANT should have some code for doing it properly.

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Util
                 {
                     b.Append("   ")
                      .Append(f.FullName)
-                     .Append("\n");
+                     .Append('\n');
                 }
                 throw new IOException(b.ToString());
             }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -905,14 +905,14 @@ namespace Lucene.Net.Analysis.Core
                 // intentional: initReader gets its own separate random
                 random = new Randomizer(seed);
                 TokenizerSpec tokenizerSpec = NewTokenizer(random, charFilterSpec.reader);
-                sb.Append("\n");
+                sb.Append('\n');
                 sb.Append("tokenizer=");
                 sb.Append(tokenizerSpec.toString);
                 TokenFilterSpec tokenFilterSpec = NewFilterChain(random, tokenizerSpec.tokenizer, tokenizerSpec.offsetsAreCorrect);
-                sb.Append("\n");
+                sb.Append('\n');
                 sb.Append("filters=");
                 sb.Append(tokenFilterSpec.toString);
-                sb.Append("\n");
+                sb.Append('\n');
                 sb.Append("offsetsAreCorrect=" + tokenFilterSpec.offsetsAreCorrect);
                 return sb.ToString();
             }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilter.cs
@@ -64,7 +64,7 @@ namespace Lucene.Net.Analysis.Core
             for (int i = 0; i < 20; i++)
             {
                 string w = English.Int32ToEnglish(i).Trim();
-                sb.Append(w).Append(" ");
+                sb.Append(w).Append(' ');
                 if (i % 3 != 0)
                 {
                     a.Add(w);

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestTypeTokenFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestTypeTokenFilter.cs
@@ -55,12 +55,12 @@ namespace Lucene.Net.Analysis.Core
             {
                 if (i % 3 != 0)
                 {
-                    sb.Append(i).Append(" ");
+                    sb.Append(i).Append(' ');
                 }
                 else
                 {
                     string w = English.Int32ToEnglish(i).Trim();
-                    sb.Append(w).Append(" ");
+                    sb.Append(w).Append(' ');
                 }
             }
             log(sb.ToString());

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestStemmerOverrideFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestStemmerOverrideFilter.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 builder.Add(entry.Key, entry.Value);
                 if (Random.nextBoolean() || output.Count == 0)
                 {
-                    input.Append(entry.Key).Append(" ");
+                    input.Append(entry.Key).Append(' ');
                     output.Add(entry.Value);
                 }
             }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharTokenizers.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharTokenizers.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Analysis.Util
                 builder.Append("\ud801\udc1cabc");
                 if ((i % 10) == 0)
                 {
-                    builder.Append(" ");
+                    builder.Append(' ');
                 }
             }
             // internal buffer size is 1024 make sure we have a surrogate pair right at the border
@@ -77,7 +77,7 @@ namespace Lucene.Net.Analysis.Util
                 var builder = new StringBuilder();
                 for (int j = 0; j < 1 + i; j++)
                 {
-                    builder.Append("a");
+                    builder.Append('a');
                 }
                 builder.Append("\ud801\udc1cabc");
                 var tokenizer = new LowerCaseTokenizer(TEST_VERSION_CURRENT, new StringReader(builder.ToString()));
@@ -95,7 +95,7 @@ namespace Lucene.Net.Analysis.Util
 
             for (var i = 0; i < 255; i++)
             {
-                builder.Append("A");
+                builder.Append('A');
             }
             var tokenizer = new LowerCaseTokenizer(TEST_VERSION_CURRENT, new StringReader(builder.ToString() + builder.ToString()));
             AssertTokenStreamContents(tokenizer, new[] { builder.ToString().ToLowerInvariant(), builder.ToString().ToLowerInvariant() });
@@ -111,7 +111,7 @@ namespace Lucene.Net.Analysis.Util
 
             for (var i = 0; i < 254; i++)
             {
-                builder.Append("A");
+                builder.Append('A');
             }
             builder.Append("\ud801\udc1c");
             var tokenizer = new LowerCaseTokenizer(TEST_VERSION_CURRENT, new StringReader(builder.ToString() + builder.ToString()));

--- a/src/Lucene.Net.Tests.Classification/ClassificationTestBase.cs
+++ b/src/Lucene.Net.Tests.Classification/ClassificationTestBase.cs
@@ -260,7 +260,7 @@ namespace Lucene.Net.Classification
             for (int i = 0; i < 20; i++)
             {
                 builder.Append(TestUtil.RandomSimpleString(random, 5));
-                builder.Append(" ");
+                builder.Append(' ');
             }
             return builder.ToString();
         }

--- a/src/Lucene.Net.Tests.Expressions/TestDemoExpressions.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestDemoExpressions.cs
@@ -186,7 +186,7 @@ namespace Lucene.Net.Expressions
             {
                 if (i > 0)
                 {
-                    sb.Append("+");
+                    sb.Append('+');
                 }
                 sb.Append("x" + i);
                 bindings.Add(new SortField("x" + i, SortFieldType.SCORE));

--- a/src/Lucene.Net.Tests.Join/Support/TestBlockJoinValidation.cs
+++ b/src/Lucene.Net.Tests.Join/Support/TestBlockJoinValidation.cs
@@ -208,7 +208,7 @@ namespace Lucene.Net.Tests.Join
             {
                 if (stringBuilder.Length > 0)
                 {
-                    stringBuilder.Append("_");
+                    stringBuilder.Append('_');
                 }
                 stringBuilder.Append(documentNumber);
             }

--- a/src/Lucene.Net.Tests.Join/TestBlockJoinValidation.cs
+++ b/src/Lucene.Net.Tests.Join/TestBlockJoinValidation.cs
@@ -206,7 +206,7 @@ namespace Lucene.Net.Search.Join
             {
                 if (stringBuilder.Length > 0)
                 {
-                    stringBuilder.Append("_");
+                    stringBuilder.Append('_');
                 }
                 stringBuilder.Append(documentNumber);
             }

--- a/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Classic/TestQueryParser.cs
@@ -415,7 +415,7 @@ namespace Lucene.Net.QueryParsers.Classic
                 if (AddSynonym) // inject our synonym
                 {
                     ClearAttributes();
-                    TermAtt.SetEmpty().Append("國");
+                    TermAtt.SetEmpty().Append('國');
                     PosIncAtt.PositionIncrement = 0;
                     AddSynonym = false;
                     return true;

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
@@ -1394,22 +1394,22 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                 if (upto == 0)
                 {
                     posIncr.PositionIncrement = (1);
-                    term.SetEmpty().Append("a");
+                    term.SetEmpty().Append('a');
                 }
                 else if (upto == 1)
                 {
                     posIncr.PositionIncrement = (1);
-                    term.SetEmpty().Append("b");
+                    term.SetEmpty().Append('b');
                 }
                 else if (upto == 2)
                 {
                     posIncr.PositionIncrement = (0);
-                    term.SetEmpty().Append("c");
+                    term.SetEmpty().Append('c');
                 }
                 else
                 {
                     posIncr.PositionIncrement = (0);
-                    term.SetEmpty().Append("d");
+                    term.SetEmpty().Append('d');
                 }
                 upto++;
                 return true;

--- a/src/Lucene.Net.Tests/Analysis/TestToken.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestToken.cs
@@ -125,7 +125,7 @@ namespace Lucene.Net.Analysis
                 string content = buf.ToString();
                 Assert.AreEqual(content.Length, t.Length);
                 Assert.AreEqual(content, t.ToString());
-                buf.Append("a");
+                buf.Append('a');
             }
             Assert.AreEqual(20000, t.Length);
 
@@ -138,7 +138,7 @@ namespace Lucene.Net.Analysis
                 string content = buf.ToString();
                 Assert.AreEqual(content.Length, t.Length);
                 Assert.AreEqual(content, t.ToString());
-                buf.Append("a");
+                buf.Append('a');
             }
             Assert.AreEqual(20000, t.Length);
         }

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
                 t.SetEmpty().Append(buf);
                 Assert.AreEqual(buf.Length, t.Length);
                 Assert.AreEqual(buf.ToString(), t.ToString());
-                buf.Append("a");
+                buf.Append('a');
             }
             Assert.AreEqual(20000, t.Length);
         }

--- a/src/Lucene.Net.Tests/Codecs/Lucene41/TestBlockPostingsFormat2.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene41/TestBlockPostingsFormat2.cs
@@ -160,7 +160,7 @@ namespace Lucene.Net.Codecs.Lucene41
                     for (int j = 0; j < 16; j++)
                     {
                         val.Append(proto);
-                        val.Append(" ");
+                        val.Append(' ');
                     }
                     ((Field)f).SetStringValue(val.ToString());
                 }

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
@@ -624,7 +624,7 @@ namespace Lucene.Net.Index
         {
             StringBuilder sb = new StringBuilder();
             Document doc = new Document();
-            sb.Append("a");
+            sb.Append('a');
             sb.Append(n);
             FieldType customType2 = new FieldType(TextField.TYPE_STORED);
             customType2.IsTokenized = false;

--- a/src/Lucene.Net.Tests/Index/TestDocsAndPositions.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocsAndPositions.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Index
                 for (int j = 0; j < num; j++)
                 {
                     int nextInt = Random.Next(max);
-                    builder.Append(nextInt).Append(" ");
+                    builder.Append(nextInt).Append(' ');
                     if (nextInt == term)
                     {
                         positions.Add(Convert.ToInt32(j));

--- a/src/Lucene.Net.Tests/Index/TestDocumentWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentWriter.cs
@@ -221,7 +221,7 @@ namespace Lucene.Net.Index
                         RestoreState(state);
                         payloadAtt.Payload = null;
                         posIncrAtt.PositionIncrement = 0;
-                        termAtt.SetEmpty().Append("b");
+                        termAtt.SetEmpty().Append('b');
                         state = null;
                         return true;
                     }

--- a/src/Lucene.Net.Tests/Index/TestOmitTf.cs
+++ b/src/Lucene.Net.Tests/Index/TestOmitTf.cs
@@ -320,7 +320,7 @@ namespace Lucene.Net.Index
             for (int i = 0; i < 30; i++)
             {
                 Document doc = new Document();
-                sb.Append(term).Append(" ");
+                sb.Append(term).Append(' ');
                 string content = sb.ToString();
                 Field noTf = NewField("noTf", content + (i % 2 == 0 ? "" : " notf"), omitType);
                 doc.Add(noTf);

--- a/src/Lucene.Net.Tests/Index/TestPayloads.cs
+++ b/src/Lucene.Net.Tests/Index/TestPayloads.cs
@@ -157,7 +157,7 @@ namespace Lucene.Net.Index
             for (int i = 0; i < terms.Length; i++)
             {
                 sb.Append(terms[i].Text);
-                sb.Append(" ");
+                sb.Append(' ');
             }
             string content = sb.ToString();
 
@@ -331,11 +331,11 @@ namespace Lucene.Net.Index
             for (int i = 0; i < n; i++)
             {
                 sb.Length = 0;
-                sb.Append("t");
+                sb.Append('t');
                 int zeros = maxDigits - (int)(Math.Log(i) / Math.Log(10));
                 for (int j = 0; j < zeros; j++)
                 {
-                    sb.Append("0");
+                    sb.Append('0');
                 }
                 sb.Append(i);
                 terms[i] = new Term(fieldName, sb.ToString());

--- a/src/Lucene.Net.Tests/Search/BaseTestRangeFilter.cs
+++ b/src/Lucene.Net.Tests/Search/BaseTestRangeFilter.cs
@@ -89,7 +89,7 @@ namespace Lucene.Net.Search
             string s = Convert.ToString(n);
             for (int i = s.Length; i <= intLength; i++)
             {
-                b.Append("0");
+                b.Append('0');
             }
             b.Append(s);
 

--- a/src/Lucene.Net.Tests/Search/TestMultiPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiPhraseQuery.cs
@@ -401,13 +401,13 @@ namespace Lucene.Net.Search
             Directory dir = new RAMDirectory();
             Token[] tokens = new Token[3];
             tokens[0] = new Token();
-            tokens[0].Append("a");
+            tokens[0].Append('a');
             tokens[0].PositionIncrement = 1;
             tokens[1] = new Token();
-            tokens[1].Append("b");
+            tokens[1].Append('b');
             tokens[1].PositionIncrement = 0;
             tokens[2] = new Token();
-            tokens[2].Append("c");
+            tokens[2].Append('c');
             tokens[2].PositionIncrement = 0;
 
             RandomIndexWriter writer = new RandomIndexWriter(Random, dir);

--- a/src/Lucene.Net.Tests/Store/TestWindowsMMap.cs
+++ b/src/Lucene.Net.Tests/Store/TestWindowsMMap.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Store
             for (int fx = 0; fx < fl; fx++)
             {
                 fb.Append(RandomToken());
-                fb.Append(" ");
+                fb.Append(' ');
             }
             return fb.ToString();
         }

--- a/src/Lucene.Net.Tests/Support/Diagnostics/TestDebugging.cs
+++ b/src/Lucene.Net.Tests/Support/Diagnostics/TestDebugging.cs
@@ -200,8 +200,8 @@ namespace Lucene.Net.Diagnostics
                     parameters.Add(test.Parameter);
                     if (i > 0)
                     {
-                        messageFormat.Append(" ");
-                        expectedMessage.Append(" ");
+                        messageFormat.Append(' ');
+                        expectedMessage.Append(' ');
                     }
                     messageFormat.Append(test.MessageFormatPrefix);
                     messageFormat.Append(i.ToString(CultureInfo.InvariantCulture));

--- a/src/Lucene.Net.Tests/Util/TestQueryBuilder.cs
+++ b/src/Lucene.Net.Tests/Util/TestQueryBuilder.cs
@@ -306,7 +306,7 @@ namespace Lucene.Net.Util
                 if (addSynonym) // inject our synonym
                 {
                     ClearAttributes();
-                    termAtt.SetEmpty().Append("國");
+                    termAtt.SetEmpty().Append('國');
                     posIncAtt.PositionIncrement = 0;
                     addSynonym = false;
                     return true;

--- a/src/Lucene.Net/Document/Document.cs
+++ b/src/Lucene.Net/Document/Document.cs
@@ -480,10 +480,10 @@ namespace Lucene.Net.Documents
                 }
                 if (i != fields.Count - 1)
                 {
-                    buffer.Append(" ");
+                    buffer.Append(' ');
                 }
             }
-            buffer.Append(">");
+            buffer.Append('>');
             return buffer.ToString();
         }
 

--- a/src/Lucene.Net/Document/FieldType.cs
+++ b/src/Lucene.Net/Document/FieldType.cs
@@ -290,7 +290,7 @@ namespace Lucene.Net.Documents
             {
                 if (result.Length > 0)
                 {
-                    result.Append(",");
+                    result.Append(',');
                 }
                 result.Append("indexed");
                 if (IsTokenized)
@@ -335,7 +335,7 @@ namespace Lucene.Net.Documents
             {
                 if (result.Length > 0)
                 {
-                    result.Append(",");
+                    result.Append(',');
                 }
                 result.Append("docValueType=");
                 result.Append(docValueType);

--- a/src/Lucene.Net/Index/CompositeReader.cs
+++ b/src/Lucene.Net/Index/CompositeReader.cs
@@ -89,7 +89,7 @@ namespace Lucene.Net.Index
                 buffer.Append(subReaders[0]);
                 for (int i = 1, c = subReaders.Count; i < c; ++i)
                 {
-                    buffer.Append(" ").Append(subReaders[i]);
+                    buffer.Append(' ').Append(subReaders[i]);
                 }
             }
             buffer.Append(')');

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -5043,7 +5043,7 @@ namespace Lucene.Net.Index
                     {
                         builder.Append(info.Info.Name).Append(", ");
                     }
-                    builder.Append("]");
+                    builder.Append(']');
                     // don't call mergingSegments.toString() could lead to ConcurrentModException
                     // since merge updates the segments FieldInfos
                     if (infoStream.IsEnabled("IW"))

--- a/src/Lucene.Net/Index/LogMergePolicy.cs
+++ b/src/Lucene.Net/Index/LogMergePolicy.cs
@@ -748,7 +748,7 @@ namespace Lucene.Net.Index
             sb.Append("maxMergeDocs=").Append(m_maxMergeDocs).Append(", ");
             sb.Append("maxCFSSegmentSizeMB=").Append(MaxCFSSegmentSizeMB).Append(", ");
             sb.Append("noCFSRatio=").Append(m_noCFSRatio);
-            sb.Append("]");
+            sb.Append(']');
             return sb.ToString();
         }
     }

--- a/src/Lucene.Net/Index/StandardDirectoryReader.cs
+++ b/src/Lucene.Net/Index/StandardDirectoryReader.cs
@@ -300,7 +300,7 @@ namespace Lucene.Net.Index
             string segmentsFile = segmentInfos.GetSegmentsFileName();
             if (segmentsFile != null)
             {
-                buffer.Append(segmentsFile).Append(":").Append(segmentInfos.Version);
+                buffer.Append(segmentsFile).Append(':').Append(segmentInfos.Version);
             }
             if (writer != null)
             {

--- a/src/Lucene.Net/Search/AutomatonQuery.cs
+++ b/src/Lucene.Net/Search/AutomatonQuery.cs
@@ -126,13 +126,13 @@ namespace Lucene.Net.Search
             if (!m_term.Field.Equals(field, StringComparison.Ordinal))
             {
                 buffer.Append(m_term.Field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
             buffer.Append(this.GetType().Name);
             buffer.Append(" {");
             buffer.Append('\n');
             buffer.Append(m_automaton.ToString());
-            buffer.Append("}");
+            buffer.Append('}');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Search/BooleanQuery.cs
+++ b/src/Lucene.Net/Search/BooleanQuery.cs
@@ -611,7 +611,7 @@ namespace Lucene.Net.Search
             bool needParens = Boost != 1.0 || MinimumNumberShouldMatch > 0;
             if (needParens)
             {
-                buffer.Append("(");
+                buffer.Append('(');
             }
 
             for (int i = 0; i < clauses.Count; i++)
@@ -619,11 +619,11 @@ namespace Lucene.Net.Search
                 BooleanClause c = clauses[i];
                 if (c.IsProhibited)
                 {
-                    buffer.Append("-");
+                    buffer.Append('-');
                 }
                 else if (c.IsRequired)
                 {
-                    buffer.Append("+");
+                    buffer.Append('+');
                 }
 
                 Query subQuery = c.Query;
@@ -631,9 +631,9 @@ namespace Lucene.Net.Search
                 {
                     if (subQuery is BooleanQuery) // wrap sub-bools in parens
                     {
-                        buffer.Append("(");
+                        buffer.Append('(');
                         buffer.Append(subQuery.ToString(field));
-                        buffer.Append(")");
+                        buffer.Append(')');
                     }
                     else
                     {
@@ -647,13 +647,13 @@ namespace Lucene.Net.Search
 
                 if (i != clauses.Count - 1)
                 {
-                    buffer.Append(" ");
+                    buffer.Append(' ');
                 }
             }
 
             if (needParens)
             {
-                buffer.Append(")");
+                buffer.Append(')');
             }
 
             if (MinimumNumberShouldMatch > 0)

--- a/src/Lucene.Net/Search/BooleanScorer.cs
+++ b/src/Lucene.Net/Search/BooleanScorer.cs
@@ -301,9 +301,9 @@ namespace Lucene.Net.Search
             for (SubScorer sub = scorers; sub != null; sub = sub.Next)
             {
                 buffer.Append(sub.Scorer.ToString());
-                buffer.Append(" ");
+                buffer.Append(' ');
             }
-            buffer.Append(")");
+            buffer.Append(')');
             return buffer.ToString();
         }
     }

--- a/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
+++ b/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
@@ -312,16 +312,16 @@ namespace Lucene.Net.Search
         public override string ToString(string field)
         {
             StringBuilder buffer = new StringBuilder();
-            buffer.Append("(");
+            buffer.Append('(');
             int numDisjunctions = disjuncts.Count;
             for (int i = 0; i < numDisjunctions; i++)
             {
                 Query subquery = disjuncts[i];
                 if (subquery is BooleanQuery) // wrap sub-bools in parens
                 {
-                    buffer.Append("(");
+                    buffer.Append('(');
                     buffer.Append(subquery.ToString(field));
-                    buffer.Append(")");
+                    buffer.Append(')');
                 }
                 else
                 {
@@ -332,15 +332,15 @@ namespace Lucene.Net.Search
                     buffer.Append(" | ");
                 }
             }
-            buffer.Append(")");
+            buffer.Append(')');
             if (tieBreakerMultiplier != 0.0f)
             {
-                buffer.Append("~");
+                buffer.Append('~');
                 buffer.Append(tieBreakerMultiplier);
             }
             if (Boost != 1.0)
             {
-                buffer.Append("^");
+                buffer.Append('^');
                 buffer.Append(Boost);
             }
             return buffer.ToString();

--- a/src/Lucene.Net/Search/DocTermOrdsRangeFilter.cs
+++ b/src/Lucene.Net/Search/DocTermOrdsRangeFilter.cs
@@ -148,7 +148,7 @@ namespace Lucene.Net.Search
 
         public override sealed string ToString()
         {
-            StringBuilder sb = (new StringBuilder(field)).Append(":");
+            StringBuilder sb = (new StringBuilder(field)).Append(':');
             return sb.Append(includeLower ? '[' : '{')
                 .Append((lowerVal is null) ? "*" : lowerVal.ToString())
                 .Append(" TO ")

--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -1082,8 +1082,8 @@ namespace Lucene.Net.Search
             public override string ToString()
             {
                 StringBuilder b = new StringBuilder();
-                b.Append(''').Append(ReaderKey).Append("'=>");
-                b.Append(''').Append(FieldName).Append("',");
+                b.Append('\'').Append(ReaderKey).Append("'=>");
+                b.Append('\'').Append(FieldName).Append("',");
                 b.Append(CacheType).Append(',').Append(custom is null ? "null" : custom.ToString()); // LUCENENET specific: use field instead of property
                 b.Append("=>").Append(Value.GetType().FullName).Append('#');
                 b.Append(RuntimeHelpers.GetHashCode(Value));

--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -1082,10 +1082,10 @@ namespace Lucene.Net.Search
             public override string ToString()
             {
                 StringBuilder b = new StringBuilder();
-                b.Append("'").Append(ReaderKey).Append("'=>");
-                b.Append("'").Append(FieldName).Append("',");
-                b.Append(CacheType).Append(",").Append(custom is null ? "null" : custom.ToString()); // LUCENENET specific: use field instead of property
-                b.Append("=>").Append(Value.GetType().FullName).Append("#");
+                b.Append(''').Append(ReaderKey).Append("'=>");
+                b.Append(''').Append(FieldName).Append("',");
+                b.Append(CacheType).Append(',').Append(custom is null ? "null" : custom.ToString()); // LUCENENET specific: use field instead of property
+                b.Append("=>").Append(Value.GetType().FullName).Append('#');
                 b.Append(RuntimeHelpers.GetHashCode(Value));
 
                 string s = EstimatedSize;

--- a/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
+++ b/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
@@ -733,7 +733,7 @@ namespace Lucene.Net.Search
         // From line 516 in Lucene
         public override sealed string ToString()
         {
-            StringBuilder sb = (new StringBuilder(field)).Append(":");
+            StringBuilder sb = (new StringBuilder(field)).Append(':');
             return sb.Append(includeLower ? '[' : '{').Append((lowerVal is null) ? "*" : lowerVal.ToString()).Append(" TO ").Append((upperVal is null) ? "*" : upperVal.ToString()).Append(includeUpper ? ']' : '}').ToString();
         }
 

--- a/src/Lucene.Net/Search/FuzzyQuery.cs
+++ b/src/Lucene.Net/Search/FuzzyQuery.cs
@@ -166,7 +166,7 @@ namespace Lucene.Net.Search
             if (!term.Field.Equals(field, StringComparison.Ordinal))
             {
                 buffer.Append(term.Field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
             buffer.Append(term.Text);
             buffer.Append('~');

--- a/src/Lucene.Net/Search/MultiPhraseQuery.cs
+++ b/src/Lucene.Net/Search/MultiPhraseQuery.cs
@@ -381,7 +381,7 @@ namespace Lucene.Net.Search
             if (field is null || !field.Equals(f, StringComparison.Ordinal))
             {
                 buffer.Append(field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
 
             buffer.Append("\"");
@@ -397,7 +397,7 @@ namespace Lucene.Net.Search
                 }
                 else
                 {
-                    buffer.Append(" ");
+                    buffer.Append(' ');
                     for (int j = 1; j < (position - lastPos); j++)
                     {
                         buffer.Append("? ");
@@ -405,16 +405,16 @@ namespace Lucene.Net.Search
                 }
                 if (terms.Length > 1)
                 {
-                    buffer.Append("(");
+                    buffer.Append('(');
                     for (int j = 0; j < terms.Length; j++)
                     {
                         buffer.Append(terms[j].Text);
                         if (j < terms.Length - 1)
                         {
-                            buffer.Append(" ");
+                            buffer.Append(' ');
                         }
                     }
-                    buffer.Append(")");
+                    buffer.Append(')');
                 }
                 else
                 {
@@ -427,7 +427,7 @@ namespace Lucene.Net.Search
 
             if (slop != 0)
             {
-                buffer.Append("~");
+                buffer.Append('~');
                 buffer.Append(slop);
             }
 

--- a/src/Lucene.Net/Search/Payloads/PayloadNearQuery.cs
+++ b/src/Lucene.Net/Search/Payloads/PayloadNearQuery.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Search.Payloads
             buffer.Append(m_slop);
             buffer.Append(", ");
             buffer.Append(m_inOrder);
-            buffer.Append(")");
+            buffer.Append(')');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Search/PhraseQuery.cs
+++ b/src/Lucene.Net/Search/PhraseQuery.cs
@@ -448,7 +448,7 @@ namespace Lucene.Net.Search
             if (field != null && !field.Equals(f, StringComparison.Ordinal))
             {
                 buffer.Append(field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
 
             buffer.Append("\"");
@@ -487,7 +487,7 @@ namespace Lucene.Net.Search
 
             if (slop != 0)
             {
-                buffer.Append("~");
+                buffer.Append('~');
                 buffer.Append(slop);
             }
 

--- a/src/Lucene.Net/Search/PrefixFilter.cs
+++ b/src/Lucene.Net/Search/PrefixFilter.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Search
             StringBuilder buffer = new StringBuilder();
             buffer.Append("PrefixFilter(");
             buffer.Append(Prefix.ToString());
-            buffer.Append(")");
+            buffer.Append(')');
             return buffer.ToString();
         }
     }

--- a/src/Lucene.Net/Search/PrefixQuery.cs
+++ b/src/Lucene.Net/Search/PrefixQuery.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Search
             if (!Field.Equals(field, StringComparison.Ordinal))
             {
                 buffer.Append(Field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
             buffer.Append(_prefix.Text);
             buffer.Append('*');

--- a/src/Lucene.Net/Search/RegexpQuery.cs
+++ b/src/Lucene.Net/Search/RegexpQuery.cs
@@ -105,7 +105,7 @@ namespace Lucene.Net.Search
             if (!m_term.Field.Equals(field, StringComparison.Ordinal))
             {
                 buffer.Append(m_term.Field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
             buffer.Append('/');
             buffer.Append(m_term.Text);

--- a/src/Lucene.Net/Search/Spans/FieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net/Search/Spans/FieldMaskingSpanQuery.cs
@@ -131,7 +131,7 @@ namespace Lucene.Net.Search.Spans
             StringBuilder buffer = new StringBuilder();
             buffer.Append("mask(");
             buffer.Append(maskedQuery.ToString(field));
-            buffer.Append(")");
+            buffer.Append(')');
             buffer.Append(ToStringUtils.Boost(Boost));
             buffer.Append(" as ");
             buffer.Append(this.field);

--- a/src/Lucene.Net/Search/Spans/SpanFirstQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanFirstQuery.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Search.Spans
             buffer.Append(m_match.ToString(field));
             buffer.Append(", ");
             buffer.Append(m_end);
-            buffer.Append(")");
+            buffer.Append(')');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Search/Spans/SpanMultiTermQueryWrapper.cs
+++ b/src/Lucene.Net/Search/Spans/SpanMultiTermQueryWrapper.cs
@@ -103,7 +103,7 @@ namespace Lucene.Net.Search.Spans
             StringBuilder builder = new StringBuilder();
             builder.Append("SpanMultiTermQueryWrapper(");
             builder.Append(m_query.ToString(field));
-            builder.Append(")");
+            builder.Append(')');
             if (Boost != 1F)
             {
                 builder.Append('^');

--- a/src/Lucene.Net/Search/Spans/SpanNearPayloadCheckQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanNearPayloadCheckQuery.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Search.Spans
                 ToStringUtils.ByteArray(buffer, bytes);
                 buffer.Append(';');
             }
-            buffer.Append(")");
+            buffer.Append(')');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Search/Spans/SpanNearQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanNearQuery.cs
@@ -124,7 +124,7 @@ namespace Lucene.Net.Search.Spans
             buffer.Append(m_slop);
             buffer.Append(", ");
             buffer.Append(m_inOrder);
-            buffer.Append(")");
+            buffer.Append(')');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Search/Spans/SpanNotQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanNotQuery.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Search.Spans
             buffer.Append(Convert.ToString(pre));
             buffer.Append(", ");
             buffer.Append(Convert.ToString(post));
-            buffer.Append(")");
+            buffer.Append(')');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Search/Spans/SpanPayloadCheckQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanPayloadCheckQuery.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Search.Spans
                 ToStringUtils.ByteArray(buffer, bytes);
                 buffer.Append(';');
             }
-            buffer.Append(")");
+            buffer.Append(')');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Search/Spans/SpanPositionRangeQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanPositionRangeQuery.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Search.Spans
             buffer.Append(m_match.ToString(field));
             buffer.Append(", ").Append(m_start).Append(", ");
             buffer.Append(m_end);
-            buffer.Append(")");
+            buffer.Append(')');
             buffer.Append(ToStringUtils.Boost(Boost));
             return buffer.ToString();
         }

--- a/src/Lucene.Net/Search/TermQuery.cs
+++ b/src/Lucene.Net/Search/TermQuery.cs
@@ -215,7 +215,7 @@ namespace Lucene.Net.Search
             if (!term.Field.Equals(field, StringComparison.Ordinal))
             {
                 buffer.Append(term.Field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
             buffer.Append(term.Text);
             buffer.Append(ToStringUtils.Boost(Boost));

--- a/src/Lucene.Net/Search/TermRangeQuery.cs
+++ b/src/Lucene.Net/Search/TermRangeQuery.cs
@@ -129,7 +129,7 @@ namespace Lucene.Net.Search
             if (!Field.Equals(field, StringComparison.Ordinal))
             {
                 buffer.Append(Field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
             buffer.Append(includeLower ? '[' : '{');
             // TODO: all these toStrings for queries should just output the bytes, it might not be UTF-8!

--- a/src/Lucene.Net/Search/WildcardQuery.cs
+++ b/src/Lucene.Net/Search/WildcardQuery.cs
@@ -123,7 +123,7 @@ namespace Lucene.Net.Search
             if (!Field.Equals(field, StringComparison.Ordinal))
             {
                 buffer.Append(Field);
-                buffer.Append(":");
+                buffer.Append(':');
             }
             buffer.Append(Term.Text);
             buffer.Append(ToStringUtils.Boost(Boost));

--- a/src/Lucene.Net/Util/Automaton/RegExp.cs
+++ b/src/Lucene.Net/Util/Automaton/RegExp.cs
@@ -663,11 +663,11 @@ namespace Lucene.Net.Util.Automaton
             switch (kind)
             {
                 case Kind.REGEXP_UNION:
-                    b.Append("(");
+                    b.Append('(');
                     exp1.ToStringBuilder(b);
-                    b.Append("|");
+                    b.Append('|');
                     exp2.ToStringBuilder(b);
-                    b.Append(")");
+                    b.Append(')');
                     break;
 
                 case Kind.REGEXP_CONCATENATION:
@@ -676,75 +676,75 @@ namespace Lucene.Net.Util.Automaton
                     break;
 
                 case Kind.REGEXP_INTERSECTION:
-                    b.Append("(");
+                    b.Append('(');
                     exp1.ToStringBuilder(b);
-                    b.Append("&");
+                    b.Append('&');
                     exp2.ToStringBuilder(b);
-                    b.Append(")");
+                    b.Append(')');
                     break;
 
                 case Kind.REGEXP_OPTIONAL:
-                    b.Append("(");
+                    b.Append('(');
                     exp1.ToStringBuilder(b);
                     b.Append(")?");
                     break;
 
                 case Kind.REGEXP_REPEAT:
-                    b.Append("(");
+                    b.Append('(');
                     exp1.ToStringBuilder(b);
                     b.Append(")*");
                     break;
 
                 case Kind.REGEXP_REPEAT_MIN:
-                    b.Append("(");
+                    b.Append('(');
                     exp1.ToStringBuilder(b);
                     b.Append("){").Append(min).Append(",}");
                     break;
 
                 case Kind.REGEXP_REPEAT_MINMAX:
-                    b.Append("(");
+                    b.Append('(');
                     exp1.ToStringBuilder(b);
-                    b.Append("){").Append(min).Append(",").Append(max).Append("}");
+                    b.Append("){").Append(min).Append(',').Append(max).Append('}');
                     break;
 
                 case Kind.REGEXP_COMPLEMENT:
                     b.Append("~(");
                     exp1.ToStringBuilder(b);
-                    b.Append(")");
+                    b.Append(')');
                     break;
 
                 case Kind.REGEXP_CHAR:
-                    b.Append("\\").AppendCodePoint(c);
+                    b.Append('\\').AppendCodePoint(c);
                     break;
 
                 case Kind.REGEXP_CHAR_RANGE:
-                    b.Append("[\\").AppendCodePoint(from).Append("-\\").AppendCodePoint(to).Append("]");
+                    b.Append("[\\").AppendCodePoint(from).Append("-\\").AppendCodePoint(to).Append(']');
                     break;
 
                 case Kind.REGEXP_ANYCHAR:
-                    b.Append(".");
+                    b.Append('.');
                     break;
 
                 case Kind.REGEXP_EMPTY:
-                    b.Append("#");
+                    b.Append('#');
                     break;
 
                 case Kind.REGEXP_STRING:
-                    b.Append("\"").Append(s).Append("\"");
+                    b.Append('\"').Append(s).Append('\"');
                     break;
 
                 case Kind.REGEXP_ANYSTRING:
-                    b.Append("@");
+                    b.Append('@');
                     break;
 
                 case Kind.REGEXP_AUTOMATON:
-                    b.Append("<").Append(s).Append(">");
+                    b.Append('<').Append(s).Append('>');
                     break;
 
                 case Kind.REGEXP_INTERVAL:
                     string s1 = Convert.ToString(min, CultureInfo.InvariantCulture);
                     string s2 = Convert.ToString(max, CultureInfo.InvariantCulture);
-                    b.Append("<");
+                    b.Append('<');
                     if (digits > 0)
                     {
                         for (int i = s1.Length; i < digits; i++)
@@ -752,7 +752,7 @@ namespace Lucene.Net.Util.Automaton
                             b.Append('0');
                         }
                     }
-                    b.Append(s1).Append("-");
+                    b.Append(s1).Append('-');
                     if (digits > 0)
                     {
                         for (int i = s2.Length; i < digits; i++)
@@ -760,7 +760,7 @@ namespace Lucene.Net.Util.Automaton
                             b.Append('0');
                         }
                     }
-                    b.Append(s2).Append(">");
+                    b.Append(s2).Append('>');
                     break;
             }
             return b;

--- a/src/Lucene.Net/Util/Automaton/RunAutomaton.cs
+++ b/src/Lucene.Net/Util/Automaton/RunAutomaton.cs
@@ -85,11 +85,11 @@ namespace Lucene.Net.Util.Automaton
                         {
                             max = _maxInterval;
                         }
-                        b.Append(" ");
+                        b.Append(' ');
                         Transition.AppendCharString(min, b);
                         if (min != max)
                         {
-                            b.Append("-");
+                            b.Append('-');
                             Transition.AppendCharString(max, b);
                         }
                         b.Append(" -> ").Append(k).Append("\n");

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -345,7 +345,7 @@ namespace Lucene.Net.Util.Automaton
             b.Append(":\n");
             foreach (Transition t in GetTransitions())
             {
-                b.Append("  ").Append(t.ToString()).Append("\n");
+                b.Append("  ").Append(t.ToString()).Append('\n');
             }
             return b.ToString();
         }

--- a/src/Lucene.Net/Util/Automaton/Transition.cs
+++ b/src/Lucene.Net/Util/Automaton/Transition.cs
@@ -178,7 +178,7 @@ namespace Lucene.Net.Util.Automaton
                 }
                 else if (c < 0x10000000)
                 {
-                    b.Append("0").Append(s);
+                    b.Append('0').Append(s);
                 }
                 else
                 {
@@ -197,7 +197,7 @@ namespace Lucene.Net.Util.Automaton
             AppendCharString(min, b);
             if (min != max)
             {
-                b.Append("-");
+                b.Append('-');
                 AppendCharString(max, b);
             }
             b.Append(" -> ").Append(to.number);
@@ -211,7 +211,7 @@ namespace Lucene.Net.Util.Automaton
             AppendCharString(min, b);
             if (min != max)
             {
-                b.Append("-");
+                b.Append('-');
                 AppendCharString(max, b);
             }
             b.Append("\"]\n");


### PR DESCRIPTION
Fixes #674.