### PR TITLE
Lucene.Net.Search.Similarities: Statically imported SimilarityBase, where approrpriate

### DIFF
--- a/src/Lucene.Net/Search/Similarities/BasicModelBE.cs
+++ b/src/Lucene.Net/Search/Similarities/BasicModelBE.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using static Lucene.Net.Search.Similarities.SimilarityBase;
 
 namespace Lucene.Net.Search.Similarities
 {
@@ -46,7 +47,7 @@ namespace Lucene.Net.Search.Similarities
             double F = stats.TotalTermFreq + 1 + tfn;
             // approximation only holds true when F << N, so we use N += F
             double N = F + stats.NumberOfDocuments;
-            return (float)(-SimilarityBase.Log2((N - 1) * Math.E) + this.F(N + F - 1, N + F - tfn - 2) - this.F(F, F - tfn));
+            return (float)(-Log2((N - 1) * Math.E) + this.F(N + F - 1, N + F - tfn - 2) - this.F(F, F - tfn));
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Lucene.Net.Search.Similarities
         [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         private double F(double n, double m)
         {
-            return (m + 0.5) * SimilarityBase.Log2(n / m) + (n - m) * SimilarityBase.Log2(n);
+            return (m + 0.5) * Log2(n / m) + (n - m) * Log2(n);
         }
 
         public override string ToString()

--- a/src/Lucene.Net/Search/Similarities/BasicModelD.cs
+++ b/src/Lucene.Net/Search/Similarities/BasicModelD.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using static Lucene.Net.Search.Similarities.SimilarityBase;
 
 namespace Lucene.Net.Search.Similarities
 {
@@ -49,8 +50,8 @@ namespace Lucene.Net.Search.Similarities
             double phi = (double)tfn / F;
             double nphi = 1 - phi;
             double p = 1.0 / (stats.NumberOfDocuments + 1);
-            double D = phi * SimilarityBase.Log2(phi / p) + nphi * SimilarityBase.Log2(nphi / (1 - p));
-            return (float)(D * F + 0.5 * SimilarityBase.Log2(1 + 2 * Math.PI * tfn * nphi));
+            double D = phi * Log2(phi / p) + nphi * Log2(nphi / (1 - p));
+            return (float)(D * F + 0.5 * Log2(1 + 2 * Math.PI * tfn * nphi));
         }
 
         public override string ToString()

--- a/src/Lucene.Net/Search/Similarities/BasicModelG.cs
+++ b/src/Lucene.Net/Search/Similarities/BasicModelG.cs
@@ -1,3 +1,5 @@
+﻿using static Lucene.Net.Search.Similarities.SimilarityBase;
+
 namespace Lucene.Net.Search.Similarities
 {
     /*
@@ -39,7 +41,7 @@ namespace Lucene.Net.Search.Similarities
             double N = stats.NumberOfDocuments;
             double lambda = F / (N + F);
             // -log(1 / (lambda + 1)) -> log(lambda + 1)
-            return (float)(SimilarityBase.Log2(lambda + 1) + tfn * SimilarityBase.Log2((1 + lambda) / lambda));
+            return (float)(Log2(lambda + 1) + tfn * Log2((1 + lambda) / lambda));
         }
 
         public override string ToString()

--- a/src/Lucene.Net/Search/Similarities/BasicModelIF.cs
+++ b/src/Lucene.Net/Search/Similarities/BasicModelIF.cs
@@ -1,3 +1,5 @@
+﻿using static Lucene.Net.Search.Similarities.SimilarityBase;
+
 namespace Lucene.Net.Search.Similarities
 {
     /*
@@ -34,7 +36,7 @@ namespace Lucene.Net.Search.Similarities
         {
             long N = stats.NumberOfDocuments;
             long F = stats.TotalTermFreq;
-            return tfn * (float)(SimilarityBase.Log2(1 + (N + 1) / (F + 0.5)));
+            return tfn * (float)(Log2(1 + (N + 1) / (F + 0.5)));
         }
 
         public override string ToString()

--- a/src/Lucene.Net/Search/Similarities/BasicModelIn.cs
+++ b/src/Lucene.Net/Search/Similarities/BasicModelIn.cs
@@ -1,3 +1,5 @@
+﻿using static Lucene.Net.Search.Similarities.SimilarityBase;
+
 namespace Lucene.Net.Search.Similarities
 {
     /*
@@ -34,7 +36,7 @@ namespace Lucene.Net.Search.Similarities
         {
             long N = stats.NumberOfDocuments;
             long n = stats.DocFreq;
-            return tfn * (float)(SimilarityBase.Log2((N + 1) / (n + 0.5)));
+            return tfn * (float)(Log2((N + 1) / (n + 0.5)));
         }
 
         public override sealed Explanation Explain(BasicStats stats, float tfn)

--- a/src/Lucene.Net/Search/Similarities/BasicModelIne.cs
+++ b/src/Lucene.Net/Search/Similarities/BasicModelIne.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using static Lucene.Net.Search.Similarities.SimilarityBase;
 
 namespace Lucene.Net.Search.Similarities
 {
@@ -38,7 +39,7 @@ namespace Lucene.Net.Search.Similarities
             long N = stats.NumberOfDocuments;
             long F = stats.TotalTermFreq;
             double ne = N * (1 - Math.Pow((N - 1) / (double)N, F));
-            return tfn * (float)(SimilarityBase.Log2((N + 1) / (ne + 0.5)));
+            return tfn * (float)(Log2((N + 1) / (ne + 0.5)));
         }
 
         public override string ToString()

--- a/src/Lucene.Net/Search/Similarities/BasicModelP.cs
+++ b/src/Lucene.Net/Search/Similarities/BasicModelP.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using static Lucene.Net.Search.Similarities.SimilarityBase;
 
 namespace Lucene.Net.Search.Similarities
 {
@@ -32,7 +33,7 @@ namespace Lucene.Net.Search.Similarities
     {
         /// <summary>
         /// <c>log2(Math.E)</c>, precomputed. </summary>
-        protected internal static double LOG2_E = SimilarityBase.Log2(Math.E);
+        protected internal static double LOG2_E = Log2(Math.E);
 
         /// <summary>
         /// Sole constructor: parameter-free </summary>
@@ -43,7 +44,7 @@ namespace Lucene.Net.Search.Similarities
         public override sealed float Score(BasicStats stats, float tfn)
         {
             float lambda = (float)(stats.TotalTermFreq + 1) / (stats.NumberOfDocuments + 1);
-            return (float)(tfn * SimilarityBase.Log2(tfn / lambda) + (lambda + 1 / (12 * tfn) - tfn) * LOG2_E + 0.5 * SimilarityBase.Log2(2 * Math.PI * tfn));
+            return (float)(tfn * Log2(tfn / lambda) + (lambda + 1 / (12 * tfn) - tfn) * LOG2_E + 0.5 * Log2(2 * Math.PI * tfn));
         }
 
         public override string ToString()

--- a/src/Lucene.Net/Search/Similarities/NormalizationH2.cs
+++ b/src/Lucene.Net/Search/Similarities/NormalizationH2.cs
@@ -1,3 +1,5 @@
+﻿using static Lucene.Net.Search.Similarities.SimilarityBase;
+
 namespace Lucene.Net.Search.Similarities
 {
     /*
@@ -50,7 +52,7 @@ namespace Lucene.Net.Search.Similarities
 
         public override sealed float Tfn(BasicStats stats, float tf, float len)
         {
-            return (float)(tf * SimilarityBase.Log2(1 + c * stats.AvgFieldLength / len));
+            return (float)(tf * Log2(1 + c * stats.AvgFieldLength / len));
         }
 
         public override string ToString()


### PR DESCRIPTION
Statically imported `SimilarityBase` where appropriate so the `Log2` method doesn't have to be qualified (like in Lucene). Fixes #694.