### PR TITLE
Lucene.Net.Analysis.Kuromoji.Util.CSVUtil: Fixed QuoteEscape method

### DIFF
--- a/src/Lucene.Net.Analysis.Kuromoji/Util/CSVUtil.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Util/CSVUtil.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Analysis.Ja.Util
 
             if (result.IndexOf('\"') >= 0)
             {
-                result.Replace("\"", ESCAPED_QUOTE);
+                result = result.Replace("\"", ESCAPED_QUOTE); // LUCENENET 4.8.0: Applied SOLR-9413 (was fixed in Lucene 6.2/7.0)
             }
             if (result.IndexOf(COMMA) >= 0)
             {

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/Util/TestCSVUtil.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/Util/TestCSVUtil.cs
@@ -1,0 +1,60 @@
+﻿// Lucene version compatibility level 8.2.0
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System;
+
+namespace Lucene.Net.Analysis.Ja.Util
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Tests for the CSVUtil class.
+    /// </summary>
+    public class TestCSVUtil : LuceneTestCase
+    {
+        [Test]
+        public void TestQuoteEscapeQuotes()
+        {
+            String input = "\"Let It Be\" is a song and album by the The Beatles.";
+            String expectedOutput = input.Replace("\"", "\"\"");
+            ImplTestQuoteEscape(input, expectedOutput);
+        }
+
+        [Test]
+        public void TestQuoteEscapeComma()
+        {
+            String input = "To be, or not to be ...";
+            String expectedOutput = '"' + input + '"';
+            ImplTestQuoteEscape(input, expectedOutput);
+        }
+
+        [Test]
+        public void TestQuoteEscapeQuotesAndComma()
+        {
+            String input = "\"To be, or not to be ...\" is a well-known phrase from Shakespeare's Hamlet.";
+            String expectedOutput = '"' + input.Replace("\"", "\"\"") + '"';
+            ImplTestQuoteEscape(input, expectedOutput);
+        }
+
+        private void ImplTestQuoteEscape(String input, String expectedOutput)
+        {
+            String actualOutput = CSVUtil.QuoteEscape(input);
+            assertEquals(expectedOutput, actualOutput);
+        }
+    }
+}


### PR DESCRIPTION
Applied [SOLR-9413](https://issues.apache.org/jira/browse/SOLR-9413) patch to fix the `QuoteEscape()` method and add tests. Fixes #660.