### PR TITLE
Removed 3 private nested classes that were not in use

### DIFF
--- a/src/Lucene.Net.Codecs/Memory/DirectDocValuesProducer.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectDocValuesProducer.cs
@@ -654,12 +654,6 @@ namespace Lucene.Net.Codecs.Memory
             internal BinaryEntry values;
         }
 
-        internal class FSTEntry
-        {
-#pragma warning disable 649 // LUCENENET NOTE: Never assigned
-            internal long offset;
-            internal long numOrds;
-#pragma warning restore 649
-        }
+        // LUCENENET specific - removed FSTEntry because it is not in use.
     }
 }

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
@@ -203,51 +203,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             return fst.GetSizeInBytes();
         }
 
-        private class AnalyzingComparer : IComparer<BytesRef>
-        {
-            private readonly ByteArrayDataInput readerA = new ByteArrayDataInput();
-            private readonly ByteArrayDataInput readerB = new ByteArrayDataInput();
-            private readonly BytesRef scratchA = new BytesRef();
-            private readonly BytesRef scratchB = new BytesRef();
-
-            public virtual int Compare(BytesRef a, BytesRef b)
-            {
-                readerA.Reset(a.Bytes, a.Offset, a.Length);
-                readerB.Reset(b.Bytes, b.Offset, b.Length);
-
-                // By token:
-                scratchA.Length = (ushort)readerA.ReadInt16();
-                scratchA.Bytes = a.Bytes;
-                scratchA.Offset = readerA.Position;
-
-                scratchB.Bytes = b.Bytes;
-                scratchB.Length = (ushort)readerB.ReadInt16();
-                scratchB.Offset = readerB.Position;
-
-                int cmp = scratchA.CompareTo(scratchB);
-                if (cmp != 0)
-                {
-                    return cmp;
-                }
-                readerA.SkipBytes(scratchA.Length);
-                readerB.SkipBytes(scratchB.Length);
-
-                // By length (smaller surface forms sorted first):
-                cmp = a.Length - b.Length;
-                if (cmp != 0)
-                {
-                    return cmp;
-                }
-
-                // By surface form:
-                scratchA.Offset = readerA.Position;
-                scratchA.Length = a.Length - scratchA.Offset;
-                scratchB.Offset = readerB.Position;
-                scratchB.Length = b.Length - scratchB.Offset;
-
-                return scratchA.CompareTo(scratchB);
-            }
-        }
+        // LUCENENET specific - removed AnalyzingComparer because it is not in use.
 
         private Analyzer AddShingles(Analyzer other)
         {

--- a/src/Lucene.Net/Support/Arrays.cs
+++ b/src/Lucene.Net/Support/Arrays.cs
@@ -217,6 +217,13 @@ namespace Lucene.Net.Support
 #endif
         }
 
-        // LUCENENET specific - removed EmptyArrayHolder because it is not in use.
+#if !FEATURE_ARRAYEMPTY
+        private static class EmptyArrayHolder<T>
+        {
+#pragma warning disable CA1825 // Avoid zero-length array allocations.
+            public static readonly T[] EMPTY = new T[0];
+#pragma warning restore CA1825 // Avoid zero-length array allocations.
+        }
+#endif
     }
 }

--- a/src/Lucene.Net/Support/Arrays.cs
+++ b/src/Lucene.Net/Support/Arrays.cs
@@ -217,11 +217,6 @@ namespace Lucene.Net.Support
 #endif
         }
 
-        private static class EmptyArrayHolder<T>
-        {
-#pragma warning disable CA1825 // Avoid zero-length array allocations.
-            public static readonly T[] EMPTY = new T[0];
-#pragma warning restore CA1825 // Avoid zero-length array allocations.
-        }
+        // LUCENENET specific - removed EmptyArrayHolder because it is not in use.
     }
 }


### PR DESCRIPTION
Classes removed: DirectDocValuesProducer.FSTEntry,  FreeTextSuggester.AnalyzingComparer and Arrays.EmptyArrayHolder. Replaced code with appropriate LUCENENET comment.  Related to Issue #669