### PR TITLE
PERFORMANCE: Reduced char[] and string allocations (mostly in analysis)

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -73,6 +73,7 @@
     <RandomizedTestingGeneratorsPackageVersion>2.7.8</RandomizedTestingGeneratorsPackageVersion>
     <SharpZipLibPackageVersion>1.1.0</SharpZipLibPackageVersion>
     <Spatial4nPackageVersion>0.4.1.1</Spatial4nPackageVersion>
+    <SystemMemoryPackageVersion>4.5.4</SystemMemoryPackageVersion>
     <SystemReflectionEmitPackageVersion>4.3.0</SystemReflectionEmitPackageVersion>
     <SystemReflectionEmitILGenerationPackageVersion>4.3.0</SystemReflectionEmitILGenerationPackageVersion>
     <SystemReflectionTypeExtensionsPackageVersion>4.3.0</SystemReflectionTypeExtensionsPackageVersion>

--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
@@ -31095,15 +31095,12 @@ namespace Lucene.Net.Analysis.CharFilters
             zzLexicalState = newState;
         }
 
-
-        /// <summary>
-        /// Returns the text matched by the current regular expression.
-        /// </summary>
-        /// <returns>Returns the text matched by the current regular expression.</returns>
-        private string YyText()
-        {
-            return new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
-        }
+        // LUCENENET: Not used - refactored to read the array directly to avoid allocations
+        ///// <summary>
+        ///// Returns the text matched by the current regular expression.
+        ///// </summary>
+        ///// <returns>Returns the text matched by the current regular expression.</returns>
+        //private string YyText => new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
 
         /// <summary>
         /// Returns the character at position <tt>pos</tt> from the 
@@ -31372,9 +31369,9 @@ namespace Lucene.Net.Analysis.CharFilters
                             inputSegment.Write(zzBuffer, zzStartRead, matchLength);
                             if (matchLength <= 7)
                             { // 0x10FFFF = 1114111: max 7 decimal chars
-                                // LUCENENET: Originally, we got the value of YyText(), which allocates..so we can eliminate the allocation
-                                // by grabbing the values YyText() converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
-                                if (!J2N.Numerics.Int32.TryParse(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead, radix: 10, out int codePoint))
+                                // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                                // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                                if (!Integer.TryParse(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead, radix: 10, out int codePoint))
                                 {
                                     if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing code point '{0}'", new CharArrayFormatter(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead));
                                 }
@@ -31627,7 +31624,9 @@ namespace Lucene.Net.Analysis.CharFilters
                             inputSegment.Write(zzBuffer, zzStartRead, matchLength);
                             if (matchLength <= 6)
                             { // 10FFFF: max 6 hex chars
-                                if (!J2N.Numerics.Int32.TryParse(zzBuffer, zzStartRead + 1, matchLength - 1, radix: 16, out int codePoint))
+                                // LUCENENET: Originally, we got the value of new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead), which allocates.
+                                // We can eliminate the allocation by grabbing the values YyText converts to a string via index and length.
+                                if (!Integer.TryParse(zzBuffer, zzStartRead + 1, matchLength - 1, radix: 16, out int codePoint))
                                 {
                                     if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing hex code point '{0}'", new CharArrayFormatter(zzBuffer, zzStartRead + 1, matchLength - 1));
                                 }
@@ -31666,7 +31665,9 @@ namespace Lucene.Net.Analysis.CharFilters
                         {
                             if (inputSegment.Length > 2)
                             { // Chars between "<!" and "--" - this is not a comment
-                                inputSegment.Append(YyText());
+                                // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                                // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                                inputSegment.Append(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
                             }
                             else
                             {
@@ -31812,7 +31813,9 @@ namespace Lucene.Net.Analysis.CharFilters
                         {
                             if (inputSegment.Length > 2)
                             { // Chars between "<!" and "[CDATA[" - this is not a CDATA section
-                                inputSegment.Append(YyText());
+                                // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                                // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                                inputSegment.Append(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
                             }
                             else
                             {
@@ -31884,27 +31887,33 @@ namespace Lucene.Net.Analysis.CharFilters
                         { // Handle paired UTF-16 surrogates.
                             outputSegment = entitySegment;
                             outputSegment.Clear();
-                            string surrogatePair = YyText();
-                            char highSurrogate = '\u0000';
-                            // LUCENENET: Optimized parse so we don't allocate a substring.
-                            if (Integer.TryParse(surrogatePair, 2, 6 - 2, 16, out int highSurrogateInt32))
+                            //string surrogatePair = YyText; // LUCENENET: Refactored to use the underlying array directly instead of allocating substrings
+                            int highSurrogate = '\u0000'; // LUCENENET: Use int to allow out parameters to use without casting.
+
+                            // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                            // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                            int startIndex = zzStartRead + 2;
+                            int length = 4; // (6 - 2)
+
+                            // High surrogates are in decimal range [55296, 56319]
+                            if (!Integer.TryParse(zzBuffer, startIndex, length, radix: 16, out highSurrogate))
                             {
-                                highSurrogate = (char)highSurrogateInt32;
-                            }
-                            else // should never happen
-                            {
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", surrogatePair.Substring(2, 6 - 2));
-                            }
-                            try
-                            {
-                                // LUCENENET: Optimized parse so we don't allocate a substring
-                                outputSegment.UnsafeWrite((char)Integer.Parse(surrogatePair, 10, 14 - 10, 16));
-                            }
-                            catch (Exception e) when (e.IsException())
-                            { // should never happen
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", surrogatePair.Substring(10, 14 - 10));
+                                // should never happen
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", new CharArrayFormatter(zzBuffer, startIndex, length));
                             }
 
+                            // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                            // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                            startIndex = zzStartRead + 10;
+                            length = 4; // (14 - 10)
+
+                            // Low surrogates are in decimal range [56320, 57343]
+                            if (!Integer.TryParse(zzBuffer, startIndex, length, radix: 16, out int lowSurrogate))
+                            {
+                                // should never happen
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", new CharArrayFormatter(zzBuffer, startIndex, length));
+                            }
+                            outputSegment.UnsafeWrite((char)lowSurrogate);
                             // add (previously matched input length) + (this match length) - (substitution length)
                             cumulativeDiff += inputSegment.Length + YyLength - 2;
                             // position the correction at (already output length) + (substitution length)
@@ -31916,32 +31925,38 @@ namespace Lucene.Net.Analysis.CharFilters
                     case 103: break;
                     case 51:
                         { // Handle paired UTF-16 surrogates.
-                            string surrogatePair = YyText();
-                            char highSurrogate = '\u0000';
-                            char lowSurrogate = '\u0000';
-                            // LUCENENET: Optimized parse so we don't allocate a substring.
-                            if (Integer.TryParse(surrogatePair, 2, 6 - 2, 16, out int highSurrogateInt32))
+                            // string surrogatePair = YyText; // LUCENENET: Refactored to use the underlying array directly instead of allocating substrings
+                            int highSurrogate = '\u0000'; // LUCENENET: Use int to allow out parameters to use without casting.
+                            int lowSurrogate = '\u0000'; // LUCENENET: Use int to allow out parameters to use without casting.
+
+                            // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                            // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                            int startIndex = zzStartRead + 2;
+                            int length = 4; // (6 - 2)
+
+                            // High surrogates are in decimal range [55296, 56319]
+                            if (!Integer.TryParse(zzBuffer, startIndex, length, radix: 16, out highSurrogate))
                             {
-                                highSurrogate = (char)highSurrogateInt32;
+                                // should never happen
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", new CharArrayFormatter(zzBuffer, startIndex, length));
                             }
-                            else // should never happen
+
+                            // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                            // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                            startIndex = zzStartRead + 9;
+                            length = 5; // (14 - 9)
+
+                            // Low surrogates are in decimal range [56320, 57343]
+                            if (!Integer.TryParse(zzBuffer, startIndex, length, radix: 10, out lowSurrogate))
                             {
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", surrogatePair.Substring(2, 6 - 2));
+                                // should never happen
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", new CharArrayFormatter(zzBuffer, startIndex, length));
                             }
-                            try
-                            { // Low surrogates are in decimal range [56320, 57343]
-                                // LUCENENET: Optimized parse so we don't allocate a substring
-                                lowSurrogate = (char)Integer.Parse(surrogatePair, 9, 14 - 9, 10);
-                            }
-                            catch (Exception e) when (e.IsException())
-                            { // should never happen
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", surrogatePair.Substring(9, 14 - 9));
-                            }
-                            if (char.IsLowSurrogate(lowSurrogate))
+                            if (char.IsLowSurrogate((char)lowSurrogate))
                             {
                                 outputSegment = entitySegment;
                                 outputSegment.Clear();
-                                outputSegment.UnsafeWrite(lowSurrogate);
+                                outputSegment.UnsafeWrite((char)lowSurrogate);
                                 // add (previously matched input length) + (this match length) - (substitution length)
                                 cumulativeDiff += inputSegment.Length + YyLength - 2;
                                 // position the correction at (already output length) + (substitution length)
@@ -31950,7 +31965,9 @@ namespace Lucene.Net.Analysis.CharFilters
                                 YyBegin(YYINITIAL);
                                 return highSurrogate;
                             }
-                            YyPushBack(surrogatePair.Length - 1); // Consume only '#'
+                            // LUCENENET: Using the underlying array to parse, so need to calculate surrogatePair.Length as (zzMarkedPos - zzStartRead)
+                            // which would be the length of YyText, if allocated.
+                            YyPushBack((zzMarkedPos - zzStartRead) - 1); // Consume only '#'
                             inputSegment.Append('#');
                             YyBegin(NUMERIC_CHARACTER);
                         }
@@ -31958,30 +31975,37 @@ namespace Lucene.Net.Analysis.CharFilters
                     case 104: break;
                     case 52:
                         { // Handle paired UTF-16 surrogates.
-                            string surrogatePair = YyText();
-                            char highSurrogate = '\u0000';
-                            // LUCENENET: Optimized parse so we don't allocate a substring.
-                            if (Integer.TryParse(surrogatePair, 1, 6 - 1, 10, out int highSurrogateInt32))
-                            { // High surrogates are in decimal range [55296, 56319]
-                                highSurrogate = (char)highSurrogateInt32;
-                            }
-                            else // should never happen
+                            //string surrogatePair = YyText; // LUCENENET: Refactored to use the underlying array directly instead of allocating substrings
+                            int highSurrogate = '\u0000'; // LUCENENET: Use int to allow out parameters to use without casting.
+
+                            // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                            // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                            int startIndex = zzStartRead + 1;
+                            int length = 5; // (6 - 1)
+
+                            // High surrogates are in decimal range [55296, 56319]
+                            if (!Integer.TryParse(zzBuffer, startIndex, length, radix: 10, out highSurrogate))
                             {
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", surrogatePair.Substring(1, 6 - 1));
+                                // should never happen
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", new CharArrayFormatter(zzBuffer, startIndex, length));
                             }
-                            if (char.IsHighSurrogate(highSurrogate))
+                            if (char.IsHighSurrogate((char)highSurrogate))
                             {
                                 outputSegment = entitySegment;
                                 outputSegment.Clear();
-                                try
+
+                                // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                                // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                                startIndex = zzStartRead + 10;
+                                length = 4; // (14 - 10)
+
+                                // Low surrogates are in decimal range [56320, 57343]
+                                if (!Integer.TryParse(zzBuffer, startIndex, length, radix: 16, out int lowSurrogate))
                                 {
-                                    // LUCENENET: Optimized parse so we don't allocate a substring.
-                                    outputSegment.UnsafeWrite((char)Integer.Parse(surrogatePair, 10, 14 - 10, 16));
+                                    // should never happen
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", new CharArrayFormatter(zzBuffer, startIndex, length));
                                 }
-                                catch (Exception e) when (e.IsException())
-                                { // should never happen
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", surrogatePair.Substring(10, 14 - 10));
-                                }
+                                outputSegment.UnsafeWrite((char)lowSurrogate);
                                 // add (previously matched input length) + (this match length) - (substitution length)
                                 cumulativeDiff += inputSegment.Length + YyLength - 2;
                                 // position the correction at (already output length) + (substitution length)
@@ -31990,7 +32014,9 @@ namespace Lucene.Net.Analysis.CharFilters
                                 YyBegin(YYINITIAL);
                                 return highSurrogate;
                             }
-                            YyPushBack(surrogatePair.Length - 1); // Consume only '#'
+                            // LUCENENET: Using the underlying array to parse, so need to calculate surrogatePair.Length as (zzMarkedPos - zzStartRead)
+                            // which would be the length of YyText, if allocated.
+                            YyPushBack((zzMarkedPos - zzStartRead) - 1); // Consume only '#'
                             inputSegment.Append('#');
                             YyBegin(NUMERIC_CHARACTER);
                         }
@@ -31998,34 +32024,40 @@ namespace Lucene.Net.Analysis.CharFilters
                     case 105: break;
                     case 53:
                         { // Handle paired UTF-16 surrogates.
-                            string surrogatePair = YyText();
-                            char highSurrogate = '\u0000';
-                            // LUCENENET: Optimized parse so we don't allocate a substring.
-                            if (Integer.TryParse(surrogatePair, 1, 6 - 1, 10, out int highSurrogateInt32))
-                            { // High surrogates are in decimal range [55296, 56319]
-                                highSurrogate = (char)highSurrogateInt32;
-                            }
-                            else // should never happen
+                            //string surrogatePair = YyText(); // LUCENENET: Refactored to use the underlying array directly instead of allocating substrings
+                            int highSurrogate = '\u0000'; // LUCENENET: Use int to allow out parameters to use without casting.
+
+                            // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                            // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                            int startIndex = zzStartRead + 1;
+                            int length = 5; // (6 - 1)
+
+                            // High surrogates are in decimal range [55296, 56319]
+                            if (!Integer.TryParse(zzBuffer, startIndex, length, radix: 10, out highSurrogate))
                             {
-                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", surrogatePair.Substring(1, 6 - 1));
+                                // should never happen
+                                if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing high surrogate '{0}'", new CharArrayFormatter(zzBuffer, startIndex, length));
                             }
-                            if (char.IsHighSurrogate(highSurrogate))
+                            if (char.IsHighSurrogate((char)highSurrogate))
                             {
-                                char lowSurrogate = '\u0000';
-                                // LUCENENET: Optimized parse so we don't allocate a substring.
-                                if (Integer.TryParse(surrogatePair, 9, 14 - 9, 10, out int lowSurrogateInt32))
-                                { // Low surrogates are in decimal range [56320, 57343]
-                                    lowSurrogate = (char)lowSurrogateInt32;
-                                }
-                                else // should never happen
+                                int lowSurrogate = '\u0000'; // LUCENENET: Use int to allow out parameters to use without casting.
+
+                                // LUCENENET: Originally, we got the value of YyText property, which allocates. We can eliminate the allocation
+                                // by grabbing the values YyText converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                                startIndex = zzStartRead + 9;
+                                length = 5; // (14 - 9)
+
+                                // Low surrogates are in decimal range [56320, 57343]
+                                if (!Integer.TryParse(zzBuffer, startIndex, length, radix: 10, out lowSurrogate))
                                 {
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", surrogatePair.Substring(9, 14 - 9));
+                                    // should never happen
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing low surrogate '{0}'", new CharArrayFormatter(zzBuffer, startIndex, length));
                                 }
-                                if (char.IsLowSurrogate(lowSurrogate))
+                                if (char.IsLowSurrogate((char)lowSurrogate))
                                 {
                                     outputSegment = entitySegment;
                                     outputSegment.Clear();
-                                    outputSegment.UnsafeWrite(lowSurrogate);
+                                    outputSegment.UnsafeWrite((char)lowSurrogate);
                                     // add (previously matched input length) + (this match length) - (substitution length)
                                     cumulativeDiff += inputSegment.Length + YyLength - 2;
                                     // position the correction at (already output length) + (substitution length)
@@ -32035,7 +32067,9 @@ namespace Lucene.Net.Analysis.CharFilters
                                     return highSurrogate;
                                 }
                             }
-                            YyPushBack(surrogatePair.Length - 1); // Consume only '#'
+                            // LUCENENET: Using the underlying array to parse, so need to calculate surrogatePair.Length as (zzMarkedPos - zzStartRead)
+                            // which would be the length of YyText, if allocated.
+                            YyPushBack((zzMarkedPos - zzStartRead) - 1); // Consume only '#'
                             inputSegment.Append('#');
                             YyBegin(NUMERIC_CHARACTER);
                         }

--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
@@ -2,6 +2,7 @@
 using J2N;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Diagnostics;
+using Lucene.Net.Support.Text;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
@@ -31371,10 +31372,11 @@ namespace Lucene.Net.Analysis.CharFilters
                             inputSegment.Write(zzBuffer, zzStartRead, matchLength);
                             if (matchLength <= 7)
                             { // 0x10FFFF = 1114111: max 7 decimal chars
-                                string decimalCharRef = YyText();
-                                if (!int.TryParse(decimalCharRef, NumberStyles.Integer, CultureInfo.InvariantCulture, out int codePoint))
+                                // LUCENENET: Originally, we got the value of YyText(), which allocates..so we can eliminate the allocation
+                                // by grabbing the values YyText() converts to a string: new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
+                                if (!J2N.Numerics.Int32.TryParse(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead, radix: 10, out int codePoint))
                                 {
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing code point '{0}'", decimalCharRef);
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing code point '{0}'", new CharArrayFormatter(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead));
                                 }
                                 if (codePoint <= 0x10FFFF)
                                 {
@@ -31625,11 +31627,9 @@ namespace Lucene.Net.Analysis.CharFilters
                             inputSegment.Write(zzBuffer, zzStartRead, matchLength);
                             if (matchLength <= 6)
                             { // 10FFFF: max 6 hex chars
-                                string hexCharRef
-                                    = new string(zzBuffer, zzStartRead + 1, matchLength - 1);
-                                if (!int.TryParse(hexCharRef, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int codePoint))
+                                if (!J2N.Numerics.Int32.TryParse(zzBuffer, zzStartRead + 1, matchLength - 1, radix: 16, out int codePoint))
                                 {
-                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing hex code point '{0}'", hexCharRef);
+                                    if (Debugging.AssertsEnabled) Debugging.Assert(false, "Exception parsing hex code point '{0}'", new CharArrayFormatter(zzBuffer, zzStartRead + 1, matchLength - 1));
                                 }
                                 if (codePoint <= 0x10FFFF)
                                 {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Ga/IrishLowerCaseFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Ga/IrishLowerCaseFilter.cs
@@ -1,6 +1,8 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using J2N;
 using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Util;
+using System;
 using System.Globalization;
 
 namespace Lucene.Net.Analysis.Ga
@@ -62,10 +64,13 @@ namespace Lucene.Net.Analysis.Ga
                     chLen = chLen + 1;
                 }
 
-                for (int i = idx; i < chLen;)
-                {
-                    i += Character.ToChars(Character.ToLower(chArray[i], culture), chArray, i); // LUCENENET specific - use Irish culture when lowercasing
-                }
+                // LUCENENET: Reduce allocations by using the stack and spans
+                var source = new ReadOnlySpan<char>(chArray, idx, chLen);
+                var destination = chArray.AsSpan(idx, chLen);
+                var spare = chLen * sizeof(char) <= Constants.MaxStackByteLimit ? stackalloc char[chLen] : new char[chLen];
+                source.ToLower(spare, culture); // LUCENENET specific - use Irish culture when lowercasing
+                spare.CopyTo(destination);
+
                 return true;
             }
             else

--- a/src/Lucene.Net.Analysis.Common/Analysis/In/IndicNormalizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/In/IndicNormalizer.cs
@@ -42,12 +42,14 @@ namespace Lucene.Net.Analysis.In
 
         private class ScriptData
         {
+            internal readonly Regex block;
             internal readonly UnicodeBlock flag;
             internal readonly int @base;
             internal OpenBitSet decompMask;
 
-            internal ScriptData(UnicodeBlock flag, int @base)
+            internal ScriptData(Regex block, UnicodeBlock flag, int @base)
             {
+                this.block = block;
                 this.flag = flag;
                 this.@base = @base;
             }
@@ -232,24 +234,24 @@ namespace Lucene.Net.Analysis.In
             new int[] { 0x73, 0x4B,   -1, 0x13, (int)UnicodeBlock.GURMUKHI }
         };
 
-        private static readonly IDictionary<Regex, ScriptData> scripts = LoadScripts(); // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        private static readonly IList<ScriptData> scripts = LoadScripts(); // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
 
-        private static IDictionary<Regex, ScriptData> LoadScripts()
+        private static IList<ScriptData> LoadScripts()
         {
-            IDictionary<Regex, ScriptData> result = new Dictionary<Regex, ScriptData>(capacity: 9)
+            IList<ScriptData> result = new List<ScriptData>(capacity: 9)
             {
-                { new Regex(@"\p{IsDevanagari}", RegexOptions.Compiled), new ScriptData(UnicodeBlock.DEVANAGARI, 0x0900) },
-                { new Regex(@"\p{IsBengali}", RegexOptions.Compiled), new ScriptData(UnicodeBlock.BENGALI, 0x0980) },
-                { new Regex(@"\p{IsGurmukhi}", RegexOptions.Compiled), new ScriptData(UnicodeBlock.GURMUKHI, 0x0A00) },
-                { new Regex(@"\p{IsGujarati}", RegexOptions.Compiled), new ScriptData(UnicodeBlock.GUJARATI, 0x0A80) },
-                { new Regex(@"\p{IsOriya}", RegexOptions.Compiled), new ScriptData(UnicodeBlock.ORIYA, 0x0B00) },
-                { new Regex(@"\p{IsTamil}", RegexOptions.Compiled), new ScriptData(UnicodeBlock.TAMIL, 0x0B80) },
-                { new Regex(@"\p{IsTelugu}", RegexOptions.Compiled), new ScriptData(UnicodeBlock.TELUGU, 0x0C00) },
-                { new Regex(@"\p{IsKannada}", RegexOptions.Compiled), new ScriptData(UnicodeBlock.KANNADA, 0x0C80) },
-                { new Regex(@"\p{IsMalayalam}", RegexOptions.Compiled), new ScriptData(UnicodeBlock.MALAYALAM, 0x0D00) },
+                new ScriptData(new Regex(@"\p{IsDevanagari}",  RegexOptions.Compiled),  UnicodeBlock.DEVANAGARI,  0x0900),
+                new ScriptData(new Regex(@"\p{IsBengali}",     RegexOptions.Compiled),  UnicodeBlock.BENGALI,     0x0980),
+                new ScriptData(new Regex(@"\p{IsGurmukhi}",    RegexOptions.Compiled),  UnicodeBlock.GURMUKHI,    0x0A00),
+                new ScriptData(new Regex(@"\p{IsGujarati}",    RegexOptions.Compiled),  UnicodeBlock.GUJARATI,    0x0A80),
+                new ScriptData(new Regex(@"\p{IsOriya}",       RegexOptions.Compiled),  UnicodeBlock.ORIYA,       0x0B00),
+                new ScriptData(new Regex(@"\p{IsTamil}",       RegexOptions.Compiled),  UnicodeBlock.TAMIL,       0x0B80),
+                new ScriptData(new Regex(@"\p{IsTelugu}",      RegexOptions.Compiled),  UnicodeBlock.TELUGU,      0x0C00),
+                new ScriptData(new Regex(@"\p{IsKannada}",     RegexOptions.Compiled),  UnicodeBlock.KANNADA,     0x0C80),
+                new ScriptData(new Regex(@"\p{IsMalayalam}",   RegexOptions.Compiled),  UnicodeBlock.MALAYALAM,   0x0D00),
             };
 
-            foreach (ScriptData sd in result.Values)
+            foreach (ScriptData sd in result)
             {
                 sd.decompMask = new OpenBitSet(0x7F);
                 for (int i = 0; i < decompositions.Length; i++)
@@ -277,9 +279,8 @@ namespace Lucene.Net.Analysis.In
         {
             for (int i = 0; i < len; i++)
             {
-                var block = GetBlockForChar(text[i]);
-                ScriptData sd;
-                if (scripts.TryGetValue(block, out sd) && sd != null)
+                Regex block;
+                if ((block = GetBlockForChar(text[i], out ScriptData sd)) != unknownScript)
                 {
                     int ch = text[i] - sd.@base;
                     if (sd.decompMask.Get(ch))
@@ -302,7 +303,7 @@ namespace Lucene.Net.Analysis.In
             }
 
             int ch1 = text[pos + 1] - sd.@base;
-            var block1 = GetBlockForChar(text[pos + 1]);
+            var block1 = GetBlockForChar(text[pos + 1], out _);
             if (block1 != block0) // needs to be the same writing system
             {
                 return len;
@@ -313,7 +314,7 @@ namespace Lucene.Net.Analysis.In
             if (pos + 2 < len)
             {
                 ch2 = text[pos + 2] - sd.@base;
-                var block2 = GetBlockForChar(text[pos + 2]);
+                var block2 = GetBlockForChar(text[pos + 2], out _);
                 if (text[pos + 2] == '\u200D') // ZWJ
                 {
                     ch2 = 0xFF;
@@ -344,22 +345,49 @@ namespace Lucene.Net.Analysis.In
             return len;
         }
 
+        // LUCENENET: Never matches - we just use this as a placeholder
+        private static readonly Regex unknownScript = new Regex(@"[^\S\s]", RegexOptions.Compiled);
+        [ThreadStatic]
+        private static ScriptData previousScriptData;
+
         /// <summary>
-        /// LUCENENET: Returns the unicode block for the specified character
+        /// LUCENENET: Returns the unicode block for the specified character. Caches the
+        /// last script and script data used on the current thread to optimize performance
+        /// when not switching between scripts.
         /// </summary>
-        private static Regex GetBlockForChar(char c) // LUCENENET: CA1822: Mark members as static
+        private static Regex GetBlockForChar(char c, out ScriptData scriptData) // LUCENENET: CA1822: Mark members as static
         {
             string charAsString = c.ToString();
-            foreach (var block in scripts.Keys)
+            // Store reference locally to avoid threading issues
+            ScriptData previousScriptDataLocal = previousScriptData;
+            Regex previousScript = previousScriptDataLocal?.block;
+
+            // Optimize to try the most recent script first.
+            if (previousScript?.IsMatch(charAsString) ?? false)
             {
-                if (block.IsMatch(charAsString))
-                {
-                    return block;
-                }
+                scriptData = previousScriptDataLocal;
+                return previousScript;
             }
 
-            // return a regex that never matches, nor is in our scripts dictionary
-            return new Regex(@"[^\S\s]");
+            return GetBlockForCharSlow(previousScript, charAsString, out scriptData);
+
+            static Regex GetBlockForCharSlow(Regex previousScript, string charAsString, out ScriptData scriptData)
+            { 
+                foreach (var script in scripts)
+                {
+                    Regex block = script.block;
+                    if (block != previousScript && block.IsMatch(charAsString))
+                    {
+                        previousScriptData = script;
+                        scriptData = script;
+                        return block;
+                    }
+                }
+
+                scriptData = null;
+                // return a regex that never matches, nor is in our scripts dictionary
+                return unknownScript;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Nl/DutchAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Nl/DutchAnalyzer.cs
@@ -176,7 +176,7 @@ namespace Lucene.Net.Analysis.Nl
                     {
                         char[] nextKey = iter.NextKey();
                         spare.CopyChars(nextKey, 0, nextKey.Length);
-                        builder.Add(new string(spare.Chars), iter.CurrentValue);
+                        builder.Add(spare.Chars, iter.CurrentValue);
                     }
                 }
                 try

--- a/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiWordFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiWordFilter.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 #if FEATURE_BREAKITERATOR
 using ICU4N.Text;
 using Lucene.Net.Analysis.Core;
@@ -138,7 +138,7 @@ namespace Lucene.Net.Analysis.Th
 
             // reinit CharacterIterator
             charIterator.SetText(clonedTermAtt.Buffer, 0, clonedTermAtt.Length);
-            breaker.SetText(new string(charIterator.Text, charIterator.Start, charIterator.Length));
+            breaker.SetText(charIterator);
             int end2 = breaker.Next();
             if (end2 != BreakIterator.Done)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
@@ -82,10 +82,7 @@ namespace Lucene.Net.Analysis.Util
         public virtual OpenStringBuilder Append(ICharSequence csq, int startIndex, int count) // LUCENENET specific: changed to startIndex/length to match .NET
         {
             EnsureCapacity(count);
-            for (int i = startIndex; i < startIndex + count; i++)
-            {
-                UnsafeWrite(csq[i]);
-            }
+            UnsafeWrite(csq, startIndex, count);
             return this;
         }
 
@@ -99,10 +96,7 @@ namespace Lucene.Net.Analysis.Util
         public virtual OpenStringBuilder Append(string csq, int startIndex, int count) // LUCENENET specific: changed to startIndex/length to match .NET
         {
             EnsureCapacity(count);
-            for (int i = startIndex; i < startIndex + count; i++)
-            {
-                UnsafeWrite(csq[i]);
-            }
+            UnsafeWrite(csq, startIndex, count);
             return this;
         }
 
@@ -116,10 +110,7 @@ namespace Lucene.Net.Analysis.Util
         public virtual OpenStringBuilder Append(StringBuilder csq, int startIndex, int count) // LUCENENET specific: changed to startIndex/length to match .NET
         {
             EnsureCapacity(count);
-            for (int i = startIndex; i < startIndex + count; i++)
-            {
-                UnsafeWrite(csq[i]);
-            }
+            UnsafeWrite(csq, startIndex, count);
             return this;
         }
 
@@ -134,10 +125,7 @@ namespace Lucene.Net.Analysis.Util
         public virtual OpenStringBuilder Append(char[] value, int startIndex, int count)
         {
             EnsureCapacity(count);
-            for (int i = startIndex; i < startIndex + count; i++)
-            {
-                UnsafeWrite(value[i]);
-            }
+            UnsafeWrite(value, startIndex, count);
             return this;
         }
 
@@ -208,6 +196,40 @@ namespace Lucene.Net.Analysis.Util
         {
             b.CopyTo(off, m_buf, this.m_len, len);
             this.m_len += len;
+        }
+
+        // LUCENENET specific overload for string
+        public virtual void UnsafeWrite(string b, int off, int len)
+        {
+            b.CopyTo(off, m_buf, this.m_len, len);
+            this.m_len += len;
+        }
+
+        // LUCENENET specific overload for ICharSequence
+        public virtual void UnsafeWrite(ICharSequence b, int off, int len)
+        {
+            if (!b.HasValue) return;
+
+            if (b is StringBuilderCharSequence sb)
+            {
+                UnsafeWrite(sb.Value, off, len);
+                return;
+            }
+            if (b is StringCharSequence str)
+            {
+                UnsafeWrite(str.Value, off, len);
+                return;
+            }
+            if (b is CharArrayCharSequence chars)
+            {
+                UnsafeWrite(chars.Value, off, len);
+                return;
+            }
+
+            for (int i = off; i < off + len; i++)
+            {
+                UnsafeWrite(b[i]);
+            }
         }
 
         protected virtual void Resize(int len)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/SegmentingTokenizerBase.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/SegmentingTokenizerBase.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 #if FEATURE_BREAKITERATOR
 using ICU4N.Text;
 using Lucene.Net.Analysis.TokenAttributes;
@@ -105,7 +105,7 @@ namespace Lucene.Net.Analysis.Util
         {
             base.Reset();
             wrapper.SetText(m_buffer, 0, 0);
-            iterator.SetText(new string(wrapper.Text, wrapper.Start, wrapper.Length));
+            iterator.SetText(wrapper);
             length = usableLength = m_offset = 0;
         }
 
@@ -176,7 +176,7 @@ namespace Lucene.Net.Analysis.Util
             }
 
             wrapper.SetText(m_buffer, 0, Math.Max(0, usableLength));
-            iterator.SetText(new string(wrapper.Text, wrapper.Start, wrapper.Length));
+            iterator.SetText(wrapper);
         }
 
         // TODO: refactor to a shared readFully somewhere

--- a/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
+++ b/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
@@ -50,6 +50,14 @@
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
@@ -151,12 +151,11 @@ namespace Lucene.Net.Analysis.Ja
                     int bgCost = costs.Get(backPosData.lastRightID[posData.backIndex[idx]],
                                                  dict.GetLeftId(posData.backID[idx]));
 
-                    string surfaceForm = new string(fragment,
-                                                          posData.backPos[idx] - startPos,
-                                                          pos - posData.backPos[idx]);
+                    // LUCENENET: Removed unnecessary surfaceForm allocation and appended
+                    // the chars directly to the StringBuilder below.
 
                     sb.Append(" [label=\"");
-                    sb.Append(surfaceForm);
+                    sb.Append(fragment, posData.backPos[idx] - startPos, pos - posData.backPos[idx]); 
                     sb.Append(' ');
                     sb.Append(wordCost);
                     if (bgCost >= 0)

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextUtil.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextUtil.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Codecs.SimpleText
 
         public static void Write(DataOutput output, string s, BytesRef scratch)
         {
-            UnicodeUtil.UTF16toUTF8(s.ToCharArray(), 0, s.Length, scratch);
+            UnicodeUtil.UTF16toUTF8(s, 0, s.Length, scratch);
             Write(output, scratch);
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/In/TestIndicNormalizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/In/TestIndicNormalizer.cs
@@ -1,5 +1,6 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using Lucene.Net.Analysis.Core;
+using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System.IO;
 
@@ -59,6 +60,13 @@ namespace Lucene.Net.Analysis.In
                 return new TokenStreamComponents(tokenizer, new IndicNormalizationFilter(tokenizer));
             });
             CheckOneTerm(a, "", "");
+        }
+
+        [Test, LuceneNetSpecific]
+        public virtual void TestUnknownScript()
+        {
+            check("foo", "foo");
+            check("bar", "bar");
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestStemmerOverrideFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestStemmerOverrideFilter.cs
@@ -4,6 +4,7 @@ using J2N.Collections.Generic.Extensions;
 using J2N.Text;
 using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.En;
+using Lucene.Net.Attributes;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -54,6 +55,32 @@ namespace Lucene.Net.Analysis.Miscellaneous
             // but also mark it with KeywordAttribute so Porter will not change it.
             StemmerOverrideFilter.Builder builder = new StemmerOverrideFilter.Builder(true);
             builder.Add("boOkEd", "books");
+            Tokenizer tokenizer = new KeywordTokenizer(new StringReader("BooKeD"));
+            TokenStream stream = new PorterStemFilter(new StemmerOverrideFilter(tokenizer, builder.Build()));
+            AssertTokenStreamContents(stream, new string[] { "books" });
+        }
+
+        [Test, LuceneNetSpecific]
+        public virtual void TestIgnoreCase_CharArray()
+        {
+            // lets make booked stem to books
+            // the override filter will convert "booked" to "books",
+            // but also mark it with KeywordAttribute so Porter will not change it.
+            StemmerOverrideFilter.Builder builder = new StemmerOverrideFilter.Builder(true);
+            builder.Add("boOkEd".ToCharArray(), "books");
+            Tokenizer tokenizer = new KeywordTokenizer(new StringReader("BooKeD"));
+            TokenStream stream = new PorterStemFilter(new StemmerOverrideFilter(tokenizer, builder.Build()));
+            AssertTokenStreamContents(stream, new string[] { "books" });
+        }
+
+        [Test, LuceneNetSpecific]
+        public virtual void TestIgnoreCase_CharSequence()
+        {
+            // lets make booked stem to books
+            // the override filter will convert "booked" to "books",
+            // but also mark it with KeywordAttribute so Porter will not change it.
+            StemmerOverrideFilter.Builder builder = new StemmerOverrideFilter.Builder(true);
+            builder.Add("boOkEd".AsCharSequence(), "books");
             Tokenizer tokenizer = new KeywordTokenizer(new StringReader("BooKeD"));
             TokenStream stream = new PorterStemFilter(new StemmerOverrideFilter(tokenizer, builder.Build()));
             AssertTokenStreamContents(stream, new string[] { "books" });

--- a/src/Lucene.Net.Tests.TestFramework.DependencyInjection/Configuration/TestConfigurationService.cs
+++ b/src/Lucene.Net.Tests.TestFramework.DependencyInjection/Configuration/TestConfigurationService.cs
@@ -34,5 +34,13 @@ namespace Lucene.Net.Configuration
             Assert.AreEqual("barValue", ConfigurationSettings.CurrentConfiguration["bar"]);
             Assert.AreEqual("bazValue", ConfigurationSettings.CurrentConfiguration["baz"]);
         }
+
+        [Test]
+        public void TestCustomMaxStackByteLimit()
+        {
+            // This custom value is configured in Startup.cs.
+            // 5000 chosen because it is not likely to ever be made a default.
+            Assert.AreEqual(5000, Constants.MaxStackByteLimit);
+        }
     }
 }

--- a/src/Lucene.Net.Tests.TestFramework.DependencyInjection/Startup.cs
+++ b/src/Lucene.Net.Tests.TestFramework.DependencyInjection/Startup.cs
@@ -41,7 +41,8 @@ public class Startup : LuceneTestFrameworkInitializer
             {
                 ["foo"] = "fooValue",
                 ["bar"] = "barValue",
-                ["baz"] = "bazValue"
+                ["baz"] = "bazValue",
+                ["maxStackByteLimit"] = "5000",
             });
         ConfigureServices(serviceCollection, configurationBuilder);
         IServiceProvider services = serviceCollection.BuildServiceProvider();

--- a/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net
         [TestCase(typeof(Lucene.Net.Analysis.Analyzer))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:ConcurrentHashSet|PlatformHelper|DateTimeOffsetUtil)|^Lucene\.ExceptionExtensions");
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:ConcurrentHashSet|PlatformHelper|DateTimeOffsetUtil)|^Lucene\.ExceptionExtensions|^Lucene\.Net\.Util\.Constants\.MaxStackByteLimit");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
@@ -1,4 +1,6 @@
 ﻿using J2N;
+using J2N.Text;
+using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System;
 using Assert = Lucene.Net.TestFramework.Assert;
@@ -155,6 +157,86 @@ namespace Lucene.Net.Util
 
         [Test]
         public virtual void TestUTF8toUTF32()
+        {
+            BytesRef utf8 = new BytesRef(20);
+            Int32sRef utf32 = new Int32sRef(20);
+            int[] codePoints = new int[20];
+            int num = AtLeast(50000);
+            for (int i = 0; i < num; i++)
+            {
+                string s = TestUtil.RandomUnicodeString(Random);
+                UnicodeUtil.UTF16toUTF8(s, 0, s.Length, utf8);
+                UnicodeUtil.UTF8toUTF32(utf8, utf32);
+
+                int charUpto = 0;
+                int intUpto = 0;
+
+                while (charUpto < s.Length)
+                {
+                    int cp = Character.CodePointAt(s, charUpto);
+                    codePoints[intUpto++] = cp;
+                    charUpto += Character.CharCount(cp);
+                }
+                if (!ArrayUtil.Equals(codePoints, 0, utf32.Int32s, utf32.Offset, intUpto))
+                {
+                    Console.WriteLine("FAILED");
+                    for (int j = 0; j < s.Length; j++)
+                    {
+                        Console.WriteLine("  char[" + j + "]=" + ((int)s[j]).ToString("x"));
+                    }
+                    Console.WriteLine();
+                    Assert.AreEqual(intUpto, utf32.Length);
+                    for (int j = 0; j < intUpto; j++)
+                    {
+                        Console.WriteLine("  " + utf32.Int32s[j].ToString("x") + " vs " + codePoints[j].ToString("x"));
+                    }
+                    Assert.Fail("mismatch");
+                }
+            }
+        }
+
+        [Test, LuceneNetSpecific]
+        public virtual void TestUTF8toUTF32_ICharSequence()
+        {
+            BytesRef utf8 = new BytesRef(20);
+            Int32sRef utf32 = new Int32sRef(20);
+            int[] codePoints = new int[20];
+            int num = AtLeast(50000);
+            for (int i = 0; i < num; i++)
+            {
+                string s = TestUtil.RandomUnicodeString(Random);
+                UnicodeUtil.UTF16toUTF8(s.AsCharSequence(), 0, s.Length, utf8);
+                UnicodeUtil.UTF8toUTF32(utf8, utf32);
+
+                int charUpto = 0;
+                int intUpto = 0;
+
+                while (charUpto < s.Length)
+                {
+                    int cp = Character.CodePointAt(s, charUpto);
+                    codePoints[intUpto++] = cp;
+                    charUpto += Character.CharCount(cp);
+                }
+                if (!ArrayUtil.Equals(codePoints, 0, utf32.Int32s, utf32.Offset, intUpto))
+                {
+                    Console.WriteLine("FAILED");
+                    for (int j = 0; j < s.Length; j++)
+                    {
+                        Console.WriteLine("  char[" + j + "]=" + ((int)s[j]).ToString("x"));
+                    }
+                    Console.WriteLine();
+                    Assert.AreEqual(intUpto, utf32.Length);
+                    for (int j = 0; j < intUpto; j++)
+                    {
+                        Console.WriteLine("  " + utf32.Int32s[j].ToString("x") + " vs " + codePoints[j].ToString("x"));
+                    }
+                    Assert.Fail("mismatch");
+                }
+            }
+        }
+
+        [Test, LuceneNetSpecific]
+        public virtual void TestUTF8toUTF32_CharArray()
         {
             BytesRef utf8 = new BytesRef(20);
             Int32sRef utf32 = new Int32sRef(20);

--- a/src/Lucene.Net/Document/CompressionTools.cs
+++ b/src/Lucene.Net/Document/CompressionTools.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Util;
+﻿using Lucene.Net.Util;
 using System.IO;
 using System.IO.Compression;
 
@@ -78,7 +78,7 @@ namespace Lucene.Net.Documents
         public static byte[] CompressString(string value, CompressionLevel compressionLevel)
         {
             var result = new BytesRef();
-            UnicodeUtil.UTF16toUTF8(value.ToCharArray(), 0, value.Length, result);
+            UnicodeUtil.UTF16toUTF8(value, 0, value.Length, result);
             return Compress(result.Bytes, 0, result.Length, compressionLevel);
         }
 

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -134,6 +134,7 @@
     <InternalsVisibleTo Include="Lucene.Net.Tests.Spatial" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.Suggest" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.TestFramework" />
+    <InternalsVisibleTo Include="Lucene.Net.Tests.TestFramework.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -66,13 +66,15 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
     <PackageReference Include="Prism.Core" Version="$(PrismCorePackageVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
     <PackageReference Include="Prism.Core" Version="$(PrismCorePackageVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <InternalsVisibleTo Include="Lucene.Net.Analysis.Common" />
     <InternalsVisibleTo Include="Lucene.Net.Analysis.Kuromoji" />

--- a/src/Lucene.Net/Support/Text/CharArrayFormatter.cs
+++ b/src/Lucene.Net/Support/Text/CharArrayFormatter.cs
@@ -1,0 +1,42 @@
+﻿namespace Lucene.Net.Support.Text
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// LUCENENET specific simple formatter to pass a value to
+    /// <see cref="Lucene.Net.Diagnostics.Debugging.Assert{T0}(bool, string, T0)"/>
+    /// in order to defer allocating until the assert fails.
+    /// </summary>
+    internal struct CharArrayFormatter
+    {
+        private char[] value;
+        private int startIndex;
+        private int length;
+        public CharArrayFormatter(char[] value, int startIndex, int length)
+        {
+            this.value = value;
+            this.startIndex = startIndex;
+            this.length = length;
+        }
+
+        public override string ToString()
+        {
+            return new string(value, startIndex, length);
+        }
+    }
+}

--- a/src/Lucene.Net/Util/Constants.cs
+++ b/src/Lucene.Net/Util/Constants.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if NETFRAMEWORK
@@ -30,6 +30,11 @@ namespace Lucene.Net.Util
     /// </summary>
     public static class Constants // LUCENENET specific - made static because all members are static and constructor in Lucene was private
     {
+        /// <summary>
+        /// The maximum stack allocation size before switching to making allocations on the heap.
+        /// </summary>
+        internal static int MaxStackByteLimit = SystemProperties.GetPropertyAsInt32("maxStackByteLimit", defaultValue: 2048); // LUCENENET specific
+
         // LUCENENET NOTE: IMPORTANT - this line must be placed before RUNTIME_VERSION so it can be parsed.
         private static readonly Regex VERSION = new Regex(@"(\d+\.\d+(?:\.\d+)?(?:\.\d+)?)", RegexOptions.Compiled);
 

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -123,11 +123,108 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Encode characters from a <see cref="T:char[]"/> <paramref name="source"/>, starting at
+        /// and ending at <paramref name="result"/>. After encoding, <c>result.Offset</c> will always be 0.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="result"/> is <c>null</c>.</exception>
+        // TODO: broken if incoming result.offset != 0
+        // LUCENENET specific overload
+        public static void UTF16toUTF8(Span<char> source, BytesRef result)
+        {
+            // LUCENENET: Added guard clause
+            if (result is null)
+                throw new ArgumentNullException(nameof(result));
+
+            int length = source.Length;
+
+            int upto = 0;
+            int i = 0;
+            int end = source.Length;
+            var @out = result.Bytes;
+
+            // Pre-allocate for worst case 4-for-1
+            int maxLen = length * 4;
+            if (@out.Length < maxLen)
+            {
+                @out = result.Bytes = new byte[maxLen];
+            }
+            result.Offset = 0;
+
+            while (i < end)
+            {
+                int code = (int)source[i++];
+
+                if (code < 0x80)
+                {
+                    @out[upto++] = (byte)code;
+                }
+                else if (code < 0x800)
+                {
+                    @out[upto++] = (byte)(0xC0 | (code >> 6));
+                    @out[upto++] = (byte)(0x80 | (code & 0x3F));
+                }
+                else if (code < 0xD800 || code > 0xDFFF)
+                {
+                    @out[upto++] = (byte)(0xE0 | (code >> 12));
+                    @out[upto++] = (byte)(0x80 | ((code >> 6) & 0x3F));
+                    @out[upto++] = (byte)(0x80 | (code & 0x3F));
+                }
+                else
+                {
+                    // surrogate pair
+                    // confirm valid high surrogate
+                    if (code < 0xDC00 && i < end)
+                    {
+                        var utf32 = (int)source[i];
+                        // confirm valid low surrogate and write pair
+                        if (utf32 >= 0xDC00 && utf32 <= 0xDFFF)
+                        {
+                            utf32 = (code << 10) + utf32 + SURROGATE_OFFSET;
+                            i++;
+                            @out[upto++] = (byte)(0xF0 | (utf32 >> 18));
+                            @out[upto++] = (byte)(0x80 | ((utf32 >> 12) & 0x3F));
+                            @out[upto++] = (byte)(0x80 | ((utf32 >> 6) & 0x3F));
+                            @out[upto++] = (byte)(0x80 | (utf32 & 0x3F));
+                            continue;
+                        }
+                    }
+                    // replace unpaired surrogate or out-of-order low surrogate
+                    // with substitution character
+                    @out[upto++] = 0xEF;
+                    @out[upto++] = 0xBF;
+                    @out[upto++] = 0xBD;
+                }
+            }
+            //assert matches(source, offset, length, out, upto);
+            result.Length = upto;
+        }
+
+        /// <summary>
+        /// Encode characters from a <see cref="T:char[]"/> <paramref name="source"/>, starting at
         /// <paramref name="offset"/> for <paramref name="length"/> chars. After encoding, <c>result.Offset</c> will always be 0.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="result"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="offset"/> or <paramref name="length"/> is less than zero.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="offset"/> and <paramref name="length"/> refer to a location outside of <paramref name="source"/>.
+        /// </exception>
         // TODO: broken if incoming result.offset != 0
         public static void UTF16toUTF8(char[] source, int offset, int length, BytesRef result)
         {
+            // LUCENENET: Added guard clauses
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+            if (result is null)
+                throw new ArgumentNullException(nameof(result));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(offset)} must not be negative.");
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
+            if (offset > source.Length - length) // Checks for int overflow
+                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
+
             int upto = 0;
             int i = offset;
             int end = offset + length;
@@ -193,9 +290,29 @@ namespace Lucene.Net.Util
         /// Encode characters from this <see cref="ICharSequence"/>, starting at <paramref name="offset"/>
         /// for <paramref name="length"/> characters. After encoding, <c>result.Offset</c> will always be 0.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="result"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="offset"/> or <paramref name="length"/> is less than zero.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="offset"/> and <paramref name="length"/> refer to a location outside of <paramref name="source"/>.
+        /// </exception>
         // TODO: broken if incoming result.offset != 0
-        public static void UTF16toUTF8(ICharSequence s, int offset, int length, BytesRef result)
+        public static void UTF16toUTF8(ICharSequence source, int offset, int length, BytesRef result)
         {
+            // LUCENENET: Added guard clauses
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+            if (result is null)
+                throw new ArgumentNullException(nameof(result));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(offset)} must not be negative.");
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
+            if (offset > source.Length - length) // Checks for int overflow
+                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
+
             int end = offset + length;
 
             var @out = result.Bytes;
@@ -210,7 +327,7 @@ namespace Lucene.Net.Util
             int upto = 0;
             for (int i = offset; i < end; i++)
             {
-                var code = (int)s[i];
+                var code = (int)source[i];
                 if (code < 0x80)
                 {
                     @out[upto++] = (byte)code;
@@ -232,7 +349,7 @@ namespace Lucene.Net.Util
                     // confirm valid high surrogate
                     if (code < 0xDC00 && (i < end - 1))
                     {
-                        int utf32 = (int)s[i + 1];
+                        int utf32 = (int)source[i + 1];
                         // confirm valid low surrogate and write pair
                         if (utf32 >= 0xDC00 && utf32 <= 0xDFFF)
                         {
@@ -262,9 +379,29 @@ namespace Lucene.Net.Util
         /// <para/>
         /// LUCENENET specific.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="result"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="offset"/> or <paramref name="length"/> is less than zero.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="offset"/> and <paramref name="length"/> refer to a location outside of <paramref name="source"/>.
+        /// </exception>
         // TODO: broken if incoming result.offset != 0
-        public static void UTF16toUTF8(string s, int offset, int length, BytesRef result)
+        public static void UTF16toUTF8(string source, int offset, int length, BytesRef result)
         {
+            // LUCENENET: Added guard clauses
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+            if (result is null)
+                throw new ArgumentNullException(nameof(result));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(offset)} must not be negative.");
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
+            if (offset > source.Length - length) // Checks for int overflow
+                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
+
             int end = offset + length;
 
             var @out = result.Bytes;
@@ -279,7 +416,7 @@ namespace Lucene.Net.Util
             int upto = 0;
             for (int i = offset; i < end; i++)
             {
-                var code = (int)s[i];
+                var code = (int)source[i];
                 if (code < 0x80)
                 {
                     @out[upto++] = (byte)code;
@@ -301,7 +438,7 @@ namespace Lucene.Net.Util
                     // confirm valid high surrogate
                     if (code < 0xDC00 && (i < end - 1))
                     {
-                        int utf32 = (int)s[i + 1];
+                        int utf32 = (int)source[i + 1];
                         // confirm valid low surrogate and write pair
                         if (utf32 >= 0xDC00 && utf32 <= 0xDFFF)
                         {


### PR DESCRIPTION
- **PERFORMANCE:** `Lucene.Net.Document.CompressionTools::CompressString()`: Eliminated unnecessary `ToCharArray()` allocation
- **PERFORMANCE:** `Lucene.Net.Codecs.SimpleText.SimpleTextUtil::Write()`: Removed unnecessary `ToCharArray()` allocation
- **PERFORMANCE:** `Lucene.Net.Analysis.CharFilters.HTMLStripCharFilter`: Removed allocation during parse of hexadecimal integers by using `J2N.Numerics.Int32.TryParse()` overloads to specify index, length and radix. Now, the reference to the underlying `char[]` is passed to `OpenStringBuilder.Append()` with index and length so it copies directly from array to array instead of allocating substrings.
- **PERFORMANCE:** Added a `CharArrayFormatter` struct to defer the allocation of constructing a string for `Debugging.Assert()` until after an assertion failure.
- **PERFORMANCE:** Added `maxStackByteLimit` system property that can be used to increase/decrease the stack threshold bytes where it switches to the heap.
- **PERFORMANCE:** `StemmerOverrideFilter.Builder` - Added overloads of `Add()` for `char[]` and `ICharSequence`. Added guard clauses. Modified to use `Span<char>` on the stack when under the `maxStackByteLimit` setting.
- **PERFORMANCE:** `Lucene.Net.Util.UnicodeUtil`: Added an overload of `UTF16toUTF8()` for `Span<T>` source to `BytesRef` destination. Added documentation and guard clauses. Renamed `s` parameter to `source` to be consistent across all overloads.
- **PERFORMANCE:** `Lucene.Net.Analysis.Util.CharacterUtils`: Use spans and stackalloc to reduce heap allocations when lowercasing.
- `Lucene.Net.Util.TestUnicodeUtil::TestUTF8toUTF32()`: Added tests for `ICharSequence` and `char[]` overloads, changed the original test to test `string` instead of `char[]`.
- **PERFORMANCE:** `Lucene.Net.Analysis.Util.SegmentingTokenizerBase`: Removed unnecessary string allocations that were added during the port due to missing APIs that are now available.
- **PERFORMANCE:** `Lucene.Net.Analysis.Ja.GraphvizFormatter`: Removed unnecessary `surfaceForm` variable string allocation.
- **PERFORMANCE:** `Lucene.Net.Analysis.In.IndicNormalizer`: Replaced static constructor with inline `LoadScripts()` method. Moved location of scripts field to ensure decompositions is initialized first.
- **PERFORMANCE:** `Lucene.Net.Analysis.In.IndicNormalizer`: Refactored `ScriptData` from using `Dictionary<Regex, ScriptData>` to using `List<ScriptData>` which eliminated unnecessary hashtable lookup. Use static fields for `unknownScript` and `[ThreadStatic] previousScriptData` to cache the last script seen to optimize character script matching.
- **PERFORMANCE:** `Lucene.Net.Analysis.Th.ThaiWordBreaker`: Removed unnecessary string allocations and concatenation. Use `CharsRef` to reuse the same memory. Removed `Regex` and replaced with `UnicodeSet` to detect Thai code points, since the latter doesn't require converting to a string to detect a match.
- **PERFORMANCE:** `Lucene.Net.Analysis.Ga.IrishLowerCaseFilter`: Use stack and spans to reduce allocations and improve throughput.
- **PERFORMANCE:** `Lucene.Net.Analysis.Util.OpenStringBuilder`: Added overloads of `UnsafeWrite()` for `string` an `ICharSequence`. Optimized `Append()` methods to call `UnsafeWrite` with index and count to optimize the operation depending on the type of object passed.