### PR TITLE
Updated Azure DevOps Mac OS used for Net3.1 Testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -461,7 +461,7 @@ stages:
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         macOS:
           osName: 'macOS'
-          imageName: 'macOS-10.15' # macOS-latest should not be used here because we may get OS Darwin 19.6.0, which isn't supported fully (we get PlatformNotSupportedException).
+          imageName: 'macOS-latest'
           maximumParallelJobs: 7
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
     displayName: 'Test netcoreapp3.1,x64 on'


### PR DESCRIPTION
The macOS-10.15 environment is deprecated and will be removed from Azure DevOps on December 1st, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5583 
So this PR updates our use of MacOS-10.15 to macOS-latest.