### PR TITLE
Path.GetFileName() Updates

### DIFF
--- a/src/Lucene.Net.Suggest/Suggest/Fst/ExternalRefSorter.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/ExternalRefSorter.cs
@@ -1,4 +1,5 @@
-﻿using Lucene.Net.Util;
+﻿using Lucene.Net.Support.IO;
+using Lucene.Net.Util;
 using System;
 using System.IO;
 
@@ -39,7 +40,7 @@ namespace Lucene.Net.Search.Suggest.Fst
         public ExternalRefSorter(OfflineSorter sort)
         {
             this.sort = sort;
-            this.input = new FileInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+            this.input = FileSupport.CreateTempFile("RefSorter-", ".raw", OfflineSorter.GetDefaultTempDir());
             this.writer = new OfflineSorter.ByteSequencesWriter(input);
         }
 
@@ -58,7 +59,7 @@ namespace Lucene.Net.Search.Suggest.Fst
             {
                 CloseWriter();
 
-                sorted = new FileInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+                sorted = FileSupport.CreateTempFile("RefSorter-", ".sorted", OfflineSorter.GetDefaultTempDir());
                 sort.Sort(input, sorted);
 
                 input.Delete();

--- a/src/Lucene.Net/Support/IO/FileSupport.cs
+++ b/src/Lucene.Net/Support/IO/FileSupport.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Support.IO
             try
             {
                 // This could throw, but we don't care about this HResult value.
-                fileName = Path.GetTempFileName();
+                fileName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()); // LUCENENET NOTE: Path.GetTempFileName() is considered insecure because the filename can be guessed https://rules.sonarsource.com/csharp/RSPEC-5445
             }
             catch
             {


### PR DESCRIPTION
- `Lucene.Net.Support.IO.FileSupport::GetFileIOExceptionHResult()`: Avoid `Path.GetTempFileName()` because it is not secure. https://rules.sonarsource.com/csharp/RSPEC-5445
- `Lucene.Net.Search.Suggest.Fst.ExternalRefSorter`: Changed temp path generation to use `FileSupport.CreateTempFile()` with named prefix and extension because it more closely matches Lucene and makes the files more easily identifiable.