### PR TITLE
Fixed constructors of abstract classes according to SonarCloud recommendations (fixes #677)

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/BaseCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/BaseCharFilter.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using J2N.Numerics;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
@@ -38,7 +38,7 @@ namespace Lucene.Net.Analysis.CharFilters
         private int[] diffs;
         private int size = 0;
 
-        public BaseCharFilter(TextReader @in)
+        protected BaseCharFilter(TextReader @in) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
             : base(@in)
         {
         }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymMap.cs
@@ -338,7 +338,7 @@ namespace Lucene.Net.Analysis.Synonym
         {
             private readonly Analyzer analyzer;
 
-            public Parser(bool dedup, Analyzer analyzer) 
+            protected Parser(bool dedup, Analyzer analyzer) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
                 : base(dedup)
             {
                 this.analyzer = analyzer;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharTokenizer.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using J2N;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Diagnostics;
@@ -71,7 +71,7 @@ namespace Lucene.Net.Analysis.Util
         ///          Lucene version to match </param>
         /// <param name="input">
         ///          the input to split up into tokens </param>
-        public CharTokenizer(LuceneVersion matchVersion, TextReader input)
+        protected CharTokenizer(LuceneVersion matchVersion, TextReader input) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
             : base(input)
         {
             Init(matchVersion);
@@ -86,7 +86,7 @@ namespace Lucene.Net.Analysis.Util
         ///          the attribute factory to use for this <see cref="Tokenizer"/> </param>
         /// <param name="input">
         ///          the input to split up into tokens </param>
-        public CharTokenizer(LuceneVersion matchVersion, AttributeFactory factory, TextReader input)
+        protected CharTokenizer(LuceneVersion matchVersion, AttributeFactory factory, TextReader input) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
             : base(factory, input)
         {
             Init(matchVersion);

--- a/src/Lucene.Net.Analysis.Phonetic/Language/ColognePhonetic.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/ColognePhonetic.cs
@@ -193,13 +193,13 @@ namespace Lucene.Net.Analysis.Phonetic.Language
 
             protected int m_length = 0;
 
-            public CologneBuffer(char[] data)
+            protected CologneBuffer(char[] data) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
             {
                 this.m_data = data;
                 this.m_length = data.Length;
             }
 
-            public CologneBuffer(int buffSize)
+            protected CologneBuffer(int buffSize) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
             {
                 this.m_data = new char[buffSize];
                 this.m_length = 0;

--- a/src/Lucene.Net.Codecs/IntBlock/VariableIntBlockIndexInput.cs
+++ b/src/Lucene.Net.Codecs/IntBlock/VariableIntBlockIndexInput.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Codecs.IntBlock
         private readonly IndexInput input;
         protected readonly int m_maxBlockSize;
 
-        protected internal VariableInt32BlockIndexInput(IndexInput input)
+        protected VariableInt32BlockIndexInput(IndexInput input)
         {
             this.input = input;
             m_maxBlockSize = input.ReadInt32();

--- a/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTOrdTermsReader.cs
@@ -302,7 +302,7 @@ namespace Lucene.Net.Codecs.Memory
                 private readonly int[] docFreq; // LUCENENET: marked readonly
                 private readonly long[] totalTermFreq; // LUCENENET: marked readonly
 
-                internal BaseTermsEnum(TermsReader outerInstance)
+                private protected BaseTermsEnum(TermsReader outerInstance) // LUCENENET: Changed from internal to private protected
                 {
                     this.outerInstance = outerInstance;
                     this.state = outerInstance.outerInstance.postingsReader.NewTermState();

--- a/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermsReader.cs
@@ -259,7 +259,7 @@ namespace Lucene.Net.Codecs.Memory
                 /// Decodes metadata into customized term state. </summary>
                 internal abstract void DecodeMetaData();
 
-                internal BaseTermsEnum(FSTTermsReader.TermsReader outerInstance)
+                private protected BaseTermsEnum(FSTTermsReader.TermsReader outerInstance) // LUCENENET: Changed from internal to private protected
                 {
                     this.outerInstance = outerInstance;
                     this.state = outerInstance.outerInstance.postingsReader.NewTermState();

--- a/src/Lucene.Net.Expressions/Bindings.cs
+++ b/src/Lucene.Net.Expressions/Bindings.cs
@@ -1,4 +1,5 @@
-using Lucene.Net.Queries.Function;
+﻿using Lucene.Net.Queries.Function;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Lucene.Net.Expressions
 {
@@ -35,6 +36,8 @@ namespace Lucene.Net.Expressions
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </remarks>
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S3442:\"abstract\" classes should not have \"public\" constructors", Justification = "Public is required for Relection")]
         public Bindings() // LUCENENET NOTE: This must be public for the Reflection code to work right.
         {
         }

--- a/src/Lucene.Net.Expressions/Expression.cs
+++ b/src/Lucene.Net.Expressions/Expression.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Queries.Function;
+﻿using Lucene.Net.Queries.Function;
 using Lucene.Net.Search;
 using Lucene.Net.Support;
 using System.Diagnostics.CodeAnalysis;
@@ -63,6 +63,8 @@ namespace Lucene.Net.Expressions
         /// <param name="variables">
         /// Names of external variables referred to by the expression
         /// </param>
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S3442:\"abstract\" classes should not have \"public\" constructors", Justification = "Public is required for Relection")]
         public Expression(string sourceText, string[] variables) // LUCENENET NOTE: This must be public for the Reflection code to work right.
         {
             // javadocs

--- a/src/Lucene.Net.Facet/Taxonomy/TaxonomyFacets.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/TaxonomyFacets.cs
@@ -76,7 +76,7 @@ namespace Lucene.Net.Facet.Taxonomy
         /// <summary>
         /// Sole constructor. 
         /// </summary>
-        protected internal TaxonomyFacets(string indexFieldName, TaxonomyReader taxoReader, FacetsConfig config)
+        protected TaxonomyFacets(string indexFieldName, TaxonomyReader taxoReader, FacetsConfig config)
         {
             this.m_indexFieldName = indexFieldName;
             this.m_taxoReader = taxoReader;

--- a/src/Lucene.Net.Grouping/Term/TermGroupFacetCollector.cs
+++ b/src/Lucene.Net.Grouping/Term/TermGroupFacetCollector.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Search.Grouping.Terms
             }
         }
 
-        internal TermGroupFacetCollector(string groupField, string facetField, BytesRef facetPrefix, int initialSize)
+        private protected TermGroupFacetCollector(string groupField, string facetField, BytesRef facetPrefix, int initialSize) // LUCENENET: Changed from internal to private protected
             : base(groupField, facetField, facetPrefix)
         {
             groupedFacetHits = new JCG.List<GroupedFacetHit>(initialSize);

--- a/src/Lucene.Net.Join/TermsCollector.cs
+++ b/src/Lucene.Net.Join/TermsCollector.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Search.Join
         private readonly string _field;
         private readonly BytesRefHash _collectorTerms = new BytesRefHash();
 
-        internal TermsCollector(string field)
+        private protected TermsCollector(string field) // LUCENENET: Changed from internal to private protected
         {
             _field = field;
         }

--- a/src/Lucene.Net.Join/TermsWithScoreCollector.cs
+++ b/src/Lucene.Net.Join/TermsWithScoreCollector.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Search.Join
         private Scorer _scorer;
         private float[] _scoreSums = new float[INITIAL_ARRAY_SIZE];
 
-        internal TermsWithScoreCollector(string field, ScoreMode scoreMode)
+        private protected TermsWithScoreCollector(string field, ScoreMode scoreMode) // LUCENENET: Changed from internal to private protected
         {
             this._field = field;
             this._scoreMode = scoreMode;

--- a/src/Lucene.Net.Queries/TermsFilter.cs
+++ b/src/Lucene.Net.Queries/TermsFilter.cs
@@ -398,11 +398,11 @@ namespace Lucene.Net.Queries
 
             public abstract bool MoveNext();
 
-            public FieldAndTermEnum()
+            protected FieldAndTermEnum() // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
             {
             }
 
-            public FieldAndTermEnum(string field)
+            protected FieldAndTermEnum(string field) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
             {
                 this.Field = field;
             }

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Config/AbstractQueryConfig.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Config/AbstractQueryConfig.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Config
     {
         private readonly IDictionary<ConfigurationKey, object> configMap = new Dictionary<ConfigurationKey, object>();
 
-        internal AbstractQueryConfig()
+        private protected AbstractQueryConfig() // LUCENENET: Changed from internal to private protected
         {
             // although this class is public, it can only be constructed from package
         }

--- a/src/Lucene.Net.QueryParser/Surround/Query/RewriteQuery.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/RewriteQuery.cs
@@ -26,10 +26,10 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         protected readonly string m_fieldName;
         protected readonly BasicQueryFactory m_qf;
 
-        public RewriteQuery(
+        protected RewriteQuery(
             SQ srndQuery,
             string fieldName,
-            BasicQueryFactory qf)
+            BasicQueryFactory qf) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
         {
             this.m_srndQuery = srndQuery;
             this.m_fieldName = fieldName;

--- a/src/Lucene.Net/Analysis/AnalyzerWrapper.cs
+++ b/src/Lucene.Net/Analysis/AnalyzerWrapper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 
 namespace Lucene.Net.Analysis
@@ -38,7 +38,7 @@ namespace Lucene.Net.Analysis
         /// the wrapped <see cref="Analyzer"/>s are unknown, <see cref="Analyzer.PER_FIELD_REUSE_STRATEGY"/> is assumed.
         /// </summary>
         [Obsolete("Use AnalyzerWrapper(Analyzer.ReuseStrategy) and specify a valid Analyzer.ReuseStrategy, probably retrieved from the wrapped analyzer using Analyzer.Strategy.")]
-        protected internal AnalyzerWrapper()
+        protected AnalyzerWrapper()
             : this(PER_FIELD_REUSE_STRATEGY)
         {
         }
@@ -52,7 +52,7 @@ namespace Lucene.Net.Analysis
         /// <see cref="Analyzer.PER_FIELD_REUSE_STRATEGY"/>.
         /// </summary>
         /// <seealso cref="Analyzer.Strategy"/>
-        protected internal AnalyzerWrapper(ReuseStrategy reuseStrategy)
+        protected AnalyzerWrapper(ReuseStrategy reuseStrategy)
             : base(reuseStrategy)
         {
         }

--- a/src/Lucene.Net/Analysis/TokenFilter.cs
+++ b/src/Lucene.Net/Analysis/TokenFilter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 
 namespace Lucene.Net.Analysis
@@ -34,7 +34,7 @@ namespace Lucene.Net.Analysis
 
         /// <summary>
         /// Construct a token stream filtering the given input. </summary>
-        protected internal TokenFilter(TokenStream input)
+        protected TokenFilter(TokenStream input)
             : base(input)
         {
             this.m_input = input;

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Analysis
 
         /// <summary>
         /// Construct a token stream processing the given input. </summary>
-        protected internal Tokenizer(TextReader input)
+        protected Tokenizer(TextReader input)
         {
             this.inputPending = input ?? throw new ArgumentNullException(nameof(input), "input must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
         }
@@ -50,7 +50,7 @@ namespace Lucene.Net.Analysis
         /// <summary>
         /// Construct a token stream processing the given input using the given <see cref="Util.AttributeSource.AttributeFactory"/>.
         /// </summary>
-        protected internal Tokenizer(AttributeFactory factory, TextReader input)
+        protected Tokenizer(AttributeFactory factory, TextReader input)
             : base(factory)
         {
             this.inputPending = input ?? throw new ArgumentNullException(nameof(input), "input must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)

--- a/src/Lucene.Net/Codecs/Compressing/CompressionMode.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressionMode.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
@@ -125,7 +125,7 @@ namespace Lucene.Net.Codecs.Compressing
 
         /// <summary>
         /// Sole constructor. </summary>
-        protected internal CompressionMode()
+        protected CompressionMode()
         {
         }
 

--- a/src/Lucene.Net/Codecs/Compressing/Compressor.cs
+++ b/src/Lucene.Net/Codecs/Compressing/Compressor.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Codecs.Compressing
+﻿namespace Lucene.Net.Codecs.Compressing
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,7 +26,7 @@ namespace Lucene.Net.Codecs.Compressing
     {
         /// <summary>
         /// Sole constructor, typically called from sub-classes. </summary>
-        protected internal Compressor()
+        protected Compressor()
         {
         }
 

--- a/src/Lucene.Net/Codecs/Compressing/Decompressor.cs
+++ b/src/Lucene.Net/Codecs/Compressing/Decompressor.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Codecs.Compressing
     {
         /// <summary>
         /// Sole constructor, typically called from sub-classes. </summary>
-        protected internal Decompressor()
+        protected Decompressor()
         {
         }
 

--- a/src/Lucene.Net/Codecs/DocValuesConsumer.cs
+++ b/src/Lucene.Net/Codecs/DocValuesConsumer.cs
@@ -1,4 +1,4 @@
-using J2N.Collections.Generic.Extensions;
+﻿using J2N.Collections.Generic.Extensions;
 using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
@@ -66,7 +66,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal DocValuesConsumer()
+        protected DocValuesConsumer()
         {
         }
 

--- a/src/Lucene.Net/Codecs/DocValuesProducer.cs
+++ b/src/Lucene.Net/Codecs/DocValuesProducer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Lucene.Net.Codecs
 {
@@ -38,7 +38,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal DocValuesProducer()
+        protected DocValuesProducer()
         {
         }
 

--- a/src/Lucene.Net/Codecs/FieldInfosFormat.cs
+++ b/src/Lucene.Net/Codecs/FieldInfosFormat.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Codecs
+﻿namespace Lucene.Net.Codecs
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -30,7 +30,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal FieldInfosFormat()
+        protected FieldInfosFormat()
         {
         }
 

--- a/src/Lucene.Net/Codecs/FieldInfosReader.cs
+++ b/src/Lucene.Net/Codecs/FieldInfosReader.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Codecs
+﻿namespace Lucene.Net.Codecs
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -32,7 +32,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal FieldInfosReader()
+        protected FieldInfosReader()
         {
         }
 

--- a/src/Lucene.Net/Codecs/FieldInfosWriter.cs
+++ b/src/Lucene.Net/Codecs/FieldInfosWriter.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Codecs
+﻿namespace Lucene.Net.Codecs
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -32,7 +32,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal FieldInfosWriter()
+        protected FieldInfosWriter()
         {
         }
 

--- a/src/Lucene.Net/Codecs/FieldsConsumer.cs
+++ b/src/Lucene.Net/Codecs/FieldsConsumer.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -52,7 +52,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal FieldsConsumer()
+        protected FieldsConsumer()
         {
         }
 

--- a/src/Lucene.Net/Codecs/FieldsProducer.cs
+++ b/src/Lucene.Net/Codecs/FieldsProducer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Lucene.Net.Codecs
 {
@@ -33,7 +33,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal FieldsProducer()
+        protected FieldsProducer()
         {
         }
 

--- a/src/Lucene.Net/Codecs/FilterCodec.cs
+++ b/src/Lucene.Net/Codecs/FilterCodec.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Codecs
+﻿namespace Lucene.Net.Codecs
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -58,7 +58,7 @@ namespace Lucene.Net.Codecs
         /// create a no-arg ctor and pass the delegate codec
         /// and a unique name to this ctor.
         /// </summary>
-        protected internal FilterCodec(Codec @delegate)
+        protected FilterCodec(Codec @delegate)
             : base()
         {
             this.m_delegate = @delegate;

--- a/src/Lucene.Net/Codecs/LiveDocsFormat.cs
+++ b/src/Lucene.Net/Codecs/LiveDocsFormat.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal LiveDocsFormat()
+        protected LiveDocsFormat()
         {
         }
 

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
@@ -320,7 +320,7 @@ namespace Lucene.Net.Codecs.Lucene40
             protected bool m_skipped;
             protected internal readonly IBits m_liveDocs;
 
-            internal SegmentDocsEnumBase(Lucene40PostingsReader outerInstance, IndexInput startFreqIn, IBits liveDocs)
+            private protected SegmentDocsEnumBase(Lucene40PostingsReader outerInstance, IndexInput startFreqIn, IBits liveDocs) // LUCENENET: Changed from internal to private protected
             {
                 this.outerInstance = outerInstance;
                 this.startFreqIn = startFreqIn;

--- a/src/Lucene.Net/Codecs/NormsFormat.cs
+++ b/src/Lucene.Net/Codecs/NormsFormat.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 
 namespace Lucene.Net.Codecs
 {
@@ -31,7 +31,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal NormsFormat()
+        protected NormsFormat()
         {
         }
 

--- a/src/Lucene.Net/Codecs/PostingsBaseFormat.cs
+++ b/src/Lucene.Net/Codecs/PostingsBaseFormat.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Codecs
+﻿namespace Lucene.Net.Codecs
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -43,7 +43,7 @@ namespace Lucene.Net.Codecs
 
         /// <summary>
         /// Sole constructor. </summary>
-        protected internal PostingsBaseFormat(string name)
+        protected PostingsBaseFormat(string name)
         {
             this.Name = name;
         }

--- a/src/Lucene.Net/Codecs/PostingsConsumer.cs
+++ b/src/Lucene.Net/Codecs/PostingsConsumer.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -55,7 +55,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal PostingsConsumer()
+        protected PostingsConsumer()
         {
         }
 

--- a/src/Lucene.Net/Codecs/PostingsReaderBase.cs
+++ b/src/Lucene.Net/Codecs/PostingsReaderBase.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Index;
+﻿using Lucene.Net.Index;
 using System;
 
 namespace Lucene.Net.Codecs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal PostingsReaderBase()
+        protected PostingsReaderBase()
         {
         }
 

--- a/src/Lucene.Net/Codecs/PostingsWriterBase.cs
+++ b/src/Lucene.Net/Codecs/PostingsWriterBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Lucene.Net.Codecs
 {
@@ -44,7 +44,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal PostingsWriterBase()
+        protected PostingsWriterBase()
         {
         }
 

--- a/src/Lucene.Net/Codecs/SegmentInfoFormat.cs
+++ b/src/Lucene.Net/Codecs/SegmentInfoFormat.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Codecs
+﻿namespace Lucene.Net.Codecs
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -32,7 +32,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal SegmentInfoFormat()
+        protected SegmentInfoFormat()
         {
         }
 

--- a/src/Lucene.Net/Codecs/SegmentInfoReader.cs
+++ b/src/Lucene.Net/Codecs/SegmentInfoReader.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 
 namespace Lucene.Net.Codecs
 {
@@ -34,7 +34,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal SegmentInfoReader()
+        protected SegmentInfoReader()
         {
         }
 

--- a/src/Lucene.Net/Codecs/SegmentInfoWriter.cs
+++ b/src/Lucene.Net/Codecs/SegmentInfoWriter.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 
 namespace Lucene.Net.Codecs
 {
@@ -35,7 +35,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal SegmentInfoWriter()
+        protected SegmentInfoWriter()
         {
         }
 

--- a/src/Lucene.Net/Codecs/StoredFieldsFormat.cs
+++ b/src/Lucene.Net/Codecs/StoredFieldsFormat.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Codecs
+﻿namespace Lucene.Net.Codecs
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,7 +31,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal StoredFieldsFormat()
+        protected StoredFieldsFormat()
         {
         }
 

--- a/src/Lucene.Net/Codecs/StoredFieldsReader.cs
+++ b/src/Lucene.Net/Codecs/StoredFieldsReader.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal StoredFieldsReader()
+        protected StoredFieldsReader()
         {
         }
 

--- a/src/Lucene.Net/Codecs/StoredFieldsWriter.cs
+++ b/src/Lucene.Net/Codecs/StoredFieldsWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -50,7 +50,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal StoredFieldsWriter()
+        protected StoredFieldsWriter()
         {
         }
 

--- a/src/Lucene.Net/Codecs/TermVectorsFormat.cs
+++ b/src/Lucene.Net/Codecs/TermVectorsFormat.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Codecs
+﻿namespace Lucene.Net.Codecs
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,7 +31,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal TermVectorsFormat()
+        protected TermVectorsFormat()
         {
         }
 

--- a/src/Lucene.Net/Codecs/TermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/TermVectorsReader.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal TermVectorsReader()
+        protected TermVectorsReader()
         {
         }
 

--- a/src/Lucene.Net/Codecs/TermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/TermVectorsWriter.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal TermVectorsWriter()
+        protected TermVectorsWriter()
         {
         }
 

--- a/src/Lucene.Net/Codecs/TermsConsumer.cs
+++ b/src/Lucene.Net/Codecs/TermsConsumer.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Codecs
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal TermsConsumer()
+        protected TermsConsumer()
         {
         }
 

--- a/src/Lucene.Net/Index/CompositeReader.cs
+++ b/src/Lucene.Net/Index/CompositeReader.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -64,7 +64,7 @@ namespace Lucene.Net.Index
         /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
-        protected internal CompositeReader()
+        protected CompositeReader()
             : base()
         {
         }

--- a/src/Lucene.Net/Index/IndexReader.cs
+++ b/src/Lucene.Net/Index/IndexReader.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Index
         private bool closedByChild = false;
         private readonly AtomicInt32 refCount = new AtomicInt32(1);
 
-        internal IndexReader()
+        private protected IndexReader() // LUCENENET: Changed from internal to private protected
         {
             if (!(this is CompositeReader || this is AtomicReader))
             {

--- a/src/Lucene.Net/Index/IndexReaderContext.cs
+++ b/src/Lucene.Net/Index/IndexReaderContext.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Index
         /// the ord for this reader in the parent, <c>0</c> if parent is <c>null</c> </summary>
         public int OrdInParent { get; private set; }
 
-        internal IndexReaderContext(CompositeReaderContext parent, int ordInParent, int docBaseInParent)
+        private protected IndexReaderContext(CompositeReaderContext parent, int ordInParent, int docBaseInParent) // LUCENENET: Changed from internal to private protected
         {
             if (!(this is CompositeReaderContext || this is AtomicReaderContext))
             {

--- a/src/Lucene.Net/Index/MergeState.cs
+++ b/src/Lucene.Net/Index/MergeState.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -39,7 +39,7 @@ namespace Lucene.Net.Index
         /// </summary>
         public abstract class DocMap
         {
-            internal DocMap()
+            private protected DocMap() // LUCENENET: Changed from internal to private protected
             {
             }
 

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -283,7 +283,7 @@ namespace Lucene.Net.Search
         /// Expert: Internal cache. </summary>
         internal abstract class Cache<TKey, TValue> where TKey : CacheKey
         {
-            internal Cache(FieldCacheImpl wrapper)
+            private protected Cache(FieldCacheImpl wrapper) // LUCENENET: Changed from internal to private protected
             {
                 this.wrapper = wrapper;
             }

--- a/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
+++ b/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
@@ -714,7 +714,7 @@ namespace Lucene.Net.Search
         internal readonly bool includeLower;
         internal readonly bool includeUpper;
 
-        protected internal FieldCacheRangeFilter(string field, FieldCache.IParser parser, T lowerVal, T upperVal, bool includeLower, bool includeUpper)
+        private protected FieldCacheRangeFilter(string field, FieldCache.IParser parser, T lowerVal, T upperVal, bool includeLower, bool includeUpper)
         {
             this.field = field;
             this.parser = parser;

--- a/src/Lucene.Net/Search/FieldValueHitQueue.cs
+++ b/src/Lucene.Net/Search/FieldValueHitQueue.cs
@@ -174,7 +174,7 @@ namespace Lucene.Net.Search
         where T : FieldValueHitQueue.Entry
     {
         // prevent instantiation and extension.
-        internal FieldValueHitQueue(SortField[] fields, int size)
+        private protected FieldValueHitQueue(SortField[] fields, int size) // LUCENENET: Changed from private to private protected
             : base(size)
         {
             // When we get here, fields.length is guaranteed to be > 0, therefore no

--- a/src/Lucene.Net/Store/BaseDirectory.cs
+++ b/src/Lucene.Net/Store/BaseDirectory.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Store
 
         /// <summary>
         /// Sole constructor. </summary>
-        protected internal BaseDirectory()
+        protected BaseDirectory()
             : base()
         {
         }

--- a/src/Lucene.Net/Store/BufferedIndexOutput.cs
+++ b/src/Lucene.Net/Store/BufferedIndexOutput.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Store
 
         // LUCENENET specific - added constructor overload so FSDirectory can still subclass BufferedIndexOutput, but
         // utilize its own buffer, since FileStream is already buffered in .NET.
-        internal BufferedIndexOutput(int bufferSize, CRC32 crc)
+        private protected BufferedIndexOutput(int bufferSize, CRC32 crc)
         {
             if (bufferSize <= 0)
             {

--- a/src/Lucene.Net/Store/ByteBufferIndexInput.cs
+++ b/src/Lucene.Net/Store/ByteBufferIndexInput.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Store
             }
         }
 
-        internal ByteBufferIndexInput(string resourceDescription, ByteBuffer[] buffers, long length, int chunkSizePower, bool trackClones)
+        private protected ByteBufferIndexInput(string resourceDescription, ByteBuffer[] buffers, long length, int chunkSizePower, bool trackClones) // LUCENENET: Changed from internal to private protected
             : base(resourceDescription)
         {
             //this.buffers = buffers; // LUCENENET: this is set in SetBuffers()

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -113,7 +113,7 @@ namespace Lucene.Net.Store
         /// <param name="lockFactory"> the lock factory to use, or null for the default
         /// (<seealso cref="NativeFSLockFactory"/>); </param>
         /// <exception cref="IOException"> if there is a low-level I/O error </exception>
-        protected internal FSDirectory(DirectoryInfo path, LockFactory lockFactory)
+        protected FSDirectory(DirectoryInfo path, LockFactory lockFactory)
         {
             // new ctors use always NativeFSLockFactory as default:
             if (lockFactory is null)

--- a/src/Lucene.Net/Support/Util/NumberFormat.cs
+++ b/src/Lucene.Net/Support/Util/NumberFormat.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Util
         //private int maximumFractionDigits;
         //private int minimumFractionDigits;
 
-        public NumberFormat(IFormatProvider formatProvider)
+        protected NumberFormat(IFormatProvider formatProvider) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
         {
             this.formatProvider = formatProvider;
         }

--- a/src/Lucene.Net/Util/Automaton/LevenshteinAutomata.cs
+++ b/src/Lucene.Net/Util/Automaton/LevenshteinAutomata.cs
@@ -1,4 +1,4 @@
-using J2N;
+﻿using J2N;
 using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
@@ -257,7 +257,7 @@ namespace Lucene.Net.Util.Automaton
             protected readonly int m_n;
             private readonly int[] minErrors;
 
-            internal ParametricDescription(int w, int n, int[] minErrors)
+            private protected ParametricDescription(int w, int n, int[] minErrors) // LUCENENET: Changed from internal to private protected
             {
                 this.m_w = w;
                 this.m_n = n;

--- a/src/Lucene.Net/Util/Fst/Builder.cs
+++ b/src/Lucene.Net/Util/Fst/Builder.cs
@@ -578,7 +578,7 @@ namespace Lucene.Net.Util.Fst
     /// </summary>
     public abstract class Builder
     {
-        internal Builder() { } // Disallow external creation
+        private protected Builder() { } // Disallow external creation
 
         /// <summary>
         /// Expert: this is invoked by Builder whenever a suffix

--- a/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Util.Packed
         internal int pendingOff;
         internal float acceptableOverheadRatio;
 
-        internal AbstractAppendingInt64Buffer(int initialBlockCount, int pageSize, float acceptableOverheadRatio)
+        private protected AbstractAppendingInt64Buffer(int initialBlockCount, int pageSize, float acceptableOverheadRatio) // LUCENENET: Changed from internal to private protected
         {
             values = new PackedInt32s.Reader[initialBlockCount];
             pending = new long[pageSize];

--- a/src/Lucene.Net/Util/Packed/AbstractPagedMutable.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractPagedMutable.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Util.Packed
         internal readonly PackedInt32s.Mutable[] subMutables;
         internal readonly int bitsPerValue;
 
-        internal AbstractPagedMutable(int bitsPerValue, long size, int pageSize)
+        private protected AbstractPagedMutable(int bitsPerValue, long size, int pageSize) // LUCENENET: Changed from internal to private protected
         {
             this.bitsPerValue = bitsPerValue;
             this.size = size;

--- a/src/Lucene.Net/Util/Packed/Packed64SingleBlock.cs
+++ b/src/Lucene.Net/Util/Packed/Packed64SingleBlock.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Util.Packed
 
         internal readonly long[] blocks;
 
-        internal Packed64SingleBlock(int valueCount, int bitsPerValue)
+        private protected Packed64SingleBlock(int valueCount, int bitsPerValue) // LUCENENET: Changed from internal to private protected
             : base(valueCount, bitsPerValue)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(IsSupported(bitsPerValue));


### PR DESCRIPTION
Fixes #677.

On all abstract classes:

- Changed public constructors to protected
- Changed internal constructors to private protected
- Changed protected internal constructors to protected (SonarCloud gave [incorrect advice](https://github.com/apache/lucenenet/issues/648#issuecomment-1299606844) to make them private protected)

- **BREAKING:**  `Lucene.Net.Search.FieldCacheRangeFilter<T>`: Changed accessibility from protected internal to private protected. This class was not intended to be subclassed by users.