### PR TITLE
fix: Aligned disposable patterns

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAndSuffixAwareTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAndSuffixAwareTokenFilter.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 namespace Lucene.Net.Analysis.Miscellaneous
 {
     /*
@@ -96,6 +96,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
             {
                 suffix.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         public override void End()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAndSuffixAwareTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAndSuffixAwareTokenFilter.cs
@@ -96,7 +96,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
             {
                 suffix.Dispose();
             }
-            base.Dispose(disposing);
+            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
         }
 
         public override void End()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAwareTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAwareTokenFilter.cs
@@ -182,7 +182,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 prefix.Dispose();
                 suffix.Dispose();
             }
-            base.Dispose(disposing);
+            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
         }
 
         public override void Reset()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAwareTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAwareTokenFilter.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Util;
 
@@ -182,6 +182,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 prefix.Dispose();
                 suffix.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         public override void Reset()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
@@ -138,7 +138,7 @@ namespace Lucene.Net.Analysis.Util
                 this.isDisposing = false;
 #endif
             }
-            base.Dispose(disposing);
+            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
         }
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
@@ -138,6 +138,7 @@ namespace Lucene.Net.Analysis.Util
                 this.isDisposing = false;
 #endif
             }
+            base.Dispose(disposing);
         }
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -1179,7 +1179,7 @@ namespace Lucene.Net.Analysis.Util
             /// <summary>
             /// LUCENENET specific class to iterate the values in the <see cref="KeyCollection"/>.
             /// </summary>
-            private sealed class KeyEnumerator : IEnumerator<string>
+            private class KeyEnumerator : IEnumerator<string>
             {
                 private readonly EntryIterator entryIterator;
 
@@ -1290,7 +1290,7 @@ namespace Lucene.Net.Analysis.Util
             /// <summary>
             /// LUCENENET specific class to enumerate the values in the <see cref="ValueCollection"/>.
             /// </summary>
-            private sealed class ValueEnumerator : IEnumerator<TValue>
+            private class ValueEnumerator : IEnumerator<TValue>
             {
                 private readonly EntryIterator entryIterator;
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -1179,7 +1179,7 @@ namespace Lucene.Net.Analysis.Util
             /// <summary>
             /// LUCENENET specific class to iterate the values in the <see cref="KeyCollection"/>.
             /// </summary>
-            private class KeyEnumerator : IEnumerator<string>
+            private sealed class KeyEnumerator : IEnumerator<string>
             {
                 private readonly EntryIterator entryIterator;
 
@@ -1290,7 +1290,7 @@ namespace Lucene.Net.Analysis.Util
             /// <summary>
             /// LUCENENET specific class to enumerate the values in the <see cref="ValueCollection"/>.
             /// </summary>
-            private class ValueEnumerator : IEnumerator<TValue>
+            private sealed class ValueEnumerator : IEnumerator<TValue>
             {
                 private readonly EntryIterator entryIterator;
 

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/NearRealtimeReaderTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/NearRealtimeReaderTask.cs
@@ -123,7 +123,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 }
                 Console.WriteLine();
             }
-            base.Dispose(disposing);
+            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
         }
 
         public override bool SupportsParams => true;

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/NearRealtimeReaderTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/NearRealtimeReaderTask.cs
@@ -123,6 +123,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 }
                 Console.WriteLine();
             }
+            base.Dispose(disposing);
         }
 
         public override bool SupportsParams => true;

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/TaskSequence.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/TaskSequence.cs
@@ -76,6 +76,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 }
                 RunData.DocMaker.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         private void InitTasksArray()

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/TaskSequence.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/TaskSequence.cs
@@ -76,7 +76,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 }
                 RunData.DocMaker.Dispose();
             }
-            base.Dispose(disposing);
+            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
         }
 
         private void InitTasksArray()

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
@@ -497,10 +497,19 @@ namespace Lucene.Net.Codecs.Memory
                 }
             }
 
+            protected virtual void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    this.counts.Dispose();
+                    this.ords.Dispose();
+                }
+            }
+
             public void Dispose()
             {
-                this.counts.Dispose();
-                this.ords.Dispose();
+                Dispose(true);
+                GC.SuppressFinalize(this);
             }
 
             // LUCENENET: Remove() not supported in .NET

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
@@ -497,6 +497,12 @@ namespace Lucene.Net.Codecs.Memory
                 }
             }
 
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
             protected virtual void Dispose(bool disposing)
             {
                 if (disposing)
@@ -504,12 +510,6 @@ namespace Lucene.Net.Codecs.Memory
                     this.counts.Dispose();
                     this.ords.Dispose();
                 }
-            }
-
-            public void Dispose()
-            {
-                Dispose(true);
-                GC.SuppressFinalize(this);
             }
 
             // LUCENENET: Remove() not supported in .NET

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
@@ -213,7 +213,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             return memoryUsage;
         }
 
-        private class EntryEnumerator : IEnumerator<Entry>
+        private sealed class EntryEnumerator : IEnumerator<Entry>
         {
             internal Entry next; // next entry to return
             internal int index; // current slot

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CollisionMap.cs
@@ -213,7 +213,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             return memoryUsage;
         }
 
-        private sealed class EntryEnumerator : IEnumerator<Entry>
+        private sealed class EntryEnumerator : IEnumerator<Entry> // LUCENENET: Marked sealed
         {
             internal Entry next; // next entry to return
             internal int index; // current slot

--- a/src/Lucene.Net.Spatial/Prefix/AbstractVisitingPrefixTreeFilter.cs
+++ b/src/Lucene.Net.Spatial/Prefix/AbstractVisitingPrefixTreeFilter.cs
@@ -367,7 +367,7 @@ namespace Lucene.Net.Spatial.Prefix
         /// <summary>
         /// Used for <see cref="VNode.children"/>.
         /// </summary>
-        private class VNodeCellEnumerator : IEnumerator<VNode>
+        private sealed class VNodeCellEnumerator : IEnumerator<VNode>
         {
             internal readonly IEnumerator<Cell> cellIter;
             private readonly VNode vNode;

--- a/src/Lucene.Net.Spatial/Prefix/AbstractVisitingPrefixTreeFilter.cs
+++ b/src/Lucene.Net.Spatial/Prefix/AbstractVisitingPrefixTreeFilter.cs
@@ -367,7 +367,7 @@ namespace Lucene.Net.Spatial.Prefix
         /// <summary>
         /// Used for <see cref="VNode.children"/>.
         /// </summary>
-        private sealed class VNodeCellEnumerator : IEnumerator<VNode>
+        private sealed class VNodeCellEnumerator : IEnumerator<VNode>// LUCENENET: Marked sealed
         {
             internal readonly IEnumerator<Cell> cellIter;
             private readonly VNode vNode;

--- a/src/Lucene.Net/Analysis/TokenFilter.cs
+++ b/src/Lucene.Net/Analysis/TokenFilter.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Analysis
             {
                 m_input.Dispose();
             }
-            base.Dispose(disposing);
+            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
         }
 
         /// <summary>

--- a/src/Lucene.Net/Analysis/TokenFilter.cs
+++ b/src/Lucene.Net/Analysis/TokenFilter.cs
@@ -82,6 +82,7 @@ namespace Lucene.Net.Analysis
             {
                 m_input.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -79,7 +79,7 @@ namespace Lucene.Net.Analysis
                 inputPending = ILLEGAL_STATE_READER;
                 m_input = ILLEGAL_STATE_READER;
             }
-            base.Dispose(disposing);
+            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
         }
 
         /// <summary>

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -79,6 +79,7 @@ namespace Lucene.Net.Analysis
                 inputPending = ILLEGAL_STATE_READER;
                 m_input = ILLEGAL_STATE_READER;
             }
+            base.Dispose(disposing);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Codecs/PerField/PerFieldDocValuesFormat.cs
+++ b/src/Lucene.Net/Codecs/PerField/PerFieldDocValuesFormat.cs
@@ -1,4 +1,4 @@
-using J2N.Runtime.CompilerServices;
+﻿using J2N.Runtime.CompilerServices;
 using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
@@ -94,7 +94,16 @@ namespace Lucene.Net.Codecs.PerField
 
             public void Dispose()
             {
-                Consumer.Dispose();
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Consumer.Dispose();
+                }
             }
         }
 

--- a/src/Lucene.Net/Codecs/PerField/PerFieldPostingsFormat.cs
+++ b/src/Lucene.Net/Codecs/PerField/PerFieldPostingsFormat.cs
@@ -89,7 +89,16 @@ namespace Lucene.Net.Codecs.PerField
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void Dispose()
             {
-                Consumer.Dispose();
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Consumer.Dispose();
+                }
             }
         }
 

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -594,7 +594,16 @@ namespace Lucene.Net.Index
 
             public void Dispose()
             {
-                DropAll(false);
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    DropAll(false);
+                }
             }
 
             /// <summary>

--- a/src/Lucene.Net/Index/PrefixCodedTerms.cs
+++ b/src/Lucene.Net/Index/PrefixCodedTerms.cs
@@ -87,7 +87,7 @@ namespace Lucene.Net.Index
             public void Dispose()
             {
                 Dispose(true);
-                GC.SuppressFinalize(true);
+                GC.SuppressFinalize(this);
             }
 
             protected virtual void Dispose(bool disposing)

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -562,7 +562,7 @@ namespace Lucene.Net.Store
                         }
                     }
                 }
-                //base.Dispose(disposing); // Causes object to be disposed in some tests
+                //base.Dispose(disposing); // LUCENENET: No need to call base class, we are not using the functionality of BufferedIndexOutput
             }
 
             /// <summary>

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -562,6 +562,7 @@ namespace Lucene.Net.Store
                         }
                     }
                 }
+                //base.Dispose(disposing); // Causes object to be disposed in some tests
             }
 
             /// <summary>

--- a/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
+++ b/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
@@ -358,7 +358,7 @@ namespace Lucene.Net.Support.IO
             {
                 textWriter.Dispose();
             }
-            base.Dispose(disposing);
+            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
         }
     }
 }

--- a/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
+++ b/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
@@ -358,6 +358,7 @@ namespace Lucene.Net.Support.IO
             {
                 textWriter.Dispose();
             }
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
@@ -621,14 +621,23 @@ namespace Lucene.Net.Index
 
             public void Dispose()
             {
-                if (_isDisposed)
-                {
-                    return;
-                }
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
 
-                _isDisposed = true;
-                _lock.Dispose();
-                _cancellationTokenSource.Dispose();
+            protected virtual void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    if (_isDisposed)
+                    {
+                        return;
+                    }
+
+                    _isDisposed = true;
+                    _lock.Dispose();
+                    _cancellationTokenSource.Dispose();
+                }
             }
 
             public override string ToString()

--- a/src/Lucene.Net/Util/PrintStreamInfoStream.cs
+++ b/src/Lucene.Net/Util/PrintStreamInfoStream.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Util
             {
                 m_stream.Dispose();
             }
-            base.Dispose(disposing);
+            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
         }
 
         public virtual bool IsSystemStream => isSystemStream;

--- a/src/Lucene.Net/Util/PrintStreamInfoStream.cs
+++ b/src/Lucene.Net/Util/PrintStreamInfoStream.cs
@@ -1,4 +1,4 @@
-using J2N.Threading.Atomic;
+﻿using J2N.Threading.Atomic;
 using Lucene.Net.Support.IO;
 using System;
 using System.IO;
@@ -90,6 +90,7 @@ namespace Lucene.Net.Util
             {
                 m_stream.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         public virtual bool IsSystemStream => isSystemStream;

--- a/src/dotnet/tools/lucene-cli/CommandLine/CommandLineApplication.cs
+++ b/src/dotnet/tools/lucene-cli/CommandLine/CommandLineApplication.cs
@@ -534,7 +534,7 @@ namespace Lucene.Net.Cli.CommandLine
             }
         }
 
-        private class CommandArgumentEnumerator : IEnumerator<CommandArgument>
+        private sealed class CommandArgumentEnumerator : IEnumerator<CommandArgument>
         {
             private readonly IEnumerator<CommandArgument> _enumerator;
 

--- a/src/dotnet/tools/lucene-cli/SourceCode/SourceCodeSectionReader.cs
+++ b/src/dotnet/tools/lucene-cli/SourceCode/SourceCodeSectionReader.cs
@@ -150,6 +150,7 @@ namespace Lucene.Net.Cli.SourceCode
             {
                 this.reader?.Dispose();
             }
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
Related to #265 

I've run through most of the issues reported in Sonarcloud related to the use of the IDisposable pattern (https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS3881&id=apache_lucenenet)

This PR is meant to further expose which implementations of the pattern require more investigation while also removing the easiest areas where the pattern just needs a simple alignment. This means that if any of the following changes exposes an issue requiring much more effort this is best to be moved to comment on the existing issue and have a solution opened in another PR. I realize that a correct implementation of this pattern can be advanced and is related to at least a handful of issues opened in this repository which is why I want to take the approach stated 😄 .

To help the review I've outlined the changes here in some categories:

## Issues from private classes were marked `sealed`
Private classes don't have to uphold the same pattern as other classes if they are marked `sealed`.

## Basic implementation of pattern in some classes
The following files had a class where the following template was implemented.
```csharp
public void Dispose()
{
    Dispose(true);
    GC.SuppressFinalize(this);
}

protected virtual void Dispose(bool disposing)
{
    if (disposing)
    {
        // Cleanup
    }
}
```

1. BufferedCharFilter
2. MemoryDocValuesConsumer
3. PerFieldDocValuesFormat
4. PerFieldPostingsFormat
5. IndexWriter
6. TaskMergeScheduler

## `base.Dispose(disposing)` referencing code
The `base.Dispose(disposing)` line in `BufferedCharFilter` references the dispose method in `Lucene.Net.Analysis.CharFilter`

## `base.Dispose(disposing)` referencing disposing methods in `System.IO`
The changes in the following files have `base.Dispose(disposing)` methods which reference code in `System.IO`

1. SourceCodeSectionReader
2. SafeTextWriterWrapper

## Fixed `GC.SuppressFinalize` call
In `PrefixCodedTerms` the call to `GC.SuppressFinalize` had the object parameter set to `true` instead of `this`

## `FSDirectory`
There's a commented `base.Disposing(disposed)` change in `FSDirectory` which when activated causes at least 140 tests to fail (I didn't run it all the way through when I noticed the error). Please validate that the `Dispose(bool)` method isn't supposed to call its base.

## Other `base.Dispose(dispoing)`
Other places that aren't part of the categories above reference an empty `Dispose(bool)` method in its base. Therefore, this shouldn't cause any side effects and only make future development more reliable as the classes will follow the same dispose pattern.

## Sidenote
Assuming the comment around this `Dispose` method is correct this issue can be removed as intended either in SonarCloud or in source: https://sonarcloud.io/project/issues?issues=AYRH0T17_qq9ReJdi40Q&open=AYRH0T17_qq9ReJdi40Q&id=apache_lucenenet