### PR TITLE
BREAKING: Lucene.Net.Index.IndexWriter: Fixed Dispose(waitForMerges) vs Dispose(disposing)

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
@@ -443,7 +443,7 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Dispose this writer. </summary>
-        /// <seealso cref="IndexWriter.Dispose(bool)"/>
+        /// <seealso cref="IndexWriter.Dispose()"/>
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
See #265.

Fixed `Dispose()` overloads so there is no method signature conflict between the public `Dispose(waitForMerges)` method and the protected `Dispose(disposing)` method which is meant for end users to override. This was done by adding a `protected virtual void Dispose(bool disposing, bool waitForMerges)` overload and removing `virtual` from the public `Dispose(bool waitForMerges)` overload.

This may break some existing code that either

1. Subclasses `IndexWriter` and overrides the `public virtual void Dispose(bool disposing)` method. Instead, the subclass should override `protected virtual void Dispose(bool disposing, bool waitForMerges)`.
2. Subclasses `IndexWriter` and implements a finalizer, in which case the call should now call `Dispose(disposing: false, waitForMerges: true)`. Previously, finalizers were not supported because there was no `Dispose()` overload to call to pass the `disposing` parameter.
