### PR TITLE
BREAKING: Lucene.Net.Index.IndexReader: Refactored `IReaderClosedListener`

### DIFF
--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -2018,7 +2018,7 @@ namespace Lucene.Net.Util
                     {
                         Console.WriteLine("NOTE: newSearcher using ExecutorService with " + threads + " threads");
                     }
-                    r.AddReaderClosedListener(new ReaderClosedListenerAnonymousClass(ex));
+                    r.AddReaderDisposedListener(new ReaderClosedListenerAnonymousClass(ex));
                 }
                 IndexSearcher ret;
                 if (wrapWithAssertions)
@@ -3171,7 +3171,7 @@ namespace Lucene.Net.Util
             return Random.NextGaussian();
         }
 
-        private sealed class ReaderClosedListenerAnonymousClass : IndexReader.IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass : IReaderDisposedListener
         {
             private readonly LimitedConcurrencyLevelTaskScheduler ex;
 
@@ -3180,7 +3180,7 @@ namespace Lucene.Net.Util
                 this.ex = ex;
             }
 
-            public void OnClose(IndexReader reader)
+            public void OnDispose(IndexReader reader)
             {
                 ex?.Shutdown();
                 //TestUtil.ShutdownExecutorService(ex);

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
@@ -1089,9 +1089,9 @@ namespace Lucene.Net.Index
             writer.Commit();
             DirectoryReader reader = writer.GetReader();
             int[] closeCount = new int[1];
-            IndexReader.IReaderClosedListener listener = new ReaderClosedListenerAnonymousClass(this, reader, closeCount);
+            IReaderDisposedListener listener = new ReaderClosedListenerAnonymousClass(this, reader, closeCount);
 
-            reader.AddReaderClosedListener(listener);
+            reader.AddReaderDisposedListener(listener);
 
             reader.Dispose();
 
@@ -1100,7 +1100,7 @@ namespace Lucene.Net.Index
             writer.Dispose();
 
             DirectoryReader reader2 = DirectoryReader.Open(dir);
-            reader2.AddReaderClosedListener(listener);
+            reader2.AddReaderDisposedListener(listener);
 
             closeCount[0] = 0;
             reader2.Dispose();
@@ -1108,7 +1108,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private sealed class ReaderClosedListenerAnonymousClass : IndexReader.IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass : IReaderDisposedListener
         {
             private readonly TestDirectoryReader outerInstance;
 
@@ -1122,7 +1122,7 @@ namespace Lucene.Net.Index
                 this.closeCount = closeCount;
             }
 
-            public void OnClose(IndexReader reader)
+            public void OnDispose(IndexReader reader)
             {
                 closeCount[0]++;
             }

--- a/src/Lucene.Net.Tests/Index/TestIndexReaderClose.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexReaderClose.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Index
                 bool throwOnClose = !Rarely();
                 AtomicReader wrap = SlowCompositeReaderWrapper.Wrap(open);
                 FilterAtomicReader reader = new FilterAtomicReaderAnonymousClass(this, wrap, throwOnClose);
-                //IList<IndexReader.IReaderClosedListener> listeners = new JCG.List<IndexReader.IReaderClosedListener>(); // LUCENENET: This list is unused (and was unused in Java)
+                //IList<IReaderDisposedListener> listeners = new JCG.List<IReaderDisposedListener>(); // LUCENENET: This list is unused (and was unused in Java)
                 int listenerCount = Random.Next(20);
                 AtomicInt32 count = new AtomicInt32();
                 bool faultySet = false;
@@ -56,17 +56,17 @@ namespace Lucene.Net.Index
                     if (Rarely())
                     {
                         faultySet = true;
-                        reader.AddReaderClosedListener(new FaultyListener());
+                        reader.AddReaderDisposedListener(new FaultyListener());
                     }
                     else
                     {
                         count.IncrementAndGet();
-                        reader.AddReaderClosedListener(new CountListener(count));
+                        reader.AddReaderDisposedListener(new CountListener(count));
                     }
                 }
                 if (!faultySet && !throwOnClose)
                 {
-                    reader.AddReaderClosedListener(new FaultyListener());
+                    reader.AddReaderDisposedListener(new FaultyListener());
                 }
                 try
                 {
@@ -127,7 +127,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        private sealed class CountListener : IndexReader.IReaderClosedListener
+        private sealed class CountListener : IReaderDisposedListener
         {
             internal readonly AtomicInt32 count;
 
@@ -136,15 +136,15 @@ namespace Lucene.Net.Index
                 this.count = count;
             }
 
-            public void OnClose(IndexReader reader)
+            public void OnDispose(IndexReader reader)
             {
                 count.DecrementAndGet();
             }
         }
 
-        private sealed class FaultyListener : IndexReader.IReaderClosedListener
+        private sealed class FaultyListener : IReaderDisposedListener
         {
-            public void OnClose(IndexReader reader)
+            public void OnDispose(IndexReader reader)
             {
                 throw IllegalStateException.Create("GRRRRRRRRRRRR!");
             }

--- a/src/Lucene.Net.Tests/Index/TestParallelCompositeReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestParallelCompositeReader.cs
@@ -31,7 +31,6 @@ namespace Lucene.Net.Index
     using LuceneTestCase = Lucene.Net.Util.LuceneTestCase;
     using MockAnalyzer = Lucene.Net.Analysis.MockAnalyzer;
     using Occur = Lucene.Net.Search.Occur;
-    using IReaderClosedListener = Lucene.Net.Index.IndexReader.IReaderClosedListener;
 
     [TestFixture]
     public class TestParallelCompositeReader : LuceneTestCase
@@ -161,7 +160,7 @@ namespace Lucene.Net.Index
 
             foreach (AtomicReaderContext cxt in pr.Leaves)
             {
-                cxt.Reader.AddReaderClosedListener(new ReaderClosedListenerAnonymousClass(this, listenerClosedCount));
+                cxt.Reader.AddReaderDisposedListener(new ReaderClosedListenerAnonymousClass(this, listenerClosedCount));
             }
             pr.Dispose();
             ir1.Dispose();
@@ -169,7 +168,7 @@ namespace Lucene.Net.Index
             dir1.Dispose();
         }
 
-        private sealed class ReaderClosedListenerAnonymousClass : IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass : IReaderDisposedListener
         {
             private readonly TestParallelCompositeReader outerInstance;
 
@@ -181,7 +180,7 @@ namespace Lucene.Net.Index
                 this.listenerClosedCount = listenerClosedCount;
             }
 
-            public void OnClose(IndexReader reader)
+            public void OnDispose(IndexReader reader)
             {
                 listenerClosedCount[0]++;
             }
@@ -203,14 +202,14 @@ namespace Lucene.Net.Index
 
             foreach (AtomicReaderContext cxt in pr.Leaves)
             {
-                cxt.Reader.AddReaderClosedListener(new ReaderClosedListenerAnonymousClass2(this, listenerClosedCount));
+                cxt.Reader.AddReaderDisposedListener(new ReaderClosedListenerAnonymousClass2(this, listenerClosedCount));
             }
             pr.Dispose();
             Assert.AreEqual(3, listenerClosedCount[0]);
             dir1.Dispose();
         }
 
-        private sealed class ReaderClosedListenerAnonymousClass2 : IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass2 : IReaderDisposedListener
         {
             private readonly TestParallelCompositeReader outerInstance;
 
@@ -222,7 +221,7 @@ namespace Lucene.Net.Index
                 this.listenerClosedCount = listenerClosedCount;
             }
 
-            public void OnClose(IndexReader reader)
+            public void OnDispose(IndexReader reader)
             {
                 listenerClosedCount[0]++;
             }

--- a/src/Lucene.Net.Tests/Support/TestIDisposable.cs
+++ b/src/Lucene.Net.Tests/Support/TestIDisposable.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Analysis.Core;
+﻿using Lucene.Net.Analysis.Core;
 using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
@@ -58,7 +58,7 @@ namespace Lucene.Net.Support
                     {
                     }
 
-                    Assert.Throws<ObjectDisposedException>(() => reader.RemoveReaderClosedListener(null), "IndexReader shouldn't be open here");
+                    Assert.Throws<ObjectDisposedException>(() => reader.RemoveReaderDisposedListener(null), "IndexReader shouldn't be open here");
                 }
                 
                 Assert.Throws<ObjectDisposedException>(() => writer.AddDocument(doc), "IndexWriter shouldn't be open here");

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -228,9 +228,9 @@ namespace Lucene.Net.Search
         }
 
         // composite/SlowMultiReaderWrapper fieldcaches don't purge until composite reader is closed.
-        internal readonly IndexReader.IReaderClosedListener purgeReader;
+        internal readonly IReaderDisposedListener purgeReader;
 
-        private sealed class ReaderClosedListenerAnonymousClass : IndexReader.IReaderClosedListener
+        private sealed class ReaderClosedListenerAnonymousClass : IReaderDisposedListener
         {
             private readonly FieldCacheImpl outerInstance;
 
@@ -239,7 +239,7 @@ namespace Lucene.Net.Search
                 this.outerInstance = outerInstance;
             }
 
-            public void OnClose(IndexReader owner)
+            public void OnDispose(IndexReader owner)
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(owner is AtomicReader);
                 outerInstance.PurgeByCacheKey(((AtomicReader)owner).CoreCacheKey);
@@ -259,12 +259,12 @@ namespace Lucene.Net.Search
                 object key = reader.CoreCacheKey;
                 if (key is AtomicReader atomicReader)
                 {
-                    atomicReader.AddReaderClosedListener(purgeReader);
+                    atomicReader.AddReaderDisposedListener(purgeReader);
                 }
                 else
                 {
                     // last chance
-                    reader.AddReaderClosedListener(purgeReader);
+                    reader.AddReaderDisposedListener(purgeReader);
                 }
             }
 #if !FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR

--- a/src/Lucene.Net/Support/ObsoleteAPI/IndexReader.cs
+++ b/src/Lucene.Net/Support/ObsoleteAPI/IndexReader.cs
@@ -1,0 +1,79 @@
+﻿using System;
+
+namespace Lucene.Net.Index
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public abstract partial class IndexReader
+    {
+        /// <summary>
+        /// A custom listener that's invoked when the <see cref="IndexReader"/>
+        /// is closed.
+        /// <para/>
+        /// @lucene.experimental
+        /// </summary>
+        [Obsolete("Use IReaderDisposedListener interface instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public interface IReaderClosedListener
+        {
+            /// <summary>
+            /// Invoked when the <see cref="IndexReader"/> is closed. </summary>
+            void OnClose(IndexReader reader);
+        }
+
+        [Obsolete("This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        private sealed class ReaderCloseListenerWrapper : IReaderDisposedListener
+        {
+            private readonly IReaderClosedListener listener;
+            public ReaderCloseListenerWrapper(IReaderClosedListener listener)
+            {
+                this.listener = listener ?? throw new ArgumentNullException(nameof(listener));
+            }
+
+            public void OnDispose(IndexReader reader) => listener.OnClose(reader);
+
+            public override bool Equals(object obj) => listener.Equals(obj);
+            public override int GetHashCode() => listener.GetHashCode();
+            public override string ToString() => listener.ToString();
+        }
+
+        /// <summary>
+        /// Expert: adds a <see cref="IReaderClosedListener"/>.  The
+        /// provided listener will be invoked when this reader is closed.
+        /// <para/>
+        /// @lucene.experimental
+        /// </summary>
+        [Obsolete("Use AddReaderDisposedListerner method instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public void AddReaderClosedListener(IReaderClosedListener listener)
+        {
+            EnsureOpen();
+            readerDisposedListeners.Add(new ReaderCloseListenerWrapper(listener));
+        }
+
+        /// <summary>
+        /// Expert: remove a previously added <see cref="IReaderClosedListener"/>.
+        /// <para/>
+        /// @lucene.experimental
+        /// </summary>
+        [Obsolete("Use RemoveReaderDisposedListerner method instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public void RemoveReaderClosedListener(IReaderClosedListener listener)
+        {
+            EnsureOpen();
+            readerDisposedListeners.Remove(new ReaderCloseListenerWrapper(listener));
+        }
+    }
+}


### PR DESCRIPTION
- De-nested `IReaderClosedListener` from `IndexReader`.
- Renamed `IReaderClosedListener` > `IReaderDisposedListener`.
- Renamed `IReaderClosedListener.OnClose()` > `IReaderDisposedListener.OnDispose()`
- Renamed `AddReaderClosedListener()` > `AddReaderDisposedListener()`.
- Renamed `RemoveReaderClosedListener()` > `RemoveReaderDisposedListener()`.