### PR TITLE
Remove .NET5 from builds

### DIFF
--- a/.build/azure-templates/publish-test-results-for-test-projects.yml
+++ b/.build/azure-templates/publish-test-results-for-test-projects.yml
@@ -74,17 +74,6 @@ steps:
 - template: publish-test-results.yml
   parameters:
     testProjectName: 'Lucene.Net.Tests.CodeAnalysis'
-    framework: 'net5.0' # Since condtions are not supported for templates, we check for the file existence within publish-test-results.yml
-    vsTestPlatform: '${{ parameters.vsTestPlatform }}'
-    osName: '${{ parameters.osName }}'
-    testResultsFormat: '${{ parameters.testResultsFormat }}'
-    testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
-    testResultsFileName: '${{ parameters.testResultsFileName }}'
-
-# Special case: Only supports net6.0, net5.0, and netcoreapp3.1
-- template: publish-test-results.yml
-  parameters:
-    testProjectName: 'Lucene.Net.Tests.Cli'
     framework: 'net6.0' # Since condtions are not supported for templates, we check for the file existence within publish-test-results.yml
     vsTestPlatform: '${{ parameters.vsTestPlatform }}'
     osName: '${{ parameters.osName }}'
@@ -92,20 +81,11 @@ steps:
     testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
     testResultsFileName: '${{ parameters.testResultsFileName }}'
 
+# Special case: Only supports net6.0
 - template: publish-test-results.yml
   parameters:
     testProjectName: 'Lucene.Net.Tests.Cli'
-    framework: 'net5.0' # Since condtions are not supported for templates, we check for the file existence within publish-test-results.yml
-    vsTestPlatform: '${{ parameters.vsTestPlatform }}'
-    osName: '${{ parameters.osName }}'
-    testResultsFormat: '${{ parameters.testResultsFormat }}'
-    testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
-    testResultsFileName: '${{ parameters.testResultsFileName }}'
-
-- template: publish-test-results.yml
-  parameters:
-    testProjectName: 'Lucene.Net.Tests.Cli'
-    framework: 'netcoreapp3.1' # Since condtions are not supported for templates, we check for the file existence within publish-test-results.yml
+    framework: 'net6.0' # Since condtions are not supported for templates, we check for the file existence within publish-test-results.yml
     vsTestPlatform: '${{ parameters.vsTestPlatform }}'
     osName: '${{ parameters.osName }}'
     testResultsFormat: '${{ parameters.testResultsFormat }}'

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -39,7 +39,7 @@
   </PropertyGroup>
   
   <!-- Features in .NET Standard, .NET Core, .NET 5.x, and .NET 6.x only (no .NET Framework support) -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0' ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or '$(TargetFramework)' == 'net6.0' ">
     
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ARRAYEMPTY</DefineConstants>
@@ -49,8 +49,8 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <!-- Features in .NET Standard 2.1, .NET 5.x, and .NET 6.x only -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or $(TargetFramework.StartsWith('netcoreapp3.')) Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0' ">
+  <!-- Features in .NET Standard 2.1 and .NET 6.x only -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net6.0' ">
 
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ADDORUPDATE</DefineConstants>
@@ -60,15 +60,15 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, and .NET 6.x -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0' ">
+  <!-- Features in .NET Standard 2.x and .NET 6.x -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard2.')) Or '$(TargetFramework)' == 'net6.0' ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ICONFIGURATIONROOT_PROVIDERS</DefineConstants>
 
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, and .NET 6.x  -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0' ">
+  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, and .NET 6.x  -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or '$(TargetFramework)' == 'net6.0' ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_GETCALLINGASSEMBLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_FILESTREAM_LOCK</DefineConstants>
@@ -80,8 +80,8 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x (No .NET 6.x support) -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or '$(TargetFramework)' == 'net5.0' ">
+  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, (No .NET 6.x support) -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_INITIALIZELIFETIMESERVICE</DefineConstants>
 

--- a/TestTargetFramework.props
+++ b/TestTargetFramework.props
@@ -28,13 +28,13 @@
     this setting only affects the test projects. -->
     <!--<TargetFramework>net461</TargetFramework>-->
     <!--<TargetFramework>net48</TargetFramework>-->
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!--<TargetFramework>net6.0</TargetFramework>-->
 
     <!-- Allow the build script to pass in the test frameworks to build for.
       This overrides the above TargetFramework setting. 
       LUCENENET TODO: Due to a parsing bug, we cannot pass a string with a ; to dotnet msbuild, so passing true as a workaround -->
-    <TargetFrameworks Condition=" '$(TestFrameworks)' == 'true' ">net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TestFrameworks)' == 'true' ">net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TestFrameworks)' == 'true' AND $([MSBuild]::IsOsPlatform('Windows')) ">$(TargetFrameworks);net48;net461</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,13 +239,6 @@ stages:
     - template: '.build/azure-templates/publish-test-binaries.yml'
       parameters:
         publishDirectory: $(PublishTempDirectory)
-        framework: 'net5.0'
-        binaryArtifactName: '$(BinaryArtifactName)'
-        testSettingsFilePath: '$(Build.ArtifactStagingDirectory)/$(TestSettingsFileName)'
-
-    - template: '.build/azure-templates/publish-test-binaries.yml'
-      parameters:
-        publishDirectory: $(PublishTempDirectory)
         framework: 'net461'
         binaryArtifactName: '$(BinaryArtifactName)'
         testSettingsFilePath: '$(Build.ArtifactStagingDirectory)/$(TestSettingsFileName)'
@@ -370,66 +363,6 @@ stages:
       parameters:
         osName: $(osName)
         framework: 'net6.0'
-        vsTestPlatform: 'x86'
-        testBinariesArtifactName: '$(TestBinariesArtifactName)'
-        nugetArtifactName: '$(NuGetArtifactName)'
-        testResultsArtifactName: '$(TestResultsArtifactName)'
-        maximumParallelJobs: $(maximumParallelJobs)
-        maximumAllowedFailures: $(maximumAllowedFailures)
-        dotNetSdkVersion: '$(DotNetSDKVersion)'
-
-  - job: Test_net5_0_x64
-    condition: and(succeeded(), ne(variables['RunTests'], 'false'))
-    strategy:
-      matrix:
-        Windows:
-          osName: 'Windows'
-          imageName: 'windows-2019'
-          maximumParallelJobs: 8
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        Linux:
-          osName: 'Linux'
-          imageName: 'ubuntu-latest'
-          maximumParallelJobs: 7
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        macOS:
-          osName: 'macOS'
-          imageName: 'macOS-latest'
-          maximumParallelJobs: 7
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-    displayName: 'Test net5.0,x64 on'
-    pool:
-      vmImage: $(imageName)
-    steps:
-    - template: '.build/azure-templates/run-tests-on-os.yml'
-      parameters:
-        osName: $(osName)
-        framework: 'net5.0'
-        vsTestPlatform: 'x64'
-        testBinariesArtifactName: '$(TestBinariesArtifactName)'
-        nugetArtifactName: '$(NuGetArtifactName)'
-        testResultsArtifactName: '$(TestResultsArtifactName)'
-        maximumParallelJobs: $(maximumParallelJobs)
-        maximumAllowedFailures: $(maximumAllowedFailures)
-        dotNetSdkVersion: '$(DotNetSDKVersion)'
-
-  - job: Test_net5_0_x86 # Only run Nightly or if explicitly enabled with RunX86Tests
-    condition: and(succeeded(), ne(variables['RunTests'], 'false'), or(eq(variables['IsNightly'], 'true'), eq(variables['RunX86Tests'], 'true')))
-    strategy:
-      matrix:
-        Windows:
-          osName: 'Windows'
-          imageName: 'windows-2019'
-          maximumParallelJobs: 8
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-    displayName: 'Test net5.0,x86 on'
-    pool:
-      vmImage: $(imageName)
-    steps:
-    - template: '.build/azure-templates/run-tests-on-os.yml'
-      parameters:
-        osName: $(osName)
-        framework: 'net5.0'
         vsTestPlatform: 'x86'
         testBinariesArtifactName: '$(TestBinariesArtifactName)'
         nugetArtifactName: '$(NuGetArtifactName)'

--- a/src/dotnet/Lucene.Net.Tests.CodeAnalysis/Lucene.Net.Tests.CodeAnalysis.csproj
+++ b/src/dotnet/Lucene.Net.Tests.CodeAnalysis/Lucene.Net.Tests.CodeAnalysis.csproj
@@ -22,11 +22,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Lucene.Net.CodeAnalysis</RootNamespace>
     
     <IsPublishable>false</IsPublishable>
-    <IsPublishable Condition=" '$(TargetFramework)' == 'net5.0' ">true</IsPublishable>
+    <IsPublishable Condition=" '$(TargetFramework)' == 'net6.0' ">true</IsPublishable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
@@ -25,7 +25,7 @@
 
   <PropertyGroup>
     <!-- Allow specific target framework to flow in from TestTargetFrameworks.props -->
-    <TargetFrameworks Condition=" '$(TargetFramework)' == '' ">net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFramework)' == '' ">net6.0</TargetFrameworks>
     <!-- If .NET Frameowrk is specified, just target the latest version -->
     <TargetFramework Condition=" $(TargetFramework.StartsWith('net4')) ">net6.0</TargetFramework>
     <AssemblyTitle>Lucene.Net.Tests.Cli</AssemblyTitle>

--- a/src/dotnet/tools/lucene-cli/lucene-cli.csproj
+++ b/src/dotnet/tools/lucene-cli/lucene-cli.csproj
@@ -24,7 +24,7 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
 
     <IsPublishable>true</IsPublishable>
     <IsPublishable Condition="$(TargetFramework.StartsWith('net4'))">false</IsPublishable>

--- a/websites/apidocs/apiSpec/core/Lucene_Net_Codecs.md
+++ b/websites/apidocs/apiSpec/core/Lucene_Net_Codecs.md
@@ -186,7 +186,7 @@ Here is an example project file for .NET 5 for testing a project named `MyCodecs
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
.NET5.0 is no longer supported and will not receive any additional security updates.

This PR removes .NET5.0 configurations from the build & test targets. 