### PR TITLE
Finished BufferedCharFilter implementation

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -80,9 +80,11 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x (No .NET 6.x support) -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or '$(TargetFramework)' == 'net5.0' ">
+  <!-- Features in .NET Framework 4.5+ and .NET Standard 2.x only (No .NET Core support) -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) ">
 
+    <!-- NOTE: The API for this exists in .NET Core, but it throws a PlatformNotSupportedException.
+         We simply don't override this to get the same behavior. -->
     <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_INITIALIZELIFETIMESERVICE</DefineConstants>
 
   </PropertyGroup>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
@@ -342,8 +342,7 @@ namespace Lucene.Net.Analysis.Util
                      * underlying stream would block.
                      */
                     // LUCENENET specific: only CharFilter derived types support IsReady
-                    var charFilter = @in as CharFilter;
-                    if (outstanding == 0 || (outstanding < length) && charFilter != null && !charFilter.IsReady)
+                    if (outstanding == 0 || (outstanding < length) && @in is CharFilter charFilter && !charFilter.IsReady)
                     {
                         break;
                     }
@@ -514,8 +513,7 @@ namespace Lucene.Net.Analysis.Util
                 {
                     EnsureOpen();
                     // LUCENENET specific: only CharFilter derived types support IsReady
-                    var charFilter = @in as CharFilter;
-                    return ((end - pos) > 0) || (charFilter != null && charFilter.IsReady);
+                    return ((end - pos) > 0) || (@in is CharFilter charFilter && charFilter.IsReady);
                 }
                 finally
                 {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Support.Threading;
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Lucene.Net.Analysis.Util
@@ -607,50 +608,154 @@ namespace Lucene.Net.Analysis.Util
             }
         }
 
-#region LUCENENET Specific Methods
+        #region LUCENENET Specific Methods
 
+        /// <summary>
+        /// Reads a single character from this reader and returns it with the two
+        /// higher-order bytes set to 0. If possible, <see cref="BufferedCharFilter"/> returns a
+        /// character from the buffer. If there are no characters available in the
+        /// buffer, it fills the buffer and then returns a character. It returns -1
+        /// if there are no more characters in the source reader. Unlike <see cref="Read()"/>,
+        /// this method does not advance the current position.
+        /// </summary>
+        /// <returns>The character read or -1 if the end of the source reader has been reached.</returns>
+        /// <exception cref="IOException">If this reader is disposed or some other I/O error occurs.</exception>
         public override int Peek()
         {
-            throw new NotImplementedException();
+            UninterruptableMonitor.Enter(m_lock);
+            try
+            {
+                EnsureOpen();
+                /* Are there buffered characters available? */
+                if (pos < end || FillBuf() != -1)
+                {
+                    return buf[pos];
+                }
+                return -1;
+            }
+            finally
+            {
+                UninterruptableMonitor.Exit(m_lock);
+            }
         }
 
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => @in.Equals(obj);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => @in.GetHashCode();
+
+        /// <inheritdoc/>
+        public override string ToString() => @in.ToString();
+
+#if FEATURE_STREAM_READ_SPAN
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
+        public override int Read(Span<char> buffer)
+        {
+            throw UnsupportedOperationException.Create();
+        }
+
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
+        public override ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
+        {
+            throw UnsupportedOperationException.Create();
+        }
+
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
+        public override int ReadBlock(Span<char> buffer)
+        {
+            throw UnsupportedOperationException.Create();
+        }
+
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
+        public override ValueTask<int> ReadBlockAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
+        {
+            throw UnsupportedOperationException.Create();
+        }
+#endif
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override Task<int> ReadAsync(char[] buffer, int index, int count)
         {
-            throw new NotImplementedException();
+            throw UnsupportedOperationException.Create();
         }
 
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override int ReadBlock(char[] buffer, int index, int count)
         {
-            throw new NotImplementedException();
+            throw UnsupportedOperationException.Create();
         }
 
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)
         {
-            throw new NotImplementedException();
+            throw UnsupportedOperationException.Create();
         }
 
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override Task<string> ReadLineAsync()
         {
-            throw new NotImplementedException();
+            throw UnsupportedOperationException.Create();
         }
 
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override string ReadToEnd()
         {
-            throw new NotImplementedException();
+            throw UnsupportedOperationException.Create();
         }
 
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override Task<string> ReadToEndAsync()
         {
-            throw new NotImplementedException();
+            throw UnsupportedOperationException.Create();
         }
 #if FEATURE_TEXTWRITER_INITIALIZELIFETIMESERVICE
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
+        // LUCENENET: We don't override this on .NET Core, it throws a
+        // PlatformNotSupportedException, which is the behavior we want.
         public override object InitializeLifetimeService()
         {
-            throw new NotImplementedException();
+            throw UnsupportedOperationException.Create();
         }
 #endif
 
 #if FEATURE_TEXTWRITER_CLOSE
+        /// <summary>
+        /// Not supported.
+        /// </summary>
+        /// <exception cref="NotSupportedException">The call didn't originate from within <see cref="Dispose(bool)"/>.</exception>
         public override void Close()
         {
             if (!isDisposing)
@@ -659,6 +764,6 @@ namespace Lucene.Net.Analysis.Util
             }
         }
 #endif
-        #endregion
+        #endregion LUCENENET Specific Methods
     }
 }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
@@ -302,7 +302,8 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="IOException">if this reader is disposed or some other I/O error occurs.</exception>
         public override int Read(char[] buffer, int offset, int length)
         {
-            lock(m_lock)
+            UninterruptableMonitor.Enter(m_lock);
+            try
             {
                 EnsureOpen();
                 // LUCENENT specific - refactored guard clauses to throw individual messages.
@@ -378,6 +379,10 @@ namespace Lucene.Net.Analysis.Util
                 int count = length - outstanding;
                 return (count > 0 || count == length) ? count : 0 /*-1*/;
             }
+            finally
+            {
+                UninterruptableMonitor.Exit(m_lock);
+            }
         }
 
         /// <summary>
@@ -391,7 +396,8 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="IOException">if this reader is disposed or some other I/O error occurs.</exception>
         public override string ReadLine()
         {
-            lock(m_lock)
+            UninterruptableMonitor.Enter(m_lock);
+            try
             {
                 EnsureOpen();
                 /* has the underlying stream been exhausted? */
@@ -485,6 +491,10 @@ namespace Lucene.Net.Analysis.Util
                         result.Append(buf, pos, end - pos - 1);
                     }
                 }
+            }
+            finally
+            {
+                UninterruptableMonitor.Exit(m_lock);
             }
         }
 

--- a/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
+++ b/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
@@ -93,6 +93,8 @@ namespace Lucene.Net.Support.IO
         }
 
 #if FEATURE_TEXTWRITER_INITIALIZELIFETIMESERVICE
+        // LUCENENET: We don't override this on .NET Core, it throws a
+        // PlatformNotSupportedException, which is the behavior we want.
         public override object InitializeLifetimeService()
         {
             return Run(() => textWriter.InitializeLifetimeService());


### PR DESCRIPTION
Well, sort of. An implementation of `Peek()` was added. Several of the method overloads were changed from throwing `NotImplementedException` to `NotSupportedException`.

Fixed locks in `Read()` and `Read(char[] buffer, int offset, int length)` to use `UninterruptableMonitor`.