### PR TITLE
TestTargetFramework.props: Disabled EoL warnings in Test Projects

### DIFF
--- a/TestTargetFramework.props
+++ b/TestTargetFramework.props
@@ -53,6 +53,9 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Warnings to be Disabled in Test Projects">
+    <!-- We purposely test on EoL frameworks for testing netstandard2.1, but we want to keep this warning in production code. -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    
     <NoWarn Label="Nested types should not be visible">$(NoWarn);CA1034</NoWarn>
     <NoWarn Label="Use Literals Where Appropriate">$(NoWarn);CA1802</NoWarn>
     <NoWarn Label="Add readonly modifier">$(NoWarn);CA1822</NoWarn>


### PR DESCRIPTION
Disabled EoL warnings in test projects so we don't get false flags for testing with net5.0. We use net5.0 to test the netstandard2.1 target framework and will continue doing so for the foreseeable future.