### PR TITLE
Lucene.Net.Support.DictionaryExtensions: Reduced dependency on the Put() method + added docs

### DIFF
--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/Segmentation/TestICUTokenizerFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/Segmentation/TestICUTokenizerFactory.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
             TextReader reader = new StringReader
                 ("  Don't,break.at?/(punct)!  \u201Cnice\u201D\r\n\r\n85_At:all; `really\" +2=3$5,&813 !@#%$^)(*@#$   ");
             IDictionary<string, string> args = new Dictionary<string, string>();
-            args.Put(ICUTokenizerFactory.RULEFILES, "Latn:Latin-break-only-on-whitespace.rbbi");
+            args[ICUTokenizerFactory.RULEFILES] = "Latn:Latin-break-only-on-whitespace.rbbi";
             ICUTokenizerFactory factory = new ICUTokenizerFactory(args);
             factory.Inform(new ClasspathResourceLoader(this.GetType()));
             TokenStream stream = factory.Create(reader);
@@ -64,7 +64,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
             TextReader reader = new StringReader
                 ("One-two punch.  Brang-, not brung-it.  This one--not that one--is the right one, -ish.");
             IDictionary<string, string> args = new Dictionary<string, string>();
-            args.Put(ICUTokenizerFactory.RULEFILES, "Latn:Latin-dont-break-on-hyphens.rbbi");
+            args[ICUTokenizerFactory.RULEFILES] = "Latn:Latin-dont-break-on-hyphens.rbbi";
             ICUTokenizerFactory factory = new ICUTokenizerFactory(args);
             factory.Inform(new ClasspathResourceLoader(GetType()));
             TokenStream stream = factory.Create(reader);
@@ -85,7 +85,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
             TextReader reader = new StringReader
                 ("Some English.  Немного русский.  ข้อความภาษาไทยเล็ก ๆ น้อย ๆ  More English.");
             IDictionary<string, string> args = new Dictionary<string, string>();
-            args.Put(ICUTokenizerFactory.RULEFILES, "Cyrl:KeywordTokenizer.rbbi,Thai:KeywordTokenizer.rbbi");
+            args[ICUTokenizerFactory.RULEFILES] = "Cyrl:KeywordTokenizer.rbbi,Thai:KeywordTokenizer.rbbi";
             ICUTokenizerFactory factory = new ICUTokenizerFactory(args);
             factory.Inform(new ClasspathResourceLoader(GetType()));
             TokenStream stream = factory.Create(reader);

--- a/src/Lucene.Net.Tests.Analysis.ICU/Collation/TestICUCollationKeyFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Collation/TestICUCollationKeyFilterFactory.cs
@@ -244,8 +244,8 @@ namespace Lucene.Net.Collation
             String germanUmlaut = "Töne";
             String germanOE = "Toene";
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put("custom", "rules.txt");
-            args.Put("strength", "primary");
+            args["custom"] = "rules.txt";
+            args["strength"] = "primary";
             ICUCollationKeyFilterFactory factory = new ICUCollationKeyFilterFactory(args);
             factory.Inform(new StringMockResourceLoader(tailoredRules));
             TokenStream tsUmlaut = factory.Create(
@@ -318,7 +318,7 @@ namespace Lucene.Net.Collation
                 String prev = args.Put(keysAndValues[i], keysAndValues[i + 1]);
                 assertNull("duplicate values for key: " + keysAndValues[i], prev);
             }
-            String previous = args.Put("luceneMatchVersion", TEST_VERSION_CURRENT.toString());
+            String previous = args.Put("luceneMatchVersion", TEST_VERSION_CURRENT.ToString());
             assertNull("duplicate values for key: luceneMatchVersion", previous);
             TokenFilterFactory factory = null;
             try

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseIterationMarkCharFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseIterationMarkCharFilterFactory.cs
@@ -59,8 +59,8 @@ namespace Lucene.Net.Analysis.Ja
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
 
             IDictionary<String, String> filterArgs = new Dictionary<String, String>();
-            filterArgs.Put("normalizeKanji", "true");
-            filterArgs.Put("normalizeKana", "false");
+            filterArgs["normalizeKanji"] = "true";
+            filterArgs["normalizeKana"] = "false";
             JapaneseIterationMarkCharFilterFactory filterFactory = new JapaneseIterationMarkCharFilterFactory(filterArgs);
 
             TextReader filter = filterFactory.Create(
@@ -77,8 +77,8 @@ namespace Lucene.Net.Analysis.Ja
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
 
             IDictionary<String, String> filterArgs = new Dictionary<String, String>();
-            filterArgs.Put("normalizeKanji", "false");
-            filterArgs.Put("normalizeKana", "true");
+            filterArgs["normalizeKanji"] = "false";
+            filterArgs["normalizeKana"] = "true";
             JapaneseIterationMarkCharFilterFactory filterFactory = new JapaneseIterationMarkCharFilterFactory(filterArgs);
 
             TextReader filter = filterFactory.Create(

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapanesePartOfSpeechStopFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapanesePartOfSpeechStopFilterFactory.cs
@@ -39,8 +39,8 @@ namespace Lucene.Net.Analysis.Ja
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
             TokenStream ts = tokenizerFactory.Create(new StringReader("私は制限スピードを超える。"));
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put("luceneMatchVersion", TEST_VERSION_CURRENT.toString());
-            args.Put("tags", "stoptags.txt");
+            args["luceneMatchVersion"] = TEST_VERSION_CURRENT.ToString();
+            args["tags"] = "stoptags.txt";
             JapanesePartOfSpeechStopFilterFactory factory = new JapanesePartOfSpeechStopFilterFactory(args);
             factory.Inform(new StringMockResourceLoader(tags));
             ts = factory.Create(ts);

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseTokenizerFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseTokenizerFactory.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Analysis.Ja
         public void TestMode()
         {
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put("mode", "normal");
+            args["mode"] = "normal";
             JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(args);
             factory.Inform(new StringMockResourceLoader(""));
             TokenStream ts = factory.Create(new StringReader("シニアソフトウェアエンジニア"));
@@ -84,7 +84,7 @@ namespace Lucene.Net.Analysis.Ja
                 "# Custom reading for sumo wrestler\n" +
                 "朝青龍,朝青龍,アサショウリュウ,カスタム人名\n";
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put("userDictionary", "userdict.txt");
+            args["userDictionary"] = "userdict.txt";
             JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(args);
             factory.Inform(new StringMockResourceLoader(userDict));
             TokenStream ts = factory.Create(new StringReader("関西国際空港に行った"));
@@ -100,7 +100,7 @@ namespace Lucene.Net.Analysis.Ja
         public void TestPreservePunctuation()
         {
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put("discardPunctuation", "false");
+            args["discardPunctuation"] = "false";
             JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(args);
             factory.Inform(new StringMockResourceLoader(""));
             TokenStream ts = factory.Create(

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/Language/Bm/PhoneticEngineRegressionTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/Language/Bm/PhoneticEngineRegressionTest.cs
@@ -39,42 +39,42 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
             // concat is true, ruleType is EXACT
             args = new JCG.SortedDictionary<String, String>();
-            args.Put("nameType", "GENERIC");
+            args["nameType"] = "GENERIC";
             Assert.AreEqual(Encode(args, true, "Angelo"), "agilo|angilo|aniilo|anilo|anxilo|anzilo|ogilo|ongilo|oniilo|onilo|onxilo|onzilo");
-            args.Put("ruleType", "EXACT");
+            args["ruleType"] = "EXACT";
             Assert.AreEqual(Encode(args, true, "Angelo"), "anZelo|andZelo|angelo|anhelo|anjelo|anxelo");
             Assert.AreEqual(Encode(args, true, "D'Angelo"), "(anZelo|andZelo|angelo|anhelo|anjelo|anxelo)-(danZelo|dandZelo|dangelo|danhelo|danjelo|danxelo)");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, true, "Angelo"), "andZelo|angelo|anxelo");
             Assert.AreEqual(Encode(args, true, "1234"), "");
 
             // concat is false, ruleType is EXACT
             args = new JCG.SortedDictionary<String, String>();
             Assert.AreEqual(Encode(args, false, "Angelo"), "agilo|angilo|aniilo|anilo|anxilo|anzilo|ogilo|ongilo|oniilo|onilo|onxilo|onzilo");
-            args.Put("ruleType", "EXACT");
+            args["ruleType"] = "EXACT";
             Assert.AreEqual(Encode(args, false, "Angelo"), "anZelo|andZelo|angelo|anhelo|anjelo|anxelo");
             Assert.AreEqual(Encode(args, false, "D'Angelo"), "(anZelo|andZelo|angelo|anhelo|anjelo|anxelo)-(danZelo|dandZelo|dangelo|danhelo|danjelo|danxelo)");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, false, "Angelo"), "andZelo|angelo|anxelo");
             Assert.AreEqual(Encode(args, false, "1234"), "");
 
             // concat is true, ruleType is APPROX
             args = new JCG.SortedDictionary<String, String>();
             Assert.AreEqual(Encode(args, true, "Angelo"), "agilo|angilo|aniilo|anilo|anxilo|anzilo|ogilo|ongilo|oniilo|onilo|onxilo|onzilo");
-            args.Put("ruleType", "APPROX");
+            args["ruleType"] = "APPROX";
             Assert.AreEqual(Encode(args, true, "Angelo"), "agilo|angilo|aniilo|anilo|anxilo|anzilo|ogilo|ongilo|oniilo|onilo|onxilo|onzilo");
             Assert.AreEqual(Encode(args, true, "D'Angelo"), "(agilo|angilo|aniilo|anilo|anxilo|anzilo|ogilo|ongilo|oniilo|onilo|onxilo|onzilo)-(dagilo|dangilo|daniilo|danilo|danxilo|danzilo|dogilo|dongilo|doniilo|donilo|donxilo|donzilo)");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, true, "Angelo"), "angilo|anxilo|anzilo|ongilo|onxilo|onzilo");
             Assert.AreEqual(Encode(args, true, "1234"), "");
 
             // concat is false, ruleType is APPROX
             args = new JCG.SortedDictionary<String, String>();
             Assert.AreEqual(Encode(args, false, "Angelo"), "agilo|angilo|aniilo|anilo|anxilo|anzilo|ogilo|ongilo|oniilo|onilo|onxilo|onzilo");
-            args.Put("ruleType", "APPROX");
+            args["ruleType"] = "APPROX";
             Assert.AreEqual(Encode(args, false, "Angelo"), "agilo|angilo|aniilo|anilo|anxilo|anzilo|ogilo|ongilo|oniilo|onilo|onxilo|onzilo");
             Assert.AreEqual(Encode(args, false, "D'Angelo"), "(agilo|angilo|aniilo|anilo|anxilo|anzilo|ogilo|ongilo|oniilo|onilo|onxilo|onzilo)-(dagilo|dangilo|daniilo|danilo|danxilo|danzilo|dogilo|dongilo|doniilo|donilo|donxilo|donzilo)");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, false, "Angelo"), "angilo|anxilo|anzilo|ongilo|onxilo|onzilo");
             Assert.AreEqual(Encode(args, false, "1234"), "");
         }
@@ -86,45 +86,45 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
             // concat is true, ruleType is EXACT
             args = new JCG.SortedDictionary<String, String>();
-            args.Put("nameType", "ASHKENAZI");
+            args["nameType"] = "ASHKENAZI";
             Assert.AreEqual(Encode(args, true, "Angelo"), "AnElO|AnSelO|AngElO|AngzelO|AnkselO|AnzelO");
-            args.Put("ruleType", "EXACT");
+            args["ruleType"] = "EXACT";
             Assert.AreEqual(Encode(args, true, "Angelo"), "andZelo|angelo|anhelo|anxelo");
             Assert.AreEqual(Encode(args, true, "D'Angelo"), "dandZelo|dangelo|danhelo|danxelo");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, true, "Angelo"), "angelo|anxelo");
             Assert.AreEqual(Encode(args, true, "1234"), "");
 
             // concat is false, ruleType is EXACT
             args = new JCG.SortedDictionary<String, String>();
-            args.Put("nameType", "ASHKENAZI");
+            args["nameType"] = "ASHKENAZI";
             Assert.AreEqual(Encode(args, false, "Angelo"), "AnElO|AnSelO|AngElO|AngzelO|AnkselO|AnzelO");
-            args.Put("ruleType", "EXACT");
+            args["ruleType"] = "EXACT";
             Assert.AreEqual(Encode(args, false, "Angelo"), "andZelo|angelo|anhelo|anxelo");
             Assert.AreEqual(Encode(args, false, "D'Angelo"), "dandZelo|dangelo|danhelo|danxelo");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, false, "Angelo"), "angelo|anxelo");
             Assert.AreEqual(Encode(args, false, "1234"), "");
 
             // concat is true, ruleType is APPROX
             args = new JCG.SortedDictionary<String, String>();
-            args.Put("nameType", "ASHKENAZI");
+            args["nameType"] = "ASHKENAZI";
             Assert.AreEqual(Encode(args, true, "Angelo"), "AnElO|AnSelO|AngElO|AngzelO|AnkselO|AnzelO");
-            args.Put("ruleType", "APPROX");
+            args["ruleType"] = "APPROX";
             Assert.AreEqual(Encode(args, true, "Angelo"), "AnElO|AnSelO|AngElO|AngzelO|AnkselO|AnzelO");
             Assert.AreEqual(Encode(args, true, "D'Angelo"), "dAnElO|dAnSelO|dAngElO|dAngzelO|dAnkselO|dAnzelO");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, true, "Angelo"), "AnSelO|AngElO|AngzelO|AnkselO");
             Assert.AreEqual(Encode(args, true, "1234"), "");
 
             // concat is false, ruleType is APPROX
             args = new JCG.SortedDictionary<String, String>();
-            args.Put("nameType", "ASHKENAZI");
+            args["nameType"] = "ASHKENAZI";
             Assert.AreEqual(Encode(args, false, "Angelo"), "AnElO|AnSelO|AngElO|AngzelO|AnkselO|AnzelO");
-            args.Put("ruleType", "APPROX");
+            args["ruleType"] = "APPROX";
             Assert.AreEqual(Encode(args, false, "Angelo"), "AnElO|AnSelO|AngElO|AngzelO|AnkselO|AnzelO");
             Assert.AreEqual(Encode(args, false, "D'Angelo"), "dAnElO|dAnSelO|dAngElO|dAngzelO|dAnkselO|dAnzelO");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, false, "Angelo"), "AnSelO|AngElO|AngzelO|AnkselO");
             Assert.AreEqual(Encode(args, false, "1234"), "");
         }
@@ -136,45 +136,45 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
             // concat is true, ruleType is EXACT
             args = new JCG.SortedDictionary<String, String>();
-            args.Put("nameType", "SEPHARDIC");
+            args["nameType"] = "SEPHARDIC";
             Assert.AreEqual(Encode(args, true, "Angelo"), "anhila|anhilu|anzila|anzilu|nhila|nhilu|nzila|nzilu");
-            args.Put("ruleType", "EXACT");
+            args["ruleType"] = "EXACT";
             Assert.AreEqual(Encode(args, true, "Angelo"), "anZelo|andZelo|anxelo");
             Assert.AreEqual(Encode(args, true, "D'Angelo"), "anZelo|andZelo|anxelo");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, true, "Angelo"), "andZelo|anxelo");
             Assert.AreEqual(Encode(args, true, "1234"), "");
 
             // concat is false, ruleType is EXACT
             args = new JCG.SortedDictionary<String, String>();
-            args.Put("nameType", "SEPHARDIC");
+            args["nameType"] = "SEPHARDIC";
             Assert.AreEqual(Encode(args, false, "Angelo"), "anhila|anhilu|anzila|anzilu|nhila|nhilu|nzila|nzilu");
-            args.Put("ruleType", "EXACT");
+            args["ruleType"] = "EXACT";
             Assert.AreEqual(Encode(args, false, "Angelo"), "anZelo|andZelo|anxelo");
             Assert.AreEqual(Encode(args, false, "D'Angelo"), "danZelo|dandZelo|danxelo");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, false, "Angelo"), "andZelo|anxelo");
             Assert.AreEqual(Encode(args, false, "1234"), "");
 
             // concat is true, ruleType is APPROX
             args = new JCG.SortedDictionary<String, String>();
-            args.Put("nameType", "SEPHARDIC");
+            args["nameType"] = "SEPHARDIC";
             Assert.AreEqual(Encode(args, true, "Angelo"), "anhila|anhilu|anzila|anzilu|nhila|nhilu|nzila|nzilu");
-            args.Put("ruleType", "APPROX");
+            args["ruleType"] = "APPROX";
             Assert.AreEqual(Encode(args, true, "Angelo"), "anhila|anhilu|anzila|anzilu|nhila|nhilu|nzila|nzilu");
             Assert.AreEqual(Encode(args, true, "D'Angelo"), "anhila|anhilu|anzila|anzilu|nhila|nhilu|nzila|nzilu");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, true, "Angelo"), "anhila|anhilu|anzila|anzilu|nhila|nhilu|nzila|nzilu");
             Assert.AreEqual(Encode(args, true, "1234"), "");
 
             // concat is false, ruleType is APPROX
             args = new JCG.SortedDictionary<String, String>();
-            args.Put("nameType", "SEPHARDIC");
+            args["nameType"] = "SEPHARDIC";
             Assert.AreEqual(Encode(args, false, "Angelo"), "anhila|anhilu|anzila|anzilu|nhila|nhilu|nzila|nzilu");
-            args.Put("ruleType", "APPROX");
+            args["ruleType"] = "APPROX";
             Assert.AreEqual(Encode(args, false, "Angelo"), "anhila|anhilu|anzila|anzilu|nhila|nhilu|nzila|nzilu");
             Assert.AreEqual(Encode(args, false, "D'Angelo"), "danhila|danhilu|danzila|danzilu|nhila|nhilu|nzila|nzilu");
-            args.Put("languageSet", "italian,greek,spanish");
+            args["languageSet"] = "italian,greek,spanish";
             Assert.AreEqual(Encode(args, false, "Angelo"), "anhila|anhilu|anzila|anzilu|nhila|nhilu|nzila|nzilu");
             Assert.AreEqual(Encode(args, false, "1234"), "");
         }

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/TestBeiderMorseFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/TestBeiderMorseFilterFactory.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Analysis.Phonetic
         public void TestLanguageSet()
         {
             IDictionary<String, String> args = new Dictionary<string, string>();
-            args.Put("languageSet", "polish");
+            args["languageSet"] = "polish";
             BeiderMorseFilterFactory factory = new BeiderMorseFilterFactory(args);
             TokenStream ts = factory.Create(new MockTokenizer(new StringReader("Weinberg"), MockTokenizer.WHITESPACE, false));
             AssertTokenStreamContents(ts,
@@ -58,8 +58,8 @@ namespace Lucene.Net.Analysis.Phonetic
         public void TestOptions()
         {
             IDictionary<String, String> args = new Dictionary<string, string>();
-            args.Put("nameType", "ASHKENAZI");
-            args.Put("ruleType", "EXACT");
+            args["nameType"] = "ASHKENAZI";
+            args["ruleType"] = "EXACT";
             BeiderMorseFilterFactory factory = new BeiderMorseFilterFactory(args);
             TokenStream ts = factory.Create(new MockTokenizer(new StringReader("Weinberg"), MockTokenizer.WHITESPACE, false));
             AssertTokenStreamContents(ts,

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/TestPhoneticFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/TestPhoneticFilterFactory.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Analysis.Phonetic
         public void TestFactoryDefaults()
         {
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put(PhoneticFilterFactory.ENCODER, "Metaphone");
+            args[PhoneticFilterFactory.ENCODER] = "Metaphone";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
             assertTrue(factory.GetEncoder() is Metaphone);
@@ -45,8 +45,8 @@ namespace Lucene.Net.Analysis.Phonetic
         public void TestInjectFalse()
         {
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put(PhoneticFilterFactory.ENCODER, "Metaphone");
-            args.Put(PhoneticFilterFactory.INJECT, "false");
+            args[PhoneticFilterFactory.ENCODER] = "Metaphone";
+            args[PhoneticFilterFactory.INJECT] = "false";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
             assertFalse(factory.inject);
@@ -56,8 +56,8 @@ namespace Lucene.Net.Analysis.Phonetic
         public void TestMaxCodeLength()
         {
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put(PhoneticFilterFactory.ENCODER, "Metaphone");
-            args.Put(PhoneticFilterFactory.MAX_CODE_LENGTH, "2");
+            args[PhoneticFilterFactory.ENCODER] = "Metaphone";
+            args[PhoneticFilterFactory.MAX_CODE_LENGTH] = "2";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
             assertEquals(2, ((Metaphone)factory.GetEncoder()).MaxCodeLen);
@@ -85,7 +85,7 @@ namespace Lucene.Net.Analysis.Phonetic
             try
             {
                 IDictionary<String, String> args = new Dictionary<String, String>();
-                args.Put("encoder", "XXX");
+                args["encoder"] = "XXX";
                 PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
                 factory.Inform(new ClasspathResourceLoader(factory.GetType()));
                 fail();
@@ -102,7 +102,7 @@ namespace Lucene.Net.Analysis.Phonetic
             try
             {
                 IDictionary<String, String> args = new Dictionary<String, String>();
-                args.Put("encoder", "org.apache.commons.codec.language.NonExistence");
+                args["encoder"] = "org.apache.commons.codec.language.NonExistence";
                 PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
                 factory.Inform(new ClasspathResourceLoader(factory.GetType()));
                 fail();
@@ -120,7 +120,7 @@ namespace Lucene.Net.Analysis.Phonetic
         public void TestFactoryReflection()
         {
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put(PhoneticFilterFactory.ENCODER, "Metaphone");
+            args[PhoneticFilterFactory.ENCODER] = "Metaphone";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
             assertTrue(factory.GetEncoder() is Metaphone);
@@ -135,7 +135,7 @@ namespace Lucene.Net.Analysis.Phonetic
         public void TestFactoryReflectionCaverphone2()
         {
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put(PhoneticFilterFactory.ENCODER, "Caverphone2");
+            args[PhoneticFilterFactory.ENCODER] = "Caverphone2";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
             assertTrue(factory.GetEncoder() is Caverphone2);
@@ -146,7 +146,7 @@ namespace Lucene.Net.Analysis.Phonetic
         public void TestFactoryReflectionCaverphone()
         {
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put(PhoneticFilterFactory.ENCODER, "Caverphone");
+            args[PhoneticFilterFactory.ENCODER] = "Caverphone";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
             assertTrue(factory.GetEncoder() is Caverphone2);
@@ -217,8 +217,8 @@ namespace Lucene.Net.Analysis.Phonetic
         {
             Tokenizer tokenizer = new MockTokenizer(new StringReader(input), MockTokenizer.WHITESPACE, false);
             IDictionary<String, String> args = new Dictionary<String, String>();
-            args.Put("encoder", algName);
-            args.Put("inject", inject);
+            args["encoder"] = algName;
+            args["inject"] = inject;
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
             TokenStream stream = factory.Create(tokenizer);

--- a/src/Lucene.Net.Tests.Grouping/TestGrouping.cs
+++ b/src/Lucene.Net.Tests.Grouping/TestGrouping.cs
@@ -588,7 +588,7 @@ namespace Lucene.Net.Search.Grouping
                         sortedGroupFields.Add(FillFields(d, groupSort));
                     }
                     l = new JCG.List<GroupDoc>();
-                    groups.Put(d.group, l);
+                    groups[d.group] = l;
                 }
                 l.Add(d);
             }
@@ -974,7 +974,7 @@ namespace Lucene.Net.Search.Grouping
                     {
                         //Console.WriteLine("  term=real" + contentID);
                         IDictionary<float, J2N.Numerics.Single> termScoreMap = new Dictionary<float, J2N.Numerics.Single>();
-                        scoreMap.Put("real" + contentID, termScoreMap);
+                        scoreMap["real" + contentID] = termScoreMap;
                         //Console.WriteLine("term=real" + contentID + " dfold=" + s.docFreq(new Term("content", "real"+contentID)) +
                         //" dfnew=" + sBlocks.docFreq(new Term("content", "real"+contentID)));
                         ScoreDoc[] hits = sBlocks.Search(new TermQuery(new Term("content", "real" + contentID)), numDocs).ScoreDocs;
@@ -985,7 +985,7 @@ namespace Lucene.Net.Search.Grouping
                             gd.score2 = hit.Score;
                             assertEquals(gd.id, docIDToIDBlocks.Get(hit.Doc));
                             //Console.WriteLine("    score=" + gd.score + " score2=" + hit.score + " id=" + docIDToIDBlocks.get(hit.doc));
-                            termScoreMap.Put(gd.score, gd.score2);
+                            termScoreMap[gd.score] = gd.score2;
                         }
                     }
 

--- a/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
@@ -1244,7 +1244,7 @@ namespace Lucene.Net.Search.Highlight
             TestHighlightRunner helper = new TestHighlightRunner((instance) =>
             {
                 IDictionary<String, String> synonyms = new JCG.Dictionary<String, String>();
-                synonyms.Put("football", "soccer,footie");
+                synonyms["football"] = "soccer,footie";
                 Analyzer analyzer = new SynonymAnalyzer(synonyms);
 
                 String s = "football-soccer in the euro 2004 footie competition";

--- a/src/Lucene.Net.Tests.Highlighter/VectorHighlight/FastVectorHighlighterTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/VectorHighlight/FastVectorHighlighterTest.cs
@@ -649,13 +649,13 @@ namespace Lucene.Net.Search.VectorHighlight
 #pragma warning disable 612, 618 // LUCENENET NOTE: Class calls obsolete (default) constructor
             public AnalyzerWrapperAnonymousClass()
             {
-                fieldAnalyzers.Put("field", new MockAnalyzer(Random, MockTokenizer.WHITESPACE, true, MockTokenFilter.ENGLISH_STOPSET));
-                fieldAnalyzers.Put("field_exact", new MockAnalyzer(Random));
-                fieldAnalyzers.Put("field_super_exact", new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false));
-                fieldAnalyzers.Put("field_characters", new MockAnalyzer(Random, new CharacterRunAutomaton(new RegExp(".").ToAutomaton()), true));
-                fieldAnalyzers.Put("field_tripples", new MockAnalyzer(Random, new CharacterRunAutomaton(new RegExp("...").ToAutomaton()), true));
-                fieldAnalyzers.Put("field_sliced", fieldAnalyzers["field"]);
-                fieldAnalyzers.Put("field_der_red", fieldAnalyzers["field"]);  // This is required even though we provide a token stream
+                fieldAnalyzers["field"] = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, true, MockTokenFilter.ENGLISH_STOPSET);
+                fieldAnalyzers["field_exact"] = new MockAnalyzer(Random);
+                fieldAnalyzers["field_super_exact"] = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
+                fieldAnalyzers["field_characters"] = new MockAnalyzer(Random, new CharacterRunAutomaton(new RegExp(".").ToAutomaton()), true);
+                fieldAnalyzers["field_tripples"] = new MockAnalyzer(Random, new CharacterRunAutomaton(new RegExp("...").ToAutomaton()), true);
+                fieldAnalyzers["field_sliced"] = fieldAnalyzers["field"];
+                fieldAnalyzers["field_der_red"] = fieldAnalyzers["field"];  // This is required even though we provide a token stream
             }
 #pragma warning restore 612, 618
             protected override Analyzer GetWrappedAnalyzer(string fieldName)

--- a/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
+++ b/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
@@ -132,7 +132,7 @@ namespace Lucene.Net.Documents
                         if (!fieldValueCounts.TryGetValue(f.Name, out int count))
                             count = 0;
                         count++;
-                        fieldValueCounts.Put(f.Name, count);
+                        fieldValueCounts[f.Name] = count;
                         assertTrue(f.Name + " is " + f.GetType(),
                                    f is LazyDocument.LazyField);
                         LazyDocument.LazyField lf = (LazyDocument.LazyField)f;

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
@@ -485,7 +485,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
 
             IDictionary<string, DateResolution> fieldMap = new JCG.Dictionary<string, DateResolution>();
             // set a field specific date resolution
-            fieldMap.Put(monthField, DateResolution.MONTH);
+            fieldMap[monthField] = DateResolution.MONTH;
 #pragma warning disable 612, 618
             qp.SetDateResolution(fieldMap);
 #pragma warning restore 612, 618
@@ -494,7 +494,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
             qp.SetDateResolution(DateResolution.MILLISECOND);
 
             // set second field specific date resolution
-            fieldMap.Put(hourField, DateResolution.HOUR);
+            fieldMap[hourField] = DateResolution.HOUR;
 #pragma warning disable 612, 618
             qp.SetDateResolution(fieldMap);
 #pragma warning restore 612, 618

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestMultiFieldQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestMultiFieldQPHelper.cs
@@ -144,8 +144,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         public void TestBoostsSimple()
         {
             IDictionary<String, float> boosts = new Dictionary<String, float>();
-            boosts.Put("b", 5);
-            boosts.Put("t", 10);
+            boosts["b"] = 5;
+            boosts["t"] = 10;
             String[] fields = { "b", "t" };
             StandardQueryParser mfqp = new StandardQueryParser();
             mfqp.SetMultiFields(fields);

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -260,8 +260,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                     continue;
                 }
 
-                numericConfigMap.Put(type.ToString(), new NumericConfig(PRECISION_STEP,
-                    NUMBER_FORMAT, type)); 
+                numericConfigMap[type.ToString()] = new NumericConfig(PRECISION_STEP, NUMBER_FORMAT, type); 
 
                 FieldType ft2 = new FieldType(Int32Field.TYPE_NOT_STORED);
                 ft2.NumericType = (type);
@@ -289,17 +288,16 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                         field = null!;
                         break;
                 }
-                numericFieldMap.Put(type.ToString(), field);
+                numericFieldMap[type.ToString()] = field;
                 doc.Add(field);
             }
 
-            numericConfigMap.Put(DATE_FIELD_NAME, new NumericConfig(PRECISION_STEP,
-                DATE_FORMAT, NumericType.INT64));
+            numericConfigMap[DATE_FIELD_NAME] = new NumericConfig(PRECISION_STEP, DATE_FORMAT, NumericType.INT64);
             FieldType ft = new FieldType(Int64Field.TYPE_NOT_STORED);
             ft.IsStored = (true);
             ft.NumericPrecisionStep = (PRECISION_STEP);
             Int64Field dateField = new Int64Field(DATE_FIELD_NAME, 0L, ft);
-            numericFieldMap.Put(DATE_FIELD_NAME, dateField);
+            numericFieldMap[DATE_FIELD_NAME] = dateField;
             doc.Add(dateField);
 
             foreach (NumberType numberType in (NumberType[])Enum.GetValues(typeof(NumberType)))

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
@@ -802,7 +802,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             IDictionary<string, DateResolution> dateRes = new Dictionary<string, DateResolution>();
 
             // set a field specific date resolution    
-            dateRes.Put(monthField, DateResolution.MONTH);
+            dateRes[monthField] = DateResolution.MONTH;
 #pragma warning disable 612, 618
             qp.SetDateResolution(dateRes);
 #pragma warning restore 612, 618
@@ -811,7 +811,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             qp.SetDateResolution(DateResolution.MILLISECOND);
 
             // set second field specific date resolution
-            dateRes.Put(hourField, DateResolution.HOUR);
+            dateRes[hourField] = DateResolution.HOUR;
 #pragma warning disable 612, 618
             qp.SetDateResolution(dateRes);
 #pragma warning restore 612, 618

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestStandardQP.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestStandardQP.cs
@@ -113,7 +113,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(cqpC is StandardQueryParser);
             StandardQueryParser qp = (StandardQueryParser)cqpC;
-            qp.DateResolutionMap.Put(field, value);
+            qp.DateResolutionMap[field] = value;
         }
 
 

--- a/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
+++ b/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
@@ -262,8 +262,8 @@ namespace Lucene.Net.Spatial.Prefix
                     indexedShape = randomRectangle();//just one rect
                 }
 
-                indexedShapes.Put(id, indexedShape);
-                indexedShapesGS.Put(id, gridSnap(indexedShape));
+                indexedShapes[id] = indexedShape;
+                indexedShapesGS[id] = gridSnap(indexedShape);
 
                 adoc(id, indexedShape);
 

--- a/src/Lucene.Net.Tests.Suggest/Suggest/DocumentDictionaryTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/DocumentDictionaryTest.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Search.Suggest
                     term = field.GetStringValue();
                 }
 
-                docs.Put(term, doc);
+                docs[term] = doc;
             }
             return new KeyValuePair<IList<string>, IDictionary<string, Document>>(invalidDocTerms, docs);
         }

--- a/src/Lucene.Net.Tests.Suggest/Suggest/DocumentValueSourceDictionaryTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/DocumentValueSourceDictionaryTest.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Search.Suggest
                     contexts.SetBytesValue(new BytesRef("ctx_" + i + "_" + j));
                     doc.Add(contexts);
                 }
-                docs.Put(field.GetStringValue(), doc);
+                docs[field.GetStringValue()] = doc;
             }
             return docs;
         }

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Fst/WFSTCompletionTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Fst/WFSTCompletionTest.cs
@@ -164,7 +164,7 @@ namespace Lucene.Net.Search.Suggest.Fst
                 }
                 // we can probably do Integer.MAX_VALUE here, but why worry.
                 int weight = LuceneTestCase.Random.nextInt(1 << 24);
-                slowCompletor.Put(s, (long)weight);
+                slowCompletor[s] = (long)weight;
                 keys[i] = new Input(s, weight);
             }
 

--- a/src/Lucene.Net.Tests.Suggest/Suggest/TestInputIterator.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/TestInputIterator.cs
@@ -68,10 +68,10 @@ namespace Lucene.Net.Search.Suggest
                     }
                 } while (sorted.ContainsKey(key2));
                 long value = random.Next();
-                sortedWithoutPayload.Put(key2, value);
-                sorted.Put(key2, new KeyValuePair<long, BytesRef>(value, payload));
-                sortedWithContext.Put(key2, new KeyValuePair<long, ISet<BytesRef>>(value, ctxs));
-                sortedWithPayloadAndContext.Put(key2, new KeyValuePair<long, KeyValuePair<BytesRef, ISet<BytesRef>>>(value, new KeyValuePair<BytesRef, ISet<BytesRef>>(payload, ctxs)));
+                sortedWithoutPayload[key2] = value;
+                sorted[key2] = new KeyValuePair<long, BytesRef>(value, payload);
+                sortedWithContext[key2] = new KeyValuePair<long, ISet<BytesRef>>(value, ctxs);
+                sortedWithPayloadAndContext[key2] = new KeyValuePair<long, KeyValuePair<BytesRef, ISet<BytesRef>>>(value, new KeyValuePair<BytesRef, ISet<BytesRef>>(payload, ctxs));
                 unsorted[i] = new Input(key2, value, payload);
                 unsortedWithoutPayload[i] = new Input(key2, value);
                 unsortedWithContexts[i] = new Input(key2, value, ctxs);
@@ -129,7 +129,7 @@ namespace Lucene.Net.Search.Suggest
             {
                 long value = wrapper.Weight;
                 BytesRef payload = wrapper.Payload;
-                actual.Put(BytesRef.DeepCopyOf(wrapper.Current), new KeyValuePair<long, BytesRef>(value, BytesRef.DeepCopyOf(payload)));
+                actual[BytesRef.DeepCopyOf(wrapper.Current)] = new KeyValuePair<long, BytesRef>(value, BytesRef.DeepCopyOf(payload));
             }
             assertEquals(sorted, actual, aggressive: false);
 
@@ -154,7 +154,7 @@ namespace Lucene.Net.Search.Suggest
             {
                 long value = wrapperWithoutPayload.Weight;
                 assertNull(wrapperWithoutPayload.Payload);
-                actualWithoutPayload.Put(BytesRef.DeepCopyOf(wrapperWithoutPayload.Current), value);
+                actualWithoutPayload[BytesRef.DeepCopyOf(wrapperWithoutPayload.Current)] = value;
             }
             assertEquals(sortedWithoutPayload, actualWithoutPayload, aggressive: false);
         }

--- a/src/Lucene.Net/Support/DictionaryExtensions.cs
+++ b/src/Lucene.Net/Support/DictionaryExtensions.cs
@@ -20,27 +20,72 @@ namespace Lucene.Net.Support
      * limitations under the License.
      */
 
+    /// <summary>
+    /// Extensions to <see cref="IDictionary{TKey, TValue}"/>.
+    /// </summary>
     internal static class DictionaryExtensions
     {
-        public static void PutAll<TKey, TValue>(this IDictionary<TKey, TValue> dict, IEnumerable<KeyValuePair<TKey, TValue>> kvps)
+        /// <summary>
+        /// Copies all of the mappings from the specified <paramref name="collection"/> to this dictionary.
+        /// These mappings will replace any mappings that this dictionary had for any of the keys currently
+        /// in the specified dictionary.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key.</typeparam>
+        /// <typeparam name="TValue">The type of value.</typeparam>
+        /// <param name="dictionary">This dictionary.</param>
+        /// <param name="collection">The collection to merge.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="dictionary"/> or <paramref name="collection"/> is <c>null</c>.</exception>
+        public static void PutAll<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, IEnumerable<KeyValuePair<TKey, TValue>> collection)
         {
-            if (dict is null)
-                throw new ArgumentNullException(nameof(dict));
+            if (dictionary is null)
+                throw new ArgumentNullException(nameof(dictionary));
+            if (collection is null)
+                throw new ArgumentNullException(nameof(collection));
 
-            foreach (var kvp in kvps)
+            foreach (var kvp in collection)
             {
-                dict[kvp.Key] = kvp.Value;
+                dictionary[kvp.Key] = kvp.Value;
             }
         }
 
-        public static TValue Put<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue value) // LUCENENET TODO: Refactor to account for value types. See CharArrayDictionary<TValue> implementation.
+        /// <summary>
+        /// Associates the specified value with the specified key in this dictionary.
+        /// If the dictionary previously contained a mapping for the key, the old value is replaced.
+        /// <para/>
+        /// <b>Usage Note:</b> Unless the return value is required, it is more efficient to use
+        /// the setter of the dictionary indexer than this method.
+        /// <para/>
+        /// This method will only work right if <typeparamref name="TValue"/> is a nullable type, since
+        /// it may not be possible to distinguish value types with actual values from their default value.
+        /// Java collections only accept reference types, so this is a direct port from Java, not accounting
+        /// for value types.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key.</typeparam>
+        /// <typeparam name="TValue">The type of value.</typeparam>
+        /// <param name="dictionary">This dictionary.</param>
+        /// <param name="key">The key with which the specified <paramref name="value"/> is associated.</param>
+        /// <param name="value">The value to be associated with the specified <paramref name="key"/>.</param>
+        /// <returns>The previous value associated with key, or <c>null</c> if there was no mapping for key.
+        /// (A <c>null</c> return can also indicate that the map previously associated <c>null</c> with key.)</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="dictionary"/> is <c>null</c>.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// The underlying dictionary implementation doesn't accept <c>null</c> for <paramref name="key"/>.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// The underlying dictionary implementation doesn't accept <c>null</c> for <paramref name="value"/>.
+        /// </exception>
+        public static TValue Put<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {
-            if (dict is null)
-                throw new ArgumentNullException(nameof(dict));
+            if (dictionary is null)
+                throw new ArgumentNullException(nameof(dictionary));
 
-            if (!dict.TryGetValue(key, out TValue oldValue))
+            if (!dictionary.TryGetValue(key, out TValue oldValue))
                 oldValue = default;
-            dict[key] = value;
+            dictionary[key] = value;
             return oldValue;
         }
 


### PR DESCRIPTION
`Lucene.Net.Support.DictionaryExtensions`: Reduced dependency on the `Put()` method and added documentation to indicate that it doesn't work with non-nullable value types. Also documented the `PutAll()` method and added guard clause.