### PR TITLE
SWEEP: Fixed SonarCloud issues that were found in "new code"

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Core/StopAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Core/StopAnalyzer.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Analysis.Core
         /// An unmodifiable set containing some common English words that are not usually useful
         /// for searching.
         /// </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly CharArraySet ENGLISH_STOP_WORDS_SET = LoadEnglishStopWordsSet();

--- a/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchAnalyzer.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Analysis.Fr
 
         /// <summary>
         /// Default set of articles for <see cref="ElisionFilter"/> </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly CharArraySet DEFAULT_ARTICLES = new CharArraySet(

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/BufferedCharFilter.cs
@@ -641,15 +641,6 @@ namespace Lucene.Net.Analysis.Util
             }
         }
 
-        /// <inheritdoc/>
-        public override bool Equals(object obj) => @in.Equals(obj);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => @in.GetHashCode();
-
-        /// <inheritdoc/>
-        public override string ToString() => @in.ToString();
-
 #if FEATURE_STREAM_READ_SPAN
         /// <summary>
         /// Not supported.

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArraySet.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArraySet.cs
@@ -14,6 +14,8 @@ using System.Text;
 using JCG = J2N.Collections.Generic;
 #nullable enable
 
+// LUCENENET specific - this class was significantly refactored from its Java counterpart to look and act more like collections in .NET.
+
 namespace Lucene.Net.Analysis.Util
 {
     /*
@@ -66,12 +68,15 @@ namespace Lucene.Net.Analysis.Util
     /// </para>
     /// </summary>
     [DebuggerDisplay("Count = {Count}, Values = {ToString()}")]
+    [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+    [SuppressMessage("CodeQuality", "S3218:Inner class members should not shadow outer class \"static\" or type members", Justification = "Following Microsoft's code style for collections")]
+    [SuppressMessage("CodeQuality", "S1939:Inheritance list should not be redundant", Justification = "Following Microsoft's code style for collections")]
     public class CharArraySet : ISet<string>, ICollection<string>, ICollection, IReadOnlyCollection<string>
 #if FEATURE_READONLYSET
         , IReadOnlySet<string>
 #endif
     {
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly CharArraySet Empty = new CharArraySet(CharArrayDictionary<object>.Empty);
@@ -775,14 +780,14 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="array">The one-dimensional <see cref="T:string[]"/> Array that is the destination of the 
         /// elements copied from <see cref="CharArraySet"/>. The Array must have zero-based indexing.</param>
-        /// <param name="index">The zero-based index in array at which copying begins.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than zero.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> is less than zero.</exception>
         /// <exception cref="ArgumentException">The number of elements in the source is greater
-        /// than the available space from <paramref name="index"/> to the end of the destination array.</exception>
-        public void CopyTo(string[] array, int index)
+        /// than the available space from <paramref name="arrayIndex"/> to the end of the destination array.</exception>
+        public void CopyTo(string[] array, int arrayIndex)
         {
-            CopyTo(array, index, map.Count);
+            CopyTo(array, arrayIndex, map.Count);
         }
 
         /// <summary>
@@ -791,30 +796,30 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="array">The one-dimensional <see cref="T:string[]"/> Array that is the destination of the 
         /// elements copied from <see cref="CharArraySet"/>. The Array must have zero-based indexing.</param>
-        /// <param name="index">The zero-based index in array at which copying begins.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> or <paramref name="count"/> is less than zero.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> or <paramref name="count"/> is less than zero.</exception>
         /// <exception cref="ArgumentException">
-        /// <paramref name="index"/> is greater than the length of the destination <paramref name="array"/>.
+        /// <paramref name="arrayIndex"/> is greater than the length of the destination <paramref name="array"/>.
         /// <para/>
         /// -or-
         /// <para/>
-        /// <paramref name="count"/> is greater than the available space from the <paramref name="index"/>
+        /// <paramref name="count"/> is greater than the available space from the <paramref name="arrayIndex"/>
         /// to the end of the destination <paramref name="array"/>.
         /// </exception>
-        internal void CopyTo(string[] array, int index, int count)
+        internal void CopyTo(string[] array, int arrayIndex, int count)
         {
             if (array is null)
                 throw new ArgumentNullException(nameof(array));
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (arrayIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex), arrayIndex, SR.ArgumentOutOfRange_NeedNonNegNum);
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), count, SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (index > array.Length || count > array.Length - index)
+            if (arrayIndex > array.Length || count > array.Length - arrayIndex)
                 throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
 
             using var iter = GetEnumerator();
-            for (int i = index, numCopied = 0; numCopied < count && iter.MoveNext(); i++, numCopied++)
+            for (int i = arrayIndex, numCopied = 0; numCopied < count && iter.MoveNext(); i++, numCopied++)
             {
                 array[i] = iter.Current;
             }
@@ -856,30 +861,30 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="array">The jagged <see cref="T:char[][]"/> array or <see cref="IList{T}"/> of type char[] that is the destination of the
         /// elements copied from <see cref="CharArraySet"/>. The Array must have zero-based indexing.</param>
-        /// <param name="index">The zero-based index in array at which copying begins.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> or <paramref name="count"/> is less than zero.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> or <paramref name="count"/> is less than zero.</exception>
         /// <exception cref="ArgumentException">
-        /// <paramref name="index"/> is greater than the length of the destination <paramref name="array"/>.
+        /// <paramref name="arrayIndex"/> is greater than the length of the destination <paramref name="array"/>.
         /// <para/>
         /// -or-
         /// <para/>
-        /// <paramref name="count"/> is greater than the available space from the <paramref name="index"/>
+        /// <paramref name="count"/> is greater than the available space from the <paramref name="arrayIndex"/>
         /// to the end of the destination <paramref name="array"/>.
         /// </exception>
-        internal void CopyTo(IList<char[]> array, int index, int count)
+        internal void CopyTo(IList<char[]> array, int arrayIndex, int count)
         {
             if (array is null)
                 throw new ArgumentNullException(nameof(array));
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (arrayIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex), arrayIndex, SR.ArgumentOutOfRange_NeedNonNegNum);
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), count, SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (index > array.Count || count > array.Count - index)
+            if (arrayIndex > array.Count || count > array.Count - arrayIndex)
                 throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
 
             using var iter = GetEnumerator();
-            for (int i = index, numCopied = 0; numCopied < count && iter.MoveNext(); i++, numCopied++)
+            for (int i = arrayIndex, numCopied = 0; numCopied < count && iter.MoveNext(); i++, numCopied++)
             {
                 array[i] = (char[])iter.CurrentValue.Clone();
             }
@@ -905,14 +910,14 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="array">The one-dimensional <see cref="T:ICharSequence[]"/> Array that is the destination of the 
         /// elements copied from <see cref="CharArraySet"/>. The Array must have zero-based indexing.</param>
-        /// <param name="index">The zero-based index in array at which copying begins.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than zero.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> is less than zero.</exception>
         /// <exception cref="ArgumentException">The number of elements in the source is greater
-        /// than the available space from <paramref name="index"/> to the end of the destination array.</exception>
-        public void CopyTo(ICharSequence[] array, int index)
+        /// than the available space from <paramref name="arrayIndex"/> to the end of the destination array.</exception>
+        public void CopyTo(ICharSequence[] array, int arrayIndex)
         {
-            CopyTo(array, index, map.Count);
+            CopyTo(array, arrayIndex, map.Count);
         }
 
         /// <summary>
@@ -921,30 +926,30 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="array">The one-dimensional <see cref="T:ICharSequence[]"/> Array that is the destination of the 
         /// elements copied from <see cref="CharArraySet"/>. The Array must have zero-based indexing.</param>
-        /// <param name="index">The zero-based index in array at which copying begins.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> or <paramref name="count"/> is less than zero.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> or <paramref name="count"/> is less than zero.</exception>
         /// <exception cref="ArgumentException">
-        /// <paramref name="index"/> is greater than the length of the destination <paramref name="array"/>.
+        /// <paramref name="arrayIndex"/> is greater than the length of the destination <paramref name="array"/>.
         /// <para/>
         /// -or-
         /// <para/>
-        /// <paramref name="count"/> is greater than the available space from the <paramref name="index"/>
+        /// <paramref name="count"/> is greater than the available space from the <paramref name="arrayIndex"/>
         /// to the end of the destination <paramref name="array"/>.
         /// </exception>
-        internal void CopyTo(ICharSequence[] array, int index, int count)
+        internal void CopyTo(ICharSequence[] array, int arrayIndex, int count)
         {
             if (array is null)
                 throw new ArgumentNullException(nameof(array));
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (arrayIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex), arrayIndex, SR.ArgumentOutOfRange_NeedNonNegNum);
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), count, SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (index > array.Length || count > array.Length - index)
+            if (arrayIndex > array.Length || count > array.Length - arrayIndex)
                 throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
 
             using var iter = GetEnumerator();
-            for (int i = index, numCopied = 0; numCopied < count && iter.MoveNext(); i++, numCopied++)
+            for (int i = arrayIndex, numCopied = 0; numCopied < count && iter.MoveNext(); i++, numCopied++)
             {
                 array[i] = ((char[])iter.CurrentValue.Clone()).AsCharSequence();
             }
@@ -1901,17 +1906,7 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="other">collection to be checked for containment in this collection</param>
         /// <returns><c>true</c> if this <see cref="CharArraySet"/> contains all of the elements in the specified collection; otherwise, <c>false</c>.</returns>
         [Obsolete("Use the IsSupersetOf() method instead. This method will be removed in 4.8.0 release candidate."), EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual bool ContainsAll(IEnumerable<string> other)
-        {
-            foreach (var local in other)
-            {
-                if (local is null || !this.Contains(local))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
+        public virtual bool ContainsAll(IEnumerable<string> other) => IsSupersetOf(other);
 
         /// <summary>
         /// Returns <c>true</c> if this collection contains all of the elements
@@ -1920,17 +1915,7 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="other">collection to be checked for containment in this collection</param>
         /// <returns><c>true</c> if this <see cref="CharArraySet"/> contains all of the elements in the specified collection; otherwise, <c>false</c>.</returns>
         [Obsolete("Use the IsSupersetOf() method instead. This method will be removed in 4.8.0 release candidate."), EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual bool ContainsAll<T>(IEnumerable<T> other)
-        {
-            foreach (var local in other)
-            {
-                if (local is null || !this.Contains(local))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
+        public virtual bool ContainsAll<T>(IEnumerable<T> other) => IsSupersetOf(other);
 
         /// <summary>
         /// Returns <c>true</c> if this collection contains all of the elements

--- a/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
@@ -591,7 +591,7 @@ namespace Lucene.Net.Expressions.JS
         /// <para/>
         /// See the <see cref="Lucene.Net.Expressions.JS">package documentation</see> for a list.
         /// </remarks>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly IDictionary<string, MethodInfo> DEFAULT_FUNCTIONS = LoadDefaultFunctions();

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharArrayMap.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharArrayMap.cs
@@ -586,13 +586,13 @@ namespace Lucene.Net.Analysis.Util
 
             // Full array
             var array1 = new KeyValuePair<string, int?>[target.Count];
-            target.CopyTo(array1, 0);
+            ((ICollection<KeyValuePair<string, int?>>)target).CopyTo(array1, 0);
             assertTrue(stopwords.SetEquals(array1));
 
             // Bounded to lower start index
             int startIndex = 3;
             var array2 = new KeyValuePair<string, int?>[target.Count + startIndex];
-            target.CopyTo(array2, startIndex);
+            ((ICollection<KeyValuePair<string, int?>>)target).CopyTo(array2, startIndex);
 
             assertEquals(default, array2[0]);
             assertEquals(default, array2[1]);

--- a/src/Lucene.Net/Codecs/PostingsFormat.cs
+++ b/src/Lucene.Net/Codecs/PostingsFormat.cs
@@ -71,7 +71,7 @@ namespace Lucene.Net.Codecs
 
         /// <summary>
         /// Zero-length <see cref="PostingsFormat"/> array. </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly PostingsFormat[] EMPTY = Arrays.Empty<PostingsFormat>();

--- a/src/Lucene.Net/Index/Fields.cs
+++ b/src/Lucene.Net/Index/Fields.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Index
         /// <summary>
         /// Zero-length <see cref="Fields"/> array.
         /// </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly Fields[] EMPTY_ARRAY = Arrays.Empty<Fields>();

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -1129,7 +1129,10 @@ namespace Lucene.Net.Index
         /// finished (which should be at most a few seconds), and
         /// then return. </param>
         [MethodImpl(MethodImplOptions.NoInlining)]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "This is Lucene's alternate path to Dispose() and we must suppress the finalizer here.")]
+        [SuppressMessage("Usage", "S2953:Methods named \"Dispose\" should implement \"IDisposable.Dispose\"", Justification = "This is Lucene's alternate path to Dispose() and we must suppress the finalizer here.")]
+        [SuppressMessage("Usage", "S3971:\"GC.SuppressFinalize\" should not be called", Justification = "This is Lucene's alternate path to Dispose() and we must suppress the finalizer here.")]
         public void Dispose(bool waitForMerges)
         {
             Dispose(disposing: true, waitForMerges);
@@ -1218,7 +1221,7 @@ namespace Lucene.Net.Index
 
         private bool AssertEventQueueAfterClose()
         {
-            if (eventQueue.Count == 0)
+            if (eventQueue.IsEmpty)
             {
                 return true;
             }
@@ -1786,7 +1789,7 @@ namespace Lucene.Net.Index
             UninterruptableMonitor.Enter(this);
             try
             {
-                if (!(readerIn is AtomicReader reader))
+                if (readerIn is not AtomicReader reader)
                 {
                     // Composite reader: lookup sub-reader and re-base docID:
                     IList<AtomicReaderContext> leaves = readerIn.Leaves;
@@ -1801,7 +1804,7 @@ namespace Lucene.Net.Index
                 }
                 // else: Reader is already atomic: use the incoming docID
 
-                if (!(reader is SegmentReader segmentReader))
+                if (reader is not SegmentReader segmentReader)
                 {
                     throw new ArgumentException("the reader must be a SegmentReader or composite reader containing only SegmentReaders");
                 }
@@ -2612,7 +2615,7 @@ namespace Lucene.Net.Index
                 {
                     return false;
                 }
-                bool newMergesFound = false;
+                bool newMergesFound; // LUCENENET specific - removed unnecessary assignment
                 MergePolicy.MergeSpecification spec;
                 if (maxNumSegments != UNBOUNDED_MAX_MERGE_SEGMENTS)
                 {
@@ -3701,7 +3704,7 @@ namespace Lucene.Net.Index
             IDictionary<string, string> attributes;
             // copy the attributes map, we might modify it below.
             // also we need to ensure its read-write, since we will invoke the SIwriter (which might want to set something).
-#pragma warning disable 612, 618
+#pragma warning disable CS0618 // Type or member is obsolete
             if (info.Info.Attributes is null)
             {
                 attributes = new Dictionary<string, string>();
@@ -3710,7 +3713,7 @@ namespace Lucene.Net.Index
             {
                 attributes = new Dictionary<string, string>(info.Info.Attributes);
             }
-#pragma warning restore 612, 618
+#pragma warning restore CS0618 // Type or member is obsolete
             if (docStoreFiles3xOnly != null)
             {
                 // only violate the codec this way if it's preflex &
@@ -3754,9 +3757,9 @@ namespace Lucene.Net.Index
             }
             catch (Exception uoe) when (uoe.IsUnsupportedOperationException())
             {
-#pragma warning disable 612, 618
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (currentCodec is Lucene3xCodec)
-#pragma warning restore 612, 618
+#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     // OK: 3x codec cannot write a new SI file;
                     // SegmentInfos will write this on commit

--- a/src/Lucene.Net/Index/MultiTermsEnum.cs
+++ b/src/Lucene.Net/Index/MultiTermsEnum.cs
@@ -52,7 +52,7 @@ namespace Lucene.Net.Index
 
         public class TermsEnumIndex
         {
-            [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+            [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
             [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
             [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
             public static readonly TermsEnumIndex[] EMPTY_ARRAY = Arrays.Empty<TermsEnumIndex>();

--- a/src/Lucene.Net/Index/ReaderSlice.cs
+++ b/src/Lucene.Net/Index/ReaderSlice.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Index
     {
         /// <summary>
         /// Zero-length <see cref="ReaderSlice"/> array. </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly ReaderSlice[] EMPTY_ARRAY = Arrays.Empty<ReaderSlice>();

--- a/src/Lucene.Net/Index/Terms.cs
+++ b/src/Lucene.Net/Index/Terms.cs
@@ -184,7 +184,7 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Zero-length array of <see cref="Terms"/>. </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly Terms[] EMPTY_ARRAY = Arrays.Empty<Terms>();

--- a/src/Lucene.Net/Support/Arrays.cs
+++ b/src/Lucene.Net/Support/Arrays.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Diagnostics;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -115,7 +116,7 @@ namespace Lucene.Net.Support
         }
 
         #region ArrayFiller<T>
-        private class ArrayFiller<T>
+        private static class ArrayFiller<T>
         {
             public static readonly IArrayFiller<T> Default = LoadArrayFiller();
 
@@ -133,13 +134,13 @@ namespace Lucene.Net.Support
 
         }
 
-        private interface IArrayFiller<T>
+        private interface IArrayFiller<in T>
         {
             void Fill(T[] array, T value, int startIndex, int count);
         }
 
 #if FEATURE_ARRAY_FILL
-        private class ArrayFillArrayFiller<T> : IArrayFiller<T>
+        private sealed class ArrayFillArrayFiller<T> : IArrayFiller<T>
         {
             public void Fill(T[] array, T value, int startIndex, int count)
             {
@@ -147,7 +148,7 @@ namespace Lucene.Net.Support
             }
         }
 #endif
-        private class SpanFillArrayFiller<T> : IArrayFiller<T>
+        private sealed class SpanFillArrayFiller<T> : IArrayFiller<T>
         {
             public void Fill(T[] array, T value, int startIndex, int count)
             {
@@ -218,12 +219,13 @@ namespace Lucene.Net.Support
             ArrayCopier<T>.Default.Copy(sourceArray, sourceIndex, destinationArray, destinationIndex, length);
         }
 
-        private class PlatformDetection
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S3400:Methods should not return constants", Justification = "Clearly, this is not always a constant value (SonarCloud bug)")]
+        private static class PlatformDetection
         {
             // We put this in its own class so every type doesn't have to reload it. But, at the same time,
             // we don't want to have to load this just to use the Arrays class.
             public static readonly bool IsFullFramework = LoadIsFullFramework();
-            //public static readonly bool IsNetNative = RuntimeInformation.FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase);
             public static readonly bool IsNetCore = LoadIsNetCore();
 
             private static bool LoadIsFullFramework()
@@ -251,7 +253,7 @@ namespace Lucene.Net.Support
 
         #region ArrayCopier<T>
 
-        private class ArrayCopier<T>
+        private static class ArrayCopier<T>
         {
             public static readonly IArrayCopier<T> Default = LoadArrayCopier();
 
@@ -320,12 +322,12 @@ namespace Lucene.Net.Support
             }
         }
 
-        private interface IArrayCopier<T>
+        private interface IArrayCopier<in T>
         {
             void Copy(T[] sourceArray, int sourceIndex, T[] destinationArray, int destinationIndex, int length);
         }
 
-        private class SpanArrayCopier<T> : IArrayCopier<T>
+        private sealed class SpanArrayCopier<T> : IArrayCopier<T>
         {
             public void Copy(T[] sourceArray, int sourceIndex, T[] destinationArray, int destinationIndex, int length)
             {
@@ -333,7 +335,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class SystemArrayCopyArrayCopier<T> : IArrayCopier<T>
+        private sealed class SystemArrayCopyArrayCopier<T> : IArrayCopier<T>
         {
             public void Copy(T[] sourceArray, int sourceIndex, T[] destinationArray, int destinationIndex, int length)
             {
@@ -343,7 +345,7 @@ namespace Lucene.Net.Support
 
         #region Primitive Type Buffer.MemoryCopy() Array Copiers
         // We save some arithmetic by having a specialized type for byte, since we know it is measured in bytes.
-        private class ByteBufferMemoryCopyArrayCopier : IArrayCopier<byte>
+        private sealed class ByteBufferMemoryCopyArrayCopier : IArrayCopier<byte>
         {
             public void Copy(byte[] sourceArray, int sourceIndex, byte[] destinationArray, int destinationIndex, int length)
             {
@@ -360,7 +362,7 @@ namespace Lucene.Net.Support
         }
 
         // We save some arithmetic by having a specialized type for byte, since we know it is measured in bytes.
-        private class SByteBufferMemoryCopyArrayCopier : IArrayCopier<sbyte>
+        private sealed class SByteBufferMemoryCopyArrayCopier : IArrayCopier<sbyte>
         {
             public void Copy(sbyte[] sourceArray, int sourceIndex, sbyte[] destinationArray, int destinationIndex, int length)
             {
@@ -379,7 +381,7 @@ namespace Lucene.Net.Support
         // LUCENENET NOTE: Tried to make the following types one generic type, but SDKs prior to .NET 7 won't compile it.
         // See: https://github.com/dotnet/runtime/issues/76255
 
-        private class Int16BufferMemoryCopyArrayCopier : IArrayCopier<short>
+        private sealed class Int16BufferMemoryCopyArrayCopier : IArrayCopier<short>
         {
             public void Copy(short[] sourceArray, int sourceIndex, short[] destinationArray, int destinationIndex, int length)
             {
@@ -398,7 +400,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class UInt16BufferMemoryCopyArrayCopier : IArrayCopier<ushort>
+        private sealed class UInt16BufferMemoryCopyArrayCopier : IArrayCopier<ushort>
         {
             public void Copy(ushort[] sourceArray, int sourceIndex, ushort[] destinationArray, int destinationIndex, int length)
             {
@@ -417,7 +419,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class Int32BufferMemoryCopyArrayCopier : IArrayCopier<int>
+        private sealed class Int32BufferMemoryCopyArrayCopier : IArrayCopier<int>
         {
             public void Copy(int[] sourceArray, int sourceIndex, int[] destinationArray, int destinationIndex, int length)
             {
@@ -436,7 +438,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class UInt32BufferMemoryCopyArrayCopier : IArrayCopier<uint>
+        private sealed class UInt32BufferMemoryCopyArrayCopier : IArrayCopier<uint>
         {
             public void Copy(uint[] sourceArray, int sourceIndex, uint[] destinationArray, int destinationIndex, int length)
             {
@@ -455,7 +457,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class Int64BufferMemoryCopyArrayCopier : IArrayCopier<long>
+        private sealed class Int64BufferMemoryCopyArrayCopier : IArrayCopier<long>
         {
             public void Copy(long[] sourceArray, int sourceIndex, long[] destinationArray, int destinationIndex, int length)
             {
@@ -474,7 +476,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class UInt64BufferMemoryCopyArrayCopier : IArrayCopier<ulong>
+        private sealed class UInt64BufferMemoryCopyArrayCopier : IArrayCopier<ulong>
         {
             public void Copy(ulong[] sourceArray, int sourceIndex, ulong[] destinationArray, int destinationIndex, int length)
             {
@@ -493,7 +495,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class SingleBufferMemoryCopyArrayCopier : IArrayCopier<float>
+        private sealed class SingleBufferMemoryCopyArrayCopier : IArrayCopier<float>
         {
             public void Copy(float[] sourceArray, int sourceIndex, float[] destinationArray, int destinationIndex, int length)
             {
@@ -512,7 +514,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class DoubleBufferMemoryCopyArrayCopier : IArrayCopier<double>
+        private sealed class DoubleBufferMemoryCopyArrayCopier : IArrayCopier<double>
         {
             public void Copy(double[] sourceArray, int sourceIndex, double[] destinationArray, int destinationIndex, int length)
             {
@@ -531,7 +533,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class CharBufferMemoryCopyArrayCopier : IArrayCopier<char>
+        private sealed class CharBufferMemoryCopyArrayCopier : IArrayCopier<char>
         {
             public void Copy(char[] sourceArray, int sourceIndex, char[] destinationArray, int destinationIndex, int length)
             {
@@ -550,7 +552,7 @@ namespace Lucene.Net.Support
             }
         }
 
-        private class BooleanBufferMemoryCopyArrayCopier : IArrayCopier<bool>
+        private sealed class BooleanBufferMemoryCopyArrayCopier : IArrayCopier<bool>
         {
             public void Copy(bool[] sourceArray, int sourceIndex, bool[] destinationArray, int destinationIndex, int length)
             {

--- a/src/Lucene.Net/Util/Bits.cs
+++ b/src/Lucene.Net/Util/Bits.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Util
 
     public static class Bits
     {
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly IBits[] EMPTY_ARRAY = Arrays.Empty<IBits>();

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Util
     {
         /// <summary>
         /// An empty byte array for convenience </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly byte[] EMPTY_BYTES = Arrays.Empty<byte>();

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Util
     {
         /// <summary>
         /// An empty character array for convenience </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly char[] EMPTY_CHARS = Arrays.Empty<char>();

--- a/src/Lucene.Net/Util/IntsRef.cs
+++ b/src/Lucene.Net/Util/IntsRef.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Util
         /// <para/>
         /// NOTE: This was EMPTY_INTS in Lucene
         /// </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly int[] EMPTY_INT32S = Arrays.Empty<int>();

--- a/src/Lucene.Net/Util/LongsRef.cs
+++ b/src/Lucene.Net/Util/LongsRef.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Util
         /// <para/>
         /// NOTE: This was EMPTY_LONGS in Lucene
         /// </summary>
-        [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly long[] EMPTY_INT64S = Arrays.Empty<long>();

--- a/src/dotnet/tools/lucene-cli/CommandLine/CommandLineApplication.cs
+++ b/src/dotnet/tools/lucene-cli/CommandLine/CommandLineApplication.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Cli.CommandLine
      * limitations under the License.
      */
 
-    [SuppressMessage("Performance", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+    [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
     [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "This was part of the original design")]
     [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "This was part of the original design")]
     public class CommandLineApplication


### PR DESCRIPTION
This contains breaking changes:

- `Lucene.Net.Analysis.Util.CharArrayDictionary<TValue>`: Removed the `CopyTo()` overloads from the public API. They are still accessible through `ICollection.CopyTo()`, but it is better to use the `Enumerator` to gain direct access to the `CurrentKey` and `CurrentValue` properties. `CopyTo()` was not something that existed in Lucene, but since `CharArrayMap` was created by subclassing `AbstractMap` (getting all of the "normal" functionality for free), we added it to make the collection "normal". However, `Dictionary<TKey, TValue>` doesn't expose its `CopyTo()` method publicly, so we are following suit.