### PR TITLE
Align InputStreamDataInput and OutputStreamDataOutput closer to the Java Source

### DIFF
--- a/src/Lucene.Net/Store/InputStreamDataInput.cs
+++ b/src/Lucene.Net/Store/InputStreamDataInput.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Store
 
         public InputStreamDataInput(Stream @is)
         {
-            this._is = @is ?? throw new ArgumentNullException(nameof(@is));
+            this._is = @is ?? throw new ArgumentNullException(nameof(@is)); // LUCENENET specific - added null guard clause
         }
 
         public override byte ReadByte()

--- a/src/Lucene.Net/Store/InputStreamDataInput.cs
+++ b/src/Lucene.Net/Store/InputStreamDataInput.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 
 namespace Lucene.Net.Store
@@ -25,16 +25,16 @@ namespace Lucene.Net.Store
     /// </summary>
     public class InputStreamDataInput : DataInput, IDisposable
     {
-        private BinaryReader _reader;
+        private readonly Stream _is;
 
         public InputStreamDataInput(Stream @is)
         {
-            this._reader = new BinaryReader(@is);
+            this._is = @is ?? throw new ArgumentNullException(nameof(@is));
         }
 
         public override byte ReadByte()
         {
-            int v = _reader.ReadByte();
+            int v = _is.ReadByte();
             if (v == -1)
             {
                 throw EOFException.Create();
@@ -46,7 +46,7 @@ namespace Lucene.Net.Store
         {
             while (len > 0)
             {
-                int cnt = _reader.Read(b, offset, len);
+                int cnt = _is.Read(b, offset, len);
                 if (cnt < 0)
                 {
                     // Partially read the input, but no more data available in the stream.
@@ -60,23 +60,14 @@ namespace Lucene.Net.Store
         public void Dispose()
         {
             Dispose(true);
-
             GC.SuppressFinalize(this);
         }
 
-        private bool disposed = false;
-
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (disposing)
             {
-                if (disposing)
-                {
-                    _reader.Dispose();
-                }
-
-                _reader = null;
-                disposed = true;
+                _is.Dispose();
             }
         }
     }

--- a/src/Lucene.Net/Store/OutputStreamDataOutput.cs
+++ b/src/Lucene.Net/Store/OutputStreamDataOutput.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 
 namespace Lucene.Net.Store
@@ -25,21 +25,21 @@ namespace Lucene.Net.Store
     /// </summary>
     public class OutputStreamDataOutput : DataOutput, IDisposable
     {
-        private readonly BinaryWriter _writer;
+        private readonly Stream _os;
 
         public OutputStreamDataOutput(Stream os)
         {
-            this._writer = new BinaryWriter(os);
+            this._os = os;
         }
 
         public override void WriteByte(byte b)
         {
-            _writer.Write(b);
+            _os.WriteByte(b);
         }
 
         public override void WriteBytes(byte[] b, int offset, int length)
         {
-            _writer.Write(b, offset, length);
+            _os.Write(b, offset, length);
         }
 
         /// <summary>
@@ -57,13 +57,12 @@ namespace Lucene.Net.Store
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources;
         /// <c>false</c> to release only unmanaged resources.</param>
-
         // LUCENENET specific - implemented proper dispose pattern
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
             {
-                _writer.Dispose();
+                _os.Dispose();
             }
         }
     }

--- a/src/Lucene.Net/Store/OutputStreamDataOutput.cs
+++ b/src/Lucene.Net/Store/OutputStreamDataOutput.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Store
 
         public OutputStreamDataOutput(Stream os)
         {
-            this._os = os;
+            this._os = os ?? throw new ArgumentNullException(nameof(os)); // LUCENENET specific - added null guard clause
         }
 
         public override void WriteByte(byte b)


### PR DESCRIPTION
From talks in #763

Fixed InputStreamDataInput and OutputStreamDataOutput so that they don't wrap their input streams to BinaryReader/Writers to align the code closer to the Java source which just uses the input.

I also aligned the dispose method of the two so they behave the same.

This is a PR done a bit in blind as I can't build the full lucene source at the moment.