### PR TITLE
Make TextStartPos and TextEndPos of TextFragment publicly readable

### DIFF
--- a/src/Lucene.Net.Highlighter/Highlight/TextFragment.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/TextFragment.cs
@@ -43,9 +43,9 @@ namespace Lucene.Net.Search.Highlight
             protected internal set => score = value;
         }
 
-        // LUCENENET specific - made these fields into properties, since they are for internal consumption
-        internal int TextEndPos { get; set; }
-        internal int TextStartPos { get; set; }
+        // LUCENENET specific
+        public int TextEndPos { get; internal set; }
+        public int TextStartPos { get; internal set; }
 
         /// <summary>
         /// the fragment sequence number


### PR DESCRIPTION
I am using ```Lucene.Net.Search.Highlight``` to display search result. Right now, ```Highlighter.GetBestTextFragments``` is returning an array of ```TextFragment```.  

I would like to highlight these fragments in the context of the full document as well as doing some further processing depending on where the fragment occurs. To do so, I need to identify the start and end position of these ```TextFragment``` in the document. 

It seems that these positions are already available in ```TextFragment```:
https://github.com/apache/lucenenet/blob/0bbc3798c1a8abcf06fac3f53df6e07a7312c3d5/src/Lucene.Net.Highlighter/Highlight/TextFragment.cs#L46-L48

If they represent the actual position of the fragment in the original text, they can be made public to enable the mentioned use cases. 

The pull request is a small change to make them publicly readable.