### PR TITLE
Remove virtual on a method that's being called from constructor

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
@@ -638,7 +638,8 @@ namespace Lucene.Net.Analysis.Shingle
             /// <see cref="outputUnigrams"/> = true.
             /// </para>
             /// </summary>
-            public virtual void Reset()
+            // LUCENENET specific - S1699 - marked non-virtual because calling virtual members from the constructor is not a safe operation in .NET
+            public void Reset()
             {
                 previousValue = value = minValue;
             }

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesProducer.cs
@@ -1067,7 +1067,8 @@ namespace Lucene.Net.Codecs.Lucene45
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal virtual TermsEnum GetTermsEnum()
+            // LUCENENET specific - S1699 - marked non-virtual because calling virtual members from the constructor is not a safe operation in .NET
+            internal TermsEnum GetTermsEnum()
             {
                 try
                 {
@@ -1080,7 +1081,8 @@ namespace Lucene.Net.Codecs.Lucene45
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal virtual TermsEnum GetTermsEnum(IndexInput input)
+            // LUCENENET specific - S1699 - marked non-virtual because calling virtual members from the constructor is not a safe operation in .NET
+            internal TermsEnum GetTermsEnum(IndexInput input)
             {
                 input.Seek(bytes.offset);
 

--- a/src/Lucene.Net/Search/MinShouldMatchSumScorer.cs
+++ b/src/Lucene.Net/Search/MinShouldMatchSumScorer.cs
@@ -451,7 +451,9 @@ namespace Lucene.Net.Search
             return false; // scorer already exhausted
         }
 
-        internal virtual bool MinheapCheck()
+        // LUCENENET specific - S1699 - marked non-virtual because calling virtual members
+        // from the constructor is not a safe operation in .NET
+        private bool MinheapCheck()
         {
             return MinheapCheck(0);
         }


### PR DESCRIPTION
This PR fixes some of the issues with virtual calls being made from constructors. The issues were reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

Particularly here we are addressing that have this issue and are either private or internal to Lucene and can be changed without impacting public API surface.