### PR TITLE
BREAKING: Remove virtual on a method that's being called from constructor in TernaryTree

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
@@ -32,6 +32,15 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
     /// fast lookup. It provides the provides the method to hyphenate a word.
     /// <para/>
     /// This class has been taken from the Apache FOP project (http://xmlgraphics.apache.org/fop/). They have been slightly modified. 
+    ///
+    /// Lucene.NET specific note:
+    /// If you are going to extend this class by inheriting from it, you should be aware that the
+    /// base class TernaryTree initializes its state in the constructor by calling its protected Init() method.
+    /// If your subclass needs to initialize its own state, you add your own "Initialize()" method
+    /// and call it both from the inside of your constructor and you will need to override the Balance() method
+    /// and call "Initialize()" before the call to base.Balance().
+    /// Your class can use the data that is initialized in the base class after the call to base.Balance().
+    ///
     /// </summary>
     public class HyphenationTree : TernaryTree, IPatternConsumer
     {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/TernaryTree.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/TernaryTree.cs
@@ -125,7 +125,9 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
             Init();
         }
 
-        protected virtual void Init()
+         // LUCENENET specific - S1699 - marked non-virtual because calling
+         // virtual members from the constructor is not a safe operation in .NET
+        protected void Init()
         {
             m_root = (char)0;
             m_freenode = (char)1;


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

I have changed my mind on TernaryTree and believe that making Init not virtual is a better fix than introducing locking/lazy initialization.

TernaryTree is an internal class that's being subclassed by public HyphenationTree class. HyphenationTree does not call Init anywhere. This:

```c#
internal class TernaryTree
{
    public TernaryTree() { Init(); }

    protected virtual void Init() { ... }
}

public class HyphenationTree
{
    public HyphenationTree () 
}
```

Since HyphenationTree is public, by removing the virtual from Init() we are breaking the API. Someone could have subclassed HyphenationTree and overridden Init() method. But it has to be a very low odds occurrence, and if someone has done that, they will get an error and have to deal with initialization as opposed code compiling successfully but then failing in surprising ways once run.

Lucene.NET 3.0.3 has those classes commented out, no one would have done subclassing in that version. So people coming from 4.6.1 beta would be impacted, and we already have breaking changes that are part of beta.
