### PR TITLE
BREAKING: Make AbstractAnalysisFactory.Get non-virtual to avoid issues in constructors

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
@@ -129,24 +129,32 @@ namespace Lucene.Net.Analysis.Util
             throw new ArgumentException($"Configuration Error: '{name}' value must be one of {Collections.ToString(allowedValues)}");
         }
 
-        public virtual string Get(IDictionary<string, string> args, string name, string defaultVal = null)
+        // LUCENENET specific - S1699 - marked non-virtual because calling
+        // virtual members from the constructor is not a safe operation in .NET
+        public string Get(IDictionary<string, string> args, string name, string defaultVal = null)
         {
             if (args.TryGetValue(name, out string s))
                 args.Remove(name);
             return s ?? defaultVal;
         }
 
-        public virtual string Get(IDictionary<string, string> args, string name, ICollection<string> allowedValues)
+        // LUCENENET specific - S1699 - marked non-virtual because calling
+        // virtual members from the constructor is not a safe operation in .NET
+        public string Get(IDictionary<string, string> args, string name, ICollection<string> allowedValues)
         {
             return Get(args, name, allowedValues, defaultVal: null);
         }
 
-        public virtual string Get(IDictionary<string, string> args, string name, ICollection<string> allowedValues, string defaultVal)
+        // LUCENENET specific - S1699 - marked non-virtual because calling
+        // virtual members from the constructor is not a safe operation in .NET
+        public string Get(IDictionary<string, string> args, string name, ICollection<string> allowedValues, string defaultVal)
         {
             return Get(args, name, allowedValues, defaultVal, caseSensitive: true);
         }
 
-        public virtual string Get(IDictionary<string, string> args, string name, ICollection<string> allowedValues, string defaultVal, bool caseSensitive)
+        // LUCENENET specific - S1699 - marked non-virtual because calling
+        // virtual members from the constructor is not a safe operation in .NET
+        public string Get(IDictionary<string, string> args, string name, ICollection<string> allowedValues, string defaultVal, bool caseSensitive)
         {
             if (!args.TryGetValue(name, out string s) || s is null)
             {


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

In this case, AbstractAnalysisFactory calls "Get" from the constructor. Get is virtual, but it does not feel like the intent here is to make that method extendable. It's a WIDELY extended class inside Lucene via TokenFilterFactory and all the classes that inherit from it, and none of them override Get implementations. 