### PR TITLE
BREAKING: remove virtual method call from constructor in OpenStringBuilder

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Analysis.Util
 
         public OpenStringBuilder(char[] arr, int len)
         {
-            Set(arr, len);
+            SetInternal(arr, len);
         }
 
         public virtual int Length
@@ -56,7 +56,12 @@ namespace Lucene.Net.Analysis.Util
             set => m_len = value;
         }
 
-        public virtual void Set(char[] arr, int end)
+        public virtual void Set(char[] arr, int end) => SetInternal(arr, end);
+
+        // LUCENENET specific - S1699 - introduced this to allow the constructor to
+        // still call "Set" functionality without having to call the virtual method
+        // that could be overridden by a subclass and don't have the state it expects
+        private void SetInternal(char[] arr, int end)
         {
             this.m_buf = arr;
             this.m_len = end;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
@@ -47,6 +47,7 @@ namespace Lucene.Net.Analysis.Util
 
         public OpenStringBuilder(char[] arr, int len)
         {
+            // LUCENENET specific - calling private method instead of public virtual
             SetInternal(arr, len);
         }
 


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on OpenStringBuilder. The pattern here is to create a private method that the constructor can use and virtual methods can use as well.