### PR TITLE
BREAKING: remove virtual designation as it's called from constructor

### DIFF
--- a/src/Lucene.Net.Suggest/Spell/SpellChecker.cs
+++ b/src/Lucene.Net.Suggest/Spell/SpellChecker.cs
@@ -142,6 +142,7 @@ namespace Lucene.Net.Search.Spell
         /// <param name="spellIndexDir"> the spell directory to use </param>
         /// <exception cref="ObjectDisposedException"> if the Spellchecker is already closed </exception>
         /// <exception cref="IOException"> if spellchecker can not open the directory </exception>
+        // TODO: we should make this final as it is called in the constructor
         // LUCENENET specific - S1699 - marked non-virtual because calling
         // virtual members from the constructor is not a safe operation in .NET
         public void SetSpellIndex(Directory spellIndexDir)

--- a/src/Lucene.Net.Suggest/Spell/SpellChecker.cs
+++ b/src/Lucene.Net.Suggest/Spell/SpellChecker.cs
@@ -142,8 +142,9 @@ namespace Lucene.Net.Search.Spell
         /// <param name="spellIndexDir"> the spell directory to use </param>
         /// <exception cref="ObjectDisposedException"> if the Spellchecker is already closed </exception>
         /// <exception cref="IOException"> if spellchecker can not open the directory </exception>
-        // TODO: we should make this final as it is called in the constructor
-        public virtual void SetSpellIndex(Directory spellIndexDir)
+        // LUCENENET specific - S1699 - marked non-virtual because calling
+        // virtual members from the constructor is not a safe operation in .NET
+        public void SetSpellIndex(Directory spellIndexDir)
         {
             // this could be the same directory as the current spellIndex
             // modifications to the directory should be synchronized


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on SpellChecker. We are simply removing the virtual designation. It seems like Lucene team has been planning this as well based on TODO: comment above the method but has not pulled the trigger. We are going to go ahead and do that.