### PR TITLE
BREAKING: remove virtual call from the constructor for DisjunctionMaxQuery

### DIFF
--- a/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
+++ b/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
@@ -86,7 +86,7 @@ namespace Lucene.Net.Search
         public DisjunctionMaxQuery(ICollection<Query> disjuncts, float tieBreakerMultiplier)
         {
             this.tieBreakerMultiplier = tieBreakerMultiplier;
-            Add(disjuncts);
+            AddInternal(disjuncts); // LUCENENET specific - calling private instead of virtual
         }
 
         /// <summary>
@@ -101,10 +101,13 @@ namespace Lucene.Net.Search
         /// Add a collection of disjuncts to this disjunction
         /// via <see cref="T:IEnumerable{Query}"/> </summary>
         /// <param name="disjuncts"> A collection of queries to add as disjuncts. </param>
-        public virtual void Add(ICollection<Query> disjuncts)
-        {
+        public virtual void Add(ICollection<Query> disjuncts) =>
+            AddInternal(disjuncts);
+
+        // LUCENENET specific - S1699 - introduced private AddInternal that
+        // is called from virtual Add and constructor
+        private void AddInternal(ICollection<Query> disjuncts) =>
             this.disjuncts.AddRange(disjuncts);
-        }
 
         /// <returns> An <see cref="T:IEnumerator{Query}"/> over the disjuncts </returns>
         public virtual IEnumerator<Query> GetEnumerator()


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on DisjunctionMaxQuery where we add a private method to call from the constructor and a virtual method that used to be called from the constructor.