### PR TITLE
BREAKING: Fix/virtual calls from constructors for cell

### DIFF
--- a/src/Lucene.Net.Spatial/Prefix/Tree/Cell.cs
+++ b/src/Lucene.Net.Spatial/Prefix/Tree/Cell.cs
@@ -89,7 +89,8 @@ namespace Lucene.Net.Spatial.Prefix.Tree
             if (token.Length > 0 && token[token.Length - 1] == (char)LEAF_BYTE)
             {
                 this.token = token.Substring(0, (token.Length - 1) - 0);
-                SetLeaf();
+                // LUCENENET specific - calling private instead of virtual to avoid initialization issues
+                SetLeafInternal(); 
             }
             if (Level == 0)
             {
@@ -157,7 +158,9 @@ namespace Lucene.Net.Spatial.Prefix.Tree
             if (bytes![b_off + b_len - 1] == LEAF_BYTE)
             {
                 b_len--;
-                SetLeaf();
+                // LUCENENET specific - calling internal vs virtual
+                // to avoid issues when this is called from constructor
+                SetLeafInternal();
             }
             else
             {
@@ -175,7 +178,11 @@ namespace Lucene.Net.Spatial.Prefix.Tree
         public virtual bool IsLeaf => m_leaf;
 
         /// <summary>Note: not supported at level 0.</summary>
-        public virtual void SetLeaf()
+        public virtual void SetLeaf() => SetLeafInternal();
+
+        // LUCENENET specific - S1699 - private method that can be called
+        // from constructor without causing initialization issues
+        private void SetLeafInternal()
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(Level != 0);
             m_leaf = true;

--- a/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
+++ b/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
@@ -86,7 +86,7 @@ namespace Lucene.Net.Search
         public DisjunctionMaxQuery(ICollection<Query> disjuncts, float tieBreakerMultiplier)
         {
             this.tieBreakerMultiplier = tieBreakerMultiplier;
-            Add(disjuncts);
+            AddInternal(disjuncts); // LUCENENET specific - calling private instead of virtual
         }
 
         /// <summary>
@@ -101,10 +101,13 @@ namespace Lucene.Net.Search
         /// Add a collection of disjuncts to this disjunction
         /// via <see cref="T:IEnumerable{Query}"/> </summary>
         /// <param name="disjuncts"> A collection of queries to add as disjuncts. </param>
-        public virtual void Add(ICollection<Query> disjuncts)
-        {
+        public virtual void Add(ICollection<Query> disjuncts) =>
+            AddInternal(disjuncts);
+
+        // LUCENENET specific - S1699 - introduced private AddInternal that
+        // is called from virtual Add and constructor
+        private void AddInternal(ICollection<Query> disjuncts) =>
             this.disjuncts.AddRange(disjuncts);
-        }
 
         /// <returns> An <see cref="T:IEnumerator{Query}"/> over the disjuncts </returns>
         public virtual IEnumerator<Query> GetEnumerator()


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on Cell where we add a private method to call from the constructor and a virtual method that used to be called from the constructor, as well as B_fixLeaf() method that another constructor calls.