### PR TITLE
BREAKING: remove virtual call from the constructor for RollingBuffer and related classes

### DIFF
--- a/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
@@ -123,7 +123,7 @@ namespace Lucene.Net.Analysis
         // it without referring to the generic closing type.
         // removed virtual NewPosition() method and added factory in the constructor
 
-        protected internal LookaheadTokenFilter(TokenStream input, Func<T> factory)
+        protected internal LookaheadTokenFilter(TokenStream input, IRollingBufferItemFactory<T> factory)
             : base(input)
         {
             m_positions = new RollingBufferAnonymousClass(factory);
@@ -165,7 +165,7 @@ namespace Lucene.Net.Analysis
         {
             // LUCENENET specific - adjusted to accept factory as a parameter
             // instead of using NewInstance virtual
-            public RollingBufferAnonymousClass(Func<T> factory)
+            public RollingBufferAnonymousClass(IRollingBufferItemFactory<T> factory)
                 : base(factory)
             {
             }

--- a/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
@@ -165,8 +165,8 @@ namespace Lucene.Net.Analysis
         {
             // LUCENENET specific - adjusted to accept factory as a parameter
             // instead of using NewInstance virtual
-            public RollingBufferAnonymousClass(IRollingBufferItemFactory<T> factory)
-                : base(factory)
+            public RollingBufferAnonymousClass(IRollingBufferItemFactory<T> itemFactory)
+                : base(itemFactory)
             {
             }
         }

--- a/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Util;
+using System;
 using System.Collections.Generic;
 using Console = Lucene.Net.Util.SystemConsole;
 using JCG = J2N.Collections.Generic;
@@ -120,11 +121,12 @@ namespace Lucene.Net.Analysis
 
         // LUCENENET specific - moved Position class to a non-generic class named LookaheadTokenFilter so we can refer to
         // it without referring to the generic closing type.
+        // removed virtual NewPosition() method and added factory in the constructor
 
-        protected internal LookaheadTokenFilter(TokenStream input)
+        protected internal LookaheadTokenFilter(TokenStream input, Func<T> factory)
             : base(input)
         {
-            m_positions = new RollingBufferAnonymousClass(this);
+            m_positions = new RollingBufferAnonymousClass(factory);
             m_posIncAtt = AddAttribute<IPositionIncrementAttribute>();
             m_posLenAtt = AddAttribute<IPositionLengthAttribute>();
             m_offsetAtt = AddAttribute<IOffsetAttribute>();
@@ -157,23 +159,15 @@ namespace Lucene.Net.Analysis
         {
         }
 
-        protected abstract T NewPosition();
-
         protected readonly RollingBuffer<T> m_positions;
 
         private sealed class RollingBufferAnonymousClass : RollingBuffer<T>
         {
-            private readonly LookaheadTokenFilter<T> outerInstance;
-
-            public RollingBufferAnonymousClass(LookaheadTokenFilter<T> outerInstance)
-                : base(outerInstance.NewPosition)
+            // LUCENENET specific - adjusted to accept factory as a parameter
+            // instead of using NewInstance virtual
+            public RollingBufferAnonymousClass(Func<T> factory)
+                : base(factory)
             {
-                this.outerInstance = outerInstance;
-            }
-
-            protected override T NewInstance()
-            {
-                return outerInstance.NewPosition();
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
@@ -93,7 +93,7 @@ namespace Lucene.Net.Analysis
     /// position, restoring them, providing access to them, etc.
     /// </summary>
     public abstract class LookaheadTokenFilter<T> : LookaheadTokenFilter
-        where T : LookaheadTokenFilter.Position, IResettable
+        where T : LookaheadTokenFilter.Position
     {
         protected readonly static bool DEBUG = 
 #if VERBOSE_TEST_LOGGING

--- a/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/LookaheadTokenFilter.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Analysis
         /// </summary>
         // LUCENENET NOTE: This class was originally marked protected, but was made public because of
         // inconsistent accessibility issues with using it as a generic constraint.
-        public class Position : RollingBuffer.IResettable
+        public class Position : IResettable
         {
             // Buffered input tokens at this position:
             public IList<AttributeSource.State> InputTokens { get; private set; } = new JCG.List<AttributeSource.State>();
@@ -93,7 +93,7 @@ namespace Lucene.Net.Analysis
     /// position, restoring them, providing access to them, etc.
     /// </summary>
     public abstract class LookaheadTokenFilter<T> : LookaheadTokenFilter
-        where T : LookaheadTokenFilter.Position
+        where T : LookaheadTokenFilter.Position, IResettable
     {
         protected readonly static bool DEBUG = 
 #if VERBOSE_TEST_LOGGING
@@ -123,10 +123,10 @@ namespace Lucene.Net.Analysis
         // it without referring to the generic closing type.
         // removed virtual NewPosition() method and added factory in the constructor
 
-        protected internal LookaheadTokenFilter(TokenStream input, IRollingBufferItemFactory<T> factory)
+        protected internal LookaheadTokenFilter(TokenStream input, IRollingBufferItemFactory<T> itemFactory)
             : base(input)
         {
-            m_positions = new RollingBufferAnonymousClass(factory);
+            m_positions = new RollingBufferAnonymousClass(itemFactory);
             m_posIncAtt = AddAttribute<IPositionIncrementAttribute>();
             m_posLenAtt = AddAttribute<IPositionLengthAttribute>();
             m_offsetAtt = AddAttribute<IOffsetAttribute>();

--- a/src/Lucene.Net.TestFramework/Analysis/MockGraphTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockGraphTokenFilter.cs
@@ -42,16 +42,12 @@ namespace Lucene.Net.Analysis
         private readonly long seed;
         private Random random;
 
+        // LUCENENET specific - removed NewPosition override and using factory instead
         public MockGraphTokenFilter(Random random, TokenStream input)
-            : base(input)
+            : base(input, () => new Position())
         {
             seed = random.NextInt64();
             termAtt = AddAttribute<ICharTermAttribute>();
-        }
-
-        protected override Position NewPosition()
-        {
-            return new Position();
         }
 
         protected override void AfterPosition()

--- a/src/Lucene.Net.TestFramework/Analysis/MockGraphTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockGraphTokenFilter.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Analysis
 
         // LUCENENET specific - removed NewPosition override and using factory instead
         public MockGraphTokenFilter(Random random, TokenStream input)
-            : base(input, () => new Position())
+            : base(input, RollingBufferItemFactory<LookaheadTokenFilter.Position>.Default)
         {
             seed = random.NextInt64();
             termAtt = AddAttribute<ICharTermAttribute>();

--- a/src/Lucene.Net.TestFramework/Analysis/MockRandomLookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockRandomLookaheadTokenFilter.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Util;
 using RandomizedTesting.Generators;
 using System;
 using System.Threading;
@@ -34,7 +35,7 @@ namespace Lucene.Net.Analysis
 
         // LUCENENET specific - removed NewPosition override and using factory instead
         public MockRandomLookaheadTokenFilter(Random random, TokenStream @in)
-            : base(@in, () => new Position())
+            : base(@in, RollingBufferItemFactory<LookaheadTokenFilter.Position>.Default)
         {
             this.termAtt = AddAttribute<ICharTermAttribute>();
             this.seed = random.NextInt64();

--- a/src/Lucene.Net.TestFramework/Analysis/MockRandomLookaheadTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockRandomLookaheadTokenFilter.cs
@@ -32,17 +32,13 @@ namespace Lucene.Net.Analysis
         private readonly J2N.Randomizer random;
         private readonly long seed;
 
+        // LUCENENET specific - removed NewPosition override and using factory instead
         public MockRandomLookaheadTokenFilter(Random random, TokenStream @in)
-            : base(@in)
+            : base(@in, () => new Position())
         {
             this.termAtt = AddAttribute<ICharTermAttribute>();
             this.seed = random.NextInt64();
             this.random = new J2N.Randomizer(seed);
-        }
-
-        protected override Position NewPosition()
-        {
-            return new Position();
         }
 
         protected override void AfterPosition()

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TestLookaheadTokenFilter.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TestLookaheadTokenFilter.cs
@@ -1,4 +1,5 @@
 ﻿// Lucene version compatibility level 8.2.0
+using Lucene.Net.Util;
 using RandomizedTesting.Generators;
 using System;
 using Test = NUnit.Framework.TestAttribute;
@@ -45,7 +46,7 @@ namespace Lucene.Net.Analysis
         {
             // LUCENENET specific - removed NewPosition override and using factory instead
             public NeverPeeksLookaheadTokenFilter(TokenStream input)
-                : base(input, () => new Position())
+                : base(input, RollingBufferItemFactory<LookaheadTokenFilter.Position>.Default)
             {
             }
 

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TestLookaheadTokenFilter.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TestLookaheadTokenFilter.cs
@@ -43,14 +43,10 @@ namespace Lucene.Net.Analysis
 
         private sealed class NeverPeeksLookaheadTokenFilter : LookaheadTokenFilter<LookaheadTokenFilter.Position>
         {
+            // LUCENENET specific - removed NewPosition override and using factory instead
             public NeverPeeksLookaheadTokenFilter(TokenStream input)
-                : base(input)
+                : base(input, () => new Position())
             {
-            }
-
-            protected override Position NewPosition()
-            {
-                return new Position();
             }
 
             public override bool IncrementToken()

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TrivialLookaheadFilter.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TrivialLookaheadFilter.cs
@@ -34,17 +34,13 @@ namespace Lucene.Net.Analysis
 
         private int insertUpto;
 
+        // LUCENENET specific - removed NewPosition override and using factory instead
         public TrivialLookaheadFilter(TokenStream input)
-            : base(input)
+            : base(input, () => new TestPosition())
         {
             termAtt = AddAttribute<ICharTermAttribute>();
             posIncAtt = AddAttribute<IPositionIncrementAttribute>();
             offsetAtt = AddAttribute<IOffsetAttribute>();
-        }
-
-        protected override TestPosition NewPosition()
-        {
-            return new TestPosition();
         }
 
         public override bool IncrementToken()

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TrivialLookaheadFilter.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TrivialLookaheadFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Lucene version compatibility level 8.2.0
 
 using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Util;
 using System;
 using JCG = J2N.Collections.Generic;
 
@@ -36,7 +37,7 @@ namespace Lucene.Net.Analysis
 
         // LUCENENET specific - removed NewPosition override and using factory instead
         public TrivialLookaheadFilter(TokenStream input)
-            : base(input, () => new TestPosition())
+            : base(input, RollingBufferItemFactory<TestPosition>.Default)
         {
             termAtt = AddAttribute<ICharTermAttribute>();
             posIncAtt = AddAttribute<IPositionIncrementAttribute>();

--- a/src/Lucene.Net.Tests/Analysis/TestLookaheadTokenFilter.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestLookaheadTokenFilter.cs
@@ -40,14 +40,10 @@ namespace Lucene.Net.Analysis
 
         private class NeverPeeksLookaheadTokenFilter : LookaheadTokenFilter<LookaheadTokenFilter.Position>
         {
+            // LUCENENET specific - removed NewPosition override and using factory instead
             public NeverPeeksLookaheadTokenFilter(TokenStream input)
-                : base(input)
+                : base(input, () => new Position())
             {
-            }
-
-            protected override Position NewPosition()
-            {
-                return new Position();
             }
 
             public sealed override bool IncrementToken()

--- a/src/Lucene.Net.Tests/Analysis/TestLookaheadTokenFilter.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestLookaheadTokenFilter.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using Lucene.Net.Util;
+using NUnit.Framework;
 using RandomizedTesting.Generators;
 using System;
 
@@ -42,7 +43,7 @@ namespace Lucene.Net.Analysis
         {
             // LUCENENET specific - removed NewPosition override and using factory instead
             public NeverPeeksLookaheadTokenFilter(TokenStream input)
-                : base(input, () => new Position())
+                : base(input, RollingBufferItemFactory<LookaheadTokenFilter.Position>.Default)
             {
             }
 

--- a/src/Lucene.Net.Tests/Analysis/TrivialLookaheadFilter.cs
+++ b/src/Lucene.Net.Tests/Analysis/TrivialLookaheadFilter.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
@@ -35,7 +36,7 @@ namespace Lucene.Net.Analysis
 
         // LUCENENET specific - removed NewPosition override and using factory instead
         internal TrivialLookaheadFilter(TokenStream input)
-            : base(input, () => new TestPosition())
+            : base(input, RollingBufferItemFactory<TestPosition>.Default)
         {
             termAtt = AddAttribute<ICharTermAttribute>();
             posIncAtt = AddAttribute<IPositionIncrementAttribute>();

--- a/src/Lucene.Net.Tests/Analysis/TrivialLookaheadFilter.cs
+++ b/src/Lucene.Net.Tests/Analysis/TrivialLookaheadFilter.cs
@@ -33,17 +33,13 @@ namespace Lucene.Net.Analysis
 
         private int insertUpto;
 
+        // LUCENENET specific - removed NewPosition override and using factory instead
         internal TrivialLookaheadFilter(TokenStream input)
-            : base(input)
+            : base(input, () => new TestPosition())
         {
             termAtt = AddAttribute<ICharTermAttribute>();
             posIncAtt = AddAttribute<IPositionIncrementAttribute>();
             offsetAtt = AddAttribute<IOffsetAttribute>();
-        }
-
-        protected override TestPosition NewPosition()
-        {
-            return new TestPosition();
         }
 
         public override bool IncrementToken()

--- a/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
+++ b/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Util
     [TestFixture]
     public class TestRollingBuffer : LuceneTestCase
     {
-        private class Position : RollingBuffer.IResettable
+        private class Position : IResettable
         {
             public int Pos { get; set; }
 
@@ -92,13 +92,13 @@ namespace Lucene.Net.Util
         {
             // LUCENENET specific - removed NewPosition override and using factory instead
             public RollingBufferAnonymousClass()
-                : base(RollingBufferAnonymousClassFactory.Default)
+                : base(PositionFactory.Default)
             {
             }
 
-            private class RollingBufferAnonymousClassFactory : IRollingBufferItemFactory<Position>
+            private class PositionFactory : IRollingBufferItemFactory<Position>
             {
-                public static readonly RollingBufferAnonymousClassFactory Default = new RollingBufferAnonymousClassFactory();
+                public static readonly PositionFactory Default = new PositionFactory();
 
                 public Position Create(object rollingBuffer)
                 {

--- a/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
+++ b/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
@@ -90,16 +90,22 @@ namespace Lucene.Net.Util
 
         private sealed class RollingBufferAnonymousClass : RollingBuffer<Position>
         {
+            // LUCENENET specific - removed NewPosition override and using factory instead
             public RollingBufferAnonymousClass()
-                : base(NewInstanceFunc)
+                : base(RollingBufferAnonymousClassFactory.Default)
             {
             }
 
-            public static Position NewInstanceFunc()
+            private class RollingBufferAnonymousClassFactory : IRollingBufferItemFactory<Position>
             {
-                Position pos = new Position();
-                pos.Pos = -1;
-                return pos;
+                public static readonly RollingBufferAnonymousClassFactory Default = new RollingBufferAnonymousClassFactory();
+
+                public Position Create(object rollingBuffer)
+                {
+                    Position pos = new Position();
+                    pos.Pos = -1;
+                    return pos;
+                }
             }
         }
     }

--- a/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
+++ b/src/Lucene.Net.Tests/Util/TestRollingBuffer.cs
@@ -101,13 +101,6 @@ namespace Lucene.Net.Util
                 pos.Pos = -1;
                 return pos;
             }
-
-            protected override Position NewInstance()
-            {
-                Position pos = new Position();
-                pos.Pos = -1;
-                return pos;
-            }
         }
     }
 }

--- a/src/Lucene.Net/Analysis/TokenStreamToAutomaton.cs
+++ b/src/Lucene.Net/Analysis/TokenStreamToAutomaton.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Analysis
             set => this.unicodeArcs = value;
         }
 
-        private class Position : RollingBuffer.IResettable
+        private class Position : IResettable
         {
             // Any tokens that ended at our position arrive to this state:
             internal State arriving;

--- a/src/Lucene.Net/Analysis/TokenStreamToAutomaton.cs
+++ b/src/Lucene.Net/Analysis/TokenStreamToAutomaton.cs
@@ -85,15 +85,11 @@ namespace Lucene.Net.Analysis
             }
         }
 
+        /// LUCENENET specific - removed NewInstance override and using NewPosition as factory
         private class Positions : RollingBuffer<Position>
         {
             public Positions()
                 : base(NewPosition) { }
-
-            protected override Position NewInstance()
-            {
-                return NewPosition();
-            }
 
             private static Position NewPosition()
             {

--- a/src/Lucene.Net/Analysis/TokenStreamToAutomaton.cs
+++ b/src/Lucene.Net/Analysis/TokenStreamToAutomaton.cs
@@ -85,16 +85,11 @@ namespace Lucene.Net.Analysis
             }
         }
 
-        /// LUCENENET specific - removed NewInstance override and using NewPosition as factory
         private class Positions : RollingBuffer<Position>
         {
+            // LUCENENET specific - removed NewInstance override and using PositionsFactory to create instances
             public Positions()
-                : base(NewPosition) { }
-
-            private static Position NewPosition()
-            {
-                return new Position();
-            }
+                : base(RollingBufferItemFactory<Position>.Default) { }
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/RollingBuffer.cs
+++ b/src/Lucene.Net/Util/RollingBuffer.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Util
     /// </summary>
     public class RollingBufferItemFactory<T> : IRollingBufferItemFactory<T> where T : new()
     {
-        public static readonly RollingBufferItemFactory<T> Default = new RollingBufferItemFactory<T>();
+        public static RollingBufferItemFactory<T> Default { get; } = new RollingBufferItemFactory<T>();
         public virtual T Create(object rollingBuffer)
         {
             return new T();

--- a/src/Lucene.Net/Util/RollingBuffer.cs
+++ b/src/Lucene.Net/Util/RollingBuffer.cs
@@ -72,14 +72,14 @@ namespace Lucene.Net.Util
         // How many valid Position are held in the
         // array:
         private int count;
-        private IRollingBufferItemFactory<T> factory;
+        private IRollingBufferItemFactory<T> itemFactory;
 
-        protected RollingBuffer(IRollingBufferItemFactory<T> factory)
+        protected RollingBuffer(IRollingBufferItemFactory<T> itemFactory)
         {
-            this.factory = factory; // LUCENENET specific - storing factory for usage in class
+            this.itemFactory = itemFactory; // LUCENENET specific - storing factory for usage in class
             for (int idx = 0; idx < buffer.Length; idx++)
             {
-                buffer[idx] = factory.Create(this);
+                buffer[idx] = itemFactory.Create(this);
             }
         }
 
@@ -134,7 +134,7 @@ namespace Lucene.Net.Util
                     Arrays.Copy(buffer, 0, newBuffer, buffer.Length - nextWrite, nextWrite);
                     for (int i = buffer.Length; i < newBuffer.Length; i++)
                     {
-                        newBuffer[i] = this.factory.Create(this); // LUCENENET specific - using factory to create new instance
+                        newBuffer[i] = this.itemFactory.Create(this); // LUCENENET specific - using factory to create new instance
                     }
                     nextWrite = buffer.Length;
                     buffer = newBuffer;

--- a/src/Lucene.Net/Util/RollingBuffer.cs
+++ b/src/Lucene.Net/Util/RollingBuffer.cs
@@ -43,6 +43,7 @@ namespace Lucene.Net.Util
     /// <para/>
     /// @lucene.internal
     /// </summary>
+    // LUCENENET specific - removed NewInstance override and using NewPosition as factory
     public abstract class RollingBuffer<T>
         where T : RollingBuffer.IResettable
     {
@@ -57,24 +58,16 @@ namespace Lucene.Net.Util
         // How many valid Position are held in the
         // array:
         private int count;
-
-        protected RollingBuffer()
-        {
-            for (var idx = 0; idx < buffer.Length; idx++)
-            {
-                buffer[idx] = NewInstance(); // TODO GIVE ROLLING BUFFER A DELEGATE FOR NEW INSTANCE
-            }
-        }
+        private Func<T> factory;
 
         protected RollingBuffer(Func<T> factory)
         {
+            this.factory = factory; // LUCENENET specific - storing factory for usage in class
             for (int idx = 0; idx < buffer.Length; idx++)
             {
                 buffer[idx] = factory();
             }
         }
-
-        protected abstract T NewInstance();
 
         public virtual void Reset()
         {
@@ -127,7 +120,7 @@ namespace Lucene.Net.Util
                     Arrays.Copy(buffer, 0, newBuffer, buffer.Length - nextWrite, nextWrite);
                     for (int i = buffer.Length; i < newBuffer.Length; i++)
                     {
-                        newBuffer[i] = NewInstance();
+                        newBuffer[i] = this.factory(); // LUCENENET specific - using factory to create new instance
                     }
                     nextWrite = buffer.Length;
                     buffer = newBuffer;

--- a/src/Lucene.Net/Util/RollingBuffer.cs
+++ b/src/Lucene.Net/Util/RollingBuffer.cs
@@ -22,18 +22,11 @@ namespace Lucene.Net.Util
      */
 
     /// <summary>
-    /// LUCENENET specific class to allow referencing static members of
-    /// <see cref="RollingBuffer{T}"/> without referencing its generic closing type.
+    /// Implement to reset an instance
     /// </summary>
-    public static class RollingBuffer
+    public interface IResettable
     {
-        /// <summary>
-        /// Implement to reset an instance
-        /// </summary>
-        public interface IResettable
-        {
-            void Reset();
-        }
+        void Reset();
     }
 
     /// <summary>
@@ -66,7 +59,7 @@ namespace Lucene.Net.Util
     /// </summary>
     // LUCENENET specific - removed NewInstance override and using NewPosition as factory
     public abstract class RollingBuffer<T>
-        where T : RollingBuffer.IResettable
+        where T : IResettable
     {
         private T[] buffer = new T[8];
 

--- a/src/Lucene.Net/Util/RollingBuffer.cs
+++ b/src/Lucene.Net/Util/RollingBuffer.cs
@@ -45,6 +45,10 @@ namespace Lucene.Net.Util
         T Create(object rollingBuffer);
     }
 
+    /// <summary>
+    /// LUCENENET specific class that provides default implementation for
+    /// <see cref="IRollingBufferItemFactory{T}"/>.
+    /// </summary>
     public class RollingBufferItemFactory<T> : IRollingBufferItemFactory<T> where T : new()
     {
         public static readonly RollingBufferItemFactory<T> Default = new RollingBufferItemFactory<T>();


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on RollingBuffer and its subclasses. Instead of providing a virtual NewInstance to override, we accept a factory method in the constructor and use it whenever new instance is needed.