### PR TITLE
BREAKING: Fix/virtual calls from constructors for AbstractBlockPackedWriter

### DIFF
--- a/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
@@ -67,12 +67,17 @@ namespace Lucene.Net.Util.Packed
         protected AbstractBlockPackedWriter(DataOutput @out, int blockSize) // LUCENENET specific - marked protected instead of public
         {
             PackedInt32s.CheckBlockSize(blockSize, MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
-            Reset(@out);
+            ResetInternal(@out); // LUCENENET specific - calling private method instead of virtual Reset
             m_values = new long[blockSize];
         }
 
         /// <summary>
         /// Reset this writer to wrap <paramref name="out"/>. The block size remains unchanged.
+        ///
+        /// NOTE: When overriding this method, be aware that the constructor of this class calls 
+        /// a private method and not this virtual method. So if you need to override
+        /// the behavior during the initialization, call your own private method from the constructor
+        /// with whatever custom behavior you need.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual void Reset(DataOutput @out) => ResetInternal(@out);

--- a/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
@@ -72,9 +72,12 @@ namespace Lucene.Net.Util.Packed
         }
 
         /// <summary>
-        /// Reset this writer to wrap <paramref name="out"/>. The block size remains unchanged. </summary>
+        /// Reset this writer to wrap <paramref name="out"/>. The block size remains unchanged.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public virtual void Reset(DataOutput @out)
+        public virtual void Reset(DataOutput @out) => ResetInternal(@out);
+
+        private void ResetInternal(DataOutput @out)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(@out != null);
             this.m_out = @out;

--- a/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
@@ -82,6 +82,7 @@ namespace Lucene.Net.Util.Packed
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual void Reset(DataOutput @out) => ResetInternal(@out);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ResetInternal(DataOutput @out)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(@out != null);


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on AbstractBlockPackedWriter, creating a private method that the constructor and public virtual methods can call.