### PR TITLE
Supress sonar cloud warnings about constructor making virtual call

### DIFF
--- a/src/Lucene.Net.Join/TermsIncludingScoreQuery.cs
+++ b/src/Lucene.Net.Join/TermsIncludingScoreQuery.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Index;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Lucene.Net.Search.Join
 {
@@ -360,6 +361,8 @@ namespace Lucene.Net.Search.Join
 
             internal int currentDoc = -1;
             
+            [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+            [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Internal class")]
             internal SVInOrderScorer(TermsIncludingScoreQuery outerInstance, Weight weight, IBits acceptDocs,
                 TermsEnum termsEnum, int maxDoc, long cost) 
                 : base(weight)


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one includes all the cases where we will ignore the warning and accept the code as is due to the fix being too invasive and not justifiable (e.g. classes are internal to Lucene.NET)