### PR TITLE
BREAKING: remove virtual call from the constructor for IndexSearcher

### DIFF
--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Search
             this.executor = executor;
             this.m_readerContext = context;
             m_leafContexts = context.Leaves;
-            this.m_leafSlices = executor is null ? null : Slices(m_leafContexts);
+            this.m_leafSlices = executor is null ? null : SlicesInternal(m_leafContexts);
         }
 
         /// <summary>
@@ -160,8 +160,17 @@ namespace Lucene.Net.Search
         /// Expert: Creates an array of leaf slices each holding a subset of the given leaves.
         /// Each <see cref="LeafSlice"/> is executed in a single thread. By default there
         /// will be one <see cref="LeafSlice"/> per leaf (<see cref="AtomicReaderContext"/>).
+        /// 
+        /// NOTE: When overriding this method, be aware that the constructor of this class calls 
+        /// a private method and not this virtual method. So if you need to override
+        /// the behavior during the initialization, call your own private method from the constructor
+        /// with whatever custom behavior you need.
         /// </summary>
         protected virtual LeafSlice[] Slices(IList<AtomicReaderContext> leaves)
+            => SlicesInternal(leaves);
+
+        // LUCENENET specific - creating this so that we can call it from the constructor
+        protected LeafSlice[] SlicesInternal(IList<AtomicReaderContext> leaves)
         {
             LeafSlice[] slices = new LeafSlice[leaves.Count];
             for (int i = 0; i < slices.Length; i++)

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Search
             this.executor = executor;
             this.m_readerContext = context;
             m_leafContexts = context.Leaves;
-            this.m_leafSlices = executor is null ? null : SlicesInternal(m_leafContexts);
+            this.m_leafSlices = executor is null ? null : GetSlicesInternal(m_leafContexts);
         }
 
         /// <summary>
@@ -166,11 +166,12 @@ namespace Lucene.Net.Search
         /// the behavior during the initialization, call your own private method from the constructor
         /// with whatever custom behavior you need.
         /// </summary>
-        protected virtual LeafSlice[] Slices(IList<AtomicReaderContext> leaves)
-            => SlicesInternal(leaves);
+        // LUCENENET specific - renamed to GetSlices to better indicate the purpose of this method
+        protected virtual LeafSlice[] GetSlices(IList<AtomicReaderContext> leaves)
+            => GetSlicesInternal(leaves);
 
         // LUCENENET specific - creating this so that we can call it from the constructor
-        protected LeafSlice[] SlicesInternal(IList<AtomicReaderContext> leaves)
+        protected LeafSlice[] GetSlicesInternal(IList<AtomicReaderContext> leaves)
         {
             LeafSlice[] slices = new LeafSlice[leaves.Count];
             for (int i = 0; i < slices.Length; i++)


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on IndexSearcher. Creating a private method that constructor can call and calling the private method from the virtual method.