### PR TITLE
BREAKING: Lucene.Net.Util.PriorityQueue<T>: Replaced (int, bool) constructor and removed constructor call to virtual GetSentinelObject() method

### DIFF
--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTask.cs
@@ -205,7 +205,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
 
         protected virtual ICollector CreateCollector()
         {
-            return TopScoreDocCollector.Create(NumHits, true);
+            return TopScoreDocCollector.Create(NumHits, docsScoredInOrder: true);
         }
 
 

--- a/src/Lucene.Net.Benchmark/Quality/Utils/QualityQueriesFinder.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Utils/QualityQueriesFinder.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Index;
 using Lucene.Net.Store;
+using Lucene.Net.Util;
 using System;
 using System.IO;
 using Console = Lucene.Net.Util.SystemConsole;
@@ -94,7 +95,7 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
 
         private string[] BestTerms(string field, int numTerms)
         {
-            Util.PriorityQueue<TermDf> pq = new TermsDfQueue(numTerms);
+            PriorityQueue<TermDf> pq = new TermsDfQueue(numTerms);
             IndexReader ir = DirectoryReader.Open(dir);
             try
             {
@@ -140,10 +141,10 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
             }
         }
 
-        private class TermsDfQueue : Util.PriorityQueue<TermDf>
+        private class TermsDfQueue : PriorityQueue<TermDf>
         {
             internal TermsDfQueue(int maxSize)
-                    : base(maxSize)
+                : base(maxSize)
             {
             }
 

--- a/src/Lucene.Net.Facet/TopOrdAndFloatQueue.cs
+++ b/src/Lucene.Net.Facet/TopOrdAndFloatQueue.cs
@@ -33,15 +33,26 @@ namespace Lucene.Net.Facet
         // LUCENENET specific - de-nested OrdAndValue and made it into a generic struct
         // so it can be used with this class and TopOrdAndInt32Queue
 
+#nullable enable
+
         /// <summary>
-        /// Sole constructor.
+        /// Initializes a new instance of <see cref="TopOrdAndSingleQueue"/> with the
+        /// specified <paramref name="topN"/> size.
         /// </summary>
-        public TopOrdAndSingleQueue(int topN) : base(topN, false)
+        public TopOrdAndSingleQueue(int topN) : base(topN) // LUCENENET NOTE: Doesn't pre-populate because sentinelFactory is null
         {
         }
 
+#nullable restore
+
         protected internal override bool LessThan(OrdAndValue<float> a, OrdAndValue<float> b)
         {
+            // LUCENENET specific - added guard clauses
+            if (a is null)
+                throw new ArgumentNullException(nameof(a));
+            if (b is null)
+                throw new ArgumentNullException(nameof(b));
+
             if (a.Value < b.Value)
             {
                 return true;

--- a/src/Lucene.Net.Facet/TopOrdAndIntQueue.cs
+++ b/src/Lucene.Net.Facet/TopOrdAndIntQueue.cs
@@ -1,5 +1,6 @@
 ﻿// Lucene version compatibility level 4.8.1
 using Lucene.Net.Util;
+using System;
 
 namespace Lucene.Net.Facet
 {
@@ -31,16 +32,27 @@ namespace Lucene.Net.Facet
         // LUCENENET specific - de-nested OrdAndValue and made it into a generic struct
         // so it can be used with this class and TopOrdAndSingleQueue
 
+#nullable enable
+
         /// <summary>
-        /// Sole constructor.
+        /// Initializes a new instance of <see cref="TopOrdAndInt32Queue"/> with the specified
+        /// <paramref name="topN"/> size.
         /// </summary>
         public TopOrdAndInt32Queue(int topN)
-            : base(topN, false)
+            : base(topN) // LUCENENET NOTE: Doesn't pre-populate because sentinelFactory is null
         {
         }
 
+#nullable restore
+
         protected internal override bool LessThan(OrdAndValue<int> a, OrdAndValue<int> b)
         {
+            // LUCENENET specific - added guard clauses
+            if (a is null)
+                throw new ArgumentNullException(nameof(a));
+            if (b is null)
+                throw new ArgumentNullException(nameof(b));
+
             if (a.Value < b.Value)
             {
                 return true;

--- a/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
+++ b/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
@@ -191,15 +191,17 @@ namespace Lucene.Net.Misc
         /// Priority queue for <see cref="TermStats"/> objects
         /// 
         /// </summary>
-        internal sealed class TermStatsQueue : Util.PriorityQueue<TermStats>
+        internal sealed class TermStatsQueue : PriorityQueue<TermStats>
         {
             internal readonly IComparer<TermStats> comparer;
 
+#nullable enable
             internal TermStatsQueue(int size, IComparer<TermStats> comparer) 
                 : base(size)
             {
-                this.comparer = comparer;
+                this.comparer = comparer ?? throw new ArgumentNullException(nameof(comparer)); // LUCENENET: Added null guard clause
             }
+#nullable restore
 
             protected internal override bool LessThan(TermStats termInfoA, TermStats termInfoB)
             {

--- a/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
+++ b/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
@@ -352,7 +352,7 @@ namespace Lucene.Net.Sandbox.Queries
             }
         }
 
-        internal class ScoreTermQueue : Util.PriorityQueue<ScoreTerm>
+        internal class ScoreTermQueue : PriorityQueue<ScoreTerm>
         {
             public ScoreTermQueue(int size)
                 : base(size)
@@ -361,7 +361,7 @@ namespace Lucene.Net.Sandbox.Queries
 
             /// <summary>
             /// (non-Javadoc)
-            /// <see cref="Util.PriorityQueue{T}.LessThan(T, T)"/>
+            /// <see cref="PriorityQueue{T}.LessThan(T, T)"/>
             /// </summary>
             protected internal override bool LessThan(ScoreTerm termA, ScoreTerm termB)
             {

--- a/src/Lucene.Net.Suggest/Suggest/Lookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Lookup.cs
@@ -162,17 +162,26 @@ namespace Lucene.Net.Search.Suggest
         /// </summary>
         public sealed class LookupPriorityQueue : PriorityQueue<LookupResult>
         {
+#nullable enable
             // TODO: should we move this out of the interface into a utility class?
             /// <summary>
-            /// Creates a new priority queue of the specified size.
+            /// Creates a new priority queue of the specified <paramref name="size"/>.
             /// </summary>
             public LookupPriorityQueue(int size)
                 : base(size)
             {
             }
 
+#nullable restore
+
             protected internal override bool LessThan(LookupResult a, LookupResult b)
             {
+                // LUCENENET: Added guard clauses
+                if (a is null)
+                    throw new ArgumentNullException(nameof(a));
+                if (b is null)
+                    throw new ArgumentNullException(nameof(b));
+
                 return a.Value < b.Value;
             }
 

--- a/src/Lucene.Net.Tests/Util/TestPriorityQueue.cs
+++ b/src/Lucene.Net.Tests/Util/TestPriorityQueue.cs
@@ -45,8 +45,17 @@ namespace Lucene.Net.Util
             }
 
             public IntegerQueue(int count, bool prepopulate)
-                : base(count, prepopulate)
+                : base(count, prepopulate ? SentinelFactory.Default : null)
             {
+            }
+
+            // LUCENENET specific - "prepopulate" is now controlled by whether
+            // or not SentinelFactory is null.
+            private class SentinelFactory : SentinelFactory<int?, IntegerQueue>
+            {
+                public static SentinelFactory Default { get; } = new SentinelFactory();
+
+                public override int? Create(IntegerQueue integerQueue) => int.MaxValue;
             }
 
             protected internal override bool LessThan(int? a, int? b)
@@ -157,19 +166,6 @@ namespace Lucene.Net.Util
 
         #region LUCENENET SPECIFIC TESTS
 
-        private class IntegerQueueWithSentinel : IntegerQueue
-        {
-            public IntegerQueueWithSentinel(int count, bool prepopulate)
-                : base(count, prepopulate)
-            {
-            }
-
-            protected override int? GetSentinelObject()
-            {
-                return int.MaxValue;
-            }
-        }
-
         private class MyType
         {
             public MyType(int field)
@@ -272,7 +268,7 @@ namespace Lucene.Net.Util
         {
             int maxSize = 10;
             // Populates the internal array
-            PriorityQueue<int?> pq = new IntegerQueueWithSentinel(maxSize, true);
+            PriorityQueue<int?> pq = new IntegerQueue(maxSize, true);
             Assert.AreEqual(pq.Top, int.MaxValue);
             Assert.AreEqual(pq.Count, 10);
 
@@ -435,7 +431,7 @@ namespace Lucene.Net.Util
             
             // Add an element to a prepopulated queue
             int maxSize = 10;
-            PriorityQueue<int?> pq = new IntegerQueueWithSentinel(maxSize, true);
+            PriorityQueue<int?> pq = new IntegerQueue(maxSize, true);
 
             try
             {

--- a/src/Lucene.Net/Index/MultiTermsEnum.cs
+++ b/src/Lucene.Net/Index/MultiTermsEnum.cs
@@ -79,11 +79,15 @@ namespace Lucene.Net.Index
         public TermsEnumWithSlice[] MatchArray => top;
 
         /// <summary>
-        /// Sole constructor. </summary>
-        /// <param name="slices"> Which sub-reader slices we should
-        /// merge.</param>
+        /// Initializes a new instance of <see cref="MultiTermsEnum"/> with the specified <paramref name="slices"/>. </summary>
+        /// <param name="slices"> Which sub-reader slices we should merge.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="slices"/> is <c>null</c>.</exception>
         public MultiTermsEnum(ReaderSlice[] slices)
         {
+            // LUCENENET: Added guard clause
+            if (slices is null)
+                throw new ArgumentNullException(nameof(slices));
+
             queue = new TermMergeQueue(slices.Length);
             top = new TermsEnumWithSlice[slices.Length];
             subs = new TermsEnumWithSlice[slices.Length];

--- a/src/Lucene.Net/Search/FieldValueHitQueue.cs
+++ b/src/Lucene.Net/Search/FieldValueHitQueue.cs
@@ -1,7 +1,10 @@
 ﻿using Lucene.Net.Diagnostics;
+using Lucene.Net.Index;
 using Lucene.Net.Support;
+using Lucene.Net.Util;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
 using System.IO;
 
 namespace Lucene.Net.Search
@@ -51,13 +54,14 @@ namespace Lucene.Net.Search
         {
             private readonly int oneReverseMul; // LUCENENET: marked readonly
 
+#nullable enable
             public OneComparerFieldValueHitQueue(SortField[] fields, int size)
                 : base(fields, size)
             {
+                if (fields is null)
+                    throw new ArgumentNullException(nameof(fields)); // LUCENENET: Added guard clause
                 if (fields.Length == 0)
-                {
                     throw new ArgumentException("Sort must contain at least one field");
-                }
 
                 SortField field = fields[0];
                 SetComparer(0, field.GetComparer(size, 0));
@@ -65,6 +69,7 @@ namespace Lucene.Net.Search
 
                 ReverseMul[0] = oneReverseMul;
             }
+#nullable restore
 
             /// <summary> Returns whether <c>a</c> is less relevant than <c>b</c>.</summary>
             /// <param name="hitA">ScoreDoc</param>
@@ -72,6 +77,12 @@ namespace Lucene.Net.Search
             /// <returns><c>true</c> if document <c>a</c> should be sorted after document <c>b</c>.</returns>
             protected internal override bool LessThan(T hitA, T hitB)
             {
+                // LUCENENET specific - added null guard clauses
+                if (hitA is null)
+                    throw new ArgumentNullException(nameof(hitA));
+                if (hitB is null)
+                    throw new ArgumentNullException(nameof(hitB));
+
                 if (Debugging.AssertsEnabled)
                 {
                     Debugging.Assert(hitA != hitB);
@@ -95,9 +106,14 @@ namespace Lucene.Net.Search
         internal sealed class MultiComparersFieldValueHitQueue<T> : FieldValueHitQueue<T>
             where T : FieldValueHitQueue.Entry
         {
+#nullable enable
             public MultiComparersFieldValueHitQueue(SortField[] fields, int size)
                 : base(fields, size)
             {
+                // LUCENENET specific - added null guard clause
+                if (fields is null)
+                    throw new ArgumentNullException(nameof(fields));
+
                 int numComparers = m_comparers.Length;
                 for (int i = 0; i < numComparers; ++i)
                 {
@@ -110,6 +126,12 @@ namespace Lucene.Net.Search
 
             protected internal override bool LessThan(T hitA, T hitB)
             {
+                // LUCENENET specific - added null guard clauses
+                if (hitA is null)
+                    throw new ArgumentNullException(nameof(hitA));
+                if (hitB is null)
+                    throw new ArgumentNullException(nameof(hitB));
+
                 if (Debugging.AssertsEnabled)
                 {
                     Debugging.Assert(hitA != hitB);
@@ -145,6 +167,10 @@ namespace Lucene.Net.Search
         public static FieldValueHitQueue<T> Create<T>(SortField[] fields, int size)
             where T : FieldValueHitQueue.Entry
         {
+            // LUCENENET specific - added null guard clause
+            if (fields is null)
+                throw new ArgumentNullException(nameof(fields));
+
             if (fields.Length == 0)
             {
                 throw new ArgumentException("Sort must contain at least one field");
@@ -159,6 +185,8 @@ namespace Lucene.Net.Search
                 return new FieldValueHitQueue.MultiComparersFieldValueHitQueue<T>(fields, size);
             }
         }
+
+#nullable restore
     }
 
     /// <summary>
@@ -170,9 +198,10 @@ namespace Lucene.Net.Search
     /// @since 2.9 </summary>
     /// <seealso cref="IndexSearcher.Search(Query,Filter,int,Sort)"/>
     /// <seealso cref="FieldCache"/>
-    public abstract class FieldValueHitQueue<T> : Util.PriorityQueue<T>
+    public abstract class FieldValueHitQueue<T> : PriorityQueue<T>
         where T : FieldValueHitQueue.Entry
     {
+#nullable enable
         // prevent instantiation and extension.
         private protected FieldValueHitQueue(SortField[] fields, int size) // LUCENENET: Changed from private to private protected
             : base(size)
@@ -188,6 +217,7 @@ namespace Lucene.Net.Search
             m_comparers = new FieldComparer[numComparers];
             m_reverseMul = new int[numComparers];
         }
+#nullable restore
 
         [WritableArray]
         [SuppressMessage("Microsoft.Performance", "CA1819", Justification = "Lucene's design requires some writable array properties")]

--- a/src/Lucene.Net/Search/HitQueue.cs
+++ b/src/Lucene.Net/Search/HitQueue.cs
@@ -1,4 +1,8 @@
-﻿namespace Lucene.Net.Search
+﻿using Lucene.Net.Util;
+using System;
+#nullable enable
+
+namespace Lucene.Net.Search
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -16,8 +20,6 @@
      * See the License for the specific language governing permissions and
      * limitations under the License.
      */
-
-    using Lucene.Net.Util;
 
     internal sealed class HitQueue : PriorityQueue<ScoreDoc>
     {
@@ -53,29 +55,44 @@
         /// }
         /// </code>
         ///
-        /// <para/><b>NOTE</b>: this class pre-allocate a full array of
+        /// <para/><b>NOTE</b>: this overload will pre-allocate a full array of
         /// length <paramref name="size"/>.
         /// </summary>
         /// <param name="size">
         ///          The requested size of this queue. </param>
         /// <param name="prePopulate">
         ///          Specifies whether to pre-populate the queue with sentinel values. </param>
-        /// <seealso cref="GetSentinelObject()"/>
+        /// <seealso cref="SentinelFactory"/>
         internal HitQueue(int size, bool prePopulate)
-            : base(size, prePopulate)
+            : base(size, prePopulate ? SentinelFactory.Default : null)
         {
         }
 
-        protected override ScoreDoc GetSentinelObject()
+        // LUCENENET specific - Rather than having a GetSentinelObject() method on PriorityQueue<T>,
+        // and a "prePopulate" boolean value, population is controlled by whether ISentinelFactory<T>
+        // has an instance or is null. This is the singleton instance that is injected when "prePopulate"
+        // is true.
+        internal sealed class SentinelFactory : SentinelFactory<ScoreDoc, HitQueue>
         {
-            // Always set the doc Id to MAX_VALUE so that it won't be favored by
-            // lessThan. this generally should not happen since if score is not NEG_INF,
-            // TopScoreDocCollector will always add the object to the queue.
-            return new ScoreDoc(int.MaxValue, float.NegativeInfinity);
+            public static SentinelFactory Default { get; } = new SentinelFactory();
+
+            public override ScoreDoc Create(HitQueue priorityQueue)
+            {
+                // Always set the doc Id to MAX_VALUE so that it won't be favored by
+                // lessThan. this generally should not happen since if score is not NEG_INF,
+                // TopScoreDocCollector will always add the object to the queue.
+                return new ScoreDoc(int.MaxValue, float.NegativeInfinity);
+            }
         }
 
         protected internal override sealed bool LessThan(ScoreDoc hitA, ScoreDoc hitB)
         {
+            // LUCENENET: Added guard clauses
+            if (hitA is null)
+                throw new ArgumentNullException(nameof(hitA));
+            if (hitB is null)
+                throw new ArgumentNullException(nameof(hitB));
+
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
             if (NumericUtils.SingleToSortableInt32(hitA.Score) == NumericUtils.SingleToSortableInt32(hitB.Score))
             {

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -460,7 +460,7 @@ namespace Lucene.Net.Search
             }
             else
             {
-                HitQueue hq = new HitQueue(nDocs, false);
+                HitQueue hq = new HitQueue(nDocs, prePopulate: false);
                 ReentrantLock @lock = new ReentrantLock();
                 ExecutionHelper<TopDocs> runner = new ExecutionHelper<TopDocs>(executor);
 
@@ -538,7 +538,7 @@ namespace Lucene.Net.Search
         {
             if (sort is null)
             {
-                throw new ArgumentNullException("Sort must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
+                throw new ArgumentNullException(nameof(sort), "Sort must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
             }
 
             int limit = reader.MaxDoc;

--- a/src/Lucene.Net/Search/Spans/SpanOrQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanOrQuery.cs
@@ -177,7 +177,7 @@ namespace Lucene.Net.Search.Spans
             return h;
         }
 
-        private class SpanQueue : Util.PriorityQueue<Spans>
+        private class SpanQueue : PriorityQueue<Spans>
         {
             public SpanQueue(int size)
                 : base(size)

--- a/src/Lucene.Net/Search/TopFieldCollector.cs
+++ b/src/Lucene.Net/Search/TopFieldCollector.cs
@@ -1161,6 +1161,8 @@ namespace Lucene.Net.Search
             this.fillFields = fillFields;
         }
 
+#nullable enable
+
         /// <summary>
         /// Creates a new <see cref="TopFieldCollector"/> from the given
         /// arguments.
@@ -1196,9 +1198,10 @@ namespace Lucene.Net.Search
         /// <returns> A <see cref="TopFieldCollector"/> instance which will sort the results by
         ///         the sort criteria. </returns>
         /// <exception cref="IOException"> If there is a low-level I/O error </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="sort"/> is <c>null</c>.</exception>
         public static TopFieldCollector Create(Sort sort, int numHits, bool fillFields, bool trackDocScores, bool trackMaxScore, bool docsScoredInOrder)
         {
-            return Create(sort, numHits, null, fillFields, trackDocScores, trackMaxScore, docsScoredInOrder);
+            return Create(sort, numHits, after: null, fillFields, trackDocScores, trackMaxScore, docsScoredInOrder);
         }
 
         /// <summary>
@@ -1238,7 +1241,8 @@ namespace Lucene.Net.Search
         /// <returns> A <see cref="TopFieldCollector"/> instance which will sort the results by
         ///         the sort criteria. </returns>
         /// <exception cref="IOException"> If there is a low-level I/O error </exception>
-        public static TopFieldCollector Create(Sort sort, int numHits, FieldDoc after, bool fillFields, bool trackDocScores, bool trackMaxScore, bool docsScoredInOrder)
+        /// <exception cref="ArgumentNullException"><paramref name="sort"/> is <c>null</c>.</exception>
+        public static TopFieldCollector Create(Sort sort, int numHits, FieldDoc? after, bool fillFields, bool trackDocScores, bool trackMaxScore, bool docsScoredInOrder)
         {
             // LUCENENET specific: Added guard clause for null
             if (sort is null)
@@ -1353,6 +1357,10 @@ namespace Lucene.Net.Search
 
         protected override void PopulateResults(ScoreDoc[] results, int howMany)
         {
+            // LUCENENET specific - Added guard clause
+            if (results is null)
+                throw new ArgumentNullException(nameof(results));
+
             if (fillFields)
             {
                 // avoid casting if unnecessary.
@@ -1372,7 +1380,7 @@ namespace Lucene.Net.Search
             }
         }
 
-        protected override TopDocs NewTopDocs(ScoreDoc[] results, int start)
+        protected override TopDocs NewTopDocs(ScoreDoc[]? results, int start)
         {
             if (results is null)
             {

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -2321,7 +2321,7 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        internal class NodeAndInCount : IComparable<NodeAndInCount>
+        internal class NodeAndInCount : IComparable<NodeAndInCount> // LUCENENET TODO: This is a candidate for a struct
         {
             internal int Node { get; private set; }
             internal int Count { get; private set; }
@@ -2350,16 +2350,23 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
+#nullable enable
         internal class NodeQueue : PriorityQueue<NodeAndInCount>
         {
             public NodeQueue(int topN)
-                : base(topN, false)
+                : base(topN) // LUCENENET NOTE: Doesn't pre-populate because sentinelFactory is null
             {
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             protected internal override bool LessThan(NodeAndInCount a, NodeAndInCount b)
             {
+                // LUCENENET specific - added guard clauses
+                if (a is null)
+                    throw new ArgumentNullException(nameof(a));
+                if (b is null)
+                    throw new ArgumentNullException(nameof(b));
+
                 int cmp = a.CompareTo(b);
                 if (Debugging.AssertsEnabled) Debugging.Assert(cmp != 0);
                 return cmp < 0;

--- a/src/Lucene.Net/Util/OfflineSorter.cs
+++ b/src/Lucene.Net/Util/OfflineSorter.cs
@@ -547,6 +547,12 @@ namespace Lucene.Net.Util
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             protected internal override bool LessThan(FileAndTop a, FileAndTop b)
             {
+                // LUCENENET: Added guard clauses
+                if (a is null)
+                    throw new ArgumentNullException(nameof(a));
+                if (b is null)
+                    throw new ArgumentNullException(nameof(b));
+
                 return outerInstance.comparer.Compare(a.Current, b.Current) < 0;
             }
         }

--- a/src/Lucene.Net/Util/WAH8DocIdSet.cs
+++ b/src/Lucene.Net/Util/WAH8DocIdSet.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -106,6 +105,7 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Same as <see cref="Intersect(ICollection{WAH8DocIdSet}, int)"/> with the default index interval. </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="docIdSets"/> is <c>null</c>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static WAH8DocIdSet Intersect(ICollection<WAH8DocIdSet> docIdSets)
         {
@@ -116,6 +116,7 @@ namespace Lucene.Net.Util
         /// Compute the intersection of the provided sets. This method is much faster than
         /// computing the intersection manually since it operates directly at the byte level.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="docIdSets"/> is <c>null</c>.</exception>
         public static WAH8DocIdSet Intersect(ICollection<WAH8DocIdSet> docIdSets, int indexInterval)
         {
             // LUCENENET: Added guard clause for null
@@ -183,6 +184,7 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Same as <see cref="Union(ICollection{WAH8DocIdSet}, int)"/> with the default index interval. </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="docIdSets"/> is <c>null</c>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static WAH8DocIdSet Union(ICollection<WAH8DocIdSet> docIdSets)
         {
@@ -193,8 +195,13 @@ namespace Lucene.Net.Util
         /// Compute the union of the provided sets. This method is much faster than
         /// computing the union manually since it operates directly at the byte level.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="docIdSets"/> is <c>null</c>.</exception>
         public static WAH8DocIdSet Union(ICollection<WAH8DocIdSet> docIdSets, int indexInterval)
         {
+            // LUCENENET: Added guard clause for null
+            if (docIdSets is null)
+                throw new ArgumentNullException(nameof(docIdSets));
+
             switch (docIdSets.Count)
             {
                 case 0:
@@ -246,14 +253,22 @@ namespace Lucene.Net.Util
 
         private sealed class PriorityQueueAnonymousClass : PriorityQueue<WAH8DocIdSet.Iterator>
         {
+#nullable enable
             public PriorityQueueAnonymousClass(int numSets)
                 : base(numSets)
             {
             }
+#nullable restore
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             protected internal override bool LessThan(Iterator a, Iterator b)
             {
+                // LUCENENET specific - added guard clauses
+                if (a is null)
+                    throw new ArgumentException(nameof(a));
+                if (b is null)
+                    throw new ArgumentException(nameof(b));
+
                 return a.wordNum < b.wordNum;
             }
         }


### PR DESCRIPTION
This breaks API compatibility in 2 ways:

1. The `PriorityQueue<T>(int, bool)` constructor was replaced with `PriorityQueue<T>(int, ISentinelFactory<T>)`.
2. The virtual `GetSentinelObject()` method was removed from `PriorityQueue<T>`.


This also removes ambiguity since both "prepopulate" had to be specified as "true" in the constructor **AND** the `GetSentinelObject()` method had to be overridden in a subclass for it to work. Now there is a single signal. Pass `null` to **not** populate. Pass a `ISentinelFactory<T>` implementation to populate.

This PR also contains some related `null` guard clauses and nullable reference type updates to the API (so it is clear when a `null` is accepted for a given parameter.