### PR TITLE
add ignore attributes

### DIFF
--- a/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
@@ -99,9 +99,15 @@ namespace Lucene.Net.Benchmarks.ByTask
         private readonly IDictionary<string, object> perfObjects = new Dictionary<string, object>();
 
         // constructor
+        public PerfRunData(Config config) : this(config, true)
+        {    
+        }
+
+        // LUCENENET specific - added performReinit parameter to allow subclasses to skip reinit
+        // since it's a virtual method. Subclass can call that method itself if needed.
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
-        public PerfRunData(Config config)
+        protected PerfRunData(Config config, bool performReinit)
         {
             this.config = config;
             // analyzer (default is standard analyzer)
@@ -125,7 +131,10 @@ namespace Lucene.Net.Benchmarks.ByTask
             qmkrClass = Type.GetType(config.Get("query.maker", typeof(SimpleQueryMaker).AssemblyQualifiedName));
 
             // index stuff
-            Reinit(false);
+            if (performReinit)
+            {
+                Reinit(false);
+            }
 
             // statistic points
             points = new Points(config);

--- a/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
@@ -11,6 +11,7 @@ using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using Console = Lucene.Net.Util.SystemConsole;
@@ -98,6 +99,8 @@ namespace Lucene.Net.Benchmarks.ByTask
         private readonly IDictionary<string, object> perfObjects = new Dictionary<string, object>();
 
         // constructor
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
         public PerfRunData(Config config)
         {
             this.config = config;

--- a/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
@@ -113,7 +113,8 @@ namespace Lucene.Net.Benchmarks.ByTask
         [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
         protected PerfRunData(Config config, bool performReinit, bool logQueries)
         {
-            this.config = config;
+            this.config = config ?? throw new ArgumentNullException(nameof(config));
+            
             // analyzer (default is standard analyzer)
             analyzer = NewAnalyzerTask.CreateAnalyzer(config.Get("analyzer",
                 typeof(Lucene.Net.Analysis.Standard.StandardAnalyzer).AssemblyQualifiedName));

--- a/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
@@ -99,15 +99,19 @@ namespace Lucene.Net.Benchmarks.ByTask
         private readonly IDictionary<string, object> perfObjects = new Dictionary<string, object>();
 
         // constructor
-        public PerfRunData(Config config) : this(config, true)
+        public PerfRunData(Config config) : this(
+            config,
+            performReinit: true,
+            logQueries: string.Equals(config?.Get("log.queries", "false") ?? "false", "true", StringComparison.OrdinalIgnoreCase))
         {    
         }
 
         // LUCENENET specific - added performReinit parameter to allow subclasses to skip reinit
-        // since it's a virtual method. Subclass can call that method itself if needed.
+        // since it's a virtual method. Also added logQueries parameter to allow to skip calling
+        // virtual GetQueryMarker. Subclass can call these methods itself if needed.
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
-        protected PerfRunData(Config config, bool performReinit)
+        protected PerfRunData(Config config, bool performReinit, bool logQueries)
         {
             this.config = config;
             // analyzer (default is standard analyzer)
@@ -139,7 +143,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             // statistic points
             points = new Points(config);
 
-            if (bool.Parse(config.Get("log.queries", "false")))
+            if (logQueries)
             {
                 Console.WriteLine("------------> queries:");
                 Console.WriteLine(GetQueryMaker(new SearchTask(this)).PrintQueries());

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTask.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
 using Console = Lucene.Net.Util.SystemConsole;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
 {
@@ -44,6 +45,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     /// <para/>
     /// Other side effects: none.
     /// </remarks>
+    [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+    [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]    
     public abstract class ReadTask : PerfTask
     {
         private readonly IQueryMaker queryMaker;

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTask.cs
@@ -45,14 +45,14 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     /// <para/>
     /// Other side effects: none.
     /// </remarks>
-    [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
-    [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]    
     public abstract class ReadTask : PerfTask
     {
         private readonly IQueryMaker queryMaker;
 
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]    
         protected ReadTask(PerfRunData runData) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
-            : base(runData)
+            : this(runData, null)
         {
             if (WithSearch)
             {
@@ -62,6 +62,14 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             {
                 queryMaker = null;
             }
+        }
+
+        // LUCENENET specific - added this constructor to allow subclasses to initialize it
+        // without having to call constructor that makes a virtual method call
+        protected ReadTask(PerfRunData runData, IQueryMaker queryMaker)
+            : base(runData)
+        {
+            this.queryMaker = queryMaker;
         }
 
         public override int DoLogic()

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTask.cs
@@ -47,12 +47,13 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     /// </remarks>
     public abstract class ReadTask : PerfTask
     {
-        private readonly IQueryMaker queryMaker;
+        #nullable enable
+        private readonly IQueryMaker? queryMaker;
 
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]    
         protected ReadTask(PerfRunData runData) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
-            : this(runData, null)
+            : this(runData, queryMaker: null)
         {
             if (WithSearch)
             {
@@ -63,14 +64,14 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 queryMaker = null;
             }
         }
-
         // LUCENENET specific - added this constructor to allow subclasses to initialize it
         // without having to call constructor that makes a virtual method call
-        protected ReadTask(PerfRunData runData, IQueryMaker queryMaker)
+        protected ReadTask(PerfRunData runData, IQueryMaker? queryMaker)
             : base(runData)
         {
             this.queryMaker = queryMaker;
         }
+        #nullable restore
 
         public override int DoLogic()
         {

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteLineDocTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteLineDocTask.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -92,7 +93,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
 
         private readonly object lineFileLock = new object(); // LUCENENET specific - lock to ensure writes don't collide for this instance
 
-
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
         public WriteLineDocTask(PerfRunData runData)
             : base(runData)
         {

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteLineDocTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteLineDocTask.cs
@@ -83,7 +83,9 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
 
         private int docSize = 0;
         protected readonly string m_fname;
-        private readonly TextWriter lineFileOut;
+        // LUCENENET specific - changed to protected to allow subclass access in case
+        // it needs to be used in WriteHeader from the subclass's constructor
+        protected readonly TextWriter m_lineFileOut;
         private readonly DocMaker docMaker;
         private readonly DisposableThreadLocal<StringBuilder> threadBuffer = new DisposableThreadLocal<StringBuilder>();
         private readonly DisposableThreadLocal<Regex> threadNormalizer = new DisposableThreadLocal<Regex>();
@@ -93,9 +95,14 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
 
         private readonly object lineFileLock = new object(); // LUCENENET specific - lock to ensure writes don't collide for this instance
 
+        public WriteLineDocTask(PerfRunData runData)
+            : this(runData, performWriteHeader: true)
+        {
+        }
+
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
-        public WriteLineDocTask(PerfRunData runData)
+        public WriteLineDocTask(PerfRunData runData, bool performWriteHeader)
             : base(runData)
         {
             Config config = runData.Config;
@@ -105,7 +112,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 throw new ArgumentException("line.file.out must be set");
             }
             Stream @out = StreamUtils.GetOutputStream(new FileInfo(m_fname));
-            lineFileOut = new StreamWriter(@out, Encoding.UTF8);
+            m_lineFileOut = new StreamWriter(@out, Encoding.UTF8);
             docMaker = runData.DocMaker;
 
             // init fields 
@@ -143,7 +150,10 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 }
             }
 
-            WriteHeader(lineFileOut);
+            if (performWriteHeader)
+            {
+                WriteHeader(m_lineFileOut);
+            }
         }
 
         /// <summary>
@@ -230,7 +240,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         /// </summary>
         protected virtual TextWriter LineFileOut(Document doc)
         {
-            return lineFileOut;
+            return m_lineFileOut;
         }
 
         protected override void Dispose(bool disposing)
@@ -239,7 +249,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             {
                 threadBuffer.Dispose(); // LUCENENET specific: ThreadLocal is disposable
                 threadNormalizer.Dispose(); // LUCENENET specific: ThreadLocal is disposable
-                lineFileOut.Dispose();
+                m_lineFileOut.Dispose();
             }
             base.Dispose(disposing);
         }


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on the findings in the Benchmark project. Adding attributes to ignore the warnings as opposed to introducing a workaround or a breaking change.