### PR TITLE
Supress sonar cloud virtual method from constructor call error

### DIFF
--- a/src/Lucene.Net/Util/OpenBitSetDISI.cs
+++ b/src/Lucene.Net/Util/OpenBitSetDISI.cs
@@ -1,21 +1,22 @@
 namespace Lucene.Net.Util
 {
+    using System.Diagnostics.CodeAnalysis;
     /*
-     * Licensed to the Apache Software Foundation (ASF) under one or more
-     * contributor license agreements.  See the NOTICE file distributed with
-     * this work for additional information regarding copyright ownership.
-     * The ASF licenses this file to You under the Apache License, Version 2.0
-     * (the "License"); you may not use this file except in compliance with
-     * the License.  You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
     using DocIdSetIterator = Lucene.Net.Search.DocIdSetIterator;
 
@@ -31,6 +32,8 @@ namespace Lucene.Net.Util
         /// Also give a maximum size one larger than the largest doc id for which a
         /// bit may ever be set on this <see cref="OpenBitSetDISI"/>.
         /// </summary>
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "This class will get removed in later versions of Lucene, see LUCENE-6010")]
         public OpenBitSetDISI(DocIdSetIterator disi, int maxSize)
             : base(maxSize)
         {


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on OpenBitSetDISI class. It gets deleted in later version of Lucene, so figured it's not worth addressing the issue here, especially since the fix does not appear to be trivial (e.g. we can't resort to private easily as it calls another virtual method in the logic, or introduce a different constructor).