### PR TITLE
add ignore attributes

### DIFF
--- a/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
@@ -30,6 +30,7 @@ using J2N.Text;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
@@ -275,6 +276,8 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// <param name="culture">The culture used for lowercasing.</param>
         /// <exception cref="IOException">
         ///              A problem occured while reading the data. </exception>
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "This class gets deprecated and removed in later versions")]
         public JaspellTernarySearchTrie(FileInfo file, bool compression, CultureInfo culture)
             : this(culture)
         {

--- a/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
@@ -267,6 +267,11 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// the form "word TAB float".
         /// 
         /// <para>Uses the supplied culture to lowercase words before comparing.</para>
+        /// <para>NOTE for subclasses: this constructor calls a virtual method, which could
+        /// result in your override of it being called before the class is properly initialized.
+        /// To overcome the issue, you could override <see cref="JaspellTernarySearchTrie(CultureInfo)"/>
+        /// constructor and then call the logic in a way that suits your needs.
+        /// </para>
         /// </summary>
         /// <param name="file">
         ///          The <see cref="FileInfo"/> with the data to load into the Trie. </param>


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

JaspellTernarySearchTrie gets removed in the later versions of Lucene: https://github.com/apache/lucene/commit/4213f9d3cd1742082ebac74fb6510dc8c46bfd95. It is not worth it for us to find a way to extend this class without virtual method calls being a potential issue.