### PR TITLE
Remove unnecessary index writer getting opened

### DIFF
--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -179,7 +179,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             if (DirectoryReader.IndexExists(dir))
             {
                 // Already built; open it:
-                writer = new IndexWriter(dir, GetIndexWriterConfig(matchVersion, GetGramAnalyzer(), OpenMode.APPEND));
+                // LUCENENET specific, deleted writer = new IndexWriter based on LUCENE-7670
                 m_searcherMgr = new SearcherManager(writer, true, null);
             }
         }

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -180,7 +180,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             {
                 // Already built; open it:
                 // LUCENENET specific, deleted writer = new IndexWriter based on LUCENE-7670
-                m_searcherMgr = new SearcherManager(writer, true, null);
+                m_searcherMgr = new SearcherManager(dir, null);
             }
         }
 


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on AnalyzingInfixSuggester. After going back to Lucene repository and looking at the history of the file, I found this:

https://issues.apache.org/jira/browse/LUCENE-7670

and https://github.com/apache/lucene/commit/c1fe88b7c6fa861d5101f9702a7832d29b8032ee

The opening of a writer appears to be a bug that was fixed, and the line was removed. Removing the line eliminates the sonar cloud issue as well.