### PR TITLE
BREAKING: Introducing ValuePriorityQueue<T>

### DIFF
--- a/src/Lucene.Net.Facet/Taxonomy/FloatTaxonomyFacets.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/FloatTaxonomyFacets.cs
@@ -1,6 +1,8 @@
 ﻿// Lucene version compatibility level 4.8.1
 using Lucene.Net.Diagnostics;
+using Lucene.Net.Util;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -33,6 +35,8 @@ namespace Lucene.Net.Facet.Taxonomy
     /// </summary>
     public abstract class SingleTaxonomyFacets : TaxonomyFacets
     {
+        private const int OrdAndSingleByteSize = sizeof(int) + sizeof(float); // LUCENENET specific - so we can calculate stack size
+
         /// <summary>
         /// Per-ordinal value. </summary>
         protected readonly float[] m_values;
@@ -104,7 +108,8 @@ namespace Lucene.Net.Facet.Taxonomy
             return m_values[ord];
         }
 
-        public override FacetResult GetTopChildren(int topN, string dim, params string[] path)
+#nullable enable
+        public override FacetResult? GetTopChildren(int topN, string dim, params string[] path)
         {
             if (topN <= 0)
             {
@@ -118,64 +123,81 @@ namespace Lucene.Net.Facet.Taxonomy
                 return null;
             }
 
-            TopOrdAndSingleQueue q = new TopOrdAndSingleQueue(Math.Min(m_taxoReader.Count, topN));
-            float bottomValue = 0;
-
-            int ord = m_children[dimOrd];
-            float sumValues = 0;
-            int childCount = 0;
-
-            while (ord != TaxonomyReader.INVALID_ORDINAL)
+            // LUCENENET: Refactored PriorityQueue<T> subclass into IPriorityComparer<T>
+            // implementation, which can be passed into ValuePriorityQueue. ValuePriorityQueue
+            // lives on the stack, and if the array size is small enough, we also allocate the
+            // array on the stack. Fallback to the array pool if it is beyond MaxStackByteLimit.
+            int bufferSize = PriorityQueue.GetArrayHeapSize(Math.Min(m_taxoReader.Count, topN));
+            bool usePool = OrdAndSingleByteSize * bufferSize > Constants.MaxStackByteLimit;
+            OrdAndValue<float>[]? arrayToReturnToPool = usePool ? ArrayPool<OrdAndValue<float>>.Shared.Rent(bufferSize) : null;
+            try
             {
-                if (m_values[ord] > 0)
+                Span<OrdAndValue<float>> buffer = usePool ? arrayToReturnToPool : stackalloc OrdAndValue<float>[bufferSize];
+                ValuePriorityQueue<OrdAndValue<float>> q = new ValuePriorityQueue<OrdAndValue<float>>(buffer, TopOrdAndSingleComparer.Default);
+
+                float bottomValue = 0;
+
+                int ord = m_children[dimOrd];
+                float sumValues = 0;
+                int childCount = 0;
+
+                while (ord != TaxonomyReader.INVALID_ORDINAL)
                 {
-                    sumValues += m_values[ord];
-                    childCount++;
-                    if (m_values[ord] > bottomValue)
+                    if (m_values[ord] > 0)
                     {
-                        // LUCENENET specific - use struct instead of reusing class instance for better performance
-                        q.Insert(new OrdAndValue<float>(ord, m_values[ord]));
-                        if (q.Count == topN)
+                        sumValues += m_values[ord];
+                        childCount++;
+                        if (m_values[ord] > bottomValue)
                         {
-                            bottomValue = q.Top.Value;
+                            // LUCENENET specific - use struct instead of reusing class instance for better performance
+                            q.Insert(new OrdAndValue<float>(ord, m_values[ord]));
+                            if (q.Count == topN)
+                            {
+                                bottomValue = q.Top.Value;
+                            }
                         }
                     }
+
+                    ord = m_siblings[ord];
                 }
 
-                ord = m_siblings[ord];
-            }
-
-            if (sumValues == 0)
-            {
-                return null;
-            }
-
-            if (dimConfig.IsMultiValued)
-            {
-                if (dimConfig.RequireDimCount)
+                if (sumValues == 0)
                 {
-                    sumValues = m_values[dimOrd];
+                    return null;
+                }
+
+                if (dimConfig.IsMultiValued)
+                {
+                    if (dimConfig.RequireDimCount)
+                    {
+                        sumValues = m_values[dimOrd];
+                    }
+                    else
+                    {
+                        // Our sum'd count is not correct, in general:
+                        sumValues = -1;
+                    }
                 }
                 else
                 {
-                    // Our sum'd count is not correct, in general:
-                    sumValues = -1;
+                    // Our sum'd dim count is accurate, so we keep it
                 }
-            }
-            else
-            {
-                // Our sum'd dim count is accurate, so we keep it
-            }
 
-            LabelAndValue[] labelValues = new LabelAndValue[q.Count];
-            for (int i = labelValues.Length - 1; i >= 0; i--)
-            {
-                var ordAndValue = q.Pop();
-                FacetLabel child = m_taxoReader.GetPath(ordAndValue.Ord);
-                labelValues[i] = new LabelAndValue(child.Components[cp.Length], ordAndValue.Value);
-            }
+                LabelAndValue[] labelValues = new LabelAndValue[q.Count];
+                for (int i = labelValues.Length - 1; i >= 0; i--)
+                {
+                    var ordAndValue = q.Pop();
+                    FacetLabel child = m_taxoReader.GetPath(ordAndValue.Ord);
+                    labelValues[i] = new LabelAndValue(child.Components[cp.Length], ordAndValue.Value);
+                }
 
-            return new FacetResult(dim, path, sumValues, labelValues, childCount);
+                return new FacetResult(dim, path, sumValues, labelValues, childCount);
+            }
+            finally
+            {
+                if (arrayToReturnToPool is not null)
+                    ArrayPool<OrdAndValue<float>>.Shared.Return(arrayToReturnToPool);
+            }
         }
     }
 }

--- a/src/Lucene.Net.Facet/Taxonomy/FloatTaxonomyFacets.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/FloatTaxonomyFacets.cs
@@ -123,7 +123,7 @@ namespace Lucene.Net.Facet.Taxonomy
                 return null;
             }
 
-            // LUCENENET: Refactored PriorityQueue<T> subclass into IPriorityComparer<T>
+            // LUCENENET: Refactored PriorityQueue<T> subclass into PriorityComparer<T>
             // implementation, which can be passed into ValuePriorityQueue. ValuePriorityQueue
             // lives on the stack, and if the array size is small enough, we also allocate the
             // array on the stack. Fallback to the array pool if it is beyond MaxStackByteLimit.
@@ -133,7 +133,7 @@ namespace Lucene.Net.Facet.Taxonomy
             try
             {
                 Span<OrdAndValue<float>> buffer = usePool ? arrayToReturnToPool : stackalloc OrdAndValue<float>[bufferSize];
-                ValuePriorityQueue<OrdAndValue<float>> q = new ValuePriorityQueue<OrdAndValue<float>>(buffer, TopOrdAndSingleComparer.Default);
+                var q = new ValuePriorityQueue<OrdAndValue<float>>(buffer, TopOrdAndSingleComparer.Default);
 
                 float bottomValue = 0;
 

--- a/src/Lucene.Net.Facet/Taxonomy/IntTaxonomyFacets.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/IntTaxonomyFacets.cs
@@ -127,7 +127,7 @@ namespace Lucene.Net.Facet.Taxonomy
                 return null;
             }
 
-            // LUCENENET: Refactored PriorityQueue<T> subclass into IPriorityComparer<T>
+            // LUCENENET: Refactored PriorityQueue<T> subclass into PriorityComparer<T>
             // implementation, which can be passed into ValuePriorityQueue. ValuePriorityQueue
             // lives on the stack, and if the array size is small enough, we also allocate the
             // array on the stack. Fallback to the array pool if it is beyond MaxStackByteLimit.
@@ -137,7 +137,7 @@ namespace Lucene.Net.Facet.Taxonomy
             try
             {
                 Span<OrdAndValue<int>> buffer = usePool ? arrayToReturnToPool : stackalloc OrdAndValue<int>[bufferSize];
-                ValuePriorityQueue<OrdAndValue<int>> q = new ValuePriorityQueue<OrdAndValue<int>>(buffer, TopOrdAndInt32Comparer.Default);
+                var q = new ValuePriorityQueue<OrdAndValue<int>>(buffer, TopOrdAndInt32Comparer.Default);
 
                 int bottomValue = 0;
 

--- a/src/Lucene.Net.Facet/TopOrdAndFloatQueue.cs
+++ b/src/Lucene.Net.Facet/TopOrdAndFloatQueue.cs
@@ -94,6 +94,7 @@ namespace Lucene.Net.Facet
     // and stack allocated.
     [StructLayout(LayoutKind.Sequential)]
     public struct OrdAndValue<T> : IEquatable<OrdAndValue<T>>
+        where T : struct
     {
         private int ord;
         private T value;
@@ -116,7 +117,7 @@ namespace Lucene.Net.Facet
         }
 
         #region Added for better .NET support
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is OrdAndValue<T> other && Equals(other);
         }

--- a/src/Lucene.Net.Facet/TopOrdAndFloatQueue.cs
+++ b/src/Lucene.Net.Facet/TopOrdAndFloatQueue.cs
@@ -56,9 +56,9 @@ namespace Lucene.Net.Facet
     /// <para/>
     /// NOTE: This is a refactoring of TopOrdAndFloatQueue in Lucene
     /// </summary>
-    // LUCENENET: Refactored PriorityQueue<T> subclass into IPriorityComparer<T>
+    // LUCENENET: Refactored PriorityQueue<T> subclass into PriorityComparer<T>
     // implementation, which can be passed into ValuePriorityQueue.
-    public sealed class TopOrdAndSingleComparer : IPriorityComparer<OrdAndValue<float>>
+    public sealed class TopOrdAndSingleComparer : PriorityComparer<OrdAndValue<float>>
     {
         /// <summary>
         /// Returns a default sort order comparer for <see cref="OrdAndValue{Single}"/>.
@@ -67,7 +67,7 @@ namespace Lucene.Net.Facet
         /// </summary>
         public static TopOrdAndSingleComparer Default { get; } = new TopOrdAndSingleComparer();
 
-        internal bool LessThan(OrdAndValue<float> a, OrdAndValue<float> b)
+        protected internal override bool LessThan(OrdAndValue<float> a, OrdAndValue<float> b)
         {
             if (a.Value < b.Value)
             {
@@ -82,9 +82,6 @@ namespace Lucene.Net.Facet
                 return a.Ord > b.Ord;
             }
         }
-
-        bool IPriorityComparer<OrdAndValue<float>>.LessThan(OrdAndValue<float> a, OrdAndValue<float> b)
-            => LessThan(a, b);
     }
 
     /// <summary>

--- a/src/Lucene.Net.Facet/TopOrdAndIntQueue.cs
+++ b/src/Lucene.Net.Facet/TopOrdAndIntQueue.cs
@@ -56,9 +56,9 @@ namespace Lucene.Net.Facet
     /// <para/>
     /// NOTE: This is a refactoring of TopOrdAndIntQueue in Lucene
     /// </summary>
-    // LUCENENET: Refactored PriorityQueue<T> subclass into IPriorityComparer<T>
+    // LUCENENET: Refactored PriorityQueue<T> subclass into PriorityComparer<T>
     // implementation, which can be passed into ValuePriorityQueue.
-    public sealed class TopOrdAndInt32Comparer : IPriorityComparer<OrdAndValue<int>>
+    public sealed class TopOrdAndInt32Comparer : PriorityComparer<OrdAndValue<int>>
     {
         /// <summary>
         /// Returns a default sort order comparer for <see cref="OrdAndValue{Int32}"/>.
@@ -67,7 +67,7 @@ namespace Lucene.Net.Facet
         /// </summary>
         public static TopOrdAndInt32Comparer Default { get; } = new TopOrdAndInt32Comparer();
 
-        internal bool LessThan(OrdAndValue<int> a, OrdAndValue<int> b)
+        protected internal override bool LessThan(OrdAndValue<int> a, OrdAndValue<int> b)
         {
             if (a.Value < b.Value)
             {
@@ -82,7 +82,5 @@ namespace Lucene.Net.Facet
                 return a.Ord > b.Ord;
             }
         }
-        bool IPriorityComparer<OrdAndValue<int>>.LessThan(OrdAndValue<int> a, OrdAndValue<int> b)
-            => LessThan(a, b);
     }
 }

--- a/src/Lucene.Net.Tests.Facet/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.Facet/Support/TestApiConsistency.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Tests.Facet
         [TestCase(typeof(Lucene.Net.Facet.Facets))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly);
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Facet\.Taxonomy\.(?:Single|Int32)TaxonomyFacets\.OrdAnd(?:Single|Int32)ByteSize");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net
         [TestCase(typeof(Lucene.Net.Analysis.Analyzer))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:ConcurrentHashSet|PlatformHelper|DateTimeOffsetUtil|Arrays|IO\.FileSupport)|^Lucene\.ExceptionExtensions|^Lucene\.Net\.Util\.Constants\.MaxStackByteLimit");
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:ConcurrentHashSet|PlatformHelper|DateTimeOffsetUtil|Arrays|IO\.FileSupport)|^Lucene\.ExceptionExtensions|^Lucene\.Net\.Util\.Constants\.MaxStackByteLimit|^Lucene\.Net\.Search\.TopDocs\.ShardByteSize");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests/Util/TestPriorityQueue.cs
+++ b/src/Lucene.Net.Tests/Util/TestPriorityQueue.cs
@@ -35,11 +35,11 @@ namespace Lucene.Net.Util
     {
         private static readonly int MAX_PQ_SIZE = ArrayUtil.MAX_ARRAY_LENGTH - 1;
 
-        private class IntegerComparer : IPriorityComparer<int?>
+        private class IntegerComparer : PriorityComparer<int?>
         {
             public static IntegerComparer Default { get; } = new IntegerComparer();
 
-            public bool LessThan(int? a, int? b)
+            protected internal override bool LessThan(int? a, int? b)
             {
                 return (a < b);
             }
@@ -304,10 +304,10 @@ namespace Lucene.Net.Util
             }
         }
 
-        private class MyComparer : IPriorityComparer<MyType>
+        private class MyComparer : PriorityComparer<MyType>
         {
             public static MyComparer Default { get; } = new MyComparer();
-            public bool LessThan(MyType a, MyType b)
+            protected internal override bool LessThan(MyType a, MyType b)
             {
                 return a.Field < b.Field;
             }
@@ -939,7 +939,7 @@ namespace Lucene.Net.Util
             for (int i = 1; i < size; i++)
             {
                 T next = pq.Pop();
-                Assert.IsTrue(pq.Comparer.LessThan(last, next) || last.Equals(next));
+                Assert.IsTrue(pq.Comparer.Compare(last, next) < 0 || last.Equals(next));
                 last = next;
             }
         }

--- a/src/Lucene.Net/Search/HitQueue.cs
+++ b/src/Lucene.Net/Search/HitQueue.cs
@@ -72,11 +72,11 @@ namespace Lucene.Net.Search
         // and a "prePopulate" boolean value, population is controlled by whether ISentinelFactory<T>
         // has an instance or is null. This is the singleton instance that is injected when "prePopulate"
         // is true.
-        internal sealed class SentinelFactory : SentinelFactory<ScoreDoc, HitQueue>
+        internal sealed class SentinelFactory : ISentinelFactory<ScoreDoc>
         {
             public static SentinelFactory Default { get; } = new SentinelFactory();
 
-            public override ScoreDoc Create(HitQueue priorityQueue)
+            public ScoreDoc Create()
             {
                 // Always set the doc Id to MAX_VALUE so that it won't be favored by
                 // lessThan. this generally should not happen since if score is not NEG_INF,

--- a/src/Lucene.Net/Search/TopDocs.cs
+++ b/src/Lucene.Net/Search/TopDocs.cs
@@ -2,8 +2,10 @@
 using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Lucene.Net.Search
 {
@@ -69,36 +71,76 @@ namespace Lucene.Net.Search
             this.maxScore = maxScore;
         }
 
+#nullable enable
+
+        private static readonly int ShardByteSize = Marshal.SizeOf(typeof(Shard)); // LUCENENET specific so we can calculate stack size
+
+        // LUCENENET specific - Renamed ShardRef to Shard and made it into a struct
+        // so we can allocate arrays of them on the stack.
         // Refers to one hit:
-        private class ShardRef
+        [StructLayout(LayoutKind.Sequential)]
+        private struct Shard : IEquatable<Shard>
         {
+            [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+            [SuppressMessage("Major Code Smell", "S2933:Fields that are only assigned in the constructor should be \"readonly\"", Justification = "Structs are known to have performance issues with readonly fields")]
+            [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs are known to have performance issues with readonly fields")]
+            private int shardIndex;
+            private int hitIndex;
+
             // Which shard (index into shardHits[]):
-            internal int ShardIndex { get; private set; }
+            internal int ShardIndex => shardIndex;
 
             // Which hit within the shard:
-            internal int HitIndex { get; set; }
-
-            public ShardRef(int shardIndex)
+            internal int HitIndex
             {
-                this.ShardIndex = shardIndex;
+                get => hitIndex;
+                set => hitIndex = value;
             }
+
+            public Shard(int shardIndex)
+            {
+                this.shardIndex = shardIndex;
+                this.hitIndex = 0;
+            }
+
+            public bool Equals(Shard other)
+            {
+                return shardIndex == other.shardIndex && hitIndex == other.hitIndex;
+            }
+
+            public override bool Equals(object? obj)
+            {
+                if (obj is Shard shard)
+                    return Equals(shard);
+                return false;
+            }
+
+            public override int GetHashCode()
+                => shardIndex.GetHashCode() ^ hitIndex.GetHashCode();
 
             public override string ToString()
             {
-                return "ShardRef(shardIndex=" + ShardIndex + " hitIndex=" + HitIndex + ")";
+                return $"{nameof(Shard)}({nameof(shardIndex)}={shardIndex} {nameof(hitIndex)}={hitIndex})";
             }
+
+            public static bool operator ==(Shard shard1, Shard shard2)
+            {
+                return shard1.Equals(shard2);
+            }
+
+            public static bool operator !=(Shard shard1, Shard shard2)
+                => !(shard1 == shard2);
         }
 
-#nullable enable
+        // LUCENENET specific - refactored ScoreMergeSortQueue into ScoreMergeSortComparer so it can be passed into a ValuePriorityQueue
 
-        // Specialized MergeSortQueue that just merges by
+        // Specialized MergeSortComparer that just merges by
         // relevance score, descending:
-        private sealed class ScoreMergeSortQueue : PriorityQueue<ShardRef> // LUCENENET specific - marked sealed
+        private sealed class ScoreMergeSortComparer : IPriorityComparer<Shard> // LUCENENET specific - marked sealed
         {
             internal readonly ScoreDoc[][] shardHits;
 
-            public ScoreMergeSortQueue(TopDocs[] shardHits)
-                : base(shardHits?.Length ?? 0)
+            public ScoreMergeSortComparer(TopDocs[] shardHits)
             {
                 if (shardHits is null)
                     throw new ArgumentNullException(nameof(shardHits));
@@ -111,14 +153,8 @@ namespace Lucene.Net.Search
             }
 
             // Returns true if first is < second
-            protected internal override bool LessThan(ShardRef first, ShardRef second)
+            bool IPriorityComparer<Shard>.LessThan(Shard first, Shard second)
             {
-                // LUCENENET specific - added guard clauses
-                if (first is null)
-                    throw new ArgumentNullException(nameof(first));
-                if (second is null)
-                    throw new ArgumentNullException(nameof(second));
-
                 if (Debugging.AssertsEnabled) Debugging.Assert(first != second);
                 float firstScore = shardHits[first.ShardIndex][first.HitIndex].Score;
                 float secondScore = shardHits[second.ShardIndex][second.HitIndex].Score;
@@ -154,7 +190,8 @@ namespace Lucene.Net.Search
             }
         }
 
-        private sealed class MergeSortQueue : PriorityQueue<ShardRef> // LUCENENET specific - marked sealed
+        // LUCENENET specific - refactored MergeSortQueue into MergeSortComparer so it can be passed into a ValuePriorityQueue
+        private sealed class MergeSortComparer : IPriorityComparer<Shard> // LUCENENET specific - marked sealed
         {
             // These are really FieldDoc instances:
             internal readonly ScoreDoc[][] shardHits;
@@ -162,8 +199,7 @@ namespace Lucene.Net.Search
             internal readonly FieldComparer[] comparers;
             internal readonly int[] reverseMul;
 
-            public MergeSortQueue(Sort sort, TopDocs[] shardHits)
-                : base(shardHits?.Length ?? 0)
+            public MergeSortComparer(Sort sort, TopDocs[] shardHits)
             {
                 if (shardHits is null)
                     throw new ArgumentNullException(nameof(shardHits));
@@ -204,17 +240,9 @@ namespace Lucene.Net.Search
                 }
             }
 
-
-
             // Returns true if first is < second
-            protected internal override bool LessThan(ShardRef first, ShardRef second)
+            bool IPriorityComparer<Shard>.LessThan(Shard first, Shard second)
             {
-                // LUCENENET specific - added guard clauses
-                if (first is null)
-                    throw new ArgumentNullException(nameof(first));
-                if (second is null)
-                    throw new ArgumentNullException(nameof(second));
-
                 if (Debugging.AssertsEnabled) Debugging.Assert(first != second);
                 FieldDoc firstFD = (FieldDoc)shardHits[first.ShardIndex][first.HitIndex];
                 FieldDoc secondFD = (FieldDoc)shardHits[second.ShardIndex][second.HitIndex];
@@ -289,82 +317,102 @@ namespace Lucene.Net.Search
             if (shardHits is null)
                 throw new ArgumentNullException(nameof(shardHits));
 
-            PriorityQueue<ShardRef> queue;
+            // LUCENENET: Refactored PriorityQueue<T> subclasses into IPriorityComparer<T>
+            // implementations, which can be passed into ValuePriorityQueue. ValuePriorityQueue
+            // lives on the stack, and if the array size is small enough, we also allocate the
+            // array on the stack. Fallback to the array pool if it is beyond MaxStackByteLimit.
+            IPriorityComparer<Shard> comparer;
             if (sort is null)
             {
-                queue = new ScoreMergeSortQueue(shardHits);
+                comparer = new ScoreMergeSortComparer(shardHits);
             }
             else
             {
-                queue = new MergeSortQueue(sort, shardHits);
+                comparer = new MergeSortComparer(sort, shardHits);
             }
-
-            int totalHitCount = 0;
-            int availHitCount = 0;
-            float maxScore = float.Epsilon; // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
-            for (int shardIDX = 0; shardIDX < shardHits.Length; shardIDX++)
+            int bufferSize = PriorityQueue.GetArrayHeapSize(shardHits.Length);
+            bool usePool = ShardByteSize * bufferSize > Constants.MaxStackByteLimit;
+            Shard[]? arrayToReturnToPool = usePool ? ArrayPool<Shard>.Shared.Rent(bufferSize) : null;
+            try
             {
-                TopDocs shard = shardHits[shardIDX];
-                // totalHits can be non-zero even if no hits were
-                // collected, when searchAfter was used:
-                totalHitCount += shard.TotalHits;
-                if (shard.ScoreDocs != null && shard.ScoreDocs.Length > 0)
+                Span<Shard> buffer = usePool ? arrayToReturnToPool : stackalloc Shard[bufferSize];
+                ValuePriorityQueue<Shard> queue = new ValuePriorityQueue<Shard>(buffer, comparer);
+
+                int totalHitCount = 0;
+                int availHitCount = 0;
+                float maxScore = float.Epsilon; // LUCENENET: Epsilon in .NET is the same as MIN_VALUE in Java
+                for (int shardIDX = 0; shardIDX < shardHits.Length; shardIDX++)
                 {
-                    availHitCount += shard.ScoreDocs.Length;
-                    queue.Add(new ShardRef(shardIDX));
-                    maxScore = Math.Max(maxScore, shard.MaxScore);
-                    //System.out.println("  maxScore now " + maxScore + " vs " + shard.getMaxScore());
-                }
-            }
-
-            if (availHitCount == 0)
-            {
-                maxScore = float.NaN;
-            }
-
-            ScoreDoc[] hits;
-            if (availHitCount <= start)
-            {
-                hits = Arrays.Empty<ScoreDoc>();
-            }
-            else
-            {
-                hits = new ScoreDoc[Math.Min(size, availHitCount - start)];
-                int requestedResultWindow = start + size;
-                int numIterOnHits = Math.Min(availHitCount, requestedResultWindow);
-                int hitUpto = 0;
-                while (hitUpto < numIterOnHits)
-                {
-                    if (Debugging.AssertsEnabled) Debugging.Assert(queue.Count > 0);
-                    ShardRef @ref = queue.Pop();
-                    ScoreDoc hit = shardHits[@ref.ShardIndex].ScoreDocs[@ref.HitIndex++];
-                    hit.ShardIndex = @ref.ShardIndex;
-                    if (hitUpto >= start)
+                    TopDocs shard = shardHits[shardIDX];
+                    // totalHits can be non-zero even if no hits were
+                    // collected, when searchAfter was used:
+                    totalHitCount += shard.TotalHits;
+                    if (shard.ScoreDocs != null && shard.ScoreDocs.Length > 0)
                     {
-                        hits[hitUpto - start] = hit;
-                    }
-
-                    //System.out.println("  hitUpto=" + hitUpto);
-                    //System.out.println("    doc=" + hits[hitUpto].doc + " score=" + hits[hitUpto].score);
-
-                    hitUpto++;
-
-                    if (@ref.HitIndex < shardHits[@ref.ShardIndex].ScoreDocs.Length)
-                    {
-                        // Not done with this these TopDocs yet:
-                        queue.Add(@ref);
+                        availHitCount += shard.ScoreDocs.Length;
+                        queue.Add(new Shard(shardIDX));
+                        maxScore = Math.Max(maxScore, shard.MaxScore);
+                        //System.out.println("  maxScore now " + maxScore + " vs " + shard.getMaxScore());
                     }
                 }
+
+                if (availHitCount == 0)
+                {
+                    maxScore = float.NaN;
+                }
+
+                ScoreDoc[] hits;
+                if (availHitCount <= start)
+                {
+                    hits = Arrays.Empty<ScoreDoc>();
+                }
+                else
+                {
+                    hits = new ScoreDoc[Math.Min(size, availHitCount - start)];
+                    int requestedResultWindow = start + size;
+                    int numIterOnHits = Math.Min(availHitCount, requestedResultWindow);
+                    int hitUpto = 0;
+                    while (hitUpto < numIterOnHits)
+                    {
+                        if (Debugging.AssertsEnabled) Debugging.Assert(queue.Count > 0);
+                        // LUCENENET NOTE: Since we are popping this from the queue and then
+                        // adding it back, we properly get our updated HitIndex into the queue.
+                        Shard @ref = queue.Pop();
+                        ScoreDoc hit = shardHits[@ref.ShardIndex].ScoreDocs[@ref.HitIndex++];
+                        hit.ShardIndex = @ref.ShardIndex;
+                        if (hitUpto >= start)
+                        {
+                            hits[hitUpto - start] = hit;
+                        }
+
+                        //System.out.println("  hitUpto=" + hitUpto);
+                        //System.out.println("    doc=" + hits[hitUpto].doc + " score=" + hits[hitUpto].score);
+
+                        hitUpto++;
+
+                        if (@ref.HitIndex < shardHits[@ref.ShardIndex].ScoreDocs.Length)
+                        {
+                            // Not done with this these TopDocs yet:
+                            queue.Add(@ref);
+                        }
+                    }
+                }
+
+                if (sort is null)
+                {
+                    return new TopDocs(totalHitCount, hits, maxScore);
+                }
+                else
+                {
+                    return new TopFieldDocs(totalHitCount, hits, sort.GetSort(), maxScore);
+                }
+            }
+            finally
+            {
+                if (arrayToReturnToPool is not null)
+                    ArrayPool<Shard>.Shared.Return(arrayToReturnToPool);
             }
 
-            if (sort is null)
-            {
-                return new TopDocs(totalHitCount, hits, maxScore);
-            }
-            else
-            {
-                return new TopFieldDocs(totalHitCount, hits, sort.GetSort(), maxScore);
-            }
         }
     }
 }

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -1688,7 +1688,7 @@ namespace Lucene.Net.Util.Fst
 
 #nullable enable
 
-            // LUCENENET: Refactored PriorityQueue<T> subclass into IPriorityComparer<T>
+            // LUCENENET: Refactored PriorityQueue<T> subclass into PriorityComparer<T>
             // implementation, which can be passed into ValuePriorityQueue. ValuePriorityQueue
             // lives on the stack, and if the array size is small enough, we also allocate the
             // array on the stack. Fallback to the array pool if it is beyond MaxStackByteLimit.
@@ -1698,7 +1698,7 @@ namespace Lucene.Net.Util.Fst
             try
             {
                 Span<FST.NodeAndInCount?> buffer = usePool ? arrayToReturnToPool : stackalloc FST.NodeAndInCount?[bufferSize];
-                ValuePriorityQueue<FST.NodeAndInCount?> q = new ValuePriorityQueue<FST.NodeAndInCount?>(buffer, FST.NodeComparer.Default);
+                var q = new ValuePriorityQueue<FST.NodeAndInCount?>(buffer, FST.NodeComparer.Default);
 #nullable restore
 
                 // TODO: we could use more RAM efficient selection algo here...
@@ -2390,11 +2390,11 @@ namespace Lucene.Net.Util.Fst
 #nullable enable
         // LUCENENET: Refactored NodeQueue into NodeComparer
         // implementation, which can be passed into ValuePriorityQueue.
-        internal class NodeComparer : IPriorityComparer<NodeAndInCount?>
+        internal class NodeComparer : PriorityComparer<NodeAndInCount?>
         {
             public static NodeComparer Default { get; } = new NodeComparer();
 
-            internal bool LessThan(NodeAndInCount? a, NodeAndInCount? b)
+            protected internal override bool LessThan(NodeAndInCount? a, NodeAndInCount? b)
             {
                     // LUCENENET specific - added guard clauses
                     if (a is null)
@@ -2406,9 +2406,6 @@ namespace Lucene.Net.Util.Fst
                 if (Debugging.AssertsEnabled) Debugging.Assert(cmp != 0);
                 return cmp < 0;
             }
-
-            bool IPriorityComparer<NodeAndInCount?>.LessThan(NodeAndInCount? a, NodeAndInCount? b)
-                => LessThan(a, b);
         }
     }
 }

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -3,9 +3,12 @@ using J2N.Numerics;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using JCG = J2N.Collections.Generic;
 
@@ -1681,38 +1684,60 @@ namespace Lucene.Net.Util.Fst
             int topN = Math.Min(maxDerefNodes, inCounts.Count);
 
             // Find top nodes with highest number of incoming arcs:
-            FST.NodeQueue q = new FST.NodeQueue(topN);
+            IDictionary<int, int> topNodeMap = null;
 
-            // TODO: we could use more RAM efficient selection algo here...
-            FST.NodeAndInCount bottom = null;
-            for (int node = 0; node < inCounts.Count; node++)
+#nullable enable
+
+            // LUCENENET: Refactored PriorityQueue<T> subclass into IPriorityComparer<T>
+            // implementation, which can be passed into ValuePriorityQueue. ValuePriorityQueue
+            // lives on the stack, and if the array size is small enough, we also allocate the
+            // array on the stack. Fallback to the array pool if it is beyond MaxStackByteLimit.
+            int bufferSize = PriorityQueue.GetArrayHeapSize(topN);
+            bool usePool = FST.NodeAndInCount.ByteSize * bufferSize > Constants.MaxStackByteLimit;
+            FST.NodeAndInCount?[]? arrayToReturnToPool = usePool ? ArrayPool<FST.NodeAndInCount?>.Shared.Rent(bufferSize) : null;
+            try
             {
-                if (inCounts.Get(node) >= minInCountDeref)
+                Span<FST.NodeAndInCount?> buffer = usePool ? arrayToReturnToPool : stackalloc FST.NodeAndInCount?[bufferSize];
+                ValuePriorityQueue<FST.NodeAndInCount?> q = new ValuePriorityQueue<FST.NodeAndInCount?>(buffer, FST.NodeComparer.Default);
+#nullable restore
+
+                // TODO: we could use more RAM efficient selection algo here...
+                FST.NodeAndInCount? bottom = null;
+
+                for (int node = 0; node < inCounts.Count; node++)
                 {
-                    if (bottom is null)
+                    if (inCounts.Get(node) >= minInCountDeref)
                     {
-                        q.Add(new FST.NodeAndInCount(node, (int)inCounts.Get(node)));
-                        if (q.Count == topN)
+                        if (!bottom.HasValue)
                         {
-                            bottom = q.Top;
+                            q.Add(new FST.NodeAndInCount(node, (int)inCounts.Get(node)));
+                            if (q.Count == topN)
+                            {
+                                bottom = q.Top;
+                            }
+                        }
+                        else if (inCounts.Get(node) > bottom.Value.Count)
+                        {
+                            q.InsertWithOverflow(new FST.NodeAndInCount(node, (int)inCounts.Get(node)));
                         }
                     }
-                    else if (inCounts.Get(node) > bottom.Count)
-                    {
-                        q.InsertWithOverflow(new FST.NodeAndInCount(node, (int)inCounts.Get(node)));
-                    }
+                }
+
+                // Free up RAM:
+                inCounts = null;
+
+                topNodeMap = new Dictionary<int, int>(q.Count); // LUCENENET: Allocate the dictionary prior to the loop
+                for (int downTo = q.Count - 1; downTo >= 0; downTo--)
+                {
+                    FST.NodeAndInCount? n = q.Pop();
+                    topNodeMap[n.Value.Node] = downTo; // LUCENENET: we are bound in the loop by Count, so we won't go past the end and get null here.
+                    //System.out.println("map node=" + n.Node + " inCount=" + n.count + " to newID=" + downTo);
                 }
             }
-
-            // Free up RAM:
-            inCounts = null;
-
-            IDictionary<int, int> topNodeMap = new Dictionary<int, int>();
-            for (int downTo = q.Count - 1; downTo >= 0; downTo--)
+            finally
             {
-                FST.NodeAndInCount n = q.Pop();
-                topNodeMap[n.Node] = downTo;
-                //System.out.println("map node=" + n.Node + " inCount=" + n.count + " to newID=" + downTo);
+                if (arrayToReturnToPool is not null)
+                    ArrayPool<FST.NodeAndInCount?>.Shared.Return(arrayToReturnToPool);
             }
 
             // +1 because node ords start at 1 (0 is reserved as stop node):
@@ -2321,56 +2346,69 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        internal class NodeAndInCount : IComparable<NodeAndInCount> // LUCENENET TODO: This is a candidate for a struct
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct NodeAndInCount : IComparable<NodeAndInCount> // LUCENENET specific - made into a struct
         {
-            internal int Node { get; private set; }
-            internal int Count { get; private set; }
+            public const int ByteSize = sizeof(int) + sizeof(int);
+
+            [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+            [SuppressMessage("Major Code Smell", "S2933:Fields that are only assigned in the constructor should be \"readonly\"", Justification = "Structs are known to have performance issues with readonly fields")]
+            [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs are known to have performance issues with readonly fields")]
+            private int node;
+            [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+            [SuppressMessage("Major Code Smell", "S2933:Fields that are only assigned in the constructor should be \"readonly\"", Justification = "Structs are known to have performance issues with readonly fields")]
+            [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs are known to have performance issues with readonly fields")]
+            private int count;
+
+            internal int Node => node;
+            internal int Count => count;
 
             public NodeAndInCount(int node, int count)
             {
-                this.Node = node;
-                this.Count = count;
+                this.node = node;
+                this.count = count;
             }
 
-            public virtual int CompareTo(NodeAndInCount other)
+            public int CompareTo(NodeAndInCount other)
             {
-                if (Count > other.Count)
+                if (count > other.count)
                 {
                     return 1;
                 }
-                else if (Count < other.Count)
+                else if (count < other.count)
                 {
                     return -1;
                 }
                 else
                 {
                     // Tie-break: smaller node compares as greater than
-                    return other.Node - Node;
+                    return other.node - node;
                 }
             }
         }
 
 #nullable enable
-        internal class NodeQueue : PriorityQueue<NodeAndInCount>
+        // LUCENENET: Refactored NodeQueue into NodeComparer
+        // implementation, which can be passed into ValuePriorityQueue.
+        internal class NodeComparer : IPriorityComparer<NodeAndInCount?>
         {
-            public NodeQueue(int topN)
-                : base(topN) // LUCENENET NOTE: Doesn't pre-populate because sentinelFactory is null
-            {
-            }
+            public static NodeComparer Default { get; } = new NodeComparer();
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            protected internal override bool LessThan(NodeAndInCount a, NodeAndInCount b)
+            internal bool LessThan(NodeAndInCount? a, NodeAndInCount? b)
             {
-                // LUCENENET specific - added guard clauses
-                if (a is null)
-                    throw new ArgumentNullException(nameof(a));
-                if (b is null)
-                    throw new ArgumentNullException(nameof(b));
+                    // LUCENENET specific - added guard clauses
+                    if (a is null)
+                        throw new ArgumentNullException(nameof(a));
+                    if (b is null)
+                        throw new ArgumentNullException(nameof(b));
 
-                int cmp = a.CompareTo(b);
+                    int cmp = a.Value.CompareTo(b.Value);
                 if (Debugging.AssertsEnabled) Debugging.Assert(cmp != 0);
                 return cmp < 0;
             }
+
+            bool IPriorityComparer<NodeAndInCount?>.LessThan(NodeAndInCount? a, NodeAndInCount? b)
+                => LessThan(a, b);
         }
     }
 }

--- a/src/Lucene.Net/Util/PriorityQueue.cs
+++ b/src/Lucene.Net/Util/PriorityQueue.cs
@@ -31,14 +31,15 @@ namespace Lucene.Net.Util
     /// <remarks>
     /// This interface can be implemented to provide sentinel
     /// instances. The implementation of this interface can be passed to
-    /// a constructor of <see cref="PriorityQueue{T}"/>. If an instance
-    /// is provided, the <see cref="PriorityQueue{T}"/> constructor will use
-    /// the <see cref="Create{TQueue}(TQueue)"/> method to fill the queue,
+    /// a constructor of <see cref="PriorityQueue{T}"/> or <see cref="ValuePriorityQueue{T}"/>.
+    /// If an instance is provided, the either constructor will use
+    /// the <see cref="Create()"/> method to fill the queue,
     /// so that code which uses the queue can always assume it is full and only
     /// change the top without attempting to insert any new items.
     /// <para/>
     /// Those sentinel values should always compare worse than any non-sentinel
-    /// value (i.e., <see cref="PriorityQueue{T}.LessThan(T, T)"/> should always favor the
+    /// value (i.e., <see cref="PriorityQueue{T}.LessThan(T, T)"/> or
+    /// <see cref="IPriorityComparer{T}.LessThan(T, T)"/> should always favor the
     /// non-sentinel values).
     /// <para/>
     /// When using a <see cref="ISentinelFactory{T}"/>, the following usage pattern
@@ -55,17 +56,14 @@ namespace Lucene.Net.Util
     /// pqTop.Change();
     /// pqTop = pq.UpdateTop();
     /// </code>
-    /// <b>NOTE:</b> <see cref="Create{TQueue}(TQueue)"/> will be called by the
-    /// <see cref="PriorityQueue{T}"/> constructor <see cref="PriorityQueue{T}.Count"/>
+    /// <b>NOTE:</b> <see cref="Create()"/> will be called by the
+    /// <see cref="PriorityQueue{T}"/> or <see cref="ValuePriorityQueue{T}"/> constructor
+    /// <see cref="PriorityQueue{T}.Count"/> or <see cref="ValuePriorityQueue{T}.Count"/>
     /// times, relying on a new instance to be returned. Therefore you should ensure any call to this
-    /// <see cref="Create{TQueue}(TQueue)"/> creates a new instance and behaves consistently, e.g., it cannot
+    /// <see cref="Create()"/> creates a new instance and behaves consistently, e.g., it cannot
     /// return <c>null</c> if it previously returned non-<c>null</c>.
-    /// <para/>
-    /// To make implementing this interface easier, it is recommended to use the
-    /// <see cref="SentinelFactory{T, TPriorityQueue}"/> abstract class.
     /// </remarks>
     /// <typeparam name="T">The type of sentinel instance to create.</typeparam>
-    /// <seealso cref="SentinelFactory{T, TPriorityQueue}"/>
     // LUCENENET specific interface to eliminate the virtual method call in the PriorityQueue<T> constructor.
     public interface ISentinelFactory<T>
     {
@@ -73,171 +71,125 @@ namespace Lucene.Net.Util
         /// Creates a sentinel instance of <typeparamref name="T"/> to fill an element
         /// of a <see cref="PriorityQueue{T}"/>.
         /// </summary>
-        /// <typeparam name="TQueue">The type of priority queue that is calling this method.</typeparam>
-        /// <param name="priorityQueue">The <see cref="PriorityQueue{T}"/> instance that is calling this method.
-        /// <para/>
-        /// <b>NOTE:</b> The call to this method happens in the constructor, so it occurs prior to any
-        /// subclass construtor state being set. If you need to access state from your subclass, you should
-        /// pass that state into the constructor of the implementation of this interface.</param>
         /// <returns>A newly created sentinel instance for use in a single element of <see cref="PriorityQueue{T}"/>.</returns>
-        T Create<TQueue>(TQueue priorityQueue) where TQueue : PriorityQueue<T>;
+        T Create();
     }
 
     /// <summary>
-    /// Provides the sentinel instances of <typeparamref name="T"/> to a
-    /// <see cref="PriorityQueue{T}"/>.
+    /// A comparer for use with <see cref="ValuePriorityQueue{T}"/>.
+    /// <para/>
+    /// This comparer makes it easy to convert <see cref="PriorityQueue{T}"/>-derived
+    /// subclasses into comparers that can be used with <see cref="ValuePriorityQueue{T}"/>.
     /// </summary>
-    /// <remarks>
-    /// This class can be extended to provide sentinel
-    /// instances. The concrete class instance can be passed to
-    /// a constructor of <see cref="PriorityQueue{T}"/>. If an instance
-    /// is provided, the <see cref="PriorityQueue{T}"/> constructor will use
-    /// the <see cref="Create(TPriorityQueue)"/> method to fill the queue,
-    /// so that code which uses the queue can always assume it is full and only
-    /// change the top without attempting to insert any new items.
-    /// <para/>
-    /// Those sentinel values should always compare worse than any non-sentinel
-    /// value (i.e., <see cref="PriorityQueue{T}.LessThan(T, T)"/> should always favor the
-    /// non-sentinel values).
-    /// <para/>
-    /// When using a <see cref="ISentinelFactory{T}"/>, the following usage pattern
-    /// is recommended:
-    /// <code>
-    /// // Implements ISentinelFactory&lt;T&gt;.Create(PriorityQueue&lt;T&gt;)
-    /// var sentinelFactory = new MySentinelFactory&lt;MyObject&gt;();
-    /// PriorityQueue&lt;MyObject&gt; pq = new MyQueue&lt;MyObject&gt;(sentinelFactory);
-    /// // save the 'top' element, which is guaranteed to not be <c>default</c>.
-    /// MyObject pqTop = pq.Top;
-    /// &lt;...&gt;
-    /// // now in order to add a new element, which is 'better' than top (after
-    /// // you've verified it is better), it is as simple as:
-    /// pqTop.Change();
-    /// pqTop = pq.UpdateTop();
-    /// </code>
-    /// <b>NOTE:</b> <see cref="Create(TPriorityQueue)"/> will be called by the
-    /// <see cref="PriorityQueue{T}"/> constructor <see cref="PriorityQueue{T}.Count"/>
-    /// times, relying on a new instance to be returned. Therefore you should ensure any call to this
-    /// <see cref="Create(TPriorityQueue)"/> creates a new instance and behaves consistently, e.g., it cannot
-    /// return <c>null</c> if it previously returned non-<c>null</c>.
-    /// </remarks>
-    /// <typeparam name="T">The type of sentinel instance to create.</typeparam>
-    /// <typeparam name="TPriorityQueue"></typeparam>
-    // LUCENENET specific class to eliminate the virtual method call in the PriorityQueue<T> constructor.
-    public abstract class SentinelFactory<T, TPriorityQueue> : ISentinelFactory<T>
-        where TPriorityQueue : PriorityQueue<T>
+    /// <typeparam name="T">The type of item to compare. This may be either a value type or a reference type.</typeparam>
+    public interface IPriorityComparer<T>
     {
         /// <summary>
-        /// Creates a sentinel instance of <typeparamref name="T"/> to fill an element
-        /// of a <see cref="PriorityQueue{T}"/>.
+        /// Determines the ordering of objects in this priority queue.  Subclasses
+        /// must define this one method.
         /// </summary>
-        /// <param name="priorityQueue">The <see cref="PriorityQueue{T}"/> instance that is calling this method.
-        /// <para/>
-        /// <b>NOTE:</b> The call to this method happens in the constructor, so it occurs prior to any
-        /// subclass construtor state being set. If you need to access state from your subclass, you should
-        /// pass that state into the constructor of the implementation of this interface.</param>
-        /// <returns></returns>
-        public abstract T Create(TPriorityQueue priorityQueue);
-        T ISentinelFactory<T>.Create<TQueue>(TQueue priorityQueue)
-            => Create((TPriorityQueue)(object)priorityQueue);
+        /// <param name="a">The left value to compare.</param>
+        /// <param name="b">The right value to compare.</param>
+        /// <returns> <c>true</c> if parameter <paramref name="a"/> is less than parameter <paramref name="b"/>; otherwise <c>false</c>. </returns>
+        bool LessThan(T a, T b);
     }
 
     /// <summary>
-    /// A <see cref="PriorityQueue{T}"/> maintains a partial ordering of its elements such that the
+    /// A <see cref="ValuePriorityQueue{T}"/> maintains a partial ordering of its elements such that the
     /// element with least priority can always be found in constant time. Put()'s and Pop()'s
     /// require log(size) time.
-    ///
-    /// <para/><b>NOTE</b>: this class will pre-allocate a full array of
-    /// length <c>maxSize+1</c> if instantiated with a constructor that
-    /// accepts a <see cref="ISentinelFactory{T}"/>. That maximum size can
-    /// grow as we insert elements over time.
     /// <para/>
-    /// <b>NOTE</b>: The type of <typeparamref name="T"/> must be either a class
-    /// or a nullable value type. Non-nullable value types are not supported and may
-    /// produce undefined behavior.
+    /// This ref struct has the same behavior as <see cref="PriorityQueue{T}"/>, but can be
+    /// used to reduce allocations in scenarios where ref structs are allowed. If the type of
+    /// <typeparamref name="T"/> is a struct the passed in <see cref="Span{T}"/> buffer
+    /// may also be allocated on the stack, as allowed.
+    ///
+    /// <para/><b>NOTE</b>: The allocation size of the supplied <see cref="Span{T}"/> buffer
+    /// must be <c>maxSize+1</c>. The <see cref="PriorityQueue.GetArrayHeapSize(int)"/> method
+    /// can be used to get the correct calculation and to validate bounds of maxSize.
+    /// <para/>
+    /// If instantiated with a constructor that accepts a <see cref="ISentinelFactory{T}"/>,
+    /// that factory will be used to populate the elements of the array.
+    /// <para/>
+    /// <b>NOTE</b>: The type of <typeparamref name="T"/> may be either a class
+    /// or a value type. But do note that it was specifically designed with
+    /// nullable types in mind, so there may be cases where you need to use a
+    /// nullable value type to get it to behave correctly.
     /// <para/>
     /// @lucene.internal
     /// </summary>
-#if FEATURE_SERIALIZABLE
-    [Serializable]
-#endif
-    public abstract class PriorityQueue<T>
+    public ref struct ValuePriorityQueue<T>
     {
-        private int size = 0;
-        internal readonly int maxSize; // LUCENENET: Internal for testing
-        internal T?[] heap; // LUCENENET: Internal for testing
+        private int size;
+        internal int maxSize; // LUCENENET: Internal for testing
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("Major Code Smell", "S2933:Fields that are only assigned in the constructor should be \"readonly\"", Justification = "Structs are known to have performance issues with readonly fields")]
+        [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs are known to have performance issues with readonly fields")]
+        private Span<T> heap;
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("Major Code Smell", "S2933:Fields that are only assigned in the constructor should be \"readonly\"", Justification = "Structs are known to have performance issues with readonly fields")]
+        [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs are known to have performance issues with readonly fields")]
+        private IPriorityComparer<T> comparer;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="PriorityQueue{T}"/> with the
-        /// specified <paramref name="maxSize"/>.
+        /// Initializes a new instance of <see cref="ValuePriorityQueue{T}"/> with the specified
+        /// <paramref name="buffer"/> and <paramref name="comparer"/>.
         /// </summary>
-        /// <param name="maxSize">The maximum number of elements this queue can hold.</param>
-        protected PriorityQueue(int maxSize) // LUCENENET specific - made protected instead of public
-            : this(maxSize, sentinelFactory: null)
+        /// <param name="buffer">The buffer to use for priority queue operations.
+        /// <para/>
+        /// To determine the correct size of buffer to allocate, use the
+        /// <see cref="PriorityQueue.GetArrayHeapSize(int)"/> method.
+        /// </param>
+        /// <param name="comparer">A <see cref="IPriorityComparer{T}"/> implementation that is
+        /// used to determine the order of items in the priority queue.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
+        public ValuePriorityQueue(Span<T> buffer, IPriorityComparer<T> comparer)
+            : this(buffer, comparer, sentinelFactory: null)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="PriorityQueue{T}"/> with the
-        /// specified <paramref name="maxSize"/> and <paramref name="sentinelFactory"/>.
+        /// Initializes a new instance of <see cref="ValuePriorityQueue{T}"/> with the specified
+        /// <paramref name="buffer"/> and <paramref name="comparer"/>.
         /// </summary>
-        /// <param name="maxSize">The maximum number of elements this queue can hold.</param>
+        /// <param name="buffer">The buffer to use for priority queue operations.
+        /// <para/>
+        /// To determine the correct size of buffer to allocate, use the
+        /// <see cref="PriorityQueue.GetArrayHeapSize(int)"/> method.
+        /// </param>
+        /// <param name="comparer">A <see cref="IPriorityComparer{T}"/> implementation that is
+        /// used to determine the order of items in the priority queue.</param>
         /// <param name="sentinelFactory">If not <c>null</c>, the queue will be pre-populated.
-        /// This factory will be called <paramref name="maxSize"/> times to get an instance
-        /// to provide to each element in the queue.</param>
+        /// This factory will be called <paramref name="buffer"/>.Length - 1 times to get an instance
+        /// to provide to each element in the queue. <paramref name="sentinelFactory"/> should
+        /// return a new instance on each call, but each sentinel instance should consistently
+        /// represent the same value.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
         /// <seealso cref="ISentinelFactory{T}"/>
-        /// <seealso cref="SentinelFactory{T, TPriorityQueue}"/>
-        protected PriorityQueue(int maxSize, ISentinelFactory<T>? sentinelFactory)
+        public ValuePriorityQueue(Span<T> buffer, IPriorityComparer<T> comparer, ISentinelFactory<T>? sentinelFactory)
         {
-            int heapSize;
-            if (0 == maxSize)
-            {
-                // We allocate 1 extra to avoid if statement in top()
-                heapSize = 2;
-            }
-            else
-            {
-                if (maxSize > ArrayUtil.MAX_ARRAY_LENGTH)
-                {
-                    // Don't wrap heapSize to -1, in this case, which
-                    // causes a confusing NegativeArraySizeException.
-                    // Note that very likely this will simply then hit
-                    // an OOME, but at least that's more indicative to
-                    // caller that this values is too big.  We don't +1
-                    // in this case, but it's very unlikely in practice
-                    // one will actually insert this many objects into
-                    // the PQ:
-                    // Throw exception to prevent confusing OOME:
-                    throw new ArgumentOutOfRangeException(nameof(maxSize), "maxSize must be <= " + ArrayUtil.MAX_ARRAY_LENGTH + "; got: " + maxSize); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
-                }
-                else
-                {
-                    // NOTE: we add +1 because all access to heap is
-                    // 1-based not 0-based.  heap[0] is unused.
-                    heapSize = maxSize + 1;
-                }
-            }
-            this.maxSize = maxSize;
-            this.heap = new T[heapSize];
+            this.comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+            heap = buffer;
+            // NOTE: we subtract 1 because all access to heap is
+            // 1-based not 0-based.  heap[0] is unused.
+            maxSize = buffer.Length - 1;
+            size = 0;
             // LUCENENET: If we have a sentinel factory, it means we should pre-populate the array
             // with sentinel values.
             if (sentinelFactory is not null)
             {
                 for (int i = 1; i < heap.Length; i++)
                 {
-                    heap[i] = sentinelFactory.Create(this);
+                    heap[i] = sentinelFactory.Create();
                 }
                 size = maxSize;
             }
         }
 
-        /// <summary>
-        /// Determines the ordering of objects in this priority queue.  Subclasses
-        /// must define this one method. </summary>
-        /// <returns> <c>true</c> if parameter <paramref name="a"/> is less than parameter <paramref name="b"/>. </returns>
-        protected internal abstract bool LessThan(T a, T b); // LUCENENET: Internal for testing
+        /// <summary>Returns the underlying storage of the queue.</summary>
+        public Span<T> RawHeap => heap;
 
-        // LUCENENET specific - refactored getSentinelObject() method into ISentinelFactory<T> and
-        // SentinelFactory<T, TPriorityQueue>
+        public IPriorityComparer<T> Comparer => comparer;
 
 #nullable restore
 
@@ -247,7 +199,8 @@ namespace Lucene.Net.Util
         /// the heap, an <see cref="IndexOutOfRangeException"/> is thrown.
         /// </summary>
         /// <returns> The new 'top' element in the queue. </returns>
-        public T Add(T element)
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with PriorityQueue<T>
+        public T Add(T element) // LUCENENET TODO: Factor out the IndexOutOfRangeException here and make a TryAdd() method.
         {
             size++;
             heap[size] = element;
@@ -260,13 +213,14 @@ namespace Lucene.Net.Util
         /// If the given <paramref name="element"/> is smaller than then full
         /// heap's minimum, it won't be added.
         /// </summary>
-        public virtual void Insert(T element) // LUCENENET specific - added as a more efficient way to insert value types without reuse
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with PriorityQueue<T>
+        public void Insert(T element) // LUCENENET specific - added as a more efficient way to insert value types without reuse
         {
             if (size < maxSize)
             {
                 Add(element);
             }
-            else if (size > 0 && !LessThan(element, heap[1]))
+            else if (size > 0 && !comparer.LessThan(element, heap[1]))
             {
                 heap[1] = element;
                 UpdateTop();
@@ -283,14 +237,15 @@ namespace Lucene.Net.Util
         /// heap and now has been replaced by a larger one, or <c>null</c>
         /// if the queue wasn't yet full with <see cref="maxSize"/> elements.
         /// </summary>
-        public virtual T InsertWithOverflow(T element)
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with PriorityQueue<T>
+        public T InsertWithOverflow(T element)
         {
             if (size < maxSize)
             {
                 Add(element);
                 return default;
             }
-            else if (size > 0 && !LessThan(element, heap[1]))
+            else if (size > 0 && !comparer.LessThan(element, heap[1]))
             {
                 T ret = heap[1];
                 heap[1] = element;
@@ -316,6 +271,7 @@ namespace Lucene.Net.Util
         /// Removes and returns the least element of the <see cref="PriorityQueue{T}"/> in log(size)
         /// time.
         /// </summary>
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with PriorityQueue<T>
         public T Pop()
         {
             if (size > 0)
@@ -352,6 +308,325 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <returns> The new 'top' element. </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with PriorityQueue<T>
+        public T UpdateTop()
+        {
+            DownHeap();
+            return heap[1];
+        }
+
+        /// <summary>
+        /// Returns the number of elements currently stored in the <see cref="PriorityQueue{T}"/>.
+        /// NOTE: This was size() in Lucene.
+        /// </summary>
+        public int Count => size;
+
+        /// <summary>
+        /// Removes all entries from the <see cref="PriorityQueue{T}"/>. </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with PriorityQueue<T>
+        public void Clear()
+        {
+            for (int i = 0; i <= size; i++)
+            {
+                heap[i] = default;
+            }
+            size = 0;
+        }
+
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with PriorityQueue<T>
+        private void UpHeap()
+        {
+            int i = size;
+            T node = heap[i]; // save bottom node
+            int j = i.TripleShift(1);
+            while (j > 0 && comparer.LessThan(node, heap[j]))
+            {
+                heap[i] = heap[j]; // shift parents down
+                i = j;
+                j = j.TripleShift(1);
+            }
+            heap[i] = node; // install saved node
+        }
+
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with PriorityQueue<T>
+        private void DownHeap()
+        {
+            int i = 1;
+            T node = heap[i]; // save top node
+            int j = i << 1; // find smaller child
+            int k = j + 1;
+            if (k <= size && comparer.LessThan(heap[k], heap[j]))
+            {
+                j = k;
+            }
+            while (j <= size && comparer.LessThan(heap[j], node))
+            {
+                heap[i] = heap[j]; // shift up child
+                i = j;
+                j = i << 1;
+                k = j + 1;
+                if (k <= size && comparer.LessThan(heap[k], heap[j]))
+                {
+                    j = k;
+                }
+            }
+            heap[i] = node; // install saved node
+        }
+    }
+
+#nullable enable
+
+    /// <summary>
+    /// LUCENENET specific static methods for managing priority queues.
+    /// </summary>
+    public static class PriorityQueue
+    {
+        /// <summary>
+        /// Gets the heap size for the specified <paramref name="maxSize"/> of
+        /// a priority queue and checks to ensure it is within bounds.
+        /// <para/>
+        /// Heap size is 1 greater than <paramref name="maxSize"/>, since priority
+        /// queue is 1-based rather than 0-based.
+        /// </summary>
+        /// <param name="maxSize">The maximum length of the priority queue.</param>
+        /// <returns>The heap size to allocate for the priority queue.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxSize"/> is less than 0.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="maxSize"/> is greater than <see cref="ArrayUtil.MAX_ARRAY_LENGTH"/>.
+        /// </exception>
+        public static int GetArrayHeapSize(int maxSize)
+        {
+            if (maxSize < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxSize), "Non-negative number required.");
+
+            int heapSize;
+            if (0 == maxSize)
+            {
+                // We allocate 1 extra to avoid if statement in top()
+                heapSize = 2;
+            }
+            else
+            {
+                if (maxSize > ArrayUtil.MAX_ARRAY_LENGTH)
+                {
+                    // Don't wrap heapSize to -1, in this case, which
+                    // causes a confusing NegativeArraySizeException.
+                    // Note that very likely this will simply then hit
+                    // an OOME, but at least that's more indicative to
+                    // caller that this values is too big.  We don't +1
+                    // in this case, but it's very unlikely in practice
+                    // one will actually insert this many objects into
+                    // the PQ:
+                    // Throw exception to prevent confusing OOME:
+                    throw new ArgumentOutOfRangeException(nameof(maxSize), "maxSize must be <= " + ArrayUtil.MAX_ARRAY_LENGTH + "; got: " + maxSize); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                }
+                else
+                {
+                    // NOTE: we add +1 because all access to heap is
+                    // 1-based not 0-based.  heap[0] is unused.
+                    heapSize = maxSize + 1;
+                }
+            }
+            return heapSize;
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="PriorityQueue{T}"/> maintains a partial ordering of its elements such that the
+    /// element with least priority can always be found in constant time. Put()'s and Pop()'s
+    /// require log(size) time.
+    ///
+    /// <para/><b>NOTE</b>: this class will pre-allocate a full array of
+    /// length <c>maxSize+1</c> if instantiated with a constructor that
+    /// accepts a <see cref="ISentinelFactory{T}"/>. That maximum size can
+    /// grow as we insert elements over time.
+    /// <para/>
+    /// <b>NOTE</b>: The type of <typeparamref name="T"/> may be either a class
+    /// or a value type. But do note that it was specifically designed with
+    /// nullable types in mind, so there may be cases where you need to use a
+    /// nullable value type to get it to behave correctly.
+    /// <para/>
+    /// @lucene.internal
+    /// </summary>
+#if FEATURE_SERIALIZABLE
+    [Serializable]
+#endif
+    public abstract class PriorityQueue<T>
+    {
+        private int size = 0;
+        internal readonly int maxSize; // LUCENENET: Internal for testing
+        internal T?[] heap; // LUCENENET: Internal for testing
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PriorityQueue{T}"/> with the
+        /// specified <paramref name="maxSize"/>.
+        /// </summary>
+        /// <param name="maxSize">The maximum number of elements this queue can hold.</param>
+        protected PriorityQueue(int maxSize) // LUCENENET specific - made protected instead of public
+            : this(maxSize, sentinelFactory: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PriorityQueue{T}"/> with the
+        /// specified <paramref name="maxSize"/> and <paramref name="sentinelFactory"/>.
+        /// </summary>
+        /// <param name="maxSize">The maximum number of elements this queue can hold.</param>
+        /// <param name="sentinelFactory">If not <c>null</c>, the queue will be pre-populated.
+        /// This factory will be called <paramref name="maxSize"/> times to get an instance
+        /// to provide to each element in the queue. <paramref name="sentinelFactory"/> should
+        /// return a new instance on each call, but each sentinel instance should consistently
+        /// represent the same value.</param>
+        /// <seealso cref="ISentinelFactory{T}"/>
+        protected PriorityQueue(int maxSize, ISentinelFactory<T>? sentinelFactory)
+        {
+            int heapSize = PriorityQueue.GetArrayHeapSize(maxSize);
+            this.maxSize = maxSize;
+            this.heap = new T[heapSize];
+            // LUCENENET: If we have a sentinel factory, it means we should pre-populate the array
+            // with sentinel values.
+            if (sentinelFactory is not null)
+            {
+                for (int i = 1; i < heap.Length; i++)
+                {
+                    heap[i] = sentinelFactory.Create();
+                }
+                size = maxSize;
+            }
+        }
+
+        /// <summary>
+        /// Determines the ordering of objects in this priority queue.  Subclasses
+        /// must define this one method. </summary>
+        /// <returns> <c>true</c> if parameter <paramref name="a"/> is less than parameter <paramref name="b"/>. </returns>
+        protected internal abstract bool LessThan(T a, T b); // LUCENENET: Internal for testing
+
+        // LUCENENET specific - refactored getSentinelObject() method into ISentinelFactory<T> and
+        // SentinelFactory<T, TPriorityQueue>
+
+#nullable restore
+
+        /// <summary>
+        /// Adds an Object to a <see cref="PriorityQueue{T}"/> in log(size) time. If one tries to add
+        /// more objects than <see cref="maxSize"/> from initialize and it is not possible to resize
+        /// the heap, an <see cref="IndexOutOfRangeException"/> is thrown.
+        /// </summary>
+        /// <returns> The new 'top' element in the queue. </returns>
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with ValuePriorityQueue<T>
+        public T Add(T element)
+        {
+            size++;
+            heap[size] = element;
+            UpHeap();
+            return heap[1];
+        }
+
+        /// <summary>
+        /// Adds an Object to a <see cref="PriorityQueue{T}"/> in log(size) time.
+        /// If the given <paramref name="element"/> is smaller than then full
+        /// heap's minimum, it won't be added.
+        /// </summary>
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with ValuePriorityQueue<T>
+        public virtual void Insert(T element) // LUCENENET specific - added as a more efficient way to insert value types without reuse
+        {
+            if (size < maxSize)
+            {
+                Add(element);
+            }
+            else if (size > 0 && !LessThan(element, heap[1]))
+            {
+                heap[1] = element;
+                UpdateTop();
+            }
+        }
+
+        /// <summary>
+        /// Adds an Object to a <see cref="PriorityQueue{T}"/> in log(size) time.
+        /// It returns the object (if any) that was
+        /// dropped off the heap because it was full. This can be
+        /// the given parameter (in case it is smaller than the
+        /// full heap's minimum, and couldn't be added), or another
+        /// object that was previously the smallest value in the
+        /// heap and now has been replaced by a larger one, or <c>null</c>
+        /// if the queue wasn't yet full with <see cref="maxSize"/> elements.
+        /// </summary>
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with ValuePriorityQueue<T>
+        public virtual T InsertWithOverflow(T element)
+        {
+            if (size < maxSize)
+            {
+                Add(element);
+                return default;
+            }
+            else if (size > 0 && !LessThan(element, heap[1]))
+            {
+                T ret = heap[1];
+                heap[1] = element;
+                UpdateTop();
+                return ret;
+            }
+            else
+            {
+                return element;
+            }
+        }
+
+        /// <summary>
+        /// Returns the least element of the <see cref="PriorityQueue{T}"/> in constant time.
+        /// Returns <c>null</c> if the queue is empty. </summary>
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with ValuePriorityQueue<T>
+        public T Top =>
+            // We don't need to check size here: if maxSize is 0,
+            // then heap is length 2 array with both entries null.
+            // If size is 0 then heap[1] is already null.
+            heap[1];
+
+        /// <summary>
+        /// Removes and returns the least element of the <see cref="PriorityQueue{T}"/> in log(size)
+        /// time.
+        /// </summary>
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with ValuePriorityQueue<T>
+        public T Pop()
+        {
+            if (size > 0)
+            {
+                T result = heap[1]; // save first value
+                heap[1] = heap[size]; // move last to first
+                heap[size] = default; // permit GC of objects
+                size--;
+                DownHeap(); // adjust heap
+                return result;
+            }
+            else
+            {
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Should be called when the Object at top changes values. Still log(n) worst
+        /// case, but it's at least twice as fast to
+        ///
+        /// <code>
+        /// pq.Top.Change();
+        /// pq.UpdateTop();
+        /// </code>
+        ///
+        /// instead of
+        ///
+        /// <code>
+        /// o = pq.Pop();
+        /// o.Change();
+        /// pq.Push(o);
+        /// </code>
+        /// </summary>
+        /// <returns> The new 'top' element. </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with ValuePriorityQueue<T>
         public T UpdateTop()
         {
             DownHeap();
@@ -376,6 +651,7 @@ namespace Lucene.Net.Util
             size = 0;
         }
 
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with ValuePriorityQueue<T>
         private void UpHeap()
         {
             int i = size;
@@ -390,6 +666,7 @@ namespace Lucene.Net.Util
             heap[i] = node; // install saved node
         }
 
+        // LUCENENET: IMPORTANT - this implementation should remain in sync with ValuePriorityQueue<T>
         private void DownHeap()
         {
             int i = 1;


### PR DESCRIPTION
This adds a new ref struct to the project, `Lucene.Net.Util.ValuePriorityQueue<T>`. This struct contains the most of the same API and business logic as `PriorityQueue<T>`, but allows the memory used to be allocated elsewhere as `Span<T>` and passed in.

The amount to allocate can be calculated by calling `PriorityQueue.GetArrayHeapSize(maxSize)`, where `maxSize` is the external size of the `PriorityQueue` (representing the same value that is passed into the constructor of the current `PriorityQueue<T>`). The actual allocation amount is 1 greater than the priority queue size because it is 1-based rather than 0-based.

We get around the issue with structs not being inheritable by introducing a new `PriorityComparer<T>` abstract class with a single `bool LessThan(T a, T b)` method. This signature makes converting existing subclasses of `PriorityQueue<T>` to `PriorityComparer<T>` straightforward, as there are no business logic changes to make. This `IComparer<T>` is a required constructor argument of `ValuePriorityQueue<T>`. It can be either a `PriorityComparer<T>` or `IComparer<T>`, although if it returns a 0 (equal), that value is considered the same as 1 (greater than) by the priority queue.

This also modifies `SingleTaxonomyFacets`, `Int32TaxonomyFacets`, `TopDocs` merge and `FST` pack to use `ValuePriorityQueue<T>` and converts the item types they deal with from class to struct so they can be stack allocated if the size is below `Constants.MaxStackByteLimit`, which is set using the [system property](https://github.com/apache/lucenenet/issues/307) `maxStackByteLimit`.

Closes #774. Thanks @eladmarg for the suggestion.

There are a few more places in the codebase where this type can be useful, but unfortunately the types they use don't convert easily into structs so although we can eliminate the heap allocation of the priority queue itself, we will need some configuration and/or logic to decide whether to allocate the array directly or use an array pool.

## Breaking Changes

1. Changed `OrdAndValue<T>` from class to struct.
2. Added generic constraint to `OrdAndValue<T> where T : struct`.