### PR TITLE
BREAKING: SrndTruncQuery fix for virtual call being made from constructor

### DIFF
--- a/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
@@ -27,9 +27,9 @@ namespace Lucene.Net.QueryParsers.Surround.Query
     /// </summary>
     public abstract class SimpleTerm : SrndQuery, IDistanceSubQuery, IComparable<SimpleTerm>
     {
-        protected SimpleTerm(bool q) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
+        protected SimpleTerm(bool quoted) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
         { 
-            quoted = q; 
+            this.quoted = quoted; 
         }
 
         private readonly bool quoted; // LUCENENET: marked readonly

--- a/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Index;
 using Lucene.Net.Util;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.RegularExpressions;
 

--- a/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
@@ -29,12 +29,20 @@ namespace Lucene.Net.QueryParsers.Surround.Query
     public class SrndTruncQuery : SimpleTerm
     {
         public SrndTruncQuery(string truncated, char unlimited, char mask)
-            : base(false) /* not quoted */
+            : this(truncated, unlimited, mask, q: false) /* not quoted */
+        {
+            TruncatedToPrefixAndPattern();
+        }
+
+        // LUCENENET specific - this is for provided for subclasses to use and avoid
+        // the virtual call to TruncatedToPrefixAndPattern(), which they can do
+        // in their own constructor.
+        protected SrndTruncQuery(string truncated, char unlimited, char mask, bool q)
+            : base(q)
         {
             this.truncated = truncated;
             this.unlimited = unlimited;
             this.mask = mask;
-            TruncatedToPrefixAndPattern();
         }
 
         private readonly string truncated;

--- a/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
@@ -32,7 +32,7 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
         public SrndTruncQuery(string truncated, char unlimited, char mask)
-            : this(truncated, unlimited, mask, q: false) /* not quoted */
+            : this(truncated, unlimited, mask, quoted: false) /* not quoted */
         {
             TruncatedToPrefixAndPattern();
         }
@@ -40,8 +40,8 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         // LUCENENET specific - this is for provided for subclasses to use and avoid
         // the virtual call to TruncatedToPrefixAndPattern(), which they can do
         // in their own constructor.
-        protected SrndTruncQuery(string truncated, char unlimited, char mask, bool q)
-            : base(q)
+        protected SrndTruncQuery(string truncated, char unlimited, char mask, bool quoted)
+            : base(quoted)
         {
             this.truncated = truncated;
             this.unlimited = unlimited;

--- a/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SrndTruncQuery.cs
@@ -28,6 +28,8 @@ namespace Lucene.Net.QueryParsers.Surround.Query
     /// </summary>
     public class SrndTruncQuery : SimpleTerm
     {
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
         public SrndTruncQuery(string truncated, char unlimited, char mask)
             : this(truncated, unlimited, mask, q: false) /* not quoted */
         {


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on SrndTruncQuery. We are adding a protected constructor that subclasses can use.