### PR TITLE
Add suppress attributes and comment on using constructors for QueryParserTokenManager

### DIFF
--- a/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
@@ -1170,7 +1170,13 @@ namespace Lucene.Net.QueryParsers.Classic
             m_input_stream = stream;
         }
 
-        /// <summary>Constructor. </summary>
+        /// <summary>Constructor. 
+        /// <para>Note that this constructor calls a virtual method <see cref="SwitchTo(int)" />. If you
+        /// are subclassing this class, use <see cref="QueryParserTokenManager(ICharStream)" /> constructor and
+        /// call SwitchTo if needed.</para>
+        /// </summary>
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
         public QueryParserTokenManager(ICharStream stream, int lexState):this(stream)
         {
             SwitchTo(lexState);


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on QueryParserTokenManager. We are suppressing the warnings and including docs with a note for subclasses to use a different constructor if needed.