### PR TITLE
IndexSearcher fix for virtual calls from constructor

### DIFF
--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -142,7 +142,8 @@ namespace Lucene.Net.Search
         /// LUCENENET specific constructor that can be used by the subclasses to
         /// control whether or not the leaf slices are allocated.
         /// If you choose to skip allocating the leaf slices here, you must 
-        /// call <see cref="GetSlices"/> in your subclass's constructor.
+        /// initialize <see cref="m_leafSlices" /> in your subclass's constructor, either
+        /// by calling <see cref="GetSlices"/> or using your own logic
         /// </summary>
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
@@ -472,7 +473,6 @@ namespace Lucene.Net.Search
 
                 if (m_leafSlices == null)
                     throw new InvalidOperationException("m_leafSlices must not be null and initialized in the constructor");
-            
 
                 for (int i = 0; i < m_leafSlices.Length; i++) // search each sub
                 {
@@ -569,6 +569,9 @@ namespace Lucene.Net.Search
 
                 ReentrantLock @lock = new ReentrantLock();
                 ExecutionHelper<TopFieldDocs> runner = new ExecutionHelper<TopFieldDocs>(executor);
+
+                if (m_leafSlices == null)
+                    throw new InvalidOperationException("m_leafSlices must not be null and initialized in the constructor");
 
                 for (int i = 0; i < m_leafSlices.Length; i++) // search each leaf slice
                 {

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -472,6 +472,10 @@ namespace Lucene.Net.Search
                 ReentrantLock @lock = new ReentrantLock();
                 ExecutionHelper<TopDocs> runner = new ExecutionHelper<TopDocs>(executor);
 
+                if (m_leafSlices == null)
+                    throw new InvalidOperationException("m_leafSlices must not be null and initialized in the constructor");
+            
+
                 for (int i = 0; i < m_leafSlices.Length; i++) // search each sub
                 {
                     runner.Submit(new SearcherCallableNoSort(@lock, this, m_leafSlices[i], weight, after, nDocs, hq).Call);

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -165,8 +165,7 @@ namespace Lucene.Net.Search
             if (context is null)
                 throw new ArgumentNullException(nameof(context));
 
-            if (Debugging.AssertsEnabled)
-                Debugging.Assert(context.IsTopLevel,"IndexSearcher's ReaderContext must be topLevel for reader {0}", context.Reader);
+            if (Debugging.AssertsEnabled) Debugging.Assert(context.IsTopLevel, "IndexSearcher's ReaderContext must be topLevel for reader {0}", context.Reader);
 
             reader = context.Reader;
             this.executor = executor;
@@ -230,6 +229,9 @@ namespace Lucene.Net.Search
         /// <exception cref="ArgumentNullException"><paramref name="fieldVisitor"/> is <c>null</c>.</exception>
         public virtual void Doc(int docID, StoredFieldVisitor fieldVisitor)
         {
+            if (fieldVisitor is null)
+                throw new ArgumentNullException(nameof(fieldVisitor));
+
             reader.Document(docID, fieldVisitor);
         }
 

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -1,5 +1,4 @@
 ﻿using Lucene.Net.Diagnostics;
-using Lucene.Net.Support;
 using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
@@ -7,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Lucene.Net.Search
@@ -144,7 +142,7 @@ namespace Lucene.Net.Search
         /// LUCENENET specific constructor that can be used by the subclasses to
         /// control whether or not the leaf slices are allocated.
         /// If you choose to skip allocating the leaf slices here, you must 
-        /// call <see cref="Slices"/> in your subclass's constructor.
+        /// call <see cref="GetSlices"/> in your subclass's constructor.
         /// </summary>
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
@@ -158,7 +156,7 @@ namespace Lucene.Net.Search
 
             if (allocateLeafSlices)
             {
-                this.m_leafSlices = Slices(m_leafContexts);
+                this.m_leafSlices = GetSlices(m_leafContexts);
             }
         }
 
@@ -179,7 +177,7 @@ namespace Lucene.Net.Search
         /// Each <see cref="LeafSlice"/> is executed in a single thread. By default there
         /// will be one <see cref="LeafSlice"/> per leaf (<see cref="AtomicReaderContext"/>).
         /// </summary>
-        protected virtual LeafSlice[] Slices(IList<AtomicReaderContext> leaves)
+        protected virtual LeafSlice[] GetSlices(IList<AtomicReaderContext> leaves)
         {
             LeafSlice[] slices = new LeafSlice[leaves.Count];
             for (int i = 0; i < slices.Length; i++)
@@ -468,7 +466,7 @@ namespace Lucene.Net.Search
             }
             else
             {
-                HitQueue hq = new HitQueue(nDocs, false);
+                HitQueue hq = new HitQueue(nDocs, prePopulate: false);
                 ReentrantLock @lock = new ReentrantLock();
                 ExecutionHelper<TopDocs> runner = new ExecutionHelper<TopDocs>(executor);
 
@@ -550,7 +548,7 @@ namespace Lucene.Net.Search
         {
             if (sort is null)
             {
-                throw new ArgumentNullException("Sort must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
+                throw new ArgumentNullException(nameof(sort), "Sort must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
             }
 
             int limit = reader.MaxDoc;

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -878,6 +878,7 @@ namespace Lucene.Net.Search
             }
         }
 
+        #nullable restore
         /// <summary>
         /// A helper class that wraps a <see cref="TaskSchedulerCompletionService{T}"/> and provides an
         /// iterable interface to the completed <see cref="Func{T}"/> delegates.
@@ -956,7 +957,8 @@ namespace Lucene.Net.Search
                 return this;
             }
         }
-
+        #nullable enable
+        
         /// <summary>
         /// A class holding a subset of the <see cref="IndexSearcher"/>s leaf contexts to be
         /// executed within a single thread.

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -144,7 +144,7 @@ namespace Lucene.Net.Search
         /// control whether the leaf slices are allocated in the base class or subclass.
         /// </summary>
         /// <remarks>
-        /// If executor is non-<c>null</c> and you choose to skip allocating the leaf slices
+        /// If <paramref name="executor"/> is non-<c>null</c> and you choose to skip allocating the leaf slices
         /// (i.e. <paramref name="allocateLeafSlices"/> == <c>false</c>), you must
         /// set the <see cref="m_leafSlices"/> field in your subclass constructor.
         /// This is commonly done by calling <see cref="GetSlices(IList{AtomicReaderContext})"/>


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This one focuses on IndexSearcher. Since we discovered a separate constructor approach as an elegant way to address this issue, let's use it for IndexSearcher.