### PR TITLE
Fix slow test: use different sleep method if resolution is low

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/RandomCodec.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomCodec.cs
@@ -96,10 +96,10 @@ namespace Lucene.Net.Index
                 if (Debugging.AssertsEnabled) Debugging.Assert(previousMappings.Count < 10000, "test went insane");
             }
 
-            //if (LuceneTestCase.VERBOSE)
-            //{
-            Console.WriteLine("RandomCodec.GetPostingsFormatForField(\"" + name + "\") returned '" + codec.Name + "' with underlying type '" + codec.GetType().ToString() + "'.");
-            //}
+            if (LuceneTestCase.Verbose)
+            {
+                Console.WriteLine("RandomCodec.GetPostingsFormatForField(\"" + name + "\") returned '" + codec.Name + "' with underlying type '" + codec.GetType().ToString() + "'.");
+            }
 
             return codec;
         }
@@ -119,10 +119,10 @@ namespace Lucene.Net.Index
                 if (Debugging.AssertsEnabled) Debugging.Assert(previousDVMappings.Count < 10000, "test went insane");
             }
 
-            //if (LuceneTestCase.VERBOSE)
-            //{
+            if (LuceneTestCase.Verbose)
+            {
                 Console.WriteLine("RandomCodec.GetDocValuesFormatForField(\"" + name + "\") returned '" + codec.Name + "' with underlying type '" + codec.GetType().ToString() + "'.");
-            //}
+            }
 
             return codec;
         }

--- a/src/Lucene.Net.Tests.Facet/SlowRAMDirectory.cs
+++ b/src/Lucene.Net.Tests.Facet/SlowRAMDirectory.cs
@@ -1,4 +1,5 @@
 ﻿// Lucene version compatibility level 4.8.1
+using RandomizedTesting.Generators;
 using System;
 using System.Diagnostics;
 using System.Threading;

--- a/src/Lucene.Net.Tests.Facet/SlowRAMDirectory.cs
+++ b/src/Lucene.Net.Tests.Facet/SlowRAMDirectory.cs
@@ -35,6 +35,7 @@ namespace Lucene.Net.Facet
     public class SlowRAMDirectory : RAMDirectory
     {
         private const int IO_SLEEP_THRESHOLD = 50;
+        private const int MINIMUM_SUPPORTED_THREAD_SLEEP_TIME = 15;
 
         internal Random random;
         private int sleepMillis;
@@ -81,7 +82,7 @@ namespace Lucene.Net.Facet
             {
                 // LUCENENET specific - timer resolution on windows by default is 15ms and small sleeps will end up taking
                 // 15ms instead causing certain tests to run slowly. Instead, we'll use a Stopwatch to get more accurate
-                if (sTime > 15)
+                if (sTime > MINIMUM_SUPPORTED_THREAD_SLEEP_TIME)
                 {
                     Thread.Sleep(sTime);
                 }

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyCombined.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyCombined.cs
@@ -784,6 +784,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
         // Test that getParentArrays is valid when retrieved during refresh
         [Test]
+        [Slow]
         public virtual void TestTaxonomyReaderRefreshRaces()
         {
             // compute base child arrays - after first chunk, and after the other

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyCombined.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyCombined.cs
@@ -784,7 +784,6 @@ namespace Lucene.Net.Facet.Taxonomy
 
         // Test that getParentArrays is valid when retrieved during refresh
         [Test]
-        [Slow]
         public virtual void TestTaxonomyReaderRefreshRaces()
         {
             // compute base child arrays - after first chunk, and after the other


### PR DESCRIPTION
This fixes an issue with a slow test in TestTaxonomyCombined. The original issue description is here:

The issue has been brought up in https://github.com/apache/lucenenet/issues/836, under `TestTaxonomyCombined.TestTaxonomyRefreshRaces()` section

After debugging the issue, I discovered that the cause of the slow down are System.Thread.Sleep(1) calls being made thousands of times with intent of sleep taking 1ms. On windows however, that could take much more than 1ms, 15ms normally, confirmed locally and found a discussion about it here:

https://stackoverflow.com/questions/19066900/thread-sleep1-takes-longer-than-1ms

I setup Java version locally to compare the running times and after the fix, Java version and .NET version is running in basically identical amount of time. Locally I get it to run in 3-4s range, the same with Java version. Before the fix, it took 30-40s depending on what random generated loop variable values were.

I found some ways to influence System.Threading.Thread.Sleep behavior here https://stackoverflow.com/questions/15071359/how-to-set-timer-resolution-from-c-sharp-to-1-ms but it seemed like it's not worth the effort if the class is used just for that Facet test fixture.
