### PR TITLE
Revert "Remove unnecessary index writer getting opened"

### DIFF
--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -179,8 +179,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             if (DirectoryReader.IndexExists(dir))
             {
                 // Already built; open it:
-                // LUCENENET specific, deleted writer = new IndexWriter based on LUCENE-7670
-                m_searcherMgr = new SearcherManager(dir, null);
+                writer = new IndexWriter(dir, GetIndexWriterConfig(matchVersion, GetGramAnalyzer(), OpenMode.APPEND));
+                m_searcherMgr = new SearcherManager(writer, true, null);
             }
         }
 


### PR DESCRIPTION
Reverts apache/lucenenet#825

As explained in #839, this is causing a `AnalyzingInfixSuggesterTest.TestRandomNRT()` test failure because we apparently don't have all of the patches required to make it pass.