### PR TITLE
BUG: TestIndexWriterOnJRECrash: Removed using block

### DIFF
--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
@@ -302,7 +302,7 @@ namespace Lucene.Net.Index
         {
             if (file is DirectoryInfo directoryInfo)
             {
-                using BaseDirectoryWrapper dir = NewFSDirectory(directoryInfo);
+                BaseDirectoryWrapper dir = NewFSDirectory(directoryInfo);
                 dir.CheckIndexOnDispose = false; // don't double-checkindex
                 if (DirectoryReader.IndexExists(dir))
                 {


### PR DESCRIPTION
Removed using block to ensure that our original CheckIndex error bubbles up instead of any issue disposing (or double-disposing) the directory.

This test occasionally failed because of #841 also, and this will fix that issue.