### PR TITLE
BREAKING: Use factory classes for DirectoryTaxonomyWriter and DirectoryTaxonomyReader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ websites/apidocs/api/**/*.manifest
 
 # Apache Releases on Subversion
 svn-*/
+
+# vscode files
+.vscode/

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
@@ -24,6 +24,9 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
     /// <summary>
     /// This class offers some hooks for extending classes to control the
     /// <see cref="IndexReader"/> instance that is used by <see cref="DirectoryTaxonomyReader"/>.
+    /// <para/>
+    /// This class is specific to Lucene.NET to allow to customize the <see cref="DirectoryReader"/> instance
+    /// before it is used by <see cref="DirectoryTaxonomyReader"/>.
     /// </summary>
     public class DirectoryTaxonomyIndexReaderFactory
     {

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
@@ -37,6 +37,8 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// </summary>
         public virtual DirectoryReader OpenIndexReader(Directory directory)
         {
+            // LUCENENET specific - added null check
+            if (directory is null) throw new System.ArgumentNullException(nameof(directory));
             return DirectoryReader.Open(directory);
         }
 
@@ -45,6 +47,8 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// </summary>
         public virtual DirectoryReader OpenIndexReader(IndexWriter writer)
         {
+            // LUCENENET specific - added null check
+            if (writer is null) throw new System.ArgumentNullException(nameof(writer));
             return DirectoryReader.Open(writer, applyAllDeletes: false);
         }
     }

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
@@ -1,0 +1,46 @@
+using Lucene.Net.Index;
+    
+namespace Lucene.Net.Facet.Taxonomy.Directory
+{
+    /*
+    * Licensed to the Apache Software Foundation (ASF) under one or more
+    * contributor license agreements.  See the NOTICE file distributed with
+    * this work for additional information regarding copyright ownership.
+    * The ASF licenses this file to You under the Apache License, Version 2.0
+    * (the "License"); you may not use this file except in compliance with
+    * the License.  You may obtain a copy of the License at
+    *
+    *     http://www.apache.org/licenses/LICENSE-2.0
+    *
+    * Unless required by applicable law or agreed to in writing, software
+    * distributed under the License is distributed on an "AS IS" BASIS,
+    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    * See the License for the specific language governing permissions and
+    * limitations under the License.
+    */
+
+    using Directory = Lucene.Net.Store.Directory;
+
+    /// <summary>
+    /// This class offers some hooks for extending classes to control the
+    /// <see cref="IndexReader"/> instance that is used by <see cref="DirectoryTaxonomyReader"/>.
+    /// </summary>
+    public class DirectoryTaxonomyIndexReaderFactory
+    {
+        /// <summary>
+        /// Open the <see cref="DirectoryReader"/> from this <see cref="Directory"/>. 
+        /// </summary>
+        public virtual DirectoryReader OpenIndexReader(Directory directory)
+        {
+            return DirectoryReader.Open(directory);
+        }
+
+        /// <summary>
+        /// Open the <see cref="DirectoryReader"/> from this <see cref="IndexWriter"/>. 
+        /// </summary>
+        public virtual DirectoryReader OpenIndexReader(IndexWriter writer)
+        {
+            return DirectoryReader.Open(writer, false);
+        }
+    }
+}

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
@@ -27,6 +27,8 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
     /// </summary>
     public class DirectoryTaxonomyIndexReaderFactory
     {
+        public static DirectoryTaxonomyIndexReaderFactory Default { get; } = new DirectoryTaxonomyIndexReaderFactory();
+        
         /// <summary>
         /// Open the <see cref="DirectoryReader"/> from this <see cref="Directory"/>. 
         /// </summary>

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexReaderFactory.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// </summary>
         public virtual DirectoryReader OpenIndexReader(IndexWriter writer)
         {
-            return DirectoryReader.Open(writer, false);
+            return DirectoryReader.Open(writer, applyAllDeletes: false);
         }
     }
 }

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
@@ -26,6 +26,9 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
     /// <summary>
     /// This class offers some hooks for extending classes to control the
     /// <see cref="IndexWriter"/> instance that is used by <see cref="DirectoryTaxonomyWriter"/>.
+    /// <para/>
+    /// This class is specific to Lucene.NET to allow to customize the <see cref="IndexWriter"/> instance
+    /// and its configuration before it is used by <see cref="DirectoryTaxonomyWriter"/>.
     /// </summary>
     public class DirectoryTaxonomyIndexWriterFactory
     {

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
@@ -5,21 +5,21 @@ using Lucene.Net.Util;
 namespace Lucene.Net.Facet.Taxonomy.Directory
 {
     /*
-        * Licensed to the Apache Software Foundation (ASF) under one or more
-        * contributor license agreements.  See the NOTICE file distributed with
-        * this work for additional information regarding copyright ownership.
-        * The ASF licenses this file to You under the Apache License, Version 2.0
-        * (the "License"); you may not use this file except in compliance with
-        * the License.  You may obtain a copy of the License at
-        *
-        *     http://www.apache.org/licenses/LICENSE-2.0
-        *
-        * Unless required by applicable law or agreed to in writing, software
-        * distributed under the License is distributed on an "AS IS" BASIS,
-        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        * See the License for the specific language governing permissions and
-        * limitations under the License.
-        */
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
 
     using Directory = Lucene.Net.Store.Directory;
 

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
@@ -29,6 +29,8 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
     /// </summary>
     public class DirectoryTaxonomyIndexWriterFactory
     {
+        public static DirectoryTaxonomyIndexWriterFactory Default { get; } = new DirectoryTaxonomyIndexWriterFactory();
+        
         /// <summary>
         /// Open internal index writer, which contains the taxonomy data.
         /// <para/>

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
@@ -1,0 +1,79 @@
+using Lucene.Net.Index;
+using Lucene.Net.Index.Extensions;
+using Lucene.Net.Util;
+
+namespace Lucene.Net.Facet.Taxonomy.Directory
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+     using Directory = Lucene.Net.Store.Directory;
+
+    /// <summary>
+    /// This class offers some hooks for extending classes to control the
+    /// <see cref="IndexWriter"/> instance that is used by <see cref="DirectoryTaxonomyWriter"/>.
+    /// </summary>
+    public class DirectoryTaxonomyIndexWriterFactory
+    {
+         /// <summary>
+        /// Open internal index writer, which contains the taxonomy data.
+        /// <para/>
+        /// Extensions may provide their own <see cref="IndexWriter"/> implementation or instance. 
+        /// <para/>
+        /// <b>NOTE:</b> the instance this method returns will be disposed upon calling
+        /// to <see cref="DirectoryTaxonomyWriter.Dispose()"/>.
+        /// <para/>
+        /// <b>NOTE:</b> the merge policy in effect must not merge none adjacent segments. See
+        /// comment in <see cref="CreateIndexWriterConfig(OpenMode)"/> for the logic behind this.
+        /// </summary>
+        /// <seealso cref="CreateIndexWriterConfig(OpenMode)"/>
+        /// <param name="directory">
+        ///          the <see cref="Store.Directory"/> on top of which an <see cref="IndexWriter"/>
+        ///          should be opened. </param>
+        /// <param name="config">
+        ///          configuration for the internal index writer. </param>
+        public virtual IndexWriter OpenIndexWriter(Directory directory, IndexWriterConfig config)
+        {
+            return new IndexWriter(directory, config);
+        }
+
+        /// <summary>
+        /// Create the <see cref="IndexWriterConfig"/> that would be used for opening the internal index writer.
+        /// <para/>
+        /// Extensions can configure the <see cref="IndexWriter"/> as they see fit,
+        /// including setting a <see cref="Index.MergeScheduler"/>, or
+        /// <see cref="Index.IndexDeletionPolicy"/>, different RAM size
+        /// etc.
+        /// <para/>
+        /// <b>NOTE:</b> internal docids of the configured index must not be altered.
+        /// For that, categories are never deleted from the taxonomy index.
+        /// In addition, merge policy in effect must not merge none adjacent segments.
+        /// </summary>
+        /// <seealso cref="OpenIndexWriter(Directory, IndexWriterConfig)"/>
+        /// <param name="openMode"> see <see cref="OpenMode"/> </param>
+        public virtual IndexWriterConfig CreateIndexWriterConfig(OpenMode openMode)
+        {
+            // TODO: should we use a more optimized Codec, e.g. Pulsing (or write custom)?
+            // The taxonomy has a unique structure, where each term is associated with one document
+
+            // :Post-Release-Update-Version.LUCENE_XY:
+            // Make sure we use a MergePolicy which always merges adjacent segments and thus
+            // keeps the doc IDs ordered as well (this is crucial for the taxonomy index).
+            return (new IndexWriterConfig(LuceneVersion.LUCENE_48, null)).SetOpenMode(openMode).SetMergePolicy(new LogByteSizeMergePolicy());
+        }
+    }
+}

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyIndexWriterFactory.cs
@@ -5,23 +5,23 @@ using Lucene.Net.Util;
 namespace Lucene.Net.Facet.Taxonomy.Directory
 {
     /*
-     * Licensed to the Apache Software Foundation (ASF) under one or more
-     * contributor license agreements.  See the NOTICE file distributed with
-     * this work for additional information regarding copyright ownership.
-     * The ASF licenses this file to You under the Apache License, Version 2.0
-     * (the "License"); you may not use this file except in compliance with
-     * the License.  You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
+        * Licensed to the Apache Software Foundation (ASF) under one or more
+        * contributor license agreements.  See the NOTICE file distributed with
+        * this work for additional information regarding copyright ownership.
+        * The ASF licenses this file to You under the Apache License, Version 2.0
+        * (the "License"); you may not use this file except in compliance with
+        * the License.  You may obtain a copy of the License at
+        *
+        *     http://www.apache.org/licenses/LICENSE-2.0
+        *
+        * Unless required by applicable law or agreed to in writing, software
+        * distributed under the License is distributed on an "AS IS" BASIS,
+        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        * See the License for the specific language governing permissions and
+        * limitations under the License.
+        */
 
-     using Directory = Lucene.Net.Store.Directory;
+    using Directory = Lucene.Net.Store.Directory;
 
     /// <summary>
     /// This class offers some hooks for extending classes to control the
@@ -29,7 +29,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
     /// </summary>
     public class DirectoryTaxonomyIndexWriterFactory
     {
-         /// <summary>
+        /// <summary>
         /// Open internal index writer, which contains the taxonomy data.
         /// <para/>
         /// Extensions may provide their own <see cref="IndexWriter"/> implementation or instance. 

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
@@ -108,8 +108,13 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// <exception cref="Index.CorruptIndexException"> if the Taxonomy is corrupt. </exception>
         /// <exception cref="IOException"> if another error occurred. </exception>
         public DirectoryTaxonomyReader(Directory directory)
+            : this(DirectoryTaxonomyIndexReaderFactory.Default, directory)
         {
-            indexReader = OpenIndexReader(directory);
+        }
+
+        public DirectoryTaxonomyReader(DirectoryTaxonomyIndexReaderFactory indexReaderFactory, Directory directory)
+        {
+            indexReader = indexReaderFactory.OpenIndexReader(directory);
             taxoWriter = null;
             taxoEpoch = -1;
 
@@ -128,10 +133,15 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         ///          The <see cref="DirectoryTaxonomyWriter"/> from which to obtain newly
         ///          added categories, in real-time. </param>
         public DirectoryTaxonomyReader(DirectoryTaxonomyWriter taxoWriter)
+            : this(DirectoryTaxonomyIndexReaderFactory.Default, taxoWriter)
+        {
+        }
+
+        public DirectoryTaxonomyReader(DirectoryTaxonomyIndexReaderFactory indexReaderFactory, DirectoryTaxonomyWriter taxoWriter)
         {
             this.taxoWriter = taxoWriter;
             taxoEpoch = taxoWriter.TaxonomyEpoch;
-            indexReader = OpenIndexReader(taxoWriter.InternalIndexWriter);
+            indexReader = indexReaderFactory.OpenIndexReader(taxoWriter.InternalIndexWriter);
 
             // These are the default cache sizes; they can be configured after
             // construction with the cache's setMaxSize() method
@@ -236,22 +246,6 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                     IOUtils.DisposeWhileHandlingException(r2);
                 }
             }
-        }
-
-        /// <summary>
-        /// Open the <see cref="DirectoryReader"/> from this <see cref="Directory"/>. 
-        /// </summary>
-        protected virtual DirectoryReader OpenIndexReader(Directory directory)
-        {
-            return DirectoryReader.Open(directory);
-        }
-
-        /// <summary>
-        /// Open the <see cref="DirectoryReader"/> from this <see cref="IndexWriter"/>. 
-        /// </summary>
-        protected virtual DirectoryReader OpenIndexReader(IndexWriter writer)
-        {
-            return DirectoryReader.Open(writer, false);
         }
 
         /// <summary>

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
@@ -101,7 +101,8 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         }
 
         /// <summary>
-        /// Open for reading a taxonomy stored in a given <see cref="Directory"/>.
+        /// Open for reading a taxonomy stored in a given <see cref="Directory"/>. Uses <see cref="DirectoryTaxonomyIndexReaderFactory.Default"/> as
+        /// for <see cref="DirectoryTaxonomyIndexReaderFactory"/>.
         /// </summary>
         /// <param name="directory"> The <see cref="Directory"/> in which the taxonomy resides. </param>
         /// <exception cref="Index.CorruptIndexException"> if the Taxonomy is corrupt. </exception>
@@ -111,8 +112,18 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         {
         }
 
+        /// <summary>
+        /// Open for reading a taxonomy stored in a given <see cref="Directory"/>.
+        /// </summary>
+        /// <param name="indexReaderFactory"> The <see cref="DirectoryTaxonomyIndexReaderFactory"/> to use to open the index reader. </param>
+        /// <param name="directory"> The <see cref="Directory"/> in which the taxonomy resides. </param>
+        /// <exception cref="Index.CorruptIndexException"> if the Taxonomy is corrupt. </exception>
+        /// <exception cref="IOException"> if another error occurred. </exception>
         public DirectoryTaxonomyReader(DirectoryTaxonomyIndexReaderFactory indexReaderFactory, Directory directory)
         {
+            // LUCENENET specific - uses indexReaderFactory to open the index reader instead of
+            // calling virtual method
+            if (indexReaderFactory is null) throw new ArgumentNullException(nameof(indexReaderFactory));
             indexReader = indexReaderFactory.OpenIndexReader(directory);
             taxoWriter = null;
             taxoEpoch = -1;
@@ -126,7 +137,8 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
         /// <summary>
         /// Opens a <see cref="DirectoryTaxonomyReader"/> over the given
-        /// <see cref="DirectoryTaxonomyWriter"/> (for NRT).
+        /// <see cref="DirectoryTaxonomyWriter"/> (for NRT). Uses <see cref="DirectoryTaxonomyIndexReaderFactory.Default"/>
+        /// for <see cref="DirectoryTaxonomyIndexReaderFactory"/>.
         /// </summary>
         /// <param name="taxoWriter">
         ///          The <see cref="DirectoryTaxonomyWriter"/> from which to obtain newly
@@ -136,10 +148,25 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         {
         }
 
+        /// <summary>
+        /// Opens a <see cref="DirectoryTaxonomyReader"/> over the given
+        /// <see cref="DirectoryTaxonomyWriter"/> (for NRT).
+        /// </summary>
+        /// <param name="indexReaderFactory"> The <see cref="DirectoryTaxonomyIndexReaderFactory"/> to use to open the index reader. </param>
+        /// <param name="taxoWriter">
+        ///          The <see cref="DirectoryTaxonomyWriter"/> from which to obtain newly
+        ///          added categories, in real-time. </param>
+        /// <exception cref="ArgumentNullException"> if <paramref name="indexReaderFactory"/> or <paramref name="taxoWriter"/> is <c>null</c>. </exception>
         public DirectoryTaxonomyReader(DirectoryTaxonomyIndexReaderFactory indexReaderFactory, DirectoryTaxonomyWriter taxoWriter)
         {
+            // LUCENENET added null checks
+            if (taxoWriter is null) throw new ArgumentNullException(nameof(taxoWriter));
             this.taxoWriter = taxoWriter;
             taxoEpoch = taxoWriter.TaxonomyEpoch;
+            
+            // LUCENENET specific - uses indexReaderFactory to open the index reader instead of
+            // calling virtual method
+            if (indexReaderFactory is null) throw new ArgumentNullException(nameof(indexReaderFactory));
             indexReader = indexReaderFactory.OpenIndexReader(taxoWriter.InternalIndexWriter);
 
             // These are the default cache sizes; they can be configured after
@@ -246,6 +273,14 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                 }
             }
         }
+
+        /// LUCENENET specific - OpenIndexReader(Directory directory) and
+        /// OpenIndexReader(IndexWriter writer) were
+        /// moved to <see cref="DirectoryTaxonomyIndexReaderFactory"/> to allow extended classes
+        /// to customize writer behavior. This is a breaking change from Lucene, and required
+        /// in order to offer the same functionality in .NET as Lucene offers in Java. These virtual methods
+        /// were being called from the constructors and have different initialization sequence in .NET
+        /// so a factory approach was used instead.
 
         /// <summary>
         /// Expert: returns the underlying <see cref="DirectoryReader"/> instance that is

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyReader.cs
@@ -30,7 +30,6 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
     using DocIdSetIterator = Lucene.Net.Search.DocIdSetIterator;
     using DocsEnum = Lucene.Net.Index.DocsEnum;
     using Document = Lucene.Net.Documents.Document;
-    using IndexWriter = Lucene.Net.Index.IndexWriter;
     using IOUtils = Lucene.Net.Util.IOUtils;
     using MultiFields = Lucene.Net.Index.MultiFields;
 

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -181,7 +181,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// <exception cref="IOException">
         ///     if another error occurred. </exception>
         public DirectoryTaxonomyWriter(Directory directory, OpenMode openMode,
-            ITaxonomyWriterCache cache) : this(directory, openMode, cache, new DirectoryTaxonomyIndexWriterFactory())
+            ITaxonomyWriterCache cache) : this(directory, openMode, cache, DirectoryTaxonomyIndexWriterFactory.Default)
         {
         }
 

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -170,7 +170,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         ///    A <see cref="ITaxonomyWriterCache"/> implementation which determines
         ///    the in-memory caching policy. See for example
         ///    <see cref="WriterCache.LruTaxonomyWriterCache"/> and <see cref="Cl2oTaxonomyWriterCache"/>.
-        ///    If null or missing, <see cref="DefaultTaxonomyWriterCache()"/> is used. </param>
+        ///    If null or missing, <see cref="CreateDefaultTaxonomyWriterCache()"/> is used. </param>
         /// <exception cref="CorruptIndexException">
         ///     if the taxonomy is corrupted. </exception>
         /// <exception cref="LockObtainFailedException">
@@ -180,7 +180,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         ///     removed using <see cref="Unlock(Directory)"/>. </exception>
         /// <exception cref="IOException">
         ///     if another error occurred. </exception>
-        public DirectoryTaxonomyWriter(Directory directory, OpenMode openMode, 
+        public DirectoryTaxonomyWriter(Directory directory, OpenMode openMode,
             ITaxonomyWriterCache cache) : this(directory, openMode, cache, new DirectoryTaxonomyIndexWriterFactory())
         {
         }
@@ -203,7 +203,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         ///    A <see cref="ITaxonomyWriterCache"/> implementation which determines
         ///    the in-memory caching policy. See for example
         ///    <see cref="WriterCache.LruTaxonomyWriterCache"/> and <see cref="Cl2oTaxonomyWriterCache"/>.
-        ///    If null or missing, <see cref="DefaultTaxonomyWriterCache()"/> is used. </param>
+        ///    If null or missing, <see cref="CreateDefaultTaxonomyWriterCache()"/> is used. </param>
         /// <param name="indexWriterFactory">
         ///    A <see cref="DirectoryTaxonomyIndexWriterFactory"/> implementation that can be used to
         ///    customize the <see cref="IndexWriter"/> configuration and writer itself that's used to 
@@ -218,12 +218,12 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// <exception cref="IOException">
         ///     if another error occurred. </exception>
         /// <exception cref="System.ArgumentNullException"> if <paramref name="indexWriterFactory"/> is <c>null</c> </exception>
-        protected DirectoryTaxonomyWriter(Directory directory, OpenMode openMode, 
+        protected DirectoryTaxonomyWriter(Directory directory, OpenMode openMode,
             ITaxonomyWriterCache cache, DirectoryTaxonomyIndexWriterFactory indexWriterFactory)
         {
             dir = directory;
 
-            if (indexWriterFactory == null) throw new ArgumentNullException(nameof(indexWriterFactory));
+            if (indexWriterFactory is null) throw new ArgumentNullException(nameof(indexWriterFactory));
             IndexWriterConfig config = indexWriterFactory.CreateIndexWriterConfig(openMode);
             indexWriter = indexWriterFactory.OpenIndexWriter(dir, config);
 
@@ -270,7 +270,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
             if (cache is null)
             {
-                cache = DefaultTaxonomyWriterCache();
+                cache = CreateDefaultTaxonomyWriterCache();
             }
             this.cache = cache;
 
@@ -292,6 +292,14 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                 cacheIsComplete = false;
             }
         }
+
+        /// LUCENENET specific - OpenIndexWriter(Directory directory, IndexWriterConfig config)
+        /// and protected virtual IndexWriterConfig CreateIndexWriterConfig(OpenMode openMode) were
+        /// moved to <see cref="DirectoryTaxonomyIndexWriterFactory"/> to allow extended classes
+        /// to customize the configs and writers. This is a breaking change from Lucene, and required
+        /// in order to offer the same functionality in .NET as Lucene offers in Java. These virtual methods
+        /// were being called from the constructors and have different initialization sequence in .NET
+        /// so a factory approach was used instead.
 
         /// <summary>
         /// Opens a <see cref="ReaderManager"/> from the internal <see cref="IndexWriter"/>. 
@@ -321,10 +329,10 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
         /// <summary>
         /// Creates a new instance with a default cache as defined by
-        /// <see cref="DefaultTaxonomyWriterCache()"/>.
+        /// <see cref="CreateDefaultTaxonomyWriterCache()"/>.
         /// </summary>
         public DirectoryTaxonomyWriter(Directory directory, OpenMode openMode)
-            : this(directory, openMode, DefaultTaxonomyWriterCache())
+            : this(directory, openMode, CreateDefaultTaxonomyWriterCache())
         {
         }
 
@@ -337,7 +345,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// cached in memory while building it.
         /// </para>
         /// </summary>
-        public static ITaxonomyWriterCache DefaultTaxonomyWriterCache()
+        public static ITaxonomyWriterCache CreateDefaultTaxonomyWriterCache()
         {
             return new Cl2oTaxonomyWriterCache(1024, 0.15f, 3);
         }
@@ -348,10 +356,10 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         public DirectoryTaxonomyWriter(Directory directory) : this(directory, OpenMode.CREATE_OR_APPEND) { }
 
         /// <summary>
-        /// Create this with <see cref="OpenMode.CREATE_OR_APPEND"/> and <see cref="DefaultTaxonomyWriterCache()"/>.
+        /// Create this with <see cref="OpenMode.CREATE_OR_APPEND"/> and <see cref="CreateDefaultTaxonomyWriterCache()"/>.
         /// </summary>
         public DirectoryTaxonomyWriter(Directory directory, DirectoryTaxonomyIndexWriterFactory indexWriterFactory)
-            : this(directory, OpenMode.CREATE_OR_APPEND, DefaultTaxonomyWriterCache(), indexWriterFactory) { }
+            : this(directory, OpenMode.CREATE_OR_APPEND, CreateDefaultTaxonomyWriterCache(), indexWriterFactory) { }
 
         /// <summary>
         /// Frees used resources as well as closes the underlying <see cref="IndexWriter"/>,

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -181,7 +181,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// <exception cref="IOException">
         ///     if another error occurred. </exception>
         public DirectoryTaxonomyWriter(Directory directory, OpenMode openMode,
-            ITaxonomyWriterCache cache) : this(directory, openMode, cache, DirectoryTaxonomyIndexWriterFactory.Default)
+            ITaxonomyWriterCache cache) : this(DirectoryTaxonomyIndexWriterFactory.Default, directory, openMode, cache)
         {
         }
 
@@ -217,9 +217,9 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         ///     removed using <see cref="Unlock(Directory)"/>. </exception>
         /// <exception cref="IOException">
         ///     if another error occurred. </exception>
-        /// <exception cref="System.ArgumentNullException"> if <paramref name="indexWriterFactory"/> is <c>null</c> </exception>
-        protected DirectoryTaxonomyWriter(Directory directory, OpenMode openMode,
-            ITaxonomyWriterCache cache, DirectoryTaxonomyIndexWriterFactory indexWriterFactory)
+        /// <exception cref="ArgumentNullException"> if <paramref name="indexWriterFactory"/> is <c>null</c> </exception>
+        public DirectoryTaxonomyWriter(DirectoryTaxonomyIndexWriterFactory indexWriterFactory, Directory directory,
+            OpenMode openMode, ITaxonomyWriterCache cache)
         {
             dir = directory;
 
@@ -345,7 +345,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// cached in memory while building it.
         /// </para>
         /// </summary>
-        public static ITaxonomyWriterCache CreateDefaultTaxonomyWriterCache()
+        public static ITaxonomyWriterCache CreateDefaultTaxonomyWriterCache() // LUCENENET renamed with Create*
         {
             return new Cl2oTaxonomyWriterCache(1024, 0.15f, 3);
         }
@@ -353,13 +353,20 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// <summary>
         /// Create this with <see cref="OpenMode.CREATE_OR_APPEND"/>.
         /// </summary>
+        /// <param name="directory">The <see cref="Store.Directory"/> in which to store the taxonomy. Note that
+        ///    the taxonomy is written directly to that directory (not to a
+        ///    subdirectory of it). </param>
         public DirectoryTaxonomyWriter(Directory directory) : this(directory, OpenMode.CREATE_OR_APPEND) { }
 
         /// <summary>
         /// Create this with <see cref="OpenMode.CREATE_OR_APPEND"/> and <see cref="CreateDefaultTaxonomyWriterCache()"/>.
         /// </summary>
-        public DirectoryTaxonomyWriter(Directory directory, DirectoryTaxonomyIndexWriterFactory indexWriterFactory)
-            : this(directory, OpenMode.CREATE_OR_APPEND, CreateDefaultTaxonomyWriterCache(), indexWriterFactory) { }
+        /// <param name="indexWriterFactory">The <see cref="DirectoryTaxonomyIndexWriterFactory"/> to use to create the <see cref="IndexWriter"/>.</param>
+        /// <param name="directory">The <see cref="Store.Directory"/> in which to store the taxonomy. Note that
+        ///    the taxonomy is written directly to that directory (not to a
+        ///    subdirectory of it). </param>
+        public DirectoryTaxonomyWriter(DirectoryTaxonomyIndexWriterFactory indexWriterFactory, Directory directory)
+            : this(indexWriterFactory, directory, OpenMode.CREATE_OR_APPEND, CreateDefaultTaxonomyWriterCache()) { }
 
         /// <summary>
         /// Frees used resources as well as closes the underlying <see cref="IndexWriter"/>,

--- a/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
+++ b/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
@@ -1,6 +1,5 @@
 ﻿using J2N.Text;
 using Lucene.Net.Diagnostics;
-using Lucene.Net.Facet.Taxonomy.Directory;
 using Lucene.Net.Facet.Taxonomy.WriterCache;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
@@ -41,46 +40,8 @@ namespace Lucene.Net.Replicator
     /// @lucene.experimental
     /// </remarks>
     /// <seealso cref="IndexRevision"/>
-    public class IndexAndTaxonomyRevision : IRevision
+    public partial class IndexAndTaxonomyRevision : IRevision
     {
-        /// <summary>
-        /// A <see cref="DirectoryTaxonomyIndexWriterFactory"/> which sets the underlying
-        /// <see cref="Index.IndexWriter"/>'s <see cref="IndexDeletionPolicy"/> to
-        /// <see cref="SnapshotDeletionPolicy"/>.
-        /// </summary>
-        public class SnapshotDirectoryTaxonomyIndexWriterFactory : DirectoryTaxonomyIndexWriterFactory
-        {
-            private SnapshotDeletionPolicy sdp;
-            private IndexWriter writer; // LUCENENET: this gets disposed when the DirectoryTaxonomyWriter that uses the factory is disposed
-
-            /// <summary>
-            /// Creates a new <see cref="IndexWriterConfig"/> using <see cref="DirectoryTaxonomyIndexWriterFactory.CreateIndexWriterConfig"/> and
-            /// sets IndexDeletionPolicy to <see cref="SnapshotDeletionPolicy"/>.
-            /// </summary>
-            public override IndexWriterConfig CreateIndexWriterConfig(OpenMode openMode)
-            {
-                IndexWriterConfig conf = base.CreateIndexWriterConfig(openMode);
-                conf.IndexDeletionPolicy = sdp = new SnapshotDeletionPolicy(conf.IndexDeletionPolicy);
-                return conf;
-            }
-
-            /// <inheritdoc/>
-            public override IndexWriter OpenIndexWriter(Directory directory, IndexWriterConfig config)
-            {
-                return writer = base.OpenIndexWriter(directory, config);
-            }
-
-            /// <summary>
-            /// Gets the <see cref="SnapshotDeletionPolicy"/> used by the underlying <see cref="Index.IndexWriter"/>.
-            /// </summary>
-            public virtual SnapshotDeletionPolicy DeletionPolicy => sdp;
-
-            /// <summary>
-            /// Gets the <see cref="Index.IndexWriter"/> used by this <see cref="DirectoryTaxonomyWriter"/>.
-            /// </summary>
-            public virtual IndexWriter IndexWriter => writer;
-        }
-
         public const string INDEX_SOURCE = "index";
         public const string TAXONOMY_SOURCE = "taxonomy";
 

--- a/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
+++ b/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
@@ -40,12 +40,16 @@ namespace Lucene.Net.Replicator
     /// @lucene.experimental
     /// </remarks>
     /// <seealso cref="IndexRevision"/>
-    public partial class IndexAndTaxonomyRevision : IRevision
+    public class IndexAndTaxonomyRevision : IRevision
     {
+        // LUCENENET specific - de-nested SnapshotDirectoryTaxonomyWriter and rewrote it as
+        // SnapshotDirectoryTaxonomyIndexWriterFactory
+
         public const string INDEX_SOURCE = "index";
         public const string TAXONOMY_SOURCE = "taxonomy";
 
         private readonly IndexWriter indexWriter;
+        // LUCENENET specific, storing the taxonomyWriterFactory that creates writer and policies
         private readonly SnapshotDirectoryTaxonomyIndexWriterFactory taxonomyWriterFactory;
         private readonly IndexCommit indexCommit, taxonomyCommit;
         private readonly SnapshotDeletionPolicy indexSdp, taxonomySdp;

--- a/src/Lucene.Net.Replicator/Support/SnapshotDirectoryTaxonomyIndexWriterFactory.cs
+++ b/src/Lucene.Net.Replicator/Support/SnapshotDirectoryTaxonomyIndexWriterFactory.cs
@@ -1,0 +1,63 @@
+using Lucene.Net.Facet.Taxonomy.Directory;
+using Lucene.Net.Index;
+using Directory = Lucene.Net.Store.Directory;
+
+namespace Lucene.Net.Replicator
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    // LUCENENET specific - refactored SnapshotDirectoryTaxonomyWriter into SnapshotDirectoryTaxonomyIndexWriterFactory and de-nested
+    
+    /// <summary>
+    /// A <see cref="DirectoryTaxonomyIndexWriterFactory"/> which sets the underlying
+    /// <see cref="Index.IndexWriter"/>'s <see cref="IndexDeletionPolicy"/> to
+    /// <see cref="SnapshotDeletionPolicy"/>.
+    /// </summary>
+    public class SnapshotDirectoryTaxonomyIndexWriterFactory : DirectoryTaxonomyIndexWriterFactory
+    {
+        private SnapshotDeletionPolicy sdp;
+        private IndexWriter writer; // LUCENENET: this gets disposed when the DirectoryTaxonomyWriter that uses the factory is disposed
+
+        /// <summary>
+        /// Creates a new <see cref="IndexWriterConfig"/> using <see cref="DirectoryTaxonomyIndexWriterFactory.CreateIndexWriterConfig"/> and
+        /// sets IndexDeletionPolicy to <see cref="SnapshotDeletionPolicy"/>.
+        /// </summary>
+        public override IndexWriterConfig CreateIndexWriterConfig(OpenMode openMode)
+        {
+            IndexWriterConfig conf = base.CreateIndexWriterConfig(openMode);
+            conf.IndexDeletionPolicy = sdp = new SnapshotDeletionPolicy(conf.IndexDeletionPolicy);
+            return conf;
+        }
+
+        /// <inheritdoc/>
+        public override IndexWriter OpenIndexWriter(Directory directory, IndexWriterConfig config)
+        {
+            return writer = base.OpenIndexWriter(directory, config);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SnapshotDeletionPolicy"/> used by the underlying <see cref="Index.IndexWriter"/>.
+        /// </summary>
+        public virtual SnapshotDeletionPolicy DeletionPolicy => sdp;
+
+        /// <summary>
+        /// Gets the <see cref="Index.IndexWriter"/> used by this <see cref="DirectoryTaxonomyWriter"/>.
+        /// </summary>
+        public virtual IndexWriter IndexWriter => writer;
+    }
+}

--- a/src/Lucene.Net.Replicator/Support/SnapshotDirectoryTaxonomyIndexWriterFactory.cs
+++ b/src/Lucene.Net.Replicator/Support/SnapshotDirectoryTaxonomyIndexWriterFactory.cs
@@ -24,14 +24,14 @@ namespace Lucene.Net.Replicator
     // LUCENENET specific - refactored SnapshotDirectoryTaxonomyWriter into SnapshotDirectoryTaxonomyIndexWriterFactory and de-nested
     
     /// <summary>
-    /// A <see cref="DirectoryTaxonomyIndexWriterFactory"/> which sets the underlying
-    /// <see cref="Index.IndexWriter"/>'s <see cref="IndexDeletionPolicy"/> to
+    /// An implementation of <see cref="DirectoryTaxonomyIndexWriterFactory"/>
+    /// which sets the underlying <see cref="Index.IndexWriter"/>'s <see cref="IndexDeletionPolicy"/> to
     /// <see cref="SnapshotDeletionPolicy"/>.
     /// </summary>
     public class SnapshotDirectoryTaxonomyIndexWriterFactory : DirectoryTaxonomyIndexWriterFactory
     {
         private SnapshotDeletionPolicy sdp;
-        private IndexWriter writer; // LUCENENET: this gets disposed when the DirectoryTaxonomyWriter that uses the factory is disposed
+        private IndexWriter writer;
 
         /// <summary>
         /// Creates a new <see cref="IndexWriterConfig"/> using <see cref="DirectoryTaxonomyIndexWriterFactory.CreateIndexWriterConfig"/> and
@@ -56,7 +56,8 @@ namespace Lucene.Net.Replicator
         public virtual SnapshotDeletionPolicy DeletionPolicy => sdp;
 
         /// <summary>
-        /// Gets the <see cref="Index.IndexWriter"/> used by this <see cref="DirectoryTaxonomyWriter"/>.
+        /// Gets the <see cref="Index.IndexWriter"/> that was opened by <see cref="DirectoryTaxonomyWriter"/>
+        /// that is using this factory class.
         /// </summary>
         public virtual IndexWriter IndexWriter => writer;
     }

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyReader.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyReader.cs
@@ -232,7 +232,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             Directory dir = NewDirectory();
 
             // LUCENENET specific: Added DirectoryTaxonomyIndexWriterFactory constructor parameter
-            var writer = new DirectoryTaxonomyWriter(dir, new TestDirectoryTaxonomyIndexWriterFactory());
+            var writer = new DirectoryTaxonomyWriter(new TestDirectoryTaxonomyIndexWriterFactory(), dir);
             var reader = new DirectoryTaxonomyReader(writer);
 
             int numRounds = Random.Next(10) + 10;
@@ -291,7 +291,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             // note how we don't close it, since DTW will close it.
             // LUCENENET: Moved the creation of IndexWriter to TestDirectoryTaxonomyIndexWriterFactory2
             var indexWriterFactory = new TestDirectoryTaxonomyIndexWriterFactory2(Random, TEST_VERSION_CURRENT);
-            var writer = new DirectoryTaxonomyWriter(dir, indexWriterFactory);
+            var writer = new DirectoryTaxonomyWriter(indexWriterFactory, dir);
             Assert.NotNull(indexWriterFactory.iw, "iw should be set via DirectoryTaxonomyIndexWriter constructor calling factory");
 
             var reader = new DirectoryTaxonomyReader(writer);
@@ -357,7 +357,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             // note how we don't close it, since DTW will close it.
             // LUCENENET: Moved the creation of IndexWriter to TestDirectoryTaxonomyIndexWriterFactory2
             var indexWriterFactory = new TestDirectoryTaxonomyIndexWriterFactory2(Random, TEST_VERSION_CURRENT);
-            var writer = new DirectoryTaxonomyWriter(dir, indexWriterFactory);
+            var writer = new DirectoryTaxonomyWriter(indexWriterFactory, dir);
             Assert.NotNull(indexWriterFactory.iw, "iw should be set via DirectoryTaxonomyIndexWriter constructor calling factory");
             
             // add a category so that the following DTR open will cause a flush and 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyReader.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyReader.cs
@@ -231,6 +231,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             // test openIfChanged() when the taxonomy contains many segments
             Directory dir = NewDirectory();
 
+            // LUCENENET specific: Added DirectoryTaxonomyIndexWriterFactory constructor parameter
             var writer = new DirectoryTaxonomyWriter(dir, new TestDirectoryTaxonomyIndexWriterFactory());
             var reader = new DirectoryTaxonomyReader(writer);
 
@@ -266,6 +267,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             dir.Dispose();
         }
 
+        // LUCENENET specific: Converted DirectoryTaxonomyWriter anonymous class into a DirectoryTaxonomyIndexWriterFactory subclass
         private sealed class TestDirectoryTaxonomyIndexWriterFactory : DirectoryTaxonomyIndexWriterFactory
         {
             public override IndexWriterConfig CreateIndexWriterConfig(OpenMode openMode)
@@ -287,6 +289,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
             // hold onto IW to forceMerge
             // note how we don't close it, since DTW will close it.
+            // LUCENENET: Moved the creation of IndexWriter to TestDirectoryTaxonomyIndexWriterFactory2
             var indexWriterFactory = new TestDirectoryTaxonomyIndexWriterFactory2(Random, TEST_VERSION_CURRENT);
             var writer = new DirectoryTaxonomyWriter(dir, indexWriterFactory);
             Assert.NotNull(indexWriterFactory.iw, "iw should be set via DirectoryTaxonomyIndexWriter constructor calling factory");
@@ -313,6 +316,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             dir.Dispose();
         }
 
+        // LUCENENET specific: Converted DirectoryTaxonomyWriter anonymous class into a DirectoryTaxonomyIndexWriterFactory subclass
         private sealed class TestDirectoryTaxonomyIndexWriterFactory2 : DirectoryTaxonomyIndexWriterFactory
         {
             internal IndexWriter iw = null;
@@ -351,8 +355,9 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
             // hold onto IW to forceMerge
             // note how we don't close it, since DTW will close it.
+            // LUCENENET: Moved the creation of IndexWriter to TestDirectoryTaxonomyIndexWriterFactory2
             var indexWriterFactory = new TestDirectoryTaxonomyIndexWriterFactory2(Random, TEST_VERSION_CURRENT);
-            DirectoryTaxonomyWriter writer = new DirectoryTaxonomyWriter(dir, indexWriterFactory);
+            var writer = new DirectoryTaxonomyWriter(dir, indexWriterFactory);
             Assert.NotNull(indexWriterFactory.iw, "iw should be set via DirectoryTaxonomyIndexWriter constructor calling factory");
             
             // add a category so that the following DTR open will cause a flush and 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyReader.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyReader.cs
@@ -231,7 +231,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             // test openIfChanged() when the taxonomy contains many segments
             Directory dir = NewDirectory();
 
-            DirectoryTaxonomyWriter writer = new DirectoryTaxonomyWriterAnonymousClass(this, dir);
+            var writer = new DirectoryTaxonomyWriter(dir, new TestDirectoryTaxonomyIndexWriterFactory());
             var reader = new DirectoryTaxonomyReader(writer);
 
             int numRounds = Random.Next(10) + 10;
@@ -266,17 +266,9 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             dir.Dispose();
         }
 
-        private sealed class DirectoryTaxonomyWriterAnonymousClass : DirectoryTaxonomyWriter
+        private sealed class TestDirectoryTaxonomyIndexWriterFactory : DirectoryTaxonomyIndexWriterFactory
         {
-            private readonly TestDirectoryTaxonomyReader outerInstance;
-
-            public DirectoryTaxonomyWriterAnonymousClass(TestDirectoryTaxonomyReader outerInstance, Directory dir)
-                : base(dir)
-            {
-                this.outerInstance = outerInstance;
-            }
-
-            protected override IndexWriterConfig CreateIndexWriterConfig(OpenMode openMode)
+            public override IndexWriterConfig CreateIndexWriterConfig(OpenMode openMode)
             {
                 IndexWriterConfig conf = base.CreateIndexWriterConfig(openMode);
                 LogMergePolicy lmp = (LogMergePolicy)conf.MergePolicy;
@@ -295,14 +287,9 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
             // hold onto IW to forceMerge
             // note how we don't close it, since DTW will close it.
-            IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
-                .SetMergePolicy(new LogByteSizeMergePolicy()));
-
-            // LUCENENET: We need to set the index writer before the constructor of the base class is called
-            // because the DirectoryTaxonomyWriter class constructor is the consumer of the OpenIndexWriter method.
-            // The only option seems to be to set it statically before creating the instance.
-            DirectoryTaxonomyWriterAnonymousClass2.iw = iw;
-            var writer = new DirectoryTaxonomyWriterAnonymousClass2(dir);
+            var indexWriterFactory = new TestDirectoryTaxonomyIndexWriterFactory2(Random, TEST_VERSION_CURRENT);
+            var writer = new DirectoryTaxonomyWriter(dir, indexWriterFactory);
+            Assert.NotNull(indexWriterFactory.iw, "iw should be set via DirectoryTaxonomyIndexWriter constructor calling factory");
 
             var reader = new DirectoryTaxonomyReader(writer);
             Assert.AreEqual(1, reader.Count);
@@ -311,7 +298,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             // add category and call forceMerge -- this should flush IW and merge segments down to 1
             // in ParentArray.initFromReader, this used to fail assuming there are no parents.
             writer.AddCategory(new FacetLabel("1"));
-            iw.ForceMerge(1);
+            indexWriterFactory.iw.ForceMerge(1);
 
             // now calling openIfChanged should trip on the bug
             var newtr = TaxonomyReader.OpenIfChanged(reader);
@@ -326,17 +313,29 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             dir.Dispose();
         }
 
-        private sealed class DirectoryTaxonomyWriterAnonymousClass2 : DirectoryTaxonomyWriter
+        private sealed class TestDirectoryTaxonomyIndexWriterFactory2 : DirectoryTaxonomyIndexWriterFactory
         {
-            internal static IndexWriter iw = null;
+            internal IndexWriter iw = null;
+            private readonly Random random;
+            private readonly Util.LuceneVersion luceneVersion;
 
-            public DirectoryTaxonomyWriterAnonymousClass2(Directory dir)
-                : base(dir)
+            public TestDirectoryTaxonomyIndexWriterFactory2(
+                Random random,
+                Util.LuceneVersion luceneVersion)
             {
+                this.random = random;
+                this.luceneVersion = luceneVersion;
             }
 
-            protected override IndexWriter OpenIndexWriter(Directory directory, IndexWriterConfig config)
+            public override IndexWriterConfig CreateIndexWriterConfig(OpenMode openMode)
             {
+                return new IndexWriterConfig(luceneVersion, new MockAnalyzer(random))
+                            .SetMergePolicy(new LogByteSizeMergePolicy());
+            }
+
+            public override IndexWriter OpenIndexWriter(Directory directory, IndexWriterConfig config)
+            {
+                iw = base.OpenIndexWriter(directory, config);
                 return iw;
             }
         }
@@ -352,15 +351,10 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
 
             // hold onto IW to forceMerge
             // note how we don't close it, since DTW will close it.
-            var iw = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(new LogByteSizeMergePolicy()));
-
-            // LUCENENET: We need to set the index writer before the constructor of the base class is called
-            // because the DirectoryTaxonomyWriter class constructor is the consumer of the OpenIndexWriter method.
-            // The only option seems to be to set it statically before creating the instance.
-            DirectoryTaxonomyWriterAnonymousClass3.iw = iw;
-            DirectoryTaxonomyWriter writer = new DirectoryTaxonomyWriterAnonymousClass3(dir);
-
-
+            var indexWriterFactory = new TestDirectoryTaxonomyIndexWriterFactory2(Random, TEST_VERSION_CURRENT);
+            DirectoryTaxonomyWriter writer = new DirectoryTaxonomyWriter(dir, indexWriterFactory);
+            Assert.NotNull(indexWriterFactory.iw, "iw should be set via DirectoryTaxonomyIndexWriter constructor calling factory");
+            
             // add a category so that the following DTR open will cause a flush and 
             // a new segment will be created
             writer.AddCategory(new FacetLabel("a"));
@@ -370,7 +364,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             Assert.AreEqual(2, reader.ParallelTaxonomyArrays.Parents.Length);
 
             // merge all the segments so that NRT reader thinks there's a change 
-            iw.ForceMerge(1);
+            indexWriterFactory.iw.ForceMerge(1);
 
             // now calling openIfChanged should trip on the wrong assert in ParetArray's ctor
             var newtr = TaxonomyReader.OpenIfChanged(reader);
@@ -383,21 +377,6 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             reader.Dispose();
             writer.Dispose();
             dir.Dispose();
-        }
-
-        private sealed class DirectoryTaxonomyWriterAnonymousClass3 : DirectoryTaxonomyWriter
-        {
-            internal static IndexWriter iw;
-
-            public DirectoryTaxonomyWriterAnonymousClass3(Directory dir)
-                : base(dir)
-            {
-            }
-
-            protected override IndexWriter OpenIndexWriter(Directory directory, IndexWriterConfig config)
-            {
-                return iw;
-            }
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -125,7 +125,7 @@ namespace Lucene.Net.Replicator
         private IReplicationHandler handler;
         private IndexWriter publishIndexWriter;
         private DirectoryTaxonomyWriter publishTaxoWriter;
-        private IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory publishTaxoWriterFactory;
+        private SnapshotDirectoryTaxonomyIndexWriterFactory publishTaxoWriterFactory;
         private FacetsConfig config;
         private IndexAndTaxonomyReadyCallback callback;
         private DirectoryInfo clientWorkDir;
@@ -209,7 +209,7 @@ namespace Lucene.Net.Replicator
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, null);
             conf.IndexDeletionPolicy = new SnapshotDeletionPolicy(conf.IndexDeletionPolicy);
             publishIndexWriter = new IndexWriter(publishIndexDir, conf);
-            publishTaxoWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            publishTaxoWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
             publishTaxoWriter = new DirectoryTaxonomyWriter(publishTaxoDir, publishTaxoWriterFactory);
             config = new FacetsConfig();
             config.SetHierarchical("A", true);

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -124,7 +124,8 @@ namespace Lucene.Net.Replicator
         private ReplicationClient client;
         private IReplicationHandler handler;
         private IndexWriter publishIndexWriter;
-        private IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter publishTaxoWriter;
+        private DirectoryTaxonomyWriter publishTaxoWriter;
+        private IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory publishTaxoWriterFactory;
         private FacetsConfig config;
         private IndexAndTaxonomyReadyCallback callback;
         private DirectoryInfo clientWorkDir;
@@ -180,7 +181,7 @@ namespace Lucene.Net.Replicator
             });
             publishIndexWriter.Commit();
             publishTaxoWriter.Commit();
-            return new IndexAndTaxonomyRevision(publishIndexWriter, publishTaxoWriter);
+            return new IndexAndTaxonomyRevision(publishIndexWriter, publishTaxoWriterFactory);
         }
 
         private Document NewDocument(ITaxonomyWriter taxoWriter, int id)
@@ -208,7 +209,8 @@ namespace Lucene.Net.Replicator
             IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, null);
             conf.IndexDeletionPolicy = new SnapshotDeletionPolicy(conf.IndexDeletionPolicy);
             publishIndexWriter = new IndexWriter(publishIndexDir, conf);
-            publishTaxoWriter = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter(publishTaxoDir);
+            publishTaxoWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            publishTaxoWriter = new DirectoryTaxonomyWriter(publishTaxoDir, publishTaxoWriterFactory);
             config = new FacetsConfig();
             config.SetHierarchical("A", true);
         }

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -124,6 +124,8 @@ namespace Lucene.Net.Replicator
         private ReplicationClient client;
         private IReplicationHandler handler;
         private IndexWriter publishIndexWriter;
+        // LUCENENET specific - we use a SnapshotDirectoryTaxonomyWriterFactory as that's
+        // what is being used to customize the taxonomy writer now.
         private DirectoryTaxonomyWriter publishTaxoWriter;
         private SnapshotDirectoryTaxonomyIndexWriterFactory publishTaxoWriterFactory;
         private FacetsConfig config;
@@ -210,7 +212,7 @@ namespace Lucene.Net.Replicator
             conf.IndexDeletionPolicy = new SnapshotDeletionPolicy(conf.IndexDeletionPolicy);
             publishIndexWriter = new IndexWriter(publishIndexDir, conf);
             publishTaxoWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
-            publishTaxoWriter = new DirectoryTaxonomyWriter(publishTaxoDir, publishTaxoWriterFactory);
+            publishTaxoWriter = new DirectoryTaxonomyWriter(publishTaxoWriterFactory, publishTaxoDir);
             config = new FacetsConfig();
             config.SetHierarchical("A", true);
         }

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyRevisionTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyRevisionTest.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Documents;
 using Lucene.Net.Facet;
 using Lucene.Net.Facet.Taxonomy;
+using Lucene.Net.Facet.Taxonomy.Directory;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
@@ -48,10 +49,11 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
-            IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter taxoWriter = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter(taxoDir);
+            var indexWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
             try
             {
-                assertNotNull(new IndexAndTaxonomyRevision(indexWriter, taxoWriter));
+                assertNotNull(new IndexAndTaxonomyRevision(indexWriter, indexWriterFactory));
                 fail("should have failed when there are no commits to snapshot");
             }
             catch (Exception e) when (e.IsIllegalStateException())
@@ -73,23 +75,24 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
-            IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter taxoWriter = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter(taxoDir);
+            var indexWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
             try
             {
                 indexWriter.AddDocument(NewDocument(taxoWriter));
                 indexWriter.Commit();
                 taxoWriter.Commit();
-                IRevision rev1 = new IndexAndTaxonomyRevision(indexWriter, taxoWriter);
+                IRevision rev1 = new IndexAndTaxonomyRevision(indexWriter, indexWriterFactory);
                 // releasing that revision should not delete the files
                 rev1.Release();
                 assertTrue(SlowFileExists(indexDir, IndexFileNames.SEGMENTS + "_1"));
                 assertTrue(SlowFileExists(taxoDir, IndexFileNames.SEGMENTS + "_1"));
 
-                rev1 = new IndexAndTaxonomyRevision(indexWriter, taxoWriter); // create revision again, so the files are snapshotted
+                rev1 = new IndexAndTaxonomyRevision(indexWriter, indexWriterFactory); // create revision again, so the files are snapshotted
                 indexWriter.AddDocument(NewDocument(taxoWriter));
                 indexWriter.Commit();
                 taxoWriter.Commit();
-                assertNotNull(new IndexAndTaxonomyRevision(indexWriter, taxoWriter));
+                assertNotNull(new IndexAndTaxonomyRevision(indexWriter, indexWriterFactory)); // this should not fail, since there is a commit
                 rev1.Release(); // this release should trigger the delete of segments_1
                 assertFalse(SlowFileExists(indexDir, IndexFileNames.SEGMENTS + "_1"));
             }
@@ -108,13 +111,14 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
-            IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter taxoWriter = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter(taxoDir);
+            var indexWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
             try
             {
                 indexWriter.AddDocument(NewDocument(taxoWriter));
                 indexWriter.Commit();
                 taxoWriter.Commit();
-                IRevision rev = new IndexAndTaxonomyRevision(indexWriter, taxoWriter);
+                IRevision rev = new IndexAndTaxonomyRevision(indexWriter, indexWriterFactory);
                 var sourceFiles = rev.SourceFiles;
                 assertEquals(2, sourceFiles.Count);
                 foreach (var files in sourceFiles.Values)
@@ -138,13 +142,14 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
-            IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter taxoWriter = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter(taxoDir);
+            var indexWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
             try
             {
                 indexWriter.AddDocument(NewDocument(taxoWriter));
                 indexWriter.Commit();
                 taxoWriter.Commit();
-                IRevision rev = new IndexAndTaxonomyRevision(indexWriter, taxoWriter);
+                IRevision rev = new IndexAndTaxonomyRevision(indexWriter, indexWriterFactory);
                 foreach (var e in rev.SourceFiles)
                 {
                     string source = e.Key;

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyRevisionTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyRevisionTest.cs
@@ -49,8 +49,9 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
+            // LUCENENET specific - changed to use SnapshotDirectoryTaxonomyWriterFactory
             var indexWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
-            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
+            var taxoWriter = new DirectoryTaxonomyWriter(indexWriterFactory, taxoDir);
             try
             {
                 assertNotNull(new IndexAndTaxonomyRevision(indexWriter, indexWriterFactory));
@@ -75,8 +76,9 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
+            // LUCENENET specific - changed to use SnapshotDirectoryTaxonomyWriterFactory
             var indexWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
-            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
+            var taxoWriter = new DirectoryTaxonomyWriter(indexWriterFactory, taxoDir);
             try
             {
                 indexWriter.AddDocument(NewDocument(taxoWriter));
@@ -111,8 +113,9 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
+            // LUCENENET specific - changed to use SnapshotDirectoryTaxonomyWriterFactory
             var indexWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
-            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
+            var taxoWriter = new DirectoryTaxonomyWriter(indexWriterFactory, taxoDir);
             try
             {
                 indexWriter.AddDocument(NewDocument(taxoWriter));
@@ -142,8 +145,9 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
+            // LUCENENET specific - changed to use SnapshotDirectoryTaxonomyWriterFactory
             var indexWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
-            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
+            var taxoWriter = new DirectoryTaxonomyWriter(indexWriterFactory, taxoDir);
             try
             {
                 indexWriter.AddDocument(NewDocument(taxoWriter));

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyRevisionTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyRevisionTest.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
-            var indexWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            var indexWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
             try
             {
@@ -75,7 +75,7 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
-            var indexWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            var indexWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
             try
             {
@@ -111,7 +111,7 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
-            var indexWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            var indexWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
             try
             {
@@ -142,7 +142,7 @@ namespace Lucene.Net.Replicator
             IndexWriter indexWriter = new IndexWriter(indexDir, conf);
 
             Directory taxoDir = NewDirectory();
-            var indexWriterFactory = new IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyIndexWriterFactory();
+            var indexWriterFactory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
             var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, indexWriterFactory);
             try
             {


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

Here we are changing DirectoryTaxonomyWriter to use DirectoryTaxonomyIndexWriterFactory class that will create config and writer. The factor class can be subclassed and a different implementation provided and used by either DirectoryTaxonomyWriter subclasses or just passed to the class itself.

We are also adjusting DirectoryTaxonomyReader to use DirectoryTaxonomyIndexReaderFactory class that will open index reader while also providing a way for users to customize the reader that's opened in any way they want.

The two areas impacted by this: Facets and Replication. Both had a few subclasses that injected custom behavior and were adjusted to use factory approach.