### PR TITLE
Suppress virtual method call from the constructor warning for AddCategory call

### DIFF
--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -10,6 +10,7 @@ using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace Lucene.Net.Facet.Taxonomy.Directory
@@ -188,6 +189,10 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// <summary>
         /// Construct a Taxonomy writer.
         /// </summary>
+        /// <para />
+        /// NOTE to inheritors: This constructor in some cases can call AddCategory to add the root category
+        /// (e.g. if the index is empty). Therefore, if you override the AddCategory method, you should be aware
+        /// that it will be called from this constructor and some of your state might not be fully initialized at that time.
         /// <param name="directory">
         ///    The <see cref="Store.Directory"/> in which to store the taxonomy. Note that
         ///    the taxonomy is written directly to that directory (not to a
@@ -218,6 +223,8 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         /// <exception cref="IOException">
         ///     if another error occurred. </exception>
         /// <exception cref="ArgumentNullException"> if <paramref name="indexWriterFactory"/> is <c>null</c> </exception>
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "Required for continuity with Lucene's design")]
         public DirectoryTaxonomyWriter(DirectoryTaxonomyIndexWriterFactory indexWriterFactory, Directory directory,
             OpenMode openMode, ITaxonomyWriterCache cache)
         {
@@ -517,6 +524,11 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             }
         }
 
+        /// <summary>
+        /// NOTE to inheritors: This method can be called from the constructor to add the root category
+        /// (e.g. if the index is empty). Therefore, if you override the AddCategory method, you should be aware
+        /// that it will be called before your state is fully initialized.
+        /// </summary>
         public virtual int AddCategory(FacetLabel categoryPath)
         {
             EnsureOpen();


### PR DESCRIPTION
Continuation of fixes with virtual calls being made from constructors. The issue originally reported by SonarCloud scans: https://sonarcloud.io/project/issues?resolved=false&rules=csharpsquid%3AS1699&id=apache_lucenenet and referenced in this issue: https://github.com/apache/lucenenet/issues/670

This takes care of what should be the last issue in this area. We already modified DirectoryTaxonomyWriter to accept a factory for index writer and now the last remaining virtual call it makes is to AddCategory in case an empty/new taxonomy directory is being created.

There does not appear to be an easy way to translate this into a factory that makes a logical sense.

I considered adding a private AddCategory method that constructor and AddCategory could call, but it seemed like it would prevent the subclasses to completely intercept and modify the root category AddCategory call. Instead, went with the comments to warn the users about what is happening. I think a subclass has an option to do something like capture an attempt to add root category (easy to detect if it is root by ID), and save it to be written later (e.g. post constructor run from its own constructor).