### PR TITLE
SWEEP: Lucene.Net.Store: Fixed several Dispose() methods so they are safe to be called multiple times

### DIFF
--- a/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
@@ -1,6 +1,7 @@
 ﻿// Lucene version compatibility level 8.2.0
 // LUCENENET NOTE: This class now exists both here and in Lucene.Net.Tests
 using J2N.Threading;
+using Lucene.Net.Attributes;
 using Lucene.Net.Index;
 using Lucene.Net.Support;
 using Lucene.Net.Util;
@@ -453,6 +454,18 @@ namespace Lucene.Net.Store
             Assert.Throws<ObjectDisposedException>(() => {
                 dir.CreateOutput("test", NewIOContext(Random));
             });
+        }
+
+        /// <summary>
+        /// Make sure directory allows double-dispose as per the
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/dispose-pattern">dispose pattern docs</a>.
+        /// </summary>
+        [Test]
+        [LuceneNetSpecific] // GH-841, GH-265
+        public virtual void TestDoubleDispose()
+        {
+            using Directory dir = GetDirectory(CreateTempDir("testDoubleDispose"));
+            Assert.DoesNotThrow(() => dir.Dispose());
         }
 
         //        private class ListAllThread : ThreadJob

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -1399,17 +1399,16 @@ namespace Lucene.Net.Store
                 this.delegateHandle = delegateHandle;
             }
 
-            private int disposed = 0;
+            private int disposed = 0; // LUCENENET specific - allow double-dispose
 
             protected override void Dispose(bool disposing)
             {
-                if (0 == Interlocked.CompareExchange(ref this.disposed, 1, 0))
+                if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
+                if (disposing)
                 {
-                    if (disposing)
-                    {
-                        delegateHandle.Dispose();
-                        outerInstance.RemoveOpenFile(this, name);
-                    }
+                    delegateHandle.Dispose();
+                    outerInstance.RemoveOpenFile(this, name);
                 }
             }
 

--- a/src/Lucene.Net.Tests.TestFramework/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Support/TestApiConsistency.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Tests.TestFramework
         [TestCase(typeof(Lucene.Net.RandomExtensions))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly, @"ApiScanTestBase|TestUtil\.MaxRecursionBound|Assert\.FailureFormat|Lucene\.Net\.Util\.RandomizedContext\.RandomizedContextPropertyName|Lucene\.Net\.Util\.DefaultNamespaceTypeWrapper\.AllMembers");
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"ApiScanTestBase|TestUtil\.MaxRecursionBound|Assert\.FailureFormat|Lucene\.Net\.Util\.RandomizedContext\.RandomizedContextPropertyName|Lucene\.Net\.Util\.DefaultNamespaceTypeWrapper\.AllMembers|^Lucene\.Net\.Store\.BaseDirectoryWrapper\.(?:True|False)");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests/Store/TestDirectory.cs
+++ b/src/Lucene.Net.Tests/Store/TestDirectory.cs
@@ -57,6 +57,20 @@ namespace Lucene.Net.Store
             }
         }
 
+        [Test]
+        [LuceneNetSpecific] // GH-841, GH-265
+        public virtual void TestDoubleDispose()
+        {
+            DirectoryInfo tempDir = CreateTempDir(GetType().Name);
+            Directory[] dirs = new Directory[] { new RAMDirectory(), new SimpleFSDirectory(tempDir), new NIOFSDirectory(tempDir) };
+
+            foreach (Directory dir in dirs)
+            {
+                Assert.DoesNotThrow(() => dir.Dispose());
+                Assert.DoesNotThrow(() => dir.Dispose());
+            }
+        }
+
         // test is occasionally very slow, i dont know why
         // try this seed: 7D7E036AD12927F5:93333EF9E6DE44DE
         [Test]

--- a/src/Lucene.Net.Tests/Store/TestNRTCachingDirectory.cs
+++ b/src/Lucene.Net.Tests/Store/TestNRTCachingDirectory.cs
@@ -5,6 +5,7 @@ using System.IO;
 using JCG = J2N.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
+using Lucene.Net.Attributes;
 
 namespace Lucene.Net.Store
 {
@@ -201,6 +202,18 @@ namespace Lucene.Net.Store
             Assert.AreEqual("d.xyz", cfr.ListAll()[0]);
             cfr.Dispose();
             newDir.Dispose();
+        }
+
+        /// <summary>
+        /// Make sure directory allows double-dispose as per the
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/dispose-pattern">dispose pattern docs</a>.
+        /// </summary>
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestDoubleDispose()
+        {
+            using Directory newDir = new NRTCachingDirectory(NewDirectory(), 2.0, 25.0);
+            Assert.DoesNotThrow(() => newDir.Dispose());
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests/Support/TestApiConsistency.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net
         [TestCase(typeof(Lucene.Net.Analysis.Analyzer))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:ConcurrentHashSet|PlatformHelper|DateTimeOffsetUtil|Arrays|IO\.FileSupport)|^Lucene\.ExceptionExtensions|^Lucene\.Net\.Util\.Constants\.MaxStackByteLimit|^Lucene\.Net\.Search\.TopDocs\.ShardByteSize");
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"^Lucene\.Net\.Support\.(?:ConcurrentHashSet|PlatformHelper|DateTimeOffsetUtil|Arrays|IO\.FileSupport)|^Lucene\.ExceptionExtensions|^Lucene\.Net\.Util\.Constants\.MaxStackByteLimit|^Lucene\.Net\.Search\.TopDocs\.ShardByteSize|^Lucene\.Net\.Store\.BaseDirectory\.(?:True|False)");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net/Store/CompoundFileDirectory.cs
+++ b/src/Lucene.Net/Store/CompoundFileDirectory.cs
@@ -286,17 +286,15 @@ namespace Lucene.Net.Store
 
         protected override void Dispose(bool disposing)
         {
+            // allow double close - usually to be consistent with other closeables
+            if (!CompareAndSetIsOpen(expect: true, update: false)) return; // already closed
+
             UninterruptableMonitor.Enter(this);
             try
             {
                 if (disposing)
                 {
-                    if (!IsOpen)
-                    {
-                        // allow double close - usually to be consistent with other closeables
-                        return; // already closed
-                    }
-                    IsOpen = false;
+                    // LUCENENET: Moved double-dispose logic outside of lock.
                     if (writer != null)
                     {
                         if (Debugging.AssertsEnabled) Debugging.Assert(openForWrite);
@@ -455,6 +453,7 @@ namespace Lucene.Net.Store
 
             protected override void Dispose(bool disposing)
             {
+                // LUCENENET: Intentionally blank
             }
 
             public override IndexInput OpenSlice(string sliceDescription, long offset, long length)

--- a/src/Lucene.Net/Store/Directory.cs
+++ b/src/Lucene.Net/Store/Directory.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 
 namespace Lucene.Net.Store
 {
@@ -253,6 +254,7 @@ namespace Lucene.Net.Store
         private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly IndexInput @base;
+            private int disposed = 0; // LUCENENET specific - allow double-dispose
 
             public IndexInputSlicerAnonymousClass(IndexInput @base)
             {
@@ -266,6 +268,8 @@ namespace Lucene.Net.Store
 
             protected override void Dispose(bool disposing)
             {
+                if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
                 if (disposing)
                 {
                     @base.Dispose();
@@ -323,6 +327,7 @@ namespace Lucene.Net.Store
             private IndexInput @base;
             private long fileOffset;
             private long length;
+            private int disposed = 0; // LUCENENET specific - allow double-dispose
 
             internal SlicedIndexInput(string sliceDescription, IndexInput @base, long fileOffset, long length)
                 : this(sliceDescription, @base, fileOffset, length, BufferedIndexInput.BUFFER_SIZE)
@@ -377,6 +382,8 @@ namespace Lucene.Net.Store
             /// </summary>
             protected override void Dispose(bool disposing)
             {
+                if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
                 if (disposing)
                 {
                     @base.Dispose();

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -423,10 +423,7 @@ namespace Lucene.Net.Store
         /// Closes the store to future operations. </summary>
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                IsOpen = false;
-            }
+            IsOpen = false; // LUCENENET: Since there is nothing else to do here, we can safely call this. If we have other stuff to dispose, change to if (!CompareAndSetIsOpen(expect: true, update: false)) return;
         }
 
         /// <summary> the underlying filesystem directory </summary>

--- a/src/Lucene.Net/Store/InputStreamDataInput.cs
+++ b/src/Lucene.Net/Store/InputStreamDataInput.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 
 namespace Lucene.Net.Store
 {
@@ -26,6 +27,7 @@ namespace Lucene.Net.Store
     public class InputStreamDataInput : DataInput, IDisposable
     {
         private readonly Stream _is;
+        private int disposed = 0; // LUCENENET specific - allow double-dispose
 
         public InputStreamDataInput(Stream @is)
         {
@@ -65,6 +67,8 @@ namespace Lucene.Net.Store
 
         protected virtual void Dispose(bool disposing)
         {
+            if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
             if (disposing)
             {
                 _is.Dispose();

--- a/src/Lucene.Net/Store/MMapDirectory.cs
+++ b/src/Lucene.Net/Store/MMapDirectory.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Diagnostics;
 using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
+using System.Threading;
 
 namespace Lucene.Net.Store
 {
@@ -196,8 +197,8 @@ namespace Lucene.Net.Store
         private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly MMapDirectory outerInstance;
-
             private readonly MMapIndexInput full;
+            private int disposed = 0; // LUCENENET specific - allow double-dispose
 
             public IndexInputSlicerAnonymousClass(MMapDirectory outerInstance, MMapIndexInput full)
             {
@@ -220,6 +221,8 @@ namespace Lucene.Net.Store
 
             protected override void Dispose(bool disposing)
             {
+                if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
                 if (disposing)
                 {
                     full.Dispose();
@@ -231,6 +234,7 @@ namespace Lucene.Net.Store
         {
             internal MemoryMappedFile memoryMappedFile; // .NET port: this is equivalent to FileChannel.map
             private readonly FileStream fc;
+            private int disposed = 0; // LUCENENET specific - allow double-dispose
 
             internal MMapIndexInput(MMapDirectory outerInstance, string resourceDescription, FileStream fc)
                 : base(resourceDescription, null, fc.Length, outerInstance.chunkSizePower, true)
@@ -241,6 +245,8 @@ namespace Lucene.Net.Store
 
             protected override sealed void Dispose(bool disposing)
             {
+                if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
                 try
                 {
                     if (disposing)

--- a/src/Lucene.Net/Store/NIOFSDirectory.cs
+++ b/src/Lucene.Net/Store/NIOFSDirectory.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Diagnostics;
 using Lucene.Net.Support.IO;
 using System;
 using System.IO;
+using System.Threading;
 
 namespace Lucene.Net.Store
 {
@@ -119,6 +120,7 @@ namespace Lucene.Net.Store
             private readonly IOContext context;
             private readonly FileInfo path;
             private readonly FileStream descriptor;
+            private int disposed = 0; // LUCENENET specific - allow double-dispose
 
             public IndexInputSlicerAnonymousClass(IOContext context, FileInfo path, FileStream descriptor)
             {
@@ -129,6 +131,8 @@ namespace Lucene.Net.Store
 
             protected override void Dispose(bool disposing)
             {
+                if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
                 if (disposing)
                 {
                     descriptor.Dispose();
@@ -184,6 +188,8 @@ namespace Lucene.Net.Store
 
             private ByteBuffer byteBuf; // wraps the buffer for NIO
 
+            private int disposed = 0; // LUCENENET specific - allow double-dispose
+
             public NIOFSIndexInput(string resourceDesc, FileStream fc, IOContext context)
                 : base(resourceDesc, context)
             {
@@ -203,6 +209,8 @@ namespace Lucene.Net.Store
 
             protected override void Dispose(bool disposing)
             {
+                if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
                 if (disposing && !isClone)
                 {
                     m_channel.Dispose();

--- a/src/Lucene.Net/Store/OutputStreamDataOutput.cs
+++ b/src/Lucene.Net/Store/OutputStreamDataOutput.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 
 namespace Lucene.Net.Store
 {
@@ -26,6 +27,7 @@ namespace Lucene.Net.Store
     public class OutputStreamDataOutput : DataOutput, IDisposable
     {
         private readonly Stream _os;
+        private int disposed = 0; // LUCENENET specific - allow double-dispose
 
         public OutputStreamDataOutput(Stream os)
         {
@@ -60,6 +62,8 @@ namespace Lucene.Net.Store
         // LUCENENET specific - implemented proper dispose pattern
         protected virtual void Dispose(bool disposing)
         {
+            if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
             if (disposing)
             {
                 _os.Dispose();

--- a/src/Lucene.Net/Store/RAMDirectory.cs
+++ b/src/Lucene.Net/Store/RAMDirectory.cs
@@ -217,9 +217,11 @@ namespace Lucene.Net.Store
         /// Closes the store to future operations, releasing associated memory. </summary>
         protected override void Dispose(bool disposing)
         {
+            if (!CompareAndSetIsOpen(expect: true, update: false)) return; // LUCENENET: allow dispose more than once as per https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/dispose-pattern
+
             if (disposing)
             {
-                IsOpen = false;
+                // LUCENENET: Removed setter for isOpen and put it above in the if check so it is atomic
                 m_fileMap.Clear();
             }
         }

--- a/src/Lucene.Net/Store/SimpleFSDirectory.cs
+++ b/src/Lucene.Net/Store/SimpleFSDirectory.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Support.Threading;
 using System;
 using System.IO;
+using System.Threading;
 
 namespace Lucene.Net.Store
 {
@@ -115,6 +116,7 @@ namespace Lucene.Net.Store
             private readonly IOContext context;
             private readonly FileInfo file;
             private readonly FileStream descriptor;
+            private int disposed = 0; // LUCENENET specific - allow double-dispose
 
             public IndexInputSlicerAnonymousClass(IOContext context, FileInfo file, FileStream descriptor)
             {
@@ -125,6 +127,8 @@ namespace Lucene.Net.Store
 
             protected override void Dispose(bool disposing)
             {
+                if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
                 if (disposing)
                 {
                     descriptor.Dispose();
@@ -156,6 +160,8 @@ namespace Lucene.Net.Store
         /// </summary>
         protected internal class SimpleFSIndexInput : BufferedIndexInput
         {
+            private int disposed = 0; // LUCENENET specific - allow double-dispose
+
             // LUCENENET specific: chunk size not needed
             ///// <summary>
             ///// The maximum chunk size is 8192 bytes, because <seealso cref="RandomAccessFile"/> mallocs
@@ -199,6 +205,8 @@ namespace Lucene.Net.Store
 
             protected override void Dispose(bool disposing)
             {
+                if (0 != Interlocked.CompareExchange(ref this.disposed, 1, 0)) return; // LUCENENET specific - allow double-dispose
+
                 if (disposing && !IsClone)
                 {
                     m_file.Dispose();


### PR DESCRIPTION
Fixes #841. Part of #265.

This adds an atomic `CompareAndSetIsOpen(bool expect, bool update)` method to `BaseDirectory` and `BaseDirectoryWrapper` that can be used to ensure only a single call to `Dispose(bool)` will succeed. This is the same method signature as `J2N.Threading.Atomic.AtomicBoolean` and can be used the same way (without the extra heap allocation).

```c#
protected override void Dispose(bool disposing)
{
    if (!CompareAndSetIsOpen(expect: true, update: false)) return;

    // Dispose unmanaged resources
    if (disposing)
    {
        // Dispose managed resources
    }
}
```

This fixes `NRTCachingDirectory` (as well as all other directories) so they don't throw exceptions when `Dispose()` is called multiple times.

This of course means that `EnsureOpen()` will be active immediately when `Dispose()` is first called, so be mindful of its usage when the `Dispose()` method needs to call local methods to clean up.

