### PR TITLE
ci: Update action versions

### DIFF
--- a/.github/workflows/Generate-TestWorkflows.ps1
+++ b/.github/workflows/Generate-TestWorkflows.ps1
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -283,19 +283,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '$DotNet5SDKVersion'
         if: `${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '$DotNet6SDKVersion'
         if: `${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '$DotNet7SDKVersion'
 
@@ -327,7 +327,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: `${{always()}}
         with:
           name: '`${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Documentation.yml
+++ b/.github/workflows/Lucene-Net-Documentation.yml
@@ -57,7 +57,7 @@ jobs:
 
       # Checkout the main repo with all history so we get all tags
       - name: Checkout Lucene.Net source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: main-repo
           fetch-depth: 0
@@ -119,7 +119,7 @@ jobs:
         shell: powershell
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.101'
 
@@ -128,7 +128,7 @@ jobs:
         shell: powershell
 
       - name: Checkout Lucene.Net website
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.SITE_REPO }}
           ref: asf-site
@@ -142,7 +142,7 @@ jobs:
       # Because we are always building the docs against a consistent version
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.LUCENE_NET_WEBSITE_BUILD }}
           path: website-repo

--- a/.github/workflows/Lucene-Net-Tests-AllProjects.yml
+++ b/.github/workflows/Lucene-Net-Tests-AllProjects.yml
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -101,19 +101,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -137,7 +137,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Common.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Common.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -85,19 +85,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -121,7 +121,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Kuromoji.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Kuromoji.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -82,19 +82,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -118,7 +118,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Morfologik.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Morfologik.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -82,19 +82,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -118,7 +118,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Analysis-OpenNLP.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-OpenNLP.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -85,19 +85,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -121,7 +121,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Phonetic.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Phonetic.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -79,19 +79,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -115,7 +115,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Analysis-SmartCn.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-SmartCn.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -83,19 +83,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -119,7 +119,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Stempel.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Stempel.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -80,19 +80,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -116,7 +116,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Benchmark.yml
+++ b/.github/workflows/Lucene-Net-Tests-Benchmark.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -92,19 +92,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -128,7 +128,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Classification.yml
+++ b/.github/workflows/Lucene-Net-Tests-Classification.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -80,19 +80,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -116,7 +116,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Cli.yml
+++ b/.github/workflows/Lucene-Net-Tests-Cli.yml
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -100,19 +100,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -137,7 +137,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-CodeAnalysis.yml
+++ b/.github/workflows/Lucene-Net-Tests-CodeAnalysis.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -78,19 +78,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -114,7 +114,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Codecs.yml
+++ b/.github/workflows/Lucene-Net-Tests-Codecs.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -78,19 +78,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -114,7 +114,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Demo.yml
+++ b/.github/workflows/Lucene-Net-Tests-Demo.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -87,19 +87,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -123,7 +123,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Expressions.yml
+++ b/.github/workflows/Lucene-Net-Tests-Expressions.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -80,19 +80,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -116,7 +116,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Facet.yml
+++ b/.github/workflows/Lucene-Net-Tests-Facet.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -82,19 +82,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -118,7 +118,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Grouping.yml
+++ b/.github/workflows/Lucene-Net-Tests-Grouping.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -80,19 +80,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -116,7 +116,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Highlighter.yml
+++ b/.github/workflows/Lucene-Net-Tests-Highlighter.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -82,19 +82,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -118,7 +118,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-ICU.yml
+++ b/.github/workflows/Lucene-Net-Tests-ICU.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -95,19 +95,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -131,7 +131,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Join.yml
+++ b/.github/workflows/Lucene-Net-Tests-Join.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -81,19 +81,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -117,7 +117,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Memory.yml
+++ b/.github/workflows/Lucene-Net-Tests-Memory.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -83,19 +83,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -119,7 +119,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Misc.yml
+++ b/.github/workflows/Lucene-Net-Tests-Misc.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -79,19 +79,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -115,7 +115,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Queries.yml
+++ b/.github/workflows/Lucene-Net-Tests-Queries.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -79,19 +79,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -115,7 +115,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-QueryParser.yml
+++ b/.github/workflows/Lucene-Net-Tests-QueryParser.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -85,19 +85,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -121,7 +121,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Replicator.yml
+++ b/.github/workflows/Lucene-Net-Tests-Replicator.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -84,19 +84,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -120,7 +120,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Sandbox.yml
+++ b/.github/workflows/Lucene-Net-Tests-Sandbox.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -80,19 +80,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -116,7 +116,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Spatial.yml
+++ b/.github/workflows/Lucene-Net-Tests-Spatial.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -81,19 +81,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -117,7 +117,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-Suggest.yml
+++ b/.github/workflows/Lucene-Net-Tests-Suggest.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -82,19 +82,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -118,7 +118,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-TestFramework-DependencyInjection.yml
+++ b/.github/workflows/Lucene-Net-Tests-TestFramework-DependencyInjection.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -78,19 +78,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -114,7 +114,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-TestFramework.yml
+++ b/.github/workflows/Lucene-Net-Tests-TestFramework.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -80,19 +80,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -116,7 +116,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-_A-D.yml
+++ b/.github/workflows/Lucene-Net-Tests-_A-D.yml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -89,19 +89,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -125,7 +125,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-_E-I.yml
+++ b/.github/workflows/Lucene-Net-Tests-_E-I.yml
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -99,19 +99,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -135,7 +135,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-_I-J.yml
+++ b/.github/workflows/Lucene-Net-Tests-_I-J.yml
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -104,19 +104,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -140,7 +140,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-_J-S.yml
+++ b/.github/workflows/Lucene-Net-Tests-_J-S.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -91,19 +91,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -127,7 +127,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Tests-_T-Z.yml
+++ b/.github/workflows/Lucene-Net-Tests-_T-Z.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Disable .NET SDK Telemetry and Logo
         run: |
@@ -86,19 +86,19 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET 5 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.400'
         if: ${{ startswith(matrix.framework, 'net5.') }}
 
       - name: Setup .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.403'
         if: ${{ startswith(matrix.framework, 'net6.') }}
 
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.100'
 
@@ -122,7 +122,7 @@ jobs:
         shell: bash
       # upload reports as build artifacts
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{always()}}
         with:
           name: '${{env.test_results_artifact_name}}'

--- a/.github/workflows/Lucene-Net-Website.yml
+++ b/.github/workflows/Lucene-Net-Website.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Checkout the main repo with all history so we get all tags
       - name: Checkout Lucene.Net source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: main-repo
           fetch-depth: 0
@@ -106,7 +106,7 @@ jobs:
         shell: powershell
 
       - name: Checkout Lucene.Net website
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.SITE_REPO }}
           ref: asf-site
@@ -118,7 +118,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.LUCENE_NET_WEBSITE_BUILD }}
           path: website-repo

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -35,15 +35,15 @@ jobs:
           echo "DOTNET_CLI_TELEMETRY_OPTOUT=1" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
       - name: Setup .NET 7 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Cache SonarCloud packages

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -70,6 +70,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"apache_lucenenet" /o:"apache" /d:sonar.login="${{ secrets.SONARCLOUD_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"apache_lucenenet" /o:"apache" /d:sonar.token="${{ secrets.SONARCLOUD_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
           dotnet build
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONARCLOUD_TOKEN }}"
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONARCLOUD_TOKEN }}"


### PR DESCRIPTION
I noticed that the action versions that are being used are a bit outdated so I've updated them to the newest versions. As far as I could see there shouldn't be any breaking changes that should break any of the actions.

![image](https://github.com/apache/lucenenet/assets/24605285/155f0fbe-9c0b-42a9-9243-cc570b56736b)


This also updates the Sonar action based on this warning.
![image](https://github.com/apache/lucenenet/assets/24605285/f6b80e4a-0b5c-47ef-94c6-3eda642f16d7)
