### PR TITLE
Lucene.Net.Util.PriorityQueue: Removed [Serializable] attribute. 

### DIFF
--- a/src/Lucene.Net.Tests/Util/TestPriorityQueue.cs
+++ b/src/Lucene.Net.Tests/Util/TestPriorityQueue.cs
@@ -1191,32 +1191,6 @@ namespace Lucene.Net.Util
             pq.Clear();
         }
 
-#if FEATURE_SERIALIZABLE
-
-        [Test, LuceneNetSpecific]
-        public void TestSerialization()
-        {
-            var queue = new IntegerQueue(10);
-            var expected = new int?[11];
-
-            for (int i = 0; i < 10; i++)
-            {
-                queue.Add(i);
-                expected[i + 1] = i;
-            }
-
-            Assert.AreEqual(10, queue.maxSize);
-            Assert.AreEqual(expected, queue.heap);
-            Assert.AreEqual(10, queue.Count);
-
-            var clone = Clone(queue);
-
-            Assert.AreEqual(10, clone.maxSize);
-            Assert.AreEqual(expected, clone.heap);
-            Assert.AreEqual(10, clone.Count);
-        }
-#endif
-
         private static int GetArrayHeapSize(int maxSize)
         {
             return PriorityQueue.GetArrayHeapSize(maxSize);

--- a/src/Lucene.Net/Util/PriorityQueue.cs
+++ b/src/Lucene.Net/Util/PriorityQueue.cs
@@ -482,9 +482,6 @@ namespace Lucene.Net.Util
     /// <para/>
     /// @lucene.internal
     /// </summary>
-#if FEATURE_SERIALIZABLE
-    [Serializable]
-#endif
     public abstract class PriorityQueue<T>
     {
         private int size = 0;


### PR DESCRIPTION
Binary serialization is obsolete in .NET 6+, and serialization didn't technically support extension because it was missing the virtual GetObjectData and OnDeserialization methods and deserialization constructor.

This fixes the SonarCloud security hotspot [Deserializing objects without performing data validation is security-sensitive](https://sonarcloud.io/organizations/apache/rules?open=csharpsquid%3AS5766&rule_key=csharpsquid%3AS5766).