### PR TITLE
Lucene.Net.Util.OfflineSorter::DEFAULT_TEMP_DIR: Added suppression for SonarCloud S5443

### DIFF
--- a/src/Lucene.Net/Util/OfflineSorter.cs
+++ b/src/Lucene.Net/Util/OfflineSorter.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Support.IO;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -219,6 +220,8 @@ namespace Lucene.Net.Util
         /// <summary>
         /// LUCENENET specific - cache the temp directory path so we can return it from a property.
         /// </summary>
+        [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
+        [SuppressMessage("Security Hotspot", "S5443:Using publicly writable directories is security-sensitive", Justification = "Temp file names are chosen at random so they cannot be guessed by malicous users")]
         private static readonly string DEFAULT_TEMP_DIR = Path.GetTempPath();
 
         /// <summary>


### PR DESCRIPTION
Suppressed SonarCloud security hotspot S5443 [Using publicly writable directories is security-sensitive](https://sonarcloud.io/organizations/apache/rules?open=csharpsquid%3AS5443&rule_key=csharpsquid%3AS5443) because we are not writing predictable temp file names and allow using a different directory.