### PR TITLE
.build/dependencies.props: Upgraded TimeZoneConverter to 6.1.0. 

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -81,6 +81,6 @@
     <SystemSecurityCryptographyXmlPackageVersion>4.7.0</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>4.3.0</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion Condition=" '$(TargetFramework)' == 'net461' ">5.0.0</SystemTextEncodingCodePagesPackageVersion>
-    <TimeZoneConverterPackageVersion>3.5.0</TimeZoneConverterPackageVersion>
+    <TimeZoneConverterPackageVersion>6.1.0</TimeZoneConverterPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is only used in tests. We were getting some test failures (most likely because of incompatibilities with newer operating systems) that this upgrade resolves.
