### PR TITLE
Added net6.0 target to Lucene.Net.Analysis.OpenNLP and changed to using MavenReference

### DIFF
--- a/.build/TestReferences.Common.targets
+++ b/.build/TestReferences.Common.targets
@@ -25,8 +25,4 @@
     <PackageReference Include="NUnit" Version="$(NUnitPackageVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterPackageVersion)" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
-  </ItemGroup>
 </Project>

--- a/.build/azure-templates/publish-nuget-packages.yml
+++ b/.build/azure-templates/publish-nuget-packages.yml
@@ -1,4 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
+﻿# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -57,7 +57,7 @@ steps:
   inputs:
     command: push
     packagesToPush: '${{ parameters.nugetArtifactName }}/*.nupkg;!${{ parameters.nugetArtifactName }}/*.symbols.nupkg'
-    publishVstsFeed: '/${{ parameters.artifactFeedID }}'
+    publishVstsFeed: '${{ parameters.artifactFeedID }}'
     allowPackageConflicts: true
 
 - task: PublishSymbols@2

--- a/.build/azure-templates/publish-test-results-for-test-projects.yml
+++ b/.build/azure-templates/publish-test-results-for-test-projects.yml
@@ -102,7 +102,28 @@ steps:
     testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
     testResultsFileName: '${{ parameters.testResultsFileName }}'
 
-# Special case: Only supports net48
+# Special case: Only supports net7.0, net6.0 and net48
+
+- template: publish-test-results.yml
+  parameters:
+    testProjectName: 'Lucene.Net.Tests.Analysis.OpenNLP'
+    framework: 'net7.0' # Since condtions are not supported for templates, we check for the file existence within publish-test-results.yml
+    vsTestPlatform: '${{ parameters.vsTestPlatform }}'
+    osName: '${{ parameters.osName }}'
+    testResultsFormat: '${{ parameters.testResultsFormat }}'
+    testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
+    testResultsFileName: '${{ parameters.testResultsFileName }}'
+
+- template: publish-test-results.yml
+  parameters:
+    testProjectName: 'Lucene.Net.Tests.Analysis.OpenNLP'
+    framework: 'net6.0' # Since condtions are not supported for templates, we check for the file existence within publish-test-results.yml
+    vsTestPlatform: '${{ parameters.vsTestPlatform }}'
+    osName: '${{ parameters.osName }}'
+    testResultsFormat: '${{ parameters.testResultsFormat }}'
+    testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
+    testResultsFileName: '${{ parameters.testResultsFileName }}'
+
 - template: publish-test-results.yml
   parameters:
     testProjectName: 'Lucene.Net.Tests.Analysis.OpenNLP'

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -38,8 +38,8 @@
     <ICU4NLanguageDataPackageVersion>$(ICU4NPackageVersion)</ICU4NLanguageDataPackageVersion>
     <ICU4NRegionDataPackageVersion>$(ICU4NPackageVersion)</ICU4NRegionDataPackageVersion>
     <ICU4NTransliteratorPackageVersion>$(ICU4NPackageVersion)</ICU4NTransliteratorPackageVersion>
-    <IKVMPackageVersion>8.5.0</IKVMPackageVersion>
-    <IKVMMavenSdkPackageVersion>1.5.0-develop0024</IKVMMavenSdkPackageVersion>
+    <IKVMPackageVersion>8.7.3</IKVMPackageVersion>
+    <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <J2NPackageVersion>2.0.0</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.0.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -68,7 +68,7 @@
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
     <NUnit3TestAdapterPackageVersion>3.17.0</NUnit3TestAdapterPackageVersion>
     <NUnitPackageVersion>3.13.1</NUnitPackageVersion>
-    <OpenNLPNETPackageVersion>1.9.1.1</OpenNLPNETPackageVersion>
+    <OpenNLPNETPackageVersion>1.9.4.1</OpenNLPNETPackageVersion>
     <RandomizedTestingGeneratorsPackageVersion>2.7.8</RandomizedTestingGeneratorsPackageVersion>
     <SharpZipLibPackageVersion>1.4.2</SharpZipLibPackageVersion>
     <Spatial4nPackageVersion>0.4.1.1</Spatial4nPackageVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -86,7 +86,7 @@
     <TimeZoneConverterPackageVersion>6.1.0</TimeZoneConverterPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Maven Package Reference Versions">
-    <OpenNLPToolsMavenReferenceVersion>1.9.4</OpenNLPToolsMavenReferenceVersion>
+    <OpenNLPToolsMavenReferenceVersion>1.9.1</OpenNLPToolsMavenReferenceVersion>
     <OSGICoreMavenReferenceVersion>4.2.0</OSGICoreMavenReferenceVersion>
   </PropertyGroup>
 </Project>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -81,6 +81,7 @@
     <SystemSecurityCryptographyXmlPackageVersion>6.0.1</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>4.3.0</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion Condition=" '$(TargetFramework)' == 'net461' ">5.0.0</SystemTextEncodingCodePagesPackageVersion>
+    <SystemTextJsonPackageVersion>6.0.6</SystemTextJsonPackageVersion>
     <TimeZoneConverterPackageVersion>6.1.0</TimeZoneConverterPackageVersion>
   </PropertyGroup>
 </Project>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -38,6 +38,8 @@
     <ICU4NLanguageDataPackageVersion>$(ICU4NPackageVersion)</ICU4NLanguageDataPackageVersion>
     <ICU4NRegionDataPackageVersion>$(ICU4NPackageVersion)</ICU4NRegionDataPackageVersion>
     <ICU4NTransliteratorPackageVersion>$(ICU4NPackageVersion)</ICU4NTransliteratorPackageVersion>
+    <IKVMPackageVersion>8.5.0</IKVMPackageVersion>
+    <IKVMMavenSdkPackageVersion>1.5.0-develop0024</IKVMMavenSdkPackageVersion>
     <J2NPackageVersion>2.0.0</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.0.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
@@ -68,7 +70,6 @@
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
     <NUnit3TestAdapterPackageVersion>3.17.0</NUnit3TestAdapterPackageVersion>
     <NUnitPackageVersion>3.13.1</NUnitPackageVersion>
-    <OpenNLPNETPackageVersion>1.9.4.1</OpenNLPNETPackageVersion>
     <RandomizedTestingGeneratorsPackageVersion>2.7.8</RandomizedTestingGeneratorsPackageVersion>
     <SharpZipLibPackageVersion>1.4.2</SharpZipLibPackageVersion>
     <Spatial4nPackageVersion>0.4.1.1</Spatial4nPackageVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -72,7 +72,7 @@
     <RandomizedTestingGeneratorsPackageVersion>2.7.8</RandomizedTestingGeneratorsPackageVersion>
     <SharpZipLibPackageVersion>1.4.2</SharpZipLibPackageVersion>
     <Spatial4nPackageVersion>0.4.1.1</Spatial4nPackageVersion>
-    <SystemMemoryPackageVersion>4.5.4</SystemMemoryPackageVersion>
+    <SystemMemoryPackageVersion>4.5.5</SystemMemoryPackageVersion>
     <SystemReflectionEmitPackageVersion>4.3.0</SystemReflectionEmitPackageVersion>
     <SystemReflectionEmitILGenerationPackageVersion>4.3.0</SystemReflectionEmitILGenerationPackageVersion>
     <SystemReflectionTypeExtensionsPackageVersion>4.3.0</SystemReflectionTypeExtensionsPackageVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -76,7 +76,7 @@
     <SystemReflectionEmitPackageVersion>4.3.0</SystemReflectionEmitPackageVersion>
     <SystemReflectionEmitILGenerationPackageVersion>4.3.0</SystemReflectionEmitILGenerationPackageVersion>
     <SystemReflectionTypeExtensionsPackageVersion>4.3.0</SystemReflectionTypeExtensionsPackageVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageVersion>5.0.0</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <SystemRuntimeInteropServicesRuntimeInformationPackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationPackageVersion>
     <SystemSecurityCryptographyXmlPackageVersion>6.0.1</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>4.3.0</SystemTextEncodingCodePagesPackageVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -38,7 +38,7 @@
     <ICU4NLanguageDataPackageVersion>$(ICU4NPackageVersion)</ICU4NLanguageDataPackageVersion>
     <ICU4NRegionDataPackageVersion>$(ICU4NPackageVersion)</ICU4NRegionDataPackageVersion>
     <ICU4NTransliteratorPackageVersion>$(ICU4NPackageVersion)</ICU4NTransliteratorPackageVersion>
-    <IKVMPackageVersion>8.7.3</IKVMPackageVersion>
+    <IKVMPackageVersion>8.7.5</IKVMPackageVersion>
     <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <J2NPackageVersion>2.0.0</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -87,5 +87,6 @@
   </PropertyGroup>
   <PropertyGroup Label="Maven Package Reference Versions">
     <OpenNLPToolsMavenReferenceVersion>1.9.4</OpenNLPToolsMavenReferenceVersion>
+    <OSGICoreMavenReferenceVersion>4.2.0</OSGICoreMavenReferenceVersion>
   </PropertyGroup>
 </Project>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -85,4 +85,7 @@
     <SystemTextJsonPackageVersion>6.0.6</SystemTextJsonPackageVersion>
     <TimeZoneConverterPackageVersion>6.1.0</TimeZoneConverterPackageVersion>
   </PropertyGroup>
+  <PropertyGroup Label="Maven Package Reference Versions">
+    <OpenNLPToolsMavenReferenceVersion>1.9.4</OpenNLPToolsMavenReferenceVersion>
+  </PropertyGroup>
 </Project>

--- a/.github/workflows/Lucene-Net-Tests-Analysis-OpenNLP.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-OpenNLP.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net48]
+        framework: [net7.0, net48]
         platform: [x64]
         configuration: [Release]
         exclude:

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -128,9 +128,9 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4.5+ but not in .NET Standard 2.0 -->
+  <!-- Features in .NET Framework 4.5+ and .NET 6.0+ but not in .NET Standard 2.0 or .NET Standard 2.1 -->
   <!-- net461 is used to test .NET Standard 2.0, so we treat it like it is not part of this group -->
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) And '$(TargetFramework)' != 'net461'">
+  <PropertyGroup Condition=" ($(TargetFramework.StartsWith('net4')) And '$(TargetFramework)' != 'net461') Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.'))">
 
     <DefineConstants>$(DefineConstants);FEATURE_OPENNLP</DefineConstants>
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/TypeAsSynonymFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/TypeAsSynonymFilter.cs
@@ -1,0 +1,97 @@
+﻿// Lucene version compatibility level 8.2.0
+// LUCENENET NOTE: Ported because Lucene.Net.Analysis.OpenNLP requires this to be useful.
+using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Util;
+#nullable enable
+
+namespace Lucene.Net.Analysis.Miscellaneous
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Adds the <see cref="ITypeAttribute.Type"/> as a synonym,
+    /// i.e. another token at the same position, optionally with a specified prefix prepended.
+    /// </summary>
+    public sealed class TypeAsSynonymFilter : TokenFilter
+    {
+        private readonly ICharTermAttribute termAtt;
+        private readonly ITypeAttribute typeAtt;
+        private readonly IPositionIncrementAttribute posIncrAtt;
+        private readonly string? prefix;
+
+        private State? savedToken = null;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TypeAsSynonymFilter"/> with
+        /// the specified token stream.
+        /// </summary>
+        /// <param name="input">Input token stream.</param>
+        public TypeAsSynonymFilter(TokenStream input)
+            : this(input, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TypeAsSynonymFilter"/> with
+        /// the specified token stream and prefix.
+        /// </summary>
+        /// <param name="input">Input token stream.</param>
+        /// <param name="prefix">Prepend this string to every token type emitted as token text.
+        /// If <c>null</c>, nothing will be prepended.</param>
+        public TypeAsSynonymFilter(TokenStream input, string? prefix)
+            : base(input)
+        {
+            this.prefix = prefix;
+            termAtt = AddAttribute<ICharTermAttribute>();
+            typeAtt = AddAttribute<ITypeAttribute>();
+            posIncrAtt = AddAttribute<IPositionIncrementAttribute>();
+        }
+
+
+        public override bool IncrementToken()
+        {
+            if (savedToken != null)
+            {
+                // Emit last token's type at the same position
+                RestoreState(savedToken);
+                savedToken = null;
+                termAtt.SetEmpty();
+                if (prefix != null)
+                {
+                    termAtt.Append(prefix);
+                }
+                termAtt.Append(typeAtt.Type);
+                posIncrAtt.PositionIncrement = 0;
+                return true;
+            }
+            else if (m_input.IncrementToken())
+            {
+                // Ho pending token type to emit
+                savedToken = CaptureState();
+                return true;
+            }
+            return false;
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            savedToken = null;
+        }
+    }
+}

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/TypeAsSynonymFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/TypeAsSynonymFilterFactory.cs
@@ -1,0 +1,62 @@
+﻿// Lucene version compatibility level 8.2.0
+// LUCENENET NOTE: Ported because Lucene.Net.Analysis.OpenNLP requires this to be useful.
+using Lucene.Net.Analysis.Util;
+using System;
+using System.Collections.Generic;
+#nullable enable
+
+namespace Lucene.Net.Analysis.Miscellaneous
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Factory for <see cref="TypeAsSynonymFilter"/>.
+    /// <code>
+    /// &lt;fieldType name="text_type_as_synonym" class="solr.TextField" positionIncrementGap="100"&gt;
+    ///   &lt;analyzer&gt;
+    ///     &lt;tokenizer class="solr.UAX29URLEmailTokenizerFactory"/&gt;
+    ///     &lt;filter class="solr.TypeAsSynonymFilterFactory" prefix="_type_" /&gt;
+    ///   &lt;/analyzer&gt;
+    /// &lt;/fieldType&gt;
+    /// </code>
+    /// 
+    /// <para/>
+    /// If the optional <c>prefix</c> parameter is used, the specified value will be prepended
+    /// to the type, e.g.with prefix = "_type_", for a token "example.com" with type "&lt;URL&gt;",
+    /// the emitted synonym will have text "_type_&lt;URL&gt;".
+    /// </summary>
+    public class TypeAsSynonymFilterFactory : TokenFilterFactory
+    {
+        private readonly string prefix;
+
+        public TypeAsSynonymFilterFactory(IDictionary<string, string> args)
+            : base(args)
+        {
+            prefix = Get(args, "prefix");  // default value is null
+            if (args.Count > 0)
+            {
+                throw new ArgumentException(string.Format(J2N.Text.StringFormatter.CurrentCulture, "Unknown parameters: {0}", args));
+            }
+        }
+
+        public override TokenStream Create(TokenStream input)
+        {
+            return new TypeAsSynonymFilter(input, prefix);
+        }
+    }
+}

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -30,7 +30,7 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462;net6.0;</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp</PackageTags>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -30,7 +30,7 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0;</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp</PackageTags>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -30,7 +30,7 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp</PackageTags>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -31,6 +31,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp</PackageTags>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <MavenReference Include="org.apache.opennlp:opennlp-tools" Version="1.9.4" />
+    <MavenReference Include="org.apache.opennlp:opennlp-tools" Version="$(OpenNLPToolsMavenReferenceVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -30,7 +30,7 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp</PackageTags>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -53,6 +53,7 @@
 
   <ItemGroup>
     <MavenReference Include="org.apache.opennlp:opennlp-tools" Version="$(OpenNLPToolsMavenReferenceVersion)" />
+    <MavenReference Include="org.osgi:org.osgi.core" Version="$(OSGICoreMavenReferenceVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -30,7 +30,10 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <!-- Currently, IKVM doesn't officially support building NetFX on anything but Windows, so we skip it for contributors who may be on various platforms.
+        We can remove the condition once that has been addressed. See: https://github.com/ikvmnet/ikvm-maven/issues/49 -->
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp</PackageTags>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -40,8 +40,6 @@
     <RootNamespace>Lucene.Net.Analysis.OpenNlp</RootNamespace>
   </PropertyGroup>
 
-  
-
   <ItemGroup>
     <ProjectReference Include="..\dotnet\Lucene.Net.ICU\Lucene.Net.ICU.csproj" />
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />
@@ -50,7 +48,12 @@
 
   <ItemGroup>
     <PackageReference Include="ICU4N" Version="$(ICU4NPackageVersion)" />
-    <PackageReference Include="OpenNLP.NET" Version="$(OpenNLPNETPackageVersion)" />
+    <PackageReference Include="IKVM" Version="$(IKVMPackageVersion)" />
+    <PackageReference Include="IKVM.Maven.Sdk" Version="$(IKVMMavenSdkPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MavenReference Include="org.apache.opennlp:opennlp-tools" Version="1.9.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -31,7 +31,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net462</TargetFrameworks>
-    <TargetFrameworks>net462;net6.0;</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp</PackageTags>

--- a/src/Lucene.Net.Analysis.OpenNLP/overview.md
+++ b/src/Lucene.Net.Analysis.OpenNLP/overview.md
@@ -31,12 +31,14 @@ The OpenNLP Tokenizer behavior is similar to the <xref:Lucene.Net.Analysis.Core.
 
 The OpenNLP taggers annotate terms using the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute>.
 
-<xref:Lucene.Net.Analysis.OpenNlp.OpenNLPTokenizer> segments text into sentences or words. This Tokenizer uses the OpenNLP Sentence Detector and/or Tokenizer classes. When used together, the Tokenizer receives sentences and can do a better job.
-<xref:Lucene.Net.Analysis.OpenNlp.OpenNLPFilter> tags words using one or more technologies: Part-of-Speech, Chunking, and Named Entity Recognition. These tags are assigned as token types. Note that only one of these operations will tag
+- <xref:Lucene.Net.Analysis.OpenNlp.OpenNLPTokenizer> segments text into sentences or words. This Tokenizer uses the OpenNLP Sentence Detector and/or Tokenizer classes. When used together, the Tokenizer receives sentences and can do a better job.
+- <xref:Lucene.Net.Analysis.OpenNlp.OpenNLPPOSFilter> tags words for Part-of-Speech and <xref:Lucene.Net.Analysis.OpenNlp.OpenNLPChunkerFilter> tags words for Chunking. These tags are assigned as token types. Note that only one of these operations will tag
 Since the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> is not stored in the index, it is recommended that one of these filters is used following OpenNLPFilter to enable search against the assigned tags:
 
-<xref:Lucene.Net.Analysis.Payloads.TypeAsPayloadTokenFilter> copies the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> value to the <xref:Lucene.Net.Analysis.TokenAttributes.IPayloadAttribute>
-<xref:Lucene.Net.Analysis.Miscellaneous.TypeAsSynonymFilter> creates a cloned token at the same position as each tagged token, and copies the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> value to the <xref:Lucene.Net.Analysis.TokenAttributes.ICharTermAttribute>, optionally with a customized prefix (so that tags effectively occupy a different namespace from token text).
+- <xref:Lucene.Net.Analysis.Payloads.TypeAsPayloadTokenFilter> copies the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> value to the <xref:Lucene.Net.Analysis.TokenAttributes.IPayloadAttribute>
+- <xref:Lucene.Net.Analysis.Miscellaneous.TypeAsSynonymFilter> creates a cloned token at the same position as each tagged token, and copies the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> value to the <xref:Lucene.Net.Analysis.TokenAttributes.ICharTermAttribute>, optionally with a customized prefix (so that tags effectively occupy a different namespace from token text).
+
+Named Entity Recognition is also supported by OpenNLP, but there is no OpenNLPNERFilter included. For an implementation, see the [lucenenet-opennlp-mavenreference-demo](https://github.com/NightOwl888/lucenenet-opennlp-mavenreference-demo).
 
 ## MavenReference Primer
 

--- a/src/Lucene.Net.Analysis.OpenNLP/overview.md
+++ b/src/Lucene.Net.Analysis.OpenNLP/overview.md
@@ -22,3 +22,99 @@ summary: *content
 -->
 
 OpenNLP Library Integration
+
+This module exposes functionality from Apache OpenNLP to Apache Lucene.NET. The Apache OpenNLP library is a machine learning based toolkit for the processing of natural language text.
+
+For an introduction to Lucene's analysis API, see the [Lucene.Net.Analysis](../core/Lucene.Net.Analysis.html) namespace documentation.
+
+The OpenNLP Tokenizer behavior is similar to the <xref:Lucene.Net.Analysis.Core.WhiteSpaceTokenizer> but is smart about inter-word punctuation. The term stream looks very much like the way you parse words and punctuation while reading. The major difference between this tokenizer and most other tokenizers shipped with Lucene is that punctuation is tokenized. This is required for the following taggers to operate properly.
+
+The OpenNLP taggers annotate terms using the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute>.
+
+<xref:Lucene.Net.Analysis.OpenNlp.OpenNLPTokenizer> segments text into sentences or words. This Tokenizer uses the OpenNLP Sentence Detector and/or Tokenizer classes. When used together, the Tokenizer receives sentences and can do a better job.
+<xref:Lucene.Net.Analysis.OpenNlp.OpenNLPFilter> tags words using one or more technologies: Part-of-Speech, Chunking, and Named Entity Recognition. These tags are assigned as token types. Note that only one of these operations will tag
+Since the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> is not stored in the index, it is recommended that one of these filters is used following OpenNLPFilter to enable search against the assigned tags:
+
+<xref:Lucene.Net.Analysis.Payloads.TypeAsPayloadTokenFilter> copies the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> value to the <xref:Lucene.Net.Analysis.TokenAttributes.IPayloadAttribute>
+<xref:Lucene.Net.Analysis.Miscellaneous.TypeAsSynonymFilter> creates a cloned token at the same position as each tagged token, and copies the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> value to the <xref:Lucene.Net.Analysis.TokenAttributes.ICharTermAttribute>, optionally with a customized prefix (so that tags effectively occupy a different namespace from token text).
+
+## MavenReference Primer
+
+When a `<PackageReference>` is included for this NuGet package in your SDK-style MSBuild project, it will automatically include transient dependencies to [`opennlp-tools` on maven.org](https://search.maven.org/artifact/org.apache.opennlp/opennlp-tools/1.9.4/bundle). The transient dependency will automatically include a `<MavenReference>` in your MSBuild project.
+
+The `<MavenReference>` item group operates similar to a dependency in Maven. All transitive dependencies are collected and resolved, and then the final output is produced. However, unlike `PackageReference`s, `MavenReference`s are collected by the final output project, and reassessed. That is, each dependent Project within your .NET SDK-style solution contributes its `MavenReference`s to project(s) which include it, and each project makes its own dependency graph. Projects do not contribute their final built assemblies up. They only contribute their dependencies. Allowing each project in a complicated solution to make its own local conflict resolution attempt.
+
+> **NOTE** `<MavenReference>` is only supported on SDK-style MSBuild projects.
+
+## MavenReference Example
+
+This means this package can be combined with other related packages on Maven in your project and they can be accessed using the same path as in Java like a namespace in .NET. For example, you can add a `<MavenReference>` to your project to include a reference to [`opennlp-uima`](https://search.maven.org/artifact/org.apache.opennlp/opennlp-uima/1.9.1/jar). The UIMA (Unstructured Information Management Architecture) integration module is designed to work with the Apache UIMA framework. UIMA is a framework for building applications that analyze unstructured information, and it's often used for processing natural language text. The opennlp-uima module allows you to integrate OpenNLP functionality into UIMA pipelines, leveraging the capabilities of both frameworks.
+
+Here's a basic outline of how you might extend an existing Lucene.NET analyzer to incorporate OpenNLP-UIMA annotators:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Lucene.Net.Analysis.OpenNLP" Version="4.8.0-beta00017" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MavenReference Include="org.apache.opennlp:opennlp-uima" Version="1.9.1" />
+  </ItemGroup>
+</Project>
+```
+
+```c#
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Core;
+using Lucene.Net.Analysis.Util;
+using Lucene.Net.Util;
+using org.apache.uima.analysis_engine;
+using System.IO;
+
+public class CustomOpenNLPAnalyzer : OpenNLPTokenizerFactory
+{
+    // ... constructor and other methods ...
+
+    public override Tokenizer Create(AttributeFactory factory, TextReader reader)
+    {
+        Tokenizer tokenizer = base.Create(factory, reader);
+
+        // Wrap the tokenizer with UIMA annotators
+        AnalysisEngineDescription uimaSentenceAnnotator = CreateUIMASentenceAnnotator();
+        AnalysisEngineDescription uimaTokenAnnotator = CreateUIMATokenAnnotator();
+
+        // Combine OpenNLP-UIMA annotators with the existing tokenizer
+        AnalysisEngine tokenizerAndUIMAAnnotators = CreateAggregate(uimaSentenceAnnotator, uimaTokenAnnotator);
+
+        return new UIMATokenizer(tokenizer, tokenizerAndUIMAAnnotators);
+    }
+
+    // ... other methods ...
+
+    private AnalysisEngineDescription CreateUIMASentenceAnnotator() {
+        // Create and configure UIMA sentence annotator
+        // ...
+
+        return /* UIMA sentence annotator description */;
+    }
+
+    private AnalysisEngineDescription CreateUIMATokenAnnotator() {
+        // Create and configure UIMA token annotator
+        // ...
+
+        return /* UIMA token annotator description */;
+    }
+}
+```
+
+In the above example, `CustomOpenNLPAnalyzer` extends `OpenNLPTokenizerFactory` (assuming that's the analyzer you're using), and it wraps the OpenNLP tokenizer with UIMA annotators. You'll need to replace the placeholder methods (`CreateUIMASentenceAnnotator` and `CreateUIMATokenAnnotator`) with the actual code to create and configure your UIMA annotators. Please note that configuring NLP can be complex. See the [OpenNLP 1.9.4 Manual](https://opennlp.apache.org/docs/1.9.4/manual/opennlp.html) and [OpenNLP UIMA 1.9.4 API Documention](https://opennlp.apache.org/docs/1.9.4/apidocs/opennlp-uima/index.html) for details.
+
+> [!NOTE]
+> IKVM (and `<MavenReference>`) does not support Java SE higher than version 8. So it will not be possible to add a `<MavenReference>` to OpenNLP 2.x until support is added for it in IKVM.
+
+For a more complete example, see the [lucenenet-opennlp-mavenreference-demo](https://github.com/NightOwl888/lucenenet-opennlp-mavenreference-demo).

--- a/src/Lucene.Net.Facet/Lucene.Net.Facet.csproj
+++ b/src/Lucene.Net.Facet/Lucene.Net.Facet.csproj
@@ -38,11 +38,17 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
-
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net.Join\Lucene.Net.Join.csproj" />
     <ProjectReference Include="..\Lucene.Net.Queries\Lucene.Net.Queries.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.TestFramework/Analysis/CannedTokenStream.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/CannedTokenStream.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Analysis.TokenAttributes;
+﻿using Lucene.Net.Analysis.TokenAttributes;
 
 namespace Lucene.Net.Analysis
 {
@@ -31,6 +31,7 @@ namespace Lucene.Net.Analysis
         private readonly IPositionLengthAttribute posLengthAtt;
         private readonly IOffsetAttribute offsetAtt;
         private readonly IPayloadAttribute payloadAtt;
+        private readonly ITypeAttribute typeAtt; // LUCENENET specific - See IncrementToken()
         private readonly int finalOffset;
         private readonly int finalPosInc;
 
@@ -49,6 +50,7 @@ namespace Lucene.Net.Analysis
             posLengthAtt = AddAttribute<IPositionLengthAttribute>();
             offsetAtt = AddAttribute<IOffsetAttribute>();
             payloadAtt = AddAttribute<IPayloadAttribute>();
+            typeAtt = AddAttribute<ITypeAttribute>(); // LUCENENET specific - See IncrementToken()
 
             this.tokens = tokens;
             this.finalOffset = finalOffset;
@@ -76,6 +78,12 @@ namespace Lucene.Net.Analysis
                 posLengthAtt.PositionLength = token.PositionLength;
                 offsetAtt.SetOffset(token.StartOffset, token.EndOffset);
                 payloadAtt.Payload = token.Payload;
+
+                // LUCENENET: This change is from https://github.com/apache/lucene/commit/72eaeab7151d421a28ecec1634b8c48599e524f5.
+                // We need it for the TestTypeAsSynonymFilterFactory tests to pass (from lucene 8.2.0).
+                // But we don't yet have all of the PackedTokenAttributeImpl plumbing it takes to do it the way they did,
+                // so setting it explicitly as a workaround.
+                typeAtt.Type = token.Type;
                 return true;
             }
             else

--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -67,6 +67,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <!-- This is a transitive dependency of Microsoft.Extensions.Configuration.Json and IKVM. It is just here to pin the version to avoid conflicts. -->
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.ServiceModel" />

--- a/src/Lucene.Net.Tests.AllProjects/Lucene.Net.Tests.AllProjects.csproj
+++ b/src/Lucene.Net.Tests.AllProjects/Lucene.Net.Tests.AllProjects.csproj
@@ -118,16 +118,8 @@
 
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) ">
     <ProjectReference Include="..\Lucene.Net.Analysis.OpenNLP\Lucene.Net.Analysis.OpenNLP.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir).build/TestReferences.Common.targets" />

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestTypeAsSynonymFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestTypeAsSynonymFilterFactory.cs
@@ -1,4 +1,6 @@
-﻿using Lucene.Net.Analysis.Util;
+﻿// Lucene version compatibility level 8.2.0
+// LUCENENET NOTE: Ported because Lucene.Net.Analysis.OpenNLP requires this to be useful.
+using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
 
 namespace Lucene.Net.Analysis.Miscellaneous

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestTypeAsSynonymFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestTypeAsSynonymFilterFactory.cs
@@ -1,0 +1,54 @@
+﻿using Lucene.Net.Analysis.Util;
+using NUnit.Framework;
+
+namespace Lucene.Net.Analysis.Miscellaneous
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public class TestTypeAsSynonymFilterFactory : BaseTokenStreamFactoryTestCase
+    {
+        private static readonly Token[] TOKENS = { token("Visit", "<ALPHANUM>"), token("example.com", "<URL>") };
+
+        [Test]
+        public void TestBasic()
+        {
+            TokenStream stream = new CannedTokenStream(TOKENS);
+            stream = TokenFilterFactory("TypeAsSynonym").Create(stream);
+            AssertTokenStreamContents(stream, new string[] { "Visit", "<ALPHANUM>", "example.com", "<URL>" },
+                null, null, new string[] { "<ALPHANUM>", "<ALPHANUM>", "<URL>", "<URL>" }, new int[] { 1, 0, 1, 0 });
+        }
+
+        [Test]
+        public void TestPrefix()
+        {
+            TokenStream stream = new CannedTokenStream(TOKENS);
+            stream = TokenFilterFactory("TypeAsSynonym", "prefix", "_type_").Create(stream);
+            AssertTokenStreamContents(stream, new string[] { "Visit", "_type_<ALPHANUM>", "example.com", "_type_<URL>" },
+                null, null, new string[] { "<ALPHANUM>", "<ALPHANUM>", "<URL>", "<URL>" }, new int[] { 1, 0, 1, 0 });
+        }
+
+        private static Token token(string term, string type)
+        {
+            Token token = new Token();
+            token.SetEmpty();
+            token.Append(term);
+            token.Type = type;
+            return token;
+        }
+    }
+}

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
@@ -24,9 +24,7 @@
   <Import Project="$(SolutionDir)TestTargetFramework.props" />
 
   <PropertyGroup>
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFramework>net48</TargetFramework>
-
+    
     <AssemblyTitle>Lucene.Net.Tests.Analysis.OpenNLP</AssemblyTitle>
     <RootNamespace>Lucene.Net.Analysis.OpenNlp</RootNamespace>
 

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
@@ -24,17 +24,20 @@
   <Import Project="$(SolutionDir)TestTargetFramework.props" />
 
   <PropertyGroup>
-    
+    <!-- Allow specific target framework to flow in from TestTargetFrameworks.props -->
+    <TargetFrameworks Condition=" '$(TargetFramework)' == '' ">net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFramework)' == '' AND $([MSBuild]::IsOsPlatform('Windows')) ">$(TargetFrameworks);net48</TargetFrameworks>
     <AssemblyTitle>Lucene.Net.Tests.Analysis.OpenNLP</AssemblyTitle>
     <RootNamespace>Lucene.Net.Analysis.OpenNlp</RootNamespace>
+  </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' Or $(TargetFramework.StartsWith('net5.')) ">
+    <!-- For CI, we don't publish the projects and exclude them from the test run by setting IsPublishable=false and IsTestProject=false -->
     <IsPublishable>false</IsPublishable>
-    <IsPublishable Condition=" '$(TargetFramework)' == 'net48' ">true</IsPublishable>
-
-    <!-- Workaround since there are no targets on non-Windows OS. We need at least 1 TargetFramework
-        registered or MSBuild's validation will fail, so we explicitly disable it as a test project instead. -->
     <IsTestProject>false</IsTestProject>
-    <IsTestProject Condition="$([MSBuild]::IsOsPlatform('Windows'))">true</IsTestProject>
+    <!-- For the IDE, the above doesn't work. Redirect to a supported test framework instead. -->
+    <TargetFramework Condition=" $(TargetFramework.StartsWith('net5.')) ">net7.0</TargetFramework>
+    <TargetFramework Condition=" '$(TargetFramework)' == 'net461' ">net48</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
@@ -27,6 +27,7 @@
     <!-- Allow specific target framework to flow in from TestTargetFrameworks.props -->
     <TargetFrameworks Condition=" '$(TargetFramework)' == '' ">net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetFramework)' == '' AND $([MSBuild]::IsOsPlatform('Windows')) ">$(TargetFrameworks);net48</TargetFrameworks>
+    
     <AssemblyTitle>Lucene.Net.Tests.Analysis.OpenNLP</AssemblyTitle>
     <RootNamespace>Lucene.Net.Analysis.OpenNlp</RootNamespace>
   </PropertyGroup>

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -60,10 +60,14 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
+    <!-- NOTE: This is a transitive dependency only, but we are forcing an upgrade to ensure there are no conflicts with dependencies. -->
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageVersion)" />
+    <!-- NOTE: This is a transitive dependency only, but we are forcing an upgrade to ensure there are no conflicts with dependencies. -->
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Lucene.Net.Tests.Cli.csproj
@@ -26,12 +26,15 @@
   <PropertyGroup>
     <!-- Allow specific target framework to flow in from TestTargetFrameworks.props -->
     <TargetFrameworks Condition=" '$(TargetFramework)' == '' ">net7.0;net6.0</TargetFrameworks>
-    <!-- If .NET Frameowrk is specified, just target the latest version -->
-    <TargetFramework Condition=" $(TargetFramework.StartsWith('net4')) ">net7.0</TargetFramework>
     <AssemblyTitle>Lucene.Net.Tests.Cli</AssemblyTitle>
+  </PropertyGroup>
 
-    <IsPublishable Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net5.'))">false</IsPublishable>
-    <IsTestProject Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net5.'))">false</IsTestProject>
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net5.')) ">
+    <!-- For CI, we don't publish the projects and exclude them from the test run by setting IsPublishable=false and IsTestProject=false -->
+    <IsPublishable>false</IsPublishable>
+    <IsTestProject>false</IsTestProject>
+    <!-- For the IDE, the above doesn't work. Redirect to a supported test framework instead. -->
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)
Added net6.0 target to Lucene.Net.Analysis.OpenNLP and changed to using MavenReference

Closes #852, closes #460, related: #890

## Description

This supersedes and closes #852. It drops the package dependency on [OpenNLP.NET](https://www.nuget.org/packages/OpenNLP.NET), and instead uses `<MavenReference>` to add a dependency on [opennlp-tools](https://central.sonatype.com/artifact/org.apache.opennlp/opennlp-tools/1.9.4).

`<MavenReference>` does not add a binary to our distribution (except for IKVM and its dependencies). Instead, it transitively gets added to any SDK-style project that depends on Lucene.Net.Analysis.OpenNLP. Each dependency from Maven is downloaded and converted from bytecode into IL on the user's build machine.

This allows the user to add additional `<MavenReference>` dependencies, which will use Maven to resolve any versioning conflicts between common dependencies. More importantly, this ensures that only one copy of each data type exists in the project, which wouldn't be the case with a dependency on OpenNLP.NET. It also allows adding other OpenNLP components as required by the project, rather than having one binary that incorporates all of them.

The documentation from Lucene 8.2.0 was also brought over and a [MavenReference demo](https://github.com/NightOwl888/lucenenet-opennlp-mavenreference-demo) was created to demonstrate how it can be used to pull in libraries from Maven to build analyzers that are compatible with Lucene.NET.

This PR also includes a new feature - `Lucene.Net.Analysis.Miscellaneous.TypeAsSynonymFilter` which is helpful for working with the filters in `Lucene.Net.Analysis.OpenNLP`.