### PR TITLE
Lucene.Net.Index.TestIndexWriterOnJRECrash::TestNRTThreads_Mem(): Added [AwaitsFix] attribute because this test fails intermittently

### DIFF
--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
@@ -47,6 +47,7 @@ namespace Lucene.Net.Index
 
         [Test]
         [Slow]
+        [AwaitsFix]
         public override void TestNRTThreads_Mem()
         {
             //if we are not the fork


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

`Lucene.Net.Index.TestIndexWriterOnJRECrash::TestNRTThreads_Mem()`: Added [AwaitsFix] attribute because this test fails intermittently (see #894).

