### PR TITLE
PERFORMANCE: Lucene.Net.Analysis.TokenAttributes.CharTermAttribute: Optimized char copying on Append() and Subsequence()

### DIFF
--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
@@ -190,9 +190,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
                 throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
 
             char[] result = new char[length];
-            for (int i = 0, j = startIndex; i < length; i++, j++)
-                result[i] = termBuffer[j];
-
+            Arrays.Copy(termBuffer, startIndex, result, 0, length);
             return new CharArrayCharSequence(result);
         }
 

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
@@ -279,7 +279,10 @@ namespace Lucene.Net.Analysis.TokenAttributes
                 return this; // No-op
             }
 
-            return Append(value.ToString());
+            int len = value.Length;
+            value.CopyTo(0, InternalResizeBuffer(termLength + len), termLength, len);
+            Length += len;
+            return this;
         }
 
         public CharTermAttribute Append(StringBuilder value, int startIndex, int charCount)
@@ -301,7 +304,9 @@ namespace Lucene.Net.Analysis.TokenAttributes
             if (startIndex > value.Length - charCount)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(charCount)} <= {nameof(Length)}.");
 
-            return Append(value.ToString(startIndex, charCount));
+            value.CopyTo(startIndex, InternalResizeBuffer(termLength + charCount), termLength, charCount);
+            Length += charCount;
+            return this;
         }
 
         public CharTermAttribute Append(ICharTermAttribute value)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

PERFORMANCE: Lucene.Net.Analysis.TokenAttributes.CharTermAttribute: Optimized char copying on Append() and Subsequence()

## Description

This removes some allocations from the `StringBuilder` overloads of `Append()` and switches from using a for loop to `Arrays.Copy()` for `Subsequence()`.
