### PR TITLE
PERFORMANCE: Lucene.Net.Facet.Taxonomy.WriterCache.CharBlockArray: Compare equality and calculate hash code without allocating

### DIFF
--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CategoryPathUtils.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CategoryPathUtils.cs
@@ -58,7 +58,8 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             for (int i = 0; i < length; i++)
             {
                 int len = charBlockArray[offset++];
-                hash = hash * 31 + charBlockArray.Subsequence(offset, len).GetHashCode(); // LUCENENET: Corrected 2nd Subsequence parameter
+                // LUCENENET specific - calculate the hash code without the allocation caused by Subsequence
+                hash = hash * 31 + charBlockArray.GetHashCode(offset, len); // LUCENENET: Corrected 2nd parameter
                 offset += len;
             }
             return hash;
@@ -88,7 +89,8 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                     return false;
                 }
 
-                if (!cp.Components[i].Equals(charBlockArray.Subsequence(offset, len).ToString(), StringComparison.Ordinal)) // LUCENENET: Corrected 2nd Subsequence parameter
+                // LUCENENET specific - calculate the hash code without the allocation caused by Subsequence() and ToString()
+                if (!charBlockArray.Equals(offset, len, cp.Components[i].AsSpan())) // LUCENENET: Corrected 2nd parameter
                 {
                     return false;
                 }

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CompactLabelToOrdinal.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CompactLabelToOrdinal.cs
@@ -441,7 +441,8 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                         for (int i = 0; i < length; i++)
                         {
                             int len = (ushort)l2o.labelRepository[offset++];
-                            hash = hash * 31 + l2o.labelRepository.Subsequence(offset, len).GetHashCode(); // LUCENENET: Corrected 2nd Subsequence parameter
+                            // LUCENENET specific - calculate the hash code without the allocation caused by Subsequence
+                            hash = hash * 31 + l2o.labelRepository.GetHashCode(offset, len); // LUCENENET: Corrected 2nd parameter
                             offset += len;
                         }
                     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

PERFORMANCE: Lucene.Net.Facet.Taxonomy.WriterCache.CharBlockArray: Compare equality and calculate hash code without allocating

## Description

The equality and hash code generation in Lucene relied on `Subsequence()` to generate the hash code and check for equality. Subsequence always allocates. The prior implementation of equality was actually copying the characters to a `StringBuilder` (which allocates), then calling `StringBuilder.ToString()` (which allocates), then comparing using `String.Equals()`, which only accepts a string.

This has been modified to pass `startIndex` and `length` to the `CharBlockArray` when calculating hash code and comparing for binary string equality. These checks are done in `CharBlockArray` itself on the original data structure rather than copying characters out to a buffer compare them.
