### PR TITLE
Lucene.Net.Facet.Taxonomy.WriterCache.CharBlockArray: Implemented IAppendable to align with Lucene.

### DIFF
--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
     // therefore it doesn't make any difference what type of serialization is used. 
     // To make things simpler, we are using BinaryReader and BinaryWriter since 
     // BinaryFormatter is not implemented in .NET Standard 1.x.
-    internal class CharBlockArray : ICharSequence
+    internal class CharBlockArray : IAppendable, ICharSequence
     {
         private const long serialVersionUID = 1L;
 
@@ -130,10 +130,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             return index % blockSize;
         }
 
-        public virtual CharBlockArray Append(ICharSequence chars)
-        {
-            return Append(chars, 0, chars.Length);
-        }
+#nullable enable
 
         public virtual CharBlockArray Append(char c)
         {
@@ -147,45 +144,52 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             return this;
         }
 
-        public virtual CharBlockArray Append(ICharSequence chars, int start, int length)
+        public virtual CharBlockArray Append(ICharSequence? value)
         {
-            int end = start + length;
-            for (int i = start; i < end; i++)
+            if (value is null) // needed for Appendable compliance
             {
-                Append(chars[i]);
+                return this; // No-op
+            }
+
+            return Append(value, 0, value.Length);
+        }
+
+        public virtual CharBlockArray Append(ICharSequence? value, int startIndex, int length)
+        {
+            // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
+
+            if (value is null)
+            {
+                if (startIndex == 0 && length == 0)
+                    return this;
+                throw new ArgumentNullException(nameof(value));
+            }
+            if (length == 0)
+                return this;
+            if (startIndex > value.Length - length)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
+
+
+            int end = startIndex + length;
+            for (int i = startIndex; i < end; i++)
+            {
+                Append(value[i]);
             }
             return this;
         }
 
-        public virtual CharBlockArray Append(char[] chars, int start, int length)
+        public virtual CharBlockArray Append(char[]? value)
         {
-            int offset = start;
-            int remain = length;
-            while (remain > 0)
+            if (value is null) // needed for Appendable compliance
             {
-                if (this.current.length == this.blockSize)
-                {
-                    AddBlock();
-                }
-                int toCopy = remain;
-                int remainingInBlock = this.blockSize - this.current.length;
-                if (remainingInBlock < toCopy)
-                {
-                    toCopy = remainingInBlock;
-                }
-                Arrays.Copy(chars, offset, this.current.chars, this.current.length, toCopy);
-                offset += toCopy;
-                remain -= toCopy;
-                this.current.length += toCopy;
+                return this; // No-op
             }
 
-            this.length += length;
-            return this;
-        }
-
-        public virtual CharBlockArray Append(string s)
-        {
-            int remain = s.Length;
+            int remain = value.Length;
             int offset = 0;
             while (remain > 0)
             {
@@ -199,15 +203,233 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 {
                     toCopy = remainingInBlock;
                 }
-                s.CopyTo(offset, this.current.chars, this.current.length, toCopy);
+                Arrays.Copy(value, offset, this.current.chars, this.current.length, toCopy);
                 offset += toCopy;
                 remain -= toCopy;
                 this.current.length += toCopy;
             }
 
-            this.length += s.Length;
+            this.length += value.Length;
             return this;
         }
+
+        public virtual CharBlockArray Append(char[]? value, int startIndex, int length)
+        {
+            // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
+
+            if (value is null)
+            {
+                if (startIndex == 0 && length == 0)
+                    return this;
+                throw new ArgumentNullException(nameof(value));
+            }
+            if (length == 0)
+                return this;
+            if (startIndex > value.Length - length)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
+
+
+            int offset = startIndex;
+            int remain = length;
+            while (remain > 0)
+            {
+                if (this.current.length == this.blockSize)
+                {
+                    AddBlock();
+                }
+                int toCopy = remain;
+                int remainingInBlock = this.blockSize - this.current.length;
+                if (remainingInBlock < toCopy)
+                {
+                    toCopy = remainingInBlock;
+                }
+                Arrays.Copy(value, offset, this.current.chars, this.current.length, toCopy);
+                offset += toCopy;
+                remain -= toCopy;
+                this.current.length += toCopy;
+            }
+
+            this.length += length;
+            return this;
+        }
+
+        public virtual CharBlockArray Append(string? value)
+        {
+            if (value is null) // needed for Appendable compliance
+            {
+                return this; // No-op
+            }
+
+            int remain = value.Length;
+            int offset = 0;
+            while (remain > 0)
+            {
+                if (this.current.length == this.blockSize)
+                {
+                    AddBlock();
+                }
+                int toCopy = remain;
+                int remainingInBlock = this.blockSize - this.current.length;
+                if (remainingInBlock < toCopy)
+                {
+                    toCopy = remainingInBlock;
+                }
+                value.CopyTo(offset, this.current.chars, this.current.length, toCopy);
+                offset += toCopy;
+                remain -= toCopy;
+                this.current.length += toCopy;
+            }
+
+            this.length += value.Length;
+            return this;
+        }
+
+        public virtual CharBlockArray Append(string? value, int startIndex, int length)
+        {
+            // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
+
+            if (value is null)
+            {
+                if (startIndex == 0 && length == 0)
+                    return this;
+                throw new ArgumentNullException(nameof(value));
+            }
+            if (length == 0)
+                return this;
+            if (startIndex > value.Length - length)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
+
+
+            int offset = startIndex;
+            int remain = length;
+            while (remain > 0)
+            {
+                if (this.current.length == this.blockSize)
+                {
+                    AddBlock();
+                }
+                int toCopy = remain;
+                int remainingInBlock = this.blockSize - this.current.length;
+                if (remainingInBlock < toCopy)
+                {
+                    toCopy = remainingInBlock;
+                }
+                value.CopyTo(offset, this.current.chars, this.current.length, toCopy);
+                offset += toCopy;
+                remain -= toCopy;
+                this.current.length += toCopy;
+            }
+
+            this.length += length;
+            return this;
+        }
+
+        public virtual CharBlockArray Append(StringBuilder? value)
+        {
+            if (value is null) // needed for Appendable compliance
+            {
+                return this; // No-op
+            }
+
+            int remain = value.Length;
+            int offset = 0;
+            while (remain > 0)
+            {
+                if (this.current.length == this.blockSize)
+                {
+                    AddBlock();
+                }
+                int toCopy = remain;
+                int remainingInBlock = this.blockSize - this.current.length;
+                if (remainingInBlock < toCopy)
+                {
+                    toCopy = remainingInBlock;
+                }
+                value.CopyTo(offset, this.current.chars, this.current.length, toCopy);
+                offset += toCopy;
+                remain -= toCopy;
+                this.current.length += toCopy;
+            }
+
+            this.length += value.Length;
+            return this;
+        }
+
+        public virtual CharBlockArray Append(StringBuilder? value, int startIndex, int length)
+        {
+            // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
+
+            if (value is null)
+            {
+                if (startIndex == 0 && length == 0)
+                    return this;
+                throw new ArgumentNullException(nameof(value));
+            }
+            if (length == 0)
+                return this;
+            if (startIndex > value.Length - length)
+                throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
+
+            int offset = startIndex;
+            int remain = length;
+            while (remain > 0)
+            {
+                if (this.current.length == this.blockSize)
+                {
+                    AddBlock();
+                }
+                int toCopy = remain;
+                int remainingInBlock = this.blockSize - this.current.length;
+                if (remainingInBlock < toCopy)
+                {
+                    toCopy = remainingInBlock;
+                }
+                value.CopyTo(offset, this.current.chars, this.current.length, toCopy);
+                offset += toCopy;
+                remain -= toCopy;
+                this.current.length += toCopy;
+            }
+
+            this.length += length;
+            return this;
+        }
+
+#nullable restore
+
+        #region IAppendable Members
+
+        IAppendable IAppendable.Append(char value) => Append(value);
+
+        IAppendable IAppendable.Append(string value) => Append(value);
+
+        IAppendable IAppendable.Append(string value, int startIndex, int count) => Append(value, startIndex, count);
+
+        IAppendable IAppendable.Append(StringBuilder value) => Append(value);
+
+        IAppendable IAppendable.Append(StringBuilder value, int startIndex, int count) => Append(value, startIndex, count);
+
+        IAppendable IAppendable.Append(char[] value) => Append(value);
+
+        IAppendable IAppendable.Append(char[] value, int startIndex, int count) => Append(value, startIndex, count);
+
+        IAppendable IAppendable.Append(ICharSequence value) => Append(value);
+
+        IAppendable IAppendable.Append(ICharSequence value, int startIndex, int count) => Append(value, startIndex, count);
+
+
+        #endregion
 
         // LUCENENET specific - replaced with this[index]
         //public virtual char CharAt(int index)

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
@@ -1,5 +1,9 @@
 ﻿// Lucene version compatibility level 4.8.1
+using J2N.IO;
+using J2N.Text;
+using Lucene.Net.Attributes;
 using NUnit.Framework;
+using System;
 using System.IO;
 using System.Text;
 using Assert = Lucene.Net.TestFramework.Assert;
@@ -117,6 +121,201 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             for (int i = 0; i < expected2Len; i++)
             {
                 Assert.AreEqual(expected2[i], actual[i], msg);
+            }
+        }
+
+        // LUCENENET: Borrowed this test from TestCharTermAttributeImpl
+        [Test, LuceneNetSpecific]
+        public virtual void TestAppendableInterface()
+        {
+            CharBlockArray t = new CharBlockArray();
+            //Formatter formatter = new Formatter(t, Locale.ROOT);
+            //formatter.format("%d", 1234);
+            //Assert.AreEqual("1234", t.ToString());
+            //formatter.format("%d", 5678);
+            // LUCENENET: We don't have a formatter in .NET, so continue from here
+            t.Append("12345678"); // LUCENENET specific overload that accepts string
+            Assert.AreEqual("12345678", t.ToString());
+            t = new CharBlockArray();
+            t.Append("12345678".ToCharArray()); // LUCENENET specific overload that accepts char[]
+            Assert.AreEqual("12345678", t.ToString());
+            t.Append('9');
+            Assert.AreEqual("123456789", t.ToString());
+            t.Append("0".AsCharSequence());
+            Assert.AreEqual("1234567890", t.ToString());
+            t.Append("0123456789".AsCharSequence(), 1, 3 - 1); // LUCENENET: Corrected 3rd parameter
+            Assert.AreEqual("123456789012", t.ToString());
+            //t.Append((ICharSequence) CharBuffer.wrap("0123456789".ToCharArray()), 3, 5);
+            t.Append("0123456789".ToCharArray(), 3, 5 - 3); // LUCENENET: no CharBuffer in .NET, so we test char[], start, end overload // LUCENENET: Corrected 3rd parameter
+            Assert.AreEqual("12345678901234", t.ToString());
+            t.Append((ICharSequence)t);
+            Assert.AreEqual("1234567890123412345678901234", t.ToString());
+            t.Append(/*(ICharSequence)*/ new StringBuilder("0123456789"), 5, 7 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence, corrected 3rd argument
+            Assert.AreEqual("123456789012341234567890123456", t.ToString());
+            t.Append(/*(ICharSequence)*/ new StringBuilder(t.ToString())); // LUCENENET: StringBuilder doesn't implement ICharSequence
+            Assert.AreEqual("123456789012341234567890123456123456789012341234567890123456", t.ToString());
+            // very wierd, to test if a subSlice is wrapped correct :)
+            CharBuffer buf = CharBuffer.Wrap("0123456789".ToCharArray(), 3, 5);
+            Assert.AreEqual("34567", buf.ToString());
+            t = new CharBlockArray();
+            t.Append((ICharSequence)buf, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
+            Assert.AreEqual("4", t.ToString());
+            CharBlockArray t2 = new CharBlockArray();
+            t2.Append("test");
+            t.Append((ICharSequence)t2);
+            Assert.AreEqual("4test", t.ToString());
+            t.Append((ICharSequence)t2, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
+            Assert.AreEqual("4teste", t.ToString());
+
+            try
+            {
+                t.Append((ICharSequence)t2, 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                Assert.Fail("Should throw ArgumentOutOfRangeException");
+            }
+#pragma warning disable 168
+            catch (ArgumentOutOfRangeException iobe)
+#pragma warning restore 168
+            {
+            }
+
+            try
+            {
+                t.Append((ICharSequence)t2, 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                Assert.Fail("Should throw ArgumentOutOfRangeException");
+            }
+#pragma warning disable 168
+            catch (ArgumentOutOfRangeException iobe)
+#pragma warning restore 168
+            {
+            }
+
+            string expected = t.ToString();
+            t.Append((ICharSequence)null); // No-op
+            Assert.AreEqual(expected, t.ToString());
+
+
+            // LUCENENET specific - test string overloads
+            try
+            {
+                t.Append((string)t2.ToString(), 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                Assert.Fail("Should throw ArgumentOutOfRangeException");
+            }
+#pragma warning disable 168
+            catch (ArgumentOutOfRangeException iobe)
+#pragma warning restore 168
+            {
+            }
+
+            try
+            {
+                t.Append((string)t2.ToString(), 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                Assert.Fail("Should throw ArgumentOutOfRangeException");
+            }
+#pragma warning disable 168
+            catch (ArgumentOutOfRangeException iobe)
+#pragma warning restore 168
+            {
+            }
+
+            expected = t.ToString();
+            t.Append((string)null); // No-op
+            Assert.AreEqual(expected, t.ToString());
+
+            // LUCENENET specific - test char[] overloads
+            try
+            {
+                t.Append((char[])t2.ToString().ToCharArray(), 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                Assert.Fail("Should throw ArgumentOutOfRangeException");
+            }
+#pragma warning disable 168
+            catch (ArgumentOutOfRangeException iobe)
+#pragma warning restore 168
+            {
+            }
+
+            try
+            {
+                t.Append((char[])t2.ToString().ToCharArray(), 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                Assert.Fail("Should throw ArgumentOutOfRangeException");
+            }
+#pragma warning disable 168
+            catch (ArgumentOutOfRangeException iobe)
+#pragma warning restore 168
+            {
+            }
+
+            expected = t.ToString();
+            t.Append((char[])null); // No-op
+            Assert.AreEqual(expected, t.ToString());
+        }
+
+        // LUCENENET: Borrowed this test from TestCharTermAttributeImpl
+        [Test, LuceneNetSpecific]
+        public virtual void TestAppendableInterfaceWithLongSequences()
+        {
+            CharBlockArray t = new CharBlockArray();
+            t.Append("01234567890123456789012345678901234567890123456789"); // LUCENENET specific overload that accepts string
+            assertEquals("01234567890123456789012345678901234567890123456789", t.ToString());
+            t.Append("01234567890123456789012345678901234567890123456789", 3, 50 - 3); // LUCENENET specific overload that accepts string, startIndex, charCount
+            Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
+            t = new CharBlockArray();
+            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray()); // LUCENENET specific overload that accepts char[]
+            assertEquals("01234567890123456789012345678901234567890123456789", t.ToString());
+            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray(), 3, 50 - 3); // LUCENENET specific overload that accepts char[], startIndex, charCount
+            Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
+            t = new CharBlockArray();
+            t.Append(new StringCharSequence("01234567890123456789012345678901234567890123456789"));
+            //t.Append((ICharSequence) CharBuffer.wrap("01234567890123456789012345678901234567890123456789".ToCharArray()), 3, 50); // LUCENENET: No CharBuffer in .NET
+            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray(), 3, 50 - 3); // LUCENENET specific overload that accepts char[], startIndex, charCount
+            //              "01234567890123456789012345678901234567890123456789"
+            Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
+            t = new CharBlockArray();
+            t.Append(/*(ICharSequence)*/ new StringBuilder("01234567890123456789"), 5, 17 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence
+            Assert.AreEqual((ICharSequence)new StringCharSequence("567890123456"), t /*.ToString()*/);
+            t.Append(new StringBuilder(t.ToString()));
+            Assert.AreEqual((ICharSequence)new StringCharSequence("567890123456567890123456"), t /*.ToString()*/);
+            // very wierd, to test if a subSlice is wrapped correct :)
+            CharBuffer buf = CharBuffer.Wrap("012345678901234567890123456789".ToCharArray(), 3, 15);
+            Assert.AreEqual("345678901234567", buf.ToString());
+            t = new CharBlockArray();
+            t.Append(buf, 1, 14 - 1);
+            Assert.AreEqual("4567890123456", t.ToString());
+
+            // finally use a completely custom ICharSequence that is not catched by instanceof checks
+            const string longTestString = "012345678901234567890123456789";
+            t.Append(new CharSequenceAnonymousClass(longTestString));
+            Assert.AreEqual("4567890123456" + longTestString, t.ToString());
+        }
+
+        private sealed class CharSequenceAnonymousClass : ICharSequence
+        {
+            private string longTestString;
+
+            public CharSequenceAnonymousClass(string longTestString)
+            {
+                this.longTestString = longTestString;
+            }
+
+            bool ICharSequence.HasValue => longTestString != null; // LUCENENET specific (implementation of ICharSequence)
+
+            public char CharAt(int i)
+            {
+                return longTestString[i];
+            }
+
+            // LUCENENET specific - Added to .NETify
+            public char this[int i] => longTestString[i];
+
+            public int Length => longTestString.Length;
+
+            public ICharSequence Subsequence(int startIndex, int length) // LUCENENET: Changed semantics to startIndex/length to match .NET
+            {
+                return new StringCharSequence(longTestString.Substring(startIndex, length));
+            }
+
+            public override string ToString()
+            {
+                return longTestString;
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Lucene.Net.Facet.Taxonomy.WriterCache.CharBlockArray: Implemented `IAppendable` to align with Lucene.

## Description

`Lucene.Net.Facet.Taxonomy.WriterCache.CharBlockArray`: Implemented `IAppendable` to align with Lucene. Added tests to check the implementations, since we have many additional overloads in .NET. Added guard clauses for `Append()` overloads using the same semantics as the .NET StringBuilder class.
