### PR TITLE
BUG: Lucene.Net.QueryParsers.Classic.QueryParserTokenManager: Removed initialization code that caused writing a BOM to standard out upon creation. Fixes #792.

### DIFF
--- a/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.QueryParsers.Classic
 {
@@ -28,17 +29,9 @@ namespace Lucene.Net.QueryParsers.Classic
     [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "This class is based on generated code")]
     public class QueryParserTokenManager //: QueryParserConstants
     {
-        private void  InitBlock()
-        {
-            StreamWriter temp_writer;
-            temp_writer = new StreamWriter(Console.OpenStandardOutput(), Console.Out.Encoding);
-            temp_writer.AutoFlush = true;
-            debugStream = temp_writer;
-        }
-
         /// <summary>Debug output. </summary>
 #pragma warning disable IDE0052 // Remove unread private members
-        private TextWriter debugStream; // LUCENENET specific - made private, since we already have a setter
+        private TextWriter debugStream = Console.Out; // LUCENENET specific - made private, since we already have a setter
 #pragma warning restore IDE0052 // Remove unread private members
         /// <summary>Set debug output. </summary>
         public virtual void SetDebugStream(TextWriter ds)
@@ -1166,7 +1159,6 @@ namespace Lucene.Net.QueryParsers.Classic
         /// <summary>Constructor. </summary>
         public QueryParserTokenManager(ICharStream stream)
         {
-            InitBlock();
             m_input_stream = stream;
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

BUG: Lucene.Net.QueryParsers.Classic.QueryParserTokenManager: Removed initialization code that caused writing a BOM to standard out upon creation.

Fixes #792

## Description

Removed initialization code that caused writing a BOM to standard out upon creation. This also improves performance by removing an unnecessary allocation of `StreamWriter` and brings the code in line with Lucene.

