### PR TITLE
TestTargetFramework.props: Added documentation about how the TargetFramework specified in tests maps to a TargetFramework that is under test

### DIFF
--- a/TestTargetFramework.props
+++ b/TestTargetFramework.props
@@ -35,6 +35,16 @@
     <!-- Allow the build script to pass in the test frameworks to build for.
       This overrides the above TargetFramework setting. 
       LUCENENET TODO: Due to a parsing bug, we cannot pass a string with a ; to dotnet msbuild, so passing true as a workaround -->
+
+    <!-- Test Client to DLL target works as follows:
+      Test Client       | Target Under Test
+      net7.0            | net6.0
+      net6.0            | net6.0
+      net5.0            | netstandard2.1
+      net48             | net462
+      net461            | netstandard2.0
+    -->
+    
     <TargetFrameworks Condition=" '$(TestFrameworks)' == 'true' ">net7.0;net6.0;net5.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TestFrameworks)' == 'true' AND $([MSBuild]::IsOsPlatform('Windows')) ">$(TargetFrameworks);net48;net461</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

`TestTargetFramework.props`: Added documentation about how the TargetFramework specified in tests maps to a TargetFramework that is under test.

## Description

`TestTargetFramework.props`: Added documentation about how the TargetFramework specified in tests maps to a TargetFramework that is under test. 

We have had many suggestions to remove `net5.0` from our test targets because it is no longer supported. We keep `net5.0` around because everything higher will load the `net6.0` target by default, leaving a gap in our testing - `netstandard2.1`. We already force `net461` to load `netstandard2.0` in order to test it, but that seems like less of a valid test than using an obsolete framework.
