### PR TITLE
BUG: Lucene.Net.Search.FieldComparer.TermValComparer: Fixed sorting ambiguity between empty fields and missing fields

### DIFF
--- a/src/Lucene.Net/Search/FieldComparator.cs
+++ b/src/Lucene.Net/Search/FieldComparator.cs
@@ -1452,10 +1452,14 @@ namespace Lucene.Net.Search
         // TODO: should we remove this?  who really uses it?
         public sealed class TermValComparer : FieldComparer<BytesRef>
         {
-            // sentinels, just used internally in this comparer
-            private static readonly byte[] MISSING_BYTES = Arrays.Empty<byte>();
+            // LUCENENET NOTE: We can't use Arrays.Empty<byte>() here because
+            // MISSING_BYTES and NON_MISSING_BYTES are compared for reference
+            // equality and Arrays.Empty<byte>() returns a singleton instance.
 
-            private static readonly byte[] NON_MISSING_BYTES = Arrays.Empty<byte>();
+            // sentinels, just used internally in this comparer
+            private static readonly byte[] MISSING_BYTES = new byte[0];
+
+            private static readonly byte[] NON_MISSING_BYTES = new byte[0];
 
             private readonly BytesRef[] values; // LUCENENET: marked readonly
             private BinaryDocValues docTerms;

--- a/src/Lucene.Net/Search/FieldComparator.cs
+++ b/src/Lucene.Net/Search/FieldComparator.cs
@@ -251,6 +251,9 @@ namespace Lucene.Net.Search
     // type parameter to access these nested types. Also moving non-generic methods here for casting without generics.
     public abstract class FieldComparer
     {
+        // LUCENENET: This class is not intended for user subclassing. Use FieldComparer<T> instead.
+        internal FieldComparer() { }
+
         /// <summary>
         /// Returns -1 if first is less than second. Default
         /// implementation to assume the type implements <see cref="IComparable{T}"/> and


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

`Lucene.Net.Search.FieldComparer.TermValComparer`: Fixed sorting ambiguity between empty fields and missing fields

## Description

When using `Arrays.Empty<T>()` we get a singleton instance. However, this comparer uses reference equality to compare the static fields `MISSING_BYTES` and `NON_MISSING_BYTES`. This reverts back to `new byte[0]` to ensure the reference equality checks pass.

### BREAKING

This PR also adds an internal constructor to `FieldComparer`, since this is a class that we added to make Lucene.NET compile. It is confusing for users who are upgrading because in older versions `FieldComparer` was not a generic class. Users who are upgrading should use `FieldComparer<T>`, which reduces or eliminates the need for casting of the underlying type.
