### PR TITLE
ci: Only trigger SonarCloud on solution updates (not docs, website, or CI files). Fixes #873.

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -45,10 +45,10 @@ jobs:
           echo "DOTNET_NOLOGO=1" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
           echo "DOTNET_CLI_TELEMETRY_OPTOUT=1" | Out-File -FilePath  $env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
-      - name: Setup .NET 7 SDK
+      - name: Setup .NET 8 SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
       - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -21,6 +21,17 @@ on:
   push:
     branches:
       - master
+    paths: # Exclude anything that isn't the main solution (docs, images, website, etc.)
+    - '.github/workflows/sonar.yml'
+    - 'src/**'
+    - '.build/dependencies.props'
+    - '.build/TestReferences.Common.*'
+    - '**/TestTargetFramework.*'
+    - '*.sln'
+    - '**/Directory.Build.*'
+    - '!src/docs/**'
+    - '!**/*.md'
+    - '!**/*.txt'
   schedule:
     - cron: '36 12 * * *' # 12:36 PM UTC, daily (picked an odd start time to try to avoid competing for agents with other projects)
 jobs:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Only trigger SonarCloud on solution updates (not docs, website, or other files)

Fixes #873

## Description

Only trigger SonarCloud on solution updates (not docs, website, or CI files).

This PR also updates the SonarCloud workflow to use .NET 8 SDK, which we will need soon when we add .NET 8 tests.