### PR TITLE
Lucene.Net.Search.ReferenceContext<T>: Converted to ref struct and reworked TestControlledRealTimeReopenThread.TestStraightForwardDemonstration() to verify functionality

### DIFF
--- a/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
+++ b/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
@@ -787,15 +787,36 @@ namespace Lucene.Net.Search
             controlledRealTimeReopenThread.Start();
 
             //An indexSearcher only sees Doc1
-            IndexSearcher indexSearcher = searcherManager.Acquire();
-            try
+
+            // In Java, to obtain a threadsafe IndexSearcher reference, the following pattern could
+            // be used. This also works in .NET.
+            //IndexSearcher indexSearcher = searcherManager.Acquire();
+            //try
+            //{
+            //    TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), 1);
+            //    assertEquals(1, topDocs.TotalHits);             //There is only one doc
+            //}
+            //finally
+            //{
+            //    searcherManager.Release(indexSearcher);
+            //}
+
+            // However, in .NET it can be done like this with less code. We get an instance of
+            // ReferenceContext<IndexSearcher> in a using block so the call to searcherManager.Release()
+            // happens implicitly. ReferenceContext<IndexSearcher> is a ref struct so it doesn't allocate
+            // on the heap and will be deallocated at the end of this block automatically.
+            using (var context = searcherManager.GetContext())
             {
+                IndexSearcher indexSearcher = context.Reference;
                 TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), 1);
                 assertEquals(1, topDocs.TotalHits);             //There is only one doc
             }
-            finally
+
+            using (var context = searcherManager.GetContext())
             {
-                searcherManager.Release(indexSearcher);
+                IndexSearcher indexSearcher = context.Reference;
+                TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), 1);
+                assertEquals(1, topDocs.TotalHits);             //There is only one doc
             }
 
             //Add a 2nd document
@@ -806,15 +827,29 @@ namespace Lucene.Net.Search
 
             //Demonstrate that we can only see the first doc because we haven't 
             //waited 1 sec or called WaitForGeneration
-            indexSearcher = searcherManager.Acquire();
-            try
+
+            // In Java, to obtain a threadsafe IndexSearcher reference, the following pattern could
+            // be used. This also works in .NET.
+            //indexSearcher = searcherManager.Acquire();
+            //try
+            //{
+            //    TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), 1);
+            //    assertEquals(1, topDocs.TotalHits);             //Can see both docs due to auto refresh after 1.1 secs
+            //}
+            //finally
+            //{
+            //    searcherManager.Release(indexSearcher);
+            //}
+
+            // However, in .NET it can be done like this with less code. We get an instance of
+            // ReferenceContext<IndexSearcher> in a using block so the call to searcherManager.Release()
+            // happens implicitly. ReferenceContext<IndexSearcher> is a ref struct so it doesn't allocate
+            // on the heap and will be deallocated at the end of this block automatically.
+            using (var context = searcherManager.GetContext())
             {
+                IndexSearcher indexSearcher = context.Reference;
                 TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), 1);
                 assertEquals(1, topDocs.TotalHits);             //Can see both docs due to auto refresh after 1.1 secs
-            }
-            finally
-            {
-                searcherManager.Release(indexSearcher);
             }
 
 
@@ -822,15 +857,11 @@ namespace Lucene.Net.Search
             //then 1 sec so that controlledRealTimeReopenThread max interval is exceeded
             //and it calls MaybeRefresh
             Thread.Sleep(1100);     //wait 1.1 secs as ms
-            indexSearcher = searcherManager.Acquire();
-            try
+            using (var context = searcherManager.GetContext())
             {
+                IndexSearcher indexSearcher = context.Reference;
                 TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), 1);
                 assertEquals(2, topDocs.TotalHits);             //Can see both docs due to auto refresh after 1.1 secs
-            }
-            finally
-            {
-                searcherManager.Release(indexSearcher);
             }
 
 
@@ -848,15 +879,28 @@ namespace Lucene.Net.Search
             stopwatch.Stop();
             assertTrue(stopwatch.Elapsed.TotalMilliseconds <= 200 + 30);   //30ms is fudged factor to account for call overhead.
 
-            indexSearcher = searcherManager.Acquire();
-            try
+            // In Java, to obtain a threadsafe IndexSearcher reference, the following pattern could
+            // be used. This also works in .NET.
+            //indexSearcher = searcherManager.Acquire();
+            //try
+            //{
+            //    TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), 1);
+            //    assertEquals(3, topDocs.TotalHits);             //Can see both docs due to auto refresh after 1.1 secs
+            //}
+            //finally
+            //{
+            //    searcherManager.Release(indexSearcher);
+            //}
+
+            // However, in .NET it can be done like this with less code. We get an instance of
+            // ReferenceContext<IndexSearcher> in a using block so the call to searcherManager.Release()
+            // happens implicitly. ReferenceContext<IndexSearcher> is a ref struct so it doesn't allocate
+            // on the heap and will be deallocated at the end of this block automatically.
+            using (var context = searcherManager.GetContext())
             {
+                IndexSearcher indexSearcher = context.Reference;
                 TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), 1);
                 assertEquals(3, topDocs.TotalHits);             //Can see both docs due to auto refresh after 1.1 secs
-            }
-            finally
-            {
-                searcherManager.Release(indexSearcher);
             }
 
             controlledRealTimeReopenThread.Dispose();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Converted from a sealed class to a ref struct to eliminate the heap allocation. Converted `TestControlledRealTimeReopenThread.TestStraightForwardDemonstration()` to test using `ReferenceContext<T>` to verify functionality. See #920.

See #920.

