### PR TITLE
SWEEP: Reviewed usage of atomic numeric type methods

### DIFF
--- a/src/Lucene.Net.Replicator/LocalReplicator.cs
+++ b/src/Lucene.Net.Replicator/LocalReplicator.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Support.Threading;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -189,7 +190,7 @@ namespace Lucene.Net.Replicator
                 // currentVersion is either null or older than latest published revision
                 currentRevision.IncRef();
 
-                string sessionID = sessionToken.IncrementAndGet().ToString();
+                string sessionID = sessionToken.IncrementAndGet().ToString(CultureInfo.InvariantCulture);
                 SessionToken token = new SessionToken(sessionID, currentRevision.Revision);
                 sessions[sessionID] = new ReplicationSession(token, currentRevision);
                 return token;

--- a/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
@@ -572,7 +572,7 @@ namespace Lucene.Net.Codecs.RAMOnly
         // Holds all indexes created, keyed by the ID assigned in fieldsConsumer
         private readonly IDictionary<int, RAMPostings> state = new Dictionary<int, RAMPostings>();
 
-        private readonly AtomicInt64 nextID = new AtomicInt64();
+        private readonly AtomicInt32 nextID = new AtomicInt32();
 
         private readonly string RAM_ONLY_NAME = "RAMOnly";
         private const int VERSION_START = 0;
@@ -582,7 +582,7 @@ namespace Lucene.Net.Codecs.RAMOnly
 
         public override FieldsConsumer FieldsConsumer(SegmentWriteState writeState)
         {
-            int id = (int)nextID.GetAndIncrement();
+            int id = nextID.GetAndIncrement();
 
             // TODO -- ok to do this up front instead of
             // on close....?  should be ok?

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -704,7 +704,7 @@ namespace Lucene.Net.Store
                     {
                         if (existing != null)
                         {
-                            ramdir.m_sizeInBytes.AddAndGet(-existing.GetSizeInBytes()); // LUCENENET: GetAndAdd in Lucene, but we are not using the value
+                            ramdir.m_sizeInBytes.GetAndAdd(-existing.GetSizeInBytes());
                             existing.directory = null;
                         }
                         ramdir.m_fileMap[name] = file;

--- a/src/Lucene.Net.Tests/Search/TestBooleanOr.cs
+++ b/src/Lucene.Net.Tests/Search/TestBooleanOr.cs
@@ -205,7 +205,7 @@ namespace Lucene.Net.Search
             while (end.Value < docCount)
             {
                 int inc = TestUtil.NextInt32(Random, 1, 1000);
-                end.AddAndGet(inc);
+                end.GetAndAdd(inc);
                 scorer.Score(c, end);
             }
 

--- a/src/Lucene.Net/Store/RAMFile.cs
+++ b/src/Lucene.Net/Store/RAMFile.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Store
                 UninterruptableMonitor.Exit(this);
             }
 
-            directory?.m_sizeInBytes.AddAndGet(size);
+            directory?.m_sizeInBytes.GetAndAdd(size);
             return buffer;
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

SWEEP: Reviewed usage of atomic numeric type methods

Fixes #917

## Description

This aligns usages of `GetAndAdd()`, `AddAndGet()`, `IncrementAndGet()`, `GetAndIncrement()`, `DecrementAndGet()`, and `GetAndDecrement()` match Lucene (for both `AtomicInt32` and `AtomicInt64`). There were no significant issues found, but some of the adjacent code was corrected to use the correct types, casts, and formatting in the invariant culture.
