### PR TITLE
Restore fsync behavior in FSDirectory via P/Invoke, #933

### DIFF
--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
@@ -47,7 +47,6 @@ namespace Lucene.Net.Index
 
         [Test]
         [Slow]
-        [AwaitsFix]
         public override void TestNRTThreads_Mem()
         {
             //if we are not the fork

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
@@ -47,6 +47,7 @@ namespace Lucene.Net.Index
 
         [Test]
         [Slow]
+        [Repeat(25)]
         public override void TestNRTThreads_Mem()
         {
             //if we are not the fork

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Index
 
         [Test]
         [Slow]
-        [Repeat(25)]
+        [AwaitsFix]
         public override void TestNRTThreads_Mem()
         {
             //if we are not the fork

--- a/src/Lucene.Net.Tests/Support/TestConcurrentHashSet.cs
+++ b/src/Lucene.Net.Tests/Support/TestConcurrentHashSet.cs
@@ -1,0 +1,51 @@
+﻿using Lucene.Net.Attributes;
+using Lucene.Net.Support;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Lucene.Net
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public class TestConcurrentHashSet
+    {
+        [Test, LuceneNetSpecific]
+        public void TestExceptWith()
+        {
+            // Numbers 0-8, 10-80, 99
+            var initialSet = Enumerable.Range(1, 8)
+                .Concat(Enumerable.Range(1, 8).Select(i => i * 10))
+                .Append(99)
+                .Append(0);
+
+            var hashSet = new ConcurrentHashSet<int>(initialSet);
+
+            Parallel.ForEach(Enumerable.Range(1, 8), i =>
+            {
+                // Remove i and i * 10, i.e. 1 and 10, 2 and 20, etc.
+                var except = new[] { i, i * 10 };
+                hashSet.ExceptWith(except);
+            });
+
+            Assert.AreEqual(2, hashSet.Count);
+            Assert.IsTrue(hashSet.Contains(0));
+            Assert.IsTrue(hashSet.Contains(99));
+        }
+    }
+}

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -378,7 +378,7 @@ namespace Lucene.Net.Store
                 Fsync(name);
             }
 
-            // fsync the directory itsself, but only if there was any file fsynced before
+            // fsync the directory itself, but only if there was any file fsynced before
             // (otherwise it can happen that the directory does not yet exist)!
             if (toSync.Count > 0)
             {

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -67,11 +67,11 @@ namespace Lucene.Net.Store
     /// the best <see cref="FSDirectory"/> implementation given your
     /// environment, and the known limitations of each
     /// implementation. For users who have no reason to prefer a
-    /// specific implementation, it's best to simply use 
+    /// specific implementation, it's best to simply use
     /// <see cref="Open(string)"/>  (or one of its overloads). For all others, you should instantiate the
     /// desired implementation directly.
     ///
-    /// <para/>The locking implementation is by default 
+    /// <para/>The locking implementation is by default
     /// <see cref="NativeFSLockFactory"/>, but can be changed by
     /// passing in a custom <see cref="LockFactory"/> instance.
     ///
@@ -94,10 +94,8 @@ namespace Lucene.Net.Store
         public const int DEFAULT_READ_CHUNK_SIZE = 8192;
 
         protected readonly DirectoryInfo m_directory; // The underlying filesystem directory
+        protected readonly ISet<string> m_staleFiles = new ConcurrentHashSet<string>(); // Files written, but not yet sync'ed
 
-        // LUCENENET specific: No such thing as "stale files" in .NET, since Flush(true) writes everything to disk before
-        // our FileStream is disposed.
-        //protected readonly ISet<string> m_staleFiles = new ConcurrentHashSet<string>(); // Files written, but not yet sync'ed
 #pragma warning disable 612, 618
         private int chunkSize = DEFAULT_READ_CHUNK_SIZE;
 #pragma warning restore 612, 618
@@ -321,9 +319,8 @@ namespace Lucene.Net.Store
             {
                 throw new IOException("Cannot delete " + file, e);
             }
-            // LUCENENET specific: No such thing as "stale files" in .NET, since Flush(true) writes everything to disk before
-            // our FileStream is disposed.
-            //m_staleFiles.Remove(name);
+
+            m_staleFiles.Remove(name);
         }
 
         /// <summary>
@@ -366,35 +363,29 @@ namespace Lucene.Net.Store
 
         protected virtual void OnIndexOutputClosed(FSIndexOutput io)
         {
-            // LUCENENET specific: No such thing as "stale files" in .NET, since Flush(true) writes everything to disk before
-            // our FileStream is disposed.
-            //m_staleFiles.Add(io.name);
+            m_staleFiles.Add(io.name);
         }
 
         public override void Sync(ICollection<string> names)
         {
             EnsureOpen();
 
-            // LUCENENET specific: No such thing as "stale files" in .NET, since Flush(true) writes everything to disk before
-            // our FileStream is disposed. Therefore, there is nothing else to do in this method.
-            //ISet<string> toSync = new HashSet<string>(names);
-            //toSync.IntersectWith(m_staleFiles);
+            ISet<string> toSync = new HashSet<string>(names);
+            toSync.IntersectWith(m_staleFiles);
 
-            //// LUCENENET specific: Fsync breaks concurrency here.
-            //// Part of a solution suggested by Vincent Van Den Berghe: http://apache.markmail.org/message/hafnuhq2ydhfjmi2
-            ////foreach (var name in toSync)
-            ////{
-            ////    Fsync(name);
-            ////}
+            foreach (var name in toSync)
+            {
+                Fsync(name);
+            }
 
-            //// fsync the directory itsself, but only if there was any file fsynced before
-            //// (otherwise it can happen that the directory does not yet exist)!
-            //if (toSync.Count > 0)
-            //{
-            //    IOUtils.Fsync(m_directory.FullName, true);
-            //}
+            // fsync the directory itsself, but only if there was any file fsynced before
+            // (otherwise it can happen that the directory does not yet exist)!
+            if (toSync.Count > 0)
+            {
+                IOUtils.Fsync(m_directory, true);
+            }
 
-            //m_staleFiles.ExceptWith(toSync);
+            m_staleFiles.ExceptWith(toSync);
         }
 
         public override string GetLockID()
@@ -546,7 +537,7 @@ namespace Lucene.Net.Store
                         Exception priorE = null; // LUCENENET: No need to cast to IOExcpetion
                         try
                         {
-                            file.Flush(flushToDisk: true);
+                            file.Flush(flushToDisk: false);
                         }
                         catch (Exception ioe) when (ioe.IsIOException())
                         {
@@ -586,12 +577,9 @@ namespace Lucene.Net.Store
             public override long Position => file.Position; // LUCENENET specific - need to override, since we are buffering locally, renamed from getFilePointer() to match FileStream
         }
 
-        // LUCENENET specific: Fsync is pointless in .NET, since we are 
-        // calling FileStream.Flush(true) before the stream is disposed
-        // which means we never need it at the point in Java where it is called.
-        //protected virtual void Fsync(string name)
-        //{
-        //    IOUtils.Fsync(Path.Combine(m_directory.FullName, name), false);
-        //}
+        protected virtual void Fsync(string name)
+        {
+            IOUtils.Fsync(new FileInfo(Path.Combine(m_directory.FullName, name)), false);
+        }
     }
 }

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -382,7 +382,7 @@ namespace Lucene.Net.Store
             // (otherwise it can happen that the directory does not yet exist)!
             if (toSync.Count > 0)
             {
-                IOUtils.Fsync(m_directory, true);
+                IOUtils.Fsync(m_directory.FullName, true);
             }
 
             m_staleFiles.ExceptWith(toSync);
@@ -579,7 +579,7 @@ namespace Lucene.Net.Store
 
         protected virtual void Fsync(string name)
         {
-            IOUtils.Fsync(new FileInfo(Path.Combine(m_directory.FullName, name)), false);
+            IOUtils.Fsync(Path.Combine(m_directory.FullName, name), false);
         }
     }
 }

--- a/src/Lucene.Net/Support/ConcurrentHashSet.cs
+++ b/src/Lucene.Net/Support/ConcurrentHashSet.cs
@@ -204,16 +204,16 @@ namespace Lucene.Net.Support
 
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConcurrentHashSet{T}"/> 
-        /// class that contains elements copied from the specified <see cref="T:System.Collections.IEnumerable"/>, 
-        /// has the specified concurrency level, has the specified initial capacity, and uses the specified 
+        /// Initializes a new instance of the <see cref="ConcurrentHashSet{T}"/>
+        /// class that contains elements copied from the specified <see cref="T:System.Collections.IEnumerable"/>,
+        /// has the specified concurrency level, has the specified initial capacity, and uses the specified
         /// <see cref="T:System.Collections.Generic.IEqualityComparer{T}"/>.
         /// </summary>
-        /// <param name="concurrencyLevel">The estimated number of threads that will update the 
+        /// <param name="concurrencyLevel">The estimated number of threads that will update the
         /// <see cref="ConcurrentHashSet{T}"/> concurrently.</param>
-        /// <param name="collection">The <see cref="T:System.Collections.IEnumerable{T}"/> whose elements are copied to the new 
+        /// <param name="collection">The <see cref="T:System.Collections.IEnumerable{T}"/> whose elements are copied to the new
         /// <see cref="ConcurrentHashSet{T}"/>.</param>
-        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{T}"/> implementation to use 
+        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{T}"/> implementation to use
         /// when comparing items.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="collection"/> is a null reference.
@@ -638,7 +638,7 @@ namespace Lucene.Net.Support
                     // We want to make sure that GrowTable will not be called again, since table is at the maximum size.
                     // To achieve that, we set the budget to int.MaxValue.
                     //
-                    // (There is one special case that would allow GrowTable() to be called in the future: 
+                    // (There is one special case that would allow GrowTable() to be called in the future:
                     // calling Clear() on the ConcurrentHashSet will shrink the table and lower the budget.)
                     _budget = int.MaxValue;
                 }
@@ -753,7 +753,16 @@ namespace Lucene.Net.Support
 
         public void ExceptWith(IEnumerable<T> other)
         {
-            throw new NotImplementedException();
+            if (ReferenceEquals(this, other))
+            {
+                Clear();
+                return;
+            }
+
+            foreach (var item in other)
+            {
+                TryRemove(item);
+            }
         }
 
         public void IntersectWith(IEnumerable<T> other)

--- a/src/Lucene.Net/Support/IO/PosixFsyncSupport.cs
+++ b/src/Lucene.Net/Support/IO/PosixFsyncSupport.cs
@@ -1,0 +1,95 @@
+using Lucene.Net.Util;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support.IO
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static class PosixFsyncSupport
+    {
+        // https://pubs.opengroup.org/onlinepubs/009695399/functions/fsync.html
+        [DllImport("libc", SetLastError = true)]
+        private static extern int fsync(int fd);
+
+        // https://pubs.opengroup.org/onlinepubs/007904875/functions/open.html
+        [DllImport("libc", SetLastError = true)]
+        private static extern int open([MarshalAs(UnmanagedType.LPStr)] string pathname, int flags);
+
+        // https://pubs.opengroup.org/onlinepubs/009604499/functions/close.html
+        [DllImport("libc", SetLastError = true)]
+        private static extern int close(int fd);
+
+        // https://pubs.opengroup.org/onlinepubs/007904975/functions/fcntl.html
+        // and https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
+        [DllImport("libc", SetLastError = true)]
+        private static extern int fcntl(int fd, int cmd, int arg);
+
+        private const int O_RDONLY = 0;
+        private const int O_WRONLY = 1;
+
+        // https://opensource.apple.com/source/xnu/xnu-6153.81.5/bsd/sys/fcntl.h.auto.html
+        private const int F_FULLFSYNC = 51;
+
+        public static void Fsync(string path, bool isDir)
+        {
+            using DescriptorWrapper handle = new DescriptorWrapper(path, isDir);
+            handle.Flush();
+        }
+
+        private readonly ref struct DescriptorWrapper
+        {
+            private readonly int fd;
+
+            public DescriptorWrapper(string path, bool isDir)
+            {
+                fd = open(path, isDir ? O_RDONLY : O_WRONLY);
+
+                if (fd == -1)
+                {
+                    int error = Marshal.GetLastWin32Error();
+                    throw new IOException($"Unable to open path, error: 0x{error:x8}", error);
+                }
+            }
+
+            public void Flush()
+            {
+                // if macOS, use F_FULLFSYNC
+                if (Constants.MAC_OS_X)
+                {
+                    if (fcntl(fd, F_FULLFSYNC, 0) == -1)
+                    {
+                        throw new IOException("fcntl failed", Marshal.GetLastWin32Error());
+                    }
+                }
+                else if (fsync(fd) == -1)
+                {
+                    throw new IOException("fsync failed", Marshal.GetLastWin32Error());
+                }
+            }
+
+            public void Dispose()
+            {
+                if (close(fd) == -1)
+                {
+                    throw new IOException("close failed", Marshal.GetLastWin32Error());
+                }
+            }
+        }
+    }
+}

--- a/src/Lucene.Net/Support/IO/PosixFsyncSupport.cs
+++ b/src/Lucene.Net/Support/IO/PosixFsyncSupport.cs
@@ -2,8 +2,8 @@ using Lucene.Net.Util;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using static Lucene.Net.Support.Native.Interop.Posix;
-using static Lucene.Net.Support.Native.Interop.MacOS;
+using static Lucene.Net.Native.Interop.Posix;
+using static Lucene.Net.Native.Interop.MacOS;
 
 namespace Lucene.Net.Support.IO
 {

--- a/src/Lucene.Net/Support/IO/PosixFsyncSupport.cs
+++ b/src/Lucene.Net/Support/IO/PosixFsyncSupport.cs
@@ -2,6 +2,8 @@ using Lucene.Net.Util;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using static Lucene.Net.Support.Native.Interop.Posix;
+using static Lucene.Net.Support.Native.Interop.MacOS;
 
 namespace Lucene.Net.Support.IO
 {
@@ -24,32 +26,6 @@ namespace Lucene.Net.Support.IO
 
     internal static class PosixFsyncSupport
     {
-        // https://pubs.opengroup.org/onlinepubs/009695399/functions/fsync.html
-        [DllImport("libc", SetLastError = true)]
-        private static extern int fsync(int fd);
-
-        // https://pubs.opengroup.org/onlinepubs/007904875/functions/open.html
-        [DllImport("libc", SetLastError = true)]
-        private static extern int open([MarshalAs(UnmanagedType.LPStr)] string pathname, int flags);
-
-        // https://pubs.opengroup.org/onlinepubs/009604499/functions/close.html
-        [DllImport("libc", SetLastError = true)]
-        private static extern int close(int fd);
-
-        // https://pubs.opengroup.org/onlinepubs/007904975/functions/fcntl.html
-        // and https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
-        [DllImport("libc", SetLastError = true)]
-        private static extern int fcntl(int fd, int cmd, int arg);
-
-        private const int O_RDONLY = 0;
-        private const int O_WRONLY = 1;
-
-        // https://opensource.apple.com/source/xnu/xnu-6153.81.5/bsd/sys/fcntl.h.auto.html
-        private const int F_FULLFSYNC = 51;
-
-        private const int EACCES = 13;
-        private const int ENOENT = 2;
-
         public static void Fsync(string path, bool isDir)
         {
             using DescriptorWrapper handle = new DescriptorWrapper(path, isDir);

--- a/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
+++ b/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using static Lucene.Net.Support.Native.Interop.Win32;
 
 namespace Lucene.Net.Support.IO
 {
@@ -23,42 +24,6 @@ namespace Lucene.Net.Support.IO
 
     public static class WindowsFsyncSupport
     {
-        // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern IntPtr CreateFileW(
-            string lpFileName,
-            uint dwDesiredAccess,
-            uint dwShareMode,
-            IntPtr lpSecurityAttributes,
-            uint dwCreationDisposition,
-            uint dwFlagsAndAttributes,
-            IntPtr hTemplateFile
-        );
-
-        // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool FlushFileBuffers(IntPtr hFile);
-
-        // https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool CloseHandle(IntPtr hObject);
-
-        private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
-
-        // https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
-        private const int ERROR_FILE_NOT_FOUND = 2;
-        private const int ERROR_PATH_NOT_FOUND = 3;
-        private const int ERROR_ACCESS_DENIED = 5;
-
-        // https://learn.microsoft.com/en-us/windows/win32/secauthz/generic-access-rights
-        private const int GENERIC_WRITE = 0x40000000;
-
-        private const int FILE_SHARE_READ = 0x00000001;
-        private const int FILE_SHARE_WRITE = 0x00000002;
-        private const int FILE_SHARE_DELETE = 0x00000004;
-        private const int FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
-        private const int OPEN_EXISTING = 3;
-
         public static void Fsync(string path, bool isDir)
         {
             using HandleWrapper handle = new HandleWrapper(path, isDir);

--- a/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
+++ b/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support.IO
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public static class WindowsFsyncSupport
+    {
+        // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateFileW(
+            string lpFileName,
+            uint dwDesiredAccess,
+            uint dwShareMode,
+            IntPtr lpSecurityAttributes,
+            uint dwCreationDisposition,
+            uint dwFlagsAndAttributes,
+            IntPtr hTemplateFile
+        );
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool FlushFileBuffers(IntPtr hFile);
+
+        // https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool CloseHandle(IntPtr hObject);
+
+        private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+
+        private const int ERROR_ACCESS_DENIED = 5;
+
+        // https://learn.microsoft.com/en-us/windows/win32/secauthz/generic-access-rights
+        private const int GENERIC_WRITE = 0x40000000;
+
+        private const int FILE_SHARE_READ = 0x00000001;
+        private const int FILE_SHARE_WRITE = 0x00000002;
+        private const int FILE_SHARE_DELETE = 0x00000004;
+        private const int FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+        private const int OPEN_EXISTING = 3;
+
+        public static void Fsync(string path, bool isDir)
+        {
+            using HandleWrapper handle = new HandleWrapper(path, isDir);
+            handle.Flush();
+        }
+
+        private readonly ref struct HandleWrapper
+        {
+            private readonly IntPtr handle;
+
+            public HandleWrapper(string path, bool isDir)
+            {
+                handle = CreateFileW(path,
+                    GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    IntPtr.Zero,
+                    OPEN_EXISTING,
+                    (uint)(isDir ? FILE_FLAG_BACKUP_SEMANTICS : 0), // FILE_FLAG_BACKUP_SEMANTICS required to open a directory
+                    IntPtr.Zero);
+
+                if (handle == INVALID_HANDLE_VALUE)
+                {
+                    int error = Marshal.GetLastWin32Error();
+                    throw new IOException($"Unable to open directory, error: 0x{error:x8}", error);
+                }
+            }
+
+            public void Flush()
+            {
+                if (!FlushFileBuffers(handle))
+                {
+                    int error = Marshal.GetLastWin32Error();
+
+                    if (error != ERROR_ACCESS_DENIED)
+                    {
+                        // swallow ERROR_ACCESS_DENIED like in OpenJDK
+                        throw new IOException($"FlushFileBuffers failed, error: 0x{error:x8}", error);
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                if (!CloseHandle(handle))
+                {
+                    int error = Marshal.GetLastWin32Error();
+                    throw new IOException($"CloseHandle failed, error: 0x{error:x8}", error);
+                }
+            }
+        }
+    }
+}

--- a/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
+++ b/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
@@ -83,7 +83,8 @@ namespace Lucene.Net.Support.IO
                 {
                     int error = Marshal.GetLastWin32Error();
 
-                    throw error switch {
+                    throw error switch
+                    {
                         ERROR_FILE_NOT_FOUND => new FileNotFoundException($"File not found: {path}"),
                         ERROR_PATH_NOT_FOUND => new DirectoryNotFoundException($"Directory/path not found: {path}"),
                         ERROR_ACCESS_DENIED => new UnauthorizedAccessException($"Access denied to {(isDir ? "directory" : "file")}: {path}"),

--- a/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
+++ b/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using static Lucene.Net.Support.Native.Interop.Win32;
+using static Lucene.Net.Native.Interop.Win32;
 
 namespace Lucene.Net.Support.IO
 {

--- a/src/Lucene.Net/Support/Native/Interop.MacOS.Constants.cs
+++ b/src/Lucene.Net/Support/Native/Interop.MacOS.Constants.cs
@@ -1,0 +1,28 @@
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class MacOS
+        {
+            // https://opensource.apple.com/source/xnu/xnu-6153.81.5/bsd/sys/fcntl.h.auto.html
+            internal const int F_FULLFSYNC = 51;
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.MacOS.Constants.cs
+++ b/src/Lucene.Net/Support/Native/Interop.MacOS.Constants.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Close.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Close.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Close.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Close.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class Posix
+        {
+            // https://pubs.opengroup.org/onlinepubs/009604499/functions/close.html
+            [DllImport("libc", SetLastError = true)]
+            internal static extern int close(int fd);
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Constants.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Constants.cs
@@ -1,0 +1,31 @@
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class Posix
+        {
+            internal const int O_RDONLY = 0;
+            internal const int O_WRONLY = 1;
+
+            internal const int EACCES = 13;
+            internal const int ENOENT = 2;
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Constants.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Constants.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Fcntl.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Fcntl.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Fcntl.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Fcntl.cs
@@ -1,0 +1,32 @@
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class Posix
+        {
+            // https://pubs.opengroup.org/onlinepubs/007904975/functions/fcntl.html
+            // and https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
+            [DllImport("libc", SetLastError = true)]
+            internal static extern int fcntl(int fd, int cmd, int arg);
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Fsync.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Fsync.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class Posix
+        {
+            // https://pubs.opengroup.org/onlinepubs/009695399/functions/fsync.html
+            [DllImport("libc", SetLastError = true)]
+            internal static extern int fsync(int fd);
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Fsync.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Fsync.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Open.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Open.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Support/Native/Interop.Posix.Open.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Posix.Open.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class Posix
+        {
+            // https://pubs.opengroup.org/onlinepubs/007904875/functions/open.html
+            [DllImport("libc", SetLastError = true)]
+            internal static extern int open([MarshalAs(UnmanagedType.LPStr)] string pathname, int flags);
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.Win32.CloseHandle.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Win32.CloseHandle.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Support/Native/Interop.Win32.CloseHandle.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Win32.CloseHandle.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class Win32
+        {
+            // https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern bool CloseHandle(IntPtr hObject);
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.Win32.Constants.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Win32.Constants.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class Win32
+        {
+            internal static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+
+            // https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+            internal const int ERROR_FILE_NOT_FOUND = 2;
+            internal const int ERROR_PATH_NOT_FOUND = 3;
+            internal const int ERROR_ACCESS_DENIED = 5;
+
+            // https://learn.microsoft.com/en-us/windows/win32/secauthz/generic-access-rights
+            internal const int GENERIC_WRITE = 0x40000000;
+
+            internal const int FILE_SHARE_READ = 0x00000001;
+            internal const int FILE_SHARE_WRITE = 0x00000002;
+            internal const int FILE_SHARE_DELETE = 0x00000004;
+            internal const int FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+            internal const int OPEN_EXISTING = 3;
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.Win32.Constants.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Win32.Constants.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Support/Native/Interop.Win32.CreateFileW.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Win32.CreateFileW.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class Win32
+        {
+            // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+            [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+            internal static extern IntPtr CreateFileW(
+                string lpFileName,
+                uint dwDesiredAccess,
+                uint dwShareMode,
+                IntPtr lpSecurityAttributes,
+                uint dwCreationDisposition,
+                uint dwFlagsAndAttributes,
+                IntPtr hTemplateFile
+            );
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.Win32.CreateFileW.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Win32.CreateFileW.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Support/Native/Interop.Win32.FlushFileBuffers.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Win32.FlushFileBuffers.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Support.Native
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    internal static partial class Interop
+    {
+        internal static partial class Win32
+        {
+            // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern bool FlushFileBuffers(IntPtr hFile);
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Native/Interop.Win32.FlushFileBuffers.cs
+++ b/src/Lucene.Net/Support/Native/Interop.Win32.FlushFileBuffers.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Lucene.Net.Support.Native
+namespace Lucene.Net.Native
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -531,10 +531,10 @@ namespace Lucene.Net.Util
             if (isDir && Constants.WINDOWS)
             {
                 // opening a directory on Windows fails, directories can not be fsynced there
-                if (fileToSync.Exists == false)
+                if (System.IO.Directory.Exists(fileToSync.FullName) == false)
                 {
                     // yet do not suppress trying to fsync directories that do not exist
-                    throw new DirectoryNotFoundException(fileToSync.ToString());
+                    throw new DirectoryNotFoundException($"Directory does not exist: {fileToSync}");
                 }
                 return;
             }

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -519,7 +519,8 @@ namespace Lucene.Net.Util
             }
         }
 
-        public static void Fsync(FileSystemInfo fileToSync, bool isDir)
+        // LUCENENET specific: using string instead of FileSystemInfo to avoid extra allocation
+        public static void Fsync(string fileToSync, bool isDir)
         {
             // LUCENENET NOTE: there is a bug in 4.8 where it tries to fsync a directory on Windows,
             // which is not supported in OpenJDK. This change adopts the latest Lucene code as of 9.10
@@ -531,7 +532,7 @@ namespace Lucene.Net.Util
             if (isDir && Constants.WINDOWS)
             {
                 // opening a directory on Windows fails, directories can not be fsynced there
-                if (System.IO.Directory.Exists(fileToSync.FullName) == false)
+                if (System.IO.Directory.Exists(fileToSync) == false)
                 {
                     // yet do not suppress trying to fsync directories that do not exist
                     throw new DirectoryNotFoundException($"Directory does not exist: {fileToSync}");
@@ -545,11 +546,11 @@ namespace Lucene.Net.Util
                 // We must call fsync on the parent directory, requiring some custom P/Invoking
                 if (Constants.WINDOWS)
                 {
-                    WindowsFsyncSupport.Fsync(fileToSync.FullName, isDir);
+                    WindowsFsyncSupport.Fsync(fileToSync, isDir);
                 }
                 else
                 {
-                    PosixFsyncSupport.Fsync(fileToSync.FullName, isDir);
+                    PosixFsyncSupport.Fsync(fileToSync, isDir);
                 }
             }
             catch (Exception e) when (e.IsIOException())

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -1,10 +1,13 @@
 ﻿using J2N;
 using Lucene.Net.Support;
+using Lucene.Net.Support.IO;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Lucene.Net.Util
@@ -516,8 +519,53 @@ namespace Lucene.Net.Util
             }
         }
 
-        // LUCENENET specific: Fsync is pointless in .NET, since we are
-        // calling FileStream.Flush(true) before the stream is disposed
-        // which means we never need it at the point in Java where it is called.
+        public static void Fsync(FileSystemInfo fileToSync, bool isDir)
+        {
+            // LUCENENET NOTE: there is a bug in 4.8 where it tries to fsync a directory on Windows,
+            // which is not supported in OpenJDK. This change adopts the latest Lucene code as of 9.10
+            // and only fsyncs directories on Linux and macOS.
+
+            // If the file is a directory we have to open read-only, for regular files we must open r/w for
+            // the fsync to have an effect.
+            // See http://blog.httrack.com/blog/2013/11/15/everything-you-always-wanted-to-know-about-fsync/
+            if (isDir && Constants.WINDOWS)
+            {
+                // opening a directory on Windows fails, directories can not be fsynced there
+                if (fileToSync.Exists == false)
+                {
+                    // yet do not suppress trying to fsync directories that do not exist
+                    throw new DirectoryNotFoundException(fileToSync.ToString());
+                }
+                return;
+            }
+
+            try
+            {
+                // LUCENENET specific: was: file.force(true);
+                // We must call fsync on the parent directory, requiring some custom P/Invoking
+                if (Constants.WINDOWS)
+                {
+                    WindowsFsyncSupport.Fsync(fileToSync.FullName, isDir);
+                }
+                else
+                {
+                    PosixFsyncSupport.Fsync(fileToSync.FullName, isDir);
+                }
+            }
+            catch (Exception e) when (e.IsIOException())
+            {
+                if (isDir)
+                {
+                    Debug.Assert((Constants.LINUX || Constants.MAC_OS_X) == false,
+                        "On Linux and MacOSX fsyncing a directory should not throw IOException, "
+                        + "we just don't want to rely on that in production (undocumented). Got: "
+                        + e);
+                    // Ignore exception if it is a directory
+                    return;
+                }
+                // Throw original exception
+                throw;
+            }
+        }
     }
 }

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -1,4 +1,5 @@
 ﻿using J2N;
+using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
 using System;
@@ -557,10 +558,13 @@ namespace Lucene.Net.Util
             {
                 if (isDir)
                 {
-                    Debug.Assert((Constants.LINUX || Constants.MAC_OS_X) == false,
-                        "On Linux and MacOSX fsyncing a directory should not throw IOException, "
-                        + "we just don't want to rely on that in production (undocumented). Got: "
-                        + e);
+                    if (Debugging.AssertsEnabled)
+                    {
+                        Debugging.Assert((Constants.LINUX || Constants.MAC_OS_X) == false,
+                            "On Linux and MacOSX fsyncing a directory should not throw IOException, we just don't want to rely on that in production (undocumented). Got: {0}",
+                            e);
+                    }
+
                     // Ignore exception if it is a directory
                     return;
                 }

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -554,22 +554,20 @@ namespace Lucene.Net.Util
                     PosixFsyncSupport.Fsync(fileToSync, isDir);
                 }
             }
-            catch (Exception e) when (e.IsIOException())
+            catch (Exception e) when (e.IsIOException() && isDir && e is not DirectoryNotFoundException)
             {
-                if (isDir)
-                {
-                    if (Debugging.AssertsEnabled)
-                    {
-                        Debugging.Assert((Constants.LINUX || Constants.MAC_OS_X) == false,
-                            "On Linux and MacOSX fsyncing a directory should not throw IOException, we just don't want to rely on that in production (undocumented). Got: {0}",
-                            e);
-                    }
+                // LUCENENET specific - make catch specific to IOExceptions when it's a directory,
+                // but allow DirectoryNotFoundException to pass through as an equivalent would normally be
+                // thrown by the FileChannel.open call in Java which is outside the try block.
 
-                    // Ignore exception if it is a directory
-                    return;
+                if (Debugging.AssertsEnabled)
+                {
+                    Debugging.Assert((Constants.LINUX || Constants.MAC_OS_X) == false,
+                        "On Linux and MacOSX fsyncing a directory should not throw IOException, we just don't want to rely on that in production (undocumented). Got: {0}",
+                        e);
                 }
-                // Throw original exception
-                throw;
+
+                // Ignore exception if it is a directory
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable. (Existing unit tests)
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This restores the commented-out fsync behavior in FSDirectory to help mitigate a performance regression in .NET 8.

Fixes #933

## Description

See 933 for more details. Perf benchmark before:
```
| Method                  | Job      | Runtime  | IterationCount | LaunchCount | WarmupCount | N  | Mean      | Error      | StdDev   | Median    | Ratio | RatioSD |
|------------------------ |--------- |--------- |--------------- |------------ |------------ |--- |----------:|-----------:|---------:|----------:|------:|--------:|
| IndexDocumentsBenchmark | .NET 7.0 | .NET 7.0 | Default        | Default     | Default     | 10 |  44.11 ms |   3.756 ms | 11.02 ms |  40.34 ms |  1.00 |    0.00 |
| IndexDocumentsBenchmark | .NET 8.0 | .NET 8.0 | Default        | Default     | Default     | 10 | 843.36 ms |  16.485 ms | 24.16 ms | 843.93 ms | 19.11 |    4.86 |
```

After:
```
| Method                  | Job      | Runtime  | IterationCount | LaunchCount | WarmupCount | N  | Mean     | Error      | StdDev    | Median   | Ratio | RatioSD |
|------------------------ |--------- |--------- |--------------- |------------ |------------ |--- |---------:|-----------:|----------:|---------:|------:|--------:|
| IndexDocumentsBenchmark | .NET 7.0 | .NET 7.0 | Default        | Default     | Default     | 10 | 50.15 ms |   5.044 ms | 14.874 ms | 54.12 ms |  1.00 |    0.00 |
| IndexDocumentsBenchmark | .NET 8.0 | .NET 8.0 | Default        | Default     | Default     | 10 | 42.88 ms |   4.736 ms | 13.964 ms | 38.17 ms |  0.95 |    0.50 |
```
