### PR TITLE
Lucene.Net.Util.Constants: Updated to detect .NET Framework 4.8.1

### DIFF
--- a/src/Lucene.Net/Util/Constants.cs
+++ b/src/Lucene.Net/Util/Constants.cs
@@ -64,7 +64,7 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// True iff running on SunOS. </summary>
-        public static readonly bool SUN_OS = RuntimeInformation.IsOSPlatform(OSPlatform.Create("SunOS"));
+        public static readonly bool SUN_OS = RuntimeInformation.IsOSPlatform(OSPlatform.Create("SUNOS"));
 
         /// <summary>
         /// True iff running on Mac OS X </summary>
@@ -72,7 +72,7 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// True iff running on FreeBSD </summary>
-        public static readonly bool FREE_BSD = RuntimeInformation.IsOSPlatform(OSPlatform.Create("FreeBSD"));
+        public static readonly bool FREE_BSD = RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
 
         // Possible Values: X86, X64, Arm, Arm64
         public static readonly string OS_ARCH = RuntimeInformation.OSArchitecture.ToString();
@@ -197,6 +197,8 @@ namespace Lucene.Net.Util
         // Checking the version using >= will enable forward compatibility.
         private static string CheckFor45PlusVersion(int releaseKey)
         {
+            if (releaseKey >= 533320)
+                return "4.8.1";
             if (releaseKey >= 460799)
                 return "4.8";
             if (releaseKey >= 460798)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes

Added version detection for .NET Framework 4.8.1. Updated FreeBSD/SunOS detection use uppercase strings as was done in the tests in dotnet/runtime (note I don't believe SunOS is currently supported, but maybe someday it will be).
