### PR TITLE
FuzzyQuery produces a wrong result when prefix is equal to the term length

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilter.cs
@@ -366,7 +366,16 @@ namespace Lucene.Net.Analysis.Shingle
                         noShingleOutput = false;
                     }
                     offsetAtt.SetOffset(offsetAtt.StartOffset, nextToken.offsetAtt.EndOffset);
-                    posLenAtt.PositionLength = builtGramSize;
+                    // posLenAtt.PositionLength = builtGramSize;
+                    if (outputUnigrams)
+                    {
+                        posLenAtt.PositionLength = builtGramSize;
+                    }
+                    else
+                    {
+                        // position length for this token is the number of position created by shingles of smaller size.
+                        posLenAtt.PositionLength = Math.Max(1, (builtGramSize - minShingleSize) + 1);
+                    }
                     isOutputHere = true;
                     gramSize.Advance();
                     tokenAvailable = true;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Shingle/ShingleFilterTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Shingle/ShingleFilterTest.cs
@@ -1,4 +1,4 @@
-// Lucene version compatibility level 4.8.1
+﻿// Lucene version compatibility level 4.8.1
 using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.TokenAttributes;
 using NUnit.Framework;
@@ -407,6 +407,101 @@ namespace Lucene.Net.Analysis.Shingle
         {
             this.shingleFilterTest(2, 3, TEST_TOKEN_POS_INCR_GREATER_THAN_N, TRI_GRAM_TOKENS_POS_INCR_GREATER_THAN_N_WITHOUT_UNIGRAMS, TRI_GRAM_POSITION_INCREMENTS_POS_INCR_GREATER_THAN_N_WITHOUT_UNIGRAMS, TRI_GRAM_TYPES_POS_INCR_GREATER_THAN_N_WITHOUT_UNIGRAMS, false);
         }
+
+       
+
+        [Test]
+        public void testPositionLength()
+        {
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                MockBytesAttributeFactory factory = new MockBytesAttributeFactory();
+                Tokenizer tokenizer = new MockTokenizer(factory, reader, MockTokenizer.WHITESPACE, false, MockTokenizer.DEFAULT_MAX_TOKEN_LENGTH);
+                ShingleFilter filter = new ShingleFilter(tokenizer, 4, 4);
+                filter.SetOutputUnigrams(false);
+                return new TokenStreamComponents(tokenizer, filter);
+            });
+        
+            AssertTokenStreamContents(a.GetTokenStream("", "to be or not to be"),
+                new String[] {"to be or not", "be or not to", "or not to be"},
+                new int[] {0, 3, 6},
+                new int[] { 12, 15, 18 },
+                null,
+                new int[] { 1, 1, 1 },
+                new int[] { 1, 1, 1 },
+                18,
+                // offsets are correct but assertTokenStreamContents does not handle multiple terms with different offsets
+                // finishing at the same position
+                false);
+
+
+            a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                MockBytesAttributeFactory factory = new MockBytesAttributeFactory();
+                Tokenizer tokenizer = new MockTokenizer(factory, reader, MockTokenizer.WHITESPACE, false, MockTokenizer.DEFAULT_MAX_TOKEN_LENGTH);
+                ShingleFilter filter = new ShingleFilter(tokenizer, 2, 4);
+                filter.SetOutputUnigrams(false);
+                return new TokenStreamComponents(tokenizer, filter);
+            });
+  
+        AssertTokenStreamContents(a.GetTokenStream("", "to be or not to be"),
+            new String[] {"to be", "to be or", "to be or not", "be or", "be or not", "be or not to", "or not", "or not to",
+                    "or not to be", "not to", "not to be", "to be"},
+            new int[] { 0, 0, 0, 3, 3, 3, 6, 6, 6, 9, 9, 13 },
+            new int[] { 5, 8, 12, 8, 12, 15, 12, 15, 18, 15, 18, 18 },
+            null,
+            new int[] { 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1 },
+            new int[] { 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 1 },
+            18,
+            // offsets are correct but assertTokenStreamContents does not handle multiple terms with different offsets
+            // finishing at the same position
+            false);
+
+            a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                MockBytesAttributeFactory factory = new MockBytesAttributeFactory();
+                Tokenizer tokenizer = new MockTokenizer(factory, reader, MockTokenizer.WHITESPACE, false, MockTokenizer.DEFAULT_MAX_TOKEN_LENGTH);
+                ShingleFilter filter = new ShingleFilter(tokenizer, 3, 4);
+                filter.SetOutputUnigrams(false);
+                return new TokenStreamComponents(tokenizer, filter);
+            });
+    
+
+        AssertTokenStreamContents(a.GetTokenStream("", "to be or not to be"),
+            new String[] {"to be or", "to be or not", "be or not", "be or not to", "or not to",
+                    "or not to be", "not to be"},
+            new int[] { 0, 0, 3, 3, 6, 6, 9 },
+            new int[] { 8, 12, 12, 15, 15, 18, 18 },
+            null,
+            new int[] { 1, 0, 1, 0, 1, 0, 1, 0 },
+            new int[] { 1, 2, 1, 2, 1, 2, 1, 2 },
+            18,
+            // offsets are correct but assertTokenStreamContents does not handle multiple terms with different offsets
+            // finishing at the same position
+            false);
+
+            a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                MockBytesAttributeFactory factory = new MockBytesAttributeFactory();
+                Tokenizer tokenizer = new MockTokenizer(factory, reader, MockTokenizer.WHITESPACE, false, MockTokenizer.DEFAULT_MAX_TOKEN_LENGTH);
+                ShingleFilter filter = new ShingleFilter(tokenizer, 3, 5);
+                filter.SetOutputUnigrams(false);
+                return new TokenStreamComponents(tokenizer, filter);
+            });
+  
+            AssertTokenStreamContents(a.GetTokenStream("", "to be or not to be"),
+                new String[] {"to be or", "to be or not", "to be or not to", "be or not", "be or not to",
+                        "be or not to be", "or not to", "or not to be", "not to be"},
+                new int[] { 0, 0, 0, 3, 3, 3, 6, 6, 9, 9 },
+                new int[] { 8, 12, 15, 12, 15, 18, 15, 18, 18 },
+                null,
+                new int[] { 1, 0, 0, 1, 0, 0, 1, 0, 1, 0 },
+                new int[] { 1, 2, 3, 1, 2, 3, 1, 2, 1 },
+                18,
+                // offsets are correct but assertTokenStreamContents does not handle multiple terms with different offsets
+                // finishing at the same position
+                false);
+      }
 
         [Test]
         public virtual void TestReset()

--- a/src/Lucene.Net.Tests/Search/TestFuzzyQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestFuzzyQuery.cs
@@ -195,8 +195,48 @@ namespace Lucene.Net.Search
             reader.Dispose();
             directory.Dispose();
         }
-
         [Test]
+        public void TestPrefixLengthEqualStringLength()
+        {
+            Directory directory = NewDirectory();
+            RandomIndexWriter writer = new RandomIndexWriter(Random, directory);
+            AddDoc("b*a", writer);
+            AddDoc("b*ab", writer);
+            AddDoc("b*abc", writer);
+            AddDoc("b*abcd", writer);
+            String multibyte = "아프리카코끼리속";
+            AddDoc(multibyte, writer);
+            IndexReader reader = writer.GetReader();
+            IndexSearcher searcher = NewSearcher(reader);
+            writer.Dispose();
+
+            int maxEdits = 0;
+            int prefixLength = 3;
+            FuzzyQuery query = new FuzzyQuery(new Term("field", "b*a"), maxEdits, prefixLength);
+            ScoreDoc[] hits = searcher.Search(query, 1000).ScoreDocs;
+            assertEquals(1, hits.Length);
+
+            maxEdits = 1;
+            query = new FuzzyQuery(new Term("field", "b*a"), maxEdits, prefixLength);
+            hits = searcher.Search(query, 1000).ScoreDocs;
+            assertEquals(2, hits.Length);
+
+            maxEdits = 2;
+            query = new FuzzyQuery(new Term("field", "b*a"), maxEdits, prefixLength);
+            hits = searcher.Search(query, 1000).ScoreDocs;
+            assertEquals(3, hits.Length);
+
+        maxEdits = 1;
+        prefixLength = multibyte.Length - 1;
+        query = new FuzzyQuery(new Term("field", multibyte.Substring(0, prefixLength)), maxEdits, prefixLength);
+        hits = searcher.Search(query, 1000).ScoreDocs;
+        assertEquals(1, hits.Length);
+
+        reader.DoClose();
+        directory.Dispose();
+    }
+
+    [Test]
         public virtual void Test2()
         {
             Directory directory = NewDirectory();

--- a/src/Lucene.Net/Search/FuzzyQuery.cs
+++ b/src/Lucene.Net/Search/FuzzyQuery.cs
@@ -148,7 +148,7 @@ namespace Lucene.Net.Search
 
         protected override TermsEnum GetTermsEnum(Terms terms, AttributeSource atts)
         {
-            if (maxEdits == 0 || prefixLength >= term.Text.Length) // can only match if it's exact
+            if (maxEdits == 0 ) // can only match if it's exact
             {
                 return new SingleTermsEnum(terms.GetEnumerator(), term.Bytes);
             }


### PR DESCRIPTION



<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Fixes #{bug number} (in this specific format)
https://github.com/apache/lucenenet/issues/941
## Description

{Detail}
