### PR TITLE
Leave debugStream as null on construction of parser token managers

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
+++ b/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
@@ -26,11 +26,11 @@
     <Description>Analyzers for indexing content in different languages and domains for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
     <PackageDocumentationRelativeUrl>analysis-common/overview.html</PackageDocumentationRelativeUrl>
   </PropertyGroup>
-  
+
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <AssemblyTitle>Lucene.Net.Analysis.Common</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <EmbeddedResource Include="**/*.rslp" Exclude="bin/**/*;obj/**/*" Label="RSLP Test Data" />

--- a/src/Lucene.Net.Queries/Lucene.Net.Queries.csproj
+++ b/src/Lucene.Net.Queries/Lucene.Net.Queries.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <AssemblyTitle>Lucene.Net.Queries</AssemblyTitle>
     <PackageTags>$(PackageTags);query;queries</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
@@ -1,4 +1,4 @@
-﻿using Lucene.Net.Support.IO;
+using Lucene.Net.Support.IO;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -31,7 +31,7 @@ namespace Lucene.Net.QueryParsers.Classic
     {
         /// <summary>Debug output. </summary>
 #pragma warning disable IDE0052 // Remove unread private members
-        private TextWriter debugStream = Console.Out; // LUCENENET specific - made private, since we already have a setter
+        private TextWriter debugStream; // LUCENENET specific - made private, since we already have a setter
 #pragma warning restore IDE0052 // Remove unread private members
         /// <summary>Set debug output. </summary>
         public virtual void SetDebugStream(TextWriter ds)

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParserTokenManager.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParserTokenManager.cs
@@ -1,4 +1,4 @@
-﻿using Lucene.Net.Support.IO;
+using Lucene.Net.Support.IO;
 using System.Diagnostics.CodeAnalysis;
 using System;
 using System.IO;
@@ -32,7 +32,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
     {
         /// <summary>Debug output.</summary>
 #pragma warning disable IDE0052 // Remove unread private members
-        private TextWriter debugStream = Console.Out; // LUCENENET specific - made private, since we already have a setter
+        private TextWriter debugStream; // LUCENENET specific - made private, since we already have a setter
 #pragma warning restore IDE0052 // Remove unread private members
         /// <summary>Set debug output.</summary>
         public void SetDebugStream(TextWriter ds) { debugStream = new SafeTextWriterWrapper(ds); }

--- a/src/Lucene.Net.QueryParser/Lucene.Net.QueryParser.csproj
+++ b/src/Lucene.Net.QueryParser/Lucene.Net.QueryParser.csproj
@@ -28,22 +28,22 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <RootNamespace>Lucene.Net.QueryParsers</RootNamespace>
-    
+
     <AssemblyTitle>Lucene.Net.QueryParser</AssemblyTitle>
     <PackageTags>$(PackageTags);query;queryparser</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    
+
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
     <NoWarn Label="Remove unused parameter">$(NoWarn);IDE0060</NoWarn>
   </PropertyGroup>
 
-  
-  
+
+
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net.Analysis.Common\Lucene.Net.Analysis.Common.csproj" />
     <ProjectReference Include="..\Lucene.Net.Queries\Lucene.Net.Queries.csproj" />

--- a/src/Lucene.Net.Sandbox/Lucene.Net.Sandbox.csproj
+++ b/src/Lucene.Net.Sandbox/Lucene.Net.Sandbox.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <AssemblyTitle>Lucene.Net.Sandbox</AssemblyTitle>
     <PackageTags>$(PackageTags);sandbox</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -22,9 +22,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <AssemblyTitle>Lucene.Net</AssemblyTitle>
     <Description>Lucene.Net is a full-text search engine library capable of advanced text analysis, indexing, and searching. It can be used to easily add search capabilities to applications. Lucene.Net is a C# port of the popular Java Lucene search engine framework from The Apache Software Foundation, targeted at .NET Framework and .NET Core users.</Description>
@@ -36,7 +36,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  
+
 
   <PropertyGroup Label="NuGet Package File Paths">
     <LuceneNetDotNetDir>$(SolutionDir)src\dotnet\</LuceneNetDotNetDir>
@@ -99,7 +99,7 @@
     <InternalsVisibleTo Include="Lucene.Net.Suggest" />
 
     <InternalsVisibleTo Include="Lucene.Net.TestFramework" />
-    
+
     <InternalsVisibleTo Include="Lucene.Net.Tests._A-D" />
     <InternalsVisibleTo Include="Lucene.Net.Tests._E-I" />
     <InternalsVisibleTo Include="Lucene.Net.Tests._I-J" />


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)
Leave debugStream as null on construction of parser token managers.

Fixes #{bug number} (in this specific format)
Fixes #936

## Description

{Detail}

* When `debugStream` is set to `Console.Out` by default, `StandardSyntaxParserTokenManager` throws an exception when constructing a `StandardQueryParser` on OSes that do not support System.Console, such as iOS and Android.
* `debugStream` can be set later using the setter, if needed.
* The above is the same for `QueryParserTokenManager` when constructing a `QueryParser`.
* See issue https://github.com/apache/lucenenet/issues/936 for details.
