### PR TITLE
Leave debugStream as null on construction of parser token managers

### DIFF
--- a/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
@@ -1,4 +1,4 @@
-﻿using Lucene.Net.Support.IO;
+using Lucene.Net.Support.IO;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -31,7 +31,7 @@ namespace Lucene.Net.QueryParsers.Classic
     {
         /// <summary>Debug output. </summary>
 #pragma warning disable IDE0052 // Remove unread private members
-        private TextWriter debugStream = Console.Out; // LUCENENET specific - made private, since we already have a setter
+        private TextWriter debugStream; // LUCENENET specific - made private, since we already have a setter
 #pragma warning restore IDE0052 // Remove unread private members
         /// <summary>Set debug output. </summary>
         public virtual void SetDebugStream(TextWriter ds)

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParserTokenManager.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParserTokenManager.cs
@@ -1,4 +1,4 @@
-﻿using Lucene.Net.Support.IO;
+using Lucene.Net.Support.IO;
 using System.Diagnostics.CodeAnalysis;
 using System;
 using System.IO;
@@ -32,7 +32,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
     {
         /// <summary>Debug output.</summary>
 #pragma warning disable IDE0052 // Remove unread private members
-        private TextWriter debugStream = Console.Out; // LUCENENET specific - made private, since we already have a setter
+        private TextWriter debugStream; // LUCENENET specific - made private, since we already have a setter
 #pragma warning restore IDE0052 // Remove unread private members
         /// <summary>Set debug output.</summary>
         public void SetDebugStream(TextWriter ds) { debugStream = new SafeTextWriterWrapper(ds); }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)
Leave debugStream as null on construction of parser token managers.

Fixes #{bug number} (in this specific format)
Fixes #936

## Description

{Detail}

* When `debugStream` is set to `Console.Out` by default, `StandardSyntaxParserTokenManager` throws an exception when constructing a `StandardQueryParser` on OSes that do not support System.Console, such as iOS and Android.
* `debugStream` can be set later using the setter, if needed.
* The above is the same for `QueryParserTokenManager` when constructing a `QueryParser`.
* See issue https://github.com/apache/lucenenet/issues/936 for details.
