### PR TITLE
Fixes #(959): Fix TermStats.TermText access, add CLI comments and 1 CLI bug fix

### DIFF
--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/DictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/DictionaryBuilder.cs
@@ -20,6 +20,13 @@ namespace Lucene.Net.Analysis.Ja.Util
      * limitations under the License.
      */
 
+    /// <summary>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: analysis kuromoji-build-dictionary. 
+    /// </summary>
     public static class DictionaryBuilder // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
         public enum DictionaryFormat { IPADIC, UNIDIC };
@@ -62,6 +69,13 @@ namespace Lucene.Net.Analysis.Ja.Util
             Console.WriteLine("done");
         }
 
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: analysis kuromoji-build-dictionary.
+        /// </summary>
         public static void Main(string[] args)
         {
             DictionaryFormat format;

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/DictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/DictionaryBuilder.cs
@@ -21,11 +21,13 @@ namespace Lucene.Net.Analysis.Ja.Util
      */
 
     /// <summary>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: analysis kuromoji-build-dictionary. 
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// analysis kuromoji-build-dictionary.
     /// </summary>
     public static class DictionaryBuilder // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
@@ -70,11 +72,13 @@ namespace Lucene.Net.Analysis.Ja.Util
         }
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: analysis kuromoji-build-dictionary.
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// analysis kuromoji-build-dictionary.
         /// </summary>
         public static void Main(string[] args)
         {

--- a/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/Compile.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/Compile.cs
@@ -66,13 +66,14 @@ namespace Egothor.Stemmer
 {
     /// <summary>
     /// The Compile class is used to compile a stemmer table.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: analysis stempel-compile-stems
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// analysis stempel-compile-stems
     /// </summary>
     public static class Compile // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
@@ -81,19 +82,20 @@ namespace Egothor.Stemmer
         private static Trie trie;
 
         /// <summary>
-        /// <para>
-        /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-        /// it's Main method was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to that method: analysis stempel-compile-stems. 
-        /// </para>
         /// Entry point to the Compile application.
-        /// <para/>
+        /// <para />
         /// This program takes any number of arguments: the first is the name of the
         /// desired stemming algorithm to use (a list is available in the package
         /// description) , all of the rest should be the path or paths to a file or
         /// files containing a stemmer table to compile.
+        /// <para />
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// analysis stempel-compile-stems
         /// </summary>
         /// <param name="args">the command line arguments</param>
         public static void Main(string[] args)

--- a/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/Compile.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/Compile.cs
@@ -66,6 +66,13 @@ namespace Egothor.Stemmer
 {
     /// <summary>
     /// The Compile class is used to compile a stemmer table.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: analysis stempel-compile-stems
+    /// </para>
     /// </summary>
     public static class Compile // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
@@ -74,6 +81,13 @@ namespace Egothor.Stemmer
         private static Trie trie;
 
         /// <summary>
+        /// <para>
+        /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+        /// it's Main method was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to that method: analysis stempel-compile-stems. 
+        /// </para>
         /// Entry point to the Compile application.
         /// <para/>
         /// This program takes any number of arguments: the first is the name of the

--- a/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/DiffIt.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/DiffIt.cs
@@ -65,6 +65,13 @@ using JCG = J2N.Collections.Generic;
 namespace Egothor.Stemmer
 {
     /// <summary>
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: analysis stempel-patch-stems. 
+    /// </para>
     /// The DiffIt class is a means generate patch commands from an already prepared
     /// stemmer table.
     /// </summary>
@@ -82,6 +89,13 @@ namespace Egothor.Stemmer
         }
 
         /// <summary>
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: analysis stempel-patch-stems. 
+        /// </para>
         /// Entry point to the DiffIt application.
         /// <para>
         /// This application takes one argument, the path to a file containing a

--- a/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/DiffIt.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/DiffIt.cs
@@ -65,15 +65,16 @@ using JCG = J2N.Collections.Generic;
 namespace Egothor.Stemmer
 {
     /// <summary>
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
-    /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: analysis stempel-patch-stems. 
-    /// </para>
     /// The DiffIt class is a means generate patch commands from an already prepared
     /// stemmer table.
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// analysis stempel-patch-stems
     /// </summary>
     public static class DiffIt // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
@@ -89,19 +90,19 @@ namespace Egothor.Stemmer
         }
 
         /// <summary>
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: analysis stempel-patch-stems. 
-        /// </para>
         /// Entry point to the DiffIt application.
-        /// <para>
+        /// <para />
         /// This application takes one argument, the path to a file containing a
         /// stemmer table. The program reads the file and generates the patch commands
         /// for the stems.
-        /// </para>
+        /// <para />
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// analysis stempel-patch-stems
         /// </summary>
         /// <param name="args">the path to a file containing a stemmer table</param>
         public static void Main(string[] args)

--- a/src/Lucene.Net.Benchmark/ByTask/Benchmark.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Benchmark.cs
@@ -97,14 +97,15 @@ namespace Lucene.Net.Benchmarks.ByTask
         }
 
         /// <summary>
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: benchmark.
-        /// </para>
         /// Run the benchmark algorithm.
+        /// <para />
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// benchmark
         /// </summary>
         /// <param name="args">Benchmark config and algorithm files.</param>
         public static void Main(string[] args)
@@ -127,7 +128,7 @@ namespace Lucene.Net.Benchmarks.ByTask
                 //Environment.Exit(1);
             }
 
-            // verify input files 
+            // verify input files
             FileInfo algFile = new FileInfo(args[0]);
             if (!algFile.Exists /*|| !algFile.isFile() ||!algFile.canRead()*/ )
             {

--- a/src/Lucene.Net.Benchmark/ByTask/Benchmark.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Benchmark.cs
@@ -97,6 +97,13 @@ namespace Lucene.Net.Benchmarks.ByTask
         }
 
         /// <summary>
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: benchmark.
+        /// </para>
         /// Run the benchmark algorithm.
         /// </summary>
         /// <param name="args">Benchmark config and algorithm files.</param>

--- a/src/Lucene.Net.Benchmark/ByTask/Programmatic/Sample.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Programmatic/Sample.cs
@@ -24,25 +24,28 @@ namespace Lucene.Net.Benchmarks.ByTask.Programmatic
 
     /// <summary>
     /// Sample performance test written programmatically - no algorithm file is needed here.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: benchmark sample.  
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// benchmark sample
     /// </summary>
     public static class Sample // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: benchmark sample. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// benchmark sample
         /// </summary>
-        /// <param name="args"></param>
+        /// <param name="args">The command line arguments</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Sample shows optional args[] parameter")]
         public static void Main(string[] args)
         {

--- a/src/Lucene.Net.Benchmark/ByTask/Programmatic/Sample.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Programmatic/Sample.cs
@@ -24,9 +24,25 @@ namespace Lucene.Net.Benchmarks.ByTask.Programmatic
 
     /// <summary>
     /// Sample performance test written programmatically - no algorithm file is needed here.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: benchmark sample.  
+    /// </para>
     /// </summary>
     public static class Sample // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: benchmark sample. 
+        /// </summary>
+        /// <param name="args"></param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Sample shows optional args[] parameter")]
         public static void Main(string[] args)
         {

--- a/src/Lucene.Net.Benchmark/Quality/Trec/QueryDriver.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/QueryDriver.cs
@@ -31,9 +31,26 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
 
     /// <summary>
     /// Command-line tool for doing a TREC evaluation run.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: benchmark run-trec-eval.
+    /// </para>
     /// </summary>
     public static class QueryDriver // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: benchmark run-trec-eval.
+        /// </summary>
+        /// <param name="args">Must contain 4 or 5 values</param>
+        /// <exception cref="ArgumentException"></exception>
         public static void Main(string[] args)
         {
             if (args.Length < 4 || args.Length > 5)

--- a/src/Lucene.Net.Benchmark/Quality/Trec/QueryDriver.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/QueryDriver.cs
@@ -31,26 +31,28 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
 
     /// <summary>
     /// Command-line tool for doing a TREC evaluation run.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: benchmark run-trec-eval.
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// benchmark run-trec-eval
     /// </summary>
     public static class QueryDriver // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
-
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: benchmark run-trec-eval.
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// benchmark run-trec-eval
         /// </summary>
         /// <param name="args">Must contain 4 or 5 values</param>
-        /// <exception cref="ArgumentException"></exception>
+        /// <exception cref="ArgumentException">Thrown if the incorrect number of arguments are provided.</exception>
         public static void Main(string[] args)
         {
             if (args.Length < 4 || args.Length > 5)

--- a/src/Lucene.Net.Benchmark/Quality/Utils/QualityQueriesFinder.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Utils/QualityQueriesFinder.cs
@@ -27,13 +27,14 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
     /// <summary>
     /// Suggest Quality queries based on an index contents.
     /// Utility class, used for making quality test benchmarks.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: benchmark find-quality-queries.  
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// benchmark find-quality-queries
     /// </summary>
     public class QualityQueriesFinder
     {
@@ -50,11 +51,13 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
         }
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: benchmark find-quality-queries. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// benchmark find-quality-queries
         /// </summary>
         /// <param name="args">{index-dir}</param>
         /// <exception cref="IOException">if cannot access the index.</exception>

--- a/src/Lucene.Net.Benchmark/Quality/Utils/QualityQueriesFinder.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Utils/QualityQueriesFinder.cs
@@ -27,6 +27,13 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
     /// <summary>
     /// Suggest Quality queries based on an index contents.
     /// Utility class, used for making quality test benchmarks.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: benchmark find-quality-queries.  
+    /// </para>
     /// </summary>
     public class QualityQueriesFinder
     {
@@ -43,7 +50,11 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
         }
 
         /// <summary>
-        /// 
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: benchmark find-quality-queries. 
         /// </summary>
         /// <param name="args">{index-dir}</param>
         /// <exception cref="IOException">if cannot access the index.</exception>

--- a/src/Lucene.Net.Benchmark/Utils/ExtractReuters.cs
+++ b/src/Lucene.Net.Benchmark/Utils/ExtractReuters.cs
@@ -133,13 +133,15 @@ namespace Lucene.Net.Benchmarks.Utils
         }
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: benchmark extract-reuters. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// benchmark extract-reuters
         /// </summary>
-        /// <param name="args"></param>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             if (args.Length != 2)

--- a/src/Lucene.Net.Benchmark/Utils/ExtractReuters.cs
+++ b/src/Lucene.Net.Benchmark/Utils/ExtractReuters.cs
@@ -132,6 +132,14 @@ namespace Lucene.Net.Benchmarks.Utils
             }
         }
 
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: benchmark extract-reuters. 
+        /// </summary>
+        /// <param name="args"></param>
         public static void Main(string[] args)
         {
             if (args.Length != 2)

--- a/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
+++ b/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
@@ -119,13 +119,15 @@ namespace Lucene.Net.Benchmarks.Utils
         }
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: benchmark extract-wikipedia. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// benchmark extract-wikipedia
         /// </summary>
-        /// <param name="args"></param>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
 

--- a/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
+++ b/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
@@ -118,6 +118,14 @@ namespace Lucene.Net.Benchmarks.Utils
             Console.WriteLine("Extraction took " + (finish - start) + " ms");
         }
 
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: benchmark extract-wikipedia. 
+        /// </summary>
+        /// <param name="args"></param>
         public static void Main(string[] args)
         {
 

--- a/src/Lucene.Net.Demo/Facet/AssociationsFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/AssociationsFacetsExample.cs
@@ -43,8 +43,8 @@ namespace Lucene.Net.Demo.Facet
         /// <summary>
         /// Using a constant for all functionality related to a specific index
         /// is the best strategy. This allows you to upgrade Lucene.Net first
-        /// and plan the upgrade of the index binary format for a later time. 
-        /// Once the index is upgraded, you simply need to update the constant 
+        /// and plan the upgrade of the index binary format for a later time.
+        /// Once the index is upgraded, you simply need to update the constant
         /// version and redeploy your application.
         /// </summary>
         private const LuceneVersion EXAMPLE_VERSION = LuceneVersion.LUCENE_48;
@@ -157,17 +157,8 @@ namespace Lucene.Net.Demo.Facet
         }
 
 
-        /// <summary>
-        /// Runs the sum int/float associations examples and prints the results.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: demo associations-facets. 
-        /// </para>
-        /// </summary>
-        /// <param name="args">Unused</param>
+        /// <summary>Runs the sum int/float associations examples and prints the results.</summary>
+        /// <param name="args">The command line arguments</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Demo shows use of optional args argument")]
         public static void Main(string[] args)
         {

--- a/src/Lucene.Net.Demo/Facet/AssociationsFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/AssociationsFacetsExample.cs
@@ -157,7 +157,17 @@ namespace Lucene.Net.Demo.Facet
         }
 
 
-        /// <summary>Runs the sum int/float associations examples and prints the results.</summary>
+        /// <summary>
+        /// Runs the sum int/float associations examples and prints the results.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: demo associations-facets. 
+        /// </para>
+        /// </summary>
+        /// <param name="args">Unused</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Demo shows use of optional args argument")]
         public static void Main(string[] args)
         {

--- a/src/Lucene.Net.Demo/Facet/DistanceFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/DistanceFacetsExample.cs
@@ -50,8 +50,8 @@ namespace Lucene.Net.Demo.Facet
         /// <summary>
         /// Using a constant for all functionality related to a specific index
         /// is the best strategy. This allows you to upgrade Lucene.Net first
-        /// and plan the upgrade of the index binary format for a later time. 
-        /// Once the index is upgraded, you simply need to update the constant 
+        /// and plan the upgrade of the index binary format for a later time.
+        /// Once the index is upgraded, you simply need to update the constant
         /// version and redeploy your application.
         /// </summary>
         private const LuceneVersion EXAMPLE_VERSION = LuceneVersion.LUCENE_48;
@@ -263,16 +263,8 @@ namespace Lucene.Net.Demo.Facet
             indexDir?.Dispose();
         }
 
-        /// <summary>
-        /// Runs the search and drill-down examples and prints the results.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: demo distance-facets. 
-        /// </para>
-        /// </summary>
+        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             using DistanceFacetsExample example = new DistanceFacetsExample();

--- a/src/Lucene.Net.Demo/Facet/DistanceFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/DistanceFacetsExample.cs
@@ -263,7 +263,16 @@ namespace Lucene.Net.Demo.Facet
             indexDir?.Dispose();
         }
 
-        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <summary>
+        /// Runs the search and drill-down examples and prints the results.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: demo distance-facets. 
+        /// </para>
+        /// </summary>
         public static void Main(string[] args)
         {
             using DistanceFacetsExample example = new DistanceFacetsExample();

--- a/src/Lucene.Net.Demo/Facet/ExpressionAggregationFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/ExpressionAggregationFacetsExample.cs
@@ -115,7 +115,17 @@ namespace Lucene.Net.Demo.Facet
             return Search();
         }
 
-        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <summary>
+        /// Runs the search and drill-down examples and prints the results.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: demo expression-aggregation-facets. 
+        /// </para>
+        /// </summary>
+        /// <param name="args">Unused</param>
         public static void Main(string[] args)
         {
             Console.WriteLine("Facet counting example:");

--- a/src/Lucene.Net.Demo/Facet/ExpressionAggregationFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/ExpressionAggregationFacetsExample.cs
@@ -44,8 +44,8 @@ namespace Lucene.Net.Demo.Facet
         /// <summary>
         /// Using a constant for all functionality related to a specific index
         /// is the best strategy. This allows you to upgrade Lucene.Net first
-        /// and plan the upgrade of the index binary format for a later time. 
-        /// Once the index is upgraded, you simply need to update the constant 
+        /// and plan the upgrade of the index binary format for a later time.
+        /// Once the index is upgraded, you simply need to update the constant
         /// version and redeploy your application.
         /// </summary>
         private const LuceneVersion EXAMPLE_VERSION = LuceneVersion.LUCENE_48;
@@ -115,17 +115,8 @@ namespace Lucene.Net.Demo.Facet
             return Search();
         }
 
-        /// <summary>
-        /// Runs the search and drill-down examples and prints the results.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: demo expression-aggregation-facets. 
-        /// </para>
-        /// </summary>
-        /// <param name="args">Unused</param>
+        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             Console.WriteLine("Facet counting example:");

--- a/src/Lucene.Net.Demo/Facet/MultiCategoryListsFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/MultiCategoryListsFacetsExample.cs
@@ -42,8 +42,8 @@ namespace Lucene.Net.Demo.Facet
         /// <summary>
         /// Using a constant for all functionality related to a specific index
         /// is the best strategy. This allows you to upgrade Lucene.Net first
-        /// and plan the upgrade of the index binary format for a later time. 
-        /// Once the index is upgraded, you simply need to update the constant 
+        /// and plan the upgrade of the index binary format for a later time.
+        /// Once the index is upgraded, you simply need to update the constant
         /// version and redeploy your application.
         /// </summary>
         private const LuceneVersion EXAMPLE_VERSION = LuceneVersion.LUCENE_48;
@@ -134,17 +134,8 @@ namespace Lucene.Net.Demo.Facet
             return Search();
         }
 
-        /// <summary>
-        /// Runs the search example and prints the results.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: demo multi-category-lists-facets. 
-        /// </para>
-        /// </summary>
-        /// <param name="args">Unused</param>
+        /// <summary>Runs the search example and prints the results.</summary>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             Console.WriteLine("Facet counting over multiple category lists example:");

--- a/src/Lucene.Net.Demo/Facet/MultiCategoryListsFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/MultiCategoryListsFacetsExample.cs
@@ -134,7 +134,17 @@ namespace Lucene.Net.Demo.Facet
             return Search();
         }
 
-        /// <summary>Runs the search example and prints the results.</summary>
+        /// <summary>
+        /// Runs the search example and prints the results.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: demo multi-category-lists-facets. 
+        /// </para>
+        /// </summary>
+        /// <param name="args">Unused</param>
         public static void Main(string[] args)
         {
             Console.WriteLine("Facet counting over multiple category lists example:");

--- a/src/Lucene.Net.Demo/Facet/RangeFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/RangeFacetsExample.cs
@@ -40,8 +40,8 @@ namespace Lucene.Net.Demo.Facet
         /// <summary>
         /// Using a constant for all functionality related to a specific index
         /// is the best strategy. This allows you to upgrade Lucene.Net first
-        /// and plan the upgrade of the index binary format for a later time. 
-        /// Once the index is upgraded, you simply need to update the constant 
+        /// and plan the upgrade of the index binary format for a later time.
+        /// Once the index is upgraded, you simply need to update the constant
         /// version and redeploy your application.
         /// </summary>
         private const LuceneVersion EXAMPLE_VERSION = LuceneVersion.LUCENE_48;
@@ -125,17 +125,8 @@ namespace Lucene.Net.Demo.Facet
             indexDir?.Dispose();
         }
 
-        /// <summary>
-        /// Runs the search and drill-down examples and prints the results.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: demo range-facets. 
-        /// </para>
-        /// </summary>
-        /// <param name="args">Unused</param>
+        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             using RangeFacetsExample example = new RangeFacetsExample();

--- a/src/Lucene.Net.Demo/Facet/RangeFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/RangeFacetsExample.cs
@@ -125,7 +125,17 @@ namespace Lucene.Net.Demo.Facet
             indexDir?.Dispose();
         }
 
-        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <summary>
+        /// Runs the search and drill-down examples and prints the results.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: demo range-facets. 
+        /// </para>
+        /// </summary>
+        /// <param name="args">Unused</param>
         public static void Main(string[] args)
         {
             using RangeFacetsExample example = new RangeFacetsExample();

--- a/src/Lucene.Net.Demo/Facet/SimpleFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/SimpleFacetsExample.cs
@@ -233,7 +233,17 @@ namespace Lucene.Net.Demo.Facet
             return DrillSideways();
         }
 
-        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <summary>
+        /// Runs the search and drill-down examples and prints the results.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: demo simple-facets. 
+        /// </para>
+        /// </summary>
+        /// <param name="args">Unused</param>
         public static void Main(string[] args)
         {
             Console.WriteLine("Facet counting example:");

--- a/src/Lucene.Net.Demo/Facet/SimpleFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/SimpleFacetsExample.cs
@@ -42,8 +42,8 @@ namespace Lucene.Net.Demo.Facet
         /// <summary>
         /// Using a constant for all functionality related to a specific index
         /// is the best strategy. This allows you to upgrade Lucene.Net first
-        /// and plan the upgrade of the index binary format for a later time. 
-        /// Once the index is upgraded, you simply need to update the constant 
+        /// and plan the upgrade of the index binary format for a later time.
+        /// Once the index is upgraded, you simply need to update the constant
         /// version and redeploy your application.
         /// </summary>
         private const LuceneVersion EXAMPLE_VERSION = LuceneVersion.LUCENE_48;
@@ -233,17 +233,8 @@ namespace Lucene.Net.Demo.Facet
             return DrillSideways();
         }
 
-        /// <summary>
-        /// Runs the search and drill-down examples and prints the results.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: demo simple-facets. 
-        /// </para>
-        /// </summary>
-        /// <param name="args">Unused</param>
+        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             Console.WriteLine("Facet counting example:");

--- a/src/Lucene.Net.Demo/Facet/SimpleSortedSetFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/SimpleSortedSetFacetsExample.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Demo.Facet
 {
     /// <summary>
     /// Shows simple usage of faceted indexing and search
-    /// using <see cref="SortedSetDocValuesFacetField"/> and 
+    /// using <see cref="SortedSetDocValuesFacetField"/> and
     /// <see cref="SortedSetDocValuesFacetCounts"/>.
     /// </summary>
     public class SimpleSortedSetFacetsExample
@@ -43,8 +43,8 @@ namespace Lucene.Net.Demo.Facet
         /// <summary>
         /// Using a constant for all functionality related to a specific index
         /// is the best strategy. This allows you to upgrade Lucene.Net first
-        /// and plan the upgrade of the index binary format for a later time. 
-        /// Once the index is upgraded, you simply need to update the constant 
+        /// and plan the upgrade of the index binary format for a later time.
+        /// Once the index is upgraded, you simply need to update the constant
         /// version and redeploy your application.
         /// </summary>
         private const LuceneVersion EXAMPLE_VERSION = LuceneVersion.LUCENE_48;
@@ -151,17 +151,8 @@ namespace Lucene.Net.Demo.Facet
             return DrillDown();
         }
 
-        /// <summary
-        /// >Runs the search and drill-down examples and prints the results.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: demo simple-sorted-set-facets. 
-        /// </para>
-        /// </summary>
-        /// <param name="args">Unused</param>
+        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             Console.WriteLine("Facet counting example:");

--- a/src/Lucene.Net.Demo/Facet/SimpleSortedSetFacetsExample.cs
+++ b/src/Lucene.Net.Demo/Facet/SimpleSortedSetFacetsExample.cs
@@ -151,7 +151,17 @@ namespace Lucene.Net.Demo.Facet
             return DrillDown();
         }
 
-        /// <summary>Runs the search and drill-down examples and prints the results.</summary>
+        /// <summary
+        /// >Runs the search and drill-down examples and prints the results.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: demo simple-sorted-set-facets. 
+        /// </para>
+        /// </summary>
+        /// <param name="args">Unused</param>
         public static void Main(string[] args)
         {
             Console.WriteLine("Facet counting example:");

--- a/src/Lucene.Net.Demo/IndexFiles.cs
+++ b/src/Lucene.Net.Demo/IndexFiles.cs
@@ -31,15 +31,35 @@ using System.Text;
 
 namespace Lucene.Net.Demo
 {
+    // LUCENENET: Not used
+    ///// Run it with no command-line arguments for usage information.
+
+
     /// <summary>
     /// Index all text files under a directory.
     /// <para/>
     /// This is a command-line application demonstrating simple Lucene indexing.
-    /// Run it with no command-line arguments for usage information.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: demo index-files.  
+    /// </para>
     /// </summary>
     public static class IndexFiles // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
-        /// <summary>Index all text files under a directory.</summary>
+        /// <summary>
+        /// Index all text files under a directory.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: demo index-files. 
+        /// </para>
+        /// </summary>
+        /// <param name="args"></param>
         public static void Main(string[] args)
         {
             // The <CONSOLE_APP_NAME> should be the assembly name of the application

--- a/src/Lucene.Net.Demo/IndexFiles.cs
+++ b/src/Lucene.Net.Demo/IndexFiles.cs
@@ -31,47 +31,27 @@ using System.Text;
 
 namespace Lucene.Net.Demo
 {
-    // LUCENENET: Not used
-    ///// Run it with no command-line arguments for usage information.
-
-
     /// <summary>
     /// Index all text files under a directory.
     /// <para/>
     /// This is a command-line application demonstrating simple Lucene indexing.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
-    /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: demo index-files.  
-    /// </para>
     /// </summary>
     public static class IndexFiles // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
-        /// <summary>
-        /// Index all text files under a directory.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: demo index-files. 
-        /// </para>
-        /// </summary>
-        /// <param name="args"></param>
+        /// <summary>Index all text files under a directory.</summary>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             // The <CONSOLE_APP_NAME> should be the assembly name of the application
             // this code is compiled into. In .NET Framework, it is the name of the EXE file.
-            // In .NET Core, you have the option of compiling this into either an EXE or a DLL 
+            // In .NET Core, you have the option of compiling this into either an EXE or a DLL
             // (see https://docs.microsoft.com/en-us/dotnet/core/deploying/index).
             // In the latter case, the <CONSOLE_APP_NAME> will be "dotnet <DLL_NAME>.dll".
             string usage = "Usage: <CONSOLE_APP_NAME> <INDEX_DIRECTORY> <SOURCE_DIRECTORY> "
                         + "[-u|--update]\n\n"
                         + "This indexes the documents in <SOURCE_DIRECTORY>, creating a Lucene index"
                         + "in <INDEX_DIRECTORY> that can be searched with the search-files demo.";
-            
+
             // Validate required arguments are present.
             // If not, show usage information.
             if (args.Length < 2)
@@ -150,15 +130,15 @@ namespace Lucene.Net.Demo
         }
 
         /// <summary>
-        /// Recurses over files and directories found under the 
+        /// Recurses over files and directories found under the
         /// given directory and indexes each file.<para/>
-        /// 
-        /// NOTE: This method indexes one document per input file. 
-        /// This is slow. For good throughput, put multiple documents 
+        ///
+        /// NOTE: This method indexes one document per input file.
+        /// This is slow. For good throughput, put multiple documents
         /// into your input file(s).
         /// </summary>
         /// <param name="writer">
-        ///     <see cref="IndexWriter"/> to the index where the given 
+        ///     <see cref="IndexWriter"/> to the index where the given
         ///     file/dir info will be stored
         /// </param>
         /// <param name="directoryInfo">
@@ -183,7 +163,7 @@ namespace Lucene.Net.Demo
         /// Indexes the given file using the given writer.<para/>
         /// </summary>
         /// <param name="writer">
-        ///     <see cref="IndexWriter"/> to the index where the given 
+        ///     <see cref="IndexWriter"/> to the index where the given
         ///     file info will be stored.
         /// </param>
         /// <param name="file">
@@ -199,7 +179,7 @@ namespace Lucene.Net.Demo
             Document doc = new Document();
 
             // Add the path of the file as a field named "path".  Use a
-            // field that is indexed (i.e. searchable), but don't tokenize 
+            // field that is indexed (i.e. searchable), but don't tokenize
             // the field into separate words and don't index term frequency
             // or positional information:
             Field pathField = new StringField("path", file.FullName, Field.Store.YES);
@@ -228,8 +208,8 @@ namespace Lucene.Net.Demo
             }
             else
             {
-                // Existing index (an old copy of this document may have been indexed) so 
-                // we use updateDocument instead to replace the old one matching the exact 
+                // Existing index (an old copy of this document may have been indexed) so
+                // we use updateDocument instead to replace the old one matching the exact
                 // path, if present:
                 Console.WriteLine("updating " + file);
                 writer.UpdateDocument(new Term("path", file.FullName), doc);

--- a/src/Lucene.Net.Demo/SearchFiles.cs
+++ b/src/Lucene.Net.Demo/SearchFiles.cs
@@ -37,32 +37,16 @@ namespace Lucene.Net.Demo
 {
     /// <summary>
     /// Simple command-line based search demo.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
-    /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: demo search-files. 
-    /// </para>
     /// </summary>
     public static class SearchFiles // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
-        /// <summary>
-        /// Simple command-line based search demo.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
-        /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: demo search-files. 
-        /// </para>
-        /// </summary>
-        /// <param name="args"></param>
+        /// <summary>Simple command-line based search demo.</summary>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             // The <CONSOLE_APP_NAME> should be the assembly name of the application
             // this code is compiled into. In .NET Framework, it is the name of the EXE file.
-            // In .NET Core, you have the option of compiling this into either a DLL or an EXE  
+            // In .NET Core, you have the option of compiling this into either a DLL or an EXE
             // (see https://docs.microsoft.com/en-us/dotnet/core/deploying/index).
             // In the first case, the <CONSOLE_APP_NAME> will be "dotnet <DLL_NAME>.dll".
             string usage = "Usage: <CONSOLE_APP_NAME> <INDEX_DIRECTORY> [-f|--field <FIELD>] " +
@@ -70,7 +54,7 @@ namespace Lucene.Net.Demo
                 "[--raw] [-p|--page-size <NUMBER>]\n\n" +
                 "Use no --query or --queries-file option for interactive mode.\n\n" +
                 "See http://lucene.apache.org/core/4_8_0/demo/ for details.";
-            if (args.Length < 1 || args.Length > 0 && 
+            if (args.Length < 1 || args.Length > 0 &&
                 ("?".Equals(args[0], StringComparison.Ordinal) || "-h".Equals(args[0], StringComparison.Ordinal) || "--help".Equals(args[0], StringComparison.Ordinal)))
             {
                 Console.WriteLine(usage);
@@ -184,7 +168,7 @@ namespace Lucene.Net.Demo
         }
 
         /// <summary>
-        /// This demonstrates a typical paging search scenario, where the search engine presents 
+        /// This demonstrates a typical paging search scenario, where the search engine presents
         /// pages of size n to the user. The user can then go to the next page if interested in
         /// the next hits.
         /// <para/>
@@ -226,7 +210,7 @@ namespace Lucene.Net.Demo
                 for (int i = start; i < end; i++)
                 {
                     if (raw) // output raw format
-                    {                   
+                    {
                         Console.WriteLine("doc=" + hits[i].Doc + " score=" + hits[i].Score);
                         continue;
                     }

--- a/src/Lucene.Net.Demo/SearchFiles.cs
+++ b/src/Lucene.Net.Demo/SearchFiles.cs
@@ -37,10 +37,27 @@ namespace Lucene.Net.Demo
 {
     /// <summary>
     /// Simple command-line based search demo.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: demo search-files. 
+    /// </para>
     /// </summary>
     public static class SearchFiles // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
-        /// <summary>Simple command-line based search demo.</summary>
+        /// <summary>
+        /// Simple command-line based search demo.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: demo search-files. 
+        /// </para>
+        /// </summary>
+        /// <param name="args"></param>
         public static void Main(string[] args)
         {
             // The <CONSOLE_APP_NAME> should be the assembly name of the application

--- a/src/Lucene.Net.Misc/Index/CompoundFileExtractor.cs
+++ b/src/Lucene.Net.Misc/Index/CompoundFileExtractor.cs
@@ -25,34 +25,32 @@ namespace Lucene.Net.Index
 
     /// <summary>
     /// Command-line tool for extracting sub-files out of a compound file.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with two commands that map to that method: index extract-cfs and index list-cfs.  
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with two commands that map to that method:
+    /// index extract-cfs and index list-cfs
     /// </summary>
     public static class CompoundFileExtractor // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
-        // LUCENENET: Not used
-        ///// <param name="args"> Usage: org.apache.lucene.index.IndexReader [-extract] &lt;cfsfile&gt; </param>
-
-
         /// <summary>
         /// Prints the filename and size of each file within a given compound file.
         /// Add the -extract flag to extract files to the current working directory.
         /// In order to make the extracted version of the index work, you have to copy
         /// the segments file from the compound index into the directory where the extracted files are stored.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// <para />
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with two commands that map to this method: index extract-cfs and index list-cfs. 
-        /// </para>
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with two commands that map to this method:
+        /// index extract-cfs and index list-cfs
         /// </summary>
-        /// <param name="args"></param>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             string filename = null;

--- a/src/Lucene.Net.Misc/Index/CompoundFileExtractor.cs
+++ b/src/Lucene.Net.Misc/Index/CompoundFileExtractor.cs
@@ -25,15 +25,34 @@ namespace Lucene.Net.Index
 
     /// <summary>
     /// Command-line tool for extracting sub-files out of a compound file.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with two commands that map to that method: index extract-cfs and index list-cfs.  
+    /// </para>
     /// </summary>
     public static class CompoundFileExtractor // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
+        // LUCENENET: Not used
+        ///// <param name="args"> Usage: org.apache.lucene.index.IndexReader [-extract] &lt;cfsfile&gt; </param>
+
+
         /// <summary>
         /// Prints the filename and size of each file within a given compound file.
         /// Add the -extract flag to extract files to the current working directory.
         /// In order to make the extracted version of the index work, you have to copy
-        /// the segments file from the compound index into the directory where the extracted files are stored. </summary>
-        ///// <param name="args"> Usage: org.apache.lucene.index.IndexReader [-extract] &lt;cfsfile&gt; </param>
+        /// the segments file from the compound index into the directory where the extracted files are stored.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with two commands that map to this method: index extract-cfs and index list-cfs. 
+        /// </para>
+        /// </summary>
+        /// <param name="args"></param>
         public static void Main(string[] args)
         {
             string filename = null;

--- a/src/Lucene.Net.Misc/Index/IndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/IndexSplitter.cs
@@ -41,6 +41,14 @@ namespace Lucene.Net.Index
     /// @lucene.experimental You can easily
     /// accidentally remove segments from your index so be
     /// careful!
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with three commands that map to that method: index copy-segments, index delete-segments,
+    /// and index list-segments. 
+    /// </para>
     /// </summary>
     public class IndexSplitter
     {
@@ -50,6 +58,16 @@ namespace Lucene.Net.Index
 
         internal DirectoryInfo dir;
 
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with three commands that map to this method: index copy-segments, index delete-segments,
+        /// and index list-segments. 
+        /// </summary>
+        /// <param name="args"></param>
         public static void Main(string[] args)
         {
             if (args.Length < 2)

--- a/src/Lucene.Net.Misc/Index/IndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/IndexSplitter.cs
@@ -29,26 +29,27 @@ namespace Lucene.Net.Index
     /// Command-line tool that enables listing segments in an
     /// index, copying specific segments to another index, and
     /// deleting segments from an index.
-    /// 
-    /// <para>This tool does file-level copying of segments files.
+    ///
+    /// <para />
+    /// This tool does file-level copying of segments files.
     /// This means it's unable to split apart a single segment
     /// into multiple segments.  For example if your index is a
     /// single segment, this tool won't help.  Also, it does basic
     /// file-level copying (using simple
     /// Stream) so it will not work with non
-    /// FSDirectory Directory impls.</para>
-    /// 
+    /// FSDirectory Directory impls.
+    ///
     /// @lucene.experimental You can easily
     /// accidentally remove segments from your index so be
     /// careful!
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with three commands that map to that method: index copy-segments, index delete-segments,
-    /// and index list-segments. 
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with three commands that map to that method:
+    /// index copy-segments, index delete-segments, and index list-segments
     /// </summary>
     public class IndexSplitter
     {
@@ -58,16 +59,16 @@ namespace Lucene.Net.Index
 
         internal DirectoryInfo dir;
 
-
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with three commands that map to this method: index copy-segments, index delete-segments,
-        /// and index list-segments. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with three commands that map to this method:
+        /// index copy-segments, index delete-segments, and index list-segments
         /// </summary>
-        /// <param name="args"></param>
+        /// <param name="args">The command line arguments</param>
         public static void Main(string[] args)
         {
             if (args.Length < 2)

--- a/src/Lucene.Net.Misc/Index/MultiPassIndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/MultiPassIndexSplitter.cs
@@ -33,19 +33,18 @@ namespace Lucene.Net.Index
     /// here uses <see cref="IndexWriter.AddIndexes(IndexReader[])"/> where the input data
     /// comes from the input index with artificially applied deletes to the document
     /// id-s that fall outside the selected partition.
-    /// <para>Note 1: Deletes are only applied to a buffered list of deleted docs and
+    /// <para />
+    /// Note 1: Deletes are only applied to a buffered list of deleted docs and
     /// don't affect the source index - this tool works also with read-only indexes.
-    /// </para>
-    /// <para>Note 2: the disadvantage of this tool is that source index needs to be
+    /// <para />
+    /// Note 2: the disadvantage of this tool is that source index needs to be
     /// read as many times as there are parts to be created, hence the name of this
     /// tool.
-    /// 
-    /// </para>
-    /// <para><b>NOTE</b>: this tool is unaware of documents added
-    /// atomically via <see cref="IndexWriter.AddDocuments(IEnumerable{IEnumerable{IIndexableField}}, Analysis.Analyzer)"/> or 
+    /// <para />
+    /// <b>NOTE</b>: this tool is unaware of documents added
+    /// atomically via <see cref="IndexWriter.AddDocuments(IEnumerable{IEnumerable{IIndexableField}}, Analysis.Analyzer)"/> or
     /// <see cref="IndexWriter.UpdateDocuments(Term, IEnumerable{IEnumerable{IIndexableField}}, Analysis.Analyzer)"/>, which means it can easily
     /// break up such document groups.
-    /// </para>
     /// </summary>
     public class MultiPassIndexSplitter
     {
@@ -122,11 +121,13 @@ namespace Lucene.Net.Index
 
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: index split. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// index split
         /// </summary>
         /// <param name="args"></param>
         /// <exception cref="ArgumentException"></exception>

--- a/src/Lucene.Net.Misc/Index/MultiPassIndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/MultiPassIndexSplitter.cs
@@ -120,6 +120,16 @@ namespace Lucene.Net.Index
             Console.Error.WriteLine("Done.");
         }
 
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: index split. 
+        /// </summary>
+        /// <param name="args"></param>
+        /// <exception cref="ArgumentException"></exception>
         public static void Main(string[] args)
         {
             if (args.Length < 5)

--- a/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
+++ b/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
@@ -25,26 +25,29 @@ namespace Lucene.Net.Misc
 
     /// <summary>
     /// Utility to get document frequency and total number of occurrences (sum of the tf for each doc)  of a term.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: index list-term-info. 
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// index list-term-info
     /// </summary>
     public static class GetTermInfo // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: index list-term-info. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// index list-term-info
         /// </summary>
-        /// <param name="args"></param>
-        /// <exception cref="ArgumentException"></exception>
+        /// <param name="args">The command line arguments</param>
+        /// <exception cref="ArgumentException">Thrown if the incorrect number of arguments are provided</exception>
         public static void Main(string[] args)
         {
 

--- a/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
+++ b/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
@@ -24,10 +24,27 @@ namespace Lucene.Net.Misc
      */
 
     /// <summary>
-    /// Utility to get document frequency and total number of occurrences (sum of the tf for each doc)  of a term. 
+    /// Utility to get document frequency and total number of occurrences (sum of the tf for each doc)  of a term.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: index list-term-info. 
+    /// </para>
     /// </summary>
     public static class GetTermInfo // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: index list-term-info. 
+        /// </summary>
+        /// <param name="args"></param>
+        /// <exception cref="ArgumentException"></exception>
         public static void Main(string[] args)
         {
 

--- a/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
+++ b/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
@@ -156,7 +156,7 @@ namespace Lucene.Net.Misc
                     res = a.Field.CompareToOrdinal(b.Field);
                     if (res == 0)
                     {
-                        res = a.termtext.CompareTo(b.termtext);
+                        res = a.TermText.CompareTo(b.TermText);
                     }
                 }
                 return res;
@@ -180,7 +180,7 @@ namespace Lucene.Net.Misc
                     res = a.Field.CompareToOrdinal(b.Field);
                     if (res == 0)
                     {
-                        res = a.termtext.CompareTo(b.termtext);
+                        res = a.TermText.CompareTo(b.TermText);
                     }
                 }
                 return res;

--- a/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
+++ b/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
@@ -27,14 +27,20 @@ namespace Lucene.Net.Misc
      * limitations under the License.
      */
 
+    // LUCENENET: Not used
+    // If the -t flag is given, both document frequency and total tf (total
+    // number of occurrences) are reported, ordered by descending total tf.
+
     /// <summary>
     /// <see cref="HighFreqTerms"/> class extracts the top n most frequent terms
     /// (by document frequency) from an existing Lucene index and reports their
     /// document frequency.
     /// <para>
-    /// If the -t flag is given, both document frequency and total tf (total
-    /// number of occurrences) are reported, ordered by descending total tf.
-    /// 
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: index list-high-freq-terms. 
     /// </para>
     /// </summary>
     public static class HighFreqTerms // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
@@ -42,6 +48,16 @@ namespace Lucene.Net.Misc
         // The top numTerms will be displayed
         public const int DEFAULT_NUMTERMS = 100;
 
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: index list-high-freq-terms. 
+        /// </summary>
+        /// <param name="args"></param>
+        /// <exception cref="ArgumentException"></exception>
         public static void Main(string[] args)
         {
             string field = null;
@@ -81,7 +97,7 @@ namespace Lucene.Net.Misc
             }
         }
 
-        // LUCENENET specific - our wrapper console shows the correct usage
+        // LUCENENET specific - The lucene-cli docs show the correct usage
         //private static void Usage()
         //{
         //    Console.WriteLine("\n\n" + "java org.apache.lucene.misc.HighFreqTerms <index dir> [-t] [number_terms] [field]\n\t -t: order by totalTermFreq\n\n");

--- a/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
+++ b/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
@@ -35,26 +35,28 @@ namespace Lucene.Net.Misc
     /// <see cref="HighFreqTerms"/> class extracts the top n most frequent terms
     /// (by document frequency) from an existing Lucene index and reports their
     /// document frequency.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: index list-high-freq-terms. 
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// index list-high-freq-terms
     /// </summary>
     public static class HighFreqTerms // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
         // The top numTerms will be displayed
         public const int DEFAULT_NUMTERMS = 100;
 
-
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: index list-high-freq-terms. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// index list-high-freq-terms
         /// </summary>
         /// <param name="args"></param>
         /// <exception cref="ArgumentException"></exception>
@@ -180,7 +182,7 @@ namespace Lucene.Net.Misc
         }
 
         /// <summary>
-        /// Compares terms by <see cref="TermStats.TotalTermFreq"/> 
+        /// Compares terms by <see cref="TermStats.TotalTermFreq"/>
         /// </summary>
         public sealed class TotalTermFreqComparer : IComparer<TermStats>
         {
@@ -205,14 +207,14 @@ namespace Lucene.Net.Misc
 
         /// <summary>
         /// Priority queue for <see cref="TermStats"/> objects
-        /// 
+        ///
         /// </summary>
         internal sealed class TermStatsQueue : PriorityQueue<TermStats>
         {
             internal readonly IComparer<TermStats> comparer;
 
 #nullable enable
-            internal TermStatsQueue(int size, IComparer<TermStats> comparer) 
+            internal TermStatsQueue(int size, IComparer<TermStats> comparer)
                 : base(size)
             {
                 this.comparer = comparer ?? throw new ArgumentNullException(nameof(comparer)); // LUCENENET: Added null guard clause

--- a/src/Lucene.Net.Misc/Misc/IndexMergeTool.cs
+++ b/src/Lucene.Net.Misc/Misc/IndexMergeTool.cs
@@ -26,26 +26,29 @@ namespace Lucene.Net.Misc
     /// <summary>
     /// Merges indices specified on the command line into the index
     /// specified as the first command line argument.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: index merge. 
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// index merge
     /// </summary>
     public static class IndexMergeTool // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: index merge. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// index merge
         /// </summary>
-        /// <param name="args"></param>
-        /// <exception cref="ArgumentException"></exception>
+        /// <param name="args">The command line arguments</param>
+        /// <exception cref="ArgumentException">Thrown if the incorrect number of arguments are provided</exception>
         public static void Main(string[] args)
         {
             if (args.Length < 3)

--- a/src/Lucene.Net.Misc/Misc/IndexMergeTool.cs
+++ b/src/Lucene.Net.Misc/Misc/IndexMergeTool.cs
@@ -26,9 +26,26 @@ namespace Lucene.Net.Misc
     /// <summary>
     /// Merges indices specified on the command line into the index
     /// specified as the first command line argument.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: index merge. 
+    /// </para>
     /// </summary>
     public static class IndexMergeTool // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: index merge. 
+        /// </summary>
+        /// <param name="args"></param>
+        /// <exception cref="ArgumentException"></exception>
         public static void Main(string[] args)
         {
             if (args.Length < 3)

--- a/src/Lucene.Net.Misc/Misc/TermStats.cs
+++ b/src/Lucene.Net.Misc/Misc/TermStats.cs
@@ -25,14 +25,14 @@ namespace Lucene.Net.Misc
     /// </summary>
     public sealed class TermStats
     {
-        internal readonly BytesRef termtext;
+        public readonly BytesRef TermText;
         public string Field { get; set; }
         public int DocFreq { get; set; }
         public long TotalTermFreq { get; set; }
 
         internal TermStats(string field, BytesRef termtext, int df, long tf)
         {
-            this.termtext = BytesRef.DeepCopyOf(termtext);
+            this.TermText = BytesRef.DeepCopyOf(termtext);
             this.Field = field;
             this.DocFreq = df;
             this.TotalTermFreq = tf;
@@ -40,12 +40,12 @@ namespace Lucene.Net.Misc
 
         internal string GetTermText()
         {
-            return termtext.Utf8ToString();
+            return TermText.Utf8ToString();
         }
 
         public override string ToString()
         {
-            return ("TermStats: Term=" + termtext.Utf8ToString() + " DocFreq=" + DocFreq + " TotalTermFreq=" + TotalTermFreq);
+            return ("TermStats: Term=" + TermText.Utf8ToString() + " DocFreq=" + DocFreq + " TotalTermFreq=" + TotalTermFreq);
         }
     }
 }

--- a/src/Lucene.Net.Misc/Misc/TermStats.cs
+++ b/src/Lucene.Net.Misc/Misc/TermStats.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Misc
     /// </summary>
     public sealed class TermStats
     {
-        public readonly BytesRef TermText;
+        public BytesRef TermText { get; private set; }
         public string Field { get; set; }
         public int DocFreq { get; set; }
         public long TotalTermFreq { get; set; }

--- a/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
+++ b/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
@@ -122,7 +122,7 @@ namespace Lucene.Net.Misc
 
             for (int i = 0; i < terms.Length; i++)
             {
-                string termtext = terms[i].termtext.Utf8ToString();
+                string termtext = terms[i].TermText.Utf8ToString();
                 // hardcoded highTF or highTFmedDF
                 if (termtext.Contains("highTF"))
                 {
@@ -195,7 +195,7 @@ namespace Lucene.Net.Misc
 
             for (int i = 0; i < terms.Length; i++)
             {
-                string text = terms[i].termtext.Utf8ToString();
+                string text = terms[i].TermText.Utf8ToString();
                 if (text.Contains("highTF"))
                 {
                     if (text.Contains("medDF"))

--- a/src/Lucene.Net/Index/CheckIndex.cs
+++ b/src/Lucene.Net/Index/CheckIndex.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Index
             /// <summary>
             /// Empty unless you passed specific segments list to check as optional 3rd argument. </summary>
             /// <seealso cref="CheckIndex.DoCheckIndex(IList{string})"/>
-            public IList<string> SegmentsChecked { get; internal set; } // LUCENENET specific - made setter internal 
+            public IList<string> SegmentsChecked { get; internal set; } // LUCENENET specific - made setter internal
 
             /// <summary>
             /// True if the index was created with a newer version of Lucene than the <see cref="CheckIndex"/> tool. </summary>
@@ -137,7 +137,7 @@ namespace Lucene.Net.Index
             public int NumBadSegments { get; internal set; } // LUCENENET specific - made setter internal
 
             /// <summary>
-            /// True if we checked only specific segments 
+            /// True if we checked only specific segments
             /// (<see cref="DoCheckIndex(IList{string})"/> was called with non-null
             /// argument).
             /// </summary>
@@ -519,13 +519,13 @@ namespace Lucene.Net.Index
             {
                 Msg(infoStream, "ERROR: could not read any segments file in directory");
                 result.MissingSegments = true;
-                
+
                 // LUCENENET NOTE: Some tests rely on the error type being in
                 // the message. We can't get the error type with StackTrace, we
                 // need ToString() for that.
                 infoStream?.WriteLine(t.ToString());
                 //infoStream.WriteLine(t.StackTrace);
-                
+
                 return result;
             }
 
@@ -567,13 +567,13 @@ namespace Lucene.Net.Index
             catch (Exception t) when (t.IsThrowable())
             {
                 Msg(infoStream, "ERROR: could not open segments file in directory");
-                
+
                 // LUCENENET NOTE: Some tests rely on the error type being in
                 // the message. We can't get the error type with StackTrace, we
                 // need ToString() for that.
                 infoStream?.WriteLine(t.ToString());
                 //infoStream.WriteLine(t.StackTrace);
-                
+
                 result.CantOpenSegments = true;
                 return result;
             }
@@ -585,13 +585,13 @@ namespace Lucene.Net.Index
             catch (Exception t) when (t.IsThrowable())
             {
                 Msg(infoStream, "ERROR: could not read segment file version in directory");
-                
+
                 // LUCENENET NOTE: Some tests rely on the error type being in
                 // the message. We can't get the error type with StackTrace, we
                 // need ToString() for that.
                 infoStream?.WriteLine(t.ToString());
                 //infoStream.WriteLine(t.StackTrace);
-                
+
                 result.MissingSegmentVersion = true;
                 return result;
             }
@@ -745,12 +745,12 @@ namespace Lucene.Net.Index
                     segInfoStat.OpenReaderPassed = true;
 
                     infoStream?.Write("    test: check integrity.....");
-                    
+
                     reader.CheckIntegrity();
                     Msg(infoStream, "OK");
 
                     infoStream?.Write("    test: check live docs.....");
-                    
+
                     int numDocs = reader.NumDocs;
                     toLoseDocCount = numDocs;
                     if (reader.HasDeletions)
@@ -818,7 +818,7 @@ namespace Lucene.Net.Index
 
                     // Test getFieldInfos()
                     infoStream?.Write("    test: fields..............");
-                    
+
                     FieldInfos fieldInfos = reader.FieldInfos;
                     Msg(infoStream, "OK [" + fieldInfos.Count + " fields]");
                     segInfoStat.NumFields = fieldInfos.Count;
@@ -873,7 +873,7 @@ namespace Lucene.Net.Index
                     // the message. We can't get the error type with StackTrace, we
                     // need ToString() for that.
                     infoStream?.WriteLine(t.ToString());
-                    
+
                     Msg(infoStream, "");
                     result.TotLoseDocCount += toLoseDocCount;
                     result.NumBadSegments++;
@@ -954,12 +954,12 @@ namespace Lucene.Net.Index
             {
                 Msg(infoStream, "ERROR [" + e.Message + "]");
                 status.Error = e;
-             
+
                 // LUCENENET NOTE: Some tests rely on the error type being in
                 // the message. We can't get the error type with StackTrace, we
                 // need ToString() for that.
                 infoStream?.WriteLine(e.ToString());
-                //infoStream.WriteLine(e.StackTrace);      
+                //infoStream.WriteLine(e.StackTrace);
             }
 
             return status;
@@ -1645,7 +1645,7 @@ namespace Lucene.Net.Index
             try
             {
                 infoStream?.Write("    test: terms, freq, prox...");
-                
+
                 Fields fields = reader.Fields;
                 FieldInfos fieldInfos = reader.FieldInfos;
                 status = CheckFields(fields, liveDocs, maxDoc, fieldInfos, true, false, infoStream, verbose);
@@ -1660,12 +1660,12 @@ namespace Lucene.Net.Index
                 Msg(infoStream, "ERROR: " + e);
                 status = new Status.TermIndexStatus();
                 status.Error = e;
-                
+
                 // LUCENENET NOTE: Some tests rely on the error type being in
                 // the message. We can't get the error type with StackTrace, we
                 // need ToString() for that.
                 infoStream?.WriteLine(e.ToString());
-                //infoStream.WriteLine(e.StackTrace);                
+                //infoStream.WriteLine(e.StackTrace);
             }
 
             return status;
@@ -1710,12 +1710,12 @@ namespace Lucene.Net.Index
             {
                 Msg(infoStream, "ERROR [" + e.Message + "]");
                 status.Error = e;
-               
+
                 // LUCENENET NOTE: Some tests rely on the error type being in
                 // the message. We can't get the error type with StackTrace, we
                 // need ToString() for that.
                 infoStream?.WriteLine(e.ToString());
-                //infoStream.WriteLine(e.StackTrace);                
+                //infoStream.WriteLine(e.StackTrace);
             }
 
             return status;
@@ -1732,7 +1732,7 @@ namespace Lucene.Net.Index
             try
             {
                 infoStream?.Write("    test: docvalues...........");
-                
+
                 foreach (FieldInfo fieldInfo in reader.FieldInfos)
                 {
                     if (fieldInfo.HasDocValues)
@@ -1755,12 +1755,12 @@ namespace Lucene.Net.Index
             {
                 Msg(infoStream, "ERROR [" + e.Message + "]");
                 status.Error = e;
-                
+
                 // LUCENENET NOTE: Some tests rely on the error type being in
                 // the message. We can't get the error type with StackTrace, we
                 // need ToString() for that.
                 infoStream?.WriteLine(e.ToString());
-                //infoStream.WriteLine(e.StackTrace);                
+                //infoStream.WriteLine(e.StackTrace);
             }
             return status;
         }
@@ -2278,7 +2278,7 @@ namespace Lucene.Net.Index
             {
                 Msg(infoStream, "ERROR [" + e.Message + "]");
                 status.Error = e;
-               
+
                 // LUCENENET NOTE: Some tests rely on the error type being in
                 // the message. We can't get the error type with StackTrace, we
                 // need ToString() for that.
@@ -2366,14 +2366,16 @@ namespace Lucene.Net.Index
 
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: index check. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// index check
         /// </summary>
-        /// <param name="args"></param>
-        /// <exception cref="ArgumentException"></exception>
+        /// <param name="args">The command line arguments</param>
+        /// <exception cref="ArgumentException">Thrown if invalid arguments are provided</exception>
         [STAThread]
         public static void Main(string[] args)
         {

--- a/src/Lucene.Net/Index/CheckIndex.cs
+++ b/src/Lucene.Net/Index/CheckIndex.cs
@@ -2363,6 +2363,17 @@ namespace Lucene.Net.Index
         /////  <p>
         /////                     this tool exits with exit code 1 if the index cannot be opened or has any
         /////                     corruption, else 0.
+
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: index check. 
+        /// </summary>
+        /// <param name="args"></param>
+        /// <exception cref="ArgumentException"></exception>
         [STAThread]
         public static void Main(string[] args)
         {

--- a/src/Lucene.Net/Index/IndexUpgrader.cs
+++ b/src/Lucene.Net/Index/IndexUpgrader.cs
@@ -1,4 +1,4 @@
-using Lucene.Net.Util;
+﻿using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -29,12 +29,21 @@ namespace Lucene.Net.Index
     using FSDirectory = Lucene.Net.Store.FSDirectory;
     using InfoStream = Lucene.Net.Util.InfoStream;
 
+    // LUCENENET: Not used
+    ///// <code>
+    /////  java -cp lucene-core.jar Lucene.Net.Index.IndexUpgrader [-delete-prior-commits] [-verbose] indexDir
+    ///// </code>
+
     /// <summary>
     /// This is an easy-to-use tool that upgrades all segments of an index from previous Lucene versions
-    /// to the current segment file format. It can be used from command line:
-    /// <code>
-    ///  java -cp lucene-core.jar Lucene.Net.Index.IndexUpgrader [-delete-prior-commits] [-verbose] indexDir
-    /// </code>
+    /// to the current segment file format. It can be used from command line.
+    /// <para>
+    /// LUCENENET specific: In the Java implementation this class' Main
+    /// method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: index upgrade. 
+    /// </para>
     /// Alternatively this class can be instantiated and <see cref="Upgrade()"/> invoked. It uses <see cref="UpgradeIndexMergePolicy"/>
     /// and triggers the upgrade via an <see cref="IndexWriter.ForceMerge(int)"/> request to <see cref="IndexWriter"/>.
     /// <para/>
@@ -73,7 +82,16 @@ namespace Lucene.Net.Index
         /// <summary>
         /// Main method to run <see cref="IndexUpgrader"/> from the
         /// command-line.
+        /// <para>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: index upgrade. 
+        /// </para>
         /// </summary>
+        /// <param name="args"></param>
+        /// <exception cref="ArgumentException"></exception>
         public static void Main(string[] args)
         {
             ParseArgs(args).Upgrade();

--- a/src/Lucene.Net/Index/IndexUpgrader.cs
+++ b/src/Lucene.Net/Index/IndexUpgrader.cs
@@ -37,23 +37,25 @@ namespace Lucene.Net.Index
     /// <summary>
     /// This is an easy-to-use tool that upgrades all segments of an index from previous Lucene versions
     /// to the current segment file format. It can be used from command line.
-    /// <para>
-    /// LUCENENET specific: In the Java implementation this class' Main
-    /// method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: index upgrade. 
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// index upgrade
+    /// <para />
     /// Alternatively this class can be instantiated and <see cref="Upgrade()"/> invoked. It uses <see cref="UpgradeIndexMergePolicy"/>
     /// and triggers the upgrade via an <see cref="IndexWriter.ForceMerge(int)"/> request to <see cref="IndexWriter"/>.
-    /// <para/>
+    /// <para />
     /// This tool keeps only the last commit in an index; for this
     /// reason, if the incoming index has more than one commit, the tool
     /// refuses to run by default. Specify <c>-delete-prior-commits</c>
     /// to override this, allowing the tool to delete all but the last commit.
     /// From .NET code this can be enabled by passing <c>true</c> to
     /// <see cref="IndexUpgrader(Directory, LuceneVersion, TextWriter, bool)"/>.
-    /// <para/>
+    /// <para />
     /// <b>Warning:</b> this tool may reorder documents if the index was partially
     /// upgraded before execution (e.g., documents were added). If your application relies
     /// on &quot;monotonicity&quot; of doc IDs (which means that the order in which the documents
@@ -82,16 +84,17 @@ namespace Lucene.Net.Index
         /// <summary>
         /// Main method to run <see cref="IndexUpgrader"/> from the
         /// command-line.
-        /// <para>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// <para />
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: index upgrade. 
-        /// </para>
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// index upgrade
         /// </summary>
-        /// <param name="args"></param>
-        /// <exception cref="ArgumentException"></exception>
+        /// <param name="args">The command line arguments</param>
+        /// <exception cref="ArgumentException">Thrown if any incorrect arguments are provided</exception>
         public static void Main(string[] args)
         {
             ParseArgs(args).Upgrade();

--- a/src/Lucene.Net/Store/LockStressTest.cs
+++ b/src/Lucene.Net/Store/LockStressTest.cs
@@ -26,15 +26,34 @@ namespace Lucene.Net.Store
      * limitations under the License.
      */
 
+    // LUCENENET: Not used
+    /////Run without any args to see usage.
+
     /// <summary>
     /// Simple standalone tool that forever acquires &amp; releases a
-    /// lock using a specific <see cref="LockFactory"/>.  Run without any args
-    /// to see usage.
+    /// lock using a specific <see cref="LockFactory"/>.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: lock stress-test. 
+    /// </para>
     /// </summary>
     /// <seealso cref="VerifyingLockFactory"/>
     /// <seealso cref="LockVerifyServer"/>
     public static class LockStressTest // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: lock stress-test. 
+        /// </summary>
+        /// <param name="args"></param>
+        /// <exception cref="ArgumentException"></exception>
         [STAThread]
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Security Hotspot", "S2245:Using pseudorandom number generators (PRNGs) is security-sensitive", Justification = "The Random class is only used to generate a timeout value")]

--- a/src/Lucene.Net/Store/LockStressTest.cs
+++ b/src/Lucene.Net/Store/LockStressTest.cs
@@ -26,19 +26,17 @@ namespace Lucene.Net.Store
      * limitations under the License.
      */
 
-    // LUCENENET: Not used
-    /////Run without any args to see usage.
-
     /// <summary>
     /// Simple standalone tool that forever acquires &amp; releases a
     /// lock using a specific <see cref="LockFactory"/>.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: lock stress-test. 
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// lock stress-test
     /// </summary>
     /// <seealso cref="VerifyingLockFactory"/>
     /// <seealso cref="LockVerifyServer"/>
@@ -46,14 +44,16 @@ namespace Lucene.Net.Store
     {
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: lock stress-test. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// lock stress-test
         /// </summary>
-        /// <param name="args"></param>
-        /// <exception cref="ArgumentException"></exception>
+        /// <param name="args">The command line arguments</param>
+        /// <exception cref="ArgumentException">Thrown if the incorrect number of arguments are provided</exception>
         [STAThread]
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Security Hotspot", "S2245:Using pseudorandom number generators (PRNGs) is security-sensitive", Justification = "The Random class is only used to generate a timeout value")]
@@ -63,20 +63,20 @@ namespace Lucene.Net.Store
             {
                 // LUCENENET specific - our lucene-cli wrapper console shows the correct usage
                 throw new ArgumentException();
-                //Console.WriteLine("Usage: java Lucene.Net.Store.LockStressTest myID verifierHost verifierPort lockFactoryClassName lockDirName sleepTimeMS count\n" + 
-                //    "\n" + 
-                //    "  myID = int from 0 .. 255 (should be unique for test process)\n" + 
-                //    "  verifierHost = hostname that LockVerifyServer is listening on\n" + 
-                //    "  verifierPort = port that LockVerifyServer is listening on\n" + 
-                //    "  lockFactoryClassName = primary LockFactory class that we will use\n" + 
-                //    "  lockDirName = path to the lock directory (only set for Simple/NativeFSLockFactory\n" + 
-                //    "  sleepTimeMS = milliseconds to pause betweeen each lock obtain/release\n" + 
-                //    "  count = number of locking tries\n" + 
-                //    "\n" + 
-                //    "You should run multiple instances of this process, each with its own\n" + 
-                //    "unique ID, and each pointing to the same lock directory, to verify\n" + 
-                //    "that locking is working correctly.\n" + 
-                //    "\n" + 
+                //Console.WriteLine("Usage: java Lucene.Net.Store.LockStressTest myID verifierHost verifierPort lockFactoryClassName lockDirName sleepTimeMS count\n" +
+                //    "\n" +
+                //    "  myID = int from 0 .. 255 (should be unique for test process)\n" +
+                //    "  verifierHost = hostname that LockVerifyServer is listening on\n" +
+                //    "  verifierPort = port that LockVerifyServer is listening on\n" +
+                //    "  lockFactoryClassName = primary LockFactory class that we will use\n" +
+                //    "  lockDirName = path to the lock directory (only set for Simple/NativeFSLockFactory\n" +
+                //    "  sleepTimeMS = milliseconds to pause betweeen each lock obtain/release\n" +
+                //    "  count = number of locking tries\n" +
+                //    "\n" +
+                //    "You should run multiple instances of this process, each with its own\n" +
+                //    "unique ID, and each pointing to the same lock directory, to verify\n" +
+                //    "that locking is working correctly.\n" +
+                //    "\n" +
                 //    "Make sure you are first running LockVerifyServer.");
                 //Environment.FailFast("1");
             }

--- a/src/Lucene.Net/Store/LockVerifyServer.cs
+++ b/src/Lucene.Net/Store/LockVerifyServer.cs
@@ -30,16 +30,35 @@ namespace Lucene.Net.Store
 
     using IOUtils = Lucene.Net.Util.IOUtils;
 
+    // LUCENENET: Not used
+    ///// Run without any args to see usage.
+
     /// <summary>
     /// Simple standalone server that must be running when you
     /// use <see cref="VerifyingLockFactory"/>.  This server simply
     /// verifies at most one process holds the lock at a time.
-    /// Run without any args to see usage.
+    /// <para>
+    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
+    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// method within a DLL can't be directly called from the command line so we
+    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+    /// with a command that maps to that method: lock verify-server. 
+    /// </para>
     /// </summary>
     /// <seealso cref="VerifyingLockFactory"/>
     /// <seealso cref="LockStressTest"/>
     public static class LockVerifyServer // LUCENENET specific: CA1052 Static holder types should be Static or NotInheritable
     {
+
+        /// <summary>
+        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
+        /// it was intended to be called from the command line. However in .NET a
+        /// method within a DLL can't be directly called from the command line so we
+        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
+        /// with a command that maps to this method: lock verify-server. 
+        /// </summary>
+        /// <param name="args"></param>
+        /// <exception cref="ArgumentException"></exception>
         [STAThread]
         public static void Main(string[] args)
         {

--- a/src/Lucene.Net/Store/LockVerifyServer.cs
+++ b/src/Lucene.Net/Store/LockVerifyServer.cs
@@ -30,20 +30,18 @@ namespace Lucene.Net.Store
 
     using IOUtils = Lucene.Net.Util.IOUtils;
 
-    // LUCENENET: Not used
-    ///// Run without any args to see usage.
-
     /// <summary>
     /// Simple standalone server that must be running when you
     /// use <see cref="VerifyingLockFactory"/>.  This server simply
     /// verifies at most one process holds the lock at a time.
-    /// <para>
-    /// LUCENENET specific: This class is not for direct use.  In the Java implementation
-    /// it's Main method was intended to be called from the command line. However in .NET a
+    /// <para />
+    /// LUCENENET specific: In the Java implementation, this class' Main method
+    /// was intended to be called from the command line. However, in .NET a
     /// method within a DLL can't be directly called from the command line so we
-    /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-    /// with a command that maps to that method: lock verify-server. 
-    /// </para>
+    /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+    /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+    /// with a command that maps to that method:
+    /// lock verify-server
     /// </summary>
     /// <seealso cref="VerifyingLockFactory"/>
     /// <seealso cref="LockStressTest"/>
@@ -51,14 +49,16 @@ namespace Lucene.Net.Store
     {
 
         /// <summary>
-        /// LUCENENET specific: This method is not for direct use.  In the Java implementation
-        /// it was intended to be called from the command line. However in .NET a
+        /// LUCENENET specific: In the Java implementation, this Main method
+        /// was intended to be called from the command line. However, in .NET a
         /// method within a DLL can't be directly called from the command line so we
-        /// provide a <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>
-        /// with a command that maps to this method: lock verify-server. 
+        /// provide a <see href="https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools">.NET tool</see>,
+        /// <see href="https://www.nuget.org/packages/lucene-cli">lucene-cli</see>,
+        /// with a command that maps to this method:
+        /// lock verify-server
         /// </summary>
-        /// <param name="args"></param>
-        /// <exception cref="ArgumentException"></exception>
+        /// <param name="args">The command line arguments</param>
+        /// <exception cref="ArgumentException">Thrown if the incorrect number of arguments are provided</exception>
         [STAThread]
         public static void Main(string[] args)
         {

--- a/src/dotnet/tools/lucene-cli/commands/benchmark/benchmark-find-quality-queries/BenchmarkFindQualityQueriesCommand.cs
+++ b/src/dotnet/tools/lucene-cli/commands/benchmark/benchmark-find-quality-queries/BenchmarkFindQualityQueriesCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Benchmarks.Quality.Trec;
+using Lucene.Net.Benchmarks.Quality.Utils;
 
 namespace Lucene.Net.Cli
 {
@@ -25,7 +26,7 @@ namespace Lucene.Net.Cli
         {
             public Configuration(CommandLineOptions options)
             {
-                this.Main = (args) => QueryDriver.Main(args);
+                this.Main = (args) => QualityQueriesFinder.Main(args);
 
                 this.Name = "find-quality-queries";
                 this.Description = FromResource("Description");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Fixes #959: Fix TermStats.TermText access, add CLI comments and 1 CLI bug fix

## Description

1) Converts TermStats.TermText into a public property and changes it's case to follow .NET conventions.  
2) Code sweep of all the Main(args) methods that relate to the lucene-cli so they now have XML summary comments that indicate that they are not intended for direct use but rather are used by the lucene-cli.   If the Main method is in a static class that looks to be designed solely for use from the command line then similar comments are added to the class.
3) In the process of doing the code sweep to add comments, I discovered one cli command Lucene,Net.Cli.BenchmarkFindQualityQueriesCommand that was wired up to the wrong command class.  So I fixed this bug as well by wiring it up the right one which is QualityQueriesFinder.Main(args).
4) the 4th commit was due to realizing that I had one failing test due to me making TermStats.TermText a public field rather than a public property.  So this commit fixes that and the failing unit test.

