### PR TITLE
feature/website support for /latest/ and /absolute-latest/ redirection

### DIFF
--- a/websites/site/.htaccess
+++ b/websites/site/.htaccess
@@ -1,0 +1,42 @@
+﻿# -----------------------------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the ""License""); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an ""AS IS"" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -----------------------------------------------------------------------------------
+
+
+# The Lucene.NET site uses .htaccess to implement helpful URL redirection into the
+# Lucene.NET API documentation.
+#
+# We use rewrite rules to enable the following:
+# - /doc/latest/ redirects to the API docs corresponding to the latest
+#   officially released version of Lucene.NET.
+# - /doc/absolute-latest/ redirects to the API docs for the absolute
+#   latest version, including pre-release versions.
+#
+# Using URLs that start with /doc/latest/ and /doc/absolute-latest/ from the
+# main website content into the API documentation always points to the appropriate
+# version, with [R=301] signaling permanent redirects and [L] preventing further
+# rule processing.
+
+
+RewriteEngine On
+
+# Redirect /docs/latest/ to /docs/3.0.3/
+RewriteRule ^docs/latest/(.*)$ /docs/3.0.3/$1 [R=301,L]
+
+# Redirect /docs/absolute-latest/ to /docs/4.8.0-beta00016/
+RewriteRule ^docs/absolute-latest/(.*)$ /docs/4.8.0-beta00016/$1 [R=301,L]

--- a/websites/site/site.ps1
+++ b/websites/site/site.ps1
@@ -1,4 +1,4 @@
-# -----------------------------------------------------------------------------------
+﻿# -----------------------------------------------------------------------------------
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -67,6 +67,9 @@ if ($Clean) {
 	Remove-Item (Join-Path -Path $SiteFolder "obj\*") -recurse -force -ErrorAction SilentlyContinue
 	Remove-Item (Join-Path -Path $SiteFolder "obj") -force -ErrorAction SilentlyContinue
 }
+
+# Copy the .htaccess file to the _site directory after cleaning
+Copy-Item -Path (Join-Path -Path $SiteFolder ".htaccess") -Destination (Join-Path -Path $SiteFolder "_site\.htaccess") -Force
 
 $DocFxJson = Join-Path -Path $SiteFolder "docfx.json"
 $DocFxLog = Join-Path -Path $SiteFolder "obj\docfx.log"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.


<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)
Website /latest/ using .htaccess rewrite rules


## Description
I don't think there is an issue for this one but it's a feature we have been wanting for a while.

This pull request introduces a new URL redirection feature for the Lucene.NET website. It sets up two redirects into the API documentation using .htaccess rewrite rules. The implementation adds two useful URL paths:
•	/doc/latest/: Redirects users to the API documentation for the most recent officially released version of Lucene.NET.
•	/doc/absolute-latest/: Directs users to the absolute latest version of the API documentation, which may include pre-release versions.
These redirects allow the main website to link to the API documentation dynamically, without hardcoding the version number in the URLs, ensuring that users are always directed to the correct version of the documentation even as we provide new version of Lucene.NET and its accompanying API documentation.

