### PR TITLE
bugfix/website force .htaccess LF endings & introduce .gitattributes …

### DIFF
--- a/websites/site/.gitattributes
+++ b/websites/site/.gitattributes
@@ -1,0 +1,1 @@
+.htaccess text eol=lf

--- a/websites/site/.htaccess
+++ b/websites/site/.htaccess
@@ -31,6 +31,8 @@
 # main website content into the API documentation always points to the appropriate
 # version, with [R=301] signaling permanent redirects and [L] preventing further
 # rule processing.
+#
+# Note: This file is line ending sensitive. MUST use LF line endings.
 
 
 RewriteEngine On

--- a/websites/site/site.ps1
+++ b/websites/site/site.ps1
@@ -68,8 +68,9 @@ if ($Clean) {
 	Remove-Item (Join-Path -Path $SiteFolder "obj") -force -ErrorAction SilentlyContinue
 }
 
-# Copy the .htaccess file to the _site directory after cleaning
+# Copy the .htaccess  & .gitattributes files to the _site directory after cleaning
 Copy-Item -Path (Join-Path -Path $SiteFolder ".htaccess") -Destination (Join-Path -Path $SiteFolder "_site\.htaccess") -Force
+Copy-Item -Path (Join-Path -Path $SiteFolder ".gitattributes") -Destination (Join-Path -Path $SiteFolder "_site\.gitattributes") -Force
 
 $DocFxJson = Join-Path -Path $SiteFolder "docfx.json"
 $DocFxLog = Join-Path -Path $SiteFolder "obj\docfx.log"


### PR DESCRIPTION
…file


Summary of the changes (Less than 80 chars)
Ensures that the website site's .htaccess file uses LF line endings 

Details:
Fixes a bug with my previous commit [feature/website support for /latest/ and /absolute-latest/ redirection](https://github.com/apache/lucenenet/commit/c0537195aaee87b0d75e69da02e80fb7c32f9b42) that didn't appear during my testing.   Apparently, the .htaccess Apache Web Server file must have LF line endings if running on a Linux machine.  In my prior commit, the file was CRLF terminated which caused the issue  This PR fixes that and adds a .gitattributes file to ensure LF is used as the line terminator for that file.  


