### PR TITLE
BREAKING: Backport serialization fix for replicator

### DIFF
--- a/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
@@ -181,7 +181,7 @@ namespace Lucene.Net.Replicator.Http
             //.NET Note: No headers? No ContentType?... Bad use of Http?
             HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Post, QueryString(request, parameters));
 
-            req.Content = new StringContent(JToken.FromObject(entity, JsonSerializer.Create(ReplicationService.JSON_SERIALIZER_SETTINGS))
+            req.Content = new StringContent(JToken.FromObject(entity, JsonSerializer.Create())
                 .ToString(Formatting.None), Encoding.UTF8, "application/json");
 
             return Execute(req);

--- a/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
+++ b/src/Lucene.Net.Replicator/Http/HttpClientBase.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,7 +52,7 @@ namespace Lucene.Net.Replicator.Http
         // TODO compression?
 
         /// <summary>
-        /// The URL to execute requests against. 
+        /// The URL to execute requests against.
         /// </summary>
         protected string Url { get; private set; }
 
@@ -64,7 +63,7 @@ namespace Lucene.Net.Replicator.Http
         /// Creates a new <see cref="HttpClientBase"/> with the given host, port and path.
         /// </summary>
         /// <remarks>
-        /// The host, port and path parameters are normalized to <c>http://{host}:{port}{path}</c>, 
+        /// The host, port and path parameters are normalized to <c>http://{host}:{port}{path}</c>,
         /// if path is <c>null</c> or <c>empty</c> it defaults to <c>/</c>.
         /// <para/>
         /// A <see cref="HttpMessageHandler"/> is taken as an optional parameter as well, if this is not provided it defaults to <c>null</c>.
@@ -98,7 +97,7 @@ namespace Lucene.Net.Replicator.Http
         /// Creates a new <see cref="HttpClientBase"/> with the given <paramref name="url"/> and <see cref="HttpClient"/>.
         /// </summary>
         /// <remarks>
-        /// This allows full controll over how the <see cref="HttpClient"/> is created, 
+        /// This allows full controll over how the <see cref="HttpClient"/> is created,
         /// prefer the <see cref="HttpClientBase(string, HttpMessageHandler)"/> over this unless you know you need the control of the <see cref="HttpClient"/>.
         /// </remarks>
         /// <param name="url"></param>
@@ -122,7 +121,7 @@ namespace Lucene.Net.Replicator.Http
         }
 
         /// <summary>
-        /// Throws <see cref="ObjectDisposedException"/> if this client is already disposed. 
+        /// Throws <see cref="ObjectDisposedException"/> if this client is already disposed.
         /// </summary>
         /// <exception cref="ObjectDisposedException">client is already disposed.</exception>
         protected void EnsureOpen()
@@ -166,51 +165,9 @@ namespace Lucene.Net.Replicator.Http
         /// <summary>
         /// Throws an exception for any errors.
         /// </summary>
-        /// <exception cref="IOException">IO Error happened at the server, check inner exception for details.</exception>
-        /// <exception cref="HttpRequestException">Unknown error received from the server.</exception>
         protected virtual void ThrowKnownError(HttpResponseMessage response)
         {
-            Stream input;
-            try
-            {
-                //.NET Note: Bridging from Async to Sync, this is not ideal and we could consider changing the interface to be Async or provide Async overloads
-                //           and have these Sync methods with their caveats.
-                input = response.Content.ReadAsStreamAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-            }
-            catch (Exception t) when (t.IsThrowable())
-            {
-                // the response stream is not an exception - could be an error in servlet.init().
-                // LUCENENET: Check status code to see if we had an HTTP error
-                try
-                {
-                    response.EnsureSuccessStatusCode();
-                }
-                catch (HttpRequestException e)
-                {
-                    throw RuntimeException.Create(e);
-                }
-
-                throw RuntimeException.Create("Unknown error: ", t);
-            }
-
-            Exception exception;
-            try
-            {
-                TextReader reader = new StreamReader(input);
-                JsonSerializer serializer = JsonSerializer.Create(ReplicationService.JSON_SERIALIZER_SETTINGS);
-                exception = (Exception)serializer.Deserialize(new JsonTextReader(reader));
-            }
-            catch (Exception th) when (th.IsThrowable())
-            {
-                //not likely
-                throw RuntimeException.Create(string.Format("Failed to read exception object: {0} {1}", response.StatusCode, response.ReasonPhrase), th);
-            }
-            finally
-            {
-                input.Dispose();
-            }
-
-            Util.IOUtils.ReThrow(exception);
+            throw RuntimeException.Create(response.ReasonPhrase ?? $"Unknown error: {response.StatusCode}");
         }
 
         /// <summary>
@@ -272,7 +229,7 @@ namespace Lucene.Net.Replicator.Http
 
         // TODO: can we simplify this Consuming !?!?!?
         /// <summary>
-        /// Internal utility: input stream of the provided response, which optionally 
+        /// Internal utility: input stream of the provided response, which optionally
         /// consumes the response's resources when the input stream is exhausted.
         /// </summary>
         /// <exception cref="IOException"></exception>
@@ -293,7 +250,7 @@ namespace Lucene.Net.Replicator.Http
 
         // TODO: can we simplify this Consuming !?!?!?
         /// <summary>
-        /// Internal utility: input stream of the provided response, which optionally 
+        /// Internal utility: input stream of the provided response, which optionally
         /// consumes the response's resources when the input stream is exhausted.
         /// </summary>
         /// <exception cref="IOException"></exception>
@@ -321,7 +278,7 @@ namespace Lucene.Net.Replicator.Http
         }
 
         /// <summary>
-        /// Do a specific action and validate after the action that the status is still OK, 
+        /// Do a specific action and validate after the action that the status is still OK,
         /// and if not, attempt to extract the actual server side exception. Optionally
         /// release the response at exit, depending on <paramref name="consume"/> parameter.
         /// </summary>
@@ -359,11 +316,11 @@ namespace Lucene.Net.Replicator.Http
             }
             if (Debugging.AssertsEnabled) Debugging.Assert(th != null); // extra safety - if we get here, it means the Func<T> failed
             Util.IOUtils.ReThrow(th);
-            return default; // silly, if we're here, IOUtils.reThrow always throws an exception 
+            return default; // silly, if we're here, IOUtils.reThrow always throws an exception
         }
 
         /// <summary>
-        /// Disposes this <see cref="HttpClientBase"/>. 
+        /// Disposes this <see cref="HttpClientBase"/>.
         /// When called with <code>true</code>, this disposes the underlying <see cref="HttpClient"/>.
         /// </summary>
         protected virtual void Dispose(bool disposing)
@@ -376,7 +333,7 @@ namespace Lucene.Net.Replicator.Http
         }
 
         /// <summary>
-        /// Disposes this <see cref="HttpClientBase"/>. 
+        /// Disposes this <see cref="HttpClientBase"/>.
         /// This disposes the underlying <see cref="HttpClient"/>.
         /// </summary>
         public void Dispose()

--- a/src/Lucene.Net.Replicator/Http/ReplicationService.cs
+++ b/src/Lucene.Net.Replicator/Http/ReplicationService.cs
@@ -188,19 +188,9 @@ namespace Lucene.Net.Replicator.Http
                         break;
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 response.StatusCode = (int)HttpStatusCode.InternalServerError; // propagate the failure
-                try
-                {
-                    TextWriter writer = new StreamWriter(response.Body);
-                    JsonSerializer serializer = JsonSerializer.Create(JSON_SERIALIZER_SETTINGS);
-                    serializer.Serialize(writer, e, e.GetType());
-                }
-                catch (Exception e2) when (e2.IsException())
-                {
-                    throw new IOException("Could not serialize", e2);
-                }
             }
             finally
             {

--- a/src/Lucene.Net.Replicator/Http/ReplicationService.cs
+++ b/src/Lucene.Net.Replicator/Http/ReplicationService.cs
@@ -81,15 +81,6 @@ namespace Lucene.Net.Replicator.Http
         /// </summary>
         public const string REPLICATE_FILENAME_PARAM = "filename";
 
-        /// <summary>
-        /// Json Serializer Settings to use when serializing and deserializing errors.
-        /// </summary>
-        // LUCENENET specific
-        public static readonly JsonSerializerSettings JSON_SERIALIZER_SETTINGS = new JsonSerializerSettings()
-        {
-            TypeNameHandling = TypeNameHandling.All
-        };
-
         private const int SHARD_IDX = 0, ACTION_IDX = 1;
 
         private readonly string context;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Backport of a serialization fix from Lucene.

## Description

This backports a serialization fix in the upstream Lucene project to avoid arbitrary type instantiation when errors occur.

Upstream commit: https://github.com/apache/lucene/commit/b4b153f64fb0420c6e28ddea4c442e119458756c