### PR TITLE
Removed FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION from the codebase

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -46,7 +46,6 @@
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ARGITERATOR</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PROCESS_KILL_ENTIREPROCESSTREE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CONCAT_READONLYSPAN</DefineConstants>
 

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/NameIntCacheLRU.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/NameIntCacheLRU.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Support.Threading;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet.Taxonomy.WriterCache
 {
@@ -162,13 +163,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             }
             else
             {
-#if FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION
-                cache = new Dictionary<TName, int>(capacity: 1000);
-#else
-                // LUCENENET specific - we use ConcurrentDictionary here because it supports deleting while
-                // iterating through the collection, but Dictionary does not.
-                cache = new ConcurrentDictionary<TName, int>(concurrencyLevel: 3, capacity: 1000); //no need for LRU
-#endif
+                cache = new JCG.Dictionary<TName, int>(capacity: 1000);
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
+++ b/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
@@ -833,13 +833,9 @@ namespace Lucene.Net.Util.Fst
 
             // build all prefixes
 
-#if FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION
-            IDictionary<Int32sRef, CountMinOutput<T>> prefixes = new Dictionary<Int32sRef, CountMinOutput<T>>();
-#else
-            // LUCENENET: We use ConcurrentDictionary<TKey, TValue> because Dictionary<TKey, TValue> doesn't support
-            // deletion while iterating, but ConcurrentDictionary does.
-            IDictionary<Int32sRef, CountMinOutput<T>> prefixes = new ConcurrentDictionary<Int32sRef, CountMinOutput<T>>();
-#endif
+            // LUCENENET specific - using concrete type for the readerMap field, since it will eliminate boxing to an interface on GetEnumerator() calls
+            JCG.Dictionary<Int32sRef, CountMinOutput<T>> prefixes = new JCG.Dictionary<Int32sRef, CountMinOutput<T>>();
+
             Int32sRef scratch = new Int32sRef(10);
             foreach (InputOutput<T> pair in pairs)
             {
@@ -927,7 +923,7 @@ namespace Lucene.Net.Util.Fst
                     if (!keep)
                     {
                         //it.remove();
-                        prefixes.Remove(ent);
+                        prefixes.Remove(prefix);
                         //System.out.println("    remove");
                     }
                     else

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -471,13 +471,8 @@ namespace Lucene.Net.Index
                 this.outerInstance = outerInstance;
             }
 
-#if FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION
-            private readonly IDictionary<SegmentCommitInfo, ReadersAndUpdates> readerMap = new Dictionary<SegmentCommitInfo, ReadersAndUpdates>();
-#else
-            // LUCENENET: We use ConcurrentDictionary<TKey, TValue> because Dictionary<TKey, TValue> doesn't support
-            // deletion while iterating, but ConcurrentDictionary does.
-            private readonly IDictionary<SegmentCommitInfo, ReadersAndUpdates> readerMap = new ConcurrentDictionary<SegmentCommitInfo, ReadersAndUpdates>();
-#endif
+            // LUCENENET specific - using concrete type for the readerMap field, since it will eliminate boxing to an interface on GetEnumerator() calls
+            private readonly JCG.Dictionary<SegmentCommitInfo, ReadersAndUpdates> readerMap = new JCG.Dictionary<SegmentCommitInfo, ReadersAndUpdates>();
 
             // used only by asserts
             public virtual bool InfoIsLive(SegmentCommitInfo info)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes

Removed FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION from the codebase

Fixes #978

## Description

Removed FEATURE_DICTIONARY_REMOVE_CONTINUEENUMERATION from the codebase.

Also, updated private fields to use `J2N.Collections.Generic.Dictionary<TKey,TValue>` for a performance boost when we upgrade to J2N 3.x `GetEnumerator()` currently boxes from struct to interface, but the breaking API change will return the struct instead, avoiding the boxing.
