### PR TITLE
Target .NET 8, #928

### DIFF
--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -109,6 +109,7 @@ task Init -depends CheckSDK, UpdateLocalSDKVersion -description "This task makes
     Write-Host "Powershell Version: $($PSVersionTable.PSVersion)"
 
     Ensure-Directory-Exists "$artifactsDirectory"
+    Ensure-Directory-Exists "$nugetPackageDirectory" # helpful when adding this path to your nuget sources for local installs
 }
 
 task Restore -description "This task restores the dependencies" {

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -31,6 +31,7 @@
 
     <DefineConstants>$(DefineConstants);FEATURE_RANDOM_NEXTINT64_NEXTSINGLE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SPANFORMATTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SUPPORTEDOSPLATFORMATTRIBUTE</DefineConstants>
 
   </PropertyGroup>
 

--- a/TestTargetFramework.props
+++ b/TestTargetFramework.props
@@ -23,7 +23,7 @@
 <Project>
 
   <PropertyGroup>
-    <!-- Changing this setting will allow testing on all target frameworks within Visual Studio 2019.
+    <!-- Changing this setting will allow testing on all target frameworks within Visual Studio.
     Note that the main libraries are multi-targeted, so this has no effect on how they are compiled,
     this setting only affects the test projects. -->
     <!--<TargetFramework>net472</TargetFramework>-->
@@ -38,7 +38,7 @@
 
     <!-- Test Client to DLL target works as follows:
       Test Client       | Target Under Test
-      net8.0            | net6.0
+      net8.0            | net8.0
       net6.0            | net6.0
       net5.0            | netstandard2.1
       net48             | net462
@@ -67,6 +67,7 @@
 
     <!-- We purposely test on EoL frameworks for testing netstandard2.1, but we want to keep this warning in production code. -->
     <CheckEolTargetFramework Condition=" '$(TargetFramework)' == 'net5.0' ">false</CheckEolTargetFramework>
+    <SuppressTfmSupportBuildWarnings Condition=" '$(TargetFramework)' == 'net5.0' ">true</SuppressTfmSupportBuildWarnings>
 
     <NoWarn Label="Nested types should not be visible">$(NoWarn);CA1034</NoWarn>
     <NoWarn Label="Use Literals Where Appropriate">$(NoWarn);CA1802</NoWarn>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -1,6 +1,5 @@
 ﻿// Lucene version compatibility level 4.10.4
 using J2N;
-using J2N.Collections.Generic.Extensions;
 using J2N.Numerics;
 using J2N.Text;
 using Lucene.Net.Diagnostics;
@@ -726,11 +725,11 @@ namespace Lucene.Net.Analysis.Hunspell
         internal static readonly IDictionary<string, string> CHARSET_ALIASES = LoadCharsetAliases();
         private static IDictionary<string, string> LoadCharsetAliases() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            return new Dictionary<string, string>
+            return Collections.AsReadOnly(new Dictionary<string, string>
             {
                 ["microsoft-cp1251"] = "windows-1251",
                 ["TIS620-2533"] = "TIS-620"
-            }.AsReadOnly();
+            });
         }
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/AbstractAnalysisFactory.cs
@@ -1,5 +1,4 @@
 ﻿// Lucene version compatibility level 4.8.1
-using J2N.Collections.Generic.Extensions;
 using Lucene.Net.Analysis.Core;
 using Lucene.Net.Support;
 using Lucene.Net.Util;
@@ -38,7 +37,7 @@ namespace Lucene.Net.Analysis.Util
     /// The typical lifecycle for a factory consumer is:
     /// <list type="bullet">
     ///     <item><description>Create factory via its constructor (or via XXXFactory.ForName)</description></item>
-    ///     <item><description>(Optional) If the factory uses resources such as files, 
+    ///     <item><description>(Optional) If the factory uses resources such as files,
     ///         <see cref="IResourceLoaderAware.Inform(IResourceLoader)"/> is called to initialize those resources.</description></item>
     ///     <item><description>Consumer calls create() to obtain instances.</description></item>
     /// </list>
@@ -62,7 +61,7 @@ namespace Lucene.Net.Analysis.Util
         protected AbstractAnalysisFactory(IDictionary<string, string> args)
         {
             IsExplicitLuceneMatchVersion = false;
-            originalArgs = args.AsReadOnly();
+            originalArgs = Collections.AsReadOnly(args);
             string version = Get(args, LUCENE_MATCH_VERSION_PARAM);
             // LUCENENET TODO: What should we do if the version is null?
             //luceneMatchVersion = version is null ? (LuceneVersion?)null : LuceneVersionHelpers.ParseLeniently(version);
@@ -79,7 +78,7 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// this method can be called in the <see cref="TokenizerFactory.Create(TextReader)"/>
         /// or <see cref="TokenFilterFactory.Create(TokenStream)"/> methods,
-        /// to inform user, that for this factory a <see cref="m_luceneMatchVersion"/> is required 
+        /// to inform user, that for this factory a <see cref="m_luceneMatchVersion"/> is required
         /// </summary>
         [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "By design")]
         protected void AssureMatchVersion() // LUCENENET TODO: Remove this method (not used anyway in .NET)
@@ -296,7 +295,7 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Compiles a pattern for the value of the specified argument key <paramref name="name"/> 
+        /// Compiles a pattern for the value of the specified argument key <paramref name="name"/>
         /// </summary>
         protected Regex GetPattern(IDictionary<string, string> args, string name)
         {
@@ -372,7 +371,7 @@ namespace Lucene.Net.Analysis.Util
 
         /// <summary>
         /// Same as <see cref="GetWordSet(IResourceLoader, string, bool)"/>,
-        /// except the input is in snowball format. 
+        /// except the input is in snowball format.
         /// </summary>
         protected CharArraySet GetSnowballWordSet(IResourceLoader loader, string wordFiles, bool ignoreCase)
         {
@@ -428,7 +427,7 @@ namespace Lucene.Net.Analysis.Util
 
         private const string CLASS_NAME = "class";
 
-        /// <returns> the string used to specify the concrete class name in a serialized representation: the class arg.  
+        /// <returns> the string used to specify the concrete class name in a serialized representation: the class arg.
         ///         If the concrete class name was not specified via a class arg, returns <c>GetType().Name</c>. </returns>
         public virtual string GetClassArg()
         {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/AnalysisSPILoader.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/AnalysisSPILoader.cs
@@ -1,5 +1,4 @@
 ﻿// Lucene version compatibility level 4.8.1
-using J2N.Collections.Generic.Extensions;
 using Lucene.Net.Support;
 using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
@@ -98,7 +97,7 @@ namespace Lucene.Net.Analysis.Util
                         services.Add(name, service);
                     }
                 }
-                this.services = services.AsReadOnly();
+                this.services = Collections.AsReadOnly(services);
             }
             finally
             {

--- a/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
+++ b/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.csproj
@@ -26,11 +26,11 @@
     <Description>Analyzers for indexing content in different languages and domains for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
     <PackageDocumentationRelativeUrl>analysis-common/overview.html</PackageDocumentationRelativeUrl>
   </PropertyGroup>
-  
+
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.Common</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <EmbeddedResource Include="**/*.rslp" Exclude="bin/**/*;obj/**/*" Label="RSLP Test Data" />

--- a/src/Lucene.Net.Analysis.Kuromoji/Lucene.Net.Analysis.Kuromoji.csproj
+++ b/src/Lucene.Net.Analysis.Kuromoji/Lucene.Net.Analysis.Kuromoji.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.Kuromoji</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;japanese</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <EmbeddedResource Include="**/*.txt" Exclude="bin/**/*;obj/**/*" Label="Text Test Data" />

--- a/src/Lucene.Net.Analysis.Morfologik/Lucene.Net.Analysis.Morfologik.csproj
+++ b/src/Lucene.Net.Analysis.Morfologik/Lucene.Net.Analysis.Morfologik.csproj
@@ -26,11 +26,11 @@
     <Description>Analyzer for dictionary stemming, built-in Polish dictionary for the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
     <PackageDocumentationRelativeUrl>analysis-morfologik/Lucene.Net.Analysis.Morfologik.html</PackageDocumentationRelativeUrl>
   </PropertyGroup>
-  
+
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.Morfologik</AssemblyTitle>
     <RootNamespace>Lucene.Net.Analysis</RootNamespace>
@@ -39,7 +39,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -32,7 +32,7 @@
   <PropertyGroup>
     <!-- Currently, IKVM doesn't officially support building NetFX on anything but Windows, so we skip it for contributors who may be on various platforms.
         We can remove the condition once that has been addressed. See: https://github.com/ikvmnet/ikvm-maven/issues/49 -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Lang.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Lang.cs
@@ -1,7 +1,7 @@
 ﻿// commons-codec version compatibility level: 1.9
 using J2N;
-using J2N.Collections.Generic.Extensions;
 using J2N.Text;
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -218,7 +218,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private Lang(IList<LangRule> rules, Languages languages)
         {
-            this.rules = rules.AsReadOnly();
+            this.rules = Collections.AsReadOnly(rules);
             this.languages = languages;
         }
 

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
@@ -1,6 +1,5 @@
 ﻿// commons-codec version compatibility level: 1.9
 using J2N;
-using J2N.Collections.Generic.Extensions;
 using J2N.Text;
 using Lucene.Net.Support;
 using Lucene.Net.Util;
@@ -150,10 +149,10 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                         rs["common"] = ParseRules(CreateScanner(s, rt, "common"), CreateResourceName(s, rt, "common"));
                     }
 
-                    rts[rt] = rs.AsReadOnly();
+                    rts[rt] = Collections.AsReadOnly(rs);
                 }
 
-                rules[s] = rts.AsReadOnly();
+                rules[s] = Collections.AsReadOnly(rts);
             }
             return rules;
         }
@@ -217,7 +216,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static TextReader CreateScanner(string lang)
         {
-            string resName = string.Format("{0}.txt", lang); 
+            string resName = string.Format("{0}.txt", lang);
             Stream rulesIS = typeof(Languages).FindAndGetManifestResourceStream(resName);
 
             if (rulesIS is null)
@@ -869,7 +868,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
         /// <param name="i">The int position within the input.</param>
         /// <returns><c>true</c> if the pattern and left/right context match, <c>false</c> otherwise.</returns>
         // LUCENENET specific
-        public virtual bool PatternAndContextMatches(string input, int i) 
+        public virtual bool PatternAndContextMatches(string input, int i)
         {
             if (i < 0)
             {
@@ -940,7 +939,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
     public sealed class Phoneme : IPhonemeExpr
     {
-        // LUCENENET: It is no longer good practice to use binary serialization. 
+        // LUCENENET: It is no longer good practice to use binary serialization.
         // See: https://github.com/dotnet/corefx/issues/23584#issuecomment-325724568
 #if FEATURE_SERIALIZABLE
         [Serializable]

--- a/src/Lucene.Net.Analysis.Phonetic/Lucene.Net.Analysis.Phonetic.csproj
+++ b/src/Lucene.Net.Analysis.Phonetic/Lucene.Net.Analysis.Phonetic.csproj
@@ -30,7 +30,7 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.Phonetic</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;soundex;double;metaphone;sounds;like;beider;morse;cologne;caverphone;nysiis;match;rating</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <EmbeddedResource Include="Language\*.txt" />

--- a/src/Lucene.Net.Analysis.SmartCn/Lucene.Net.Analysis.SmartCn.csproj
+++ b/src/Lucene.Net.Analysis.SmartCn/Lucene.Net.Analysis.SmartCn.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.SmartCn</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;chinese;smart</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <EmbeddedResource Include="Hhmm/*.mem" Label="Dict Test Data" />

--- a/src/Lucene.Net.Analysis.Stempel/Lucene.Net.Analysis.Stempel.csproj
+++ b/src/Lucene.Net.Analysis.Stempel/Lucene.Net.Analysis.Stempel.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Analysis.Stempel</AssemblyTitle>
     <PackageTags>$(PackageTags);analysis;polish</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <EmbeddedResource Include="Pl\*.tbl;Pl\*.txt" />

--- a/src/Lucene.Net.Benchmark/Lucene.Net.Benchmark.csproj
+++ b/src/Lucene.Net.Benchmark/Lucene.Net.Benchmark.csproj
@@ -26,11 +26,11 @@
     <Description>System for benchmarking the Lucene.NET full-text search engine library from The Apache Software Foundation.</Description>
     <PackageDocumentationRelativeUrl>benchmark/Lucene.Net.Benchmarks.html</PackageDocumentationRelativeUrl>
   </PropertyGroup>
-  
+
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Benchmark</AssemblyTitle>
     <PackageTags>$(PackageTags);benchmark</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\dotnet\Lucene.Net.ICU\Lucene.Net.ICU.csproj" />

--- a/src/Lucene.Net.Classification/Lucene.Net.Classification.csproj
+++ b/src/Lucene.Net.Classification/Lucene.Net.Classification.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Classification</AssemblyTitle>
     <PackageTags>$(PackageTags);classification</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net.Codecs/Lucene.Net.Codecs.csproj
+++ b/src/Lucene.Net.Codecs/Lucene.Net.Codecs.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Codecs</AssemblyTitle>
     <PackageTags>$(PackageTags);codec</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net.Demo/Lucene.Net.Demo.csproj
+++ b/src/Lucene.Net.Demo/Lucene.Net.Demo.csproj
@@ -22,20 +22,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Demo is deployed through the dotnet/tools/lucene-cli package -->
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Demo</AssemblyTitle>
     <Description>Simple example code for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
     <PackageTags>$(PackageTags);demo</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    
+
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
     <NoWarn Label="Remove unused parameter">$(NoWarn);IDE0060</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
@@ -1,5 +1,4 @@
-﻿using J2N.Collections.Generic.Extensions;
-using J2N.Text;
+﻿using J2N.Text;
 using Antlr.Runtime;
 using Antlr.Runtime.Tree;
 using Lucene.Net.Queries.Function;
@@ -97,7 +96,7 @@ namespace Lucene.Net.Expressions.JS
 
         private readonly IDictionary<string, MethodInfo> functions;
 
-        
+
 
         private ILGenerator gen;
         private AssemblyBuilder asmBuilder;
@@ -202,7 +201,7 @@ namespace Lucene.Net.Expressions.JS
             dynamicType = modBuilder.DefineType(COMPILED_EXPRESSION_CLASS,
                 TypeAttributes.AnsiClass | TypeAttributes.AutoClass | TypeAttributes.Public | TypeAttributes.Class |
                 TypeAttributes.BeforeFieldInit | TypeAttributes.AutoLayout, EXPRESSION_TYPE);
-            
+
             ConstructorBuilder constructorBuilder = dynamicType.DefineConstructor(MethodAttributes.Public,
                 CallingConventions.HasThis,
                 new[] { typeof(string), typeof(string[]) });
@@ -634,7 +633,7 @@ namespace Lucene.Net.Expressions.JS
             {
                 throw Error.Create("Cannot resolve function", e);
             }
-            return map.AsReadOnly();
+            return Collections.AsReadOnly(map);
         }
 
         private static Type GetType(string typeName)

--- a/src/Lucene.Net.Expressions/Lucene.Net.Expressions.csproj
+++ b/src/Lucene.Net.Expressions/Lucene.Net.Expressions.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Expressions</AssemblyTitle>
     <PackageTags>$(PackageTags);expression</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net.Queries\Lucene.Net.Queries.csproj" />
@@ -51,13 +51,13 @@
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpPackageVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsPackageVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitPackageVersion)" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="$(SystemReflectionEmitILGenerationPackageVersion)" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="$(SystemReflectionTypeExtensionsPackageVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitPackageVersion)" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="$(SystemReflectionEmitILGenerationPackageVersion)" />

--- a/src/Lucene.Net.Facet/Lucene.Net.Facet.csproj
+++ b/src/Lucene.Net.Facet/Lucene.Net.Facet.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Facet</AssemblyTitle>
     <PackageTags>$(PackageTags);facet;faceted</PackageTags>

--- a/src/Lucene.Net.Grouping/Lucene.Net.Grouping.csproj
+++ b/src/Lucene.Net.Grouping/Lucene.Net.Grouping.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Grouping</AssemblyTitle>
     <PackageTags>$(PackageTags);grouping;group</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net.Highlighter/Lucene.Net.Highlighter.csproj
+++ b/src/Lucene.Net.Highlighter/Lucene.Net.Highlighter.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Highlighter</AssemblyTitle>
     <PackageTags>$(PackageTags);highlight;highlighter</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net.Memory\Lucene.Net.Memory.csproj" />

--- a/src/Lucene.Net.Join/Lucene.Net.Join.csproj
+++ b/src/Lucene.Net.Join/Lucene.Net.Join.csproj
@@ -28,19 +28,19 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <RootNamespace>Lucene.Net.Search.Join</RootNamespace>
-    
+
     <AssemblyTitle>Lucene.Net.Join</AssemblyTitle>
     <PackageTags>$(PackageTags);join</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net.Grouping\Lucene.Net.Grouping.csproj" />

--- a/src/Lucene.Net.Memory/Lucene.Net.Memory.csproj
+++ b/src/Lucene.Net.Memory/Lucene.Net.Memory.csproj
@@ -28,17 +28,17 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
-    
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+
     <AssemblyTitle>Lucene.Net.Memory</AssemblyTitle>
     <PackageTags>$(PackageTags);memory</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net.Misc/Lucene.Net.Misc.csproj
+++ b/src/Lucene.Net.Misc/Lucene.Net.Misc.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Misc</AssemblyTitle>
     <PackageTags>$(PackageTags);miscellaneous</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <Compile Remove="Store\*" />

--- a/src/Lucene.Net.Queries/Lucene.Net.Queries.csproj
+++ b/src/Lucene.Net.Queries/Lucene.Net.Queries.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Queries</AssemblyTitle>
     <PackageTags>$(PackageTags);query;queries</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net.QueryParser/Lucene.Net.QueryParser.csproj
+++ b/src/Lucene.Net.QueryParser/Lucene.Net.QueryParser.csproj
@@ -28,22 +28,22 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <RootNamespace>Lucene.Net.QueryParsers</RootNamespace>
-    
+
     <AssemblyTitle>Lucene.Net.QueryParser</AssemblyTitle>
     <PackageTags>$(PackageTags);query;queryparser</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    
+
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
     <NoWarn Label="Remove unused parameter">$(NoWarn);IDE0060</NoWarn>
   </PropertyGroup>
 
-  
-  
+
+
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net.Analysis.Common\Lucene.Net.Analysis.Common.csproj" />
     <ProjectReference Include="..\Lucene.Net.Queries\Lucene.Net.Queries.csproj" />

--- a/src/Lucene.Net.Replicator/IndexRevision.cs
+++ b/src/Lucene.Net.Replicator/IndexRevision.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -79,14 +80,14 @@ namespace Lucene.Net.Replicator
             }
             revisionFiles.Add(CreateRevisionFile(segmentsFile, dir)); // segments_N must be last
 
-            return new Dictionary<string, IList<RevisionFile>>
+            return Collections.AsReadOnly(new Dictionary<string, IList<RevisionFile>>
             {
                 { SOURCE, revisionFiles }
-            }.AsReadOnly();
+            });
         }
-   
+
         /// <summary>
-        /// Returns a string representation of a revision's version from the given 
+        /// Returns a string representation of a revision's version from the given
         /// <see cref="IndexCommit"/>
         /// </summary>
         public static string RevisionVersion(IndexCommit commit)

--- a/src/Lucene.Net.Replicator/Lucene.Net.Replicator.csproj
+++ b/src/Lucene.Net.Replicator/Lucene.Net.Replicator.csproj
@@ -30,7 +30,7 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Replicator</AssemblyTitle>
     <PackageTags>$(PackageTags);files;replication;replicate</PackageTags>

--- a/src/Lucene.Net.Replicator/ReplicationClient.cs
+++ b/src/Lucene.Net.Replicator/ReplicationClient.cs
@@ -1,8 +1,8 @@
 ﻿using J2N;
-using J2N.Collections.Generic.Extensions;
 using J2N.Threading;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Store;
+using Lucene.Net.Support;
 using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
@@ -56,7 +56,7 @@ namespace Lucene.Net.Replicator
             internal readonly CountdownEvent stop = new CountdownEvent(1);
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="intervalMillis">The interval in milliseconds.</param>
             /// <param name="threadName">The thread name.</param>
@@ -206,7 +206,7 @@ namespace Lucene.Net.Replicator
                             output = directory.CreateOutput(file.FileName, IOContext.DEFAULT);
 
                             CopyBytes(output, input);
-                            
+
                             cpFiles.Add(file.FileName);
                             // TODO add some validation, on size / checksum
                         }
@@ -230,7 +230,7 @@ namespace Lucene.Net.Replicator
                     finally
                     {
                         if (!notify)
-                        { 
+                        {
                             // cleanup after ourselves
                             IOUtils.Dispose(sourceDirectory.Values);
                             factory.CleanupSession(session.Id);
@@ -247,7 +247,7 @@ namespace Lucene.Net.Replicator
                 if (notify && !disposed)
                 { // no use to notify if we are closed already
                     // LUCENENET specific - pass the copiedFiles as read only
-                    handler.RevisionReady(session.Version, session.SourceFiles, copiedFiles.AsReadOnly(), sourceDirectory);
+                    handler.RevisionReady(session.Version, session.SourceFiles, Collections.AsReadOnly(copiedFiles), sourceDirectory);
                 }
             }
             finally
@@ -451,7 +451,7 @@ namespace Lucene.Net.Replicator
         /// is running or not.
         /// </summary>
         /// <exception cref="IOException"></exception>
-        public virtual void UpdateNow() 
+        public virtual void UpdateNow()
         {
             EnsureOpen();
 
@@ -467,8 +467,8 @@ namespace Lucene.Net.Replicator
             }
         }
 
-        /// <summary> 
-        /// Gets or sets the <see cref="Util.InfoStream"/> to use for logging messages. 
+        /// <summary>
+        /// Gets or sets the <see cref="Util.InfoStream"/> to use for logging messages.
         /// </summary>
         public virtual InfoStream InfoStream
         {
@@ -519,7 +519,7 @@ namespace Lucene.Net.Replicator
         Directory GetDirectory(string sessionId, string source); //throws IOException;
 
         /// <summary>
-        /// Called to denote that the replication actions for this session were finished and the directory is no longer needed. 
+        /// Called to denote that the replication actions for this session were finished and the directory is no longer needed.
         /// </summary>
         /// <exception cref="IOException"></exception>
         void CleanupSession(string sessionId);

--- a/src/Lucene.Net.Sandbox/Lucene.Net.Sandbox.csproj
+++ b/src/Lucene.Net.Sandbox/Lucene.Net.Sandbox.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Sandbox</AssemblyTitle>
     <PackageTags>$(PackageTags);sandbox</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />

--- a/src/Lucene.Net.Spatial/Lucene.Net.Spatial.csproj
+++ b/src/Lucene.Net.Spatial/Lucene.Net.Spatial.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Spatial</AssemblyTitle>
     <PackageTags>$(PackageTags);spatial;geo;geospatial;2d</PackageTags>
@@ -39,7 +39,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net\Lucene.Net.csproj" />
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spatial4n" Version="$(Spatial4nPackageVersion)" /> 
+    <PackageReference Include="Spatial4n" Version="$(Spatial4nPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net.Spatial/Prefix/Tree/SpatialPrefixTree.cs
+++ b/src/Lucene.Net.Spatial/Prefix/Tree/SpatialPrefixTree.cs
@@ -1,5 +1,5 @@
-﻿using J2N.Collections.Generic.Extensions;
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
+using Lucene.Net.Support;
 using Spatial4n.Context;
 using Spatial4n.Shapes;
 using System;
@@ -191,7 +191,7 @@ namespace Lucene.Net.Spatial.Prefix.Tree
         /// ~20-25% fewer cells.
         /// </param>
         /// <returns>a set of cells (no dups), sorted, immutable, non-null</returns>
-        public virtual IList<Cell> GetCells(IShape? shape, int detailLevel, bool inclParents, 
+        public virtual IList<Cell> GetCells(IShape? shape, int detailLevel, bool inclParents,
             bool simplify)
         {
             //TODO consider an on-demand iterator -- it won't build up all cells in memory.
@@ -214,8 +214,8 @@ namespace Lucene.Net.Spatial.Prefix.Tree
         /// descends.
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="cell"/> is <c>null</c>.</exception>
-        private bool RecursiveGetCells(Cell cell, IShape? shape, int detailLevel, 
-            bool inclParents, bool simplify, 
+        private bool RecursiveGetCells(Cell cell, IShape? shape, int detailLevel,
+            bool inclParents, bool simplify,
             IList<Cell> result)
         {
             // LUCENENET specific - added guard clause
@@ -286,7 +286,7 @@ namespace Lucene.Net.Spatial.Prefix.Tree
             Cell cell = GetCell(p, detailLevel);
             if (!inclParents)
             {
-                return new[] { cell }.AsReadOnly();
+                return Collections.AsReadOnly(new[] { cell });
             }
             string endToken = cell.TokenString;
             if (Debugging.AssertsEnabled) Debugging.Assert(endToken.Length == detailLevel);

--- a/src/Lucene.Net.Suggest/Lucene.Net.Suggest.csproj
+++ b/src/Lucene.Net.Suggest/Lucene.Net.Suggest.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Suggest</AssemblyTitle>
     <PackageTags>$(PackageTags);suggest;suggestion</PackageTags>
@@ -38,7 +38,7 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\Lucene.Net.Analysis.Common\Lucene.Net.Analysis.Common.csproj" />

--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -30,20 +30,20 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.TestFramework</AssemblyTitle>
     <RootNamespace>Lucene.Net</RootNamespace>
     <PackageTags>$(PackageTags);testframework;test;framework;nunit</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    
-    
+
+
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
     <NoWarn Label="Collection initialization can be simplified">$(NoWarn);IDE0028</NoWarn>
   </PropertyGroup>
 
-  
-  
+
+
   <ItemGroup>
     <None Remove="Util\europarl.lines.txt.gz" />
     <EmbeddedResource Include="Util\europarl.lines.txt.gz" />
@@ -71,12 +71,12 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <!--  Note that some of the APIs we use to test Lucene.Net are internal because they are only meant to
           make porting tests from Java easier. This means that every Lucene.Net test project requires
           InternalsVisibleTo, now and in the future to keep these APIs from public view. -->
-    
+
     <InternalsVisibleTo Include="Lucene.Net.Tests._A-D" />
     <InternalsVisibleTo Include="Lucene.Net.Tests._E-I" />
     <InternalsVisibleTo Include="Lucene.Net.Tests._I-J" />
@@ -84,7 +84,7 @@
     <InternalsVisibleTo Include="Lucene.Net.Tests._T-Z" />
 
     <InternalsVisibleTo Include="Lucene.Net.Tests.AllProjects" />
-    
+
     <InternalsVisibleTo Include="Lucene.Net.Tests.Analysis.Common" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.Analysis.Kuromoji" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.Analysis.Morfologik" />
@@ -92,7 +92,7 @@
     <InternalsVisibleTo Include="Lucene.Net.Tests.Analysis.Phonetic" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.Analysis.SmartCn" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.Analysis.Stempel" />
-    
+
     <InternalsVisibleTo Include="Lucene.Net.Tests.Benchmark" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.Classification" />
     <InternalsVisibleTo Include="Lucene.Net.Tests.Cli" />

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xSegmentInfoReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xSegmentInfoReader.cs
@@ -1,13 +1,12 @@
-using J2N.Collections.Generic.Extensions;
 using Lucene.Net.Diagnostics;
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using JCG = J2N.Collections.Generic;
 using CompoundFileDirectory = Lucene.Net.Store.CompoundFileDirectory;
 using Directory = Lucene.Net.Store.Directory;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs.Lucene3x
 {
@@ -41,7 +40,7 @@ namespace Lucene.Net.Codecs.Lucene3x
     /// <summary>
     /// Lucene 3x implementation of <see cref="SegmentInfoReader"/>.
     /// <para/>
-    /// @lucene.experimental 
+    /// @lucene.experimental
     /// </summary>
     [Obsolete("Only for reading existing 3.x indexes")]
     public class Lucene3xSegmentInfoReader : SegmentInfoReader
@@ -292,7 +291,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                 }
             }
 
-            SegmentInfo info = new SegmentInfo(dir, version, name, docCount, isCompoundFile, null, diagnostics, attributes.AsReadOnly());
+            SegmentInfo info = new SegmentInfo(dir, version, name, docCount, isCompoundFile, null, diagnostics, Collections.AsReadOnly(attributes));
             info.SetFiles(files);
 
             SegmentCommitInfo infoPerCommit = new SegmentCommitInfo(info, delCount, delGen, -1);
@@ -314,7 +313,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
             ISet<string> files = input.ReadStringSet();
 
-            SegmentInfo info = new SegmentInfo(dir, version, name, docCount, isCompoundFile, null, diagnostics, attributes.AsReadOnly());
+            SegmentInfo info = new SegmentInfo(dir, version, name, docCount, isCompoundFile, null, diagnostics, Collections.AsReadOnly(attributes));
             info.SetFiles(files);
             return info;
         }

--- a/src/Lucene.Net/Codecs/Lucene42/Lucene42FieldInfosReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene42/Lucene42FieldInfosReader.cs
@@ -1,5 +1,5 @@
-﻿using J2N.Collections.Generic.Extensions;
-using J2N.Numerics;
+﻿using J2N.Numerics;
+using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 
@@ -56,8 +56,8 @@ namespace Lucene.Net.Codecs.Lucene42
             bool success = false;
             try
             {
-                CodecUtil.CheckHeader(input, Lucene42FieldInfosFormat.CODEC_NAME, 
-                                            Lucene42FieldInfosFormat.FORMAT_START, 
+                CodecUtil.CheckHeader(input, Lucene42FieldInfosFormat.CODEC_NAME,
+                                            Lucene42FieldInfosFormat.FORMAT_START,
                                             Lucene42FieldInfosFormat.FORMAT_CURRENT);
 
                 int size = input.ReadVInt32(); //read in the size
@@ -99,8 +99,8 @@ namespace Lucene.Net.Codecs.Lucene42
                     DocValuesType docValuesType = GetDocValuesType(input, (byte)(val & 0x0F));
                     DocValuesType normsType = GetDocValuesType(input, (byte)((val.TripleShift(4)) & 0x0F));
                     IDictionary<string, string> attributes = input.ReadStringStringMap();
-                    infos[i] = new FieldInfo(name, isIndexed, fieldNumber, storeTermVector, 
-                        omitNorms, storePayloads, indexOptions, docValuesType, normsType, attributes.AsReadOnly());
+                    infos[i] = new FieldInfo(name, isIndexed, fieldNumber, storeTermVector,
+                        omitNorms, storePayloads, indexOptions, docValuesType, normsType, Collections.AsReadOnly(attributes));
                 }
 
                 CodecUtil.CheckEOF(input);

--- a/src/Lucene.Net/Codecs/Lucene46/Lucene46FieldInfosReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene46/Lucene46FieldInfosReader.cs
@@ -1,5 +1,5 @@
-﻿using J2N.Collections.Generic.Extensions;
-using J2N.Numerics;
+﻿using J2N.Numerics;
+using Lucene.Net.Support;
 using System.Collections.Generic;
 
 namespace Lucene.Net.Codecs.Lucene46
@@ -36,7 +36,7 @@ namespace Lucene.Net.Codecs.Lucene46
     /// <summary>
     /// Lucene 4.6 FieldInfos reader.
     /// <para/>
-    /// @lucene.experimental 
+    /// @lucene.experimental
     /// </summary>
     /// <seealso cref="Lucene46FieldInfosFormat"/>
     internal sealed class Lucene46FieldInfosReader : FieldInfosReader
@@ -97,7 +97,7 @@ namespace Lucene.Net.Codecs.Lucene46
                     DocValuesType normsType = GetDocValuesType(input, (byte)((val.TripleShift(4)) & 0x0F));
                     long dvGen = input.ReadInt64();
                     IDictionary<string, string> attributes = input.ReadStringStringMap();
-                    infos[i] = new FieldInfo(name, isIndexed, fieldNumber, storeTermVector, omitNorms, storePayloads, indexOptions, docValuesType, normsType, attributes.AsReadOnly());
+                    infos[i] = new FieldInfo(name, isIndexed, fieldNumber, storeTermVector, omitNorms, storePayloads, indexOptions, docValuesType, normsType, Collections.AsReadOnly(attributes));
                     infos[i].DocValuesGen = dvGen;
                 }
 

--- a/src/Lucene.Net/Index/BaseCompositeReader.cs
+++ b/src/Lucene.Net/Index/BaseCompositeReader.cs
@@ -1,4 +1,4 @@
-﻿using J2N.Collections.Generic.Extensions;
+﻿using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 
@@ -36,7 +36,7 @@ namespace Lucene.Net.Index
     /// as documents are added to and deleted from an index.  Clients should thus not
     /// rely on a given document having the same number between sessions.
     ///
-    /// <para/><b>NOTE</b>: 
+    /// <para/><b>NOTE</b>:
     /// <see cref="IndexReader"/> instances are completely thread
     /// safe, meaning multiple threads can call any of its methods,
     /// concurrently.  If your application requires external
@@ -71,7 +71,7 @@ namespace Lucene.Net.Index
         protected BaseCompositeReader(R[] subReaders)
         {
             this.subReaders = subReaders;
-            this.subReadersList = ((IndexReader[])subReaders).AsReadOnly(); // LUCENENET: Work around generic casting from R to IndexWriter
+            this.subReadersList = Collections.AsReadOnly((IndexReader[])subReaders); // LUCENENET: Work around generic casting from R to IndexWriter
             starts = new int[subReaders.Length + 1]; // build starts array
             int maxDoc = 0, numDocs = 0;
             for (int i = 0; i < subReaders.Length; i++)

--- a/src/Lucene.Net/Index/CompositeReaderContext.cs
+++ b/src/Lucene.Net/Index/CompositeReaderContext.cs
@@ -1,5 +1,5 @@
-﻿using J2N.Collections.Generic.Extensions;
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
+using Lucene.Net.Support;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
 
@@ -56,7 +56,7 @@ namespace Lucene.Net.Index
         private CompositeReaderContext(CompositeReaderContext parent, CompositeReader reader, int ordInParent, int docbaseInParent, IList<IndexReaderContext> children, IList<AtomicReaderContext> leaves)
             : base(parent, ordInParent, docbaseInParent)
         {
-            this.children = children.AsReadOnly();
+            this.children = Collections.AsReadOnly(children);
             this.leaves = leaves;
             this.reader = reader;
         }

--- a/src/Lucene.Net/Index/MergePolicy.cs
+++ b/src/Lucene.Net/Index/MergePolicy.cs
@@ -1,5 +1,5 @@
-﻿using J2N.Collections.Generic.Extensions;
-using Lucene.Net.Diagnostics;
+﻿using Lucene.Net.Diagnostics;
+using Lucene.Net.Support;
 using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
@@ -56,7 +56,7 @@ namespace Lucene.Net.Index
     /// then return the necessary merges.</para>
     ///
     /// <para>Note that the policy can return more than one merge at
-    /// a time.  In this case, if the writer is using 
+    /// a time.  In this case, if the writer is using
     /// <see cref="SerialMergeScheduler"/>, the merges will be run
     /// sequentially but if it is using
     /// <see cref="ConcurrentMergeScheduler"/> they will be run concurrently.</para>
@@ -190,7 +190,7 @@ namespace Lucene.Net.Index
                         readers.Add(reader);
                     }
                 }
-                return readers.AsReadOnly();
+                return Collections.AsReadOnly(readers);
             }
 
             /// <summary>
@@ -450,7 +450,7 @@ namespace Lucene.Net.Index
             public IList<OneMerge> Merges { get; private set; }
 
             /// <summary>
-            /// Sole constructor.  Use 
+            /// Sole constructor.  Use
             /// <see cref="Add(OneMerge)"/> to add merges.
             /// </summary>
             public MergeSpecification()
@@ -488,7 +488,7 @@ namespace Lucene.Net.Index
         /// Exception thrown if there are any problems while
         /// executing a merge.
         /// </summary>
-        // LUCENENET: It is no longer good practice to use binary serialization. 
+        // LUCENENET: It is no longer good practice to use binary serialization.
         // See: https://github.com/dotnet/corefx/issues/23584#issuecomment-325724568
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
         [Serializable]
@@ -544,7 +544,7 @@ namespace Lucene.Net.Index
         /// <c>false</c>.  Normally this exception is
         /// privately caught and suppresed by <see cref="IndexWriter"/>.
         /// </summary>
-        // LUCENENET: It is no longer good practice to use binary serialization. 
+        // LUCENENET: It is no longer good practice to use binary serialization.
         // See: https://github.com/dotnet/corefx/issues/23584#issuecomment-325724568
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
         [Serializable]
@@ -736,7 +736,7 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// Return the byte size of the provided 
+        /// Return the byte size of the provided
         /// <see cref="SegmentCommitInfo"/>, pro-rated by percentage of
         /// non-deleted documents is set.
         /// </summary>
@@ -763,7 +763,7 @@ namespace Lucene.Net.Index
 #pragma warning disable 612, 618
                 && !info.Info.HasSeparateNorms
 #pragma warning restore 612, 618
-                && info.Info.Dir == w.Directory 
+                && info.Info.Dir == w.Directory
                 && UseCompoundFile(infos, info) == info.Info.UseCompoundFile;
         }
 

--- a/src/Lucene.Net/Index/SegmentCommitInfo.cs
+++ b/src/Lucene.Net/Index/SegmentCommitInfo.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Returns the per generation updates files. </summary>
-        public virtual IDictionary<long, ISet<string>> UpdatesFiles => genUpdatesFiles.AsReadOnly();
+        public virtual IDictionary<long, ISet<string>> UpdatesFiles => Collections.AsReadOnly(genUpdatesFiles);
 
         /// <summary>
         /// Sets the updates file names per generation. Does not deep clone the map. </summary>

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -22,9 +22,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(SolutionDir).build/nuget.props" />
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net</AssemblyTitle>
     <Description>Lucene.Net is a full-text search engine library capable of advanced text analysis, indexing, and searching. It can be used to easily add search capabilities to applications. Lucene.Net is a C# port of the popular Java Lucene search engine framework from The Apache Software Foundation, targeted at .NET Framework and .NET Core users.</Description>
@@ -36,7 +36,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  
+
 
   <PropertyGroup Label="NuGet Package File Paths">
     <LuceneNetDotNetDir>$(SolutionDir)src\dotnet\</LuceneNetDotNetDir>
@@ -100,7 +100,7 @@
     <InternalsVisibleTo Include="Lucene.Net.Suggest" />
 
     <InternalsVisibleTo Include="Lucene.Net.TestFramework" />
-    
+
     <InternalsVisibleTo Include="Lucene.Net.Tests._A-D" />
     <InternalsVisibleTo Include="Lucene.Net.Tests._E-I" />
     <InternalsVisibleTo Include="Lucene.Net.Tests._I-J" />

--- a/src/Lucene.Net/Store/NativeFSLockFactory.cs
+++ b/src/Lucene.Net/Store/NativeFSLockFactory.cs
@@ -1,10 +1,9 @@
 ﻿using Lucene.Net.Support.IO;
+using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
-using System.IO;
 using System.Collections.Generic;
-using Lucene.Net.Support.Threading;
-using System.Runtime.Versioning;
+using System.IO;
 
 namespace Lucene.Net.Store
 {

--- a/src/Lucene.Net/Store/NativeFSLockFactory.cs
+++ b/src/Lucene.Net/Store/NativeFSLockFactory.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using Lucene.Net.Support.Threading;
+using System.Runtime.Versioning;
 
 namespace Lucene.Net.Store
 {
@@ -625,7 +626,7 @@ namespace Lucene.Net.Store
     }
 
     // Uses FileStream locking of file pages.
-#if NET6_0
+#if FEATURE_SUPPORTEDOSPLATFORMATTRIBUTE
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
     internal class NativeFSLock : Lock

--- a/src/Lucene.Net/Support/Collections.cs
+++ b/src/Lucene.Net/Support/Collections.cs
@@ -218,11 +218,6 @@ namespace Lucene.Net.Support
             return new ReadOnlyList<T>(list);
         }
 
-        public static ReadOnlyCollection<T> AsReadOnly<T>(ICollection<T> collection)
-        {
-            return new ReadOnlyCollection<T>(collection);
-        }
-
         public static ReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(IDictionary<TKey, TValue> dictionary)
         {
             return new ReadOnlyDictionary<TKey, TValue>(dictionary);

--- a/src/Lucene.Net/Support/Collections.cs
+++ b/src/Lucene.Net/Support/Collections.cs
@@ -88,7 +88,7 @@ namespace Lucene.Net.Support
 
         public static IDictionary<TKey, TValue> SingletonMap<TKey, TValue>(TKey key, TValue value)
         {
-            return new Dictionary<TKey, TValue> { { key, value } }.AsReadOnly();
+            return AsReadOnly(new Dictionary<TKey, TValue> { { key, value } });
         }
 
 
@@ -211,6 +211,21 @@ namespace Lucene.Net.Support
         {
             using var context = new CultureContext(culture);
             return ToString(obj);
+        }
+
+        public static ReadOnlyList<T> AsReadOnly<T>(IList<T> list)
+        {
+            return new ReadOnlyList<T>(list);
+        }
+
+        public static ReadOnlyCollection<T> AsReadOnly<T>(ICollection<T> collection)
+        {
+            return new ReadOnlyCollection<T>(collection);
+        }
+
+        public static ReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(IDictionary<TKey, TValue> dictionary)
+        {
+            return new ReadOnlyDictionary<TKey, TValue>(dictionary);
         }
 
         #region Nested Types

--- a/src/dotnet/Lucene.Net.ICU/Lucene.Net.ICU.csproj
+++ b/src/dotnet/Lucene.Net.ICU/Lucene.Net.ICU.csproj
@@ -30,7 +30,7 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.ICU</AssemblyTitle>
     <PackageTags>$(PackageTags);icu;international;unicode</PackageTags>
@@ -39,7 +39,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_BREAKITERATOR</DefineConstants>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <Compile Include="..\..\Lucene.Net.Analysis.Common\Analysis\Th\**\*.cs" LinkBase="Analysis\Th" />

--- a/src/dotnet/Lucene.Net.Replicator.AspNetCore/Lucene.Net.Replicator.AspNetCore.csproj
+++ b/src/dotnet/Lucene.Net.Replicator.AspNetCore/Lucene.Net.Replicator.AspNetCore.csproj
@@ -23,9 +23,9 @@
 
   <!-- For now, we are not deploying this to NuGet.org -->
   <!--<Import Project="$(SolutionDir).build/nuget.props" />-->
-  
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Replicator.AspNetCore</AssemblyTitle>
     <Description>AspNetCore integration of Lucene.Net.Replicator for the Lucene.Net full-text search engine library from The Apache Software Foundation.</Description>
@@ -34,12 +34,12 @@
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
 
-  
+
 
   <ItemGroup>
     <ProjectReference Include="..\..\Lucene.Net.Replicator\Lucene.Net.Replicator.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(MicrosoftAspNetCoreHttpAbstractionsPackageVersion)" />
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Adds the .NET 8 target.

Fixes #928

## Description

This PR adds the .NET 8 target. Due to a conflict between extension methods in .NET 8 and J2N, we added new methods to Collections to create J2N read-only collections instead of using the extension method. The unit tests will use the net8.0 targets when run under .NET 8 now, instead of net6.0.

Additionally, this resolves a warning when running the .NET 5 tests, and ensures the `_artifacts/NuGetPackages` folder is created in the build script before restore, which is helpful when you add that folder as a local path in your NuGet sources for testing purposes.
