### PR TITLE
Use .NET 8 target for docs generation, #928

### DIFF
--- a/websites/apidocs/docfx.analysis-common.json
+++ b/websites/apidocs/docfx.analysis-common.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-common",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-kuromoji.json
+++ b/websites/apidocs/docfx.analysis-kuromoji.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-kuromoji",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-morfologik.json
+++ b/websites/apidocs/docfx.analysis-morfologik.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-morfologik",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-opennlp.json
+++ b/websites/apidocs/docfx.analysis-opennlp.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-opennlp",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-phonetic.json
+++ b/websites/apidocs/docfx.analysis-phonetic.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-phonetic",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-smartcn.json
+++ b/websites/apidocs/docfx.analysis-smartcn.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-smartcn",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-stempel.json
+++ b/websites/apidocs/docfx.analysis-stempel.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-stempel",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.benchmark.json
+++ b/websites/apidocs/docfx.benchmark.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/benchmark",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.classification.json
+++ b/websites/apidocs/docfx.classification.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/classification",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.codecs.json
+++ b/websites/apidocs/docfx.codecs.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/codecs",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.core.json
+++ b/websites/apidocs/docfx.core.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/core",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.demo.json
+++ b/websites/apidocs/docfx.demo.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/demo",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.expressions.json
+++ b/websites/apidocs/docfx.expressions.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/expressions",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.facet.json
+++ b/websites/apidocs/docfx.facet.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/facet",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.grouping.json
+++ b/websites/apidocs/docfx.grouping.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/grouping",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.highlighter.json
+++ b/websites/apidocs/docfx.highlighter.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/highlighter",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.icu.json
+++ b/websites/apidocs/docfx.icu.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/icu",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.join.json
+++ b/websites/apidocs/docfx.join.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/join",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.json
+++ b/websites/apidocs/docfx.json
@@ -16,7 +16,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -35,7 +35,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Common",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -54,7 +54,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Kuromoji",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -73,7 +73,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Morfologik",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -92,7 +92,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.OpenNLP",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -111,7 +111,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Phonetic",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -130,7 +130,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.SmartCn",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -149,7 +149,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Stempel",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -168,7 +168,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Benchmarks",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -187,7 +187,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Classification",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -206,7 +206,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Codecs",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -225,7 +225,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Expressions",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -244,7 +244,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Facet",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -263,7 +263,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Grouping",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -282,7 +282,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Highlighter",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -301,7 +301,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.ICU",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -320,7 +320,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Join",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -339,7 +339,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Memory",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -358,7 +358,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Misc",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -377,7 +377,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Queries",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -396,7 +396,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.QueryParser",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -415,7 +415,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Replicator",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -434,7 +434,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Sandbox",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -453,7 +453,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Spatial",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -472,7 +472,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Suggest",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -490,7 +490,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.TestFramework",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     },
     {
@@ -509,7 +509,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Demo",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.memory.json
+++ b/websites/apidocs/docfx.memory.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/memory",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.misc.json
+++ b/websites/apidocs/docfx.misc.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/misc",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.queries.json
+++ b/websites/apidocs/docfx.queries.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/queries",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.queryparser.json
+++ b/websites/apidocs/docfx.queryparser.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/queryparser",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.replicator.json
+++ b/websites/apidocs/docfx.replicator.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/replicator",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.sandbox.json
+++ b/websites/apidocs/docfx.sandbox.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/sandbox",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.spatial.json
+++ b/websites/apidocs/docfx.spatial.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/spatial",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.suggest.json
+++ b/websites/apidocs/docfx.suggest.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/suggest",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.test-framework.json
+++ b/websites/apidocs/docfx.test-framework.json
@@ -16,7 +16,7 @@
       "dest": "obj/docfx/api/test-framework",
       "filter": "filterConfig.yml",
       "properties": {
-        "TargetFramework": "net6.0"
+        "TargetFramework": "net8.0"
       }
     }
   ],


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Uses the .NET 8 target for docs generation.

Related: #928

## Description

The docs generation was using the net6.0 target as the latest available; as of #982 we now have the net8.0 target, so this updates the docfx json files to use that target instead.
