### PR TITLE
Rename IndexWriter.NextMerge() to GetNextMerge(), #986

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/BaseMergePolicyTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseMergePolicyTestCase.cs
@@ -78,7 +78,7 @@ namespace Lucene.Net.Index
                 UninterruptableMonitor.Enter(this);
                 try
                 {
-                    if (!mayMerge.Value && writer.NextMerge() != null)
+                    if (!mayMerge.Value && writer.GetNextMerge() != null)
                     {
                         throw AssertionError.Create();
                     }

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterMerging.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterMerging.cs
@@ -321,7 +321,7 @@ namespace Lucene.Net.Index
                 {
                     while (true)
                     {
-                        MergePolicy.OneMerge merge = writer.NextMerge();
+                        MergePolicy.OneMerge merge = writer.GetNextMerge();
                         if (merge is null)
                         {
                             break;

--- a/src/Lucene.Net.Tests/TestMergeSchedulerExternal.cs
+++ b/src/Lucene.Net.Tests/TestMergeSchedulerExternal.cs
@@ -143,7 +143,7 @@ namespace Lucene.Net
             public override void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound)
             {
                 MergePolicy.OneMerge merge = null;
-                while ((merge = writer.NextMerge()) != null)
+                while ((merge = writer.GetNextMerge()) != null)
                 {
                     if (Verbose)
                     {

--- a/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
@@ -485,7 +485,7 @@ namespace Lucene.Net.Index
                         }
                     }
 
-                    MergePolicy.OneMerge merge = writer.NextMerge();
+                    MergePolicy.OneMerge merge = writer.GetNextMerge();
                     if (merge is null)
                     {
                         if (IsVerbose)
@@ -691,7 +691,7 @@ namespace Lucene.Net.Index
 
                         // Subsequent times through the loop we do any new
                         // merge that writer says is necessary:
-                        merge = tWriter.NextMerge();
+                        merge = tWriter.GetNextMerge();
 
                         // Notify here in case any threads were stalled;
                         // they will notice that the pending merge has

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -2680,7 +2680,7 @@ namespace Lucene.Net.Index
         /// <para/>
         /// @lucene.experimental
         /// </summary>
-        public virtual MergePolicy.OneMerge NextMerge() // LUCENENET TODO: API - Revert name to GetNextMerge() to match Java
+        public virtual MergePolicy.OneMerge GetNextMerge()
         {
             UninterruptableMonitor.Enter(this);
             try

--- a/src/Lucene.Net/Index/MergeScheduler.cs
+++ b/src/Lucene.Net/Index/MergeScheduler.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// Run the merges provided by <see cref="IndexWriter.NextMerge()"/>. </summary>
+        /// Run the merges provided by <see cref="IndexWriter.GetNextMerge()"/>. </summary>
         /// <param name="writer"> the <see cref="IndexWriter"/> to obtain the merges from. </param>
         /// <param name="trigger"> the <see cref="MergeTrigger"/> that caused this merge to happen </param>
         /// <param name="newMergesFound"> <c>true</c> iff any new merges were found by the caller; otherwise <c>false</c>

--- a/src/Lucene.Net/Index/SerialMergeScheduler.cs
+++ b/src/Lucene.Net/Index/SerialMergeScheduler.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Index
             {
                 while (true)
                 {
-                    MergePolicy.OneMerge merge = writer.NextMerge();
+                    MergePolicy.OneMerge merge = writer.GetNextMerge();
                     if (merge is null)
                     {
                         break;

--- a/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
@@ -269,7 +269,7 @@ namespace Lucene.Net.Index
                         }
                     }
 
-                    MergePolicy.OneMerge merge = writer.NextMerge();
+                    MergePolicy.OneMerge merge = writer.GetNextMerge();
                     if (merge is null)
                     {
                         if (Verbose)
@@ -576,7 +576,7 @@ namespace Lucene.Net.Index
 
                         // Subsequent times through the loop we do any new
                         // merge that writer says is necessary:
-                        merge = _writer.NextMerge();
+                        merge = _writer.GetNextMerge();
 
                         // Notify here in case any threads were stalled;
                         // they will notice that the pending merge has


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Reverts rename of `IndexWriter.NextMerge()` back to `GetNextMerge()` to match Java.

Fixes #986 

## Description

Simple refactor rename for all usages of `IndexWriter.NextMerge()` to `GetNextMerge()`.