### PR TITLE
Restored binary serialization on net8.0 and deprecated it to match the BCL (fixes #983)

### DIFF
--- a/.build/TestReferences.Common.targets
+++ b/.build/TestReferences.Common.targets
@@ -25,4 +25,6 @@
     <PackageReference Include="NUnit" Version="$(NUnitPackageVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterPackageVersion)" />
   </ItemGroup>
+
+  <Import Label="Binary Serialization Support for Tests" Project="$(SolutionDir).build/TestSerialization.targets" />
 </Project>

--- a/.build/TestSerialization.targets
+++ b/.build/TestSerialization.targets
@@ -1,0 +1,102 @@
+﻿<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+<Project>
+
+  <!-- Edits the .runtime.config file to enable binary serialization, which is disabled by default in .NET 8+.
+
+       IMPORTANT: This is only meant for testing purposes for the (now deprecated) binary serialization support.
+       Enabling this in a production environment is highly discouraged. -->
+
+  <UsingTask TaskName="UpdateRuntimeConfigProperty" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <RuntimeConfigFile ParameterType="System.String" Required="true" />
+      <PropertyName ParameterType="System.String" Required="true" />
+      <PropertyValue ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        if (File.Exists(RuntimeConfigFile))
+        {
+            // Read the file content
+            string jsonContent = File.ReadAllText(RuntimeConfigFile);
+
+            // Ensure runtimeOptions and configProperties sections exist
+            if (!jsonContent.Contains("\"runtimeOptions\""))
+            {
+                jsonContent = jsonContent.TrimEnd('}', '\n', '\r') + ",\n  \"runtimeOptions\": {\n    \"configProperties\": {\n    }\n  }\n}";
+            }
+            if (!jsonContent.Contains("\"configProperties\""))
+            {
+                int runtimeOptionsIndex = jsonContent.IndexOf("\"runtimeOptions\"");
+                int insertPosition = jsonContent.IndexOf('}', runtimeOptionsIndex);
+                jsonContent = jsonContent.Insert(insertPosition, ",\n    \"configProperties\": {\n    }\n");
+            }
+
+            // Check if the property already exists
+            int configPropertiesIndex = jsonContent.IndexOf("\"configProperties\"");
+            int propertyIndex = jsonContent.IndexOf("\"" + PropertyName + "\"", configPropertiesIndex);
+
+            if (propertyIndex != -1)
+            {
+                // Property exists, update its value
+                int valueStartIndex = jsonContent.IndexOf(':', propertyIndex) + 1;
+                int valueEndIndex = jsonContent.IndexOfAny(new char[] { ',', '}', '\n' }, valueStartIndex);
+                jsonContent = jsonContent.Remove(valueStartIndex, valueEndIndex - valueStartIndex)
+                                         .Insert(valueStartIndex, " " + PropertyValue);
+            }
+            else
+            {
+                // Property does not exist, add it
+                int closingBraceIndex = jsonContent.IndexOf('}', configPropertiesIndex);
+                jsonContent = jsonContent.Insert(closingBraceIndex, "  \"" + PropertyName + "\": " + PropertyValue + ",\n");
+            }
+
+            // Write the updated content back to the file
+            File.WriteAllText(RuntimeConfigFile, jsonContent);
+        }
+        else
+        {
+            Log.LogError("File not found: " + RuntimeConfigFile);
+        }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!-- Target to invoke the task after build -->
+  <Target Name="UpdateRuntimeConfig" AfterTargets="Build">
+    <PropertyGroup>
+      <RuntimeConfigFile>$(TargetDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFile>
+      <DotNet_8_0_OrGreater>false</DotNet_8_0_OrGreater>
+      <DotNet_8_0_OrGreater Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And ($(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or ($(TargetFramework.StartsWith('net')) And $(TargetFramework.IndexOf('.')) > 4))">true</DotNet_8_0_OrGreater>
+    </PropertyGroup>
+
+    <UpdateRuntimeConfigProperty 
+        RuntimeConfigFile="$(RuntimeConfigFile)" 
+        PropertyName="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization" 
+        PropertyValue="true" 
+        Condition="Exists('$(RuntimeConfigFile)') And '$(DotNet_8_0_OrGreater)' == 'true'" />
+  </Target>
+
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -88,16 +88,10 @@
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_GETCALLINGASSEMBLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_FILESTREAM_LOCK</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_CLOSE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_THREADPOOL_UNSAFEQUEUEWORKITEM</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETMETHOD__BINDINGFLAGS_PARAMS</DefineConstants>
-
-  </PropertyGroup>
-
-  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, and .NET 6.x, but deprecated or removed in .NET 7+  -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
-
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_EXCEPTIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_THREADPOOL_UNSAFEQUEUEWORKITEM</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETMETHOD__BINDINGFLAGS_PARAMS</DefineConstants>
 
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,6 +22,10 @@
 
   <Import Project=".build/dependencies.props" Condition="Exists('.build/dependencies.props')" />
 
+  <PropertyGroup Label="Warnings to be Disabled in Solution">
+    <NoWarn Label="Legacy serialization support APIs are obsolete">$(NoWarn);SYSLIB0051</NoWarn>
+  </PropertyGroup>
+
   <PropertyGroup Label="Solution-level Publish to Project-specific Directory">
     <PublishDir Condition="'$(AlternatePublishRootDirectory)' != ''">$(AlternatePublishRootDirectory)/$(TargetFramework)/$(MSBuildProjectName)/</PublishDir>
   </PropertyGroup>

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/NoMoreDataException.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/NoMoreDataException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -43,6 +45,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected NoMoreDataException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.Benchmark/Support/Sax/SAXException.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/SAXException.cs
@@ -4,7 +4,9 @@
 // $Id: SAXException.java,v 1.7 2002/01/30 21:13:48 dbrownell Exp $
 
 using System;
+
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -98,6 +100,8 @@ namespace Sax
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected SAXException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -107,7 +111,11 @@ namespace Sax
 #if FEATURE_CODE_ACCESS_SECURITY
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             base.GetObjectData(info, context);
             info.AddValue("Exception", exception, typeof(Exception));

--- a/src/Lucene.Net.Benchmark/Support/Sax/SAXNotRecognizedException.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/SAXNotRecognizedException.cs
@@ -6,6 +6,7 @@
 
 using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -58,6 +59,8 @@ namespace Sax
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected SAXNotRecognizedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.Benchmark/Support/Sax/SAXNotSupportedException.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/SAXNotSupportedException.cs
@@ -6,6 +6,7 @@
 
 using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -59,6 +60,8 @@ namespace Sax
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected SAXNotSupportedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.Benchmark/Support/Sax/SAXParseException.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/SAXParseException.cs
@@ -5,6 +5,7 @@
 
 using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -170,6 +171,8 @@ namespace Sax
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected SAXParseException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -182,7 +185,11 @@ namespace Sax
 #if FEATURE_CODE_ACCESS_SECURITY
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             base.GetObjectData(info, context);
             info.AddValue("publicId", publicId, typeof(string));

--- a/src/Lucene.Net.Expressions/JS/JavascriptLexer.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptLexer.cs
@@ -22,9 +22,6 @@
 // ANTLR GENERATED CODE: DO NOT EDIT (LUCENENET: Not really auto generated in the port)
 
 using System;
-#if FEATURE_SERIALIZABLE_EXCEPTIONS
-using System.Runtime.Serialization;
-#endif
 using Antlr.Runtime;
 using J2N.Text;
 using Lucene.Net.Support;

--- a/src/Lucene.Net.Highlighter/Highlight/InvalidTokenOffsetsException.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/InvalidTokenOffsetsException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -50,6 +51,8 @@ namespace Lucene.Net.Search.Highlight
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected InvalidTokenOffsetsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.Queries/Function/DocValues/DocTermsIndexDocValues.cs
+++ b/src/Lucene.Net.Queries/Function/DocValues/DocTermsIndexDocValues.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Util;
 using Lucene.Net.Util.Mutable;
 using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -185,6 +186,8 @@ namespace Lucene.Net.Queries.Function.DocValues
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             private DocTermsIndexException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {

--- a/src/Lucene.Net.QueryParser/Classic/ParseException.cs
+++ b/src/Lucene.Net.QueryParser/Classic/ParseException.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -87,6 +88,8 @@ namespace Lucene.Net.QueryParsers.Classic
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ParseException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -98,7 +101,11 @@ namespace Lucene.Net.QueryParsers.Classic
 #if FEATURE_CODE_ACCESS_SECURITY
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             base.GetObjectData(info, context);
             info.AddValue("CurrentToken", CurrentToken, typeof(Token));

--- a/src/Lucene.Net.QueryParser/Classic/QueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 using JCG = J2N.Collections.Generic;
@@ -731,6 +732,8 @@ namespace Lucene.Net.QueryParsers.Classic
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public LookaheadSuccess(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {

--- a/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 using System.Text;
@@ -73,6 +74,8 @@ namespace Lucene.Net.QueryParsers.Classic
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             protected MethodRemovedUseAnother(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {

--- a/src/Lucene.Net.QueryParser/Classic/TokenMgrError.cs
+++ b/src/Lucene.Net.QueryParser/Classic/TokenMgrError.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -180,6 +181,8 @@ namespace Lucene.Net.QueryParsers.Classic
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected TokenMgrError(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -189,7 +192,11 @@ namespace Lucene.Net.QueryParsers.Classic
 #if FEATURE_CODE_ACCESS_SECURITY
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             base.GetObjectData(info, context);
             info.AddValue("errorCode", errorCode, typeof(int));

--- a/src/Lucene.Net.QueryParser/Flexible/Core/QueryNodeError.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/QueryNodeError.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #nullable enable
@@ -103,6 +104,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Core
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected QueryNodeError(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.QueryParser/Flexible/Core/QueryNodeException.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/QueryNodeException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #nullable enable
@@ -76,6 +77,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Core
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected QueryNodeException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.QueryParser/Flexible/Core/QueryNodeParseException.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/QueryNodeParseException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -82,6 +83,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Core
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected QueryNodeParseException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -94,7 +97,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Core
 #if FEATURE_CODE_ACCESS_SECURITY
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             base.GetObjectData(info, context);
             info.AddValue("query", query, typeof(string));

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/ParseException.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/ParseException.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -102,6 +103,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ParseException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -113,7 +116,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
 #if FEATURE_CODE_ACCESS_SECURITY
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             base.GetObjectData(info, context);
             info.AddValue("CurrentToken", CurrentToken, typeof(Token));

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParser.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/StandardSyntaxParser.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 using JCG = J2N.Collections.Generic;
@@ -1094,6 +1095,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public LookaheadSuccess(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/TokenMgrError.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Parser/TokenMgrError.cs
@@ -1,6 +1,7 @@
 ﻿using J2N;
 using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -183,6 +184,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected TokenMgrError(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -192,7 +195,11 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Parser
 #if FEATURE_CODE_ACCESS_SECURITY
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             base.GetObjectData(info, context);
             info.AddValue("errorCode", errorCode, typeof(int));

--- a/src/Lucene.Net.QueryParser/Surround/Parser/ParseException.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Parser/ParseException.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -87,6 +88,8 @@ namespace Lucene.Net.QueryParsers.Surround.Parser
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ParseException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -98,7 +101,11 @@ namespace Lucene.Net.QueryParsers.Surround.Parser
 #if FEATURE_CODE_ACCESS_SECURITY
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             base.GetObjectData(info, context);
             info.AddValue("CurrentToken", CurrentToken, typeof(Token));

--- a/src/Lucene.Net.QueryParser/Surround/Parser/QueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Parser/QueryParser.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 using JCG = J2N.Collections.Generic;
@@ -708,6 +709,8 @@ namespace Lucene.Net.QueryParsers.Surround.Parser
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public LookaheadSuccess(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {

--- a/src/Lucene.Net.QueryParser/Surround/Parser/TokenMgrError.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Parser/TokenMgrError.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -180,6 +181,8 @@ namespace Lucene.Net.QueryParsers.Surround.Parser
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected TokenMgrError(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -189,7 +192,11 @@ namespace Lucene.Net.QueryParsers.Surround.Parser
 #if FEATURE_CODE_ACCESS_SECURITY
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             base.GetObjectData(info, context);
             info.AddValue("errorCode", errorCode, typeof(int));

--- a/src/Lucene.Net.QueryParser/Surround/Query/TooManyBasicQueries.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/TooManyBasicQueries.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -50,6 +51,8 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected TooManyBasicQueries(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.QueryParser/Xml/ParserException.cs
+++ b/src/Lucene.Net.QueryParser/Xml/ParserException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -59,6 +60,8 @@ namespace Lucene.Net.QueryParsers.Xml
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ParserException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.Replicator/SessionExpiredException.cs
+++ b/src/Lucene.Net.Replicator/SessionExpiredException.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -65,6 +66,8 @@ namespace Lucene.Net.Replicator
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected SessionExpiredException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.Spatial/Query/UnsupportedSpatialOperation.cs
+++ b/src/Lucene.Net.Spatial/Query/UnsupportedSpatialOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -51,6 +52,8 @@ namespace Lucene.Net.Spatial.Queries
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected UnsupportedSpatialOperationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -14,6 +14,7 @@ using System.Runtime.CompilerServices;
 using JCG = J2N.Collections.Generic;
 using Console = Lucene.Net.Util.SystemConsole;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -58,6 +59,8 @@ namespace Lucene.Net.Search
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected SearcherExpiredException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using Console = Lucene.Net.Util.SystemConsole;
 using JCG = J2N.Collections.Generic;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -1552,6 +1553,8 @@ namespace Lucene.Net.Store
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected FakeIOException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Index/CorruptIndexException.cs
+++ b/src/Lucene.Net/Index/CorruptIndexException.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -54,6 +55,8 @@ namespace Lucene.Net.Index
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected CorruptIndexException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Index/IndexFormatTooNewException.cs
+++ b/src/Lucene.Net/Index/IndexFormatTooNewException.cs
@@ -1,6 +1,8 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
+
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -77,6 +79,8 @@ namespace Lucene.Net.Index
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected IndexFormatTooNewException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Index/IndexFormatTooOldException.cs
+++ b/src/Lucene.Net/Index/IndexFormatTooOldException.cs
@@ -1,6 +1,8 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
+
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -102,6 +104,8 @@ namespace Lucene.Net.Index
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected IndexFormatTooOldException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Index/IndexNotFoundException.cs
+++ b/src/Lucene.Net/Index/IndexNotFoundException.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -49,6 +50,8 @@ namespace Lucene.Net.Index
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         private IndexNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Index/MergePolicy.cs
+++ b/src/Lucene.Net/Index/MergePolicy.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 using System.Text;
@@ -525,6 +526,8 @@ namespace Lucene.Net.Index
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             protected MergeException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {
@@ -573,6 +576,8 @@ namespace Lucene.Net.Index
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             protected MergeAbortedException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {

--- a/src/Lucene.Net/Index/TwoPhaseCommitTool.cs
+++ b/src/Lucene.Net/Index/TwoPhaseCommitTool.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -68,6 +69,8 @@ namespace Lucene.Net.Index
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             protected PrepareCommitFailException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {
@@ -105,6 +108,8 @@ namespace Lucene.Net.Index
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             protected CommitFailException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {

--- a/src/Lucene.Net/Search/BooleanQuery.cs
+++ b/src/Lucene.Net/Search/BooleanQuery.cs
@@ -4,7 +4,9 @@ using Lucene.Net.Util;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 using System.Text;
@@ -94,6 +96,8 @@ namespace Lucene.Net.Search
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             protected TooManyClausesException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {

--- a/src/Lucene.Net/Search/CollectionTerminatedException.cs
+++ b/src/Lucene.Net/Search/CollectionTerminatedException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -50,6 +52,8 @@ namespace Lucene.Net.Search
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         private CollectionTerminatedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Search/TimeLimitingCollector.cs
+++ b/src/Lucene.Net/Search/TimeLimitingCollector.cs
@@ -1,7 +1,9 @@
 ﻿using J2N.Threading;
 using Lucene.Net.Support.Threading;
 using System;
+
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 #if FEATURE_CODE_ACCESS_SECURITY
@@ -72,6 +74,8 @@ namespace Lucene.Net.Search
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             protected TimeExceededException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {
@@ -83,7 +87,11 @@ namespace Lucene.Net.Search
 #if FEATURE_CODE_ACCESS_SECURITY
             [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 #endif
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
             public override void GetObjectData(SerializationInfo info, StreamingContext context)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
             {
                 base.GetObjectData(info, context);
                 info.AddValue("timeAllowed", timeAllowed, typeof(long));

--- a/src/Lucene.Net/Store/AlreadyClosedException.cs
+++ b/src/Lucene.Net/Store/AlreadyClosedException.cs
@@ -5,6 +5,7 @@
 // which is intended to make porting efforts easier.
 //using System;
 //#if FEATURE_SERIALIZABLE_EXCEPTIONS
+//using System.ComponentModel;
 //using System.Runtime.Serialization;
 //#endif
 
@@ -54,6 +55,8 @@
 //        /// </summary>
 //        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
 //        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+//        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+//        [EditorBrowsable(EditorBrowsableState.Never)]
 //        protected AlreadyClosedException(SerializationInfo info, StreamingContext context)
 //            : base(info, context)
 //        {

--- a/src/Lucene.Net/Store/LockObtainFailedException.cs
+++ b/src/Lucene.Net/Store/LockObtainFailedException.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -52,6 +53,8 @@ namespace Lucene.Net.Store
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected LockObtainFailedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Store/LockReleaseFailedException.cs
+++ b/src/Lucene.Net/Store/LockReleaseFailedException.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.IO;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -45,6 +46,8 @@ namespace Lucene.Net.Store
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected LockReleaseFailedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/Diagnostics/AssertionException.cs
+++ b/src/Lucene.Net/Support/Diagnostics/AssertionException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -61,6 +63,8 @@ namespace Lucene.Net.Diagnostics
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected AssertionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Errors/AssertionError.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Errors/AssertionError.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -67,6 +68,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected AssertionError(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Errors/Error.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Errors/Error.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -73,6 +74,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected Error(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Errors/NoClassDefFoundError.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Errors/NoClassDefFoundError.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -68,6 +69,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected NoClassDefFoundError(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Errors/OutOfMemoryError.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Errors/OutOfMemoryError.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -69,6 +70,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected OutOfMemoryError(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Errors/ServiceConfigurationError.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Errors/ServiceConfigurationError.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -97,6 +98,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ServiceConfigurationError(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Errors/StackOverflowError.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Errors/StackOverflowError.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -65,6 +66,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected StackOverflowError(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/ClassNotFoundException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/ClassNotFoundException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -78,6 +79,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ClassNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/IOExceptions/AlreadyClosedException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/IOExceptions/AlreadyClosedException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -63,6 +64,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected AlreadyClosedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/IOExceptions/EOFException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/IOExceptions/EOFException.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -71,6 +72,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected EOFException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/NoSuchMethodException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/NoSuchMethodException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -65,6 +66,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected NoSuchMethodException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/ArrayIndexOutOfBoundsException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/ArrayIndexOutOfBoundsException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -70,6 +71,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ArrayIndexOutOfBoundsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/IllegalArgumentException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/IllegalArgumentException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -73,6 +74,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected IllegalArgumentException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/IllegalStateException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/IllegalStateException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -67,6 +68,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected IllegalStateException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/IndexOutOfBoundsException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/IndexOutOfBoundsException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -69,6 +70,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected IndexOutOfBoundsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/NullPointerException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/NullPointerException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -108,6 +109,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected NullPointerException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/NumberFormatException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/NumberFormatException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -68,6 +69,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected NumberFormatException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/RuntimeException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/RuntimeException.cs
@@ -1,5 +1,6 @@
 ﻿using Lucene.Net.Util;
 using System;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 
 namespace Lucene
@@ -74,6 +75,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected RuntimeException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/StringIndexOutOfBoundsException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/StringIndexOutOfBoundsException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -70,6 +71,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected StringIndexOutOfBoundsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/UnsupportedOperationException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/RuntimeExceptions/UnsupportedOperationException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -67,6 +68,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected UnsupportedOperationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/ExceptionHandling/Exceptions/ServletException.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/Exceptions/ServletException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -64,6 +65,8 @@ namespace Lucene
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ServletException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Support/Util/LuceneSystemException.cs
+++ b/src/Lucene.Net/Support/Util/LuceneSystemException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 
 namespace Lucene.Net.Util
@@ -91,6 +92,8 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected LuceneSystemException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Util/BytesRefHash.cs
+++ b/src/Lucene.Net/Util/BytesRefHash.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -588,6 +589,8 @@ namespace Lucene.Net.Util
             /// </summary>
             /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
             /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             protected MaxBytesLengthExceededException(SerializationInfo info, StreamingContext context)
                 : base(info, context)
             {

--- a/src/Lucene.Net/Util/SetOnce.cs
+++ b/src/Lucene.Net/Util/SetOnce.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.CompilerServices;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -115,6 +116,8 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         private AlreadySetException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Lucene.Net/Util/ThreadInterruptedException.cs
+++ b/src/Lucene.Net/Util/ThreadInterruptedException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
+using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 
@@ -55,6 +57,8 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ThreadInterruptedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Restored binary serialization and deprecated it to match the BCL

Fixes #983

We deprecated binary serialization support on all target frameworks, not just `net8.0`, but left it fully functional for those who still depend on it. This also updates the `.runtime.config` file for each of the test projects so the binary serialization tests will run.
