### PR TITLE
docs: OpenNLP: Corrected errors (transitive instead of transient) in the docs

### DIFF
--- a/src/Lucene.Net.Analysis.OpenNLP/overview.md
+++ b/src/Lucene.Net.Analysis.OpenNLP/overview.md
@@ -42,7 +42,7 @@ Named Entity Recognition is also supported by OpenNLP, but there is no OpenNLPNE
 
 ## MavenReference Primer
 
-When a `<PackageReference>` is included for this NuGet package in your SDK-style MSBuild project, it will automatically include transient dependencies to [`opennlp-tools` on maven.org](https://search.maven.org/artifact/org.apache.opennlp/opennlp-tools/1.9.4/bundle). The transient dependency will automatically include a `<MavenReference>` in your MSBuild project.
+When a `<PackageReference>` is included for this NuGet package in your SDK-style MSBuild project, it will automatically include transitive dependencies to [`opennlp-tools` on maven.org](https://search.maven.org/artifact/org.apache.opennlp/opennlp-tools/1.9.4/bundle). The transitive dependency will automatically include a `<MavenReference>` in your MSBuild project.
 
 The `<MavenReference>` item group operates similar to a dependency in Maven. All transitive dependencies are collected and resolved, and then the final output is produced. However, unlike `PackageReference`s, `MavenReference`s are collected by the final output project, and reassessed. That is, each dependent Project within your .NET SDK-style solution contributes its `MavenReference`s to project(s) which include it, and each project makes its own dependency graph. Projects do not contribute their final built assemblies up. They only contribute their dependencies. Allowing each project in a complicated solution to make its own local conflict resolution attempt.
 


### PR DESCRIPTION
… 

<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fixed some errors in the OpenNLP docs that stated "transient" instead of "transitive" dependencies.
