### PR TITLE
FuzzyQuery produces a wrong result when prefix is equal to the term length

### DIFF
--- a/src/Lucene.Net.Tests/Search/TestFuzzyQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestFuzzyQuery.cs
@@ -195,6 +195,8 @@ namespace Lucene.Net.Search
             reader.Dispose();
             directory.Dispose();
         }
+
+        // LUCENENET-specific: backported fix from Lucene 9.0.0 (lucene@45611d0, LUCENE-9365)
         [Test]
         public void TestPrefixLengthEqualStringLength()
         {
@@ -204,7 +206,7 @@ namespace Lucene.Net.Search
             AddDoc("b*ab", writer);
             AddDoc("b*abc", writer);
             AddDoc("b*abcd", writer);
-            String multibyte = "아프리카코끼리속";
+            const string multibyte = "아프리카코끼리속"; // LUCENENET-specific: made const
             AddDoc(multibyte, writer);
             IndexReader reader = writer.GetReader();
             IndexSearcher searcher = NewSearcher(reader);
@@ -226,17 +228,17 @@ namespace Lucene.Net.Search
             hits = searcher.Search(query, 1000).ScoreDocs;
             assertEquals(3, hits.Length);
 
-        maxEdits = 1;
-        prefixLength = multibyte.Length - 1;
-        query = new FuzzyQuery(new Term("field", multibyte.Substring(0, prefixLength)), maxEdits, prefixLength);
-        hits = searcher.Search(query, 1000).ScoreDocs;
-        assertEquals(1, hits.Length);
+            maxEdits = 1;
+            prefixLength = multibyte.Length - 1;
+            query = new FuzzyQuery(new Term("field", multibyte.Substring(0, prefixLength)), maxEdits, prefixLength);
+            hits = searcher.Search(query, 1000).ScoreDocs;
+            assertEquals(1, hits.Length);
 
-        reader.DoClose();
-        directory.Dispose();
-    }
+            reader.Dispose();
+            directory.Dispose();
+        }
 
-    [Test]
+        [Test]
         public virtual void Test2()
         {
             Directory directory = NewDirectory();

--- a/src/Lucene.Net.Tests/Search/TestFuzzyQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestFuzzyQuery.cs
@@ -195,8 +195,48 @@ namespace Lucene.Net.Search
             reader.Dispose();
             directory.Dispose();
         }
-
         [Test]
+        public void TestPrefixLengthEqualStringLength()
+        {
+            Directory directory = NewDirectory();
+            RandomIndexWriter writer = new RandomIndexWriter(Random, directory);
+            AddDoc("b*a", writer);
+            AddDoc("b*ab", writer);
+            AddDoc("b*abc", writer);
+            AddDoc("b*abcd", writer);
+            String multibyte = "아프리카코끼리속";
+            AddDoc(multibyte, writer);
+            IndexReader reader = writer.GetReader();
+            IndexSearcher searcher = NewSearcher(reader);
+            writer.Dispose();
+
+            int maxEdits = 0;
+            int prefixLength = 3;
+            FuzzyQuery query = new FuzzyQuery(new Term("field", "b*a"), maxEdits, prefixLength);
+            ScoreDoc[] hits = searcher.Search(query, 1000).ScoreDocs;
+            assertEquals(1, hits.Length);
+
+            maxEdits = 1;
+            query = new FuzzyQuery(new Term("field", "b*a"), maxEdits, prefixLength);
+            hits = searcher.Search(query, 1000).ScoreDocs;
+            assertEquals(2, hits.Length);
+
+            maxEdits = 2;
+            query = new FuzzyQuery(new Term("field", "b*a"), maxEdits, prefixLength);
+            hits = searcher.Search(query, 1000).ScoreDocs;
+            assertEquals(3, hits.Length);
+
+        maxEdits = 1;
+        prefixLength = multibyte.Length - 1;
+        query = new FuzzyQuery(new Term("field", multibyte.Substring(0, prefixLength)), maxEdits, prefixLength);
+        hits = searcher.Search(query, 1000).ScoreDocs;
+        assertEquals(1, hits.Length);
+
+        reader.DoClose();
+        directory.Dispose();
+    }
+
+    [Test]
         public virtual void Test2()
         {
             Directory directory = NewDirectory();

--- a/src/Lucene.Net/Search/FuzzyQuery.cs
+++ b/src/Lucene.Net/Search/FuzzyQuery.cs
@@ -148,7 +148,8 @@ namespace Lucene.Net.Search
 
         protected override TermsEnum GetTermsEnum(Terms terms, AttributeSource atts)
         {
-            if (maxEdits == 0 ) // can only match if it's exact
+            // LUCENENET-specific: backported fix from Lucene 9.0.0 (lucene@45611d0, LUCENE-9365)
+            if (maxEdits == 0) // can only match if it's exact
             {
                 return new SingleTermsEnum(terms.GetEnumerator(), term.Bytes);
             }

--- a/src/Lucene.Net/Search/FuzzyQuery.cs
+++ b/src/Lucene.Net/Search/FuzzyQuery.cs
@@ -148,7 +148,7 @@ namespace Lucene.Net.Search
 
         protected override TermsEnum GetTermsEnum(Terms terms, AttributeSource atts)
         {
-            if (maxEdits == 0 || prefixLength >= term.Text.Length) // can only match if it's exact
+            if (maxEdits == 0 ) // can only match if it's exact
             {
                 return new SingleTermsEnum(terms.GetEnumerator(), term.Bytes);
             }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

FuzzyQuery produces a wrong result when prefix is equal to the term length

Fixes #941 

## Description

See #941

(NOTE: This PR was originally opened as #945 but included an unexpected commit. This PR cherry-picks that commit.)
