### PR TITLE
website/site/.htaccess - bug fix by removing BOM and update to beta0017 redirection

### DIFF
--- a/websites/site/.gitattributes
+++ b/websites/site/.gitattributes
@@ -1,1 +1,1 @@
-.htaccess text eol=lf
+.htaccess text eol=lf working-tree-encoding=UTF-8

--- a/websites/site/.htaccess
+++ b/websites/site/.htaccess
@@ -1,4 +1,4 @@
-﻿# -----------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -32,7 +32,8 @@
 # version, with [R=301] signaling permanent redirects and [L] preventing further
 # rule processing.
 #
-# Note: This file is line ending sensitive. MUST use LF line endings.
+# Note: This file is line ending and BOM sensitive. It MUST use LF line endings and 
+# MUST NOT have a BOM.
 
 
 RewriteEngine On
@@ -40,5 +41,5 @@ RewriteEngine On
 # Redirect /docs/latest/ to /docs/3.0.3/
 RewriteRule ^docs/latest/(.*)$ /docs/3.0.3/$1 [R=301,L]
 
-# Redirect /docs/absolute-latest/ to /docs/4.8.0-beta00016/
-RewriteRule ^docs/absolute-latest/(.*)$ /docs/4.8.0-beta00016/$1 [R=301,L]
+# Redirect /docs/absolute-latest/ to /docs/4.8.0-beta00017/
+RewriteRule ^docs/absolute-latest/(.*)$ /docs/4.8.0-beta00017/$1 [R=301,L]


### PR DESCRIPTION

<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.


<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)
Fixes a website/site/.htaccess BOM bug, also updates to beta00017 redirects



## Description
Apache web server requires that the .htaccess file not be saved with a BOM.  The one previously committed accidentally contained a BOM, causing issues when deployed to the asf-site branch of the lucent-site repo.  This PR fixes that and also updates the related /docs/absolute-latest/ redirection to be to /docs/4.8.0-beta00017/

