### PR TITLE
Test review E-I, #259

### DIFF
--- a/src/Lucene.Net.TestFramework/Support/TestFramework/Assert.cs
+++ b/src/Lucene.Net.TestFramework/Support/TestFramework/Assert.cs
@@ -930,7 +930,7 @@ namespace Lucene.Net.TestFramework
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void NotNull(object anObject)
         {
-            if (!(anObject is null))
+            if (anObject is not null)
                 _NUnit.Assert.NotNull(anObject);
         }
         //
@@ -973,7 +973,7 @@ namespace Lucene.Net.TestFramework
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Null(object anObject, string message, params object[] args)
         {
-            if (!(anObject is null))
+            if (anObject is not null)
                 _NUnit.Assert.Null(anObject, message, args);
         }
         //
@@ -988,7 +988,7 @@ namespace Lucene.Net.TestFramework
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Null(object anObject)
         {
-            if (!(anObject is null))
+            if (anObject is not null)
                 _NUnit.Assert.Null(anObject);
         }
 

--- a/src/Lucene.Net.Tests/Index/BinaryTokenStream.cs
+++ b/src/Lucene.Net.Tests/Index/BinaryTokenStream.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Index
     /// A binary tokenstream that lets you index a single
     /// binary token (BytesRef value).
     /// </summary>
-    /// <seealso> cref= CannedBinaryTokenStream </seealso>
+    /// <seealso cref="Lucene.Net.Analysis.CannedBinaryTokenStream" />
     public sealed class BinaryTokenStream : TokenStream
     {
         private readonly IByteTermAttribute bytesAtt;// = addAttribute(typeof(ByteTermAttribute));

--- a/src/Lucene.Net.Tests/Index/Test2BBinaryDocValues.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BBinaryDocValues.cs
@@ -49,13 +49,14 @@ namespace Lucene.Net.Index
             {
                 ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
             }
-            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
-                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
-                            .SetRAMBufferSizeMB(256.0)
-                            .SetMergeScheduler(new ConcurrentMergeScheduler())
-                            .SetMergePolicy(NewLogMergePolicy(false, 10))
-                            .SetOpenMode(OpenMode.CREATE);
-            IndexWriter w = new IndexWriter(dir, config);
+
+            IndexWriter w = new IndexWriter(dir,
+                new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .SetRAMBufferSizeMB(256.0)
+                .SetMergeScheduler(new ConcurrentMergeScheduler())
+                .SetMergePolicy(NewLogMergePolicy(false, 10))
+                .SetOpenMode(OpenMode.CREATE));
 
             Document doc = new Document();
             var bytes = new byte[4];
@@ -116,13 +117,13 @@ namespace Lucene.Net.Index
                 ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
             }
 
-            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
-                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
-                            .SetRAMBufferSizeMB(256.0)
-                            .SetMergeScheduler(new ConcurrentMergeScheduler())
-                            .SetMergePolicy(NewLogMergePolicy(false, 10))
-                            .SetOpenMode(OpenMode.CREATE);
-            IndexWriter w = new IndexWriter(dir, config);
+            IndexWriter w = new IndexWriter(dir,
+                new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .SetRAMBufferSizeMB(256.0)
+                .SetMergeScheduler(new ConcurrentMergeScheduler())
+                .SetMergePolicy(NewLogMergePolicy(false, 10))
+                .SetOpenMode(OpenMode.CREATE));
 
             Document doc = new Document();
             var bytes = new byte[4];

--- a/src/Lucene.Net.Tests/Index/Test2BDocs.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BDocs.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Index
             Arrays.Fill(subReaders, ir);
             try
             {
-                new MultiReader(subReaders);
+                _ = new MultiReader(subReaders); // LUCENENET-specific: discard result
                 Assert.Fail();
             }
             catch (Exception expected) when (expected.IsIllegalArgumentException())

--- a/src/Lucene.Net.Tests/Index/Test2BPositions.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BPositions.cs
@@ -42,8 +42,8 @@ namespace Lucene.Net.Index
     [SuppressCodecs("SimpleText", "Memory", "Direct")]
     [TestFixture]
     public class Test2BPositions : LuceneTestCase
-    // uses lots of space and takes a few minutes
     {
+        // uses lots of space and takes a few minutes
         [Ignore("Very slow. Enable manually by removing Ignore.")]
         [Test]
         public virtual void Test()
@@ -75,7 +75,7 @@ namespace Lucene.Net.Index
             Field field = new Field("field", new MyTokenStream(), ft);
             doc.Add(field);
 
-            int numDocs = (int.MaxValue / 26) + 1;
+            const int numDocs = (int.MaxValue / 26) + 1;
             for (int i = 0; i < numDocs; i++)
             {
                 w.AddDocument(doc);
@@ -91,10 +91,11 @@ namespace Lucene.Net.Index
 
         public sealed class MyTokenStream : TokenStream
         {
-            internal readonly ICharTermAttribute termAtt;
-            internal readonly IPositionIncrementAttribute posIncAtt;
+            private readonly ICharTermAttribute termAtt;
+            private readonly IPositionIncrementAttribute posIncAtt;
             internal int index;
 
+            // LUCENENET-specific: must call AddAttribute from ctor in .NET
             public MyTokenStream()
             {
                 termAtt = AddAttribute<ICharTermAttribute>();

--- a/src/Lucene.Net.Tests/Index/Test2BPostings.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BPostings.cs
@@ -54,14 +54,14 @@ namespace Lucene.Net.Index
                 ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
             }
 
-            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
-                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
-                            .SetRAMBufferSizeMB(256.0)
-                            .SetMergeScheduler(new ConcurrentMergeScheduler())
-                            .SetMergePolicy(NewLogMergePolicy(false, 10))
-                            .SetOpenMode(OpenMode.CREATE);
+            var iwc = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .SetRAMBufferSizeMB(256.0)
+                .SetMergeScheduler(new ConcurrentMergeScheduler())
+                .SetMergePolicy(NewLogMergePolicy(false, 10))
+                .SetOpenMode(OpenMode.CREATE);
 
-            IndexWriter w = new IndexWriter(dir, config);
+            IndexWriter w = new IndexWriter(dir, iwc);
 
             MergePolicy mp = w.Config.MergePolicy;
             if (mp is LogByteSizeMergePolicy)
@@ -77,7 +77,7 @@ namespace Lucene.Net.Index
             Field field = new Field("field", new MyTokenStream(), ft);
             doc.Add(field);
 
-            int numDocs = (int.MaxValue / 26) + 1;
+            const int numDocs = (int.MaxValue / 26) + 1;
             for (int i = 0; i < numDocs; i++)
             {
                 w.AddDocument(doc);
@@ -93,9 +93,10 @@ namespace Lucene.Net.Index
 
         public sealed class MyTokenStream : TokenStream
         {
-            internal readonly ICharTermAttribute termAtt;
+            private readonly ICharTermAttribute termAtt;
             internal int index;
 
+            // LUCENENET-specific: must call AddAttribute from ctor in .NET
             public MyTokenStream()
             {
                 termAtt = AddAttribute<ICharTermAttribute>();

--- a/src/Lucene.Net.Tests/Index/Test2BPostingsBytes.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BPostingsBytes.cs
@@ -41,13 +41,13 @@ namespace Lucene.Net.Index
     /// so you get > Integer.MAX_VALUE postings data for the term
     /// @lucene.experimental
     /// </summary>
+    // disable Lucene3x: older lucene formats always had this issue.
     [SuppressCodecs("SimpleText", "Memory", "Direct", "Lucene3x")]
     [TestFixture]
     public class Test2BPostingsBytes : LuceneTestCase
-    // disable Lucene3x: older lucene formats always had this issue.
-    // @Absurd @Ignore takes ~20GB-30GB of space and 10 minutes.
-    // with some codecs needs more heap space as well.
     {
+        // @Absurd @Ignore takes ~20GB-30GB of space and 10 minutes.
+        // with some codecs needs more heap space as well.
         [Ignore("Very slow. Enable manually by removing Ignore.")]
         [Test]
         public virtual void Test()
@@ -58,13 +58,13 @@ namespace Lucene.Net.Index
                 ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
             }
 
-            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
-                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
-                            .SetRAMBufferSizeMB(256.0)
-                            .SetMergeScheduler(new ConcurrentMergeScheduler())
-                            .SetMergePolicy(NewLogMergePolicy(false, 10))
-                            .SetOpenMode(OpenMode.CREATE);
-            IndexWriter w = new IndexWriter(dir, config);
+            IndexWriter w = new IndexWriter(dir,
+                new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .SetRAMBufferSizeMB(256.0)
+                .SetMergeScheduler(new ConcurrentMergeScheduler())
+                .SetMergePolicy(NewLogMergePolicy(false, 10))
+                .SetOpenMode(OpenMode.CREATE));
 
             MergePolicy mp = w.Config.MergePolicy;
             if (mp is LogByteSizeMergePolicy)
@@ -106,7 +106,8 @@ namespace Lucene.Net.Index
             {
                 ((MockDirectoryWrapper)dir2).Throttling = Throttling.NEVER;
             }
-            IndexWriter w2 = new IndexWriter(dir2, new IndexWriterConfig(TEST_VERSION_CURRENT, null));
+            IndexWriter w2 = new IndexWriter(dir2,
+                new IndexWriterConfig(TEST_VERSION_CURRENT, null));
             w2.AddIndexes(mr);
             w2.ForceMerge(1);
             w2.Dispose();
@@ -121,7 +122,8 @@ namespace Lucene.Net.Index
             {
                 ((MockDirectoryWrapper)dir3).Throttling = Throttling.NEVER;
             }
-            IndexWriter w3 = new IndexWriter(dir3, new IndexWriterConfig(TEST_VERSION_CURRENT, null));
+            IndexWriter w3 = new IndexWriter(dir3,
+                new IndexWriterConfig(TEST_VERSION_CURRENT, null));
             w3.AddIndexes(mr);
             w3.ForceMerge(1);
             w3.Dispose();
@@ -134,10 +136,11 @@ namespace Lucene.Net.Index
 
         public sealed class MyTokenStream : TokenStream
         {
-            internal readonly ICharTermAttribute termAtt;
+            private readonly ICharTermAttribute termAtt;
             internal int index;
             internal int n;
 
+            // LUCENENET-specific: must call AddAttribute from ctor in .NET
             public MyTokenStream()
             {
                 termAtt = AddAttribute<ICharTermAttribute>();

--- a/src/Lucene.Net.Tests/Index/Test2BSortedDocValues.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BSortedDocValues.cs
@@ -48,12 +48,13 @@ namespace Lucene.Net.Index
                 ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
             }
 
-            IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
-                                .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
-                                .SetRAMBufferSizeMB(256.0)
-                                .SetMergeScheduler(new ConcurrentMergeScheduler())
-                                .SetMergePolicy(NewLogMergePolicy(false, 10))
-                                .SetOpenMode(OpenMode.CREATE));
+            IndexWriter w = new IndexWriter(dir,
+                new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .SetRAMBufferSizeMB(256.0)
+                .SetMergeScheduler(new ConcurrentMergeScheduler())
+                .SetMergePolicy(NewLogMergePolicy(false, 10))
+                .SetOpenMode(OpenMode.CREATE));
 
             Document doc = new Document();
             var bytes = new byte[2];
@@ -110,13 +111,13 @@ namespace Lucene.Net.Index
                 ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
             }
 
-            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
-                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
-                            .SetRAMBufferSizeMB(256.0)
-                            .SetMergeScheduler(new ConcurrentMergeScheduler())
-                            .SetMergePolicy(NewLogMergePolicy(false, 10))
-                            .SetOpenMode(OpenMode.CREATE);
-            IndexWriter w = new IndexWriter(dir, config);
+            IndexWriter w = new IndexWriter(dir,
+                new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .SetRAMBufferSizeMB(256.0)
+                .SetMergeScheduler(new ConcurrentMergeScheduler())
+                .SetMergePolicy(NewLogMergePolicy(false, 10))
+                .SetOpenMode(OpenMode.CREATE));
 
             Document doc = new Document();
             var bytes = new byte[4];

--- a/src/Lucene.Net.Tests/Index/Test2BTerms.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BTerms.cs
@@ -59,12 +59,12 @@ namespace Lucene.Net.Index
 
         private sealed class MyTokenStream : TokenStream
         {
-            internal readonly int tokensPerDoc;
-            internal int tokenCount;
+            private readonly int tokensPerDoc;
+            private int tokenCount;
             public readonly IList<BytesRef> savedTerms = new JCG.List<BytesRef>();
-            internal int nextSave;
-            internal long termCounter;
-            internal readonly Random random;
+            private int nextSave;
+            private long termCounter;
+            private readonly Random random;
 
             public MyTokenStream(Random random, int tokensPerDoc)
                 : base(new MyAttributeFactory(AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY))
@@ -140,7 +140,7 @@ namespace Lucene.Net.Index
 
             private sealed class MyAttributeFactory : AttributeFactory
             {
-                internal readonly AttributeFactory @delegate;
+                private readonly AttributeFactory @delegate;
 
                 public MyAttributeFactory(AttributeFactory @delegate)
                 {
@@ -172,7 +172,7 @@ namespace Lucene.Net.Index
                 throw RuntimeException.Create("this test cannot run with PreFlex codec");
             }
             Console.WriteLine("Starting Test2B");
-            long TERM_COUNT = ((long)int.MaxValue) + 100000000;
+            const long TERM_COUNT = ((long)int.MaxValue) + 100000000;
 
             int TERMS_PER_DOC = TestUtil.NextInt32(Random, 100000, 1000000);
 
@@ -188,12 +188,13 @@ namespace Lucene.Net.Index
 
             if (true)
             {
-                IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
-                                           .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
-                                           .SetRAMBufferSizeMB(256.0)
-                                           .SetMergeScheduler(new ConcurrentMergeScheduler())
-                                           .SetMergePolicy(NewLogMergePolicy(false, 10))
-                                           .SetOpenMode(OpenMode.CREATE));
+                IndexWriter w = new IndexWriter(dir,
+                    new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                   .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                   .SetRAMBufferSizeMB(256.0)
+                   .SetMergeScheduler(new ConcurrentMergeScheduler())
+                   .SetMergePolicy(NewLogMergePolicy(false, 10))
+                   .SetOpenMode(OpenMode.CREATE));
 
                 MergePolicy mp = w.Config.MergePolicy;
                 if (mp is LogByteSizeMergePolicy)
@@ -202,7 +203,7 @@ namespace Lucene.Net.Index
                     ((LogByteSizeMergePolicy)mp).MaxMergeMB = 1024 * 1024 * 1024;
                 }
 
-                Documents.Document doc = new Documents.Document();
+                Document doc = new Document();
                 MyTokenStream ts = new MyTokenStream(Random, TERMS_PER_DOC);
 
                 FieldType customType = new FieldType(TextField.TYPE_NOT_STORED);

--- a/src/Lucene.Net.Tests/Index/Test4GBStoredFields.cs
+++ b/src/Lucene.Net.Tests/Index/Test4GBStoredFields.cs
@@ -55,13 +55,13 @@ namespace Lucene.Net.Index
             MockDirectoryWrapper dir = new MockDirectoryWrapper(Random, new MMapDirectory(CreateTempDir("4GBStoredFields")));
             dir.Throttling = Throttling.NEVER;
 
-            var config = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
-                            .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
-                            .SetRAMBufferSizeMB(256.0)
-                            .SetMergeScheduler(new ConcurrentMergeScheduler())
-                            .SetMergePolicy(NewLogMergePolicy(false, 10))
-                            .SetOpenMode(OpenMode.CREATE);
-            IndexWriter w = new IndexWriter(dir, config);
+            IndexWriter w = new IndexWriter(dir,
+                new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+                .SetRAMBufferSizeMB(256.0)
+                .SetMergeScheduler(new ConcurrentMergeScheduler())
+                .SetMergePolicy(NewLogMergePolicy(false, 10))
+                .SetOpenMode(OpenMode.CREATE));
 
             MergePolicy mp = w.Config.MergePolicy;
             if (mp is LogByteSizeMergePolicy)

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -68,14 +68,21 @@ namespace Lucene.Net.Index
 
             IndexWriter writer = null;
 
-            writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE));
+            writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT,
+                new MockAnalyzer(Random))
+                .SetOpenMode(OpenMode.CREATE));
             // add 100 documents
             AddDocs(writer, 100);
             Assert.AreEqual(100, writer.MaxDoc);
             writer.Dispose();
             TestUtil.CheckIndex(dir);
 
-            writer = NewWriter(aux, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMergePolicy(NewLogMergePolicy(false)));
+            writer = NewWriter(
+                aux,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.CREATE)
+                    .SetMergePolicy(NewLogMergePolicy(false))
+            );
             // add 40 documents in separate files
             AddDocs(writer, 40);
             Assert.AreEqual(40, writer.MaxDoc);
@@ -295,11 +302,23 @@ namespace Lucene.Net.Index
             Assert.AreEqual(100, writer.MaxDoc);
             writer.Dispose();
 
-            writer = NewWriter(aux, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(1000).SetMergePolicy(NewLogMergePolicy(false)));
+            writer = NewWriter(
+                aux,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.CREATE)
+                    .SetMaxBufferedDocs(1000)
+                    .SetMergePolicy(NewLogMergePolicy(false))
+            );
             // add 140 documents in separate files
             AddDocs(writer, 40);
             writer.Dispose();
-            writer = NewWriter(aux, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(1000).SetMergePolicy(NewLogMergePolicy(false)));
+            writer = NewWriter(
+                aux,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.CREATE)
+                    .SetMaxBufferedDocs(1000)
+                    .SetMergePolicy(NewLogMergePolicy(false))
+            );
             AddDocs(writer, 100);
             writer.Dispose();
 
@@ -335,7 +354,13 @@ namespace Lucene.Net.Index
 
             SetUpDirs(dir, aux);
 
-            IndexWriter writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetMaxBufferedDocs(10).SetMergePolicy(NewLogMergePolicy(4)));
+            IndexWriter writer = NewWriter(
+                dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.APPEND)
+                    .SetMaxBufferedDocs(10)
+                    .SetMergePolicy(NewLogMergePolicy(4))
+            );
             AddDocs(writer, 10);
 
             writer.AddIndexes(aux);
@@ -360,7 +385,12 @@ namespace Lucene.Net.Index
 
             SetUpDirs(dir, aux);
 
-            IndexWriter writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetMaxBufferedDocs(9).SetMergePolicy(NewLogMergePolicy(4)));
+            IndexWriter writer = NewWriter(
+                dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.APPEND)
+                    .SetMaxBufferedDocs(9)
+                    .SetMergePolicy(NewLogMergePolicy(4)));
             AddDocs(writer, 2);
 
             writer.AddIndexes(aux);
@@ -385,7 +415,13 @@ namespace Lucene.Net.Index
 
             SetUpDirs(dir, aux);
 
-            IndexWriter writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetMaxBufferedDocs(10).SetMergePolicy(NewLogMergePolicy(4)));
+            IndexWriter writer = NewWriter(
+                dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.APPEND)
+                    .SetMaxBufferedDocs(10)
+                    .SetMergePolicy(NewLogMergePolicy(4))
+            );
 
             writer.AddIndexes(aux, new MockDirectoryWrapper(Random, new RAMDirectory(aux, NewIOContext(Random))));
             Assert.AreEqual(1060, writer.MaxDoc);
@@ -409,7 +445,8 @@ namespace Lucene.Net.Index
 
             SetUpDirs(dir, aux, true);
 
-            IndexWriterConfig dontMergeConfig = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMergePolicy(NoMergePolicy.COMPOUND_FILES);
+            IndexWriterConfig dontMergeConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMergePolicy(NoMergePolicy.COMPOUND_FILES);
             IndexWriter writer = new IndexWriter(aux, dontMergeConfig);
             for (int i = 0; i < 20; i++)
             {
@@ -420,7 +457,13 @@ namespace Lucene.Net.Index
             Assert.AreEqual(10, reader.NumDocs);
             reader.Dispose();
 
-            writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetMaxBufferedDocs(4).SetMergePolicy(NewLogMergePolicy(4)));
+            writer = NewWriter(
+                dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.APPEND)
+                    .SetMaxBufferedDocs(4)
+                    .SetMergePolicy(NewLogMergePolicy(4))
+            );
 
             if (Verbose)
             {
@@ -446,13 +489,20 @@ namespace Lucene.Net.Index
 
             SetUpDirs(dir, aux, true);
 
-            IndexWriter writer = NewWriter(aux2, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(100).SetMergePolicy(NewLogMergePolicy(10)));
+            IndexWriter writer = NewWriter(
+                aux2,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.CREATE)
+                    .SetMaxBufferedDocs(100)
+                    .SetMergePolicy(NewLogMergePolicy(10))
+            );
             writer.AddIndexes(aux);
             Assert.AreEqual(30, writer.MaxDoc);
             Assert.AreEqual(3, writer.SegmentCount);
             writer.Dispose();
 
-            IndexWriterConfig dontMergeConfig = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMergePolicy(NoMergePolicy.COMPOUND_FILES);
+            IndexWriterConfig dontMergeConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMergePolicy(NoMergePolicy.COMPOUND_FILES);
             writer = new IndexWriter(aux, dontMergeConfig);
             for (int i = 0; i < 27; i++)
             {
@@ -463,7 +513,8 @@ namespace Lucene.Net.Index
             Assert.AreEqual(3, reader.NumDocs);
             reader.Dispose();
 
-            dontMergeConfig = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMergePolicy(NoMergePolicy.COMPOUND_FILES);
+            dontMergeConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMergePolicy(NoMergePolicy.COMPOUND_FILES);
             writer = new IndexWriter(aux2, dontMergeConfig);
             for (int i = 0; i < 8; i++)
             {
@@ -474,7 +525,13 @@ namespace Lucene.Net.Index
             Assert.AreEqual(22, reader.NumDocs);
             reader.Dispose();
 
-            writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetMaxBufferedDocs(6).SetMergePolicy(NewLogMergePolicy(4)));
+            writer = NewWriter(
+                dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.APPEND)
+                    .SetMaxBufferedDocs(6)
+                    .SetMergePolicy(NewLogMergePolicy(4))
+            );
 
             writer.AddIndexes(aux, aux2);
             Assert.AreEqual(1040, writer.MaxDoc);
@@ -485,14 +542,16 @@ namespace Lucene.Net.Index
             aux2.Dispose();
         }
 
-        private IndexWriter NewWriter(Directory dir, IndexWriterConfig conf)
+        // LUCENENET-specific: made static
+        private static IndexWriter NewWriter(Directory dir, IndexWriterConfig conf)
         {
             conf.SetMergePolicy(new LogDocMergePolicy());
             IndexWriter writer = new IndexWriter(dir, conf);
             return writer;
         }
 
-        private void AddDocs(IndexWriter writer, int numDocs)
+        // LUCENENET-specific: made static
+        private static void AddDocs(IndexWriter writer, int numDocs)
         {
             for (int i = 0; i < numDocs; i++)
             {
@@ -502,7 +561,8 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void AddDocs2(IndexWriter writer, int numDocs)
+        // LUCENENET-specific: made static
+        private static void AddDocs2(IndexWriter writer, int numDocs)
         {
             for (int i = 0; i < numDocs; i++)
             {
@@ -512,7 +572,8 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void VerifyNumDocs(Directory dir, int numDocs)
+        // LUCENENET-specific: made static
+        private static void VerifyNumDocs(Directory dir, int numDocs)
         {
             IndexReader reader = DirectoryReader.Open(dir);
             Assert.AreEqual(numDocs, reader.MaxDoc);
@@ -520,7 +581,8 @@ namespace Lucene.Net.Index
             reader.Dispose();
         }
 
-        private void VerifyTermDocs(Directory dir, Term term, int numDocs)
+        // LUCENENET-specific: made static
+        private static void VerifyTermDocs(Directory dir, Term term, int numDocs)
         {
             IndexReader reader = DirectoryReader.Open(dir);
             DocsEnum docsEnum = TestUtil.Docs(Random, reader, term.Field, term.Bytes, null, null, DocsFlags.NONE);
@@ -542,7 +604,7 @@ namespace Lucene.Net.Index
         {
             IndexWriter writer = null;
 
-            writer = NewWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(1000));
+            writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(1000));
             // add 1000 documents in 1 segment
             if (withID)
             {
@@ -556,7 +618,13 @@ namespace Lucene.Net.Index
             Assert.AreEqual(1, writer.SegmentCount);
             writer.Dispose();
 
-            writer = NewWriter(aux, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(1000).SetMergePolicy(NewLogMergePolicy(false, 10)));
+            writer = NewWriter(
+                aux,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.CREATE)
+                    .SetMaxBufferedDocs(1000)
+                    .SetMergePolicy(NewLogMergePolicy(false, 10))
+            );
             // add 30 documents in 3 segments
             for (int i = 0; i < 3; i++)
             {
@@ -569,7 +637,13 @@ namespace Lucene.Net.Index
                     AddDocs(writer, 10);
                 }
                 writer.Dispose();
-                writer = NewWriter(aux, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetMaxBufferedDocs(1000).SetMergePolicy(NewLogMergePolicy(false, 10)));
+                writer = NewWriter(
+                    aux,
+                    NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                        .SetOpenMode(OpenMode.APPEND)
+                        .SetMaxBufferedDocs(1000)
+                        .SetMergePolicy(NewLogMergePolicy(false, 10))
+                );
             }
             Assert.AreEqual(30, writer.MaxDoc);
             Assert.AreEqual(3, writer.SegmentCount);
@@ -584,7 +658,9 @@ namespace Lucene.Net.Index
             LogByteSizeMergePolicy lmp = new LogByteSizeMergePolicy();
             lmp.NoCFSRatio = 0.0;
             lmp.MergeFactor = 100;
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(5).SetMergePolicy(lmp));
+            IndexWriter writer = new IndexWriter(dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(5).SetMergePolicy(lmp));
 
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);
@@ -615,7 +691,9 @@ namespace Lucene.Net.Index
             lmp.MinMergeMB = 0.0001;
             lmp.NoCFSRatio = 0.0;
             lmp.MergeFactor = 4;
-            writer = new IndexWriter(dir2, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergeScheduler(new SerialMergeScheduler()).SetMergePolicy(lmp));
+            writer = new IndexWriter(dir2,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMergeScheduler(new SerialMergeScheduler()).SetMergePolicy(lmp));
             writer.AddIndexes(dir);
             writer.Dispose();
             dir.Dispose();
@@ -624,7 +702,8 @@ namespace Lucene.Net.Index
 
         // TODO: these are also in TestIndexWriter... add a simple doc-writing method
         // like this to LuceneTestCase?
-        private void AddDoc(IndexWriter writer)
+        // LUCENENET specific - made static
+        private static void AddDoc(IndexWriter writer)
         {
             Document doc = new Document();
             doc.Add(NewTextField("content", "aaa", Field.Store.NO));
@@ -643,14 +722,16 @@ namespace Lucene.Net.Index
             internal const int NUM_THREADS = 5;
             internal readonly ThreadJob[] threads = new ThreadJob[NUM_THREADS];
 
-            public RunAddIndexesThreads(TestAddIndexes outerInstance, int numCopy)
+            public RunAddIndexesThreads(int numCopy)
             {
                 NUM_COPY = numCopy;
                 dir = new MockDirectoryWrapper(Random, new RAMDirectory());
-                IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2));
+                IndexWriter writer = new IndexWriter(dir,
+                    new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetMaxBufferedDocs(2));
                 for (int i = 0; i < NUM_INIT_DOCS; i++)
                 {
-                    outerInstance.AddDoc(writer);
+                    AddDoc(writer);
                 }
                 writer.Dispose();
 
@@ -665,7 +746,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            internal virtual void LaunchThreads(int numIter)
+            internal void LaunchThreads(int numIter)
             {
                 for (int i = 0; i < NUM_THREADS; i++)
                 {
@@ -718,7 +799,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            internal virtual void JoinThreads()
+            internal void JoinThreads()
             {
                 for (int i = 0; i < NUM_THREADS; i++)
                 {
@@ -726,13 +807,13 @@ namespace Lucene.Net.Index
                 }
             }
 
-            internal virtual void Close(bool doWait)
+            internal void Close(bool doWait)
             {
                 didClose = true;
                 writer2.Dispose(doWait);
             }
 
-            internal virtual void CloseDir()
+            internal void CloseDir()
             {
                 for (int i = 0; i < NUM_COPY; i++)
                 {
@@ -748,8 +829,8 @@ namespace Lucene.Net.Index
 
         private class CommitAndAddIndexes : RunAddIndexesThreads
         {
-            public CommitAndAddIndexes(TestAddIndexes outerInstance, int numCopy)
-                : base(outerInstance, numCopy)
+            public CommitAndAddIndexes(int numCopy)
+                : base(numCopy)
             {
             }
 
@@ -824,7 +905,7 @@ namespace Lucene.Net.Index
         {
             int NUM_ITER = TestNightly ? 15 : 5;
             const int NUM_COPY = 3;
-            CommitAndAddIndexes c = new CommitAndAddIndexes(this, NUM_COPY);
+            CommitAndAddIndexes c = new CommitAndAddIndexes(NUM_COPY);
             c.LaunchThreads(NUM_ITER);
 
             for (int i = 0; i < 100; i++)
@@ -851,8 +932,8 @@ namespace Lucene.Net.Index
 
         private class CommitAndAddIndexes2 : CommitAndAddIndexes
         {
-            public CommitAndAddIndexes2(TestAddIndexes outerInstance, int numCopy)
-                : base(outerInstance, numCopy)
+            public CommitAndAddIndexes2(int numCopy)
+                : base(numCopy)
             {
             }
 
@@ -879,7 +960,7 @@ namespace Lucene.Net.Index
         public virtual void TestAddIndexesWithClose()
         {
             const int NUM_COPY = 3;
-            CommitAndAddIndexes2 c = new CommitAndAddIndexes2(this, NUM_COPY);
+            CommitAndAddIndexes2 c = new CommitAndAddIndexes2(NUM_COPY);
             //c.writer2.setInfoStream(System.out);
             c.LaunchThreads(-1);
 
@@ -896,8 +977,8 @@ namespace Lucene.Net.Index
 
         private class CommitAndAddIndexes3 : RunAddIndexesThreads
         {
-            public CommitAndAddIndexes3(TestAddIndexes outerInstance, int numCopy)
-                : base(outerInstance, numCopy)
+            public CommitAndAddIndexes3(int numCopy)
+                : base(numCopy)
             {
             }
 
@@ -990,7 +1071,7 @@ namespace Lucene.Net.Index
         public virtual void TestAddIndexesWithCloseNoWait()
         {
             const int NUM_COPY = 50;
-            CommitAndAddIndexes3 c = new CommitAndAddIndexes3(this, NUM_COPY);
+            CommitAndAddIndexes3 c = new CommitAndAddIndexes3(NUM_COPY);
             c.LaunchThreads(-1);
 
             Thread.Sleep(TestUtil.NextInt32(Random, 10, 500));
@@ -1019,7 +1100,7 @@ namespace Lucene.Net.Index
         public virtual void TestAddIndexesWithRollback()
         {
             int NUM_COPY = TestNightly ? 50 : 5;
-            CommitAndAddIndexes3 c = new CommitAndAddIndexes3(this, NUM_COPY);
+            CommitAndAddIndexes3 c = new CommitAndAddIndexes3(NUM_COPY);
             c.LaunchThreads(-1);
 
             Thread.Sleep(TestUtil.NextInt32(Random, 10, 500));
@@ -1055,6 +1136,7 @@ namespace Lucene.Net.Index
                 writer.Dispose();
             }
 
+            // LUCENENET-specific: renamed to avoid conflict with variables above
             IndexWriterConfig conf_ = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));
             IndexWriter writer_ = new IndexWriter(dirs[0], conf_);
 
@@ -1080,7 +1162,8 @@ namespace Lucene.Net.Index
         }
 
         // just like addDocs but with ID, starting from docStart
-        private void AddDocsWithID(IndexWriter writer, int numDocs, int docStart)
+        // LUCENENET-specific: made static
+        private static void AddDocsWithID(IndexWriter writer, int numDocs, int docStart)
         {
             for (int i = 0; i < numDocs; i++)
             {
@@ -1102,7 +1185,8 @@ namespace Lucene.Net.Index
             Codec codec = new CustomPerFieldCodec();
             IndexWriter writer = null;
 
-            writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetCodec(codec));
+            writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetOpenMode(OpenMode.CREATE).SetCodec(codec));
             // add 100 documents
             AddDocsWithID(writer, 100, 0);
             Assert.AreEqual(100, writer.MaxDoc);
@@ -1110,14 +1194,26 @@ namespace Lucene.Net.Index
             writer.Dispose();
             TestUtil.CheckIndex(dir);
 
-            writer = NewWriter(aux, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetCodec(codec).SetMaxBufferedDocs(10).SetMergePolicy(NewLogMergePolicy(false)));
+            writer = NewWriter(
+                aux,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.CREATE)
+                    .SetCodec(codec)
+                    .SetMaxBufferedDocs(10)
+                    .SetMergePolicy(NewLogMergePolicy(false))
+            );
             // add 40 documents in separate files
             AddDocs(writer, 40);
             Assert.AreEqual(40, writer.MaxDoc);
             writer.Commit();
             writer.Dispose();
 
-            writer = NewWriter(aux2, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetCodec(codec));
+            writer = NewWriter(
+                aux2,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.CREATE)
+                    .SetCodec(codec)
+            );
             // add 40 documents in compound files
             AddDocs2(writer, 50);
             Assert.AreEqual(50, writer.MaxDoc);
@@ -1125,7 +1221,12 @@ namespace Lucene.Net.Index
             writer.Dispose();
 
             // test doc count before segments are merged
-            writer = NewWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetCodec(codec));
+            writer = NewWriter(
+                dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.APPEND)
+                    .SetCodec(codec)
+            );
             Assert.AreEqual(100, writer.MaxDoc);
             writer.AddIndexes(aux, aux2);
             Assert.AreEqual(190, writer.MaxDoc);
@@ -1138,16 +1239,9 @@ namespace Lucene.Net.Index
 
         private sealed class CustomPerFieldCodec : Lucene46Codec
         {
-            internal readonly PostingsFormat simpleTextFormat;
-            internal readonly PostingsFormat defaultFormat;
-            internal readonly PostingsFormat mockSepFormat;
-
-            public CustomPerFieldCodec()
-            {
-                simpleTextFormat = Codecs.PostingsFormat.ForName("SimpleText");
-                defaultFormat = Codecs.PostingsFormat.ForName("Lucene41");
-                mockSepFormat = Codecs.PostingsFormat.ForName("MockSep");
-            }
+            private readonly PostingsFormat simpleTextFormat = PostingsFormat.ForName("SimpleText");
+            private readonly PostingsFormat defaultFormat = PostingsFormat.ForName("Lucene41");
+            private readonly PostingsFormat mockSepFormat = PostingsFormat.ForName("MockSep");
 
             public override PostingsFormat GetPostingsFormatForField(string field)
             {
@@ -1186,7 +1280,7 @@ namespace Lucene.Net.Index
             IndexReader[] readers = new IndexReader[] { DirectoryReader.Open(dirs[0]), DirectoryReader.Open(dirs[1]) };
 
             Directory dir = new MockDirectoryWrapper(Random, new RAMDirectory());
-            IndexWriterConfig conf = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMergePolicy(NewLogMergePolicy(true));
+            IndexWriterConfig conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy(true));
             MergePolicy lmp = conf.MergePolicy;
             // Force creation of CFS:
             lmp.NoCFSRatio = 1.0;
@@ -1380,9 +1474,7 @@ namespace Lucene.Net.Index
                 w2.AddIndexes(src);
                 Assert.Fail("did not hit expected exception");
             }
-#pragma warning disable 168
-            catch (LockObtainFailedException lofe)
-#pragma warning restore 168
+            catch (LockObtainFailedException /*lofe*/)
             {
                 // expected
             }

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -542,16 +542,14 @@ namespace Lucene.Net.Index
             aux2.Dispose();
         }
 
-        // LUCENENET-specific: made static
-        private static IndexWriter NewWriter(Directory dir, IndexWriterConfig conf)
+        private IndexWriter NewWriter(Directory dir, IndexWriterConfig conf)
         {
             conf.SetMergePolicy(new LogDocMergePolicy());
             IndexWriter writer = new IndexWriter(dir, conf);
             return writer;
         }
 
-        // LUCENENET-specific: made static
-        private static void AddDocs(IndexWriter writer, int numDocs)
+        private void AddDocs(IndexWriter writer, int numDocs)
         {
             for (int i = 0; i < numDocs; i++)
             {
@@ -561,8 +559,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        // LUCENENET-specific: made static
-        private static void AddDocs2(IndexWriter writer, int numDocs)
+        private void AddDocs2(IndexWriter writer, int numDocs)
         {
             for (int i = 0; i < numDocs; i++)
             {
@@ -572,8 +569,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        // LUCENENET-specific: made static
-        private static void VerifyNumDocs(Directory dir, int numDocs)
+        private void VerifyNumDocs(Directory dir, int numDocs)
         {
             IndexReader reader = DirectoryReader.Open(dir);
             Assert.AreEqual(numDocs, reader.MaxDoc);
@@ -581,8 +577,7 @@ namespace Lucene.Net.Index
             reader.Dispose();
         }
 
-        // LUCENENET-specific: made static
-        private static void VerifyTermDocs(Directory dir, Term term, int numDocs)
+        private void VerifyTermDocs(Directory dir, Term term, int numDocs)
         {
             IndexReader reader = DirectoryReader.Open(dir);
             DocsEnum docsEnum = TestUtil.Docs(Random, reader, term.Field, term.Bytes, null, null, DocsFlags.NONE);
@@ -1162,8 +1157,7 @@ namespace Lucene.Net.Index
         }
 
         // just like addDocs but with ID, starting from docStart
-        // LUCENENET-specific: made static
-        private static void AddDocsWithID(IndexWriter writer, int numDocs, int docStart)
+        private void AddDocsWithID(IndexWriter writer, int numDocs, int docStart)
         {
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
+++ b/src/Lucene.Net.Tests/Index/TestAddIndexes.cs
@@ -741,7 +741,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            internal void LaunchThreads(int numIter)
+            internal virtual void LaunchThreads(int numIter)
             {
                 for (int i = 0; i < NUM_THREADS; i++)
                 {
@@ -794,7 +794,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            internal void JoinThreads()
+            internal virtual void JoinThreads()
             {
                 for (int i = 0; i < NUM_THREADS; i++)
                 {
@@ -802,13 +802,13 @@ namespace Lucene.Net.Index
                 }
             }
 
-            internal void Close(bool doWait)
+            internal virtual void Close(bool doWait)
             {
                 didClose = true;
                 writer2.Dispose(doWait);
             }
 
-            internal void CloseDir()
+            internal virtual void CloseDir()
             {
                 for (int i = 0; i < NUM_COPY; i++)
                 {

--- a/src/Lucene.Net.Tests/Index/TestAllFilesHaveChecksumFooter.cs
+++ b/src/Lucene.Net.Tests/Index/TestAllFilesHaveChecksumFooter.cs
@@ -75,8 +75,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        // LUCENENET-specific: made static
-        private static void CheckHeaders(Directory dir)
+        private void CheckHeaders(Directory dir)
         {
             foreach (string file in dir.ListAll())
             {

--- a/src/Lucene.Net.Tests/Index/TestAllFilesHaveChecksumFooter.cs
+++ b/src/Lucene.Net.Tests/Index/TestAllFilesHaveChecksumFooter.cs
@@ -75,7 +75,8 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private void CheckHeaders(Directory dir)
+        // LUCENENET-specific: made static
+        private static void CheckHeaders(Directory dir)
         {
             foreach (string file in dir.ListAll())
             {

--- a/src/Lucene.Net.Tests/Index/TestAllFilesHaveCodecHeader.cs
+++ b/src/Lucene.Net.Tests/Index/TestAllFilesHaveCodecHeader.cs
@@ -76,7 +76,8 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private void CheckHeaders(Directory dir)
+        // LUCENENET specific - made static
+        private static void CheckHeaders(Directory dir)
         {
             foreach (string file in dir.ListAll())
             {

--- a/src/Lucene.Net.Tests/Index/TestAllFilesHaveCodecHeader.cs
+++ b/src/Lucene.Net.Tests/Index/TestAllFilesHaveCodecHeader.cs
@@ -76,8 +76,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        // LUCENENET specific - made static
-        private static void CheckHeaders(Directory dir)
+        private void CheckHeaders(Directory dir)
         {
             foreach (string file in dir.ListAll())
             {

--- a/src/Lucene.Net.Tests/Index/TestAtomicUpdate.cs
+++ b/src/Lucene.Net.Tests/Index/TestAtomicUpdate.cs
@@ -37,8 +37,8 @@ namespace Lucene.Net.Index
         {
             internal volatile bool failed;
             internal int count;
-            internal static float RUN_TIME_MSEC = AtLeast(500);
-            internal TimedThread[] allThreads;
+            private static float RUN_TIME_MSEC = AtLeast(500);
+            private TimedThread[] allThreads;
 
             public abstract void DoWork();
 
@@ -73,7 +73,7 @@ namespace Lucene.Net.Index
                 }
             }
 
-            internal virtual bool AnyErrors()
+            private bool AnyErrors()
             {
                 for (int i = 0; i < allThreads.Length; i++)
                 {
@@ -101,7 +101,7 @@ namespace Lucene.Net.Index
                 // Update all 100 docs...
                 for (int i = 0; i < 100; i++)
                 {
-                    Documents.Document d = new Documents.Document();
+                    Document d = new Document();
                     d.Add(new StringField("id", Convert.ToString(i), Field.Store.YES));
                     d.Add(new TextField("contents", English.Int32ToEnglish(i + 10 * count), Field.Store.NO));
                     writer.UpdateDocument(new Term("id", Convert.ToString(i)), d);
@@ -136,14 +136,15 @@ namespace Lucene.Net.Index
         {
             TimedThread[] threads = new TimedThread[4];
 
-            IndexWriterConfig conf = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMaxBufferedDocs(7);
+            IndexWriterConfig conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(7);
             ((TieredMergePolicy)conf.MergePolicy).MaxMergeAtOnce = 3;
             IndexWriter writer = RandomIndexWriter.MockIndexWriter(directory, conf, Random);
 
             // Establish a base index of 100 docs:
             for (int i = 0; i < 100; i++)
             {
-                Documents.Document d = new Documents.Document();
+                Document d = new Document();
                 d.Add(NewStringField("id", Convert.ToString(i), Field.Store.YES));
                 d.Add(NewTextField("contents", English.Int32ToEnglish(i), Field.Store.NO));
                 if ((i - 1) % 7 == 0)
@@ -213,7 +214,7 @@ namespace Lucene.Net.Index
             {
                 RunTest(directory);
             }
-            System.IO.Directory.Delete(dirPath.FullName, true);
+            TestUtil.Rm(dirPath);
         }
     }
 }

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
@@ -159,18 +159,38 @@ namespace Lucene.Net.Index
         */
 
         internal static readonly string[] oldNames = {
-            "40.cfs", "40.nocfs", "41.cfs", "41.nocfs", "42.cfs",
-            "42.nocfs", "45.cfs", "45.nocfs", "461.cfs", "461.nocfs"
+            "40.cfs",
+            "40.nocfs",
+            "41.cfs",
+            "41.nocfs",
+            "42.cfs",
+            "42.nocfs",
+            "45.cfs",
+            "45.nocfs",
+            "461.cfs",
+            "461.nocfs"
         };
 
         internal readonly string[] unsupportedNames = {
-            "19.cfs", "19.nocfs", "20.cfs", "20.nocfs", "21.cfs",
-            "21.nocfs", "22.cfs", "22.nocfs", "23.cfs", "23.nocfs",
-            "24.cfs", "24.nocfs", "29.cfs", "29.nocfs"
+            "19.cfs",
+            "19.nocfs",
+            "20.cfs",
+            "20.nocfs",
+            "21.cfs",
+            "21.nocfs",
+            "22.cfs",
+            "22.nocfs",
+            "23.cfs",
+            "23.nocfs",
+            "24.cfs",
+            "24.nocfs",
+            "29.cfs",
+            "29.nocfs"
         };
 
         internal static readonly string[] oldSingleSegmentNames = {
-            "40.optimized.cfs", "40.optimized.nocfs"
+            "40.optimized.cfs",
+            "40.optimized.nocfs"
         };
 
         internal static IDictionary<string, Directory> oldIndexDirs;
@@ -299,16 +319,16 @@ namespace Lucene.Net.Index
                     writer = null;
                 }
 
-                StringBuilder sb = new StringBuilder(1024);
+                StringBuilder bos = new StringBuilder(512); // LUCENENET specific: allocating 512 chars instead of 1024 bytes
                 CheckIndex checker = new CheckIndex(dir);
                 CheckIndex.Status indexStatus;
-                using (var infoStream = new StringWriter(sb))
+                using (var infoStream = new StringWriter(bos))
                 {
                     checker.InfoStream = infoStream;
                     indexStatus = checker.DoCheckIndex();
                 }
                 Assert.IsFalse(indexStatus.Clean);
-                Assert.IsTrue(sb.ToString().Contains(nameof(IndexFormatTooOldException)));
+                Assert.IsTrue(bos.ToString().Contains(nameof(IndexFormatTooOldException)));
 
                 dir.Dispose();
                 TestUtil.Rm(oldIndxeDir);

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
@@ -158,18 +158,18 @@ namespace Lucene.Net.Index
         }
         */
 
-        internal static readonly string[] oldNames = new string[] {
+        internal static readonly string[] oldNames = {
             "40.cfs", "40.nocfs", "41.cfs", "41.nocfs", "42.cfs",
             "42.nocfs", "45.cfs", "45.nocfs", "461.cfs", "461.nocfs"
         };
 
-        internal readonly string[] unsupportedNames = new string[] {
+        internal readonly string[] unsupportedNames = {
             "19.cfs", "19.nocfs", "20.cfs", "20.nocfs", "21.cfs",
             "21.nocfs", "22.cfs", "22.nocfs", "23.cfs", "23.nocfs",
             "24.cfs", "24.nocfs", "29.cfs", "29.nocfs"
         };
 
-        internal static readonly string[] oldSingleSegmentNames = new string[] {
+        internal static readonly string[] oldSingleSegmentNames = {
             "40.optimized.cfs", "40.optimized.nocfs"
         };
 
@@ -178,7 +178,7 @@ namespace Lucene.Net.Index
         /// <summary>
         /// Randomizes the use of some of hte constructor variations
         /// </summary>
-        private IndexUpgrader NewIndexUpgrader(Directory dir)
+        private static IndexUpgrader NewIndexUpgrader(Directory dir)
         {
             bool streamType = Random.NextBoolean();
             int choice = TestUtil.NextInt32(Random, 0, 2);
@@ -256,9 +256,7 @@ namespace Lucene.Net.Index
                     reader = DirectoryReader.Open(dir);
                     Assert.Fail("DirectoryReader.open should not pass for " + unsupportedNames[i]);
                 }
-#pragma warning disable 168
-                catch (IndexFormatTooOldException e)
-#pragma warning restore 168
+                catch (IndexFormatTooOldException /*e*/)
                 {
                     // pass
                 }
@@ -310,7 +308,7 @@ namespace Lucene.Net.Index
                     indexStatus = checker.DoCheckIndex();
                 }
                 Assert.IsFalse(indexStatus.Clean);
-                Assert.IsTrue(sb.ToString().Contains(typeof(IndexFormatTooOldException).Name));
+                Assert.IsTrue(sb.ToString().Contains(nameof(IndexFormatTooOldException)));
 
                 dir.Dispose();
                 TestUtil.Rm(oldIndxeDir);
@@ -568,7 +566,8 @@ namespace Lucene.Net.Index
             reader.Dispose();
         }
 
-        private int Compare(string name, string v)
+        // LUCENENET-specific: made static
+        private static int Compare(string name, string v)
         {
             int v0 = Convert.ToInt32(name.Substring(0, 2));
             int v1 = Convert.ToInt32(v);
@@ -656,7 +655,8 @@ namespace Lucene.Net.Index
             mp.NoCFSRatio = doCFS ? 1.0 : 0.0;
             mp.MaxCFSSegmentSizeMB = double.PositiveInfinity;
             // TODO: remove randomness
-            IndexWriterConfig conf = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetUseCompoundFile(doCFS).SetMaxBufferedDocs(10).SetMergePolicy(mp);
+            IndexWriterConfig conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetUseCompoundFile(doCFS).SetMaxBufferedDocs(10).SetMergePolicy(mp);
             IndexWriter writer = new IndexWriter(dir, conf);
 
             for (int i = 0; i < 35; i++)
@@ -676,12 +676,14 @@ namespace Lucene.Net.Index
                 mp = new LogByteSizeMergePolicy();
                 mp.NoCFSRatio = doCFS ? 1.0 : 0.0;
                 // TODO: remove randomness
-                conf = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetUseCompoundFile(doCFS).SetMaxBufferedDocs(10).SetMergePolicy(mp);
+                conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetUseCompoundFile(doCFS).SetMaxBufferedDocs(10).SetMergePolicy(mp);
                 writer = new IndexWriter(dir, conf);
                 AddNoProxDoc(writer);
                 writer.Dispose();
 
-                conf = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetUseCompoundFile(doCFS).SetMaxBufferedDocs(10).SetMergePolicy(doCFS ? NoMergePolicy.COMPOUND_FILES : NoMergePolicy.NO_COMPOUND_FILES);
+                conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetUseCompoundFile(doCFS).SetMaxBufferedDocs(10).SetMergePolicy(doCFS ? NoMergePolicy.COMPOUND_FILES : NoMergePolicy.NO_COMPOUND_FILES);
                 writer = new IndexWriter(dir, conf);
                 Term searchTerm = new Term("id", "7");
                 writer.DeleteDocuments(searchTerm);
@@ -693,7 +695,8 @@ namespace Lucene.Net.Index
             return indexDir;
         }
 
-        private void AddDoc(IndexWriter writer, int id)
+        // LUCENENET-specific: made static
+        private static void AddDoc(IndexWriter writer, int id)
         {
             Document doc = new Document();
             doc.Add(new TextField("content", "aaa", Field.Store.NO));
@@ -746,7 +749,8 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        private void AddNoProxDoc(IndexWriter writer)
+        // LUCENENET-specific: made static
+        private static void AddNoProxDoc(IndexWriter writer)
         {
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);
@@ -761,7 +765,8 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        private int CountDocs(DocsEnum docs)
+        // LUCENENET-specific: made static
+        private static int CountDocs(DocsEnum docs)
         {
             int count = 0;
             while ((docs.NextDoc()) != DocIdSetIterator.NO_MORE_DOCS)
@@ -854,7 +859,6 @@ namespace Lucene.Net.Index
         {
             foreach (string name in oldNames)
             {
-
                 Directory dir = oldIndexDirs[name];
                 IndexReader reader = DirectoryReader.Open(dir);
                 IndexSearcher searcher = NewSearcher(reader);
@@ -873,6 +877,7 @@ namespace Lucene.Net.Index
                 }
 
                 // check that also lower-precision fields are ok
+                // LUCENENET-specific: renamed to hits_ to avoid conflict with local variable
                 ScoreDoc[] hits_ = searcher.Search(NumericRangeQuery.NewInt32Range("trieInt", 4, int.MinValue, int.MaxValue, false, false), 100).ScoreDocs;
                 Assert.AreEqual(34, hits_.Length, "wrong number of hits");
 
@@ -899,7 +904,8 @@ namespace Lucene.Net.Index
             }
         }
 
-        private int CheckAllSegmentsUpgraded(Directory dir)
+        // LUCENENET-specific: made static
+        private static int CheckAllSegmentsUpgraded(Directory dir)
         {
             SegmentInfos infos = new SegmentInfos();
             infos.Read(dir);
@@ -914,7 +920,8 @@ namespace Lucene.Net.Index
             return infos.Count;
         }
 
-        private int GetNumberOfSegments(Directory dir)
+        // LUCENENET-specific: made static
+        private static int GetNumberOfSegments(Directory dir)
         {
             SegmentInfos infos = new SegmentInfos();
             infos.Read(dir);
@@ -947,7 +954,6 @@ namespace Lucene.Net.Index
         [Slow]
         public virtual void TestCommandLineArgs()
         {
-
             foreach (string name in oldIndexDirs.Keys)
             {
                 DirectoryInfo dir = CreateTempDir(name);
@@ -1022,8 +1028,9 @@ namespace Lucene.Net.Index
                 for (int i = 0; i < 3; i++)
                 {
                     // only use Log- or TieredMergePolicy, to make document addition predictable and not suddenly merge:
-                    MergePolicy mp = Random.NextBoolean() ? (MergePolicy)NewLogMergePolicy() : NewTieredMergePolicy();
-                    IndexWriterConfig iwc = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMergePolicy(mp);
+                    MergePolicy mp = Random.NextBoolean() ? NewLogMergePolicy() : NewTieredMergePolicy();
+                    IndexWriterConfig iwc = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                        .SetMergePolicy(mp);
                     IndexWriter w = new IndexWriter(ramDir, iwc);
                     // add few more docs:
                     for (int j = 0; j < RandomMultiplier * Random.Next(30); j++)
@@ -1035,8 +1042,10 @@ namespace Lucene.Net.Index
 
                 // add dummy segments (which are all in current
                 // version) to single segment index
-                MergePolicy mp_ = Random.NextBoolean() ? (MergePolicy)NewLogMergePolicy() : NewTieredMergePolicy();
-                IndexWriterConfig iwc_ = (new IndexWriterConfig(TEST_VERSION_CURRENT, null)).SetMergePolicy(mp_);
+                // LUCENENET-specific: renamed variables to avoid conflict with ones above
+                MergePolicy mp_ = Random.NextBoolean() ? NewLogMergePolicy() : NewTieredMergePolicy();
+                IndexWriterConfig iwc_ = new IndexWriterConfig(TEST_VERSION_CURRENT, null)
+                    .SetMergePolicy(mp_);
                 IndexWriter iw = new IndexWriter(dir, iwc_);
                 iw.AddIndexes(ramDir);
                 iw.Dispose(false);

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
@@ -566,8 +566,7 @@ namespace Lucene.Net.Index
             reader.Dispose();
         }
 
-        // LUCENENET-specific: made static
-        private static int Compare(string name, string v)
+        private int Compare(string name, string v)
         {
             int v0 = Convert.ToInt32(name.Substring(0, 2));
             int v1 = Convert.ToInt32(v);
@@ -695,8 +694,7 @@ namespace Lucene.Net.Index
             return indexDir;
         }
 
-        // LUCENENET-specific: made static
-        private static void AddDoc(IndexWriter writer, int id)
+        private void AddDoc(IndexWriter writer, int id)
         {
             Document doc = new Document();
             doc.Add(new TextField("content", "aaa", Field.Store.NO));
@@ -749,8 +747,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        // LUCENENET-specific: made static
-        private static void AddNoProxDoc(IndexWriter writer)
+        private void AddNoProxDoc(IndexWriter writer)
         {
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);
@@ -765,8 +762,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        // LUCENENET-specific: made static
-        private static int CountDocs(DocsEnum docs)
+        private int CountDocs(DocsEnum docs)
         {
             int count = 0;
             while ((docs.NextDoc()) != DocIdSetIterator.NO_MORE_DOCS)
@@ -904,8 +900,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        // LUCENENET-specific: made static
-        private static int CheckAllSegmentsUpgraded(Directory dir)
+        private int CheckAllSegmentsUpgraded(Directory dir)
         {
             SegmentInfos infos = new SegmentInfos();
             infos.Read(dir);
@@ -920,8 +915,7 @@ namespace Lucene.Net.Index
             return infos.Count;
         }
 
-        // LUCENENET-specific: made static
-        private static int GetNumberOfSegments(Directory dir)
+        private int GetNumberOfSegments(Directory dir)
         {
             SegmentInfos infos = new SegmentInfos();
             infos.Read(dir);

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
@@ -389,8 +389,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        // LUCENENET-specific: made static
-        private static void DoTestHits(ScoreDoc[] hits, int expectedCount, IndexReader reader)
+        private void DoTestHits(ScoreDoc[] hits, int expectedCount, IndexReader reader)
         {
             int hitCount = hits.Length;
             Assert.AreEqual(expectedCount, hitCount, "wrong number of hits");
@@ -533,8 +532,7 @@ namespace Lucene.Net.Index
             reader.Dispose();
         }
 
-        // LUCENENET specific - made static
-        private static int Compare(string name, string v)
+        private int Compare(string name, string v)
         {
             int v0 = Convert.ToInt32(name.Substring(0, 2));
             int v1 = Convert.ToInt32(v);
@@ -662,8 +660,7 @@ namespace Lucene.Net.Index
             return indexDir;
         }
 
-        // LUCENENET specific - made static
-        private static void AddDoc(IndexWriter writer, int id)
+        private void AddDoc(IndexWriter writer, int id)
         {
             Document doc = new Document();
             doc.Add(new TextField("content", "aaa", Field.Store.NO));
@@ -715,8 +712,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        // LUCENENET specific - made static
-        private static void AddNoProxDoc(IndexWriter writer)
+        private void AddNoProxDoc(IndexWriter writer)
         {
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);
@@ -731,8 +727,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        // LUCEENET specific - made static
-        private static int CountDocs(DocsEnum docs)
+        private int CountDocs(DocsEnum docs)
         {
             int count = 0;
             while ((docs.NextDoc()) != DocIdSetIterator.NO_MORE_DOCS)
@@ -870,8 +865,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        // LUCENENET specific - made static
-        private static int CheckAllSegmentsUpgraded(Directory dir)
+        private int CheckAllSegmentsUpgraded(Directory dir)
         {
             SegmentInfos infos = new SegmentInfos();
             infos.Read(dir);
@@ -886,8 +880,7 @@ namespace Lucene.Net.Index
             return infos.Count;
         }
 
-        // LUCENENET specific - made static
-        private static int GetNumberOfSegments(Directory dir)
+        private int GetNumberOfSegments(Directory dir)
         {
             SegmentInfos infos = new SegmentInfos();
             infos.Read(dir);

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
@@ -113,18 +113,36 @@ namespace Lucene.Net.Index
         internal const string CURRENT_RESOURCE_DIRECTORY = "Lucene.Net.Tests.Index.";
 
         internal static readonly string[] oldNames = {
-            "30.cfs", "30.nocfs", "31.cfs", "31.nocfs", "32.cfs",
-            "32.nocfs", "34.cfs", "34.nocfs"
+            "30.cfs",
+            "30.nocfs",
+            "31.cfs",
+            "31.nocfs",
+            "32.cfs",
+            "32.nocfs",
+            "34.cfs",
+            "34.nocfs"
         };
 
         internal readonly string[] unsupportedNames = {
-            "19.cfs", "19.nocfs", "20.cfs", "20.nocfs", "21.cfs",
-            "21.nocfs", "22.cfs", "22.nocfs", "23.cfs", "23.nocfs",
-            "24.cfs", "24.nocfs", "29.cfs", "29.nocfs"
+            "19.cfs",
+            "19.nocfs",
+            "20.cfs",
+            "20.nocfs",
+            "21.cfs",
+            "21.nocfs",
+            "22.cfs",
+            "22.nocfs",
+            "23.cfs",
+            "23.nocfs",
+            "24.cfs",
+            "24.nocfs",
+            "29.cfs",
+            "29.nocfs"
         };
 
         internal static readonly string[] oldSingleSegmentNames = {
-            "31.optimized.cfs", "31.optimized.nocfs"
+            "31.optimized.cfs",
+            "31.optimized.nocfs"
         };
 
         internal static IDictionary<string, Directory> oldIndexDirs;
@@ -232,7 +250,7 @@ namespace Lucene.Net.Index
                     writer = null;
                 }
 
-                StringBuilder bos = new StringBuilder();
+                StringBuilder bos = new StringBuilder(512); // LUCENENET specific: allocating 512 chars instead of 1024 bytes
                 CheckIndex checker = new CheckIndex(dir);
                 checker.InfoStream = new StringWriter(bos);
                 CheckIndex.Status indexStatus = checker.DoCheckIndex();

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
@@ -36,7 +36,6 @@ namespace Lucene.Net.Index
     using BytesRef = Lucene.Net.Util.BytesRef;
     using Constants = Lucene.Net.Util.Constants;
     using Directory = Lucene.Net.Store.Directory;
-    //using IndexOptions = Lucene.Net.Index.IndexOptions;
     using DocIdSetIterator = Lucene.Net.Search.DocIdSetIterator;
     using Document = Lucene.Net.Documents.Document;
     using DoubleDocValuesField = Lucene.Net.Documents.DoubleDocValuesField;
@@ -113,18 +112,18 @@ namespace Lucene.Net.Index
         // LUCENENET specific to load resources for this type
         internal const string CURRENT_RESOURCE_DIRECTORY = "Lucene.Net.Tests.Index.";
 
-        internal static readonly string[] oldNames = new string[] {
+        internal static readonly string[] oldNames = {
             "30.cfs", "30.nocfs", "31.cfs", "31.nocfs", "32.cfs",
             "32.nocfs", "34.cfs", "34.nocfs"
         };
 
-        internal readonly string[] unsupportedNames = new string[] {
+        internal readonly string[] unsupportedNames = {
             "19.cfs", "19.nocfs", "20.cfs", "20.nocfs", "21.cfs",
             "21.nocfs", "22.cfs", "22.nocfs", "23.cfs", "23.nocfs",
             "24.cfs", "24.nocfs", "29.cfs", "29.nocfs"
         };
 
-        internal static readonly string[] oldSingleSegmentNames = new string[] {
+        internal static readonly string[] oldSingleSegmentNames = {
             "31.optimized.cfs", "31.optimized.nocfs"
         };
 
@@ -189,9 +188,7 @@ namespace Lucene.Net.Index
                     reader = DirectoryReader.Open(dir);
                     Assert.Fail("DirectoryReader.open should not pass for " + unsupportedNames[i]);
                 }
-#pragma warning disable 168
-                catch (IndexFormatTooOldException e)
-#pragma warning restore 168
+                catch (IndexFormatTooOldException /*e*/)
                 {
                     // pass
                 }
@@ -206,7 +203,8 @@ namespace Lucene.Net.Index
 
                 try
                 {
-                    writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
+                    writer = new IndexWriter(dir,
+                        NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
                     Assert.Fail("IndexWriter creation should not pass for " + unsupportedNames[i]);
                 }
                 catch (IndexFormatTooOldException e)
@@ -240,7 +238,7 @@ namespace Lucene.Net.Index
                 CheckIndex.Status indexStatus = checker.DoCheckIndex();
                 Assert.IsFalse(indexStatus.Clean);
                 checker.InfoStream.Flush();
-                Assert.IsTrue(bos.ToString().Contains(typeof(IndexFormatTooOldException).Name));
+                Assert.IsTrue(bos.ToString().Contains(nameof(IndexFormatTooOldException)));
 
                 dir.Dispose();
             }
@@ -256,7 +254,8 @@ namespace Lucene.Net.Index
                     Console.WriteLine("\nTEST: index=" + name);
                 }
                 Directory dir = NewDirectory(oldIndexDirs[name]);
-                IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
+                IndexWriter w = new IndexWriter(dir,
+                    new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
                 w.ForceMerge(1);
                 w.Dispose();
 
@@ -274,7 +273,8 @@ namespace Lucene.Net.Index
                     Console.WriteLine("\nTEST: old index " + name);
                 }
                 Directory targetDir = NewDirectory();
-                IndexWriter w = new IndexWriter(targetDir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
+                IndexWriter w = new IndexWriter(targetDir,
+                    NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
                 w.AddIndexes(oldIndexDirs[name]);
                 if (Verbose)
                 {
@@ -294,7 +294,8 @@ namespace Lucene.Net.Index
                 IndexReader reader = DirectoryReader.Open(oldIndexDirs[name]);
 
                 Directory targetDir = NewDirectory();
-                IndexWriter w = new IndexWriter(targetDir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
+                IndexWriter w = new IndexWriter(targetDir,
+                    NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
                 w.AddIndexes(reader);
                 w.Dispose();
                 reader.Dispose();
@@ -388,7 +389,8 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void DoTestHits(ScoreDoc[] hits, int expectedCount, IndexReader reader)
+        // LUCENENET-specific: made static
+        private static void DoTestHits(ScoreDoc[] hits, int expectedCount, IndexReader reader)
         {
             int hitCount = hits.Length;
             Assert.AreEqual(expectedCount, hitCount, "wrong number of hits");
@@ -531,7 +533,8 @@ namespace Lucene.Net.Index
             reader.Dispose();
         }
 
-        private int Compare(string name, string v)
+        // LUCENENET specific - made static
+        private static int Compare(string name, string v)
         {
             int v0 = Convert.ToInt32(name.Substring(0, 2));
             int v1 = Convert.ToInt32(v);
@@ -619,7 +622,8 @@ namespace Lucene.Net.Index
             mp.NoCFSRatio = doCFS ? 1.0 : 0.0;
             mp.MaxCFSSegmentSizeMB = double.PositiveInfinity;
             // TODO: remove randomness
-            IndexWriterConfig conf = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMaxBufferedDocs(10).SetMergePolicy(mp).SetUseCompoundFile(doCFS);
+            IndexWriterConfig conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(10).SetMergePolicy(mp).SetUseCompoundFile(doCFS);
             IndexWriter writer = new IndexWriter(dir, conf);
 
             for (int i = 0; i < 35; i++)
@@ -639,12 +643,15 @@ namespace Lucene.Net.Index
                 mp = new LogByteSizeMergePolicy();
                 mp.NoCFSRatio = doCFS ? 1.0 : 0.0;
                 // TODO: remove randomness
-                conf = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMaxBufferedDocs(10).SetMergePolicy(mp).SetUseCompoundFile(doCFS);
+                conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetMaxBufferedDocs(10).SetMergePolicy(mp).SetUseCompoundFile(doCFS);
                 writer = new IndexWriter(dir, conf);
                 AddNoProxDoc(writer);
                 writer.Dispose();
 
-                writer = new IndexWriter(dir, conf.SetMergePolicy(doCFS ? NoMergePolicy.COMPOUND_FILES : NoMergePolicy.NO_COMPOUND_FILES));
+                writer = new IndexWriter(dir,
+                    conf.SetMergePolicy(doCFS ? NoMergePolicy.COMPOUND_FILES : NoMergePolicy.NO_COMPOUND_FILES)
+                );
                 Term searchTerm = new Term("id", "7");
                 writer.DeleteDocuments(searchTerm);
                 writer.Dispose();
@@ -655,7 +662,8 @@ namespace Lucene.Net.Index
             return indexDir;
         }
 
-        private void AddDoc(IndexWriter writer, int id)
+        // LUCENENET specific - made static
+        private static void AddDoc(IndexWriter writer, int id)
         {
             Document doc = new Document();
             doc.Add(new TextField("content", "aaa", Field.Store.NO));
@@ -707,7 +715,8 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        private void AddNoProxDoc(IndexWriter writer)
+        // LUCENENET specific - made static
+        private static void AddNoProxDoc(IndexWriter writer)
         {
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);
@@ -722,7 +731,8 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        private int CountDocs(DocsEnum docs)
+        // LUCEENET specific - made static
+        private static int CountDocs(DocsEnum docs)
         {
             int count = 0;
             while ((docs.NextDoc()) != DocIdSetIterator.NO_MORE_DOCS)
@@ -816,7 +826,6 @@ namespace Lucene.Net.Index
         {
             foreach (string name in oldNames)
             {
-
                 Directory dir = oldIndexDirs[name];
                 IndexReader reader = DirectoryReader.Open(dir);
                 IndexSearcher searcher = new IndexSearcher(reader);
@@ -861,7 +870,8 @@ namespace Lucene.Net.Index
             }
         }
 
-        private int CheckAllSegmentsUpgraded(Directory dir)
+        // LUCENENET specific - made static
+        private static int CheckAllSegmentsUpgraded(Directory dir)
         {
             SegmentInfos infos = new SegmentInfos();
             infos.Read(dir);
@@ -876,7 +886,8 @@ namespace Lucene.Net.Index
             return infos.Count;
         }
 
-        private int GetNumberOfSegments(Directory dir)
+        // LUCENENET specific - made static
+        private static int GetNumberOfSegments(Directory dir)
         {
             SegmentInfos infos = new SegmentInfos();
             infos.Read(dir);
@@ -897,7 +908,8 @@ namespace Lucene.Net.Index
                 }
                 Directory dir = NewDirectory(oldIndexDirs[name]);
 
-                (new IndexUpgrader(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, null), false)).Upgrade();
+                new IndexUpgrader(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, null), false)
+                    .Upgrade();
 
                 CheckAllSegmentsUpgraded(dir);
 
@@ -924,8 +936,9 @@ namespace Lucene.Net.Index
                 for (int i = 0; i < 3; i++)
                 {
                     // only use Log- or TieredMergePolicy, to make document addition predictable and not suddenly merge:
-                    MergePolicy mp = Random.NextBoolean() ? (MergePolicy)NewLogMergePolicy() : NewTieredMergePolicy();
-                    IndexWriterConfig iwc = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMergePolicy(mp);
+                    MergePolicy mp = Random.NextBoolean() ? NewLogMergePolicy() : NewTieredMergePolicy();
+                    IndexWriterConfig iwc = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                        .SetMergePolicy(mp);
                     IndexWriter w = new IndexWriter(ramDir, iwc);
                     // add few more docs:
                     for (int j = 0; j < RandomMultiplier * Random.Next(30); j++)
@@ -937,8 +950,9 @@ namespace Lucene.Net.Index
 
                 // add dummy segments (which are all in current
                 // version) to single segment index
-                MergePolicy mp_ = Random.NextBoolean() ? (MergePolicy)NewLogMergePolicy() : NewTieredMergePolicy();
-                IndexWriterConfig iwc_ = (new IndexWriterConfig(TEST_VERSION_CURRENT, null)).SetMergePolicy(mp_);
+                MergePolicy mp_ = Random.NextBoolean() ? NewLogMergePolicy() : NewTieredMergePolicy();
+                IndexWriterConfig iwc_ = new IndexWriterConfig(TEST_VERSION_CURRENT, null)
+                    .SetMergePolicy(mp_);
                 IndexWriter w_ = new IndexWriter(dir, iwc_);
                 w_.AddIndexes(ramDir);
                 w_.Dispose(false);
@@ -946,7 +960,8 @@ namespace Lucene.Net.Index
                 // determine count of segments in modified index
                 int origSegCount = GetNumberOfSegments(dir);
 
-                (new IndexUpgrader(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, null), false)).Upgrade();
+                new IndexUpgrader(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, null), false)
+                    .Upgrade();
 
                 int segCount = CheckAllSegmentsUpgraded(dir);
                 Assert.AreEqual(origSegCount, segCount, "Index must still contain the same number of segments, as only one segment was upgraded and nothing else merged");

--- a/src/Lucene.Net.Tests/Index/TestBagOfPositions.cs
+++ b/src/Lucene.Net.Tests/Index/TestBagOfPositions.cs
@@ -33,7 +33,6 @@ namespace Lucene.Net.Index
      * limitations under the License.
      */
 
-    using BytesRef = Lucene.Net.Util.BytesRef;
     using Directory = Lucene.Net.Store.Directory;
     using Document = Documents.Document;
     using Field = Field;
@@ -51,7 +50,6 @@ namespace Lucene.Net.Index
                                                      // Lucene3x doesnt have totalTermFreq, so the test isn't interesting there.
     [TestFixture]
     public class TestBagOfPositions : LuceneTestCase
-    
     {
         [Test]
         [Slow]
@@ -128,7 +126,7 @@ namespace Lucene.Net.Index
                 Document document = new Document();
                 Field field = new Field("field", "", fieldType);
                 document.Add(field);
-                threads[threadID] = new ThreadAnonymousClass(this, numTerms, maxTermsPerDoc, postings, iw, startingGun, threadRandom, document, field);
+                threads[threadID] = new ThreadAnonymousClass(maxTermsPerDoc, postings, iw, startingGun, threadRandom, document, field);
                 threads[threadID].Start();
             }
             startingGun.Signal();
@@ -160,9 +158,6 @@ namespace Lucene.Net.Index
 
         private sealed class ThreadAnonymousClass : ThreadJob
         {
-            private readonly TestBagOfPositions outerInstance;
-
-            private readonly int numTerms;
             private readonly int maxTermsPerDoc;
             private readonly ConcurrentQueue<string> postings;
             private readonly RandomIndexWriter iw;
@@ -171,10 +166,8 @@ namespace Lucene.Net.Index
             private readonly Document document;
             private readonly Field field;
 
-            public ThreadAnonymousClass(TestBagOfPositions outerInstance, int numTerms, int maxTermsPerDoc, ConcurrentQueue<string> postings, RandomIndexWriter iw, CountdownEvent startingGun, Random threadRandom, Document document, Field field)
+            public ThreadAnonymousClass(int maxTermsPerDoc, ConcurrentQueue<string> postings, RandomIndexWriter iw, CountdownEvent startingGun, Random threadRandom, Document document, Field field)
             {
-                this.outerInstance = outerInstance;
-                this.numTerms = numTerms;
                 this.maxTermsPerDoc = maxTermsPerDoc;
                 this.postings = postings;
                 this.iw = iw;
@@ -189,7 +182,7 @@ namespace Lucene.Net.Index
                 try
                 {
                     startingGun.Wait();
-                    while (!(postings.Count == 0))
+                    while (!postings.IsEmpty)
                     {
                         StringBuilder text = new StringBuilder();
                         int numTerms = threadRandom.Next(maxTermsPerDoc);

--- a/src/Lucene.Net.Tests/Index/TestBagOfPostings.cs
+++ b/src/Lucene.Net.Tests/Index/TestBagOfPostings.cs
@@ -32,7 +32,6 @@ namespace Lucene.Net.Index
      * limitations under the License.
      */
 
-    using BytesRef = Lucene.Net.Util.BytesRef;
     using Directory = Lucene.Net.Store.Directory;
     using Document = Documents.Document;
     using Field = Field;
@@ -102,7 +101,7 @@ namespace Lucene.Net.Index
 
             for (int threadID = 0; threadID < threadCount; threadID++)
             {
-                threads[threadID] = new ThreadAnonymousClass(this, maxTermsPerDoc, postings, iw, startingGun);
+                threads[threadID] = new ThreadAnonymousClass(maxTermsPerDoc, postings, iw, startingGun);
                 threads[threadID].Start();
             }
             startingGun.Signal();
@@ -140,16 +139,13 @@ namespace Lucene.Net.Index
 
         private sealed class ThreadAnonymousClass : ThreadJob
         {
-            private readonly TestBagOfPostings outerInstance;
-
             private readonly int maxTermsPerDoc;
             private readonly ConcurrentQueue<string> postings;
             private readonly RandomIndexWriter iw;
             private readonly CountdownEvent startingGun;
 
-            public ThreadAnonymousClass(TestBagOfPostings outerInstance, int maxTermsPerDoc, ConcurrentQueue<string> postings, RandomIndexWriter iw, CountdownEvent startingGun)
+            public ThreadAnonymousClass(int maxTermsPerDoc, ConcurrentQueue<string> postings, RandomIndexWriter iw, CountdownEvent startingGun)
             {
-                this.outerInstance = outerInstance;
                 this.maxTermsPerDoc = maxTermsPerDoc;
                 this.postings = postings;
                 this.iw = iw;
@@ -164,7 +160,7 @@ namespace Lucene.Net.Index
                     Field field = NewTextField("field", "", Field.Store.NO);
                     document.Add(field);
                     startingGun.Wait();
-                    while (!(postings.Count == 0))
+                    while (!postings.IsEmpty)
                     {
                         StringBuilder text = new StringBuilder();
                         ISet<string> visited = new JCG.HashSet<string>();

--- a/src/Lucene.Net.Tests/Index/TestBinaryDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/Index/TestBinaryDocValuesUpdates.cs
@@ -97,8 +97,7 @@ namespace Lucene.Net.Index
             return bytes;
         }
 
-        // LUCENENET-specific: made static
-        private static Document Doc(int id)
+        private Document Doc(int id)
         {
             Document doc = new Document();
             doc.Add(new StringField("id", "doc-" + id, Store.NO));

--- a/src/Lucene.Net.Tests/Index/TestBinaryDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/Index/TestBinaryDocValuesUpdates.cs
@@ -1146,9 +1146,13 @@ namespace Lucene.Net.Index
             {
                 writer.Dispose();
                 Assert.Fail("should not have succeeded to update a segment written with an old Codec");
-            } catch (Exception e) when (e.IsUnsupportedOperationException()) {
+            }
+            catch (Exception e) when (e.IsUnsupportedOperationException())
+            {
                 writer.Rollback();
-            } finally {
+            }
+            finally
+            {
                 OldFormatImpersonationIsActive = oldValue;
             }
 

--- a/src/Lucene.Net.Tests/Index/TestBinaryDocValuesUpdates.cs
+++ b/src/Lucene.Net.Tests/Index/TestBinaryDocValuesUpdates.cs
@@ -1142,7 +1142,8 @@ namespace Lucene.Net.Index
             writer = new IndexWriter(dir, conf);
             writer.UpdateBinaryDocValue(new Term("id", "doc"), "f", ToBytes(4L));
             OldFormatImpersonationIsActive = false;
-            try {
+            try
+            {
                 writer.Dispose();
                 Assert.Fail("should not have succeeded to update a segment written with an old Codec");
             } catch (Exception e) when (e.IsUnsupportedOperationException()) {

--- a/src/Lucene.Net.Tests/Index/TestBinaryTerms.cs
+++ b/src/Lucene.Net.Tests/Index/TestBinaryTerms.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestToString()
         {
-            Term term = new Term("foo", new BytesRef(new[] { unchecked((byte)0xff), unchecked((byte)0xfe) }));
+            Term term = new Term("foo", new BytesRef(new[] { (byte)0xff, (byte)0xfe }));
             Assert.AreEqual("foo:[ff fe]", term.ToString());
         }
     }

--- a/src/Lucene.Net.Tests/Index/TestByteSlices.cs
+++ b/src/Lucene.Net.Tests/Index/TestByteSlices.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using RandomizedTesting.Generators;
-using System;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 
@@ -36,7 +35,7 @@ namespace Lucene.Net.Index
             // LUCENENET specific: NUnit will crash with an OOM if we do the full test
             // with verbosity enabled. So, making this a manual setting that can be
             // turned on if, and only if, needed for debugging. If the setting is turned
-            // on, we are decresing the number of iterations by 1/3, which seems to
+            // on, we are decreasing the number of iterations by 1/3, which seems to
             // keep it from crashing.
             bool isVerbose = false;
             if (!isVerbose)

--- a/src/Lucene.Net.Tests/Index/TestCheckIndex.cs
+++ b/src/Lucene.Net.Tests/Index/TestCheckIndex.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Index
         public virtual void TestDeletedDocs()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2));
             for (int i = 0; i < 19; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/Index/TestCodecHoldsOpenFiles.cs
+++ b/src/Lucene.Net.Tests/Index/TestCodecHoldsOpenFiles.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Documents;
 using NUnit.Framework;
 using System;
-using System.IO;
 
 namespace Lucene.Net.Index
 {
@@ -76,7 +75,7 @@ namespace Lucene.Net.Index
             Directory d = NewDirectory();
             RandomIndexWriter w = new RandomIndexWriter(Random, d);
             //int numDocs = AtLeast(100);
-            int numDocs = 5;
+            const int numDocs = 5;
             for (int i = 0; i < numDocs; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/Index/TestCompoundFile.cs
+++ b/src/Lucene.Net.Tests/Index/TestCompoundFile.cs
@@ -58,7 +58,8 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// Creates a file of the specified size with random data. </summary>
+        /// Creates a file of the specified size with random data.
+        /// </summary>
         private void CreateRandomFile(Directory dir, string name, int size)
         {
             IndexOutput os = dir.CreateOutput(name, NewIOContext(Random));
@@ -72,8 +73,8 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Creates a file of the specified size with sequential data. The first
-        ///  byte is written as the start byte provided. All subsequent bytes are
-        ///  computed as start + offset where offset is the number of the byte.
+        /// byte is written as the start byte provided. All subsequent bytes are
+        /// computed as start + offset where offset is the number of the byte.
         /// </summary>
         private void CreateSequenceFile(Directory dir, string name, sbyte start, int size)
         {
@@ -160,8 +161,8 @@ namespace Lucene.Net.Index
         // ===========================================================
 
         /// <summary>
-        /// this test creates compound file based on a single file.
-        ///  Files of different sizes are tested: 0, 1, 10, 100 bytes.
+        /// This test creates compound file based on a single file.
+        /// Files of different sizes are tested: 0, 1, 10, 100 bytes.
         /// </summary>
         [Test]
         public virtual void TestSingleFile()
@@ -187,8 +188,7 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// this test creates compound file based on two files.
-        ///
+        /// This test creates compound file based on two files.
         /// </summary>
         [Test]
         public virtual void TestTwoFiles()
@@ -219,18 +219,18 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// this test creates a compound file based on a large number of files of
-        ///  various length. The file content is generated randomly. The sizes range
-        ///  from 0 to 1Mb. Some of the sizes are selected to test the buffering
-        ///  logic in the file reading code. For this the chunk variable is set to
-        ///  the length of the buffer used internally by the compound file logic.
+        /// This test creates a compound file based on a large number of files of
+        /// various length. The file content is generated randomly. The sizes range
+        /// from 0 to 1Mb. Some of the sizes are selected to test the buffering
+        /// logic in the file reading code. For this the chunk variable is set to
+        /// the length of the buffer used internally by the compound file logic.
         /// </summary>
         [Test]
         public virtual void TestRandomFiles()
         {
             // Setup the test segment
-            string segment = "test";
-            int chunk = 1024; // internal buffer size used by the stream
+            const string segment = "test";
+            const int chunk = 1024; // internal buffer size used by the stream
             CreateRandomFile(dir, segment + ".zero", 0);
             CreateRandomFile(dir, segment + ".one", 1);
             CreateRandomFile(dir, segment + ".ten", 10);
@@ -250,7 +250,11 @@ namespace Lucene.Net.Index
 
             // Now test
             CompoundFileDirectory csw = new CompoundFileDirectory(dir, "test.cfs", NewIOContext(Random), true);
-            string[] data = new string[] { ".zero", ".one", ".ten", ".hundred", ".big1", ".big2", ".big3", ".big4", ".big5", ".big6", ".big7" };
+            string[] data = new string[]
+            {
+                ".zero", ".one", ".ten", ".hundred", ".big1", ".big2", ".big3",
+                ".big4", ".big5", ".big6", ".big7"
+            };
             for (int i = 0; i < data.Length; i++)
             {
                 string fileName = segment + data[i];
@@ -273,9 +277,9 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Setup a larger compound file with a number of components, each of
-        ///  which is a sequential file (so that we can easily tell that we are
-        ///  reading in the right byte). The methods sets up 20 files - f0 to f19,
-        ///  the size of each file is 1000 bytes.
+        /// which is a sequential file (so that we can easily tell that we are
+        /// reading in the right byte). The methods sets up 20 files - f0 to f19,
+        /// the size of each file is 1000 bytes.
         /// </summary>
         private void SetUp_2()
         {
@@ -382,8 +386,8 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// this test opens two files from a compound stream and verifies that
-        ///  their file positions are independent of each other.
+        /// This test opens two files from a compound stream and verifies that
+        /// their file positions are independent of each other.
         /// </summary>
         [Test]
         public virtual void TestRandomAccess()
@@ -464,8 +468,8 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// this test opens two files from a compound stream and verifies that
-        ///  their file positions are independent of each other.
+        /// This test opens two files from a compound stream and verifies that
+        /// their file positions are independent of each other.
         /// </summary>
         [Test]
         public virtual void TestRandomAccessClones()
@@ -611,7 +615,7 @@ namespace Lucene.Net.Index
         public virtual void TestLargeWrites()
         {
             IndexOutput os = dir.CreateOutput("testBufferStart.txt", NewIOContext(Random));
-            
+
             var largeBuf = new byte[2048];
             for (int i = 0; i < largeBuf.Length; i++)
             {

--- a/src/Lucene.Net.Tests/Index/TestConsistentFieldNumbers.cs
+++ b/src/Lucene.Net.Tests/Index/TestConsistentFieldNumbers.cs
@@ -165,7 +165,9 @@ namespace Lucene.Net.Index
             {
                 Directory dir = NewDirectory();
                 {
-                    IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(NoMergePolicy.NO_COMPOUND_FILES));
+                    IndexWriter writer = new IndexWriter(dir,
+                        NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                            .SetMergePolicy(NoMergePolicy.NO_COMPOUND_FILES));
                     Document d = new Document();
                     d.Add(new TextField("f1", "d1 first field", Field.Store.YES));
                     d.Add(new TextField("f2", "d1 second field", Field.Store.YES));
@@ -180,7 +182,9 @@ namespace Lucene.Net.Index
                 }
 
                 {
-                    IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(Random.NextBoolean() ? NoMergePolicy.NO_COMPOUND_FILES : NoMergePolicy.COMPOUND_FILES));
+                    IndexWriter writer = new IndexWriter(dir,
+                        NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                            .SetMergePolicy(Random.NextBoolean() ? NoMergePolicy.NO_COMPOUND_FILES : NoMergePolicy.COMPOUND_FILES));
                     Document d = new Document();
                     d.Add(new TextField("f1", "d2 first field", Field.Store.YES));
                     d.Add(new StoredField("f3", new byte[] { 1, 2, 3 }));
@@ -199,7 +203,9 @@ namespace Lucene.Net.Index
                 }
 
                 {
-                    IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(Random.NextBoolean() ? NoMergePolicy.NO_COMPOUND_FILES : NoMergePolicy.COMPOUND_FILES));
+                    IndexWriter writer = new IndexWriter(dir,
+                        NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                            .SetMergePolicy(Random.NextBoolean() ? NoMergePolicy.NO_COMPOUND_FILES : NoMergePolicy.COMPOUND_FILES));
                     Document d = new Document();
                     d.Add(new TextField("f1", "d3 first field", Field.Store.YES));
                     d.Add(new TextField("f2", "d3 second field", Field.Store.YES));
@@ -223,7 +229,9 @@ namespace Lucene.Net.Index
                 }
 
                 {
-                    IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(Random.NextBoolean() ? NoMergePolicy.NO_COMPOUND_FILES : NoMergePolicy.COMPOUND_FILES));
+                    IndexWriter writer = new IndexWriter(dir,
+                        NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                            .SetMergePolicy(Random.NextBoolean() ? NoMergePolicy.NO_COMPOUND_FILES : NoMergePolicy.COMPOUND_FILES));
                     writer.DeleteDocuments(new Term("f1", "d1"));
                     // nuke the first segment entirely so that the segment with gaps is
                     // loaded first!
@@ -231,7 +239,10 @@ namespace Lucene.Net.Index
                     writer.Dispose();
                 }
 
-                IndexWriter writer_ = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(new LogByteSizeMergePolicy()).SetInfoStream(new FailOnNonBulkMergesInfoStream()));
+                IndexWriter writer_ = new IndexWriter(dir,
+                    NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                        .SetMergePolicy(new LogByteSizeMergePolicy())
+                        .SetInfoStream(new FailOnNonBulkMergesInfoStream()));
                 writer_.ForceMerge(1);
                 writer_.Dispose();
 

--- a/src/Lucene.Net.Tests/Index/TestCrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestCrash.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Index
             Directory dir2 = NewDirectory(dir);
             dir.Dispose();
 
-            (new RandomIndexWriter(Random, dir2)).Dispose();
+            new RandomIndexWriter(Random, dir2).Dispose();
             dir2.Dispose();
         }
 
@@ -141,7 +141,7 @@ namespace Lucene.Net.Index
             Directory dir2 = NewDirectory(dir);
             dir.Dispose();
 
-            (new RandomIndexWriter(Random, dir2)).Dispose();
+            new RandomIndexWriter(Random, dir2).Dispose();
             dir2.Dispose();
         }
 
@@ -179,7 +179,7 @@ namespace Lucene.Net.Index
             Directory dir2 = NewDirectory(dir);
             dir.Dispose();
 
-            (new RandomIndexWriter(Random, dir2)).Dispose();
+            new RandomIndexWriter(Random, dir2).Dispose();
             dir2.Dispose();
         }
 

--- a/src/Lucene.Net.Tests/Index/TestCrashCausesCorruptIndex.cs
+++ b/src/Lucene.Net.Tests/Index/TestCrashCausesCorruptIndex.cs
@@ -71,7 +71,8 @@ namespace Lucene.Net.Index
 
             // NOTE: cannot use RandomIndexWriter because it
             // sometimes commits:
-            IndexWriter indexWriter = new IndexWriter(crashAfterCreateOutput, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
+            IndexWriter indexWriter = new IndexWriter(crashAfterCreateOutput,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
 
             indexWriter.AddDocument(Document);
             // writes segments_1:
@@ -107,7 +108,8 @@ namespace Lucene.Net.Index
             // LUCENE-3627 (before the fix): this line fails because
             // it doesn't know what to do with the created but empty
             // segments_2 file
-            IndexWriter indexWriter = new IndexWriter(realDirectory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
+            IndexWriter indexWriter = new IndexWriter(realDirectory,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
 
             // currently the test fails above.
             // however, to test the fix, the following lines should pass as well.

--- a/src/Lucene.Net.Tests/Index/TestCustomNorms.cs
+++ b/src/Lucene.Net.Tests/Index/TestCustomNorms.cs
@@ -42,8 +42,8 @@ namespace Lucene.Net.Index
     [TestFixture]
     public class TestCustomNorms : LuceneTestCase
     {
-        internal readonly string floatTestField = "normsTestFloat";
-        internal readonly string exceptionTestField = "normsTestExcp";
+        internal const string floatTestField = "normsTestFloat";
+        internal const string exceptionTestField = "normsTestExcp";
 
         [Test]
         public virtual void TestFloatNorms()
@@ -53,7 +53,7 @@ namespace Lucene.Net.Index
             analyzer.MaxTokenLength = TestUtil.NextInt32(Random, 1, IndexWriter.MAX_TERM_LENGTH);
 
             IndexWriterConfig config = NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer);
-            Similarity provider = new MySimProvider(this);
+            Similarity provider = new MySimProvider();
             config.SetSimilarity(provider);
             RandomIndexWriter writer = new RandomIndexWriter(Random, dir, config);
             LineFileDocs docs = new LineFileDocs(Random);
@@ -92,13 +92,6 @@ namespace Lucene.Net.Index
 
         public class MySimProvider : PerFieldSimilarityWrapper
         {
-            private readonly TestCustomNorms outerInstance;
-
-            public MySimProvider(TestCustomNorms outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
             internal Similarity @delegate = new DefaultSimilarity();
 
             public override float QueryNorm(float sumOfSquaredWeights)
@@ -108,7 +101,7 @@ namespace Lucene.Net.Index
 
             public override Similarity Get(string field)
             {
-                if (outerInstance.floatTestField.Equals(field, StringComparison.Ordinal))
+                if (floatTestField.Equals(field, StringComparison.Ordinal))
                 {
                     return new FloatEncodingBoostSimilarity();
                 }

--- a/src/Lucene.Net.Tests/Index/TestDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestDeletionPolicy.cs
@@ -1,10 +1,8 @@
 ﻿using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
-using Lucene.Net.Support.Threading;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
@@ -40,11 +38,10 @@ namespace Lucene.Net.Index
     using TermQuery = Lucene.Net.Search.TermQuery;
     using TestUtil = Lucene.Net.Util.TestUtil;
 
-    /*
-      Verify we can read the pre-2.1 file format, do searches
-      against it, and add documents to it.
-    */
-
+    /// <summary>
+    /// Verify we can read the pre-2.1 file format, do searches
+    /// against it, and add documents to it.
+    /// </summary>
     [TestFixture]
     public class TestDeletionPolicy : LuceneTestCase
     {
@@ -100,7 +97,7 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// this is useful for adding to a big index when you know
+        /// This is useful for adding to a big index when you know
         /// readers are not using it.
         /// </summary>
         internal class KeepNoneOnInitDeletionPolicy : IndexDeletionPolicy
@@ -207,11 +204,10 @@ namespace Lucene.Net.Index
             return Convert.ToInt64(commit.UserData["commitTime"]);
         }
 
-        /*
-         * Delete a commit only when it has been obsoleted by N
-         * seconds.
-         */
-
+        /// <summary>
+        /// Delete a commit only when it has been obsoleted by N
+        /// seconds.
+        /// </summary>
         internal class ExpirationTimeDeletionPolicy : IndexDeletionPolicy
         {
             private readonly TestDeletionPolicy outerInstance;
@@ -258,17 +254,17 @@ namespace Lucene.Net.Index
             }
         }
 
-        /*
-         * Test "by time expiration" deletion policy:
-         */
-
+        /// <summary>
+        /// Test "by time expiration" deletion policy:
+        /// </summary>
         [Test]
         public virtual void TestExpirationTimeDeletionPolicy()
         {
             const double SECONDS = 2.0;
 
             Directory dir = NewDirectory();
-            IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(new ExpirationTimeDeletionPolicy(this, dir, SECONDS));
+            IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetIndexDeletionPolicy(new ExpirationTimeDeletionPolicy(this, dir, SECONDS));
             MergePolicy mp = conf.MergePolicy;
             mp.NoCFSRatio = 1.0;
             IndexWriter writer = new IndexWriter(dir, conf);
@@ -286,7 +282,9 @@ namespace Lucene.Net.Index
                 // Record last time when writer performed deletes of
                 // past commits
                 lastDeleteTime = J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond; // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
-                conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetIndexDeletionPolicy(policy);
+                conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.APPEND)
+                    .SetIndexDeletionPolicy(policy);
                 mp = conf.MergePolicy;
                 mp.NoCFSRatio = 1.0;
                 writer = new IndexWriter(dir, conf);
@@ -347,10 +345,9 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        /*
-         * Test a silly deletion policy that keeps all commits around.
-         */
-
+        /// <summary>
+        /// Test a silly deletion policy that keeps all commits around.
+        /// </summary>
         [Test]
         public virtual void TestKeepAllDeletionPolicy()
         {
@@ -365,7 +362,10 @@ namespace Lucene.Net.Index
 
                 Directory dir = NewDirectory();
 
-                IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(new KeepAllDeletionPolicy(this, dir)).SetMaxBufferedDocs(10).SetMergeScheduler(new SerialMergeScheduler());
+                IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetIndexDeletionPolicy(new KeepAllDeletionPolicy(this, dir))
+                    .SetMaxBufferedDocs(10)
+                    .SetMergeScheduler(new SerialMergeScheduler());
                 MergePolicy mp = conf.MergePolicy;
                 mp.NoCFSRatio = useCompoundFile ? 1.0 : 0.0;
                 IndexWriter writer = new IndexWriter(dir, conf);
@@ -384,7 +384,9 @@ namespace Lucene.Net.Index
                 }
                 if (needsMerging)
                 {
-                    conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetIndexDeletionPolicy(policy);
+                    conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                        .SetOpenMode(OpenMode.APPEND)
+                        .SetIndexDeletionPolicy(policy);
                     mp = conf.MergePolicy;
                     mp.NoCFSRatio = useCompoundFile ? 1.0 : 0.0;
                     if (Verbose)
@@ -444,16 +446,20 @@ namespace Lucene.Net.Index
             }
         }
 
-        /* Uses KeepAllDeletionPolicy to keep all commits around,
-         * then, opens a new IndexWriter on a previous commit
-         * point. */
-
+        /// <summary>
+        /// Uses KeepAllDeletionPolicy to keep all commits around,
+        /// then, opens a new IndexWriter on a previous commit
+        /// point.
+        /// </summary>
         [Test]
         public virtual void TestOpenPriorSnapshot()
         {
             Directory dir = NewDirectory();
 
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(new KeepAllDeletionPolicy(this, dir)).SetMaxBufferedDocs(2).SetMergePolicy(NewLogMergePolicy(10)));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetIndexDeletionPolicy(new KeepAllDeletionPolicy(this, dir))
+                .SetMaxBufferedDocs(2)
+                .SetMergePolicy(NewLogMergePolicy(10)));
             KeepAllDeletionPolicy policy = (KeepAllDeletionPolicy)writer.Config.IndexDeletionPolicy;
             for (int i = 0; i < 10; i++)
             {
@@ -478,7 +484,8 @@ namespace Lucene.Net.Index
             Assert.IsTrue(lastCommit != null);
 
             // Now add 1 doc and merge
-            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(policy));
+            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetIndexDeletionPolicy(policy));
             AddDoc(writer);
             Assert.AreEqual(11, writer.NumDocs);
             writer.ForceMerge(1);
@@ -487,7 +494,9 @@ namespace Lucene.Net.Index
             Assert.AreEqual(6, DirectoryReader.ListCommits(dir).Count);
 
             // Now open writer on the commit just before merge:
-            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(policy).SetIndexCommit(lastCommit));
+            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetIndexDeletionPolicy(policy)
+                .SetIndexCommit(lastCommit));
             Assert.AreEqual(10, writer.NumDocs);
 
             // Should undo our rollback:
@@ -499,7 +508,9 @@ namespace Lucene.Net.Index
             Assert.AreEqual(11, r.NumDocs);
             r.Dispose();
 
-            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(policy).SetIndexCommit(lastCommit));
+            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetIndexDeletionPolicy(policy)
+                .SetIndexCommit(lastCommit));
             Assert.AreEqual(10, writer.NumDocs);
             // Commits the rollback:
             writer.Dispose();
@@ -515,7 +526,8 @@ namespace Lucene.Net.Index
             r.Dispose();
 
             // Re-merge
-            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(policy));
+            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetIndexDeletionPolicy(policy));
             writer.ForceMerge(1);
             writer.Dispose();
 
@@ -526,7 +538,8 @@ namespace Lucene.Net.Index
 
             // Now open writer on the commit just before merging,
             // but this time keeping only the last commit:
-            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexCommit(lastCommit));
+            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetIndexCommit(lastCommit));
             Assert.AreEqual(10, writer.NumDocs);
 
             // Reader still sees fully merged index, because writer
@@ -547,11 +560,11 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        /* Test keeping NO commit points.  this is a viable and
-         * useful case eg where you want to build a big index and
-         * you know there are no readers.
-         */
-
+        /// <summary>
+        /// Test keeping NO commit points. This is a viable and
+        /// useful case eg where you want to build a big index and
+        /// you know there are no readers.
+        /// </summary>
         [Test]
         public virtual void TestKeepNoneOnInitDeletionPolicy()
         {
@@ -561,7 +574,10 @@ namespace Lucene.Net.Index
 
                 Directory dir = NewDirectory();
 
-                IndexWriterConfig conf = (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetIndexDeletionPolicy(new KeepNoneOnInitDeletionPolicy(this)).SetMaxBufferedDocs(10);
+                IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.CREATE)
+                    .SetIndexDeletionPolicy(new KeepNoneOnInitDeletionPolicy(this))
+                    .SetMaxBufferedDocs(10);
                 MergePolicy mp = conf.MergePolicy;
                 mp.NoCFSRatio = useCompoundFile ? 1.0 : 0.0;
                 IndexWriter writer = new IndexWriter(dir, conf);
@@ -572,7 +588,9 @@ namespace Lucene.Net.Index
                 }
                 writer.Dispose();
 
-                conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetIndexDeletionPolicy(policy);
+                conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.APPEND)
+                    .SetIndexDeletionPolicy(policy);
                 mp = conf.MergePolicy;
                 mp.NoCFSRatio = 1.0;
                 writer = new IndexWriter(dir, conf);
@@ -594,10 +612,9 @@ namespace Lucene.Net.Index
             }
         }
 
-        /*
-         * Test a deletion policy that keeps last N commits.
-         */
-
+        /// <summary>
+        /// Test a deletion policy that keeps last N commits.
+        /// </summary>
         [Test]
         public virtual void TestKeepLastNDeletionPolicy()
         {
@@ -612,7 +629,10 @@ namespace Lucene.Net.Index
                 KeepLastNDeletionPolicy policy = new KeepLastNDeletionPolicy(this, N);
                 for (int j = 0; j < N + 1; j++)
                 {
-                    IndexWriterConfig conf = (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetIndexDeletionPolicy(policy).SetMaxBufferedDocs(10);
+                    IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                        .SetOpenMode(OpenMode.CREATE)
+                        .SetIndexDeletionPolicy(policy)
+                        .SetMaxBufferedDocs(10);
                     MergePolicy mp = conf.MergePolicy;
                     mp.NoCFSRatio = useCompoundFile ? 1.0 : 0.0;
                     IndexWriter writer = new IndexWriter(dir, conf);
@@ -662,11 +682,10 @@ namespace Lucene.Net.Index
             }
         }
 
-        /*
-         * Test a deletion policy that keeps last N commits
-         * around, through creates.
-         */
-
+        /// <summary>
+        /// Test a deletion policy that keeps last N commits
+        /// around, through creates.
+        /// </summary>
         [Test]
         public virtual void TestKeepLastNDeletionPolicyWithCreates()
         {
@@ -677,7 +696,10 @@ namespace Lucene.Net.Index
                 bool useCompoundFile = (pass % 2) != 0;
 
                 Directory dir = NewDirectory();
-                IndexWriterConfig conf = (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetIndexDeletionPolicy(new KeepLastNDeletionPolicy(this, N)).SetMaxBufferedDocs(10);
+                IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetOpenMode(OpenMode.CREATE)
+                    .SetIndexDeletionPolicy(new KeepLastNDeletionPolicy(this, N))
+                    .SetMaxBufferedDocs(10);
                 MergePolicy mp = conf.MergePolicy;
                 mp.NoCFSRatio = useCompoundFile ? 1.0 : 0.0;
                 IndexWriter writer = new IndexWriter(dir, conf);
@@ -688,7 +710,10 @@ namespace Lucene.Net.Index
 
                 for (int i = 0; i < N + 1; i++)
                 {
-                    conf = (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetIndexDeletionPolicy(policy).SetMaxBufferedDocs(10);
+                    conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                        .SetOpenMode(OpenMode.APPEND)
+                        .SetIndexDeletionPolicy(policy)
+                        .SetMaxBufferedDocs(10);
                     mp = conf.MergePolicy;
                     mp.NoCFSRatio = useCompoundFile ? 1.0 : 0.0;
                     writer = new IndexWriter(dir, conf);
@@ -699,7 +724,9 @@ namespace Lucene.Net.Index
                     }
                     // this is a commit
                     writer.Dispose();
-                    conf = (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetIndexDeletionPolicy(policy).SetMergePolicy(NoMergePolicy.COMPOUND_FILES);
+                    conf = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                        .SetIndexDeletionPolicy(policy)
+                        .SetMergePolicy(NoMergePolicy.COMPOUND_FILES);
                     writer = new IndexWriter(dir, conf);
                     policy = (KeepLastNDeletionPolicy)writer.Config.IndexDeletionPolicy;
                     writer.DeleteDocuments(new Term("id", "" + (i * (N + 1) + 3)));
@@ -711,7 +738,9 @@ namespace Lucene.Net.Index
                     Assert.AreEqual(16, hits.Length);
                     reader.Dispose();
 
-                    writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetIndexDeletionPolicy(policy));
+                    writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                        .SetOpenMode(OpenMode.CREATE)
+                        .SetIndexDeletionPolicy(policy));
                     policy = (KeepLastNDeletionPolicy)writer.Config.IndexDeletionPolicy;
                     // this will not commit: there are no changes
                     // pending because we opened for "create":

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
@@ -350,20 +350,7 @@ namespace Lucene.Net.Index
             d.Dispose();
         }
 
-        // LUCENENET specific - commented out unused method
-        // internal virtual void AssertTermDocsCount(string msg, IndexReader reader, Term term, int expected)
-        // {
-        //     DocsEnum tdocs = TestUtil.Docs(Random, reader, term.Field, new BytesRef(term.Text), MultiFields.GetLiveDocs(reader), null, 0);
-        //     int count = 0;
-        //     if (tdocs != null)
-        //     {
-        //         while (tdocs.NextDoc() != DocIdSetIterator.NO_MORE_DOCS)
-        //         {
-        //             count++;
-        //         }
-        //     }
-        //     Assert.AreEqual(expected, count, msg + ", count mismatch");
-        // }
+        // LUCENENET specific - Removed AssertTermDocsCount() because it was not in use
 
         [Test]
         public virtual void TestBinaryFields()

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReader.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using JCG = J2N.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
-using Lucene.Net.Support.Threading;
 
 namespace Lucene.Net.Index
 {
@@ -165,7 +164,8 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// Tests the IndexReader.getFieldNames implementation </summary>
+        /// Tests the IndexReader.getFieldNames implementation
+        /// </summary>
         /// <exception cref="Exception"> on error </exception>
         [Test]
         public virtual void TestGetFieldNames()
@@ -318,7 +318,8 @@ namespace Lucene.Net.Index
         {
             Directory d = NewDirectory();
             // set up writer
-            IndexWriter writer = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy()));
+            IndexWriter writer = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMergePolicy(NewLogMergePolicy()));
             // want to get some more segments here
             // new termvector fields
             int mergeFactor = ((LogMergePolicy)writer.Config.MergePolicy).MergeFactor;
@@ -349,19 +350,20 @@ namespace Lucene.Net.Index
             d.Dispose();
         }
 
-        internal virtual void AssertTermDocsCount(string msg, IndexReader reader, Term term, int expected)
-        {
-            DocsEnum tdocs = TestUtil.Docs(Random, reader, term.Field, new BytesRef(term.Text), MultiFields.GetLiveDocs(reader), null, 0);
-            int count = 0;
-            if (tdocs != null)
-            {
-                while (tdocs.NextDoc() != DocIdSetIterator.NO_MORE_DOCS)
-                {
-                    count++;
-                }
-            }
-            Assert.AreEqual(expected, count, msg + ", count mismatch");
-        }
+        // LUCENENET specific - commented out unused method
+        // internal virtual void AssertTermDocsCount(string msg, IndexReader reader, Term term, int expected)
+        // {
+        //     DocsEnum tdocs = TestUtil.Docs(Random, reader, term.Field, new BytesRef(term.Text), MultiFields.GetLiveDocs(reader), null, 0);
+        //     int count = 0;
+        //     if (tdocs != null)
+        //     {
+        //         while (tdocs.NextDoc() != DocIdSetIterator.NO_MORE_DOCS)
+        //         {
+        //             count++;
+        //         }
+        //     }
+        //     Assert.AreEqual(expected, count, msg + ", count mismatch");
+        // }
 
         [Test]
         public virtual void TestBinaryFields()
@@ -448,7 +450,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
 
             // Try to erase the data - this ensures that the writer closed all files
-            System.IO.Directory.Delete(dirFile.FullName, true);
+            TestUtil.Rm(dirFile);
             dir = NewFSDirectory(dirFile);
 
             // Now create the data set again, just as before
@@ -465,7 +467,7 @@ namespace Lucene.Net.Index
 
             // The following will fail if reader did not close
             // all files
-            System.IO.Directory.Delete(dirFile.FullName, true);
+            TestUtil.Rm(dirFile);
         }
 
         [Test]
@@ -499,12 +501,7 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        /// <summary>
-        /// LUCENENET specific
-        /// Is non-static because NewStringField, NewTextField, NewField methods
-        /// are no longer static.
-        /// </summary>
-        internal void AddDocumentWithFields(IndexWriter writer)
+        internal static void AddDocumentWithFields(IndexWriter writer)
         {
             Document doc = new Document();
 
@@ -517,12 +514,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        /// <summary>
-        /// LUCENENET specific
-        /// Is non-static because NewStringField, NewTextField, NewField methods
-        /// are no longer static.
-        /// </summary>
-        internal void AddDocumentWithDifferentFields(IndexWriter writer)
+        internal static void AddDocumentWithDifferentFields(IndexWriter writer)
         {
             Document doc = new Document();
 
@@ -535,12 +527,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        /// <summary>
-        /// LUCENENET specific
-        /// Is non-static because NewTextField, NewField methods are no longer
-        /// static.
-        /// </summary>
-        internal void AddDocumentWithTermVectorFields(IndexWriter writer)
+        internal static void AddDocumentWithTermVectorFields(IndexWriter writer)
         {
             Document doc = new Document();
             FieldType customType5 = new FieldType(TextField.TYPE_STORED);
@@ -564,11 +551,7 @@ namespace Lucene.Net.Index
             writer.AddDocument(doc);
         }
 
-        /// <summary>
-        /// LUCENENET specific
-        /// Is non-static because NewTextField is no longer static.
-        /// </summary>
-        internal void AddDoc(IndexWriter writer, string value)
+        internal static void AddDoc(IndexWriter writer, string value)
         {
             Document doc = new Document();
             doc.Add(NewTextField("content", value, Field.Store.NO));
@@ -696,7 +679,9 @@ namespace Lucene.Net.Index
             Directory d = NewDirectory();
 
             // set up writer
-            IndexWriter writer = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2).SetMergePolicy(NewLogMergePolicy(10)));
+            IndexWriter writer = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(2)
+                .SetMergePolicy(NewLogMergePolicy(10)));
             for (int i = 0; i < 27; i++)
             {
                 AddDocumentWithFields(writer);
@@ -713,7 +698,10 @@ namespace Lucene.Net.Index
             Assert.IsTrue(c.Equals(r.IndexCommit));
 
             // Change the index
-            writer = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND).SetMaxBufferedDocs(2).SetMergePolicy(NewLogMergePolicy(10)));
+            writer = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetOpenMode(OpenMode.APPEND)
+                .SetMaxBufferedDocs(2)
+                .SetMergePolicy(NewLogMergePolicy(10)));
             for (int i = 0; i < 7; i++)
             {
                 AddDocumentWithFields(writer);
@@ -726,7 +714,8 @@ namespace Lucene.Net.Index
             Assert.IsFalse(r2.IndexCommit.SegmentCount == 1);
             r2.Dispose();
 
-            writer = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND));
+            writer = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetOpenMode(OpenMode.APPEND));
             writer.ForceMerge(1);
             writer.Dispose();
 
@@ -740,7 +729,7 @@ namespace Lucene.Net.Index
             d.Dispose();
         }
 
-        internal Document CreateDocument(string id)
+        internal static Document CreateDocument(string id)
         {
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);
@@ -758,7 +747,7 @@ namespace Lucene.Net.Index
         public virtual void TestNoDir()
         {
             DirectoryInfo tempDir = CreateTempDir("doesnotexist");
-            System.IO.Directory.Delete(tempDir.FullName, true);
+            TestUtil.Rm(tempDir);
             Directory dir = NewFSDirectory(tempDir);
             try
             {
@@ -778,7 +767,8 @@ namespace Lucene.Net.Index
         {
             Directory dir = NewDirectory();
 
-            IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(2));
             writer.AddDocument(CreateDocument("a"));
             writer.AddDocument(CreateDocument("a"));
             writer.AddDocument(CreateDocument("a"));
@@ -806,7 +796,8 @@ namespace Lucene.Net.Index
         public virtual void TestFieldCacheReuseAfterReopen()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy(10)));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMergePolicy(NewLogMergePolicy(10)));
             Document doc = new Document();
             doc.Add(NewStringField("number", "17", Field.Store.NO));
             writer.AddDocument(doc);
@@ -895,7 +886,9 @@ namespace Lucene.Net.Index
             }
 
             Assert.AreEqual(-1, ((SegmentReader)r.Leaves[0].Reader).TermInfosIndexDivisor);
-            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetCodec(TestUtil.AlwaysPostingsFormat(new Lucene41PostingsFormat())).SetMergePolicy(NewLogMergePolicy(10)));
+            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetCodec(TestUtil.AlwaysPostingsFormat(new Lucene41PostingsFormat()))
+                .SetMergePolicy(NewLogMergePolicy(10)));
             writer.AddDocument(doc);
             writer.Dispose();
 
@@ -950,7 +943,8 @@ namespace Lucene.Net.Index
         public virtual void TestListCommits()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, null).SetIndexDeletionPolicy(new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy())));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, null)
+                .SetIndexDeletionPolicy(new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy())));
             SnapshotDeletionPolicy sdp = (SnapshotDeletionPolicy)writer.Config.IndexDeletionPolicy;
             writer.AddDocument(new Document());
             writer.Commit();
@@ -1089,7 +1083,7 @@ namespace Lucene.Net.Index
             writer.Commit();
             DirectoryReader reader = writer.GetReader();
             int[] closeCount = new int[1];
-            IReaderDisposedListener listener = new ReaderClosedListenerAnonymousClass(this, reader, closeCount);
+            IReaderDisposedListener listener = new ReaderClosedListenerAnonymousClass(closeCount);
 
             reader.AddReaderDisposedListener(listener);
 
@@ -1110,15 +1104,10 @@ namespace Lucene.Net.Index
 
         private sealed class ReaderClosedListenerAnonymousClass : IReaderDisposedListener
         {
-            private readonly TestDirectoryReader outerInstance;
-
-            private readonly DirectoryReader reader;
             private readonly int[] closeCount;
 
-            public ReaderClosedListenerAnonymousClass(TestDirectoryReader outerInstance, DirectoryReader reader, int[] closeCount)
+            public ReaderClosedListenerAnonymousClass(int[] closeCount)
             {
-                this.outerInstance = outerInstance;
-                this.reader = reader;
                 this.closeCount = closeCount;
             }
 
@@ -1249,7 +1238,6 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        /// @deprecated just to ensure IndexReader static methods work
         [Obsolete("just to ensure IndexReader static methods work")]
         [Test]
         public virtual void TestBackwards()

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
@@ -6,7 +6,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading;
 using JCG = J2N.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
@@ -52,25 +51,22 @@ namespace Lucene.Net.Index
             Directory dir1 = NewDirectory();
 
             CreateIndex(Random, dir1, false);
-            PerformDefaultTests(new TestReopenAnonymousClass(this, dir1));
+            PerformDefaultTests(new TestReopenAnonymousClass(dir1));
             dir1.Dispose();
 
             Directory dir2 = NewDirectory();
 
             CreateIndex(Random, dir2, true);
-            PerformDefaultTests(new TestReopenAnonymousClass2(this, dir2));
+            PerformDefaultTests(new TestReopenAnonymousClass2(dir2));
             dir2.Dispose();
         }
 
         private sealed class TestReopenAnonymousClass : TestReopen
         {
-            private readonly TestDirectoryReaderReopen outerInstance;
-
             private Directory dir1;
 
-            public TestReopenAnonymousClass(TestDirectoryReaderReopen outerInstance, Directory dir1)
+            public TestReopenAnonymousClass(Directory dir1)
             {
-                this.outerInstance = outerInstance;
                 this.dir1 = dir1;
             }
 
@@ -87,13 +83,10 @@ namespace Lucene.Net.Index
 
         private sealed class TestReopenAnonymousClass2 : TestReopen
         {
-            private readonly TestDirectoryReaderReopen outerInstance;
-
             private readonly Directory dir2;
 
-            public TestReopenAnonymousClass2(TestDirectoryReaderReopen outerInstance, Directory dir2)
+            public TestReopenAnonymousClass2(Directory dir2)
             {
-                this.outerInstance = outerInstance;
                 this.dir2 = dir2;
             }
 
@@ -131,12 +124,15 @@ namespace Lucene.Net.Index
 
         private void DoTestReopenWithCommit(Random random, Directory dir, bool withReopen)
         {
-            IndexWriter iwriter = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random)).SetOpenMode(OpenMode.CREATE).SetMergeScheduler(new SerialMergeScheduler()).SetMergePolicy(NewLogMergePolicy()));
+            IndexWriter iwriter = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random))
+                .SetOpenMode(OpenMode.CREATE)
+                .SetMergeScheduler(new SerialMergeScheduler())
+                .SetMergePolicy(NewLogMergePolicy()));
             iwriter.Commit();
             DirectoryReader reader = DirectoryReader.Open(dir);
             try
             {
-                int M = 3;
+                const int M = 3;
                 FieldType customType = new FieldType(TextField.TYPE_STORED);
                 customType.IsTokenized = false;
                 FieldType customType2 = new FieldType(TextField.TYPE_STORED);
@@ -249,7 +245,7 @@ namespace Lucene.Net.Index
             writer.ForceMerge(1);
             writer.Dispose();
 
-            TestReopen test = new TestReopenAnonymousClass3(this, dir, n);
+            TestReopen test = new TestReopenAnonymousClass3(dir, n);
 
             IList<ReaderCouple> readers = new SynchronizedList<ReaderCouple>();
             DirectoryReader firstReader = DirectoryReader.Open(dir);
@@ -281,7 +277,7 @@ namespace Lucene.Net.Index
                 }
                 else
                 {
-                    task = new ReaderThreadTaskAnonymousClass2(this, readers);
+                    task = new ReaderThreadTaskAnonymousClass2(readers);
                 }
 
                 threads[i] = new ReaderThread(task);
@@ -340,14 +336,11 @@ namespace Lucene.Net.Index
 
         private sealed class TestReopenAnonymousClass3 : TestReopen
         {
-            private readonly TestDirectoryReaderReopen outerInstance;
-
             private readonly Directory dir;
             private readonly int n;
 
-            public TestReopenAnonymousClass3(TestDirectoryReaderReopen outerInstance, Directory dir, int n)
+            public TestReopenAnonymousClass3(Directory dir, int n)
             {
-                this.outerInstance = outerInstance;
                 this.dir = dir;
                 this.n = n;
             }
@@ -375,7 +368,7 @@ namespace Lucene.Net.Index
             private readonly DirectoryReader r;
             private readonly int index;
 
-            public ReaderThreadTaskAnonymousClass(TestDirectoryReaderReopen outerInstance, Lucene.Net.Index.TestDirectoryReaderReopen.TestReopen test, IList<ReaderCouple> readers, ISet<DirectoryReader> readersToClose, DirectoryReader r, int index)
+            public ReaderThreadTaskAnonymousClass(TestDirectoryReaderReopen outerInstance, TestReopen test, IList<ReaderCouple> readers, ISet<DirectoryReader> readersToClose, DirectoryReader r, int index)
             {
                 this.outerInstance = outerInstance;
                 this.test = test;
@@ -393,7 +386,7 @@ namespace Lucene.Net.Index
                     if (index % 2 == 0)
                     {
                         // refresh reader synchronized
-                        ReaderCouple c = (outerInstance.RefreshReader(r, test, index, true));
+                        ReaderCouple c = outerInstance.RefreshReader(r, test, index, true);
                         readersToClose.Add(c.newReader);
                         readersToClose.Add(c.refreshedReader);
                         readers.Add(c);
@@ -435,13 +428,10 @@ namespace Lucene.Net.Index
 
         private sealed class ReaderThreadTaskAnonymousClass2 : ReaderThreadTask
         {
-            private readonly TestDirectoryReaderReopen outerInstance;
-
             private readonly IList<ReaderCouple> readers;
 
-            public ReaderThreadTaskAnonymousClass2(TestDirectoryReaderReopen outerInstance, IList<ReaderCouple> readers)
+            public ReaderThreadTaskAnonymousClass2(IList<ReaderCouple> readers)
             {
-                this.outerInstance = outerInstance;
                 this.readers = readers;
             }
 
@@ -583,14 +573,11 @@ namespace Lucene.Net.Index
             }
         }
 
-        /// <summary>
-        /// LUCENENET specific
-        /// Is non-static because NewIndexWriterConfig is no longer static.
-        /// </summary>
-        public void CreateIndex(Random random, Directory dir, bool multiSegment)
+        public static void CreateIndex(Random random, Directory dir, bool multiSegment)
         {
             IndexWriter.Unlock(dir);
-            IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random)).SetMergePolicy(new LogDocMergePolicy()));
+            IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(random, TEST_VERSION_CURRENT, new MockAnalyzer(random))
+                .SetMergePolicy(new LogDocMergePolicy()));
 
             for (int i = 0; i < 100; i++)
             {
@@ -724,7 +711,10 @@ namespace Lucene.Net.Index
         public virtual void TestReopenOnCommit()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(new KeepAllCommits()).SetMaxBufferedDocs(-1).SetMergePolicy(NewLogMergePolicy(10)));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetIndexDeletionPolicy(new KeepAllCommits())
+                .SetMaxBufferedDocs(-1)
+                .SetMergePolicy(NewLogMergePolicy(10)));
             for (int i = 0; i < 4; i++)
             {
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
@@ -122,7 +122,8 @@ namespace Lucene.Net.Index
             dir.Dispose();
         }
 
-        private void DoTestReopenWithCommit(Random random, Directory dir, bool withReopen)
+        // LUCENENET specific - made static
+        private static void DoTestReopenWithCommit(Random random, Directory dir, bool withReopen)
         {
             IndexWriter iwriter = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(random))
                 .SetOpenMode(OpenMode.CREATE)
@@ -185,7 +186,8 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void PerformDefaultTests(TestReopen test)
+        // LUCENENET specific - made static
+        private static void PerformDefaultTests(TestReopen test)
         {
             DirectoryReader index1 = test.OpenReader();
             DirectoryReader index2 = test.OpenReader();
@@ -273,7 +275,7 @@ namespace Lucene.Net.Index
 
                 if (i < 4 || (i >= 10 && i < 14) || i > 18)
                 {
-                    task = new ReaderThreadTaskAnonymousClass(this, test, readers, readersToClose, r, index);
+                    task = new ReaderThreadTaskAnonymousClass(test, readers, readersToClose, r, index);
                 }
                 else
                 {
@@ -360,17 +362,14 @@ namespace Lucene.Net.Index
 
         private sealed class ReaderThreadTaskAnonymousClass : ReaderThreadTask
         {
-            private readonly TestDirectoryReaderReopen outerInstance;
-
             private readonly TestReopen test;
             private readonly IList<ReaderCouple> readers;
             private readonly ISet<DirectoryReader> readersToClose;
             private readonly DirectoryReader r;
             private readonly int index;
 
-            public ReaderThreadTaskAnonymousClass(TestDirectoryReaderReopen outerInstance, TestReopen test, IList<ReaderCouple> readers, ISet<DirectoryReader> readersToClose, DirectoryReader r, int index)
+            public ReaderThreadTaskAnonymousClass(TestReopen test, IList<ReaderCouple> readers, ISet<DirectoryReader> readersToClose, DirectoryReader r, int index)
             {
-                this.outerInstance = outerInstance;
                 this.test = test;
                 this.readers = readers;
                 this.readersToClose = readersToClose;
@@ -386,7 +385,7 @@ namespace Lucene.Net.Index
                     if (index % 2 == 0)
                     {
                         // refresh reader synchronized
-                        ReaderCouple c = outerInstance.RefreshReader(r, test, index, true);
+                        ReaderCouple c = RefreshReader(r, test, index, true);
                         readersToClose.Add(c.newReader);
                         readersToClose.Add(c.refreshedReader);
                         readers.Add(c);
@@ -513,14 +512,17 @@ namespace Lucene.Net.Index
             }
         }
 
-        private object createReaderMutex = new object();
+        // LUCENENET specific - made static readonly
+        private static readonly object createReaderMutex = new object();
 
-        private ReaderCouple RefreshReader(DirectoryReader reader, bool hasChanges)
+        // LUCENENET specific - made static
+        private static ReaderCouple RefreshReader(DirectoryReader reader, bool hasChanges)
         {
             return RefreshReader(reader, null, -1, hasChanges);
         }
 
-        internal virtual ReaderCouple RefreshReader(DirectoryReader reader, TestReopen test, int modify, bool hasChanges)
+        // LUCENENET specific - made static
+        internal static ReaderCouple RefreshReader(DirectoryReader reader, TestReopen test, int modify, bool hasChanges)
         {
             UninterruptableMonitor.Enter(createReaderMutex);
             try

--- a/src/Lucene.Net.Tests/Index/TestDoc.cs
+++ b/src/Lucene.Net.Tests/Index/TestDoc.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// this test executes a number of merges and compares the contents of
+        /// This test executes a number of merges and compares the contents of
         ///  the segments created when using compound file or not using one.
         ///
         ///  TODO: the original test used to print the segment contents to System.out
@@ -130,7 +130,10 @@ namespace Lucene.Net.Index
                 wrapper.AssertNoUnreferencedFilesOnDispose = false;
             }
 
-            IndexWriter writer = new IndexWriter(directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(-1).SetMergePolicy(NewLogMergePolicy(10)));
+            IndexWriter writer = new IndexWriter(directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetOpenMode(OpenMode.CREATE)
+                .SetMaxBufferedDocs(-1)
+                .SetMergePolicy(NewLogMergePolicy(10)));
 
             SegmentCommitInfo si1 = IndexDoc(writer, "test.txt");
             PrintSegment(@out, si1);
@@ -168,7 +171,10 @@ namespace Lucene.Net.Index
                 wrapper.AssertNoUnreferencedFilesOnDispose = false;
             }
 
-            writer = new IndexWriter(directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(-1).SetMergePolicy(NewLogMergePolicy(10)));
+            writer = new IndexWriter(directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetOpenMode(OpenMode.CREATE)
+                .SetMaxBufferedDocs(-1)
+                .SetMergePolicy(NewLogMergePolicy(10)));
 
             si1 = IndexDoc(writer, "test.txt");
             PrintSegment(@out, si1);
@@ -216,19 +222,23 @@ namespace Lucene.Net.Index
             TrackingDirectoryWrapper trackingDir = new TrackingDirectoryWrapper(si1.Info.Dir);
             SegmentInfo si = new SegmentInfo(si1.Info.Dir, Constants.LUCENE_MAIN_VERSION, merged, -1, false, codec, null);
 
-            SegmentMerger merger = new SegmentMerger(new JCG.List<AtomicReader> { r1, r2 }, si, (InfoStream)InfoStream.Default, trackingDir, IndexWriterConfig.DEFAULT_TERM_INDEX_INTERVAL, CheckAbort.NONE, new FieldInfos.FieldNumbers(), context, true);
+            SegmentMerger merger = new SegmentMerger(new JCG.List<AtomicReader> { r1, r2 },
+                si, InfoStream.Default, trackingDir, IndexWriterConfig.DEFAULT_TERM_INDEX_INTERVAL,
+                CheckAbort.NONE, new FieldInfos.FieldNumbers(), context, true);
 
             MergeState mergeState = merger.Merge();
             r1.Dispose();
             r2.Dispose();
-            SegmentInfo info = new SegmentInfo(si1.Info.Dir, Constants.LUCENE_MAIN_VERSION, merged, si1.Info.DocCount + si2.Info.DocCount, false, codec, null);
+            SegmentInfo info = new SegmentInfo(si1.Info.Dir, Constants.LUCENE_MAIN_VERSION, merged,
+                si1.Info.DocCount + si2.Info.DocCount,
+                false, codec, null);
             info.SetFiles(new JCG.HashSet<string>(trackingDir.CreatedFiles));
 
             if (useCompoundFile)
             {
-                ICollection<string> filesToDelete = IndexWriter.CreateCompoundFile((InfoStream)InfoStream.Default, dir, CheckAbort.NONE, info, NewIOContext(Random));
+                ICollection<string> filesToDelete = IndexWriter.CreateCompoundFile(InfoStream.Default, dir, CheckAbort.NONE, info, NewIOContext(Random));
                 info.UseCompoundFile = true;
-                foreach (String fileToDelete in filesToDelete)
+                foreach (string fileToDelete in filesToDelete)
                 {
                     si1.Info.Dir.DeleteFile(fileToDelete);
                 }

--- a/src/Lucene.Net.Tests/Index/TestDocInverterPerFieldErrorInfo.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocInverterPerFieldErrorInfo.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Index
                 Tokenizer tokenizer = new MockTokenizer(input);
                 if (fieldName.Equals("distinctiveFieldName", StringComparison.Ordinal))
                 {
-                    TokenFilter tosser = new TokenFilterAnonymousClass(this, tokenizer);
+                    TokenFilter tosser = new TokenFilterAnonymousClass(tokenizer);
                     return new TokenStreamComponents(tokenizer, tosser);
                 }
                 else
@@ -71,12 +71,9 @@ namespace Lucene.Net.Index
 
             private sealed class TokenFilterAnonymousClass : TokenFilter
             {
-                private readonly ThrowingAnalyzer outerInstance;
-
-                public TokenFilterAnonymousClass(ThrowingAnalyzer outerInstance, Tokenizer tokenizer)
+                public TokenFilterAnonymousClass(Tokenizer tokenizer)
                     : base(tokenizer)
                 {
-                    this.outerInstance = outerInstance;
                 }
 
                 public sealed override bool IncrementToken()
@@ -132,9 +129,7 @@ namespace Lucene.Net.Index
             {
                 writer.AddDocument(doc);
             }
-#pragma warning disable 168
-            catch (BadNews badNews)
-#pragma warning restore 168
+            catch (BadNews /*badNews*/)
             {
                 Assert.Fail("Unwanted exception");
             }

--- a/src/Lucene.Net.Tests/Index/TestDocTermOrds.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocTermOrds.cs
@@ -5,7 +5,6 @@ using Lucene.Net.Search;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Console = Lucene.Net.Util.SystemConsole;
 using JCG = J2N.Collections.Generic;

--- a/src/Lucene.Net.Tests/Index/TestDocValuesIndexing.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocValuesIndexing.cs
@@ -534,7 +534,7 @@ namespace Lucene.Net.Index
                 Document doc = new Document();
                 doc.Add(field);
 
-                threads[i] = new ThreadAnonymousClass(this, w, startingGun, hitExc, doc);
+                threads[i] = new ThreadAnonymousClass(w, startingGun, hitExc, doc);
                 threads[i].Start();
             }
 
@@ -551,16 +551,13 @@ namespace Lucene.Net.Index
 
         private sealed class ThreadAnonymousClass : ThreadJob
         {
-            private readonly TestDocValuesIndexing outerInstance;
-
             private readonly IndexWriter w;
             private readonly CountdownEvent startingGun;
             private readonly AtomicBoolean hitExc;
             private readonly Document doc;
 
-            public ThreadAnonymousClass(TestDocValuesIndexing outerInstance, IndexWriter w, CountdownEvent startingGun, AtomicBoolean hitExc, Document doc)
+            public ThreadAnonymousClass(IndexWriter w, CountdownEvent startingGun, AtomicBoolean hitExc, Document doc)
             {
-                this.outerInstance = outerInstance;
                 this.w = w;
                 this.startingGun = startingGun;
                 this.hitExc = hitExc;
@@ -577,7 +574,7 @@ namespace Lucene.Net.Index
                 catch (Exception iae) when (iae.IsIllegalArgumentException())
                 {
                     // expected
-                    hitExc.Value = (true);
+                    hitExc.Value = true;
                 }
                 catch (Exception e) when (e.IsException())
                 {

--- a/src/Lucene.Net.Tests/Index/TestDocValuesWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocValuesWithThreads.cs
@@ -5,7 +5,6 @@ using Lucene.Net.Search;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using JCG = J2N.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
@@ -83,7 +82,7 @@ namespace Lucene.Net.Index
             for (int t = 0; t < numThreads; t++)
             {
                 Random threadRandom = new J2N.Randomizer(Random.NextInt64());
-                ThreadJob thread = new ThreadAnonymousClass(this, numbers, binary, sorted, numDocs, ar, startingGun, threadRandom);
+                ThreadJob thread = new ThreadAnonymousClass(numbers, binary, sorted, numDocs, ar, startingGun, threadRandom);
                 thread.Start();
                 threads.Add(thread);
             }
@@ -101,8 +100,6 @@ namespace Lucene.Net.Index
 
         private sealed class ThreadAnonymousClass : ThreadJob
         {
-            private readonly TestDocValuesWithThreads outerInstance;
-
             private readonly IList<long> numbers;
             private readonly IList<BytesRef> binary;
             private readonly IList<BytesRef> sorted;
@@ -111,9 +108,8 @@ namespace Lucene.Net.Index
             private readonly CountdownEvent startingGun;
             private readonly Random threadRandom;
 
-            public ThreadAnonymousClass(TestDocValuesWithThreads outerInstance, IList<long> numbers, IList<BytesRef> binary, IList<BytesRef> sorted, int numDocs, AtomicReader ar, CountdownEvent startingGun, Random threadRandom)
+            public ThreadAnonymousClass(IList<long> numbers, IList<BytesRef> binary, IList<BytesRef> sorted, int numDocs, AtomicReader ar, CountdownEvent startingGun, Random threadRandom)
             {
-                this.outerInstance = outerInstance;
                 this.numbers = numbers;
                 this.binary = binary;
                 this.sorted = sorted;
@@ -248,7 +244,7 @@ namespace Lucene.Net.Index
 
             long END_TIME = (J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond) + (TestNightly ? 30 : 1); // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
 
-            int NUM_THREADS = TestUtil.NextInt32(LuceneTestCase.Random, 1, 10);
+            int NUM_THREADS = TestUtil.NextInt32(Random, 1, 10);
             ThreadJob[] threads = new ThreadJob[NUM_THREADS];
             for (int thread = 0; thread < NUM_THREADS; thread++)
             {

--- a/src/Lucene.Net.Tests/Index/TestDocsAndPositions.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocsAndPositions.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// Simple testcase for <seealso cref="DocsAndPositionsEnum"/>
+        /// Simple testcase for <see cref="DocsAndPositionsEnum"/>
         /// </summary>
         [Test]
         public virtual void TestPositionsSimple()
@@ -219,7 +219,7 @@ namespace Lucene.Net.Index
             Directory dir = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy()));
             int numDocs = AtLeast(49);
-            int max = 15678;
+            const int max = 15678;
             int term = Random.Next(max);
             int[] freqInDoc = new int[numDocs];
             FieldType customType = new FieldType(TextField.TYPE_NOT_STORED);
@@ -314,7 +314,7 @@ namespace Lucene.Net.Index
         {
             Directory dir = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
-            int howMany = 1000;
+            const int howMany = 1000;
             FieldType customType = new FieldType(TextField.TYPE_NOT_STORED);
             customType.OmitNorms = true;
             for (int i = 0; i < 39; i++)

--- a/src/Lucene.Net.Tests/Index/TestDocumentWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentWriter.cs
@@ -156,7 +156,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestTokenReuse()
         {
-            Analyzer analyzer = new AnalyzerAnonymousClass2(this);
+            Analyzer analyzer = new AnalyzerAnonymousClass2();
 
             IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer));
 
@@ -184,34 +184,24 @@ namespace Lucene.Net.Index
 
         private sealed class AnalyzerAnonymousClass2 : Analyzer
         {
-            private readonly TestDocumentWriter outerInstance;
-
-            public AnalyzerAnonymousClass2(TestDocumentWriter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
             protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
             {
                 Tokenizer tokenizer = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-                return new TokenStreamComponents(tokenizer, new TokenFilterAnonymousClass(this, tokenizer));
+                return new TokenStreamComponents(tokenizer, new TokenFilterAnonymousClass(tokenizer));
             }
 
             private sealed class TokenFilterAnonymousClass : TokenFilter
             {
-                private readonly AnalyzerAnonymousClass2 outerInstance;
-
-                public TokenFilterAnonymousClass(AnalyzerAnonymousClass2 outerInstance, Tokenizer tokenizer)
+                public TokenFilterAnonymousClass(Tokenizer tokenizer)
                     : base(tokenizer)
                 {
-                    this.outerInstance = outerInstance;
-                    first = true;
+                    // LUCENENET specific: AddAttribute must be called from the ctor
                     termAtt = AddAttribute<ICharTermAttribute>();
                     payloadAtt = AddAttribute<IPayloadAttribute>();
                     posIncrAtt = AddAttribute<IPositionIncrementAttribute>();
                 }
 
-                internal bool first;
+                internal bool first = true;
                 internal AttributeSource.State state;
 
                 public sealed override bool IncrementToken()
@@ -266,7 +256,7 @@ namespace Lucene.Net.Index
             IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
             Document doc = new Document();
 
-            doc.Add(new TextField("preanalyzed", new TokenStreamAnonymousClass(this)));
+            doc.Add(new TextField("preanalyzed", new TokenStreamAnonymousClass()));
 
             writer.AddDocument(doc);
             writer.Commit();
@@ -294,18 +284,14 @@ namespace Lucene.Net.Index
 
         private sealed class TokenStreamAnonymousClass : TokenStream
         {
-            private readonly TestDocumentWriter outerInstance;
-
-            public TokenStreamAnonymousClass(TestDocumentWriter outerInstance) 
+            public TokenStreamAnonymousClass()
             {
-                this.outerInstance = outerInstance;
-                tokens = new string[] { "term1", "term2", "term3", "term2" };
-                index = 0;
+                // LUCENENET specific: AddAttribute must be called from the ctor
                 termAtt = AddAttribute<ICharTermAttribute>();
             }
 
-            private string[] tokens;
-            private int index;
+            private string[] tokens = new string[] { "term1", "term2", "term3", "term2" };
+            private int index /*= 0*/;
 
             private ICharTermAttribute termAtt;
 

--- a/src/Lucene.Net.Tests/Index/TestDocumentsWriterDeleteQueue.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentsWriterDeleteQueue.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Index
     using TermQuery = Lucene.Net.Search.TermQuery;
 
     /// <summary>
-    /// Unit test for <seealso cref="DocumentsWriterDeleteQueue"/>
+    /// Unit test for <see cref="DocumentsWriterDeleteQueue"/>
     /// </summary>
     [TestFixture]
     public class TestDocumentsWriterDeleteQueue : LuceneTestCase
@@ -213,11 +213,11 @@ namespace Lucene.Net.Index
         public virtual void TestPartiallyAppliedGlobalSlice()
         {
             DocumentsWriterDeleteQueue queue = new DocumentsWriterDeleteQueue();
-            System.Reflection.FieldInfo field = typeof(DocumentsWriterDeleteQueue).GetField("globalBufferLock", 
+            System.Reflection.FieldInfo field = typeof(DocumentsWriterDeleteQueue).GetField("globalBufferLock",
                 BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
             ReentrantLock @lock = (ReentrantLock)field.GetValue(queue);
             @lock.Lock();
-            var t = new ThreadAnonymousClass(this, queue);
+            var t = new ThreadAnonymousClass(queue);
             t.Start();
             t.Join();
             @lock.Unlock();
@@ -232,13 +232,10 @@ namespace Lucene.Net.Index
 
         private sealed class ThreadAnonymousClass : ThreadJob
         {
-            private readonly TestDocumentsWriterDeleteQueue outerInstance;
-
             private DocumentsWriterDeleteQueue queue;
 
-            public ThreadAnonymousClass(TestDocumentsWriterDeleteQueue outerInstance, DocumentsWriterDeleteQueue queue)
+            public ThreadAnonymousClass(DocumentsWriterDeleteQueue queue)
             {
-                this.outerInstance = outerInstance;
                 this.queue = queue;
             }
 

--- a/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
+++ b/src/Lucene.Net.Tests/Index/TestDocumentsWriterStallControl.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Index
     using LuceneTestCase = Lucene.Net.Util.LuceneTestCase;
 
     /// <summary>
-    /// Tests for <seealso cref="DocumentsWriterStallControl"/>
+    /// Tests for <see cref="DocumentsWriterStallControl"/>
     /// </summary>
     [TestFixture]
     [Timeout(900_000)] // 15 minutes
@@ -149,7 +149,7 @@ namespace Lucene.Net.Index
             Start(threads);
             int iters = AtLeast(10000);
             //float checkPointProbability = TestNightly ? 0.5f : 0.1f;
-            // LUCENENET specific - reduced probabliltiy on x86 to prevent it from timing out.
+            // LUCENENET specific - reduced probability on x86 to prevent it from timing out.
             float checkPointProbability = TestNightly ? (Lucene.Net.Util.Constants.RUNTIME_IS_64BIT ? 0.5f : 0.25f) : 0.1f;
             for (int i = 0; i < iters; i++)
             {

--- a/src/Lucene.Net.Tests/Index/TestDuelingCodecs.cs
+++ b/src/Lucene.Net.Tests/Index/TestDuelingCodecs.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
-using RandomizedTesting.Generators;
 using System;
 using System.Text.RegularExpressions;
 
@@ -189,7 +188,7 @@ namespace Lucene.Net.Index
             Directory leftDir = new Store.RAMDirectory();
             Directory rightDir = new Store.RAMDirectory();
 
-            int maxTermLength = 21678;
+            const int maxTermLength = 21678;
 
             Analysis.Analyzer leftAnalyzer = new Analysis.Standard.StandardAnalyzer(TEST_VERSION_CURRENT) { MaxTokenLength = maxTermLength };
             Analysis.Analyzer rightAnalyzer = new Analysis.Standard.StandardAnalyzer(TEST_VERSION_CURRENT) { MaxTokenLength = maxTermLength };
@@ -251,8 +250,8 @@ namespace Lucene.Net.Index
                 // From AssertTermsEquals
 
                 //string re = "??(*)+*.\U000e06d7*"; // Before escaping
-                string re = "??(\ue808*)+*.\udb41\uded7*"; // Faulty Regex
-                Util.Automaton.CompiledAutomaton automaton = new Util.Automaton.CompiledAutomaton((new Util.Automaton.RegExp(re, Util.Automaton.RegExpSyntax.NONE)).ToAutomaton());
+                const string re = "??(\ue808*)+*.\udb41\uded7*"; // Faulty Regex
+                Util.Automaton.CompiledAutomaton automaton = new Util.Automaton.CompiledAutomaton(new Util.Automaton.RegExp(re, Util.Automaton.RegExpSyntax.NONE).ToAutomaton());
                 if (automaton.Type == Util.Automaton.CompiledAutomaton.AUTOMATON_TYPE.NORMAL)
                 {
                     // From AssertTermsEnumEquals

--- a/src/Lucene.Net.Tests/Index/TestDuelingCodecs.cs
+++ b/src/Lucene.Net.Tests/Index/TestDuelingCodecs.cs
@@ -5,6 +5,9 @@ using Lucene.Net.Index.Extensions;
 using NUnit.Framework;
 using System;
 using System.Text.RegularExpressions;
+#if !FEATURE_RANDOM_NEXTINT64_NEXTSINGLE
+using RandomizedTesting.Generators;
+#endif
 
 namespace Lucene.Net.Index
 {

--- a/src/Lucene.Net.Tests/Index/TestExceedMaxTermLength.cs
+++ b/src/Lucene.Net.Tests/Index/TestExceedMaxTermLength.cs
@@ -36,12 +36,12 @@ namespace Lucene.Net.Index
     /// Tests that a useful exception is thrown when attempting to index a term that is
     /// too large
     /// </summary>
-    /// <seealso cref= IndexWriter#MAX_TERM_LENGTH </seealso>
+    /// <seealso cref="IndexWriter.MAX_TERM_LENGTH" />
     [TestFixture]
     public class TestExceedMaxTermLength : LuceneTestCase
     {
-        private static readonly int minTestTermLength = IndexWriter.MAX_TERM_LENGTH + 1;
-        private static readonly int maxTestTermLegnth = IndexWriter.MAX_TERM_LENGTH * 2;
+        private const int minTestTermLength = IndexWriter.MAX_TERM_LENGTH + 1;
+        private const int maxTestTermLegnth = IndexWriter.MAX_TERM_LENGTH * 2;
 
         internal Directory dir = null;
 

--- a/src/Lucene.Net.Tests/Index/TestExceedMaxTermLength.cs
+++ b/src/Lucene.Net.Tests/Index/TestExceedMaxTermLength.cs
@@ -40,8 +40,8 @@ namespace Lucene.Net.Index
     [TestFixture]
     public class TestExceedMaxTermLength : LuceneTestCase
     {
-        private const int minTestTermLength = IndexWriter.MAX_TERM_LENGTH + 1;
-        private const int maxTestTermLegnth = IndexWriter.MAX_TERM_LENGTH * 2;
+        private static readonly int minTestTermLength = IndexWriter.MAX_TERM_LENGTH + 1;
+        private static readonly int maxTestTermLegnth = IndexWriter.MAX_TERM_LENGTH * 2;
 
         internal Directory dir = null;
 

--- a/src/Lucene.Net.Tests/Index/TestFieldInfos.cs
+++ b/src/Lucene.Net.Tests/Index/TestFieldInfos.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void Test()
         {
-            string name = "testFile";
+            const string name = "testFile";
             Directory dir = NewDirectory();
             FieldInfos fieldInfos = CreateAndWriteFieldInfos(dir, name);
 
@@ -104,7 +104,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestReadOnly()
         {
-            string name = "testFile";
+            const string name = "testFile";
             Directory dir = NewDirectory();
             FieldInfos fieldInfos = CreateAndWriteFieldInfos(dir, name);
             FieldInfos readOnly = ReadFieldInfos(dir, name);

--- a/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
@@ -44,10 +44,6 @@ namespace Lucene.Net.Index
         private static Document testDoc;
         private static FieldInfos.Builder fieldInfos = null;
 
-        /// <summary>
-        /// LUCENENET specific
-        /// Is non-static because NewIndexWriterConfig is no longer static.
-        /// </summary>
         [OneTimeSetUp]
         public override void BeforeClass()
         {

--- a/src/Lucene.Net.Tests/Index/TestFlex.cs
+++ b/src/Lucene.Net.Tests/Index/TestFlex.cs
@@ -39,13 +39,16 @@ namespace Lucene.Net.Index
 
             const int DOC_COUNT = 177;
 
-            IndexWriter w = new IndexWriter(d, (new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).SetMaxBufferedDocs(7).SetMergePolicy(NewLogMergePolicy()));
+            IndexWriter w = new IndexWriter(d,
+                new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetMaxBufferedDocs(7)
+                    .SetMergePolicy(NewLogMergePolicy()));
 
             for (int iter = 0; iter < 2; iter++)
             {
                 if (iter == 0)
                 {
-                    Documents.Document doc = new Documents.Document();
+                    Document doc = new Document();
                     doc.Add(NewTextField("field1", "this is field1", Field.Store.NO));
                     doc.Add(NewTextField("field2", "this is field2", Field.Store.NO));
                     doc.Add(NewTextField("field3", "aaa", Field.Store.NO));
@@ -75,8 +78,9 @@ namespace Lucene.Net.Index
         public virtual void TestTermOrd()
         {
             Directory d = NewDirectory();
-            IndexWriter w = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetCodec(TestUtil.AlwaysPostingsFormat(new Lucene41PostingsFormat())));
-            Documents.Document doc = new Documents.Document();
+            IndexWriter w = new IndexWriter(d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetCodec(TestUtil.AlwaysPostingsFormat(new Lucene41PostingsFormat())));
+            Document doc = new Document();
             doc.Add(NewTextField("f", "a b c", Field.Store.NO));
             w.AddDocument(doc);
             w.ForceMerge(1);

--- a/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
@@ -43,9 +43,8 @@ namespace Lucene.Net.Index
     // LUCENENET specific - Specify to unzip the line file docs
     [UseTempLineDocsFile]
     [Timeout(900_000)] // 15 minutes
-    public class TestFlushByRamOrCountsPolicy : LuceneTestCase 
+    public class TestFlushByRamOrCountsPolicy : LuceneTestCase
     {
-
         private static LineFileDocs lineDocFile;
 
         [OneTimeSetUp]
@@ -95,7 +94,8 @@ namespace Lucene.Net.Index
             MockAnalyzer analyzer = new MockAnalyzer(Random);
             analyzer.MaxTokenLength = TestUtil.NextInt32(Random, 1, IndexWriter.MAX_TERM_LENGTH);
 
-            IndexWriterConfig iwc = NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer).SetFlushPolicy(flushPolicy);
+            IndexWriterConfig iwc = NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer)
+                .SetFlushPolicy(flushPolicy);
             int numDWPT = 1 + AtLeast(2);
             DocumentsWriterPerThreadPool threadPool = new DocumentsWriterPerThreadPool(numDWPT);
             iwc.SetIndexerThreadPool(threadPool);
@@ -156,7 +156,8 @@ namespace Lucene.Net.Index
                 AtomicInt32 numDocs = new AtomicInt32(numDocumentsToIndex);
                 Directory dir = NewDirectory();
                 MockDefaultFlushPolicy flushPolicy = new MockDefaultFlushPolicy();
-                IndexWriterConfig iwc = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetFlushPolicy(flushPolicy);
+                IndexWriterConfig iwc = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetFlushPolicy(flushPolicy);
 
                 int numDWPT = 1 + AtLeast(2);
                 DocumentsWriterPerThreadPool threadPool = new DocumentsWriterPerThreadPool(numDWPT);

--- a/src/Lucene.Net.Tests/Index/TestForTooMuchCloning.cs
+++ b/src/Lucene.Net.Tests/Index/TestForTooMuchCloning.cs
@@ -49,7 +49,9 @@ namespace Lucene.Net.Index
             MockDirectoryWrapper dir = NewMockDirectory();
             TieredMergePolicy tmp = new TieredMergePolicy();
             tmp.MaxMergeAtOnce = 2;
-            RandomIndexWriter w = new RandomIndexWriter(Random, dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2).SetMergePolicy(tmp));
+            RandomIndexWriter w = new RandomIndexWriter(Random, dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(2)
+                .SetMergePolicy(tmp));
             const int numDocs = 20;
             for (int docs = 0; docs < numDocs; docs++)
             {

--- a/src/Lucene.Net.Tests/Index/TestForceMergeForever.cs
+++ b/src/Lucene.Net.Tests/Index/TestForceMergeForever.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Index
         private class MyIndexWriter : IndexWriter
         {
             internal AtomicInt32 mergeCount = new AtomicInt32();
-            internal bool first;
+            private bool first;
 
             public MyIndexWriter(Directory dir, IndexWriterConfig conf)
                 : base(dir, conf)
@@ -97,7 +97,7 @@ namespace Lucene.Net.Index
 
             AtomicBoolean doStop = new AtomicBoolean();
             w.Config.SetMaxBufferedDocs(2);
-            ThreadJob t = new ThreadAnonymousClass(this, w, numStartDocs, docs, doStop);
+            ThreadJob t = new ThreadAnonymousClass(w, numStartDocs, docs, doStop);
             t.Start();
             w.ForceMerge(1);
             doStop.Value = true;
@@ -110,16 +110,13 @@ namespace Lucene.Net.Index
 
         private sealed class ThreadAnonymousClass : ThreadJob
         {
-            private readonly TestForceMergeForever outerInstance;
-
             private readonly MyIndexWriter w;
             private readonly int numStartDocs;
             private readonly LineFileDocs docs;
             private readonly AtomicBoolean doStop;
 
-            public ThreadAnonymousClass(TestForceMergeForever outerInstance, Lucene.Net.Index.TestForceMergeForever.MyIndexWriter w, int numStartDocs, LineFileDocs docs, AtomicBoolean doStop)
+            public ThreadAnonymousClass(MyIndexWriter w, int numStartDocs, LineFileDocs docs, AtomicBoolean doStop)
             {
-                this.outerInstance = outerInstance;
                 this.w = w;
                 this.numStartDocs = numStartDocs;
                 this.docs = docs;

--- a/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
@@ -2,7 +2,6 @@
 using J2N.Threading;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.TokenAttributes;
-using Lucene.Net.Attributes;
 using Lucene.Net.Codecs;
 using Lucene.Net.Codecs.SimpleText;
 using Lucene.Net.Diagnostics;
@@ -10,7 +9,6 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
 using Lucene.Net.Search;
 using Lucene.Net.Support;
-using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using RandomizedTesting.Generators;
@@ -184,7 +182,7 @@ namespace Lucene.Net.Index
         public static void AssertNoUnreferencedFiles(Directory dir, string message)
         {
             string[] startFiles = dir.ListAll();
-            (new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)))).Rollback();
+            new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).Rollback();
             string[] endFiles = dir.ListAll();
 
             Array.Sort(startFiles, StringComparer.Ordinal);
@@ -296,7 +294,7 @@ namespace Lucene.Net.Index
         public virtual void TestManyFields()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(10));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(10));
             for (int j = 0; j < 100; j++)
             {
                 Document doc = new Document();
@@ -329,9 +327,10 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestSmallRAMBuffer()
         {
-
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetRAMBufferSizeMB(0.000001).SetMergePolicy(NewLogMergePolicy(10)));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetRAMBufferSizeMB(0.000001)
+                .SetMergePolicy(NewLogMergePolicy(10)));
             int lastNumFile = dir.ListAll().Length;
             for (int j = 0; j < 9; j++)
             {
@@ -371,8 +370,8 @@ namespace Lucene.Net.Index
                     lastFlushCount = flushCount;
                 }
                 else if (j < 10)
-                // No new files should be created
                 {
+                    // No new files should be created
                     Assert.AreEqual(flushCount, lastFlushCount);
                 }
                 else if (10 == j)
@@ -518,7 +517,7 @@ namespace Lucene.Net.Index
         public virtual void TestDiverseDocs()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetRAMBufferSizeMB(0.5));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetRAMBufferSizeMB(0.5));
             int n = AtLeast(1);
             for (int i = 0; i < n; i++)
             {
@@ -576,7 +575,7 @@ namespace Lucene.Net.Index
         public virtual void TestEnablingNorms()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(10));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(10));
             // Enable norms for only 1 doc, pre flush
             FieldType customType = new FieldType(TextField.TYPE_STORED);
             customType.OmitNorms = true;
@@ -605,7 +604,9 @@ namespace Lucene.Net.Index
             Assert.AreEqual(10, hits.Length);
             reader.Dispose();
 
-            writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.CREATE).SetMaxBufferedDocs(10));
+            writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetOpenMode(OpenMode.CREATE)
+                .SetMaxBufferedDocs(10));
             // Enable norms for only 1 doc, post flush
             for (int j = 0; j < 27; j++)
             {
@@ -639,7 +640,7 @@ namespace Lucene.Net.Index
         public virtual void TestHighFreqTerm()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetRAMBufferSizeMB(0.01));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetRAMBufferSizeMB(0.01));
             // Massive doc that has 128 K a's
             StringBuilder b = new StringBuilder(1024 * 1024);
             for (int i = 0; i < 4096; i++)
@@ -719,7 +720,9 @@ namespace Lucene.Net.Index
         public virtual void TestFlushWithNoMerging()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2).SetMergePolicy(NewLogMergePolicy(10)));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(2)
+                .SetMergePolicy(NewLogMergePolicy(10)));
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);
             customType.StoreTermVectors = true;
@@ -795,7 +798,9 @@ namespace Lucene.Net.Index
             try
             {
                 Directory dir = NewDirectory();
-                IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2).SetMergePolicy(NewLogMergePolicy());
+                IndexWriterConfig conf = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetMaxBufferedDocs(2)
+                    .SetMergePolicy(NewLogMergePolicy());
                 ((LogMergePolicy)conf.MergePolicy).MergeFactor = 2;
                 IndexWriter iw = new IndexWriter(dir, conf);
                 Document document = new Document();
@@ -831,7 +836,7 @@ namespace Lucene.Net.Index
                 //lmp.setMergeFactor(2);
                 //lmp.setNoCFSRatio(0.0);
                 Document doc = new Document();
-                string contents = "aa bb cc dd ee ff gg hh ii jj kk";
+                const string contents = "aa bb cc dd ee ff gg hh ii jj kk";
 
                 FieldType customType = new FieldType(TextField.TYPE_STORED);
                 FieldType type = null;
@@ -1018,7 +1023,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestNegativePositions()
         {
-            TokenStream tokens = new TokenStreamAnonymousClass(this);
+            TokenStream tokens = new TokenStreamAnonymousClass();
 
             Directory dir = NewDirectory();
             IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
@@ -1039,11 +1044,8 @@ namespace Lucene.Net.Index
 
         private sealed class TokenStreamAnonymousClass : TokenStream
         {
-            private readonly TestIndexWriter outerInstance;
-
-            public TokenStreamAnonymousClass(TestIndexWriter outerInstance)
+            public TokenStreamAnonymousClass()
             {
-                this.outerInstance = outerInstance;
                 termAtt = AddAttribute<ICharTermAttribute>();
                 posIncrAtt = AddAttribute<IPositionIncrementAttribute>();
                 terms = new JCG.List<string> { "a", "b", "c" }.GetEnumerator();
@@ -1115,7 +1117,7 @@ namespace Lucene.Net.Index
         public virtual void TestDeadlock()
         {
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2));
             Document doc = new Document();
 
             FieldType customType = new FieldType(TextField.TYPE_STORED);
@@ -1151,8 +1153,6 @@ namespace Lucene.Net.Index
 
         private class IndexerThreadInterrupt : ThreadJob
         {
-            private readonly TestIndexWriter outerInstance;
-
             internal volatile bool failed;
             internal volatile bool finish;
 
@@ -1160,9 +1160,8 @@ namespace Lucene.Net.Index
             internal readonly Random random;
             internal readonly Directory adder;
 
-            internal IndexerThreadInterrupt(TestIndexWriter outerInstance)
+            internal IndexerThreadInterrupt()
             {
-                this.outerInstance = outerInstance;
                 this.random = new J2N.Randomizer(Random.NextInt64());
                 // make a little directory for addIndexes
                 // LUCENE-2239: won't work with NIOFS/MMAP
@@ -1444,7 +1443,7 @@ namespace Lucene.Net.Index
             /// <summary>
             /// Safely gets the ToString() of an exception while ignoring any System.Threading.ThreadInterruptedException and retrying.
             /// </summary>
-            private string GetToStringFrom(Exception exception)
+            private static string GetToStringFrom(Exception exception)
             {
                 // Clear interrupt state:
                 try
@@ -1471,8 +1470,8 @@ namespace Lucene.Net.Index
         [Ignore("Lucene.NET does not support Thread.Interrupt(). See https://github.com/apache/lucenenet/issues/526.")]
         public virtual void TestThreadInterruptDeadlock()
         {
-            IndexerThreadInterrupt t = new IndexerThreadInterrupt(this);
-            t.IsBackground = (true);
+            IndexerThreadInterrupt t = new IndexerThreadInterrupt();
+            t.IsBackground = true;
             t.Start();
 
             // Force class loader to load ThreadInterruptedException
@@ -1512,19 +1511,19 @@ namespace Lucene.Net.Index
         [Ignore("Lucene.NET does not support Thread.Interrupt(). See https://github.com/apache/lucenenet/issues/526.")]
         public virtual void TestTwoThreadsInterruptDeadlock()
         {
-            IndexerThreadInterrupt t1 = new IndexerThreadInterrupt(this);
-            t1.IsBackground = (true);
+            IndexerThreadInterrupt t1 = new IndexerThreadInterrupt();
+            t1.IsBackground = true;
             t1.Start();
 
-            IndexerThreadInterrupt t2 = new IndexerThreadInterrupt(this);
-            t2.IsBackground = (true);
+            IndexerThreadInterrupt t2 = new IndexerThreadInterrupt();
+            t2.IsBackground = true;
             t2.Start();
 
             // Force class loader to load ThreadInterruptedException
             // up front... else we can see a false failure if 2nd
             // interrupt arrives while class loader is trying to
             // init this class (in servicing a first interrupt):
-            Assert.IsTrue((new Util.ThreadInterruptedException(new System.Threading.ThreadInterruptedException())).InnerException is System.Threading.ThreadInterruptedException);
+            Assert.IsTrue(new Util.ThreadInterruptedException(new System.Threading.ThreadInterruptedException()).InnerException is System.Threading.ThreadInterruptedException);
 
             // issue 300 interrupts to child thread
             int numInterrupts = AtLeast(300);
@@ -1684,7 +1683,9 @@ namespace Lucene.Net.Index
                 mergePolicy.NoCFSRatio = 1.0;
                 mergePolicy.MaxCFSSegmentSizeMB = double.PositiveInfinity;
 
-                IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(mergePolicy).SetUseCompoundFile(true));
+                IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetMergePolicy(mergePolicy)
+                    .SetUseCompoundFile(true));
                 Document doc = new Document();
                 doc.Add(NewTextField("field", "go", Field.Store.NO));
                 w.AddDocument(doc);
@@ -1776,7 +1777,8 @@ namespace Lucene.Net.Index
             // Validates that iw.DeleteUnusedFiles() also deletes unused index commits
             // in case a deletion policy which holds onto commits is used.
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy())));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetIndexDeletionPolicy(new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy())));
             SnapshotDeletionPolicy sdp = (SnapshotDeletionPolicy)writer.Config.IndexDeletionPolicy;
 
             // First commit
@@ -1818,7 +1820,7 @@ namespace Lucene.Net.Index
             // then IndexWriter ctor succeeds. Previously (LUCENE-2386) it failed
             // when listAll() was called in IndexFileDeleter.
             Directory dir = NewFSDirectory(CreateTempDir("emptyFSDirNoLock"), NoLockFactory.GetNoLockFactory());
-            (new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)))).Dispose();
+            new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).Dispose();
             dir.Dispose();
         }
 
@@ -1832,7 +1834,10 @@ namespace Lucene.Net.Index
             // indexed, flushed (but not committed) and then IW rolls back, then no
             // files are left in the Directory.
             Directory dir = NewDirectory();
-            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2).SetMergePolicy(NewLogMergePolicy()).SetUseCompoundFile(false));
+            IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(2)
+                .SetMergePolicy(NewLogMergePolicy())
+                .SetUseCompoundFile(false));
             string[] files = dir.ListAll();
 
             // Creating over empty dir should not create any files,
@@ -1893,7 +1898,8 @@ namespace Lucene.Net.Index
         {
             BaseDirectoryWrapper dir = NewDirectory();
             dir.SetLockFactory(NoLockFactory.GetNoLockFactory());
-            IndexWriter w = new IndexWriter(dir, (IndexWriterConfig)NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2));
+            IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(2));
 
             Document doc = new Document();
             FieldType customType = new FieldType(TextField.TYPE_STORED);
@@ -1903,7 +1909,9 @@ namespace Lucene.Net.Index
             doc.Add(NewField("c", "val", customType));
             w.AddDocument(doc);
             w.AddDocument(doc);
-            IndexWriter w2 = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMaxBufferedDocs(2).SetOpenMode(OpenMode.CREATE));
+            IndexWriter w2 = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                .SetMaxBufferedDocs(2)
+                .SetOpenMode(OpenMode.CREATE));
 
             w2.Dispose();
             // If we don't do that, the test fails on Windows
@@ -2193,9 +2201,7 @@ namespace Lucene.Net.Index
                 new RandomIndexWriter(Random, d, NewIndexWriterConfig(TEST_VERSION_CURRENT, null).SetWriteLockTimeout(100));
                 Assert.Fail("should not be able to create another writer");
             }
-#pragma warning disable 168
-            catch (LockObtainFailedException lofe)
-#pragma warning restore 168
+            catch (LockObtainFailedException /*lofe*/)
             {
                 // expected
             }
@@ -2299,7 +2305,7 @@ namespace Lucene.Net.Index
         [Test]
         public virtual void TestDontInvokeAnalyzerForUnAnalyzedFields()
         {
-            Analyzer analyzer = new AnalyzerAnonymousClass(this);
+            Analyzer analyzer = new AnalyzerAnonymousClass();
             Directory dir = NewDirectory();
             IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, analyzer));
             Document doc = new Document();
@@ -2320,13 +2326,6 @@ namespace Lucene.Net.Index
 
         private sealed class AnalyzerAnonymousClass : Analyzer
         {
-            private readonly TestIndexWriter outerInstance;
-
-            public AnalyzerAnonymousClass(TestIndexWriter outerInstance)
-            {
-                this.outerInstance = outerInstance;
-            }
-
             protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
             {
                 throw IllegalStateException.Create("don't invoke me!");
@@ -2443,7 +2442,7 @@ namespace Lucene.Net.Index
                 @out.WriteByte((byte)42);
                 @out.Dispose();
 
-                (new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)))).Dispose();
+                new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))).Dispose();
 
                 Assert.IsTrue(SlowFileExists(dir, "_a.frq"));
 
@@ -2710,7 +2709,7 @@ namespace Lucene.Net.Index
 
             public virtual IEnumerator<IEnumerable<IIndexableField>> GetEnumerator()
             {
-                return new EnumeratorAnonymousClass(this, docList.GetEnumerator());
+                return new EnumeratorAnonymousClass(docList.GetEnumerator());
             }
 
             IEnumerator IEnumerable.GetEnumerator()
@@ -2720,12 +2719,10 @@ namespace Lucene.Net.Index
 
             private sealed class EnumeratorAnonymousClass : IEnumerator<IEnumerable<IIndexableField>>
             {
-                private readonly RandomFailingFieldEnumerable outerInstance;
                 private readonly IEnumerator<IEnumerable<IIndexableField>> docIter;
 
-                public EnumeratorAnonymousClass(RandomFailingFieldEnumerable outerInstance, IEnumerator<IEnumerable<IIndexableField>> docIter)
+                public EnumeratorAnonymousClass(IEnumerator<IEnumerable<IIndexableField>> docIter)
                 {
-                    this.outerInstance = outerInstance;
                     this.docIter = docIter;
                 }
 
@@ -2786,11 +2783,11 @@ namespace Lucene.Net.Index
                 {
                     if ((i & 1) == 0)
                     {
-                        (new IndexWriter(dir, iwc)).Dispose();
+                        new IndexWriter(dir, iwc).Dispose();
                     }
                     else
                     {
-                        (new IndexWriter(dir, iwc)).Rollback();
+                        new IndexWriter(dir, iwc).Rollback();
                     }
                     if (mode != 0)
                     {
@@ -2878,7 +2875,7 @@ namespace Lucene.Net.Index
             Directory dir = NewDirectory();
             IndexWriterConfig iwc = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));
             SetOnce<IndexWriter> iwRef = new SetOnce<IndexWriter>();
-            iwc.SetInfoStream(new TestPointInfoStream(iwc.InfoStream, new TestPointAnonymousClass(this, iwRef)));
+            iwc.SetInfoStream(new TestPointInfoStream(iwc.InfoStream, new TestPointAnonymousClass(iwRef)));
             IndexWriter evilWriter = new IndexWriter(dir, iwc);
             iwRef.Set(evilWriter);
             for (int i = 0; i < 1000; i++)
@@ -2897,13 +2894,10 @@ namespace Lucene.Net.Index
 
         private sealed class TestPointAnonymousClass : ITestPoint
         {
-            private readonly TestIndexWriter outerInstance;
-
             private SetOnce<IndexWriter> iwRef;
 
-            public TestPointAnonymousClass(TestIndexWriter outerInstance, SetOnce<IndexWriter> iwRef)
+            public TestPointAnonymousClass(SetOnce<IndexWriter> iwRef)
             {
-                this.outerInstance = outerInstance;
                 this.iwRef = iwRef;
             }
 

--- a/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
@@ -94,12 +94,12 @@ namespace Lucene.Net.Index
                 TermsHashConsumer termVectorsWriter = new TermVectorsConsumer(documentsWriterPerThread);
                 TermsHashConsumer freqProxWriter = new FreqProxTermsWriter();
 
-                InvertedDocConsumer termsHash = new TermsHash(documentsWriterPerThread, freqProxWriter, true, 
+                InvertedDocConsumer termsHash = new TermsHash(documentsWriterPerThread, freqProxWriter, true,
                     new TermsHash(documentsWriterPerThread, termVectorsWriter, false, null));
                 NormsConsumer normsWriter = new NormsConsumer();
                 DocInverter docInverter = new DocInverter(documentsWriterPerThread.docState, termsHash, normsWriter);
                 StoredFieldsConsumer storedFields = new TwoStoredFieldsConsumers(
-                                                            new StoredFieldsProcessor(documentsWriterPerThread), 
+                                                            new StoredFieldsProcessor(documentsWriterPerThread),
                                                             new DocValuesProcessor(documentsWriterPerThread.bytesUsed));
                 return new DocFieldProcessor(documentsWriterPerThread, docInverter, storedFields);
             }
@@ -686,13 +686,13 @@ namespace Lucene.Net.Index
         /// Initial chunks size of the shared byte[] blocks used to
         /// store postings data
         /// </summary>
-        internal static readonly int BYTE_BLOCK_NOT_MASK = ~ByteBlockPool.BYTE_BLOCK_MASK;
+        internal const int BYTE_BLOCK_NOT_MASK = ~ByteBlockPool.BYTE_BLOCK_MASK;
 
         /// <summary>
         /// if you increase this, you must fix field cache impl for
         /// getTerms/getTermsIndex requires &lt;= 32768
         /// </summary>
-        internal static readonly int MAX_TERM_LENGTH_UTF8 = ByteBlockPool.BYTE_BLOCK_SIZE - 2;
+        internal const int MAX_TERM_LENGTH_UTF8 = ByteBlockPool.BYTE_BLOCK_SIZE - 2;
 
         /// <summary>
         /// NOTE: This was IntBlockAllocator in Lucene

--- a/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
@@ -686,13 +686,13 @@ namespace Lucene.Net.Index
         /// Initial chunks size of the shared byte[] blocks used to
         /// store postings data
         /// </summary>
-        internal const int BYTE_BLOCK_NOT_MASK = ~ByteBlockPool.BYTE_BLOCK_MASK;
+        internal static readonly int BYTE_BLOCK_NOT_MASK = ~ByteBlockPool.BYTE_BLOCK_MASK;
 
         /// <summary>
         /// if you increase this, you must fix field cache impl for
         /// getTerms/getTermsIndex requires &lt;= 32768
         /// </summary>
-        internal const int MAX_TERM_LENGTH_UTF8 = ByteBlockPool.BYTE_BLOCK_SIZE - 2;
+        internal static readonly int MAX_TERM_LENGTH_UTF8 = ByteBlockPool.BYTE_BLOCK_SIZE - 2;
 
         /// <summary>
         /// NOTE: This was IntBlockAllocator in Lucene

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -195,23 +195,23 @@ namespace Lucene.Net.Index
         /// <summary>
         /// Name of the write lock in the index.
         /// </summary>
-        public const string WRITE_LOCK_NAME = "write.lock";
+        public static readonly string WRITE_LOCK_NAME = "write.lock";
 
         /// <summary>
         /// Key for the source of a segment in the <see cref="SegmentInfo.Diagnostics"/>. </summary>
-        public const string SOURCE = "source";
+        public static readonly string SOURCE = "source";
 
         /// <summary>
         /// Source of a segment which results from a merge of other segments. </summary>
-        public const string SOURCE_MERGE = "merge";
+        public static readonly string SOURCE_MERGE = "merge";
 
         /// <summary>
         /// Source of a segment which results from a flush. </summary>
-        public const string SOURCE_FLUSH = "flush";
+        public static readonly string SOURCE_FLUSH = "flush";
 
         /// <summary>
         /// Source of a segment which results from a call to <see cref="AddIndexes(IndexReader[])"/>. </summary>
-        public const string SOURCE_ADDINDEXES_READERS = "AddIndexes(params IndexReader[] readers)";
+        public static readonly string SOURCE_ADDINDEXES_READERS = "AddIndexes(params IndexReader[] readers)";
 
         /// <summary>
         /// Absolute hard maximum length for a term, in bytes once
@@ -221,7 +221,7 @@ namespace Lucene.Net.Index
         /// and a message is printed to <see cref="infoStream"/>, if set (see
         /// <see cref="IndexWriterConfig.SetInfoStream(InfoStream)"/>).
         /// </summary>
-        public const int MAX_TERM_LENGTH = DocumentsWriterPerThread.MAX_TERM_LENGTH_UTF8;
+        public static readonly int MAX_TERM_LENGTH = DocumentsWriterPerThread.MAX_TERM_LENGTH_UTF8;
 
         private volatile bool hitOOM;
 

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -195,23 +195,23 @@ namespace Lucene.Net.Index
         /// <summary>
         /// Name of the write lock in the index.
         /// </summary>
-        public static readonly string WRITE_LOCK_NAME = "write.lock";
+        public const string WRITE_LOCK_NAME = "write.lock";
 
         /// <summary>
         /// Key for the source of a segment in the <see cref="SegmentInfo.Diagnostics"/>. </summary>
-        public static readonly string SOURCE = "source";
+        public const string SOURCE = "source";
 
         /// <summary>
         /// Source of a segment which results from a merge of other segments. </summary>
-        public static readonly string SOURCE_MERGE = "merge";
+        public const string SOURCE_MERGE = "merge";
 
         /// <summary>
         /// Source of a segment which results from a flush. </summary>
-        public static readonly string SOURCE_FLUSH = "flush";
+        public const string SOURCE_FLUSH = "flush";
 
         /// <summary>
         /// Source of a segment which results from a call to <see cref="AddIndexes(IndexReader[])"/>. </summary>
-        public static readonly string SOURCE_ADDINDEXES_READERS = "AddIndexes(params IndexReader[] readers)";
+        public const string SOURCE_ADDINDEXES_READERS = "AddIndexes(params IndexReader[] readers)";
 
         /// <summary>
         /// Absolute hard maximum length for a term, in bytes once
@@ -221,7 +221,7 @@ namespace Lucene.Net.Index
         /// and a message is printed to <see cref="infoStream"/>, if set (see
         /// <see cref="IndexWriterConfig.SetInfoStream(InfoStream)"/>).
         /// </summary>
-        public static readonly int MAX_TERM_LENGTH = DocumentsWriterPerThread.MAX_TERM_LENGTH_UTF8;
+        public const int MAX_TERM_LENGTH = DocumentsWriterPerThread.MAX_TERM_LENGTH_UTF8;
 
         private volatile bool hitOOM;
 

--- a/src/Lucene.Net/Util/ByteBlockPool.cs
+++ b/src/Lucene.Net/Util/ByteBlockPool.cs
@@ -45,9 +45,9 @@ namespace Lucene.Net.Util
     /// </summary>
     public sealed class ByteBlockPool
     {
-        public const int BYTE_BLOCK_SHIFT = 15;
-        public const int BYTE_BLOCK_SIZE = 1 << BYTE_BLOCK_SHIFT;
-        public const int BYTE_BLOCK_MASK = BYTE_BLOCK_SIZE - 1;
+        public static readonly int BYTE_BLOCK_SHIFT = 15;
+        public static readonly int BYTE_BLOCK_SIZE = 1 << BYTE_BLOCK_SHIFT;
+        public static readonly int BYTE_BLOCK_MASK = BYTE_BLOCK_SIZE - 1;
 
         /// <summary>
         /// Abstract class for allocating and freeing byte

--- a/src/Lucene.Net/Util/ByteBlockPool.cs
+++ b/src/Lucene.Net/Util/ByteBlockPool.cs
@@ -45,9 +45,9 @@ namespace Lucene.Net.Util
     /// </summary>
     public sealed class ByteBlockPool
     {
-        public static readonly int BYTE_BLOCK_SHIFT = 15;
-        public static readonly int BYTE_BLOCK_SIZE = 1 << BYTE_BLOCK_SHIFT;
-        public static readonly int BYTE_BLOCK_MASK = BYTE_BLOCK_SIZE - 1;
+        public const int BYTE_BLOCK_SHIFT = 15;
+        public const int BYTE_BLOCK_SIZE = 1 << BYTE_BLOCK_SHIFT;
+        public const int BYTE_BLOCK_MASK = BYTE_BLOCK_SIZE - 1;
 
         /// <summary>
         /// Abstract class for allocating and freeing byte


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Test review for core E-I tests

Partial #259 

## Description

This updates the tests in the E-I test assembly to match upstream Lucene for style, formatting, etc. Additionally, some minor bugs (including documentation bugs) have been fixed.
