### PR TITLE
Improve message for unit test failures for lucene.testsettings.json, #999

### DIFF
--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -947,6 +947,17 @@ namespace Lucene.Net.Util
 
                       Option 2:
 
+                       Use the following .runsettings file:
+
+                      <RunSettings>
+                        <TestRunParameters>
+                          <Parameter name="tests:seed" value="{{RandomizedContext.CurrentContext.RandomSeedAsHex}}" />
+                          <Parameter name="tests:culture" value="{{Thread.CurrentThread.CurrentCulture.Name}}" />
+                        </TestRunParameters>
+                      </RunSettings>
+
+                      Option 3:
+
                        Create the following lucene.testsettings.json file somewhere between the test assembly and the root of your drive:
 
                       {

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -929,23 +929,35 @@ namespace Lucene.Net.Util
                 */
 
             TestResult result = TestExecutionContext.CurrentContext.CurrentResult;
-            string message;
+
             if (result.ResultState == ResultState.Failure || result.ResultState == ResultState.Error)
             {
-                message = result.Message + $"\n\nTo reproduce this test result:\n\n" +
-                    $"Option 1:\n\n" +
-                    $" Apply the following assembly-level attributes:\n\n" +
-                    $"[assembly: Lucene.Net.Util.RandomSeed(\"{RandomizedContext.CurrentContext.RandomSeedAsHex}\")]\n" +
-                    $"[assembly: NUnit.Framework.SetCulture(\"{Thread.CurrentThread.CurrentCulture.Name}\")]\n\n" +
-                    $"Option 2:\n\n" +
-                    $" Use the following .runsettings file:\n\n" +
-                    $"<RunSettings>\n" +
-                    $"  <TestRunParameters>\n" +
-                    $"    <Parameter name=\"tests:seed\" value=\"{RandomizedContext.CurrentContext.RandomSeedAsHex}\" />\n" +
-                    $"    <Parameter name=\"tests:culture\" value=\"{Thread.CurrentThread.CurrentCulture.Name}\" />\n" +
-                    $"  </TestRunParameters>\n" +
-                    $"</RunSettings>\n\n" +
-                    $"See the .runsettings documentation at: https://docs.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file.";
+                string message =
+                    $$"""
+                      {{result.Message}}
+
+                      To reproduce this test result:
+
+                      Option 1:
+
+                       Apply the following assembly-level attributes:
+
+                      [assembly: Lucene.Net.Util.RandomSeed("{{RandomizedContext.CurrentContext.RandomSeedAsHex}}")]
+                      [assembly: NUnit.Framework.SetCulture("{{Thread.CurrentThread.CurrentCulture.Name}}")]
+
+                      Option 2:
+
+                       Create the following lucene.testsettings.json file somewhere between the test assembly and the root of your drive:
+
+                      {
+                        "tests": {
+                           "seed": "{{RandomizedContext.CurrentContext.RandomSeedAsHex}}",
+                           "culture": "{{Thread.CurrentThread.CurrentCulture.Name}}"
+                        }
+                      }
+
+                      """;
+
                 result.SetResult(result.ResultState, message, result.StackTrace);
             }
         }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Improves the failed unit test message to provide an example lucene.testsettings.json.

Fixes #999

## Description

The lucene.testsettings.json seems to work more reliably and is a little more user-friendly than the runsettings file, so this improves the failed unit test message to provide a generated lucene.testsettings.json file. This also uses C# 11 multi-line strings instead of manual string concatenation.
