### PR TITLE
Implement ISpanAppendable in CharBlockArray and CharTermAttributeImpl

### DIFF
--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
@@ -191,8 +191,28 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 return this; // No-op
             }
 
-            // LUCENENET specific - use ReadOnlySpan<char> version
-            return Append(value.AsSpan());
+            int remain = value.Length;
+            int offset = 0;
+            while (remain > 0)
+            {
+                if (this.current.length == this.blockSize)
+                {
+                    AddBlock();
+                }
+                int toCopy = remain;
+                int remainingInBlock = this.blockSize - this.current.length;
+                if (remainingInBlock < toCopy)
+                {
+                    toCopy = remainingInBlock;
+                }
+                Arrays.Copy(value, offset, this.current.chars, this.current.length, toCopy);
+                offset += toCopy;
+                remain -= toCopy;
+                this.current.length += toCopy;
+            }
+
+            this.length += value.Length;
+            return this;
         }
 
         public virtual CharBlockArray Append(char[]? value, int startIndex, int length)
@@ -214,8 +234,28 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             if (startIndex > value.Length - length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
 
-            // LUCENENET specific - use ReadOnlySpan<char> version
-            return Append(value.AsSpan(startIndex, length));
+            int offset = startIndex;
+            int remain = length;
+            while (remain > 0)
+            {
+                if (this.current.length == this.blockSize)
+                {
+                    AddBlock();
+                }
+                int toCopy = remain;
+                int remainingInBlock = this.blockSize - this.current.length;
+                if (remainingInBlock < toCopy)
+                {
+                    toCopy = remainingInBlock;
+                }
+                Arrays.Copy(value, offset, this.current.chars, this.current.length, toCopy);
+                offset += toCopy;
+                remain -= toCopy;
+                this.current.length += toCopy;
+            }
+
+            this.length += length;
+            return this;
         }
 
         public virtual CharBlockArray Append(string? value)
@@ -225,8 +265,28 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 return this; // No-op
             }
 
-            // LUCENENET specific - use ReadOnlySpan<char> version
-            return Append(value.AsSpan());
+            int remain = value.Length;
+            int offset = 0;
+            while (remain > 0)
+            {
+                if (this.current.length == this.blockSize)
+                {
+                    AddBlock();
+                }
+                int toCopy = remain;
+                int remainingInBlock = this.blockSize - this.current.length;
+                if (remainingInBlock < toCopy)
+                {
+                    toCopy = remainingInBlock;
+                }
+                value.CopyTo(offset, this.current.chars, this.current.length, toCopy);
+                offset += toCopy;
+                remain -= toCopy;
+                this.current.length += toCopy;
+            }
+
+            this.length += value.Length;
+            return this;
         }
 
         public virtual CharBlockArray Append(string? value, int startIndex, int length)
@@ -248,8 +308,28 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             if (startIndex > value.Length - length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
 
-            // LUCENENET specific - use ReadOnlySpan<char> version
-            return Append(value.AsSpan(startIndex, length));
+            int offset = startIndex;
+            int remain = length;
+            while (remain > 0)
+            {
+                if (this.current.length == this.blockSize)
+                {
+                    AddBlock();
+                }
+                int toCopy = remain;
+                int remainingInBlock = this.blockSize - this.current.length;
+                if (remainingInBlock < toCopy)
+                {
+                    toCopy = remainingInBlock;
+                }
+                value.CopyTo(offset, this.current.chars, this.current.length, toCopy);
+                offset += toCopy;
+                remain -= toCopy;
+                this.current.length += toCopy;
+            }
+
+            this.length += length;
+            return this;
         }
 
         public virtual CharBlockArray Append(StringBuilder? value)

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
@@ -44,9 +44,9 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             // CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
             //     .onUnmappableCharacter(CodingErrorAction.REPLACE)
             //     .onMalformedInput(CodingErrorAction.REPLACE);
-            // 
-            // Encoding decoder = Encoding.GetEncoding(Encoding.UTF8.CodePage, 
-            //     new EncoderReplacementFallback("?"), 
+            //
+            // Encoding decoder = Encoding.GetEncoding(Encoding.UTF8.CodePage,
+            //     new EncoderReplacementFallback("?"),
             //     new DecoderReplacementFallback("?"));
 
             for (int i = 0; i < n; i++)
@@ -247,6 +247,11 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             expected = t.ToString();
             t.Append((char[])null); // No-op
             Assert.AreEqual(expected, t.ToString());
+
+            // LUCENENET specific - test ReadOnlySpan<char> overload
+            t = new CharBlockArray();
+            t.Append("12345678".AsSpan());
+            Assert.AreEqual("12345678", t.ToString());
         }
 
         // LUCENENET: Borrowed this test from TestCharTermAttributeImpl
@@ -285,6 +290,11 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             const string longTestString = "012345678901234567890123456789";
             t.Append(new CharSequenceAnonymousClass(longTestString));
             Assert.AreEqual("4567890123456" + longTestString, t.ToString());
+
+            // LUCENENET specific - test ReadOnlySpan<char> overload
+            t = new CharBlockArray();
+            t.Append("01234567890123456789012345678901234567890123456789".AsSpan());
+            Assert.AreEqual("01234567890123456789012345678901234567890123456789", t.ToString());
         }
 
         private sealed class CharSequenceAnonymousClass : ICharSequence

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
@@ -247,11 +247,6 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             expected = t.ToString();
             t.Append((char[])null); // No-op
             Assert.AreEqual(expected, t.ToString());
-
-            // LUCENENET specific - test ReadOnlySpan<char> overload
-            t = new CharBlockArray();
-            t.Append("12345678".AsSpan());
-            Assert.AreEqual("12345678", t.ToString());
         }
 
         // LUCENENET: Borrowed this test from TestCharTermAttributeImpl
@@ -290,11 +285,30 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             const string longTestString = "012345678901234567890123456789";
             t.Append(new CharSequenceAnonymousClass(longTestString));
             Assert.AreEqual("4567890123456" + longTestString, t.ToString());
+        }
 
-            // LUCENENET specific - test ReadOnlySpan<char> overload
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestSpanAppendableInterface()
+        {
+            CharBlockArray t = new CharBlockArray();
+
+            // Test with a span
+            t.Append("12345678".AsSpan());
+            Assert.AreEqual("12345678", t.ToString());
+
+            // test with a span slice
+            t.Append("0123456789".AsSpan(3, 5 - 3));
+            Assert.AreEqual("1234567834", t.ToString());
+
+            // test with a long span
             t = new CharBlockArray();
             t.Append("01234567890123456789012345678901234567890123456789".AsSpan());
             Assert.AreEqual("01234567890123456789012345678901234567890123456789", t.ToString());
+
+            // test with a long span slice
+            t.Append("01234567890123456789012345678901234567890123456789".AsSpan(3, 50 - 3));
+            Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
         }
 
         private sealed class CharSequenceAnonymousClass : ICharSequence

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -1,5 +1,6 @@
 ﻿using J2N.IO;
 using J2N.Text;
+using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -292,10 +293,6 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
             t.Append((char[])null); // No-op
             Assert.AreEqual("4teste", t.ToString());
-
-            // LUCENENET specific - test ReadOnlySpan<char> overload
-            t.SetEmpty().Append("12345678".AsSpan());
-            Assert.AreEqual("12345678", t.ToString());
         }
 
         [Test]
@@ -330,10 +327,29 @@ namespace Lucene.Net.Analysis.TokenAttributes
             const string longTestString = "012345678901234567890123456789";
             t.Append(new CharSequenceAnonymousClass(longTestString));
             Assert.AreEqual("4567890123456" + longTestString, t.ToString());
+        }
 
-            // LUCENENET specific - test ReadOnlySpan<char> overload
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestSpanAppendableInterface()
+        {
+            CharTermAttribute t = new CharTermAttribute();
+
+            // Test with a span
+            t.Append("12345678".AsSpan());
+            Assert.AreEqual("12345678", t.ToString());
+
+            // test with a span slice
+            t.Append("0123456789".AsSpan(3, 5 - 3));
+            Assert.AreEqual("1234567834", t.ToString());
+
+            // test with a long span
             t.SetEmpty().Append("01234567890123456789012345678901234567890123456789".AsSpan());
             Assert.AreEqual("01234567890123456789012345678901234567890123456789", t.ToString());
+
+            // test with a long span slice
+            t.Append("01234567890123456789012345678901234567890123456789".AsSpan(3, 50 - 3));
+            Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
         }
 
         private sealed class CharSequenceAnonymousClass : ICharSequence

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -292,6 +292,10 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
             t.Append((char[])null); // No-op
             Assert.AreEqual("4teste", t.ToString());
+
+            // LUCENENET specific - test ReadOnlySpan<char> overload
+            t.SetEmpty().Append("12345678".AsSpan());
+            Assert.AreEqual("12345678", t.ToString());
         }
 
         [Test]
@@ -326,6 +330,10 @@ namespace Lucene.Net.Analysis.TokenAttributes
             const string longTestString = "012345678901234567890123456789";
             t.Append(new CharSequenceAnonymousClass(longTestString));
             Assert.AreEqual("4567890123456" + longTestString, t.ToString());
+
+            // LUCENENET specific - test ReadOnlySpan<char> overload
+            t.SetEmpty().Append("01234567890123456789012345678901234567890123456789".AsSpan());
+            Assert.AreEqual("01234567890123456789012345678901234567890123456789", t.ToString());
         }
 
         private sealed class CharSequenceAnonymousClass : ICharSequence

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
@@ -26,7 +26,8 @@ namespace Lucene.Net.Analysis.TokenAttributes
     /// <summary>
     /// The term text of a <see cref="Token"/>.
     /// </summary>
-    public interface ICharTermAttribute : IAttribute, ICharSequence, IAppendable
+    public interface ICharTermAttribute : IAttribute, ICharSequence, IAppendable,
+        ISpanAppendable /* LUCENENET specific */
     {
         /// <summary>
         /// Copies the contents of buffer, starting at offset for
@@ -43,7 +44,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
         /// you can then directly alter.  If the array is too
         /// small for your token, use <see cref="ResizeBuffer(int)"/>
         /// to increase it.  After
-        /// altering the buffer be sure to call <see cref="SetLength(int)"/> 
+        /// altering the buffer be sure to call <see cref="SetLength(int)"/>
         /// to record the number of valid
         /// characters that were placed into the termBuffer.
         /// <para>
@@ -76,15 +77,15 @@ namespace Lucene.Net.Analysis.TokenAttributes
         /// the termBuffer array. Use this to truncate the termBuffer
         /// or to synchronize with external manipulation of the termBuffer.
         /// Note: to grow the size of the array,
-        /// use <see cref="ResizeBuffer(int)"/> first. 
-        /// NOTE: This is exactly the same operation as calling the <see cref="Length"/> setter, the primary 
+        /// use <see cref="ResizeBuffer(int)"/> first.
+        /// NOTE: This is exactly the same operation as calling the <see cref="Length"/> setter, the primary
         /// difference is that this method returns a reference to the current object so it can be chained.
         /// <code>
         /// obj.SetLength(30).Append("hey you");
         /// </code>
         /// </summary>
         /// <param name="length"> the truncated length </param>
-        ICharTermAttribute SetLength(int length); 
+        ICharTermAttribute SetLength(int length);
 
         /// <summary>
         /// Sets the length of the termBuffer to zero.
@@ -197,8 +198,8 @@ namespace Lucene.Net.Analysis.TokenAttributes
         /// </summary>
         /// <param name="value">The sequence of characters to append.</param>
         /// <remarks>
-        /// LUCENENET specific method, added because the .NET <see cref="string"/> data type 
-        /// doesn't implement <see cref="ICharSequence"/>. 
+        /// LUCENENET specific method, added because the .NET <see cref="string"/> data type
+        /// doesn't implement <see cref="ICharSequence"/>.
         /// </remarks>
         new ICharTermAttribute Append(string value);
 
@@ -228,8 +229,8 @@ namespace Lucene.Net.Analysis.TokenAttributes
         /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
         /// </exception>
         /// <remarks>
-        /// LUCENENET specific method, added because the .NET <see cref="string"/> data type 
-        /// doesn't implement <see cref="ICharSequence"/>. 
+        /// LUCENENET specific method, added because the .NET <see cref="string"/> data type
+        /// doesn't implement <see cref="ICharSequence"/>.
         /// </remarks>
         new ICharTermAttribute Append(string value, int startIndex, int count); // LUCENENET TODO: API - change to startIndex/length to match .NET
 
@@ -270,7 +271,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
         /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
         /// </exception>
         /// <remarks>
-        /// LUCENENET specific method, added because the .NET <see cref="StringBuilder"/> data type 
+        /// LUCENENET specific method, added because the .NET <see cref="StringBuilder"/> data type
         /// doesn't implement <see cref="ICharSequence"/>.
         /// </remarks>
         new ICharTermAttribute Append(StringBuilder value, int startIndex, int count);

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
@@ -26,8 +26,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
     /// <summary>
     /// The term text of a <see cref="Token"/>.
     /// </summary>
-    public interface ICharTermAttribute : IAttribute, ICharSequence, IAppendable,
-        ISpanAppendable /* LUCENENET specific */
+    public interface ICharTermAttribute : IAttribute, ICharSequence, IAppendable
     {
         /// <summary>
         /// Copies the contents of buffer, starting at offset for

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
@@ -216,8 +216,10 @@ namespace Lucene.Net.Analysis.TokenAttributes
             if (startIndex > value.Length - charCount)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(charCount)} <= {nameof(Length)}.");
 
-            // LUCENENET specific - use ReadOnlySpan<char> version for better performance
-            return Append(value.AsSpan(startIndex, charCount));
+            value.CopyTo(startIndex, InternalResizeBuffer(termLength + charCount), termLength, charCount);
+            Length += charCount;
+
+            return this;
         }
 
         public CharTermAttribute Append(char value)
@@ -232,8 +234,11 @@ namespace Lucene.Net.Analysis.TokenAttributes
                 //return AppendNull();
                 return this; // No-op
 
-            // LUCENENET specific - use ReadOnlySpan<char> version for better performance
-            return Append(value.AsSpan());
+            int len = value.Length;
+            value.CopyTo(InternalResizeBuffer(termLength + len), termLength);
+            Length += len;
+
+            return this;
         }
 
         public CharTermAttribute Append(char[] value, int startIndex, int charCount)
@@ -255,8 +260,10 @@ namespace Lucene.Net.Analysis.TokenAttributes
             if (startIndex > value.Length - charCount)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(charCount)} <= {nameof(Length)}.");
 
-            // LUCENENET specific - use ReadOnlySpan<char> version for better performance
-            return Append(value.AsSpan(startIndex, charCount));
+            Arrays.Copy(value, startIndex, InternalResizeBuffer(termLength + charCount), termLength, charCount);
+            Length += charCount;
+
+            return this;
         }
 
         public CharTermAttribute Append(string value)


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Implement `ISpanAppendable` in `CharBlockArray` and `CharTermAttributeImpl`

Fixes #1026

## Description

This adds `ISpanAppendable` to the `CharBlockArray` and `CharTermAttributeImpl` classes. The classes implement the interface explicitly so that we can provide a default implementation that returns itself rather than `ISpanAppendable`, to match the existing Append overloads.

Note that while `IAppendable` is now redundant in the interface list for these types, I left it there for Lucene source compatibility and reference, since `ISpanAppendable` does not exist in Lucene.
