### PR TITLE
BREAKING: Make ReusableStringReader internal

### DIFF
--- a/src/Lucene.Net/Analysis/ReusableStringReader.cs
+++ b/src/Lucene.Net/Analysis/ReusableStringReader.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Analysis
     /// <summary>
     /// Internal class to enable reuse of the string reader by <see cref="Analyzer.GetTokenStream(string, string)"/>
     /// </summary>
-    public sealed class ReusableStringReader : System.IO.TextReader
+    internal sealed class ReusableStringReader : System.IO.TextReader
     {
         private int pos = 0, size = 0;
         private string s = null;


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Make ReusableStringReader internal

Fixes #1029

## Description

This was incorrectly ported as public; this now matches Lucene. This is a breaking change.
