### PR TITLE
Fix incorrect usage of argument exceptions for Sonar csharpsquid:S3928, #682

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Shingle/ShingleFilterFactory.cs
@@ -43,23 +43,25 @@ namespace Lucene.Net.Analysis.Shingle
         private readonly string fillerToken;
 
         /// <summary>
-        /// Creates a new <see cref="ShingleFilterFactory"/> </summary>
-        public ShingleFilterFactory(IDictionary<string, string> args) 
+        /// Creates a new <see cref="ShingleFilterFactory"/>
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown if any of the <paramref name="args"/> key/value pairs are invalid.</exception>
+        public ShingleFilterFactory(IDictionary<string, string> args)
             : base(args)
         {
             maxShingleSize = GetInt32(args, "maxShingleSize", ShingleFilter.DEFAULT_MAX_SHINGLE_SIZE);
             if (maxShingleSize < 2)
             {
-                throw new ArgumentOutOfRangeException(nameof(maxShingleSize), "Invalid maxShingleSize (" + maxShingleSize + ") - must be at least 2"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentException("Invalid maxShingleSize (" + maxShingleSize + ") - must be at least 2", nameof(args));
             }
             minShingleSize = GetInt32(args, "minShingleSize", ShingleFilter.DEFAULT_MIN_SHINGLE_SIZE);
             if (minShingleSize < 2)
             {
-                throw new ArgumentOutOfRangeException(nameof(minShingleSize), "Invalid minShingleSize (" + minShingleSize + ") - must be at least 2"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentException("Invalid minShingleSize (" + minShingleSize + ") - must be at least 2", nameof(args));
             }
             if (minShingleSize > maxShingleSize)
             {
-                throw new ArgumentException("Invalid minShingleSize (" + minShingleSize + ") - must be no greater than maxShingleSize (" + maxShingleSize + ")");
+                throw new ArgumentException("Invalid minShingleSize (" + minShingleSize + ") - must be no greater than maxShingleSize (" + maxShingleSize + ")", nameof(args));
             }
             outputUnigrams = GetBoolean(args, "outputUnigrams", true);
             outputUnigramsIfNoShingles = GetBoolean(args, "outputUnigramsIfNoShingles", false);
@@ -67,7 +69,7 @@ namespace Lucene.Net.Analysis.Shingle
             fillerToken = Get(args, "fillerToken", ShingleFilter.DEFAULT_FILLER_TOKEN);
             if (args.Count > 0)
             {
-                throw new ArgumentException(string.Format(J2N.Text.StringFormatter.CurrentCulture, "Unknown parameters: {0}", args));
+                throw new ArgumentException(string.Format(J2N.Text.StringFormatter.CurrentCulture, "Unknown parameters: {0}", args), nameof(args));
             }
         }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymFilter.cs
@@ -273,7 +273,7 @@ namespace Lucene.Net.Analysis.Synonym
             this.fst = synonyms.Fst;
             if (fst is null)
             {
-                throw new ArgumentNullException(nameof(synonyms.Fst), "fst must be non-null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
+                throw new ArgumentException("synonyms.Fst must be non-null", nameof(synonyms));
             }
             this.fstReader = fst.GetBytesReader();
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymMap.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Analysis.Synonym
 
             /// <summary>
             /// If dedup is true then identical rules (same input,
-            ///  same output) will be added only once. 
+            ///  same output) will be added only once.
             /// </summary>
             public Builder(bool dedup)
             {
@@ -95,9 +95,9 @@ namespace Lucene.Net.Analysis.Synonym
             }
 
             /// <summary>
-            /// Sugar: just joins the provided terms with 
+            /// Sugar: just joins the provided terms with
             /// <see cref="SynonymMap.WORD_SEPARATOR"/>. reuse and its chars
-            /// must not be null. 
+            /// must not be null.
             /// </summary>
             public static CharsRef Join(string[] words, CharsRef reuse)
             {
@@ -163,7 +163,7 @@ namespace Lucene.Net.Analysis.Synonym
                 }
                 if (input.Length <= 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(input.Length), "input.Length must be > 0 (got " + input.Length + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentException("input.Length must be > 0 (got " + input.Length + ")", nameof(input));
                 }
                 if (numOutputWords <= 0)
                 {
@@ -171,7 +171,7 @@ namespace Lucene.Net.Analysis.Synonym
                 }
                 if (output.Length <= 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(output.Length), "output.Length must be > 0 (got " + output.Length + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentException("output.Length must be > 0 (got " + output.Length + ")", nameof(output));
                 }
 
                 if (Debugging.AssertsEnabled)
@@ -332,7 +332,7 @@ namespace Lucene.Net.Analysis.Synonym
 
         /// <summary>
         /// Abstraction for parsing synonym files.
-        /// 
+        ///
         /// @lucene.experimental
         /// </summary>
         public abstract class Parser : Builder
@@ -353,7 +353,7 @@ namespace Lucene.Net.Analysis.Synonym
             /// <summary>
             /// Sugar: analyzes the text with the analyzer and
             /// separates by <see cref="SynonymMap.WORD_SEPARATOR"/>.
-            /// reuse and its chars must not be null. 
+            /// reuse and its chars must not be null.
             /// </summary>
             public virtual CharsRef Analyze(string text, CharsRef reuse)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Analysis.Util
     /// <see cref="CharacterUtils"/> provides a unified interface to Character-related
     /// operations to implement backwards compatible character operations based on a
     /// <see cref="LuceneVersion"/> instance.
-    /// 
+    ///
     /// @lucene.internal
     /// </summary>
     public abstract class CharacterUtils
@@ -57,8 +57,8 @@ namespace Lucene.Net.Analysis.Util
         public static CharacterUtils GetInstance(LuceneVersion matchVersion)
         {
 #pragma warning disable 612, 618
-            return matchVersion.OnOrAfter(LuceneVersion.LUCENE_31) 
-                ? JAVA_5 
+            return matchVersion.OnOrAfter(LuceneVersion.LUCENE_31)
+                ? JAVA_5
                 : JAVA_4_BW_COMPAT;
 #pragma warning restore 612, 618
         }
@@ -125,7 +125,7 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="offset">
         ///          the offset to the char values in the chars array to be converted </param>
         /// <param name="limit"> the index afer the last element that should be used to calculate
-        ///        codepoint.  
+        ///        codepoint.
         /// </param>
         /// <returns> the Unicode code point at the given index </returns>
         /// <exception cref="ArgumentNullException">
@@ -170,7 +170,7 @@ namespace Lucene.Net.Analysis.Util
 
 
         /// <summary>
-        /// Converts each unicode codepoint to lowerCase via <see cref="TextInfo.ToLower(string)"/> in the invariant culture starting 
+        /// Converts each unicode codepoint to lowerCase via <see cref="TextInfo.ToLower(string)"/> in the invariant culture starting
         /// at the given offset. </summary>
         /// <param name="buffer"> the char buffer to lowercase </param>
         /// <param name="offset"> the offset to start at </param>
@@ -195,7 +195,7 @@ namespace Lucene.Net.Analysis.Util
             //    .ToLower(new string(buffer, offset, length))
             //    .CopyTo(0, buffer, offset, length);
 
-            //// Optimization provided by Vincent Van Den Berghe: 
+            //// Optimization provided by Vincent Van Den Berghe:
             //// http://search-lucene.com/m/Lucene.Net/j1zMf1uckOzOYqsi?subj=Proposal+to+speed+up+implementation+of+LowercaseFilter+charUtils+ToLower
             //new string(buffer, offset, length)
             //    .ToLowerInvariant()
@@ -212,7 +212,7 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Converts each unicode codepoint to UpperCase via <see cref="TextInfo.ToUpper(string)"/> in the invariant culture starting 
+        /// Converts each unicode codepoint to UpperCase via <see cref="TextInfo.ToUpper(string)"/> in the invariant culture starting
         /// at the given offset. </summary>
         /// <param name="buffer"> the char buffer to UPPERCASE </param>
         /// <param name="offset"> the offset to start at </param>
@@ -237,7 +237,7 @@ namespace Lucene.Net.Analysis.Util
             //    .ToUpper(new string(buffer, offset, length))
             //    .CopyTo(0, buffer, offset, length);
 
-            //// Optimization provided by Vincent Van Den Berghe: 
+            //// Optimization provided by Vincent Van Den Berghe:
             //// http://search-lucene.com/m/Lucene.Net/j1zMf1uckOzOYqsi?subj=Proposal+to+speed+up+implementation+of+LowercaseFilter+charUtils+ToLower
             //new string(buffer, offset, length)
             //    .ToUpperInvariant()
@@ -338,7 +338,7 @@ namespace Lucene.Net.Analysis.Util
 
         /// <summary>
         /// Return the index within <c>buf[start:start+count]</c> which is by <paramref name="offset"/>
-        /// code points from <paramref name="index"/>. 
+        /// code points from <paramref name="index"/>.
         /// </summary>
         public abstract int OffsetByCodePoints(char[] buf, int start, int count, int index, int offset);
 
@@ -548,7 +548,8 @@ namespace Lucene.Net.Analysis.Util
                 uint result = (uint)index + (uint)offset;
                 if (result < 0 || result > count)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index) + " + " + nameof(offset), "index + offset must be >= 0 and <= count");
+                    // LUCENENET note - it is common in .NET to use the "index" (or "start") parameter for the paramName, even though offset might be what is invalid
+                    throw new ArgumentOutOfRangeException(nameof(index), "index + offset must be >= 0 and <= count");
                 }
                 return (int)result;
             }

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilterFactory.cs
@@ -38,18 +38,21 @@ namespace Lucene.Net.Analysis.Ja
         private const string MINIMUM_LENGTH_PARAM = "minimumLength";
         private readonly int minimumLength;
 
-        /// <summary>Creates a new <see cref="JapaneseKatakanaStemFilterFactory"/></summary>
+        /// <summary>
+        /// Creates a new <see cref="JapaneseKatakanaStemFilterFactory"/>
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown if any of the <paramref name="args"/> key/value pairs are invalid.</exception>
         public JapaneseKatakanaStemFilterFactory(IDictionary<string, string> args)
             : base(args)
         {
             minimumLength = GetInt32(args, MINIMUM_LENGTH_PARAM, JapaneseKatakanaStemFilter.DEFAULT_MINIMUM_LENGTH);
             if (minimumLength < 2)
             {
-                throw new ArgumentOutOfRangeException(nameof(minimumLength), "Illegal " + MINIMUM_LENGTH_PARAM + " " + minimumLength + " (must be 2 or greater)"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentException("Illegal " + MINIMUM_LENGTH_PARAM + " " + minimumLength + " (must be 2 or greater)", nameof(args));
             }
             if (args.Count > 0)
             {
-                throw new ArgumentException(string.Format(J2N.Text.StringFormatter.CurrentCulture, "Unknown parameters: {0}", args));
+                throw new ArgumentException(string.Format(J2N.Text.StringFormatter.CurrentCulture, "Unknown parameters: {0}", args), nameof(args));
             }
         }
 

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
@@ -357,7 +357,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
         {
             if (finalRules is null)
             {
-                throw new ArgumentNullException("finalRules can not be null");// LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
+                throw new ArgumentNullException(nameof(finalRules), "finalRules can not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
             }
             if (finalRules.Count == 0)
             {

--- a/src/Lucene.Net.Benchmark/ByTask/Benchmark.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Benchmark.cs
@@ -123,7 +123,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             if (args.Length < 1)
             {
                 // LUCENENET specific - usage info printed by our wrapper console
-                throw new ArgumentException();
+                throw new ArgumentException("Benchmark requires 1 argument", nameof(args));
                 //Console.WriteLine("Usage: java Benchmark <algorithm file>");
                 //Environment.Exit(1);
             }

--- a/src/Lucene.Net.Benchmark/Quality/Trec/QueryDriver.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/QueryDriver.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
             if (args.Length < 4 || args.Length > 5)
             {
                 // LUCENENET specific - our wrapper console shows correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("QueryDriver requires 4 or 5 arguments", nameof(args));
                 //Console.Error.WriteLine("Usage: QueryDriver <topicsFile> <qrelsFile> <submissionFile> <indexDir> [querySpec]");
                 //Console.Error.WriteLine("topicsFile: input file containing queries");
                 //Console.Error.WriteLine("qrelsFile: input file containing relevance judgements");

--- a/src/Lucene.Net.Benchmark/Quality/Utils/QualityQueriesFinder.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Utils/QualityQueriesFinder.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Benchmarks.Quality.Utils
             if (args.Length < 1)
             {
                 // LUCENENET specific - our wrapper console shows correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("QualityQueriesFinder requires 1 argument", nameof(args));
                 //Console.Error.WriteLine("Usage: java QualityQueriesFinder <index-dir>");
                 //Environment.Exit(1);
             }

--- a/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
+++ b/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
@@ -177,7 +177,7 @@ namespace Lucene.Net.Benchmarks.Utils
             else
             {
                 // LUCENENET specific - our wrapper console shows correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("Wikipedia file not found", nameof(args));
                 //PrintUsage();
             }
         }

--- a/src/Lucene.Net.Facet/Taxonomy/PrintTaxonomyStats.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/PrintTaxonomyStats.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Facet.Taxonomy
     using FSDirectory = Lucene.Net.Store.FSDirectory;
 
     /// <summary>
-    /// Prints how many ords are under each dimension. 
+    /// Prints how many ords are under each dimension.
     /// </summary>
 
     // java -cp ../build/core/classes/java:../build/facet/classes/java org.apache.lucene.facet.util.PrintTaxonomyStats -printTree /s2/scratch/indices/wikibig.trunk.noparents.facets.Lucene41.nd1M/facets
@@ -54,14 +54,14 @@ namespace Lucene.Net.Facet.Taxonomy
             if (args.Length != (printTree ? 2 : 1))
             {
                 // LUCENENET specific - our wrapper console shows the correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("PrintTaxonomyStats requires 1 or 2 arguments", nameof(args));
                 //Console.WriteLine("\nUsage: java -classpath ... org.apache.lucene.facet.util.PrintTaxonomyStats [-printTree] /path/to/taxononmy/index\n");
                 //return 1;
             }
             using Store.Directory dir = FSDirectory.Open(new DirectoryInfo(path));
             using var r = new DirectoryTaxonomyReader(dir);
             PrintStats(r, System.Console.Out, printTree);
-  
+
             return 0;
         }
 

--- a/src/Lucene.Net.Highlighter/VectorHighlight/BaseFragListBuilder.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/BaseFragListBuilder.cs
@@ -137,7 +137,7 @@ namespace Lucene.Net.Search.VectorHighlight
         {
             // LUCENENET specific - added guard clause to check for null
             if (info is null)
-                throw new ArgumentNullException(nameof(WeightedPhraseInfo));
+                throw new ArgumentNullException(nameof(info));
 
             return info.TermsOffsets.Count <= 1 || matchLength <= fragCharSize;
         }

--- a/src/Lucene.Net.Misc/Index/IndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/IndexSplitter.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Index
             if (args.Length < 2)
             {
                 // LUCENENET specific - our wrapper console shows the correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("IndexSplitter requires at least 2 arguments", nameof(args));
                 //Console.Error.WriteLine("Usage: IndexSplitter <srcDir> -l (list the segments and their sizes)");
                 //Console.Error.WriteLine("IndexSplitter <srcDir> <destDir> <segments>+");
                 //Console.Error.WriteLine("IndexSplitter <srcDir> -d (delete the following segments)");

--- a/src/Lucene.Net.Misc/Index/MultiPassIndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/MultiPassIndexSplitter.cs
@@ -63,11 +63,11 @@ namespace Lucene.Net.Index
         {
             if (outputs is null || outputs.Length < 2)
             {
-                throw new IOException("Invalid number of outputs.");
+                throw new ArgumentException("Invalid number of outputs.", nameof(outputs));
             }
             if (@in is null || @in.NumDocs < 2)
             {
-                throw new IOException("Not enough documents for splitting");
+                throw new ArgumentException("Not enough documents for splitting", nameof(@in));
             }
             int numParts = outputs.Length;
             // wrap a potentially read-only input
@@ -136,7 +136,7 @@ namespace Lucene.Net.Index
             if (args.Length < 5)
             {
                 // LUCENENET specific - our wrapper console shows the correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("MultiPassIndexSplitter requires at least 5 arguments", nameof(args));
                 //Console.Error.WriteLine("Usage: MultiPassIndexSplitter -out <outputDir> -num <numParts> [-seq] <inputIndex1> [<inputIndex2 ...]");
                 //Console.Error.WriteLine("\tinputIndex\tpath to input index, multiple values are ok");
                 //Console.Error.WriteLine("\t-out ouputDir\tpath to output directory to contain partial indexes");

--- a/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
+++ b/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
@@ -64,7 +64,7 @@ namespace Lucene.Net.Misc
             else
             {
                 // LUCENENET specific - our wrapper console shows the correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("GetTermInfo requires 3 arguments", nameof(args));
                 //Usage();
                 //Environment.Exit(1);
             }

--- a/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
+++ b/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Misc
             if (args.Length == 0 || args.Length > 4)
             {
                 // LUCENENET specific - our wrapper console shows the correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("HighFreqTerms requires 1 to 4 arguments", nameof(args));
                 //Usage();
                 //Environment.Exit(1);
             }

--- a/src/Lucene.Net.Misc/Misc/IndexMergeTool.cs
+++ b/src/Lucene.Net.Misc/Misc/IndexMergeTool.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Misc
             if (args.Length < 3)
             {
                 // LUCENENET specific - our wrapper console shows the correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("IndexMergeTool requires at least 3 arguments", nameof(args));
                 //Console.Error.WriteLine("Usage: IndexMergeTool <mergedIndex> <index1> <index2> [index3] ...");
                 //Environment.Exit(1);
             }

--- a/src/Lucene.Net.Queries/TermFilter.cs
+++ b/src/Lucene.Net.Queries/TermFilter.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Queries
      * See the License for the specific language governing permissions and
      * limitations under the License.
      */
-    
+
     /// <summary>
     /// A filter that includes documents that match with a specific term.
     /// </summary>
@@ -39,7 +39,7 @@ namespace Lucene.Net.Queries
             }
             else if (term.Field is null)
             {
-                throw new ArgumentNullException(nameof(term.Field), "term.Field must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
+                throw new ArgumentException("term.Field must not be null", nameof(term));
             }
             this.term = term;
         }

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletionBuilder.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletionBuilder.cs
@@ -209,7 +209,7 @@ namespace Lucene.Net.Search.Suggest.Fst
 
             if (bucket < 0 || bucket >= buckets)
             {
-                throw new ArgumentOutOfRangeException(nameof(buckets), "Bucket outside of the allowed range [0, " + buckets + "): " + bucket); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(bucket), "Bucket outside of the allowed range [0, " + buckets + "): " + bucket); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
 
             if (scratch.Bytes.Length < utf8.Length + 1)

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
@@ -171,13 +171,13 @@ namespace Lucene.Net.Analysis.Synonym
                 return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, false));
             });
 
-            AssertAnalyzesTo(analyzer, "a b c", 
-                            new string[] { "foo", "c" }, 
-                            new int[] { 0, 4 }, 
-                            new int[] { 3, 5 }, 
-                            null, 
-                            new int[] { 1, 1 }, 
-                            new int[] { 1, 1 }, 
+            AssertAnalyzesTo(analyzer, "a b c",
+                            new string[] { "foo", "c" },
+                            new int[] { 0, 4 },
+                            new int[] { 3, 5 },
+                            null,
+                            new int[] { 1, 1 },
+                            new int[] { 1, 1 },
                             true);
             CheckAnalysisConsistency(Random, analyzer, false, "a b c");
         }
@@ -196,13 +196,13 @@ namespace Lucene.Net.Analysis.Synonym
                 return new TokenStreamComponents(tokenizer, new SynonymFilter(tokenizer, map, false));
             });
 
-            AssertAnalyzesTo(analyzer, "a b c", 
-                            new string[] { "a", "foo", "b", "c" }, 
-                            new int[] { 0, 0, 2, 4 }, 
-                            new int[] { 1, 3, 3, 5 }, 
-                            null, 
-                            new int[] { 1, 0, 1, 1 }, 
-                            new int[] { 1, 2, 1, 1 }, 
+            AssertAnalyzesTo(analyzer, "a b c",
+                            new string[] { "a", "foo", "b", "c" },
+                            new int[] { 0, 0, 2, 4 },
+                            new int[] { 1, 3, 3, 5 },
+                            null,
+                            new int[] { 1, 0, 1, 1 },
+                            new int[] { 1, 2, 1, 1 },
                             true);
             CheckAnalysisConsistency(Random, analyzer, false, "a b c");
         }
@@ -958,13 +958,13 @@ namespace Lucene.Net.Analysis.Synonym
             Tokenizer tokenizer = new MockTokenizer(new StringReader("aa bb"));
             try
             {
-                new SynonymFilter(tokenizer, (new SynonymMap.Builder(true)).Build(), true);
+                _ = new SynonymFilter(tokenizer, new SynonymMap.Builder(true).Build(), true);
                 fail("did not hit expected exception");
             }
-            catch (ArgumentNullException iae) // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
+            catch (ArgumentException iae)
             {
                 // expected
-                assertTrue(iae.Message.Contains("fst must be non-null")); // LUCENENET: .NET Adds the parameter name to the message
+                assertTrue(iae.Message.Contains("Fst must be non-null")); // LUCENENET: .NET Adds the parameter name to the message
             }
         }
     }

--- a/src/Lucene.Net.Tests.Queries/TermFilterTest.cs
+++ b/src/Lucene.Net.Tests.Queries/TermFilterTest.cs
@@ -34,39 +34,39 @@ namespace Lucene.Net.Tests.Queries
         [Test]
         public void TestCachability()
         {
-            TermFilter a = TermFilter(@"field1", @"a");
+            TermFilter a = TermFilter("field1", "a");
             var cachedFilters = new JCG.HashSet<Filter>();
             cachedFilters.Add(a);
-            assertTrue(@"Must be cached", cachedFilters.Contains(TermFilter(@"field1", @"a")));
-            assertFalse(@"Must not be cached", cachedFilters.Contains(TermFilter(@"field1", @"b")));
-            assertFalse(@"Must not be cached", cachedFilters.Contains(TermFilter(@"field2", @"a")));
+            assertTrue("Must be cached", cachedFilters.Contains(TermFilter("field1", "a")));
+            assertFalse("Must not be cached", cachedFilters.Contains(TermFilter("field1", "b")));
+            assertFalse("Must not be cached", cachedFilters.Contains(TermFilter("field2", "a")));
         }
 
         [Test]
         public void TestMissingTermAndField()
         {
-            string fieldName = @"field1";
+            const string fieldName = "field1";
             Directory rd = NewDirectory();
             RandomIndexWriter w = new RandomIndexWriter(Random, rd);
             Document doc = new Document();
-            doc.Add(NewStringField(fieldName, @"value1", Field.Store.NO));
+            doc.Add(NewStringField(fieldName, "value1", Field.Store.NO));
             w.AddDocument(doc);
             IndexReader reader = SlowCompositeReaderWrapper.Wrap(w.GetReader());
             assertTrue(reader.Context is AtomicReaderContext);
             var context = (AtomicReaderContext)reader.Context;
             w.Dispose();
 
-            DocIdSet idSet = TermFilter(fieldName, @"value1").GetDocIdSet(context, context.AtomicReader.LiveDocs);
-            assertNotNull(@"must not be null", idSet);
+            DocIdSet idSet = TermFilter(fieldName, "value1").GetDocIdSet(context, context.AtomicReader.LiveDocs);
+            assertNotNull("must not be null", idSet);
             DocIdSetIterator iter = idSet.GetIterator();
             assertEquals(iter.NextDoc(), 0);
             assertEquals(iter.NextDoc(), DocIdSetIterator.NO_MORE_DOCS);
 
-            idSet = TermFilter(fieldName, @"value2").GetDocIdSet(context, context.AtomicReader.LiveDocs);
-            assertNull(@"must be null", idSet);
+            idSet = TermFilter(fieldName, "value2").GetDocIdSet(context, context.AtomicReader.LiveDocs);
+            assertNull("must be null", idSet);
 
-            idSet = TermFilter(@"field2", @"value1").GetDocIdSet(context, context.AtomicReader.LiveDocs);
-            assertNull(@"must be null", idSet);
+            idSet = TermFilter("field2", "value1").GetDocIdSet(context, context.AtomicReader.LiveDocs);
+            assertNull("must be null", idSet);
 
             reader.Dispose();
             rd.Dispose();
@@ -81,7 +81,7 @@ namespace Lucene.Net.Tests.Queries
             var terms = new JCG.List<Term>();
             for (int i = 0; i < num; i++)
             {
-                string field = @"field" + i;
+                string field = "field" + i;
                 string str = TestUtil.RandomRealisticUnicodeString(Random);
                 terms.Add(new Term(field, str));
                 Document doc = new Document();
@@ -121,10 +121,10 @@ namespace Lucene.Net.Tests.Queries
             int num = AtLeast(100);
             for (int i = 0; i < num; i++)
             {
-                string field1 = @"field" + i;
-                string field2 = @"field" + i + num;
+                string field1 = "field" + i;
+                string field2 = "field" + i + num;
                 string value1 = TestUtil.RandomRealisticUnicodeString(Random);
-                string value2 = value1 + @"x"; // this must be not equal to value1
+                string value2 = value1 + "x"; // this must be not equal to value1
 
                 TermFilter filter1 = TermFilter(field1, value1);
                 TermFilter filter2 = TermFilter(field1, value2);
@@ -164,8 +164,8 @@ namespace Lucene.Net.Tests.Queries
         {
             try
             {
-                new TermFilter(null);
-                Assert.Fail(@"must fail - no term!");
+                _ = new TermFilter(null);
+                Assert.Fail("must fail - no term!");
             }
             catch (ArgumentNullException) // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
             {
@@ -173,10 +173,10 @@ namespace Lucene.Net.Tests.Queries
 
             try
             {
-                new TermFilter(new Term(null));
-                Assert.Fail(@"must fail - no field!");
+                _ = new TermFilter(new Term(null));
+                Assert.Fail("must fail - no field!");
             }
-            catch (ArgumentNullException) // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
+            catch (ArgumentException)
             {
             }
         }
@@ -185,15 +185,17 @@ namespace Lucene.Net.Tests.Queries
         public void TestToString()
         {
             var termsFilter = new TermFilter(new Term("field1", "a"));
-            assertEquals(@"field1:a", termsFilter.ToString());
+            assertEquals("field1:a", termsFilter.ToString());
         }
 
-        private TermFilter TermFilter(string field, string value)
+        // LUCENENET specific - made static
+        private static TermFilter TermFilter(string field, string value)
         {
             return TermFilter(new Term(field, value));
         }
 
-        private TermFilter TermFilter(Term term)
+        // LUCENENET specific - made static
+        private static TermFilter TermFilter(Term term)
         {
             return new TermFilter(term);
         }

--- a/src/Lucene.Net/Index/IndexUpgrader.cs
+++ b/src/Lucene.Net/Index/IndexUpgrader.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Index
         private static void PrintUsage()
         {
             // LUCENENET specific - our wrapper console shows the correct usage
-            throw new ArgumentException();
+            throw new ArgumentException("One or more arguments was invalid");
             //Console.Error.WriteLine("Upgrades an index so all segments created with a previous Lucene version are rewritten.");
             //Console.Error.WriteLine("Usage:");
             //Console.Error.WriteLine("  java " + typeof(IndexUpgrader).Name + " [-delete-prior-commits] [-verbose] [-dir-impl X] indexDir");

--- a/src/Lucene.Net/Index/IndexWriterConfig.cs
+++ b/src/Lucene.Net/Index/IndexWriterConfig.cs
@@ -47,19 +47,19 @@ namespace Lucene.Net.Index
     ///         OpenMode = OpenMode.CREATE
     ///     };
     /// </code>
-    /// 
-    /// However, if you prefer to match the syntax of Lucene using chained setter methods, 
+    ///
+    /// However, if you prefer to match the syntax of Lucene using chained setter methods,
     /// there are extension methods in the Lucene.Net.Index.Extensions namespace. Example usage:
     /// <code>
     ///     using Lucene.Net.Index.Extensions;
-    ///     
+    ///
     ///     ..
-    ///     
+    ///
     ///     IndexWriterConfig conf = new IndexWriterConfig(analyzer)
     ///         .SetCodec(new Lucene46Codec())
     ///         .SetOpenMode(OpenMode.CREATE);
     /// </code>
-    /// 
+    ///
     /// @since 3.1
     /// </summary>
     /// <seealso cref="IndexWriter.Config"/>
@@ -156,8 +156,8 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Creates a new config that with defaults that match the specified
-        /// <see cref="LuceneVersion"/> as well as the default 
-        /// <see cref="Analyzer"/>. If <paramref name="matchVersion"/> is &gt;= 
+        /// <see cref="LuceneVersion"/> as well as the default
+        /// <see cref="Analyzer"/>. If <paramref name="matchVersion"/> is &gt;=
         /// <see cref="LuceneVersion.LUCENE_32"/>, <see cref="TieredMergePolicy"/> is used
         /// for merging; else <see cref="LogByteSizeMergePolicy"/>.
         /// Note that <see cref="TieredMergePolicy"/> is free to select
@@ -199,7 +199,7 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public OpenMode OpenMode
         {
@@ -229,7 +229,7 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when IndexWriter is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public IndexDeletionPolicy IndexDeletionPolicy
         {
@@ -243,7 +243,7 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public IndexCommit IndexCommit
         {
@@ -258,7 +258,7 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public Similarity Similarity
         {
@@ -274,7 +274,7 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public IMergeScheduler MergeScheduler
         {
@@ -289,7 +289,7 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public long WriteLockTimeout
         {
@@ -302,7 +302,7 @@ namespace Lucene.Net.Index
         /// <para/>
         /// Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public Codec Codec
         {
@@ -318,7 +318,7 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public MergePolicy MergePolicy
         {
@@ -341,7 +341,7 @@ namespace Lucene.Net.Index
         /// <para>
         /// NOTE: this only takes effect when <see cref="IndexWriter"/> is first created.</para>
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new internal DocumentsWriterPerThreadPool IndexerThreadPool
         {
@@ -357,7 +357,7 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public int MaxThreadStates
         {
@@ -378,9 +378,9 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
-        new public bool UseReaderPooling 
+        new public bool UseReaderPooling
         {
             get => readerPooling;
             set => this.readerPooling = value;
@@ -391,7 +391,7 @@ namespace Lucene.Net.Index
         ///
         /// <para/>Only takes effect when <see cref="IndexWriter"/> is first created.
         /// </summary>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new internal IndexingChain IndexingChain
         {
@@ -409,7 +409,7 @@ namespace Lucene.Net.Index
         /// The given value must be less that 2GB (2048MB).
         /// </summary>
         /// <seealso cref="DEFAULT_RAM_PER_THREAD_HARD_LIMIT_MB"/>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public int RAMPerThreadHardLimitMB
         {
@@ -432,7 +432,7 @@ namespace Lucene.Net.Index
         /// <seealso cref="LiveIndexWriterConfig.MaxBufferedDeleteTerms"/>
         /// <seealso cref="LiveIndexWriterConfig.MaxBufferedDocs"/>
         /// <seealso cref="LiveIndexWriterConfig.RAMBufferSizeMB"/>
-        // LUCENENET NOTE: We cannot override a getter and add a setter, 
+        // LUCENENET NOTE: We cannot override a getter and add a setter,
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new internal FlushPolicy FlushPolicy
         {
@@ -515,20 +515,20 @@ namespace Lucene.Net.Index
         public IndexWriterConfig SetInfoStream(InfoStream infoStream)
         {
             this.infoStream = infoStream ?? throw new ArgumentNullException(nameof(infoStream),
-                    "Cannot set InfoStream implementation to null. " + 
+                    "Cannot set InfoStream implementation to null. " +
                     "To disable logging use InfoStream.NO_OUTPUT");
             return this;
         }
 
         /// <summary>
-        /// Convenience method that uses <see cref="TextWriterInfoStream"/> to write to the passed in <see cref="TextWriter"/>. 
+        /// Convenience method that uses <see cref="TextWriterInfoStream"/> to write to the passed in <see cref="TextWriter"/>.
         /// Must not be <c>null</c>.
         /// </summary>
         public IndexWriterConfig SetInfoStream(TextWriter printStream)
         {
             if (printStream is null)
             {
-                throw new ArgumentNullException("printStream must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
+                throw new ArgumentNullException(nameof(printStream), "printStream must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
             }
             return SetInfoStream(new TextWriterInfoStream(printStream));
         }

--- a/src/Lucene.Net/Search/MinShouldMatchSumScorer.cs
+++ b/src/Lucene.Net/Search/MinShouldMatchSumScorer.cs
@@ -95,7 +95,7 @@ namespace Lucene.Net.Search
             }
             if (numScorers <= 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(numScorers), "There must be at least 2 subScorers"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                throw new ArgumentOutOfRangeException(nameof(subScorers), "There must be at least 2 subScorers"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
 
             this.mm = minimumNrMatchers;

--- a/src/Lucene.Net/Store/CompoundFileWriter.cs
+++ b/src/Lucene.Net/Store/CompoundFileWriter.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Store
         {
             // LUCENENET specific - changed order to take advantage of throw expression and
             // changed from IllegalArgumentException to ArgumentNullException (.NET convention)
-            directory = dir ?? throw new ArgumentNullException(nameof(directory), $"{nameof(directory)} cannot be null");
+            directory = dir ?? throw new ArgumentNullException(nameof(dir), $"{nameof(directory)} cannot be null");
             dataFileName = name ?? throw new ArgumentNullException(nameof(name), $"{nameof(name)} cannot be null");
             entryTableName = IndexFileNames.SegmentFileName(IndexFileNames.StripExtension(name), "", IndexFileNames.COMPOUND_FILE_ENTRIES_EXTENSION);
         }

--- a/src/Lucene.Net/Store/LockStressTest.cs
+++ b/src/Lucene.Net/Store/LockStressTest.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Store
             if (args.Length != 7)
             {
                 // LUCENENET specific - our lucene-cli wrapper console shows the correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("LockStressTest requires 7 arguments", nameof(args));
                 //Console.WriteLine("Usage: java Lucene.Net.Store.LockStressTest myID verifierHost verifierPort lockFactoryClassName lockDirName sleepTimeMS count\n" +
                 //    "\n" +
                 //    "  myID = int from 0 .. 255 (should be unique for test process)\n" +

--- a/src/Lucene.Net/Store/LockVerifyServer.cs
+++ b/src/Lucene.Net/Store/LockVerifyServer.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Store
             if (args.Length != 2)
             {
                 // LUCENENET specific - our wrapper console shows the correct usage
-                throw new ArgumentException();
+                throw new ArgumentException("LockVerifyServer requires 2 arguments", nameof(args));
                 //Console.WriteLine("Usage: java Lucene.Net.Store.LockVerifyServer bindToIp clients\n");
                 //Environment.FailFast("1");
             }

--- a/src/Lucene.Net/Util/Automaton/BasicAutomata.cs
+++ b/src/Lucene.Net/Util/Automaton/BasicAutomata.cs
@@ -248,7 +248,7 @@ namespace Lucene.Net.Util.Automaton
         /// <param name="digits"> If &gt; 0, use fixed number of digits (strings must be prefixed
         ///          by 0's to obtain the right length) - otherwise, the number of
         ///          digits is not fixed. </param>
-        /// <exception cref="ArgumentException"> If min &gt; max or if numbers in the
+        /// <exception cref="ArgumentOutOfRangeException"> If min &gt; max or if numbers in the
         ///              interval cannot be expressed with the given fixed number of
         ///              digits. </exception>
         public static Automaton MakeInterval(int min, int max, int digits)
@@ -256,10 +256,19 @@ namespace Lucene.Net.Util.Automaton
             Automaton a = new Automaton();
             string x = Convert.ToString(min, CultureInfo.InvariantCulture);
             string y = Convert.ToString(max, CultureInfo.InvariantCulture);
-            if (min > max || (digits > 0 && y.Length > digits))
+
+            // LUCENENET specific - split into two `if` checks for different ArgumentOutOfRangeExceptions.
+            // Also changed to use ArgumentOutOfRangeException instead of IllegalArgumentException (.NET Convention).
+            if (min > max)
             {
-                throw new ArgumentException();
+                throw new ArgumentOutOfRangeException(nameof(min), "min must be less than or equal to max");
             }
+
+            if (digits > 0 && y.Length > digits)
+            {
+                throw new ArgumentOutOfRangeException(nameof(digits), $"Cannot represent numbers between {min} and {max} with {digits} digits");
+            }
+
             int d;
             if (digits > 0)
             {

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -727,15 +727,15 @@ namespace Lucene.Net.Util
                     if (v < /* 111x xxxx */ 0xe0) { pos += 2; continue; }
                     if (v < /* 1111 xxxx */ 0xf0) { pos += 3; continue; }
                     if (v < /* 1111 1xxx */ 0xf8) { pos += 4; continue; }
-                    // fallthrough, consider 5 and 6 byte sequences invalid. 
+                    // fallthrough, consider 5 and 6 byte sequences invalid.
                 }
 
                 // Anything not covered above is invalid UTF8.
-                throw new ArgumentException("Invalid UTF-8");
+                throw new ArgumentException("Invalid UTF-8", nameof(utf8));
             }
 
             // Check if we didn't go over the limit on the last character.
-            if (pos > limit) throw new ArgumentException();
+            if (pos > limit) throw new ArgumentException("Invalid UTF-8", nameof(utf8));
 
             return codePointCount;
         }
@@ -787,7 +787,7 @@ namespace Lucene.Net.Util
                         break;
 
                     default:
-                        throw new ArgumentException("invalid utf8");
+                        throw new ArgumentException("invalid utf8", nameof(utf8));
                 }
 
                 // TODO: this may read past utf8's limit.
@@ -862,11 +862,11 @@ namespace Lucene.Net.Util
             {
                 throw new ArgumentOutOfRangeException(nameof(count), "count must be >= 0"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
-            int countThreashold = 1024; // If the number of chars exceeds this, we count them instead of allocating count * 2
-            // LUCENENET: as a first approximation, assume each codepoint 
+            const int countThreashold = 1024; // If the number of chars exceeds this, we count them instead of allocating count * 2
+            // LUCENENET: as a first approximation, assume each codepoint
             // is 2 characters (since it cannot be longer than this)
             int arrayLength = count * 2;
-            // LUCENENET: if we go over the threashold, count the number of 
+            // LUCENENET: if we go over the threashold, count the number of
             // chars we will need so we can allocate the precise amount of memory
             if (count > countThreashold)
             {
@@ -889,7 +889,7 @@ namespace Lucene.Net.Util
                 int cp = codePoints[r];
                 if (cp < 0 || cp > 0x10ffff)
                 {
-                    throw new ArgumentException();
+                    throw new ArgumentException($"Invalid code point: {cp}", nameof(codePoints));
                 }
                 if (cp < 0x010000)
                 {


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix incorrect usage of argument exceptions for Sonar csharpsquid:S3928

Fixes #682

## Description

This addresses a few incorrect usages of various argument exceptions, such as missing/incorrect parameter names, using ArgumentOutOfRangeException with a parameter name that doesn't exist, missing messages for ArgumentException, and so on.

For the analysis factories, these were reverted to be ArgumentException because various analysis tools (including Sonar and ReSharper/Rider) complain about using a key name for the dictionary when it doesn't exist as a parameter.
