### PR TITLE
Replace lucene.testSettings.config references with lucene.testsettings.json

### DIFF
--- a/Lucene.Net.sln.DotSettings
+++ b/Lucene.Net.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coord/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=LUCENENET/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=LUCENENET/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=testsettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -100,7 +100,7 @@ namespace Lucene.Net.Util
     /// test message.
     /// </para>
     /// <para>
-    /// The seed can be configured with a RunSettings file, a <c>lucene.testSettings.config</c> JSON file,
+    /// The seed can be configured with a RunSettings file, a <c>lucene.testsettings.json</c> JSON file,
     /// an environment variable, or using <see cref="RandomSeedAttribute"/> at the assembly level.
     /// It is recommended to configure the culture also, since they are randomly picked from a list
     /// of cultures installed on a given machine, so the culture will vary from one machine to the next.
@@ -128,10 +128,10 @@ namespace Lucene.Net.Util
     /// [assembly: NUnit.Framework.SetCulture("sw-TZ")]
     /// </code>
     ///
-    /// <h4><i>lucene.testSettings.config</i> File Configuration Example</h4>
+    /// <h4><i>lucene.testsettings.json</i> File Configuration Example</h4>
     ///
     /// <para>
-    /// Add a file named <i>lucene.testSettings.config</i> to the executable directory or
+    /// Add a file named <i>lucene.testsettings.json</i> to the executable directory or
     /// any directory between the executable and the root of the drive with the following contents.
     /// </para>
     ///

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnJRECrash.cs
@@ -175,7 +175,7 @@ namespace Lucene.Net.Index
                     "--logger:\"console;verbosity=normal\"",
                     "--",
                     $"RunConfiguration.TargetPlatform={GetTargetPlatform()}",
-                    // LUCENENET NOTE: Since in our CI environment we create a lucene.testSettings.config file
+                    // LUCENENET NOTE: Since in our CI environment we create a lucene.testsettings.json file
                     // for all tests, we need to pass some of these settings as test run parameters to override
                     // for this process. These are read as system properties on the inside of the application.
                     TestRunParameter("assert", "true"),


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Replace lucene.testSettings.config references with lucene.testsettings.json

Fixes #997

## Description

There were still some places in comments where we were referencing `lucene.testSettings.config` as the file name for setting your seed/culture, when it should be `lucene.testsettings.json`. This does a solution-wide find and replace for those occurrences in comments.
