### PR TITLE
Fixed encoding provider loading on .NET Framework (for .NET Standard 2.0 target)

### DIFF
--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizerFactory.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizerFactory.cs
@@ -74,11 +74,8 @@ namespace Lucene.Net.Analysis.Ja
 
         static JapaneseTokenizerFactory()
         {
-#if FEATURE_ENCODINGPROVIDERS
-            // Support for EUC-JP encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
-            var encodingProvider = System.Text.CodePagesEncodingProvider.Instance;
-            System.Text.Encoding.RegisterProvider(encodingProvider);
-#endif
+            // LUCENENET: Support for EUC-JP encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
+            EncodingProviderInitializer.EnsureInitialized();
         }
 
         public virtual void Inform(IResourceLoader loader)

--- a/src/Lucene.Net.Analysis.Kuromoji/Support/Util/EncodingProviderInitializer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Support/Util/EncodingProviderInitializer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+namespace Lucene.Net.Util
+{
+    /// <summary>
+    /// Loads the <see cref="System.Text.EncodingProvider"/> for the current runtime for support of
+    /// EUC-JP encoding.
+    /// </summary>
+    internal static class EncodingProviderInitializer
+    {
+        private static int initialized;
+
+        private static bool IsNetFramework =>
+#if NETSTANDARD2_0
+            RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+#elif NET40_OR_GREATER
+            true;
+#else
+            false;
+#endif
+
+        [Conditional("FEATURE_ENCODINGPROVIDERS")]
+        public static void EnsureInitialized()
+        {
+            // Only allow a single thread to call this
+            if (0 != Interlocked.CompareExchange(ref initialized, 1, 0)) return;
+
+#if FEATURE_ENCODINGPROVIDERS
+            if (!IsNetFramework)
+            {
+                Initialize();
+            }
+#endif
+        }
+
+#if FEATURE_ENCODINGPROVIDERS
+        // NOTE: CodePagesEncodingProvider.Instance loads early, so we need this in a separate method to ensure
+        // that it isn't executed until after we know which runtime we are on.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Initialize()
+        {
+            // Support for EUC-JP encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+#endif
+    }
+}

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsWriter.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Codecs;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Store;
+using Lucene.Net.Support;
 using System.Diagnostics;
 using System.IO;
 
@@ -37,7 +38,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             this.forwardSize = forwardSize;
             this.backwardSize = backwardSize;
             //this.costs = new short[backwardSize][forwardSize];
-            this.costs = Support.RectangularArrays.ReturnRectangularArray<short>(backwardSize, forwardSize);
+            this.costs = RectangularArrays.ReturnRectangularArray<short>(backwardSize, forwardSize);
         }
 
         public void Add(int forwardId, int backwardId, int cost)

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/DictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/DictionaryBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Lucene.Net.Util;
+using System;
 using Console = Lucene.Net.Util.SystemConsole;
 
 namespace Lucene.Net.Analysis.Ja.Util
@@ -35,11 +36,8 @@ namespace Lucene.Net.Analysis.Ja.Util
 
         static DictionaryBuilder()
         {
-#if FEATURE_ENCODINGPROVIDERS
-            // Support for EUC-JP encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
-            var encodingProvider = System.Text.CodePagesEncodingProvider.Instance;
-            System.Text.Encoding.RegisterProvider(encodingProvider);
-#endif
+            // LUCENENET: Support for EUC-JP encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
+            EncodingProviderInitializer.EnsureInitialized();
         }
 
         public static void Build(DictionaryFormat format,

--- a/src/Lucene.Net.Analysis.SmartCn/AnalyzerProfile.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/AnalyzerProfile.cs
@@ -58,11 +58,8 @@ namespace Lucene.Net.Analysis.Cn.Smart
         // from ever being loaded).
         private static void Init()
         {
-#if FEATURE_ENCODINGPROVIDERS
-            // Support for GB2312 encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
-            var encodingProvider = System.Text.CodePagesEncodingProvider.Instance;
-            System.Text.Encoding.RegisterProvider(encodingProvider);
-#endif
+            // LUCENENET: Support for GB2312 encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
+            EncodingProviderInitializer.EnsureInitialized();
 
             string dirName = "smartcn-data";
             //string propName = "analysis.properties";

--- a/src/Lucene.Net.Analysis.SmartCn/Support/Util/EncodingProviderInitializer.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Support/Util/EncodingProviderInitializer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+namespace Lucene.Net.Util
+{
+    /// <summary>
+    /// Loads the <see cref="System.Text.EncodingProvider"/> for the current runtime for support of
+    /// GB2312 encoding.
+    /// </summary>
+    internal static class EncodingProviderInitializer
+    {
+        private static int initialized;
+
+        private static bool IsNetFramework =>
+#if NETSTANDARD2_0
+            RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+#elif NET40_OR_GREATER
+            true;
+#else
+            false;
+#endif
+
+        [Conditional("FEATURE_ENCODINGPROVIDERS")]
+        public static void EnsureInitialized()
+        {
+            // Only allow a single thread to call this
+            if (0 != Interlocked.CompareExchange(ref initialized, 1, 0)) return;
+
+#if FEATURE_ENCODINGPROVIDERS
+            if (!IsNetFramework)
+            {
+                Initialize();
+            }
+#endif
+        }
+
+#if FEATURE_ENCODINGPROVIDERS
+        // NOTE: CodePagesEncodingProvider.Instance loads early, so we need this in a separate method to ensure
+        // that it isn't executed until after we know which runtime we are on.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Initialize()
+        {
+            // Support for GB2312 encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+#endif
+    }
+}

--- a/src/Lucene.Net.Tests.Analysis.Common/Startup.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Startup.cs
@@ -27,6 +27,11 @@ public class Startup : LuceneTestFrameworkInitializer
         // require it to be added as well when using Hunspell, but there is no reason to load
         // the code pages by default in Lucene.Net.Analysis.Common. It should be added by consumers
         // or Hunspell that require it.
+        //
+        // Note this is in the test project, which never uses netstandard2.0. If we were using
+        // netstandard2.0, we would need an extra check to deteremine if we are on .NET Framework,
+        // which doesn't support encoding providers. See EncodingProviderInitializer in the
+        // Lucene.Net.Analysis.Kuromoji project.
         System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
 #endif
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Fixed encoding provider loading on .NET Framework (for .NET Standard 2.0 target)

Fixes #1025

## Description

Added `EncodingProviderInitializer` class to `Lucene.Net.Analysis.Kuromoji` and `Lucene.Net.Analysis.SmartCn` to prevent loading problems on the `netstandard2.0` target when the runtime is .NET Framework.
