### PR TITLE
Fix csharpsquid:S1117 SonarCloud warnings about shadowing fields with variable names

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
@@ -224,12 +224,12 @@ namespace Lucene.Net.Analysis.CharFilters
             "\x000A\x00BC\x0007\x0000\x001A\x0001\x0004\x0000\x0001\x0002\x0001\x0000\x001A\x0001\x000B\x0000\x0059\x0001\x0003\x0000" +
             "\x0006\x0001\x0002\x0000\x0006\x0001\x0002\x0000\x0006\x0001\x0002\x0000\x0003\x0001\x0023\x0000";
 
-        /** 
+        /**
          * Translates characters to character classes
          */
         private static readonly char[] ZZ_CMAP = ZzUnpackCMap(ZZ_CMAP_PACKED);
 
-        /** 
+        /**
          * Translates DFA states to action switch labels.
          */
         private static readonly int[] ZZ_ACTION = ZzUnpackAction();
@@ -348,7 +348,7 @@ namespace Lucene.Net.Analysis.CharFilters
         }
 
 
-        /** 
+        /**
          * Translates a state to a row index in the transition table
          */
         private static readonly int[] ZZ_ROWMAP = ZzUnpackRowMap();
@@ -30693,7 +30693,7 @@ namespace Lucene.Net.Analysis.CharFilters
 
         private static CharArrayDictionary<char> LoadEntityValues() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            CharArrayDictionary<char> entityValues
+            CharArrayDictionary<char> result
 #pragma warning disable 612, 618
             = new CharArrayDictionary<char>(LuceneVersion.LUCENE_CURRENT, 253, false);
 #pragma warning restore 612, 618
@@ -30775,13 +30775,13 @@ namespace Lucene.Net.Analysis.CharFilters
             for (int i = 0; i < entities.Length; i += 2)
             {
                 var value = entities[i + 1][0];
-                entityValues[entities[i]] = value;
+                result[entities[i]] = value;
                 if (upperCaseVariantsAccepted.TryGetValue(entities[i], out string upperCaseVariant) && upperCaseVariant != null)
                 {
-                    entityValues[upperCaseVariant] = value;
+                    result[upperCaseVariant] = value;
                 }
             }
-            return entityValues;
+            return result;
         }
         private static readonly int INITIAL_INPUT_SEGMENT_SIZE = 1024;
         private static readonly char BLOCK_LEVEL_START_TAG_REPLACEMENT = '\n';
@@ -31024,7 +31024,7 @@ namespace Lucene.Net.Analysis.CharFilters
                 zzEndRead += numRead;
                 return false;
             }
-            // unlikely but not impossible: read 0 characters, but not at end of stream    
+            // unlikely but not impossible: read 0 characters, but not at end of stream
             if (numRead == 0)
             {
                 int c = zzReader.Read();
@@ -31104,7 +31104,7 @@ namespace Lucene.Net.Analysis.CharFilters
         //private string YyText => new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
 
         /// <summary>
-        /// Returns the character at position <tt>pos</tt> from the 
+        /// Returns the character at position <tt>pos</tt> from the
         /// matched text. It is equivalent to YyText[pos], but faster
         /// </summary>
         /// <param name="pos">the position of the character to fetch. A value from 0 to YyLength()-1.</param>
@@ -31124,7 +31124,7 @@ namespace Lucene.Net.Analysis.CharFilters
         /// Reports an error that occured while scanning.
         /// <para/>
         /// In a wellformed scanner (no or only correct usage of
-        /// YyPushBack(int) and a match-all fallback rule) this method 
+        /// YyPushBack(int) and a match-all fallback rule) this method
         /// will only be called with things that "Can't Possibly Happen".
         /// If this method is called, something is seriously wrong
         /// (e.g. a JFlex bug producing a faulty scanner etc.).
@@ -31151,7 +31151,7 @@ namespace Lucene.Net.Analysis.CharFilters
 
         /// <summary>
         /// Pushes the specified amount of characters back into the input stream.
-        /// 
+        ///
         /// They will be read again by then next call of the scanning method
         /// </summary>
         /// <param name="number">the number of characters to be read again.

--- a/src/Lucene.Net.Analysis.Common/Analysis/Nl/DutchAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Nl/DutchAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Analysis.Nl
      */
 
     /// <summary>
-    /// <see cref="Analyzer"/> for Dutch language. 
+    /// <see cref="Analyzer"/> for Dutch language.
     /// <para>
     /// Supports an external list of stopwords (words that
     /// will not be indexed at all), an external list of exclusions (word that will
@@ -38,20 +38,20 @@ namespace Lucene.Net.Analysis.Nl
     /// A default set of stopwords is used unless an alternative list is specified, but the
     /// exclusion list is empty by default.
     /// </para>
-    /// 
+    ///
     /// <para>You must specify the required <see cref="LuceneVersion"/>
     /// compatibility when creating <see cref="DutchAnalyzer"/>:
     /// <list type="bullet">
     ///   <item><description> As of 3.6, <see cref="DutchAnalyzer(LuceneVersion, CharArraySet)"/> and
     ///        <see cref="DutchAnalyzer(LuceneVersion, CharArraySet, CharArraySet)"/> also populate
     ///        the default entries for the stem override dictionary</description></item>
-    ///   <item><description> As of 3.1, Snowball stemming is done with SnowballFilter, 
-    ///        LowerCaseFilter is used prior to StopFilter, and Snowball 
+    ///   <item><description> As of 3.1, Snowball stemming is done with SnowballFilter,
+    ///        LowerCaseFilter is used prior to StopFilter, and Snowball
     ///        stopwords are used by default.</description></item>
     ///   <item><description> As of 2.9, StopFilter preserves position
     ///        increments</description></item>
     /// </list>
-    /// 
+    ///
     /// </para>
     /// <para><b>NOTE</b>: This class uses the same <see cref="LuceneVersion"/>
     /// dependent settings as <see cref="StandardAnalyzer"/>.</para>
@@ -93,13 +93,13 @@ namespace Lucene.Net.Analysis.Nl
             private static CharArrayDictionary<string> LoadDefaultStemDict() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
             {
 #pragma warning disable 612, 618
-                var DEFAULT_STEM_DICT = new CharArrayDictionary<string>(LuceneVersion.LUCENE_CURRENT, 4, false);
+                var result = new CharArrayDictionary<string>(LuceneVersion.LUCENE_CURRENT, 4, false);
 #pragma warning restore 612, 618
-                DEFAULT_STEM_DICT["fiets"] = "fiets"; //otherwise fiet
-                DEFAULT_STEM_DICT["bromfiets"] = "bromfiets"; //otherwise bromfiet
-                DEFAULT_STEM_DICT["ei"] = "eier";
-                DEFAULT_STEM_DICT["kind"] = "kinder";
-                return DEFAULT_STEM_DICT;
+                result["fiets"] = "fiets"; //otherwise fiet
+                result["bromfiets"] = "bromfiets"; //otherwise bromfiet
+                result["ei"] = "eier";
+                result["kind"] = "kinder";
+                return result;
             }
         }
 
@@ -121,7 +121,7 @@ namespace Lucene.Net.Analysis.Nl
         private readonly LuceneVersion matchVersion;
 
         /// <summary>
-        /// Builds an analyzer with the default stop words (<see cref="DefaultStopSet"/>) 
+        /// Builds an analyzer with the default stop words (<see cref="DefaultStopSet"/>)
         /// and a few default entries for the stem exclusion table.
         /// </summary>
         public DutchAnalyzer(LuceneVersion matchVersion)
@@ -191,11 +191,11 @@ namespace Lucene.Net.Analysis.Nl
         }
 
         /// <summary>
-        /// Returns a (possibly reused) <see cref="TokenStream"/> which tokenizes all the 
+        /// Returns a (possibly reused) <see cref="TokenStream"/> which tokenizes all the
         /// text in the provided <see cref="TextReader"/>.
         /// </summary>
         /// <returns> A <see cref="TokenStream"/> built from a <see cref="StandardTokenizer"/>
-        ///   filtered with <see cref="StandardFilter"/>, <see cref="LowerCaseFilter"/>, 
+        ///   filtered with <see cref="StandardFilter"/>, <see cref="LowerCaseFilter"/>,
         ///   <see cref="StopFilter"/>, <see cref="SetKeywordMarkerFilter"/> if a stem exclusion set is provided,
         ///   <see cref="StemmerOverrideFilter"/>, and <see cref="SnowballFilter"/> </returns>
         protected internal override TokenStreamComponents CreateComponents(string fieldName, TextReader aReader)

--- a/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ScriptIterator.cs
+++ b/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ScriptIterator.cs
@@ -24,10 +24,10 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
      */
 
     /// <summary>
-    /// An iterator that locates ISO 15924 script boundaries in text. 
+    /// An iterator that locates ISO 15924 script boundaries in text.
     /// </summary>
     /// <remarks>
-    /// This is not the same as simply looking at the Unicode block, or even the 
+    /// This is not the same as simply looking at the Unicode block, or even the
     /// Script property. Some characters are 'common' across multiple scripts, and
     /// some 'inherit' the script value of text surrounding them.
     /// <para/>
@@ -36,10 +36,10 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
     /// <list type="bullet">
     ///     <item><description>
     ///         Doesn't attempt to match paired punctuation. For tokenization purposes, this
-    ///         is not necessary. Its also quite expensive. 
+    ///         is not necessary. Its also quite expensive.
     ///     </description></item>
     ///     <item><description>
-    ///         Non-spacing marks inherit the script of their base character, following 
+    ///         Non-spacing marks inherit the script of their base character, following
     ///         recommendations from UTR #24.
     ///     </description></item>
     /// </list>
@@ -157,10 +157,10 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
 
         private static int[] LoadBasicLatin() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            var basicLatin = new int[128];
-            for (int i = 0; i < basicLatin.Length; i++)
-                basicLatin[i] = UScript.GetScript(i);
-            return basicLatin;
+            var result = new int[128];
+            for (int i = 0; i < result.Length; i++)
+                result[i] = UScript.GetScript(i);
+            return result;
         }
 
         /// <summary>Fast version of <see cref="UScript.GetScript(int)"/>. Basic Latin is an array lookup.</summary>

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseAnalyzer.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Analysis.Ja
         public static ISet<string> DefaultStopTags => DefaultSetHolder.DEFAULT_STOP_TAGS;
 
         /// <summary>
-        /// Atomically loads DEFAULT_STOP_SET, DEFAULT_STOP_TAGS in a lazy fashion once the 
+        /// Atomically loads DEFAULT_STOP_SET, DEFAULT_STOP_TAGS in a lazy fashion once the
         /// outer class accesses the static final set the first time.
         /// </summary>
         private static class DefaultSetHolder
@@ -88,12 +88,12 @@ namespace Lucene.Net.Analysis.Ja
                 try
                 {
                     CharArraySet tagset = LoadStopwordSet(false, typeof(JapaneseAnalyzer), "stoptags.txt", "#");
-                    var DEFAULT_STOP_TAGS = new JCG.HashSet<string>();
+                    var result = new JCG.HashSet<string>();
                     foreach (string element in tagset)
                     {
-                        DEFAULT_STOP_TAGS.Add(element);
+                        result.Add(element);
                     }
-                    return DEFAULT_STOP_TAGS.AsReadOnly(); // LUCENENET: Made readonly as stated in the docs: https://github.com/apache/lucene/issues/11866
+                    return result.AsReadOnly(); // LUCENENET: Made readonly as stated in the docs: https://github.com/apache/lucene/issues/11866
                 }
                 catch (Exception ex) when (ex.IsIOException())
                 {

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Lang.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Lang.cs
@@ -116,12 +116,12 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static IDictionary<NameType, Lang> LoadLangs() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            IDictionary<NameType, Lang> langs = new Dictionary<NameType, Lang>();
+            IDictionary<NameType, Lang> result = new Dictionary<NameType, Lang>();
             foreach (NameType s in Enum.GetValues(typeof(NameType)))
             {
-                langs[s] = LoadFromResource(LANGUAGE_RULES_RN, Languages.GetInstance(s));
+                result[s] = LoadFromResource(LANGUAGE_RULES_RN, Languages.GetInstance(s));
             }
-            return langs;
+            return result;
         }
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Languages.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Languages.cs
@@ -72,12 +72,12 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static IDictionary<NameType, Languages> LoadLanguages() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            IDictionary<NameType, Languages> LANGUAGES = new Dictionary<NameType, Languages>();
+            IDictionary<NameType, Languages> result = new Dictionary<NameType, Languages>();
             foreach (NameType s in Enum.GetValues(typeof(NameType)))
             {
-                LANGUAGES[s] = GetInstance(LangResourceName(s));
+                result[s] = GetInstance(LangResourceName(s));
             }
-            return LANGUAGES;
+            return result;
         }
 
         public static Languages GetInstance(NameType nameType)
@@ -130,7 +130,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static string LangResourceName(NameType nameType)
         {
-            return string.Format("{0}_languages.txt", nameType.GetName()); 
+            return string.Format("{0}_languages.txt", nameType.GetName());
         }
 
         private readonly ISet<string> languages;

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/TrecDocParser.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/TrecDocParser.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
 
     /// <summary>
     /// Parser for trec doc content, invoked on doc text excluding &lt;DOC&gt; and &lt;DOCNO&gt;
-    /// which are handled in TrecContentSource. Required to be stateless and hence thread safe. 
+    /// which are handled in TrecContentSource. Required to be stateless and hence thread safe.
     /// </summary>
     public abstract class TrecDocParser
     {
@@ -48,12 +48,12 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         internal static readonly IDictionary<string, ParsePathType?> pathName2Type = LoadPathName2Type();
         private static IDictionary<string, ParsePathType?> LoadPathName2Type() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            var pathName2Type = new Dictionary<string, ParsePathType?>();
+            var result = new Dictionary<string, ParsePathType?>();
             foreach (ParsePathType ppt in Enum.GetValues(typeof(ParsePathType)))
             {
-                pathName2Type[ppt.ToString().ToUpperInvariant()] = ppt;
+                result[ppt.ToString().ToUpperInvariant()] = ppt;
             }
-            return pathName2Type;
+            return result;
         }
 
 
@@ -84,14 +84,14 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         }
 
         /// <summary>
-        /// Parse the text prepared in docBuf into a result DocData, 
+        /// Parse the text prepared in docBuf into a result DocData,
         /// no synchronization is required.
         /// </summary>
         /// <param name="docData">Reusable result.</param>
         /// <param name="name">Name that should be set to the result.</param>
         /// <param name="trecSrc">Calling trec content source.</param>
         /// <param name="docBuf">Text to parse.</param>
-        /// <param name="pathType">Type of parsed file, or <see cref="ParsePathType.UNKNOWN"/> if unknown - may be used by 
+        /// <param name="pathType">Type of parsed file, or <see cref="ParsePathType.UNKNOWN"/> if unknown - may be used by
         /// parsers to alter their behavior according to the file path type. </param>
         /// <returns></returns>
         public abstract DocData Parse(DocData docData, string name, TrecContentSource trecSrc,

--- a/src/Lucene.Net.Benchmark/Support/TagSoup/ElementType.cs
+++ b/src/Lucene.Net.Benchmark/Support/TagSoup/ElementType.cs
@@ -39,7 +39,7 @@ namespace TagSoup
         /// The content model, member-of, and flags vectors are specified as ints.
         /// </summary>
         /// <param name="name">The element type name</param>
-        /// <param name="model">ORed-together bits representing the content 
+        /// <param name="model">ORed-together bits representing the content
         /// models allowed in the content of this element type</param>
         /// <param name="memberOf">ORed-together bits representing the content models
         /// to which this element type belongs</param>
@@ -198,7 +198,7 @@ namespace TagSoup
             }
 
             string ns = GetNamespace(name, true);
-            string localName = GetLocalName(name);
+            string ln = GetLocalName(name); // LUCENENET specific - renamed from localName to not shadow field
             int i = atts.GetIndex(name);
             if (i == -1)
             {
@@ -211,7 +211,7 @@ namespace TagSoup
                 {
                     value = Normalize(value);
                 }
-                atts.AddAttribute(ns, localName, name, type, value);
+                atts.AddAttribute(ns, ln, name, type, value);
             }
             else
             {
@@ -223,7 +223,7 @@ namespace TagSoup
                 {
                     value = Normalize(value);
                 }
-                atts.SetAttribute(i, ns, localName, name, type, value);
+                atts.SetAttribute(i, ns, ln, name, type, value);
             }
         }
 

--- a/src/Lucene.Net.Misc/Document/LazyDocument.cs
+++ b/src/Lucene.Net.Misc/Document/LazyDocument.cs
@@ -51,17 +51,17 @@ namespace Lucene.Net.Documents
         }
 
         /// <summary>
-        /// Creates an IndexableField whose value will be lazy loaded if and 
-        /// when it is used. 
+        /// Creates an IndexableField whose value will be lazy loaded if and
+        /// when it is used.
         /// <para>
-        /// <b>NOTE:</b> This method must be called once for each value of the field 
-        /// name specified in sequence that the values exist.  This method may not be 
-        /// used to generate multiple, lazy, IndexableField instances refering to 
+        /// <b>NOTE:</b> This method must be called once for each value of the field
+        /// name specified in sequence that the values exist.  This method may not be
+        /// used to generate multiple, lazy, IndexableField instances refering to
         /// the same underlying IndexableField instance.
         /// </para>
         /// <para>
-        /// The lazy loading of field values from all instances of IndexableField 
-        /// objects returned by this method are all backed by a single Document 
+        /// The lazy loading of field values from all instances of IndexableField
+        /// objects returned by this method are all backed by a single Document
         /// per LazyDocument instance.
         /// </para>
         /// </summary>
@@ -95,7 +95,7 @@ namespace Lucene.Net.Documents
 
         /// <summary>
         /// non-private for test only access
-        /// @lucene.internal 
+        /// @lucene.internal
         /// </summary>
         internal virtual Document GetDocument()
         {
@@ -144,7 +144,7 @@ namespace Lucene.Net.Documents
 
 
         /// <summary>
-        /// @lucene.internal 
+        /// @lucene.internal
         /// </summary>
         public class LazyField : IIndexableField, IFormattable
         {
@@ -163,7 +163,7 @@ namespace Lucene.Net.Documents
 
             /// <summary>
             /// non-private for test only access
-            /// @lucene.internal 
+            /// @lucene.internal
             /// </summary>
             public virtual bool HasBeenLoaded => null != realValue;
 
@@ -218,7 +218,7 @@ namespace Lucene.Net.Documents
             /// <param name="provider">An object that supplies culture-specific formatting information. This parameter has no effect if this field is non-numeric.</param>
             /// <returns>The string representation of the value if it is either a <see cref="string"/> or numeric type.</returns>
             // LUCENENET specific - created overload so we can format an underlying numeric type using specified provider
-            public virtual string GetStringValue(IFormatProvider provider) 
+            public virtual string GetStringValue(IFormatProvider provider)
             {
                 return GetRealValue().GetStringValue(provider);
             }
@@ -231,7 +231,7 @@ namespace Lucene.Net.Documents
             /// <param name="format">A standard or custom numeric format string. This parameter has no effect if this field is non-numeric.</param>
             /// <returns>The string representation of the value if it is either a <see cref="string"/> or numeric type.</returns>
             // LUCENENET specific - created overload so we can format an underlying numeric type using specified format
-            public virtual string GetStringValue(string format) 
+            public virtual string GetStringValue(string format)
             {
                 return GetRealValue().GetStringValue(format);
             }
@@ -245,7 +245,7 @@ namespace Lucene.Net.Documents
             /// <param name="provider">An object that supplies culture-specific formatting information. This parameter has no effect if this field is non-numeric.</param>
             /// <returns>The string representation of the value if it is either a <see cref="string"/> or numeric type.</returns>
             // LUCENENET specific - created overload so we can format an underlying numeric type using specified format and provider
-            public virtual string GetStringValue(string format, IFormatProvider provider) 
+            public virtual string GetStringValue(string format, IFormatProvider provider)
             {
                 return GetRealValue().GetStringValue(format, provider);
             }
@@ -269,15 +269,15 @@ namespace Lucene.Net.Documents
             /// <summary>
             /// Gets the <see cref="NumericFieldType"/> of the underlying value, or <see cref="NumericFieldType.NONE"/> if the value is not set or non-numeric.
             /// <para/>
-            /// Expert: The difference between this property and <see cref="FieldType.NumericType"/> is 
+            /// Expert: The difference between this property and <see cref="FieldType.NumericType"/> is
             /// this is represents the current state of the field (whether being written or read) and the
             /// <see cref="FieldType"/> property represents instructions on how the field will be written,
             /// but does not re-populate when reading back from an index (it is write-only).
             /// <para/>
-            /// In Java, the numeric type was determined by checking the type of  
+            /// In Java, the numeric type was determined by checking the type of
             /// <see cref="GetNumericValue()"/>. However, since there are no reference number
             /// types in .NET, using <see cref="GetNumericValue()"/> so will cause boxing/unboxing. It is
-            /// therefore recommended to use this property to check the underlying type and the corresponding 
+            /// therefore recommended to use this property to check the underlying type and the corresponding
             /// <c>Get*Value()</c> method to retrieve the value.
             /// <para/>
             /// NOTE: Since Lucene codecs do not support <see cref="NumericFieldType.BYTE"/> or <see cref="NumericFieldType.INT16"/>,
@@ -387,14 +387,14 @@ namespace Lucene.Net.Documents
             // LUCENENET specific - method added for better .NET compatibility
             public virtual string ToString(string format,IFormatProvider provider)
             {
-                IIndexableField realValue = GetRealValue();
-                if(realValue is IFormattable formattable)
+                IIndexableField rv = GetRealValue();
+                if (rv is IFormattable formattable)
                 {
                     return formattable.ToString(format, provider);
                 }
                 else
                 {
-                    return realValue.ToString();
+                    return rv.ToString();
                 }
             }
         }

--- a/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
@@ -120,9 +120,9 @@ namespace Lucene.Net.QueryParsers.ComplexPhrase
             isPass2ResolvingPhrases = true;
             try
             {
-                foreach (var currentPhraseQuery in complexPhrases)
+                foreach (var enumeratorValue in complexPhrases)
                 {
-                    this.currentPhraseQuery = currentPhraseQuery;
+                    currentPhraseQuery = enumeratorValue;
                     // in each phrase, now parse the contents between quotes as a
                     // separate parse operation
                     currentPhraseQuery.ParsePhraseElements(this);

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
@@ -126,7 +126,7 @@ namespace Lucene.Net.Codecs.Lucene45
             bool missing = false;
             // TODO: more efficient?
             JCG.HashSet<long> uniqueValues = null;
-            
+
             if (optimizeStorage)
             {
                 uniqueValues = new JCG.HashSet<long>();
@@ -486,8 +486,6 @@ namespace Lucene.Net.Codecs.Lucene45
         {
             IEnumerator<long?> docToOrdCountIter = docToOrdCount.GetEnumerator();
             IEnumerator<long?> ordsIter = ords.GetEnumerator();
-
-            const long MISSING_ORD = -1;
 
             while (docToOrdCountIter.MoveNext())
             {

--- a/src/Lucene.Net/Index/FieldInfos.cs
+++ b/src/Lucene.Net/Index/FieldInfos.cs
@@ -263,13 +263,14 @@ namespace Lucene.Net.Index
                 UninterruptableMonitor.Enter(this);
                 try
                 {
-                    numberToName.TryGetValue(number, out string numberToNameStr);
-                    nameToNumber.TryGetValue(name, out int nameToNumberVal);
-                    this.docValuesType.TryGetValue(name, out DocValuesType docValuesType);
+                    // LUCENENET specific - using TryGetValue to avoid throwing an exception
+                    numberToName.TryGetValue(number, out string numberToNameValue);
+                    nameToNumber.TryGetValue(name, out int nameToNumberValue);
+                    docValuesType.TryGetValue(name, out DocValuesType docValuesTypeValue);
 
-                    return name.Equals(numberToNameStr, StringComparison.Ordinal) 
-                        && number.Equals(nameToNumber[name]) && 
-                        (dvType == DocValuesType.NONE || docValuesType == DocValuesType.NONE || dvType == docValuesType);
+                    return name.Equals(numberToNameValue, StringComparison.Ordinal)
+                        && number.Equals(nameToNumberValue) &&
+                        (dvType == DocValuesType.NONE || docValuesTypeValue == DocValuesType.NONE || dvType == docValuesTypeValue);
                 }
                 finally
                 {

--- a/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
@@ -201,9 +202,10 @@ namespace Lucene.Net.Index
             }
         }
 
+        [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType", Justification = "Matches Lucene")]
         private IEnumerable<long?> GetOrdCountEnumerable(int maxDoc)
         {
-            var iter = pendingCounts.GetIterator();
+            AppendingDeltaPackedInt64Buffer.Iterator iter = pendingCounts.GetIterator();
 
             if (Debugging.AssertsEnabled) Debugging.Assert(pendingCounts.Count == maxDoc, "MaxDoc: {0}, pending.Count: {1}", maxDoc, pending.Count);
 
@@ -213,11 +215,12 @@ namespace Lucene.Net.Index
             }
         }
 
+        [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType", Justification = "Matches Lucene")]
         private IEnumerable<long?> GetOrdsEnumerable(int[] ordMap, int maxCountPerDoc)
         {
             int currentUpTo = 0, currentLength = 0;
-            var iter = pending.GetIterator();
-            var counts = pendingCounts.GetIterator();
+            AppendingPackedInt64Buffer.Iterator iter = pending.GetIterator();
+            AppendingDeltaPackedInt64Buffer.Iterator counts = pendingCounts.GetIterator();
             int[] cd = new int[maxCountPerDoc]; // LUCENENET specific - renamed from currentDoc to cd to prevent conflict
 
             for (long ordUpto = 0; ordUpto < pending.Count; ++ordUpto)

--- a/src/Lucene.Net/Support/CRC32.cs
+++ b/src/Lucene.Net/Support/CRC32.cs
@@ -23,9 +23,10 @@ namespace Lucene.Net.Support
 {
     internal class CRC32 : IChecksum
     {
-        private static readonly uint[] crcTable = InitializeCRCTable();
+        private static readonly uint[] crcTable = LoadCRCTable();
 
-        private static uint[] InitializeCRCTable()
+        // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        private static uint[] LoadCRCTable()
         {
             uint[] result = new uint[256];
             for (uint n = 0; n < 256; n++)

--- a/src/Lucene.Net/Support/CRC32.cs
+++ b/src/Lucene.Net/Support/CRC32.cs
@@ -19,8 +19,6 @@
  *
 */
 
-using System;
-
 namespace Lucene.Net.Support
 {
     internal class CRC32 : IChecksum
@@ -29,7 +27,7 @@ namespace Lucene.Net.Support
 
         private static uint[] InitializeCRCTable()
         {
-            uint[] crcTable = new uint[256];
+            uint[] result = new uint[256];
             for (uint n = 0; n < 256; n++)
             {
                 uint c = n;
@@ -40,9 +38,9 @@ namespace Lucene.Net.Support
                     else
                         c = c >> 1;
                 }
-                crcTable[n] = c;
+                result[n] = c;
             }
-            return crcTable;
+            return result;
         }
 
         private uint crc = 0;

--- a/src/Lucene.Net/Util/SPIClassIterator.cs
+++ b/src/Lucene.Net/Util/SPIClassIterator.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Util
 
         private static JCG.HashSet<Type> LoadTypes() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            var types = new JCG.HashSet<Type>();
+            var result = new JCG.HashSet<Type>();
 
             var assembliesToExamine = Support.AssemblyUtils.GetReferencedAssemblies();
 
@@ -94,7 +94,7 @@ namespace Lucene.Net.Util
 
                             if (matchingCtors.Any())
                             {
-                                types.Add(type);
+                                result.Add(type);
                             }
                         }
                         catch
@@ -108,7 +108,7 @@ namespace Lucene.Net.Util
                     // swallow
                 }
             }
-            return types;
+            return result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix csharpsquid:S1117 SonarCloud warnings about shadowing fields with variable names

Fixes #678

## Description

This renames variables that shadowed fields of the same name, causing the SonarCloud S1117 warning. In the case of methods that replace static constructor initialization, this was named `result` instead of the field name. In other cases where there was no Lucene equivalent, the variable was renamed.

This also fixes a bug in FieldInfos where there was the possibility of a KeyNotFoundException due to a coding oversight.

This investigation discovered a potential maintainability bug in `SortedSetDocValuesWriter.Flush`. Due to GetOrdCountEnumerable and GetOrdsEnumerable (previously named with a typo) having the same return type, their names were accidentally swapped. I fixed the typo in the names and fixed the names to match upstream. I also confirmed that the signature of AddSortedSetField expected them in this order. 
