### PR TITLE
Enable TestICUFoldingFilterFactory.Test

### DIFF
--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUFoldingFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUFoldingFilterFactory.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Analysis.Icu
     {
         /** basic tests to ensure the folding is working */
         [Test]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/269")] // LUCENENET TODO: this test fails only on Linux on GitHub Actions
+        //[AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/269")] // LUCENENET TODO: this test fails only on Linux on GitHub Actions
         public void Test()
         {
             TextReader reader = new StringReader("Résumé");

--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUFoldingFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUFoldingFilterFactory.cs
@@ -30,7 +30,6 @@ namespace Lucene.Net.Analysis.Icu
     {
         /** basic tests to ensure the folding is working */
         [Test]
-        //[AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/269")] // LUCENENET TODO: this test fails only on Linux on GitHub Actions
         public void Test()
         {
             TextReader reader = new StringReader("Résumé");


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Removes `[AwaitsFix]` from TestICUFoldingFilterFactory.Test

Related #269

## Description

This test passes on Ubuntu 24.04 in my local testing. It was noted that it failed on Ubuntu 18.04 on GitHub Actions, but that is no longer a supported distribution for any of our current targets. This removes the `[AwaitsFix]` from this test to see if it passes in GitHub Actions on Ubuntu today, and if so, we can merge this to re-enable the test.
