### PR TITLE
Expressions.JS: Bitwise left shift bugfixes, #1034

### DIFF
--- a/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
@@ -430,11 +430,7 @@ namespace Lucene.Net.Expressions.JS
                     if (context.children[i] is ITerminalNode terminalNode)
                     {
                         EnterAdditive(context.additive(argIndex++));
-                        compiler.Emit(OpCodes.Conv_I4); // cast to int (truncate)
-
-                        // mask off 63 to prevent overflow (fixes issue on x86 .NET Framework, #1034)
-                        compiler.Emit(OpCodes.Ldc_I4, 0x3F);
-                        compiler.Emit(OpCodes.And);
+                        compiler.Emit(OpCodes.Conv_I4); // cast shift operand to int (truncate)
 
                         if (terminalNode.Symbol.Type == JavascriptParser.AT_BIT_SHL)
                         {

--- a/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
@@ -430,11 +430,10 @@ namespace Lucene.Net.Expressions.JS
                     if (context.children[i] is ITerminalNode terminalNode)
                     {
                         EnterAdditive(context.additive(argIndex++));
-                        compiler.Emit(OpCodes.Conv_I8); // cast to long (truncate)
+                        compiler.Emit(OpCodes.Conv_I4); // cast to int (truncate)
 
                         // mask off 63 to prevent overflow (fixes issue on x86 .NET Framework, #1034)
                         compiler.Emit(OpCodes.Ldc_I4, 0x3F);
-                        compiler.Emit(OpCodes.Conv_I8); // cast to long (truncate)
                         compiler.Emit(OpCodes.And);
 
                         if (terminalNode.Symbol.Type == JavascriptParser.AT_BIT_SHL)

--- a/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
@@ -430,7 +430,11 @@ namespace Lucene.Net.Expressions.JS
                     if (context.children[i] is ITerminalNode terminalNode)
                     {
                         EnterAdditive(context.additive(argIndex++));
-                        compiler.Emit(OpCodes.Conv_I4); // cast shift operand to int (truncate)
+                        compiler.Emit(OpCodes.Conv_I4); // cast to int (truncate)
+
+                        // mask off 63 to prevent overflow (fixes issue on x86 .NET Framework, #1034)
+                        compiler.Emit(OpCodes.Ldc_I4, 0x3F);
+                        compiler.Emit(OpCodes.And);
 
                         if (terminalNode.Symbol.Type == JavascriptParser.AT_BIT_SHL)
                         {


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Mask off 63 from shift operand to prevent overflow on x86, and cast to 32-bit operand.

Fixes #1034

## Description

On x86 .NET Framework, the ANTLR/IL changes in #996 behave differently than other platforms. This seems to be due to x86 .NET Framework not masking off the operand correctly. Other platforms mask this off by 0x3f (63) since shifting by 64 or more would overflow, so this basically wraps the shift instead of overflowing. x86 netfx for some reason does not do this correctly. This adds a mask that does no harm on other platforms, but ensures that all are operating the same way.

Additionally, to fix an issue on .NET 5/6 (still usable with our netstandard2.1 target), the right operand must be an Int32 in case it overflows. If the operand is an Int64 and it is out of range, it can crash the process as an invalid program.

Note that this inlines the CompileBinary logic and no longer uses that method because we want to only mask off the second operand, not the first.