### PR TITLE
SWEEP: Rename BeforeClass/AfterClass to OneTimeSetUp/OneTimeTearDown, #1016

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
@@ -472,13 +472,13 @@ namespace Lucene.Net.Index
         }
 
         [NUnit.Framework.OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             allTerms = null;
             fieldInfos = null;
             fields = null;
             globalLiveDocs = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         // TODO maybe instead of @BeforeClass just make a single test run: build postings & index & test it?

--- a/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BasePostingsFormatTestCase.cs
@@ -348,9 +348,9 @@ namespace Lucene.Net.Index
         }
 
         [NUnit.Framework.OneTimeSetUp]
-        public override void BeforeClass() // Renamed from CreatePostings to ensure the base class setup is called before this one
+        public override void OneTimeSetUp() // Renamed from CreatePostings to ensure the base class setup is called before this one
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             totalPostings = 0;
             totalPayloadBytes = 0;
@@ -375,7 +375,7 @@ namespace Lucene.Net.Index
                     continue;
                 }
 
-                fieldInfoArray[fieldUpto] = new FieldInfo(field, true, fieldUpto, false, false, true, 
+                fieldInfoArray[fieldUpto] = new FieldInfo(field, true, fieldUpto, false, false, true,
                                                         IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS,
                                                         DocValuesType.NONE, DocValuesType.NUMERIC, null);
                 fieldUpto++;
@@ -653,18 +653,18 @@ namespace Lucene.Net.Index
             public DocsAndPositionsEnum ReuseDocsAndPositionsEnum { get; set; }
         }
 
-        private void VerifyEnum(ThreadState threadState, 
-                                string field, 
-                                BytesRef term, 
+        private void VerifyEnum(ThreadState threadState,
+                                string field,
+                                BytesRef term,
                                 TermsEnum termsEnum,
 
                                 // Maximum options (docs/freqs/positions/offsets) to test:
-                                IndexOptions maxTestOptions, 
-                                
-                                IndexOptions maxIndexOptions, 
-                                ISet<Option> options, 
+                                IndexOptions maxTestOptions,
+
+                                IndexOptions maxIndexOptions,
+                                ISet<Option> options,
                                 bool alwaysTestMax)
-        
+
         {
             if (Verbose)
             {
@@ -698,9 +698,9 @@ namespace Lucene.Net.Index
             FieldInfo fieldInfo = currentFieldInfos.FieldInfo(field);
 
             // NOTE: can be empty list if we are using liveDocs:
-            SeedPostings expected = GetSeedPostings(term.Utf8ToString(), 
-                                                    fields[field][term], 
-                                                    useLiveDocs, 
+            SeedPostings expected = GetSeedPostings(term.Utf8ToString(),
+                                                    fields[field][term],
+                                                    useLiveDocs,
                                                     maxIndexOptions);
             Assert.AreEqual(expected.DocFreq, termsEnum.DocFreq);
 
@@ -710,12 +710,12 @@ namespace Lucene.Net.Index
             bool doCheckFreqs = allowFreqs && (alwaysTestMax || Random.Next(3) <= 2);
 
             // LUCENENET specific - to avoid boxing, changed from CompareTo() to IndexOptionsComparer.Compare()
-            bool allowPositions = IndexOptionsComparer.Default.Compare(fieldInfo.IndexOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0 && 
+            bool allowPositions = IndexOptionsComparer.Default.Compare(fieldInfo.IndexOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0 &&
                 IndexOptionsComparer.Default.Compare(maxTestOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
             bool doCheckPositions = allowPositions && (alwaysTestMax || Random.Next(3) <= 2);
 
             // LUCENENET specific - to avoid boxing, changed from CompareTo() to IndexOptionsComparer.Compare()
-            bool allowOffsets = IndexOptionsComparer.Default.Compare(fieldInfo.IndexOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) >=0 && 
+            bool allowOffsets = IndexOptionsComparer.Default.Compare(fieldInfo.IndexOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) >=0 &&
                 IndexOptionsComparer.Default.Compare(maxTestOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) >= 0;
             bool doCheckOffsets = allowOffsets && (alwaysTestMax || Random.Next(3) <= 2);
 
@@ -1099,9 +1099,9 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void TestTerms(Fields fieldsSource, ISet<Option> options, 
-                                IndexOptions maxTestOptions, 
-                                IndexOptions maxIndexOptions, 
+        private void TestTerms(Fields fieldsSource, ISet<Option> options,
+                                IndexOptions maxTestOptions,
+                                IndexOptions maxIndexOptions,
                                 bool alwaysTestMax)
         {
             if (options.Contains(Option.THREADS))
@@ -1124,9 +1124,9 @@ namespace Lucene.Net.Index
             }
         }
 
-        private void TestTermsOneThread(Fields fieldsSource, ISet<Option> options, 
-                                        IndexOptions maxTestOptions, 
-                                        IndexOptions maxIndexOptions, 
+        private void TestTermsOneThread(Fields fieldsSource, ISet<Option> options,
+                                        IndexOptions maxTestOptions,
+                                        IndexOptions maxIndexOptions,
                                         bool alwaysTestMax)
         {
             ThreadState threadState = new ThreadState();
@@ -1189,13 +1189,13 @@ namespace Lucene.Net.Index
                     savedTermState = true;
                 }
 
-                VerifyEnum(threadState, 
-                            fieldAndTerm.Field, 
-                            fieldAndTerm.Term, 
-                            termsEnum, 
-                            maxTestOptions, 
-                            maxIndexOptions, 
-                            options, 
+                VerifyEnum(threadState,
+                            fieldAndTerm.Field,
+                            fieldAndTerm.Term,
+                            termsEnum,
+                            maxTestOptions,
+                            maxIndexOptions,
+                            options,
                             alwaysTestMax);
 
                 // Sometimes save term state after pulling the enum:
@@ -1217,13 +1217,13 @@ namespace Lucene.Net.Index
                         Console.WriteLine("TEST: try enum again on same term");
                     }
 
-                    VerifyEnum(threadState, 
-                                fieldAndTerm.Field, 
-                                fieldAndTerm.Term, 
-                                termsEnum, 
-                                maxTestOptions, 
-                                maxIndexOptions, 
-                                options, 
+                    VerifyEnum(threadState,
+                                fieldAndTerm.Field,
+                                fieldAndTerm.Term,
+                                termsEnum,
+                                maxTestOptions,
+                                maxIndexOptions,
+                                options,
                                 alwaysTestMax);
                 }
             }
@@ -1348,7 +1348,7 @@ namespace Lucene.Net.Index
 
         protected override void AddRandomFields(Document doc)
         {
-            
+
             foreach (IndexOptions opts in Enum.GetValues(typeof(IndexOptions)))
             {
                 // LUCENENET: Skip our NONE option

--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -492,12 +492,12 @@ namespace Lucene.Net.Index
         private readonly DisposableThreadLocal<DocsAndPositionsEnum> docsAndPositionsEnum = new DisposableThreadLocal<DocsAndPositionsEnum>();
 
         // LUCENENET specific - cleanup DisposableThreadLocal instances after running tests
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             termsEnum.Dispose();
             docsEnum.Dispose();
             docsAndPositionsEnum.Dispose();
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         protected virtual void AssertEquals(RandomTokenStream tk, FieldType ft, Terms terms)

--- a/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Search
         }
 
         [NUnit.Framework.OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             m_reader.Dispose();
             m_directory.Dispose();
@@ -103,7 +103,7 @@ namespace Lucene.Net.Search
             m_directory = null;
             m_analyzer = null;
             m_s1 = m_s2 = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/SearchEquivalenceTestBase.cs
@@ -46,9 +46,9 @@ namespace Lucene.Net.Search
         protected static string m_stopword; // we always pick a character as a stopword
 
         [NUnit.Framework.OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
 
             Random random = Random;

--- a/src/Lucene.Net.TestFramework/Support/Configuration/ConfigurationSettingTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Support/Configuration/ConfigurationSettingTestCase.cs
@@ -34,9 +34,9 @@ namespace Lucene.Net.Configuration
 
         protected abstract IConfiguration LoadConfiguration();
 
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             var configuration = LoadConfiguration();
             // Set up mocks for ConfigurationSettings and SystemProperties
             ConfigurationSettings = new ConfigurationSettingsImpl(configuration);

--- a/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
@@ -261,7 +261,7 @@ namespace Lucene.Net.Util
         /// Access to the current <see cref="System.Random"/> instance. It is safe to use
         /// this method from multiple threads, etc., but it should be called while within a runner's
         /// scope (so no static initializers). The returned <see cref="System.Random"/> instance will be
-        /// <b>different</b> when this method is called inside a <see cref="LuceneTestCase.BeforeClass()"/> hook (static
+        /// <b>different</b> when this method is called inside a <see cref="LuceneTestCase.OneTimeSetUp"/> hook (static
         /// suite scope) and within <see cref="OneTimeSetUpAttribute"/>/ <see cref="OneTimeTearDownAttribute"/> hooks or test methods.
         ///
         /// <para/>The returned instance must not be shared with other threads or cross a single scope's

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Util
     ///
     /// <para>
     /// The preferred way to specify class (suite-level) setup/cleanup is to use
-    /// static methods annotated with <see cref="OneTimeSetUp"/> and <see cref="OneTimeTearDown"/>. Any
+    /// static methods annotated with <see cref="NUnit.Framework.OneTimeSetUpAttribute"/> and <see cref="OneTimeTearDown"/>. Any
     /// code in these methods is executed within the test framework's control and
     /// ensure proper setup has been made. <b>Try not to use static initializers
     /// (including complex readonly field initializers).</b> Static initializers are
@@ -977,12 +977,12 @@ namespace Lucene.Net.Util
         /// Sets up dependency injection of codec factories for running the test class,
         /// and also picks random defaults for culture, time zone, similarity, and default codec.
         /// <para/>
-        /// If you override this method, be sure to call <c>base.BeforeClass()</c> BEFORE setting
+        /// If you override this method, be sure to call <c>base.OneTimeSetUp()</c> BEFORE setting
         /// up your test fixture.
         /// </summary>
         // LUCENENET specific method for setting up dependency injection of test classes.
         [OneTimeSetUp]
-        public virtual void BeforeClass()
+        public virtual void OneTimeSetUp()
         {
             try
             {
@@ -995,7 +995,7 @@ namespace Lucene.Net.Util
             catch (Exception ex)
             {
                 // Write the stack trace so we have something to go on if an error occurs here.
-                throw new Exception($"An exception occurred during BeforeClass:\n{ex}", ex);
+                throw new Exception($"An exception occurred during OneTimeSetUp:\n{ex}", ex);
             }
         }
 
@@ -1029,7 +1029,7 @@ namespace Lucene.Net.Util
         /// Access to the current <see cref="System.Random"/> instance. It is safe to use
         /// this method from multiple threads, etc., but it should be called while within a runner's
         /// scope (so no static initializers). The returned <see cref="System.Random"/> instance will be
-        /// <b>different</b> when this method is called inside a <see cref="BeforeClass()"/> hook (static
+        /// <b>different</b> when this method is called inside a <see cref="OneTimeSetUp"/> hook (static
         /// suite scope) and within <see cref="Before"/>/ <see cref="After"/> hooks or test methods.
         ///
         /// <para/>The returned instance must not be shared with other threads or cross a single scope's

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Util
     ///
     /// <para>
     /// The preferred way to specify class (suite-level) setup/cleanup is to use
-    /// static methods annotated with <see cref="NUnit.Framework.OneTimeSetUpAttribute"/> and <see cref="OneTimeTearDown"/>. Any
+    /// static methods annotated with <see cref="NUnit.Framework.OneTimeSetUpAttribute"/> and <see cref="NUnit.Framework.OneTimeTearDownAttribute"/>. Any
     /// code in these methods is executed within the test framework's control and
     /// ensure proper setup has been made. <b>Try not to use static initializers
     /// (including complex readonly field initializers).</b> Static initializers are
@@ -1002,12 +1002,12 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Tears down random defaults and cleans up temporary files.
         /// <para/>
-        /// If you override this method, be sure to call <c>base.AfterClass()</c> AFTER
+        /// If you override this method, be sure to call <c>base.OneTimeTearDown()</c> AFTER
         /// tearing down your test fixture.
         /// </summary>
         // LUCENENET specific method for setting up dependency injection of test classes.
         [OneTimeTearDown]
-        public virtual void AfterClass()
+        public virtual void OneTimeTearDown()
         {
             try
             {
@@ -1017,7 +1017,7 @@ namespace Lucene.Net.Util
             catch (Exception ex)
             {
                 // Write the stack trace so we have something to go on if an error occurs here.
-                throw new Exception($"An exception occurred during AfterClass:\n{ex}", ex);
+                throw new Exception($"An exception occurred during OneTimeTearDown:\n{ex}", ex);
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -261,13 +261,13 @@ namespace Lucene.Net.Analysis.Core
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             tokenizers = null;
             tokenfilters = null;
             charfilters = null;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -196,15 +196,15 @@ namespace Lucene.Net.Analysis.Core
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             IEnumerable<Type> analysisClasses = typeof(StandardAnalyzer).Assembly.GetTypes()
                 .Where(c => {
                     var typeInfo = c;
 
-                    return !typeInfo.IsAbstract && typeInfo.IsPublic && !typeInfo.IsInterface 
+                    return !typeInfo.IsAbstract && typeInfo.IsPublic && !typeInfo.IsInterface
                         && typeInfo.IsClass && (typeInfo.GetCustomAttribute<ObsoleteAttribute>() is null)
                         && (typeInfo.IsSubclassOf(typeof(Tokenizer)) || typeInfo.IsSubclassOf(typeof(TokenFilter)) || typeInfo.IsSubclassOf(typeof(CharFilter)));
                 })
@@ -225,19 +225,19 @@ namespace Lucene.Net.Analysis.Core
 
                     if (typeInfo.IsSubclassOf(typeof(Tokenizer)))
                     {
-                        assertTrue(ctor.ToString() + " has unsupported parameter types", 
+                        assertTrue(ctor.ToString() + " has unsupported parameter types",
                             allowedTokenizerArgs.containsAll(ctor.GetParameters().Select(p => p.ParameterType).ToArray()));
                         tokenizers.Add(ctor);
                     }
                     else if (typeInfo.IsSubclassOf(typeof(TokenFilter)))
                     {
-                        assertTrue(ctor.ToString() + " has unsupported parameter types", 
+                        assertTrue(ctor.ToString() + " has unsupported parameter types",
                             allowedTokenFilterArgs.containsAll(ctor.GetParameters().Select(p => p.ParameterType).ToArray()));
                         tokenfilters.Add(ctor);
                     }
                     else if (typeInfo.IsSubclassOf(typeof(CharFilter)))
                     {
-                        assertTrue(ctor.ToString() + " has unsupported parameter types", 
+                        assertTrue(ctor.ToString() + " has unsupported parameter types",
                             allowedCharFilterArgs.containsAll(ctor.GetParameters().Select(p => p.ParameterType).ToArray()));
                         charfilters.Add(ctor);
                     }
@@ -259,7 +259,7 @@ namespace Lucene.Net.Analysis.Core
                 Console.WriteLine("charfilters = " + charfilters);
             }
         }
-        
+
         [OneTimeTearDown]
         public override void AfterClass()
         {
@@ -1113,7 +1113,7 @@ namespace Lucene.Net.Analysis.Core
                 return m_input.Read();
             }
 
-            // LUCENENET: TextReader dosn't support this overload 
+            // LUCENENET: TextReader dosn't support this overload
             //public int read(char[] cbuf)
             //{
             //    readSomething = true;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestAlternateCasing.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestAlternateCasing.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestAlternateCasing : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("alternate-casing.aff", "alternate-casing.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCaseInsensitive.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCaseInsensitive.cs
@@ -23,9 +23,9 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestCaseInsensitive : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init(true, "simple.aff", "mixedcase.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCaseSensitive.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCaseSensitive.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestCaseSensitive : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("casesensitive.aff", "casesensitive.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCircumfix.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCircumfix.cs
@@ -23,9 +23,9 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestCircumfix_ : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("circumfix.aff", "circumfix.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestComplexPrefix.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestComplexPrefix.cs
@@ -23,9 +23,9 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestComplexPrefix : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("complexprefix.aff", "complexprefix.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCondition.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCondition.cs
@@ -23,9 +23,9 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestCondition : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("condition.aff", "condition.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCondition2.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestCondition2.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestCondition2 : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("condition2.aff", "condition2.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestConditionGH418.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestConditionGH418.cs
@@ -24,9 +24,9 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestConditionGH418 : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("condition-issue-418.aff", "condition-issue-418.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestConv.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestConv.cs
@@ -23,9 +23,9 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestConv : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("conv.aff", "conv.dic");
         }
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestDependencies.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestDependencies.cs
@@ -23,11 +23,12 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestDependencies_ : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("dependencies.aff", "dependencies.dic");
         }
+
         [Test]
         public virtual void TestDependencies()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestDoubleEscape.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestDoubleEscape.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestDoubleEscape : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("double-escaped.aff", "double-escaped.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestEscaped.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestEscaped.cs
@@ -23,11 +23,12 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestEscaped : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("escaped.aff", "escaped.dic");
         }
+
         [Test]
         public virtual void TestStemming()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFlagLong.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFlagLong.cs
@@ -23,11 +23,12 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestFlagLong : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("flaglong.aff", "flaglong.dic");
         }
+
         [Test]
         public virtual void TestLongFlags()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFlagNum.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFlagNum.cs
@@ -23,11 +23,12 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestFlagNum : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("flagnum.aff", "flagnum.dic");
         }
+
         [Test]
         public virtual void TestNumFlags()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFullStrip.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestFullStrip.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestFullStrip : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("fullstrip.aff", "fullstrip.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHomonyms.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHomonyms.cs
@@ -22,13 +22,13 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestHomonyms : StemmerTestBase
     {
-
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("homonyms.aff", "homonyms.dic");
         }
+
         [Test]
         public virtual void TestExamples()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
@@ -30,9 +30,9 @@ namespace Lucene.Net.Analysis.Hunspell
         private static Dictionary dictionary;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             System.IO.Stream affixStream = typeof(TestStemmer).getResourceAsStream("simple.aff");
             System.IO.Stream dictStream = typeof(TestStemmer).getResourceAsStream("simple.dic");
             try

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestHunspellStemFilter.cs
@@ -46,10 +46,10 @@ namespace Lucene.Net.Analysis.Hunspell
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             dictionary = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestIgnore.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestIgnore.cs
@@ -22,13 +22,13 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestIgnore : StemmerTestBase
     {
-
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("ignore.aff", "ignore.dic");
         }
+
         [Test]
         public virtual void TestExamples()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestKeepCase.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestKeepCase.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestKeepCase : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("keepcase.aff", "keepcase.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestMorph.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestMorph.cs
@@ -22,13 +22,13 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestMorph : StemmerTestBase
     {
-
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("morph.aff", "morph.dic");
         }
+
         [Test]
         public virtual void TestExamples()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestMorphAlias.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestMorphAlias.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestMorphAlias : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("morphalias.aff", "morphalias.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestMorphData.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestMorphData.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestMorphData : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("morphdata.aff", "morphdata.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestNeedAffix.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestNeedAffix.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestNeedAffix : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("needaffix.aff", "needaffix.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestOnlyInCompound.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestOnlyInCompound.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestOnlyInCompound : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("onlyincompound.aff", "onlyincompound.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestOptionalCondition.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestOptionalCondition.cs
@@ -23,11 +23,12 @@ namespace Lucene.Net.Analysis.Hunspell
     public class TestOptionalCondition : StemmerTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("optional-condition.aff", "condition.dic");
         }
+
         [Test]
         public virtual void TestStemming()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestSpaces.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestSpaces.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestSpaces : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("spaces.aff", "spaces.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestStemmer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestStemmer.cs
@@ -22,24 +22,26 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestStemmer : StemmerTestBase
     {
-
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("simple.aff", "simple.dic");
         }
+
         [Test]
         public virtual void TestSimpleSuffix()
         {
             AssertStemsTo("lucene", "lucene", "lucen");
             AssertStemsTo("mahoute", "mahout");
         }
+
         [Test]
         public virtual void TestSimplePrefix()
         {
             AssertStemsTo("solr", "olr");
         }
+
         [Test]
         public virtual void TestRecursiveSuffix()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestStrangeOvergeneration.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestStrangeOvergeneration.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestStrangeOvergeneration : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("strange-overgeneration.aff", "strange-overgeneration.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestTwoFold.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestTwoFold.cs
@@ -22,13 +22,13 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestTwoFold : StemmerTestBase
     {
-
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("twofold.aff", "morph.dic");
         }
+
         [Test]
         public virtual void TestExamples()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestTwoSuffixes.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestTwoSuffixes.cs
@@ -22,13 +22,13 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestTwoSuffixes : StemmerTestBase
     {
-
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("twosuffixes.aff", "twosuffixes.dic");
         }
+
         [Test]
         public virtual void TestExamples()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestZeroAffix.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestZeroAffix.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestZeroAffix : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("zeroaffix.aff", "zeroaffix.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestZeroAffix2.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestZeroAffix2.cs
@@ -22,9 +22,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
     public class TestZeroAffix2 : StemmerTestBase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             Init("zeroaffix2.aff", "zeroaffix2.dic");
         }
 

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPSentenceBreakIterator.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPSentenceBreakIterator.cs
@@ -39,9 +39,9 @@ namespace Lucene.Net.Analysis.OpenNlp
         private const String PADDING = " Word. Word. ";
         private const String sentenceModelFile = "en-test-sent.bin";
 
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             PopulateCache();
         }
 

--- a/src/Lucene.Net.Tests.Benchmark/BenchmarkTestCase.cs
+++ b/src/Lucene.Net.Tests.Benchmark/BenchmarkTestCase.cs
@@ -47,10 +47,10 @@ namespace Lucene.Net.Benchmarks
             };
         }
 
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             WORKDIR = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
 

--- a/src/Lucene.Net.Tests.Benchmark/BenchmarkTestCase.cs
+++ b/src/Lucene.Net.Tests.Benchmark/BenchmarkTestCase.cs
@@ -31,9 +31,9 @@ namespace Lucene.Net.Benchmarks
     {
         private static DirectoryInfo WORKDIR;
 
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             WORKDIR = CreateTempDir("benchmark");
             // LUCENENET: Our directory numbers are sequential. Doing a delete
             // here will make threads collide.
@@ -88,7 +88,7 @@ namespace Lucene.Net.Benchmarks
             return getWorkDir().FullName.Replace("\\", "/");
         }
 
-        // create the benchmark and execute it. 
+        // create the benchmark and execute it.
         public Benchmark execBenchmark(String[] algLines)
         {
             String algText = algLinesToText(algLines);

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/AddIndexesTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/AddIndexesTaskTest.cs
@@ -32,9 +32,9 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     {
         private static DirectoryInfo testDir, inputDir;
 
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             testDir = CreateTempDir("addIndexesTask");
 
             // create a dummy index under inputDir

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/TestPerfTasksLogic.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/TestPerfTasksLogic.cs
@@ -49,9 +49,9 @@ namespace Lucene.Net.Benchmarks.ByTask
         //    copyToWorkDir("test-mapping-ISOLatin1Accent-partial.txt");
         //}
 
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             copyToWorkDir("reuters.first20.lines.txt");
             copyToWorkDir("test-mapping-ISOLatin1Accent-partial.txt");
         }
@@ -85,7 +85,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             // 4. test specific checks after the benchmark run completed.
             assertEquals("TestSearchTask was supposed to be called!", 279, CountingSearchTestTask.numSearches);
             assertTrue("Index does not exist?...!", DirectoryReader.IndexExists(benchmark.RunData.Directory));
-            // now we should be able to open the index for write. 
+            // now we should be able to open the index for write.
             IndexWriter iw = new IndexWriter(benchmark.RunData.Directory,
                 new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
                 .SetOpenMode(OpenMode.APPEND));
@@ -306,7 +306,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             // 4. test specific checks after the benchmark run completed.
             assertEquals("TestSearchTask was supposed to be called!", 139, CountingSearchTestTask.numSearches);
             assertTrue("Index does not exist?...!", DirectoryReader.IndexExists(benchmark.RunData.Directory));
-            // now we should be able to open the index for write. 
+            // now we should be able to open the index for write.
             IndexWriter iw = new IndexWriter(benchmark.RunData.Directory, new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetOpenMode(OpenMode.APPEND));
             iw.Dispose();
             IndexReader ir = DirectoryReader.Open(benchmark.RunData.Directory);
@@ -419,7 +419,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             {
                 if (numLines == 0 && line.StartsWith(WriteLineDocTask.FIELDS_HEADER_INDICATOR, StringComparison.Ordinal))
                 {
-                    continue; // do not count the header line as a doc 
+                    continue; // do not count the header line as a doc
                 }
                 numLines++;
             }
@@ -445,7 +445,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             // Run algo
             benchmark = execBenchmark(algLines2);
 
-            // now we should be able to open the index for write. 
+            // now we should be able to open the index for write.
             IndexWriter iw = new IndexWriter(benchmark.RunData.Directory,
                 new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
                     .SetOpenMode(OpenMode.APPEND));
@@ -964,7 +964,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             benchmark = execBenchmark(getLocaleConfig("ROOT"));
             assertEquals(CultureInfo.InvariantCulture, benchmark.RunData.Locale);
 
-            // specify just a language 
+            // specify just a language
             benchmark = execBenchmark(getLocaleConfig("de"));
             assertEquals(new CultureInfo("de"), benchmark.RunData.Locale);
 
@@ -976,7 +976,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             //benchmark = execBenchmark(getLocaleConfig("no,NO,NY"));
             //assertEquals(new CultureInfo("no-NO"/*, "NY"*/), benchmark.RunData.Locale);
 
-            // LUCENENET specific - in .NET Norwegian is specified as either nb-NO (Bokmål) or 
+            // LUCENENET specific - in .NET Norwegian is specified as either nb-NO (Bokmål) or
             // nn-NO (Nynorsk) + a few other dialects. no-NO works sometimes, but is not
             // supported across all OS's, so doesn't make a reliable test case.
             benchmark = execBenchmark(getLocaleConfig("nb,NO,NY"));
@@ -1035,7 +1035,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             //expected = new ICUCollationKeyAnalyzer(TEST_VERSION_CURRENT, Collator.Create(new CultureInfo("no-NO"/*, "NY"*/), Collator.Fallback.FallbackAllowed));
             //assertEqualCollation(expected, benchmark.RunData.Analyzer, "foobar");
 
-            // LUCENENET specific - in .NET Norwegian is specified as either nb-NO (Bokmål) or 
+            // LUCENENET specific - in .NET Norwegian is specified as either nb-NO (Bokmål) or
             // nn-NO (Nynorsk) + a few other dialects. no-NO works sometimes, but is not
             // supported across all OS's, so doesn't make a reliable test case.
 

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Facet.Taxonomy
     using IOUtils = Lucene.Net.Util.IOUtils;
 
     /// <summary>
-    /// Test for associations 
+    /// Test for associations
     /// </summary>
     [TestFixture]
     public class TestTaxonomyFacetAssociations : FacetTestCase
@@ -53,9 +53,9 @@ namespace Lucene.Net.Facet.Taxonomy
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             dir = NewDirectory();
             taxoDir = NewDirectory();
@@ -144,7 +144,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
         /// <summary>
         /// Make sure we can test both int and float assocs in one
-        ///  index, as long as we send each to a different field. 
+        ///  index, as long as we send each to a different field.
         /// </summary>
         [Test]
         public virtual void TestIntAndFloatAssocation()
@@ -163,7 +163,7 @@ namespace Lucene.Net.Facet.Taxonomy
             Assert.AreEqual(150, (int)facets.GetSpecificValue("int", "b"), "Wrong count for category 'b'!");
         }
 
-        
+
         [Test]
         public virtual void TestWrongIndexFieldName()
         {

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetAssociations.cs
@@ -98,7 +98,7 @@ namespace Lucene.Net.Facet.Taxonomy
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             reader.Dispose();
             reader = null;
@@ -109,7 +109,7 @@ namespace Lucene.Net.Facet.Taxonomy
             taxoDir.Dispose();
             taxoDir = null;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
@@ -246,9 +246,9 @@ namespace Lucene.Net.Facet.Taxonomy
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - renamed from BeforeClassCountingFacetsAggregatorTest() to ensure calling order
+        public override void OneTimeSetUp() // LUCENENET specific - renamed from BeforeClassCountingFacetsAggregatorTest() to ensure calling order
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             indexDir = NewDirectory();
             taxoDir = NewDirectory();

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
@@ -88,10 +88,10 @@ namespace Lucene.Net.Facet.Taxonomy
         private static IDictionary<string, int> allExpectedCounts, termExpectedCounts;
 
         [OneTimeTearDown]
-        public override void AfterClass() // LUCENENET specific - renamed from AfterClassCountingFacetsAggregatorTest() to ensure calling order
+        public override void OneTimeTearDown() // LUCENENET specific - renamed from AfterClassCountingFacetsAggregatorTest() to ensure calling order
         {
             IOUtils.Dispose(indexDir, taxoDir);
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         private static IList<FacetField> RandomCategories(Random random)

--- a/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Facet
         private static FacetsConfig config;
 
         [OneTimeTearDown]
-        public override void AfterClass() // LUCENENET specific - renamed from AfterClassDrillDownQueryTest() to ensure calling order
+        public override void OneTimeTearDown() // LUCENENET specific - renamed from AfterClassDrillDownQueryTest() to ensure calling order
         {
             IOUtils.Dispose(reader, taxo, dir, taxoDir);
             reader = null;
@@ -64,7 +64,7 @@ namespace Lucene.Net.Facet
             taxoDir = null;
             config = null;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [OneTimeSetUp]

--- a/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillDownQuery.cs
@@ -68,9 +68,9 @@ namespace Lucene.Net.Facet
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - renamed from BeforeClassDrillDownQueryTest() to ensure calling order
+        public override void OneTimeSetUp() // LUCENENET specific - renamed from BeforeClassDrillDownQueryTest() to ensure calling order
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             dir = NewDirectory();
             Random r = Random;
@@ -174,7 +174,7 @@ namespace Lucene.Net.Facet
 
             Assert.AreEqual(5, docs.TotalHits);
             // Check that content:foo (which yields 50% results) and facet/b (which yields 20%)
-            // would gather together 10 results (10%..) 
+            // would gather together 10 results (10%..)
             Query fooQuery = new TermQuery(new Term("content", "foo"));
             DrillDownQuery q4 = new DrillDownQuery(config, fooQuery);
             q4.Add("b");
@@ -199,7 +199,7 @@ namespace Lucene.Net.Facet
             Assert.AreEqual(5, docs.TotalHits);
 
             // Check that content:foo (which yields 50% results) and facet/b (which yields 20%)
-            // would gather together 10 results (10%..) 
+            // would gather together 10 results (10%..)
             Query fooQuery = new TermQuery(new Term("content", "foo"));
             DrillDownQuery q4 = new DrillDownQuery(config, fooQuery);
             q4.Add("b");

--- a/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
+++ b/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Documents
         public Directory dir = NewDirectory();
 
         [OneTimeTearDown]
-        public override void AfterClass() // LUCENENET specific - changed from RemoveIndex() to ensure calling order vs base class
+        public override void OneTimeTearDown() // LUCENENET specific - changed from RemoveIndex() to ensure calling order vs base class
         {
             if (null != dir)
             {
@@ -56,7 +56,7 @@ namespace Lucene.Net.Documents
                 catch (Exception e) when (e.IsException()) { /* NOOP */ }
             }
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [OneTimeSetUp]

--- a/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
+++ b/src/Lucene.Net.Tests.Misc/Document/TestLazyDocument.cs
@@ -60,9 +60,9 @@ namespace Lucene.Net.Documents
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - changed from CreateIndex() to ensure calling order vs base class
+        public override void OneTimeSetUp() // LUCENENET specific - changed from CreateIndex() to ensure calling order vs base class
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             Analyzer analyzer = new MockAnalyzer(Random);
             IndexWriter writer = new IndexWriter

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/IndexSortingTest.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/IndexSortingTest.cs
@@ -36,9 +36,9 @@ namespace Lucene.Net.Index.Sorter
         };
 
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - renamed from BeforeClassSorterUtilTest() to ensure calling order vs base class
+        public override void OneTimeSetUp() // LUCENENET specific - renamed from BeforeClassSorterUtilTest() to ensure calling order vs base class
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             // only read the values of the undeleted documents, since after addIndexes,
             // the deleted ones will be dropped from the index.

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
@@ -207,9 +207,9 @@ namespace Lucene.Net.Index.Sorter
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - renamed from BeforeClassSorterTestBase() to ensure calling order vs base class
+        public override void OneTimeSetUp() // LUCENENET specific - renamed from BeforeClassSorterTestBase() to ensure calling order vs base class
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             dir = NewDirectory();
             int numDocs = AtLeast(20);

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
@@ -219,12 +219,12 @@ namespace Lucene.Net.Index.Sorter
         }
 
         [OneTimeTearDown]
-        public override void AfterClass() // LUCENENET specific - renamed from AfterClassSorterTestBase() to ensure calling order vs base class
+        public override void OneTimeTearDown() // LUCENENET specific - renamed from AfterClassSorterTestBase() to ensure calling order vs base class
         {
             reader.Dispose();
             dir.Dispose();
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/SortingAtomicReaderTest.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/SortingAtomicReaderTest.cs
@@ -27,9 +27,9 @@ namespace Lucene.Net.Index.Sorter
     public class SortingAtomicReaderTest : SorterTestBase
     {
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - renamed from BeforeClassSortingAtomicReaderTest() to ensure calling order vs base class
+        public override void OneTimeSetUp() // LUCENENET specific - renamed from BeforeClassSortingAtomicReaderTest() to ensure calling order vs base class
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             // sort the index by id (as integer, in NUMERIC_DV_FIELD)
             Sort sort = new Sort(new SortField(NUMERIC_DV_FIELD, SortFieldType.INT32));

--- a/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
+++ b/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
@@ -52,7 +52,7 @@ namespace Lucene.Net.Misc
         }
 
         [OneTimeTearDown]
-        public override void AfterClass() // LUCENENET specific - renamed from TearDownClass() to ensure calling order vs base class
+        public override void OneTimeTearDown() // LUCENENET specific - renamed from TearDownClass() to ensure calling order vs base class
         {
             reader.Dispose();
             dir.Dispose();
@@ -60,7 +60,7 @@ namespace Lucene.Net.Misc
             reader = null;
             writer = null;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
         /******************** Tests for getHighFreqTerms **********************************/
 

--- a/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
+++ b/src/Lucene.Net.Tests.Misc/Misc/TestHighFreqTerms.cs
@@ -38,9 +38,9 @@ namespace Lucene.Net.Misc
         private static IndexReader reader = null;
 
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - renamed from SetUpClass() to ensure calling order vs base class
+        public override void OneTimeSetUp() // LUCENENET specific - renamed from SetUpClass() to ensure calling order vs base class
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             dir = NewDirectory();
             writer = new IndexWriter(dir, NewIndexWriterConfig(Random,
@@ -231,7 +231,7 @@ namespace Lucene.Net.Misc
             Random rnd = Random;
 
             /**
-             * Generate 10 documents where term n  has a docFreq of n and a totalTermFreq of n*2 (squared). 
+             * Generate 10 documents where term n  has a docFreq of n and a totalTermFreq of n*2 (squared).
              */
             for (int i = 1; i <= 10; i++)
             {
@@ -294,7 +294,7 @@ namespace Lucene.Net.Misc
         /**
          *  getContent
          *  return string containing numbers 1 to i with each number n occurring n times.
-         *  i.e. for input of 3 return string "3 3 3 2 2 1" 
+         *  i.e. for input of 3 return string "3 3 3 2 2 1"
          */
 
         private static string GetContent(int i)

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
@@ -55,10 +55,10 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             qpAnalyzer = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         public sealed class QPTestFilter : TokenFilter

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Precedence/TestPrecedenceQueryParser.cs
@@ -48,9 +48,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence
         public static Analyzer qpAnalyzer;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             qpAnalyzer = new QPTestAnalyzer();
         }
 

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         private static Analyzer? ANALYZER;
 
         private static NumberFormat? NUMBER_FORMAT;
-        
+
 
         private static StandardQueryParser? qp;
 
@@ -131,9 +131,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             ANALYZER = new MockAnalyzer(Random);
 
@@ -260,7 +260,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                     continue;
                 }
 
-                numericConfigMap[type.ToString()] = new NumericConfig(PRECISION_STEP, NUMBER_FORMAT, type); 
+                numericConfigMap[type.ToString()] = new NumericConfig(PRECISION_STEP, NUMBER_FORMAT, type);
 
                 FieldType ft2 = new FieldType(Int32Field.TYPE_NOT_STORED);
                 ft2.NumericType = (type);

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestNumericQueryParser.cs
@@ -663,7 +663,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             searcher = null;
             reader?.Dispose();
@@ -672,7 +672,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             directory = null;
             qp = null;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
     }
 }

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
@@ -58,10 +58,10 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             qpAnalyzer = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         public sealed class QPTestFilter : TokenFilter

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
     /// <summary>
     /// This test case is a copy of the core Lucene query parser test, it was adapted
     /// to use new QueryParserHelper instead of the old query parser.
-    /// 
+    ///
     /// Tests QueryParser.
     /// </summary>
     // TODO: really this should extend QueryParserTestBase too!
@@ -51,9 +51,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         public static Analyzer qpAnalyzer;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             qpAnalyzer = new QPTestAnalyzer();
         }
 
@@ -801,7 +801,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
 
             IDictionary<string, DateResolution> dateRes = new Dictionary<string, DateResolution>();
 
-            // set a field specific date resolution    
+            // set a field specific date resolution
             dateRes[monthField] = DateResolution.MONTH;
 #pragma warning disable 612, 618
             qp.SetDateResolution(dateRes);
@@ -851,7 +851,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
              * assertQueryEquals("\\[brackets", null, "brackets");
              * assertQueryEquals("\\\\", a, "\\\\"); assertQueryEquals("\\+blah", a,
              * "\\+blah"); assertQueryEquals("\\(blah", a, "\\(blah");
-             * 
+             *
              * assertQueryEquals("\\-blah", a, "\\-blah"); assertQueryEquals("\\!blah",
              * a, "\\!blah"); assertQueryEquals("\\{blah", a, "\\{blah");
              * assertQueryEquals("\\}blah", a, "\\}blah"); assertQueryEquals("\\:blah",

--- a/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Core/Messages/TestQueryParserMessagesOverridden.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Core/Messages/TestQueryParserMessagesOverridden.cs
@@ -25,9 +25,9 @@ namespace Lucene.Net.QueryParsers.Support.Flexible.Core.Messages
 
     public class TestQueryParserMessagesOverridden : LuceneTestCase
     {
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             var provider = new QueryParserResourceProvider(MessagesTest.ResourceManager);
             QueryParserMessages.SetResourceProvider(provider);

--- a/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Core/Messages/TestQueryParserMessagesOverridden.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Core/Messages/TestQueryParserMessagesOverridden.cs
@@ -33,13 +33,13 @@ namespace Lucene.Net.QueryParsers.Support.Flexible.Core.Messages
             QueryParserMessages.SetResourceProvider(provider);
         }
 
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             // Return to the default
             var provider = new QueryParserResourceProvider();
             QueryParserMessages.SetResourceProvider(provider);
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
@@ -55,10 +55,10 @@ namespace Lucene.Net.QueryParsers.Util
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             qpAnalyzer = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         public sealed class QPTestFilter : TokenFilter

--- a/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Util/QueryParserTestBase.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.QueryParsers.Util
 {
     /// <summary>
     /// In .NET the abstact members were moved to AbstractQueryParserTestBase
-    /// because the Visual Studio test runner does not find or run tests in 
+    /// because the Visual Studio test runner does not find or run tests in
     /// abstract classes.
     /// </summary>
     [TestFixture]
@@ -48,9 +48,9 @@ namespace Lucene.Net.QueryParsers.Util
         public static Analyzer qpAnalyzer;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             qpAnalyzer = new QPTestAnalyzer();
         }
 
@@ -675,7 +675,7 @@ namespace Lucene.Net.QueryParsers.Util
         {
             // we use the default Locale since LuceneTestCase randomizes it
             DateTime d = DateTime.ParseExact(s, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, CultureInfo.CurrentCulture);
-            return GetDate(d, resolution);   
+            return GetDate(d, resolution);
         }
 
         /// <summary>for testing DateTools support</summary>
@@ -729,7 +729,7 @@ namespace Lucene.Net.QueryParsers.Util
             // set default date resolution to MILLISECOND
             qp.SetDateResolution(DateResolution.MILLISECOND);
 
-            // set second field specific date resolution    
+            // set second field specific date resolution
             SetDateResolution(qp, hourField, DateResolution.HOUR);
 
             // for this field no field specific date resolution has been set,
@@ -834,7 +834,7 @@ namespace Lucene.Net.QueryParsers.Util
 
             // Tests bug LUCENE-800
             AssertQueryEquals("(item:\\\\ item:ABCD\\\\)", a, "item:\\ item:ABCD\\");
-            AssertParseException("(item:\\\\ item:ABCD\\\\))"); // unmatched closing paranthesis 
+            AssertParseException("(item:\\\\ item:ABCD\\\\))"); // unmatched closing paranthesis
             AssertQueryEquals("\\*", a, "*");
             AssertQueryEquals("\\\\", a, "\\");  // escaped backslash
 

--- a/src/Lucene.Net.Tests.QueryParser/Xml/TestParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/TestParser.cs
@@ -38,9 +38,9 @@ namespace Lucene.Net.QueryParsers.Xml
         private static IndexSearcher searcher;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             // TODO: rewrite test (this needs to set QueryParser.enablePositionIncrements, too, for work with CURRENT):
             Analyzer analyzer = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, true, MockTokenFilter.ENGLISH_STOPSET);

--- a/src/Lucene.Net.Tests.QueryParser/Xml/TestParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/TestParser.cs
@@ -71,7 +71,7 @@ namespace Lucene.Net.QueryParsers.Xml
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             reader.Dispose();
             dir.Dispose();
@@ -79,7 +79,7 @@ namespace Lucene.Net.QueryParsers.Xml
             searcher = null;
             dir = null;
             builder = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Sandbox/Queries/TestSortedSetSortFieldSelectors.cs
+++ b/src/Lucene.Net.Tests.Sandbox/Queries/TestSortedSetSortFieldSelectors.cs
@@ -53,11 +53,11 @@ namespace Lucene.Net.Sandbox.Queries
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
-            Codec.Default = (savedCodec);
+            Codec.Default = savedCodec;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         public override void SetUp()

--- a/src/Lucene.Net.Tests.Sandbox/Queries/TestSortedSetSortFieldSelectors.cs
+++ b/src/Lucene.Net.Tests.Sandbox/Queries/TestSortedSetSortFieldSelectors.cs
@@ -37,9 +37,9 @@ namespace Lucene.Net.Sandbox.Queries
         static Codec savedCodec;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             savedCodec = Codec.Default;
             // currently only these codecs that support random access ordinals

--- a/src/Lucene.Net.Tests.TestFramework/Configuration/TestConfigurationSettings.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Configuration/TestConfigurationSettings.cs
@@ -38,10 +38,8 @@ namespace Lucene.Net.Configuration
         private readonly static string currentJsonFilePath = Path.Combine(testDirectory, TestJsonFileName);
         private readonly static string parentJsonFilePath = Path.Combine(parentDirectory, TestJsonFileName);
 
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            
-
             // Create directories if they do not exist
             Directory.CreateDirectory(testDirectory);
 
@@ -65,7 +63,7 @@ namespace Lucene.Net.Configuration
             string testValue = "setup";
             Environment.SetEnvironmentVariable(testKey, testValue);
 
-            base.BeforeClass();
+            base.OneTimeSetUp();
         }
 
         public override void AfterClass()

--- a/src/Lucene.Net.Tests.TestFramework/Configuration/TestConfigurationSettings.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Configuration/TestConfigurationSettings.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Configuration
             base.OneTimeSetUp();
         }
 
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             DirectoryInfo dir = null;
 
@@ -108,7 +108,7 @@ namespace Lucene.Net.Configuration
             }
             catch { }
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         private static readonly IConfigurationFactory ConfigurationFactory = new TestConfigurationFactory

--- a/src/Lucene.Net.Tests.TestFramework/Configuration/TestSystemProperties.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Configuration/TestSystemProperties.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Configuration
             base.OneTimeSetUp();
         }
 
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             DirectoryInfo dir = null;
 
@@ -100,7 +100,7 @@ namespace Lucene.Net.Configuration
             }
             catch { }
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
 

--- a/src/Lucene.Net.Tests.TestFramework/Configuration/TestSystemProperties.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Configuration/TestSystemProperties.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Configuration
         private readonly static string currentJsonFilePath = Path.Combine(testDirectory, TestJsonFileName);
         private readonly static string parentJsonFilePath = Path.Combine(parentDirectory, TestJsonFileName);
 
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
             // Create directories if they do not exist
             Directory.CreateDirectory(testDirectory);
@@ -55,7 +55,7 @@ namespace Lucene.Net.Configuration
                 input.CopyTo(output);
             }
 
-            base.BeforeClass();
+            base.OneTimeSetUp();
         }
 
         public override void AfterClass()

--- a/src/Lucene.Net.Tests/Codecs/Lucene3x/TestLucene3xStoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene3x/TestLucene3xStoredFieldsFormat.cs
@@ -25,9 +25,9 @@ namespace Lucene.Net.Codecs.Lucene3x
     public class TestLucene3xStoredFieldsFormat : BaseStoredFieldsFormatTestCase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene3x/TestSurrogates.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene3x/TestSurrogates.cs
@@ -38,9 +38,9 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// we will manually instantiate preflex-rw here
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true;
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
@@ -74,9 +74,9 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// we will manually instantiate preflex-rw here
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             // NOTE: turn off compound file, this test will open some index files directly.
             OldFormatImpersonationIsActive = true;

--- a/src/Lucene.Net.Tests/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene3x/TestTermInfosReaderIndex.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             termEnum.Dispose();
             reader.Dispose();
@@ -131,7 +131,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             directory = null;
             index = null;
             sampleTerms = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40DocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40DocValuesFormat.cs
@@ -30,9 +30,9 @@ namespace Lucene.Net.Codecs.Lucene40
         private readonly Codec codec = new Lucene40RWCodec();
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40PostingsFormat.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40PostingsFormat.cs
@@ -30,9 +30,9 @@ namespace Lucene.Net.Codecs.Lucene40
         private readonly Codec codec = new Lucene40RWCodec();
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40PostingsReader.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40PostingsReader.cs
@@ -60,9 +60,9 @@ namespace Lucene.Net.Codecs.Lucene40
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40StoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40StoredFieldsFormat.cs
@@ -25,9 +25,9 @@ namespace Lucene.Net.Codecs.Lucene40
     public class TestLucene40StoredFieldsFormat : BaseStoredFieldsFormatTestCase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40TermVectorsFormat.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene40/TestLucene40TermVectorsFormat.cs
@@ -25,9 +25,9 @@ namespace Lucene.Net.Codecs.Lucene40
     public class TestLucene40TermVectorsFormat : BaseTermVectorsFormatTestCase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene40/TestReuseDocsEnum.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene40/TestReuseDocsEnum.cs
@@ -52,9 +52,9 @@ namespace Lucene.Net.Codecs.Lucene40
     public class TestReuseDocsEnum : LuceneTestCase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene41/TestLucene41StoredFieldsFormat.cs
@@ -25,9 +25,9 @@ namespace Lucene.Net.Codecs.Lucene41
     public class TestLucene41StoredFieldsFormat : BaseStoredFieldsFormatTestCase
     {
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }
 

--- a/src/Lucene.Net.Tests/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene42/TestLucene42DocValuesFormat.cs
@@ -30,9 +30,9 @@ namespace Lucene.Net.Codecs.Lucene42
         private readonly Codec codec = new Lucene42RWCodec();
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             OldFormatImpersonationIsActive = true; // explicitly instantiates ancient codec
         }
 

--- a/src/Lucene.Net.Tests/Index/Test2BDocs.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BDocs.cs
@@ -48,11 +48,11 @@ namespace Lucene.Net.Index
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             dir.Dispose();
             dir = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Index/Test2BDocs.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BDocs.cs
@@ -32,9 +32,9 @@ namespace Lucene.Net.Index
         internal static Directory dir;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             dir = NewFSDirectory(CreateTempDir("2Bdocs"));
             IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig(TEST_VERSION_CURRENT, null));

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
@@ -218,9 +218,9 @@ namespace Lucene.Net.Index
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             Assert.IsFalse(OldFormatImpersonationIsActive, "test infra is broken!");
             JCG.List<string> names = new JCG.List<string>(oldNames.Length + oldSingleSegmentNames.Length);

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
@@ -239,14 +239,14 @@ namespace Lucene.Net.Index
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             foreach (Directory d in oldIndexDirs.Values)
             {
                 d.Dispose();
             }
             oldIndexDirs = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
@@ -169,14 +169,14 @@ namespace Lucene.Net.Index
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             foreach (Directory d in oldIndexDirs.Values)
             {
                 d.Dispose();
             }
             oldIndexDirs = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
@@ -148,9 +148,9 @@ namespace Lucene.Net.Index
         internal static IDictionary<string, Directory> oldIndexDirs;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             assertFalse("test infra is broken!", OldFormatImpersonationIsActive);
             JCG.List<string> names = new JCG.List<string>(oldNames.Length + oldSingleSegmentNames.Length);

--- a/src/Lucene.Net.Tests/Index/TestCodecs.cs
+++ b/src/Lucene.Net.Tests/Index/TestCodecs.cs
@@ -92,9 +92,9 @@ namespace Lucene.Net.Index
         private const int TERM_DOC_FREQ_RAND = 20;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             NUM_TEST_ITER = AtLeast(20);
         }
 

--- a/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
@@ -45,9 +45,9 @@ namespace Lucene.Net.Index
         private static FieldInfos.Builder fieldInfos = null;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             testDoc = new Document();
             fieldInfos = new FieldInfos.Builder();

--- a/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestFieldsReader.cs
@@ -66,13 +66,13 @@ namespace Lucene.Net.Index
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             dir.Dispose();
             dir = null;
             fieldInfos = null;
             testDoc = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
@@ -48,9 +48,9 @@ namespace Lucene.Net.Index
         private static LineFileDocs lineDocFile;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             lineDocFile = new LineFileDocs(Random, DefaultCodecSupportsDocValues);
         }
 

--- a/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestFlushByRamOrCountsPolicy.cs
@@ -55,11 +55,11 @@ namespace Lucene.Net.Index
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             lineDocFile.Dispose();
             lineDocFile = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Index/TestIndexInput.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexInput.cs
@@ -117,12 +117,12 @@ namespace Lucene.Net.Index
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             INTS = null;
             LONGS = null;
             RANDOM_TEST_BYTES = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         private void CheckReads(DataInput @is, Type expectedEx)

--- a/src/Lucene.Net.Tests/Index/TestIndexInput.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexInput.cs
@@ -45,13 +45,13 @@ namespace Lucene.Net.Index
             (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0x7F,
             0x06, (byte) 'L', (byte) 'u', (byte) 'c', (byte) 'e', (byte) 'n', (byte) 'e',
 
-            // 2-byte UTF-8 (U+00BF "INVERTED QUESTION MARK") 
+            // 2-byte UTF-8 (U+00BF "INVERTED QUESTION MARK")
             0x02, (byte) 0xC2, (byte) 0xBF,
             0x0A, (byte) 'L', (byte) 'u', (byte) 0xC2, (byte) 0xBF,
                   (byte) 'c', (byte) 'e', (byte) 0xC2, (byte) 0xBF,
                   (byte) 'n', (byte) 'e',
 
-            // 3-byte UTF-8 (U+2620 "SKULL AND CROSSBONES") 
+            // 3-byte UTF-8 (U+2620 "SKULL AND CROSSBONES")
             0x03, (byte) 0xE2, (byte) 0x98, (byte) 0xA0,
             0x0C, (byte) 'L', (byte) 'u', (byte) 0xE2, (byte) 0x98, (byte) 0xA0,
                   (byte) 'c', (byte) 'e', (byte) 0xE2, (byte) 0x98, (byte) 0xA0,
@@ -67,12 +67,12 @@ namespace Lucene.Net.Index
                   (byte) 0xF0, (byte) 0x9D, (byte) 0x84, (byte) 0x9E,
                   (byte) 'c', (byte) 'e',
                   (byte) 0xF0, (byte) 0x9D, (byte) 0x85, (byte) 0xA0,
-                  (byte) 'n', (byte) 'e',  
+                  (byte) 'n', (byte) 'e',
 
             // null bytes
             0x01, 0x00,
             0x08, (byte) 'L', (byte) 'u', 0x00, (byte) 'c', (byte) 'e', 0x00, (byte) 'n', (byte) 'e',
-    
+
             // tests for Exceptions on invalid values
             (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0x17,
             (byte) 0x01, // guard value
@@ -86,9 +86,9 @@ namespace Lucene.Net.Index
         internal static byte[] RANDOM_TEST_BYTES;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             Random random = Random;
             INTS = new int[COUNT];

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -280,10 +280,10 @@ namespace Lucene.Net.Index
         internal DisposableThreadLocal<Thread> doFail = new DisposableThreadLocal<Thread>();
 
         // LUCENENET specific - cleanup DisposableThreadLocal instances after running tests
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             doFail.Dispose();
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         private class TestPoint1 : ITestPoint

--- a/src/Lucene.Net.Tests/Search/BaseTestRangeFilter.cs
+++ b/src/Lucene.Net.Tests/Search/BaseTestRangeFilter.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass() // LUCENENET specific: renamed from AfterClassBaseTestRangeFilter() so we can override to control the order of execution
+        public override void OneTimeTearDown() // LUCENENET specific: renamed from AfterClassBaseTestRangeFilter() so we can override to control the order of execution
         {
             signedIndexReader?.Dispose();
             unsignedIndexReader?.Dispose();
@@ -120,7 +120,7 @@ namespace Lucene.Net.Search
             unsignedIndexReader = null;
             signedIndexDir = null;
             unsignedIndexDir = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         private static IndexReader Build(Random random, TestIndex index)

--- a/src/Lucene.Net.Tests/Search/BaseTestRangeFilter.cs
+++ b/src/Lucene.Net.Tests/Search/BaseTestRangeFilter.cs
@@ -98,9 +98,9 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific: renamed from BeforeClassBaseTestRangeFilter() so we can override to control the order of execution
+        public override void OneTimeSetUp() // LUCENENET specific: renamed from BeforeClassBaseTestRangeFilter() so we can override to control the order of execution
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             maxId = AtLeast(500);
             signedIndexDir = new TestIndex(Random, int.MaxValue, int.MinValue, true);

--- a/src/Lucene.Net.Tests/Search/Payloads/TestPayloadNearQuery.cs
+++ b/src/Lucene.Net.Tests/Search/Payloads/TestPayloadNearQuery.cs
@@ -140,14 +140,14 @@ namespace Lucene.Net.Search.Payloads
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             searcher = null;
             reader.Dispose();
             reader = null;
             directory.Dispose();
             directory = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/Payloads/TestPayloadNearQuery.cs
+++ b/src/Lucene.Net.Tests/Search/Payloads/TestPayloadNearQuery.cs
@@ -115,9 +115,9 @@ namespace Lucene.Net.Search.Payloads
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, directory,

--- a/src/Lucene.Net.Tests/Search/Payloads/TestPayloadTermQuery.cs
+++ b/src/Lucene.Net.Tests/Search/Payloads/TestPayloadTermQuery.cs
@@ -149,14 +149,14 @@ namespace Lucene.Net.Search.Payloads
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             searcher = null;
             reader.Dispose();
             reader = null;
             directory.Dispose();
             directory = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/Payloads/TestPayloadTermQuery.cs
+++ b/src/Lucene.Net.Tests/Search/Payloads/TestPayloadTermQuery.cs
@@ -122,9 +122,9 @@ namespace Lucene.Net.Search.Payloads
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, directory,

--- a/src/Lucene.Net.Tests/Search/Spans/TestBasics.cs
+++ b/src/Lucene.Net.Tests/Search/Spans/TestBasics.cs
@@ -102,9 +102,9 @@ namespace Lucene.Net.Search.Spans
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             simplePayloadAnalyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader2) =>
             {

--- a/src/Lucene.Net.Tests/Search/Spans/TestBasics.cs
+++ b/src/Lucene.Net.Tests/Search/Spans/TestBasics.cs
@@ -129,7 +129,7 @@ namespace Lucene.Net.Search.Spans
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             reader.Dispose();
             directory.Dispose();
@@ -137,7 +137,7 @@ namespace Lucene.Net.Search.Spans
             reader = null;
             directory = null;
             simplePayloadAnalyzer = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/Spans/TestFieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net.Tests/Search/Spans/TestFieldMaskingSpanQuery.cs
@@ -62,9 +62,9 @@ namespace Lucene.Net.Search.Spans
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/Search/Spans/TestFieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net.Tests/Search/Spans/TestFieldMaskingSpanQuery.cs
@@ -132,14 +132,14 @@ namespace Lucene.Net.Search.Spans
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             searcher = null;
             reader.Dispose();
             reader = null;
             directory.Dispose();
             directory = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         protected internal virtual void Check(SpanQuery q, int[] docs)

--- a/src/Lucene.Net.Tests/Search/TestBoolean2.cs
+++ b/src/Lucene.Net.Tests/Search/TestBoolean2.cs
@@ -61,9 +61,9 @@ namespace Lucene.Net.Search
         private static int mulFactor;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/Search/TestBoolean2.cs
+++ b/src/Lucene.Net.Tests/Search/TestBoolean2.cs
@@ -124,7 +124,7 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             reader.Dispose();
             littleReader.Dispose();
@@ -136,7 +136,7 @@ namespace Lucene.Net.Search
             dir2 = null;
             directory = null;
             bigSearcher = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         private static readonly string[] docFields =

--- a/src/Lucene.Net.Tests/Search/TestBooleanMinShouldMatch.cs
+++ b/src/Lucene.Net.Tests/Search/TestBooleanMinShouldMatch.cs
@@ -88,14 +88,14 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             s = null;
             r.Dispose();
             r = null;
             index.Dispose();
             index = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         public virtual void VerifyNrHits(Query q, int expected)

--- a/src/Lucene.Net.Tests/Search/TestBooleanMinShouldMatch.cs
+++ b/src/Lucene.Net.Tests/Search/TestBooleanMinShouldMatch.cs
@@ -50,9 +50,9 @@ namespace Lucene.Net.Search
         /// Is non-static because NewStringField is no longer static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             string[] data =
             {

--- a/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
+++ b/src/Lucene.Net.Tests/Search/TestControlledRealTimeReopenThread.cs
@@ -84,10 +84,10 @@ namespace Lucene.Net.Search
         private bool warmCalled;
 
         // LUCENENET specific - cleanup DisposableThreadLocal instances
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             lastGens.Dispose();
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/TestDateFilter.cs
+++ b/src/Lucene.Net.Tests/Search/TestDateFilter.cs
@@ -103,7 +103,7 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass() // LUCENENET specific - renamed from TestAfter() to ensure calling order vs base class
+        public override void OneTimeTearDown() // LUCENENET specific - renamed from TestAfter() to ensure calling order vs base class
         {
             // create an index
             Directory indexStore = NewDirectory();
@@ -158,7 +158,7 @@ namespace Lucene.Net.Search
             reader.Dispose();
             indexStore.Dispose();
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
     }
 }

--- a/src/Lucene.Net.Tests/Search/TestDateFilter.cs
+++ b/src/Lucene.Net.Tests/Search/TestDateFilter.cs
@@ -38,9 +38,9 @@ namespace Lucene.Net.Search
     public class TestDateFilter : LuceneTestCase
     {
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - renamed from TestBefore() to ensure calling order vs base class
+        public override void OneTimeSetUp() // LUCENENET specific - renamed from TestBefore() to ensure calling order vs base class
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             // create an index
             Directory indexStore = NewDirectory();

--- a/src/Lucene.Net.Tests/Search/TestExplanations.cs
+++ b/src/Lucene.Net.Tests/Search/TestExplanations.cs
@@ -74,9 +74,9 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - renamed from BeforeClassTestExplanations() to ensure calling order
+        public override void OneTimeSetUp() // LUCENENET specific - renamed from BeforeClassTestExplanations() to ensure calling order
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/Search/TestExplanations.cs
+++ b/src/Lucene.Net.Tests/Search/TestExplanations.cs
@@ -63,14 +63,14 @@ namespace Lucene.Net.Search
         public const string ALTFIELD = "alt";
 
         [OneTimeTearDown]
-        public override void AfterClass() // LUCENENET specific - renamed from AfterClassTestExplanations() to ensure calling order
+        public override void OneTimeTearDown() // LUCENENET specific - renamed from AfterClassTestExplanations() to ensure calling order
         {
             searcher = null;
             reader.Dispose();
             reader = null;
             directory.Dispose();
             directory = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [OneTimeSetUp]

--- a/src/Lucene.Net.Tests/Search/TestFieldCache.cs
+++ b/src/Lucene.Net.Tests/Search/TestFieldCache.cs
@@ -107,9 +107,9 @@ namespace Lucene.Net.Search
 
         // LUCENENET: Changed to non-static because NewIndexWriterConfig is non-static
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             NUM_DOCS = AtLeast(500);
             NUM_ORDS = AtLeast(2);

--- a/src/Lucene.Net.Tests/Search/TestFieldCache.cs
+++ b/src/Lucene.Net.Tests/Search/TestFieldCache.cs
@@ -173,7 +173,7 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             reader.Dispose();
             reader = null;
@@ -181,7 +181,7 @@ namespace Lucene.Net.Search
             directory = null;
             unicodeStrings = null;
             multiValued = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/TestMinShouldMatch2.cs
+++ b/src/Lucene.Net.Tests/Search/TestMinShouldMatch2.cs
@@ -118,7 +118,7 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             atomicReader.Dispose();
             dir.Dispose();
@@ -126,7 +126,7 @@ namespace Lucene.Net.Search
             atomicReader = null;
             r = null;
             dir = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         private static void AddSome(Document doc, string[] values)

--- a/src/Lucene.Net.Tests/Search/TestMinShouldMatch2.cs
+++ b/src/Lucene.Net.Tests/Search/TestMinShouldMatch2.cs
@@ -67,9 +67,9 @@ namespace Lucene.Net.Search
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             dir = NewDirectory();
             RandomIndexWriter iw = new RandomIndexWriter(Random, dir);

--- a/src/Lucene.Net.Tests/Search/TestMultiTermConstantScore.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiTermConstantScore.cs
@@ -77,13 +77,13 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             reader?.Dispose();
             small?.Dispose();
             reader = null;
             small = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests/Search/TestMultiTermConstantScore.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiTermConstantScore.cs
@@ -45,15 +45,15 @@ namespace Lucene.Net.Search
         public const float SCORE_COMP_THRESH = 1e-6f;
 
         // LUCENENET specific - made these instance variables
-        // since our BeforeClass() and AfterClass() are instance
+        // since our OneTimeSetUp() and OneTimeTearDown() are instance
         // methods and not doing so makes them cross runner threads.
         internal /*static*/ Directory small;
         internal /*static*/ IndexReader reader;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             string[] data = new string[] { "A 1 2 3 4 5 6", "Z       4 5 6", null, "B   2   4 5 6", "Y     3   5 6", null, "C     3     6", "X       4 5 6" };
 

--- a/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
@@ -88,7 +88,7 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             reader.Dispose();
             multiReader.Dispose();
@@ -99,7 +99,7 @@ namespace Lucene.Net.Search
             reader = multiReader = multiReaderDupls = null;
             searcher = multiSearcher = multiSearcherDupls = null;
             dir = sdir1 = sdir2 = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         private Query ExtractInnerQuery(Query q)

--- a/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
@@ -52,9 +52,9 @@ namespace Lucene.Net.Search
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             dir = NewDirectory();
             sdir1 = NewDirectory();

--- a/src/Lucene.Net.Tests/Search/TestNGramPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestNGramPhraseQuery.cs
@@ -49,13 +49,13 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             reader.Dispose();
             reader = null;
             directory.Dispose();
             directory = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/TestNGramPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestNGramPhraseQuery.cs
@@ -38,9 +38,9 @@ namespace Lucene.Net.Search
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, directory);

--- a/src/Lucene.Net.Tests/Search/TestNumericRangeQuery32.cs
+++ b/src/Lucene.Net.Tests/Search/TestNumericRangeQuery32.cs
@@ -148,14 +148,14 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             searcher = null;
             reader.Dispose();
             reader = null;
             directory.Dispose();
             directory = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [SetUp]

--- a/src/Lucene.Net.Tests/Search/TestNumericRangeQuery32.cs
+++ b/src/Lucene.Net.Tests/Search/TestNumericRangeQuery32.cs
@@ -67,9 +67,9 @@ namespace Lucene.Net.Search
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             noDocs = AtLeast(4096);
             distance = (1 << 30) / noDocs;

--- a/src/Lucene.Net.Tests/Search/TestNumericRangeQuery64.cs
+++ b/src/Lucene.Net.Tests/Search/TestNumericRangeQuery64.cs
@@ -67,9 +67,9 @@ namespace Lucene.Net.Search
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             noDocs = AtLeast(4096);
             distance = (1L << 60) / noDocs;

--- a/src/Lucene.Net.Tests/Search/TestNumericRangeQuery64.cs
+++ b/src/Lucene.Net.Tests/Search/TestNumericRangeQuery64.cs
@@ -159,14 +159,14 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             searcher = null;
             reader.Dispose();
             reader = null;
             directory.Dispose();
             directory = null;
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [SetUp]

--- a/src/Lucene.Net.Tests/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestPhraseQuery.cs
@@ -59,9 +59,9 @@ namespace Lucene.Net.Search
         private static Directory directory;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             directory = NewDirectory();
             Analyzer analyzer = new AnalyzerAnonymousClass();

--- a/src/Lucene.Net.Tests/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestPhraseQuery.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             searcher = null;
             reader.Dispose();
@@ -118,7 +118,7 @@ namespace Lucene.Net.Search
             directory.Dispose();
             directory = null;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/TestPrefixInBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestPrefixInBooleanQuery.cs
@@ -51,9 +51,9 @@ namespace Lucene.Net.Search
         /// Is non-static because Similarity and TimeZone are not static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, directory);

--- a/src/Lucene.Net.Tests/Search/TestPrefixInBooleanQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestPrefixInBooleanQuery.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             searcher = null;
             reader.Dispose();
@@ -93,7 +93,7 @@ namespace Lucene.Net.Search
             directory.Dispose();
             directory = null;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Search/TestSubScorerFreqs.cs
+++ b/src/Lucene.Net.Tests/Search/TestSubScorerFreqs.cs
@@ -37,9 +37,9 @@ namespace Lucene.Net.Search
         private static IndexSearcher s;
 
         [OneTimeSetUp]
-        public override void BeforeClass() // LUCENENET specific - renamed from MakeIndex() to ensure calling order
+        public override void OneTimeSetUp() // LUCENENET specific - renamed from MakeIndex() to ensure calling order
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             dir = new RAMDirectory();
             RandomIndexWriter w = new RandomIndexWriter(Random, dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/Search/TestSubScorerFreqs.cs
+++ b/src/Lucene.Net.Tests/Search/TestSubScorerFreqs.cs
@@ -61,14 +61,14 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass() // LUCENENET specific - renamed from Finish() to ensure calling order
+        public override void OneTimeTearDown() // LUCENENET specific - renamed from Finish() to ensure calling order
         {
             s.IndexReader.Dispose();
             s = null;
             dir.Dispose();
             dir = null;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         private class CountingCollector : ICollector

--- a/src/Lucene.Net.Tests/Search/TestTermVectors.cs
+++ b/src/Lucene.Net.Tests/Search/TestTermVectors.cs
@@ -53,9 +53,9 @@ namespace Lucene.Net.Search
         /// Is non-static because NewIndexWriterConfig is no longer static.
         /// </summary>
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             directory = NewDirectory();
             RandomIndexWriter writer = new RandomIndexWriter(Random, directory, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random, MockTokenizer.SIMPLE, true)).SetMergePolicy(NewLogMergePolicy()));

--- a/src/Lucene.Net.Tests/Search/TestTermVectors.cs
+++ b/src/Lucene.Net.Tests/Search/TestTermVectors.cs
@@ -97,14 +97,14 @@ namespace Lucene.Net.Search
         }
 
         [OneTimeTearDown]
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             reader.Dispose();
             directory.Dispose();
             reader = null;
             directory = null;
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         // In a single doc, for the same field, mix the term

--- a/src/Lucene.Net.Tests/Util/TestIndexableBinaryStringTools.cs
+++ b/src/Lucene.Net.Tests/Util/TestIndexableBinaryStringTools.cs
@@ -32,9 +32,9 @@ namespace Lucene.Net.Util
         private static int MAX_RANDOM_BINARY_LENGTH;
 
         [OneTimeSetUp]
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
 
             NUM_RANDOM_TESTS = AtLeast(200);
             MAX_RANDOM_BINARY_LENGTH = AtLeast(300);

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/ConfigurationSettingsTest.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/ConfigurationSettingsTest.cs
@@ -39,14 +39,14 @@ namespace Lucene.Net.Cli.Configuration
         protected override IConfiguration LoadConfiguration()
         {
             IConfigurationRoot configuration = new ConfigurationBuilder()
-                .AddEnvironmentVariables(prefix: EnvironmentVariablePrefix) // Use a custom prefix to only load Lucene.NET settings 
+                .AddEnvironmentVariables(prefix: EnvironmentVariablePrefix) // Use a custom prefix to only load Lucene.NET settings
                 .AddJsonFile(TestJsonFilePath)
                 .Build();
 
             return configuration;
         }
 
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
             // Create directories if they do not exist
             Directory.CreateDirectory(TempFileDirectory);
@@ -62,7 +62,7 @@ namespace Lucene.Net.Cli.Configuration
             string testKey = EnvironmentVariablePrefix + "tests:setup";
             string testValue = "setup";
             Environment.SetEnvironmentVariable(testKey, testValue);
-            base.BeforeClass();
+            base.OneTimeSetUp();
         }
 
         public override void AfterClass()

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/ConfigurationSettingsTest.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/Configuration/ConfigurationSettingsTest.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Cli.Configuration
             base.OneTimeSetUp();
         }
 
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             try
             {
@@ -79,7 +79,7 @@ namespace Lucene.Net.Cli.Configuration
             }
             catch { }
 
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/InstallationTest.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/InstallationTest.cs
@@ -79,11 +79,11 @@ namespace Lucene.Net.Tests.Cli
             AssertCommandExitCode(ExitCode.Success, "dotnet", $"tool install {LuceneCliToolName} --version {packageVersion} --framework {targetFramework} --add-source \"{packageFile.DirectoryName}\" --tool-path  \"{tempWork.FullName}\"");
         }
 
-        public override void AfterClass()
+        public override void OneTimeTearDown()
         {
             // Uninstall our tool - we are done with it.
             AssertCommandExitCode(ExitCode.Success, "dotnet", $"tool uninstall  {LuceneCliToolName} --tool-path  \"{tempWork.FullName}\"");
-            base.AfterClass();
+            base.OneTimeTearDown();
         }
 
         [Test]

--- a/src/dotnet/tools/Lucene.Net.Tests.Cli/InstallationTest.cs
+++ b/src/dotnet/tools/Lucene.Net.Tests.Cli/InstallationTest.cs
@@ -40,9 +40,9 @@ namespace Lucene.Net.Tests.Cli
         private static DirectoryInfo tempWork;
         private static string packageVersion;
 
-        public override void BeforeClass()
+        public override void OneTimeSetUp()
         {
-            base.BeforeClass();
+            base.OneTimeSetUp();
             tempWork = CreateTempDir();
 
             FileInfo packageFile;


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Rename BeforeClass/AfterClass to OneTimeSetUp/OneTimeTearDown to better match NUnit conventions.

Fixes #1016

## Description

See #1016 for details and rationale. This is a breaking change because of the changes in TestFramework.
