### PR TITLE
Run tests on .NET 9 and add Stream.ReadExactly polyfill, #1019

### DIFF
--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -27,7 +27,7 @@ properties {
     [string]$testResultsDirectory = "$artifactsDirectory/TestResults"
     [string]$publishDirectory = "$artifactsDirectory/Publish"
     [string]$solutionFile = "$baseDirectory/Lucene.Net.sln"
-    [string]$minimumSdkVersion = "8.0.100"
+    [string]$minimumSdkVersion = "9.0.100"
     [string]$globalJsonFile = "$baseDirectory/global.json"
     [string]$versionPropsFile = "$baseDirectory/version.props"
     [string]$luceneReadmeFile = "$baseDirectory/src/Lucene.Net/readme-nuget.md"

--- a/.github/workflows/Generate-TestWorkflows.ps1
+++ b/.github/workflows/Generate-TestWorkflows.ps1
@@ -38,7 +38,7 @@
 
  .PARAMETER TestFrameworks
     A string array of Dotnet target framework monikers to run the tests on. The default is
-    @('net8.0','net6.0','net472','net48').
+    @('net9.0','net8.0','net6.0','net472','net48').
 
  .PARAMETER OperatingSystems
     A string array of Github Actions operating system monikers to run the tests on.
@@ -50,6 +50,10 @@
 
  .PARAMETER Configurations
     A string array of build configurations to run the tests on. The default is @('Release').
+
+ .PARAMETER DotNet9SDKVersion
+    The SDK version of .NET 9.x to install on the build agent to be used for building and
+    testing. This SDK is always installed on the build agent. The default is 9.0.x.
 
  .PARAMETER DotNet8SDKVersion
     The SDK version of .NET 8.x to install on the build agent to be used for building and
@@ -64,13 +68,15 @@ param(
 
     [string]$RepoRoot = (Split-Path (Split-Path $PSScriptRoot)),
 
-    [string[]]$TestFrameworks = @('net8.0','net6.0','net472','net48'), # targets under test: net8.0, netstandard2.1, netstandard2.0, net462
+    [string[]]$TestFrameworks = @('net9.0','net8.0','net6.0','net472','net48'), # targets under test: net8.0, net8.0, netstandard2.1, netstandard2.0, net462
 
     [string[]]$OperatingSystems = @('windows-latest', 'ubuntu-latest'),
 
     [string[]]$TestPlatforms = @('x64'),
 
     [string[]]$Configurations = @('Release'),
+
+    [string]$DotNet9SDKVersion = '9.0.x',
 
     [string]$DotNet8SDKVersion = '8.0.x',
 
@@ -154,6 +160,7 @@ function Write-TestWorkflow(
     [string[]]$TestFrameworks = @('net6.0', 'net48'),
     [string[]]$TestPlatforms = @('x64'),
     [string[]]$OperatingSystems = @('windows-latest', 'ubuntu-latest', 'macos-latest'),
+    [string]$DotNet9SDKVersion = $DotNet9SDKVersion,
     [string]$DotNet8SDKVersion = $DotNet8SDKVersion,
     [string]$DotNet6SDKVersion = $DotNet6SDKVersion) {
 
@@ -285,6 +292,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '$DotNet8SDKVersion'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '$DotNet9SDKVersion'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-AllProjects.yml
+++ b/.github/workflows/Lucene-Net-Tests-AllProjects.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -110,6 +110,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Common.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Common.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -94,6 +94,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Kuromoji.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Kuromoji.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -91,6 +91,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Morfologik.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Morfologik.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -91,6 +91,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Analysis-OpenNLP.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-OpenNLP.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net48]
+        framework: [net9.0, net8.0, net48]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -94,6 +94,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Phonetic.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Phonetic.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -88,6 +88,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Analysis-SmartCn.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-SmartCn.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -92,6 +92,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Analysis-Stempel.yml
+++ b/.github/workflows/Lucene-Net-Tests-Analysis-Stempel.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -89,6 +89,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Benchmark.yml
+++ b/.github/workflows/Lucene-Net-Tests-Benchmark.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -101,6 +101,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Classification.yml
+++ b/.github/workflows/Lucene-Net-Tests-Classification.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -89,6 +89,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Cli.yml
+++ b/.github/workflows/Lucene-Net-Tests-Cli.yml
@@ -110,6 +110,11 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
+
       - name: Setup Environment Variables
         run: |
           $project_name = [System.IO.Path]::GetFileNameWithoutExtension($env:project_path)

--- a/.github/workflows/Lucene-Net-Tests-CodeAnalysis.yml
+++ b/.github/workflows/Lucene-Net-Tests-CodeAnalysis.yml
@@ -88,6 +88,11 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
+
       - name: Setup Environment Variables
         run: |
           $project_name = [System.IO.Path]::GetFileNameWithoutExtension($env:project_path)

--- a/.github/workflows/Lucene-Net-Tests-Codecs.yml
+++ b/.github/workflows/Lucene-Net-Tests-Codecs.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -87,6 +87,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Demo.yml
+++ b/.github/workflows/Lucene-Net-Tests-Demo.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -96,6 +96,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Expressions.yml
+++ b/.github/workflows/Lucene-Net-Tests-Expressions.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -89,6 +89,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Facet.yml
+++ b/.github/workflows/Lucene-Net-Tests-Facet.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -91,6 +91,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Grouping.yml
+++ b/.github/workflows/Lucene-Net-Tests-Grouping.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -89,6 +89,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Highlighter.yml
+++ b/.github/workflows/Lucene-Net-Tests-Highlighter.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -91,6 +91,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-ICU.yml
+++ b/.github/workflows/Lucene-Net-Tests-ICU.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -104,6 +104,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Join.yml
+++ b/.github/workflows/Lucene-Net-Tests-Join.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -90,6 +90,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Memory.yml
+++ b/.github/workflows/Lucene-Net-Tests-Memory.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -92,6 +92,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Misc.yml
+++ b/.github/workflows/Lucene-Net-Tests-Misc.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -88,6 +88,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Queries.yml
+++ b/.github/workflows/Lucene-Net-Tests-Queries.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -88,6 +88,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-QueryParser.yml
+++ b/.github/workflows/Lucene-Net-Tests-QueryParser.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -94,6 +94,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Replicator.yml
+++ b/.github/workflows/Lucene-Net-Tests-Replicator.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -93,6 +93,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Sandbox.yml
+++ b/.github/workflows/Lucene-Net-Tests-Sandbox.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -89,6 +89,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Spatial.yml
+++ b/.github/workflows/Lucene-Net-Tests-Spatial.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -90,6 +90,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-Suggest.yml
+++ b/.github/workflows/Lucene-Net-Tests-Suggest.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -91,6 +91,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-TestFramework-DependencyInjection.yml
+++ b/.github/workflows/Lucene-Net-Tests-TestFramework-DependencyInjection.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -87,6 +87,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-TestFramework.yml
+++ b/.github/workflows/Lucene-Net-Tests-TestFramework.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -89,6 +89,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-_A-D.yml
+++ b/.github/workflows/Lucene-Net-Tests-_A-D.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -98,6 +98,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-_E-I.yml
+++ b/.github/workflows/Lucene-Net-Tests-_E-I.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -108,6 +108,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-_I-J.yml
+++ b/.github/workflows/Lucene-Net-Tests-_I-J.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -113,6 +113,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-_J-S.yml
+++ b/.github/workflows/Lucene-Net-Tests-_J-S.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -100,6 +100,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/.github/workflows/Lucene-Net-Tests-_T-Z.yml
+++ b/.github/workflows/Lucene-Net-Tests-_T-Z.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        framework: [net8.0, net6.0, net48, net472]
+        framework: [net9.0, net8.0, net6.0, net48, net472]
         platform: [x64]
         configuration: [Release]
         exclude:
@@ -95,6 +95,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Setup Environment Variables
         run: |

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -30,8 +30,15 @@
     <PublishDir Condition="'$(AlternatePublishRootDirectory)' != ''">$(AlternatePublishRootDirectory)/$(TargetFramework)/$(MSBuildProjectName)/</PublishDir>
   </PropertyGroup>
 
-  <!-- Features in .NET 6.x, .NET 7.x, and .NET 8.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET 9.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net9.')) ">
+
+    <DefineConstants>$(DefineConstants);FEATURE_STREAM_READEXACTLY</DefineConstants>
+
+  </PropertyGroup>
+
+  <!-- Features in .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_RANDOM_NEXTINT64_NEXTSINGLE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SPANFORMATTABLE</DefineConstants>
@@ -39,16 +46,16 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ASPNETCORE_ENDPOINT_CONFIG</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_READONLYSET</DefineConstants>
 
   </PropertyGroup>
 
-  <!-- Features in .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ARGITERATOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PROCESS_KILL_ENTIREPROCESSTREE</DefineConstants>
@@ -56,8 +63,8 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Standard, .NET Core, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x only (no .NET Framework support) -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET Standard, .NET Core, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x only (no .NET Framework support) -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_CURRENTCULTURE_SETTER</DefineConstants>
@@ -66,8 +73,8 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <!-- Features in .NET Standard 2.1, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x only -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET Standard 2.1, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x only -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ARRAY_FILL</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR</DefineConstants>
@@ -79,24 +86,28 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ICONFIGURATIONROOT_PROVIDERS</DefineConstants>
 
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x  -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x  -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_GETCALLINGASSEMBLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_FILESTREAM_LOCK</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_CLOSE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_EXCEPTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREADPOOL_UNSAFEQUEUEWORKITEM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETMETHOD__BINDINGFLAGS_PARAMS</DefineConstants>
 
+  </PropertyGroup>
+
+  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x (No .NET 9.x support)  -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_EXCEPTIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
   </PropertyGroup>
 
   <!-- Features in .NET Framework 4.5+ and .NET Standard 2.x only (No .NET Core support) -->

--- a/TestTargetFramework.props
+++ b/TestTargetFramework.props
@@ -29,7 +29,8 @@
     <!--<TargetFramework>net472</TargetFramework>-->
     <!--<TargetFramework>net48</TargetFramework>-->
     <!--<TargetFramework>net6.0</TargetFramework>-->
-    <TargetFramework>net8.0</TargetFramework>
+    <!--<TargetFramework>net8.0</TargetFramework>-->
+    <TargetFramework>net9.0</TargetFramework>
 
     <!-- Allow the build script to pass in the test frameworks to build for.
       This overrides the above TargetFramework setting.
@@ -37,13 +38,14 @@
 
     <!-- Test Client to DLL target works as follows:
       Test Client       | Target Under Test
+      net9.0            | net8.0
       net8.0            | net8.0
       net6.0            | netstandard2.1
       net48             | net462
       net472            | netstandard2.0
     -->
 
-    <TargetFrameworks Condition=" '$(TestFrameworks)' == 'true' ">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TestFrameworks)' == 'true' ">net9.0;net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TestFrameworks)' == 'true' AND $([MSBuild]::IsOsPlatform('Windows')) ">$(TargetFrameworks);net48;net472</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ variables:
 - name: BuildCounter
   value: $[counter(variables['VersionSuffix'],coalesce(variables['BuildCounterSeed'], 1250))]
 - name: DotNetSDKVersion
-  value: '8.0.204'
+  value: '9.0.100'
 - name: DocumentationArtifactName
   value: 'docs'
 - name: DocumentationArtifactZipFileName
@@ -232,10 +232,19 @@ stages:
     - template: '.build/azure-templates/publish-test-binaries.yml'
       parameters:
         publishDirectory: $(PublishDirectory)
+        framework: 'net9.0'
+        binaryArtifactName: '$(BinaryArtifactName)'
+        testSettingsFilePath: '$(Build.ArtifactStagingDirectory)/$(TestSettingsFileName)'
+        configuration: '$(BuildConfiguration)'
+        platform: '$(BuildPlatform)'
+
+    - template: '.build/azure-templates/publish-test-binaries.yml'
+      parameters:
+        publishDirectory: $(PublishDirectory)
         framework: 'net8.0'
         binaryArtifactName: '$(BinaryArtifactName)'
         testSettingsFilePath: '$(Build.ArtifactStagingDirectory)/$(TestSettingsFileName)'
-        configration: '$(BuildConfiguration)'
+        configuration: '$(BuildConfiguration)'
         platform: '$(BuildPlatform)'
 
     - template: '.build/azure-templates/publish-test-binaries.yml'
@@ -244,7 +253,7 @@ stages:
         framework: 'net6.0'
         binaryArtifactName: '$(BinaryArtifactName)'
         testSettingsFilePath: '$(Build.ArtifactStagingDirectory)/$(TestSettingsFileName)'
-        configration: '$(BuildConfiguration)'
+        configuration: '$(BuildConfiguration)'
         platform: '$(BuildPlatform)'
 
     - template: '.build/azure-templates/publish-test-binaries.yml'
@@ -253,7 +262,7 @@ stages:
         framework: 'net472'
         binaryArtifactName: '$(BinaryArtifactName)'
         testSettingsFilePath: '$(Build.ArtifactStagingDirectory)/$(TestSettingsFileName)'
-        configration: '$(BuildConfiguration)'
+        configuration: '$(BuildConfiguration)'
         platform: '$(BuildPlatform)'
 
     - template: '.build/azure-templates/publish-test-binaries.yml'
@@ -262,7 +271,7 @@ stages:
         framework: 'net48'
         binaryArtifactName: '$(BinaryArtifactName)'
         testSettingsFilePath: '$(Build.ArtifactStagingDirectory)/$(TestSettingsFileName)'
-        configration: '$(BuildConfiguration)'
+        configuration: '$(BuildConfiguration)'
         platform: '$(BuildPlatform)'
 
   - job: Docs
@@ -325,6 +334,66 @@ stages:
 - stage: Test_Stage
   displayName: 'Test Stage:'
   jobs:
+
+  - job: Test_net9_0_x64
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-latest'
+          maximumParallelJobs: 8
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        Linux:
+          osName: 'Linux'
+          imageName: 'ubuntu-latest'
+          maximumParallelJobs: 7
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        macOS:
+          osName: 'macOS'
+          imageName: 'macOS-latest'
+          maximumParallelJobs: 7
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+    displayName: 'Test net9.0,x64 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - template: '.build/azure-templates/run-tests-on-os.yml'
+        parameters:
+          osName: $(osName)
+          framework: 'net9.0'
+          vsTestPlatform: 'x64'
+          testBinariesArtifactName: '$(TestBinariesArtifactName)'
+          nugetArtifactName: '$(NuGetArtifactName)'
+          testResultsArtifactName: '$(TestResultsArtifactName)'
+          maximumParallelJobs: $(maximumParallelJobs)
+          maximumAllowedFailures: $(maximumAllowedFailures)
+          dotNetSdkVersion: '$(DotNetSDKVersion)'
+
+  - job: Test_net9_0_x86 # Only run Nightly or if explicitly enabled with RunX86Tests
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'), or(eq(variables['IsNightly'], 'true'), eq(variables['RunX86Tests'], 'true')))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-2019'
+          maximumParallelJobs: 8
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+    displayName: 'Test net9.0,x86 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - template: '.build/azure-templates/run-tests-on-os.yml'
+        parameters:
+          osName: $(osName)
+          framework: 'net9.0'
+          vsTestPlatform: 'x86'
+          testBinariesArtifactName: '$(TestBinariesArtifactName)'
+          nugetArtifactName: '$(NuGetArtifactName)'
+          testResultsArtifactName: '$(TestResultsArtifactName)'
+          maximumParallelJobs: $(maximumParallelJobs)
+          maximumAllowedFailures: $(maximumAllowedFailures)
+          dotNetSdkVersion: '$(DotNetSDKVersion)'
 
   - job: Test_net8_0_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/Lucene.Net.Tests.Analysis.OpenNLP.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <!-- Allow specific target framework to flow in from TestTargetFrameworks.props -->
     <!--suppress MsbuildTargetFrameworkTagInspection - even though this only has one target right now, we need to use the plural version for the line below -->
-    <TargetFrameworks Condition=" '$(TargetFramework)' == '' ">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFramework)' == '' ">net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetFramework)' == '' AND $([MSBuild]::IsOsPlatform('Windows')) ">$(TargetFrameworks);net48</TargetFrameworks>
 
     <AssemblyTitle>Lucene.Net.Tests.Analysis.OpenNLP</AssemblyTitle>

--- a/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Core/Messages/TestQueryParserResourceProvider.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Support/Flexible/Core/Messages/TestQueryParserResourceProvider.cs
@@ -3,6 +3,9 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System.Globalization;
 using Assert = Lucene.Net.TestFramework.Assert;
+#if !FEATURE_STREAM_READEXACTLY
+using Lucene.Net.Support;
+#endif
 
 namespace Lucene.Net.QueryParsers.Support.Flexible.Core.Messages // LUCENENET: There is no control over the namespace for code generation other than the folder, so we must use this namespace
 {
@@ -97,7 +100,7 @@ namespace Lucene.Net.QueryParsers.Support.Flexible.Core.Messages // LUCENENET: T
             // Get the expected bytes
             using var expectedStream = GetType().Assembly.GetManifestResourceStream("Lucene.Net.QueryParsers.Support.Flexible.Core.Messages.lucene-net-icon-32x32.png");
             byte[] expectedBytes = new byte[expectedStream.Length];
-            expectedStream.Read(expectedBytes, 0, (int)expectedStream.Length);
+            expectedStream.ReadExactly(expectedBytes, 0, (int)expectedStream.Length);
 
             // Check the wrapper to ensure we can read the bytes
             Assert.AreEqual(expectedBytes, MessagesTest.LUCENE_NET_ICON_32x32);

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyRevisionTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyRevisionTest.cs
@@ -10,6 +10,9 @@ using System;
 using System.IO;
 using System.Linq;
 using Directory = Lucene.Net.Store.Directory;
+#if !FEATURE_STREAM_READEXACTLY
+using Lucene.Net.Support;
+#endif
 
 namespace Lucene.Net.Replicator
 {
@@ -178,7 +181,7 @@ namespace Lucene.Net.Replicator
                             offset = skip;
                         }
                         src.ReadBytes(srcBytes, offset, srcBytes.Length - offset);
-                        @in.Read(inBytes, offset, inBytes.Length - offset);
+                        @in.ReadExactly(inBytes, offset, inBytes.Length - offset);
                         assertArrayEquals(srcBytes, inBytes);
                     }
                 }

--- a/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
@@ -6,6 +6,9 @@ using NUnit.Framework;
 using System;
 using System.Linq;
 using Assert = Lucene.Net.TestFramework.Assert;
+#if !FEATURE_STREAM_READEXACTLY
+using Lucene.Net.Support;
+#endif
 
 namespace Lucene.Net.Tests.Replicator
 {
@@ -30,7 +33,7 @@ namespace Lucene.Net.Tests.Replicator
     [LuceneNetSpecific]
     public class IndexInputStreamTest : LuceneTestCase
     {
-        
+
         [Test]
         [LuceneNetSpecific]
         public void Read_RemainingIndexInputLargerThanReadCount_ReturnsReadCount()
@@ -55,7 +58,10 @@ namespace Lucene.Net.Tests.Replicator
             int readBytes = 1.KiloBytes();
             byte[] readBuffer = new byte[readBytes];
             for (int i = section; i > 0; i--)
-                stream.Read(readBuffer, 0, readBytes);
+            {
+                stream.ReadExactly(readBuffer, 0, readBytes);
+            }
+
             Assert.AreEqual(readBuffer, buffer.Skip((section - 1) * readBytes).Take(readBytes).ToArray());
         }
 

--- a/src/Lucene.Net.Tests.Replicator/IndexRevisionTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexRevisionTest.cs
@@ -7,6 +7,9 @@ using System;
 using System.IO;
 using System.Linq;
 using Directory = Lucene.Net.Store.Directory;
+#if !FEATURE_STREAM_READEXACTLY
+using Lucene.Net.Support;
+#endif
 
 namespace Lucene.Net.Replicator
 {
@@ -160,7 +163,7 @@ namespace Lucene.Net.Replicator
                         offset = skip;
                     }
                     src.ReadBytes(srcBytes, offset, srcBytes.Length - offset);
-                    @in.Read(inBytes, offset, inBytes.Length - offset);
+                    @in.ReadExactly(inBytes, offset, inBytes.Length - offset);
                     assertArrayEquals(srcBytes, inBytes);
                     IOUtils.Dispose(src, @in);
                 }

--- a/src/Lucene.Net.Tests/Util/TestOfflineSorter.cs
+++ b/src/Lucene.Net.Tests/Util/TestOfflineSorter.cs
@@ -6,6 +6,9 @@ using System.IO;
 using JCG = J2N.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Lucene.Net.Attributes;
+#if !FEATURE_STREAM_READEXACTLY
+using Lucene.Net.Support;
+#endif
 
 namespace Lucene.Net.Util
 {
@@ -231,7 +234,8 @@ namespace Lucene.Net.Util
             using Stream is2 = sorted.Open(FileMode.Open, FileAccess.Read, FileShare.Delete);
             while ((len = is1.Read(buf1, 0, buf1.Length)) > 0)
             {
-                is2.Read(buf2, 0, len);
+                is2.ReadExactly(buf2, 0, len);
+
                 for (int i = 0; i < len; i++)
                 {
                     Assert.AreEqual(buf1[i], buf2[i]);
@@ -254,7 +258,8 @@ namespace Lucene.Net.Util
             Stream is2 = sorted;
             while ((len = is1.Read(buf1, 0, buf1.Length)) > 0)
             {
-                is2.Read(buf2, 0, len);
+                is2.ReadExactly(buf2, 0, len);
+
                 for (int i = 0; i < len; i++)
                 {
                     Assert.AreEqual(buf1[i], buf2[i]);

--- a/src/Lucene.Net/Support/StreamExtensions.cs
+++ b/src/Lucene.Net/Support/StreamExtensions.cs
@@ -1,0 +1,47 @@
+#if !FEATURE_STREAM_READEXACTLY
+using System.IO;
+
+namespace Lucene.Net.Support
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public static class StreamExtensions
+    {
+        /// <summary>
+        /// Reads exactly <paramref name="count"/> bytes from the stream into the buffer at the specified offset.
+        /// </summary>
+        /// <param name="stream">The stream to read from.</param>
+        /// <param name="buffer">The buffer to read into.</param>
+        /// <param name="offset">The offset in the buffer to start reading into.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <exception cref="EndOfStreamException">If the end of the stream is reached before reading all the bytes.</exception>
+        /// <remarks>
+        /// This method is a polyfill for platforms (prior to .NET 9) that do not have the ReadExactly method.
+        /// </remarks>
+        public static void ReadExactly(this Stream stream, byte[] buffer, int offset, int count)
+        {
+            int numRead = stream.Read(buffer, offset, count);
+
+            if (numRead < count)
+            {
+                throw new EndOfStreamException();
+            }
+        }
+    }
+}
+#endif

--- a/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene.Net.CodeAnalysis.CSharp.csproj
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.CSharp/Lucene.Net.CodeAnalysis.CSharp.csproj
@@ -24,9 +24,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <!-- netstandard1.3 is required for Visual Studio 2017 compatibility -->
+    <CheckNotRecommendedTargetFramework>false</CheckNotRecommendedTargetFramework>
   </PropertyGroup>
 
-  
   <Import Project="..\Lucene.Net.CodeAnalysis\Version.props" />
 
   <ItemGroup>

--- a/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene.Net.CodeAnalysis.VisualBasic.csproj
+++ b/src/dotnet/Lucene.Net.CodeAnalysis.VisualBasic/Lucene.Net.CodeAnalysis.VisualBasic.csproj
@@ -24,9 +24,12 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <!-- netstandard1.3 is required for Visual Studio 2017 compatibility -->
+    <CheckNotRecommendedTargetFramework>false</CheckNotRecommendedTargetFramework>
   </PropertyGroup>
 
-  
+
   <Import Project="..\Lucene.Net.CodeAnalysis\Version.props" />
 
   <ItemGroup>


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Run tests on .NET 9 and add Stream.ReadExactly polyfill

Fixes #1019
Fixes #1037

## Description

Adds .NET 9 to the test suite and sets necessary feature definitions. This also adds a polyfill extension method on Stream for the [ReadExactly](https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.readexactly?view=net-9.0) method, which causes a [build warning](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2022) on .NET 9 if you read from a stream without checking the result. Since this method neatly encapsulates this best practice, it seemed prudent to add this extension method for older targets and use the method directly on .NET 9. This de facto adds additional assertions to the tests as well, improving reliability.

Due to the netstandard1.x warning, this PR also fixes #1037 and suppresses the warning for the code analysis projects on netstandard1.3 that must support Visual Studio 2017.


