### PR TITLE
Fix overflow in ByteBlockPool, #1003

### DIFF
--- a/src/Lucene.Net/Util/ByteBlockPool.cs
+++ b/src/Lucene.Net/Util/ByteBlockPool.cs
@@ -262,7 +262,11 @@ namespace Lucene.Net.Util
             bufferUpto++;
 
             ByteUpto = 0;
-            ByteOffset += BYTE_BLOCK_SIZE;
+
+            checked // LUCENENET specific - added checked to prevent overflow, issue #1003
+            {
+                ByteOffset += BYTE_BLOCK_SIZE;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix overflow (resulting in ArrayIndexOutOfBoundsException) in ByteBlockPool

Fixes #1003

## Description

Thanks to @hidingmyname for the provided test. This fixes an arithmetic overflow that results in an ArrayIndexOutOfBoundsException in ByteBlockPool for fields with a large number of small tokens. In .NET, the `checked` block causes the overflow to throw an OverflowException, just like how the upstream Java change to use `Math.addExact(x, y)` throws an ArithmeticException in that case.