### PR TITLE
Add operator overrides for public IComparable types, #683

### DIFF
--- a/Lucene.Net.sln.DotSettings
+++ b/Lucene.Net.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coord/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=csharpsquid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LUCENENET/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=testsettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Lucene.Net.Benchmark/Quality/QualityQuery.cs
+++ b/src/Lucene.Net.Benchmark/Quality/QualityQuery.cs
@@ -28,13 +28,13 @@ namespace Lucene.Net.Benchmarks.Quality
     /// <para/>
     /// The ID allows to map the quality query with its judgements.
     /// <para/>
-    /// The name-value pairs are used by a 
+    /// The name-value pairs are used by a
     /// <see cref="IQualityQueryParser"/>
     /// to create a Lucene <see cref="Search.Query"/>.
     /// <para/>
     /// It is very likely that name-value-pairs would be mapped into fields in a Lucene query,
     /// but it is up to the QualityQueryParser how to map - e.g. all values in a single field,
-    /// or each pair as its own field, etc., - and this of course must match the way the 
+    /// or each pair as its own field, etc., - and this of course must match the way the
     /// searched index was constructed.
     /// </summary>
     public class QualityQuery : IComparable<QualityQuery>
@@ -99,5 +99,28 @@ namespace Lucene.Net.Benchmarks.Quality
                 return queryID.CompareToOrdinal(other.queryID);
             }
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(QualityQuery left, QualityQuery right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(QualityQuery left, QualityQuery right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(QualityQuery left, QualityQuery right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(QualityQuery left, QualityQuery right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(QualityQuery left, QualityQuery right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(QualityQuery left, QualityQuery right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net.Benchmark/Quality/QualityQuery.cs
+++ b/src/Lucene.Net.Benchmark/Quality/QualityQuery.cs
@@ -102,14 +102,12 @@ namespace Lucene.Net.Benchmarks.Quality
         }
 
         // LUCENENET specific - provide Equals and GetHashCode due to providing operator overrides
-        protected bool Equals(QualityQuery? other) => queryID == other?.queryID;
-
         public override bool Equals(object? obj)
         {
             if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
-            return Equals((QualityQuery)obj);
+            return queryID == ((QualityQuery)obj).queryID;
         }
 
         public override int GetHashCode() => queryID.GetHashCode();

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldPhraseList.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldPhraseList.cs
@@ -471,7 +471,7 @@ namespace Lucene.Net.Search.VectorHighlight
             }
 
             #region Operator overrides
-            #nullable enable
+#nullable enable
             // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
             public static bool operator <(WeightedPhraseInfo? left, WeightedPhraseInfo? right)
@@ -492,7 +492,7 @@ namespace Lucene.Net.Search.VectorHighlight
             public static bool operator !=(WeightedPhraseInfo? left, WeightedPhraseInfo? right)
                 => !(left == right);
 
-            #nullable restore
+#nullable restore
             #endregion
 
             /// <summary>
@@ -569,7 +569,7 @@ namespace Lucene.Net.Search.VectorHighlight
                 }
 
                 #region Operator overrides
-                #nullable enable
+#nullable enable
                 // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
                 public static bool operator <(Toffs? left, Toffs? right)
@@ -590,7 +590,7 @@ namespace Lucene.Net.Search.VectorHighlight
                 public static bool operator !=(Toffs? left, Toffs? right)
                     => !(left == right);
 
-                #nullable restore
+#nullable restore
                 #endregion
             }
         }

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldPhraseList.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldPhraseList.cs
@@ -442,7 +442,7 @@ namespace Lucene.Net.Search.VectorHighlight
 
             public override bool Equals(object obj)
             {
-                if (this == obj)
+                if (ReferenceEquals(this, obj))
                 {
                     return true;
                 }
@@ -469,6 +469,29 @@ namespace Lucene.Net.Search.VectorHighlight
                 }
                 return true;
             }
+
+            #region Operator overrides
+            // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+            public static bool operator <(WeightedPhraseInfo left, WeightedPhraseInfo right)
+                => left is null ? right is not null : left.CompareTo(right) < 0;
+
+            public static bool operator <=(WeightedPhraseInfo left, WeightedPhraseInfo right)
+                => left is null || left.CompareTo(right) <= 0;
+
+            public static bool operator >(WeightedPhraseInfo left, WeightedPhraseInfo right)
+                => left is not null && left.CompareTo(right) > 0;
+
+            public static bool operator >=(WeightedPhraseInfo left, WeightedPhraseInfo right)
+                => left is null ? right is null : left.CompareTo(right) >= 0;
+
+            public static bool operator ==(WeightedPhraseInfo left, WeightedPhraseInfo right)
+                => left?.Equals(right) ?? right is null;
+
+            public static bool operator !=(WeightedPhraseInfo left, WeightedPhraseInfo right)
+                => !(left == right);
+
+            #endregion
 
             /// <summary>
             /// Term offsets (start + end)
@@ -512,7 +535,7 @@ namespace Lucene.Net.Search.VectorHighlight
 
                 public override bool Equals(object obj)
                 {
-                    if (this == obj)
+                    if (ReferenceEquals(this, obj))
                     {
                         return true;
                     }
@@ -535,12 +558,36 @@ namespace Lucene.Net.Search.VectorHighlight
                     }
                     return true;
                 }
+
                 public override string ToString()
                 {
                     StringBuilder sb = new StringBuilder();
                     sb.Append('(').Append(startOffset).Append(',').Append(endOffset).Append(')');
                     return sb.ToString();
                 }
+
+                #region Operator overrides
+                // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+                public static bool operator <(Toffs left, Toffs right)
+                    => left is null ? right is not null : left.CompareTo(right) < 0;
+
+                public static bool operator <=(Toffs left, Toffs right)
+                    => left is null || left.CompareTo(right) <= 0;
+
+                public static bool operator >(Toffs left, Toffs right)
+                    => left is not null && left.CompareTo(right) > 0;
+
+                public static bool operator >=(Toffs left, Toffs right)
+                    => left is null ? right is null : left.CompareTo(right) >= 0;
+
+                public static bool operator ==(Toffs left, Toffs right)
+                    => left?.Equals(right) ?? right is null;
+
+                public static bool operator !=(Toffs left, Toffs right)
+                    => !(left == right);
+
+                #endregion
             }
         }
     }

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldPhraseList.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldPhraseList.cs
@@ -471,26 +471,28 @@ namespace Lucene.Net.Search.VectorHighlight
             }
 
             #region Operator overrides
+            #nullable enable
             // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-            public static bool operator <(WeightedPhraseInfo left, WeightedPhraseInfo right)
+            public static bool operator <(WeightedPhraseInfo? left, WeightedPhraseInfo? right)
                 => left is null ? right is not null : left.CompareTo(right) < 0;
 
-            public static bool operator <=(WeightedPhraseInfo left, WeightedPhraseInfo right)
+            public static bool operator <=(WeightedPhraseInfo? left, WeightedPhraseInfo? right)
                 => left is null || left.CompareTo(right) <= 0;
 
-            public static bool operator >(WeightedPhraseInfo left, WeightedPhraseInfo right)
+            public static bool operator >(WeightedPhraseInfo? left, WeightedPhraseInfo? right)
                 => left is not null && left.CompareTo(right) > 0;
 
-            public static bool operator >=(WeightedPhraseInfo left, WeightedPhraseInfo right)
+            public static bool operator >=(WeightedPhraseInfo? left, WeightedPhraseInfo? right)
                 => left is null ? right is null : left.CompareTo(right) >= 0;
 
-            public static bool operator ==(WeightedPhraseInfo left, WeightedPhraseInfo right)
+            public static bool operator ==(WeightedPhraseInfo? left, WeightedPhraseInfo? right)
                 => left?.Equals(right) ?? right is null;
 
-            public static bool operator !=(WeightedPhraseInfo left, WeightedPhraseInfo right)
+            public static bool operator !=(WeightedPhraseInfo? left, WeightedPhraseInfo? right)
                 => !(left == right);
 
+            #nullable restore
             #endregion
 
             /// <summary>
@@ -567,26 +569,28 @@ namespace Lucene.Net.Search.VectorHighlight
                 }
 
                 #region Operator overrides
+                #nullable enable
                 // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-                public static bool operator <(Toffs left, Toffs right)
+                public static bool operator <(Toffs? left, Toffs? right)
                     => left is null ? right is not null : left.CompareTo(right) < 0;
 
-                public static bool operator <=(Toffs left, Toffs right)
+                public static bool operator <=(Toffs? left, Toffs? right)
                     => left is null || left.CompareTo(right) <= 0;
 
-                public static bool operator >(Toffs left, Toffs right)
+                public static bool operator >(Toffs? left, Toffs? right)
                     => left is not null && left.CompareTo(right) > 0;
 
-                public static bool operator >=(Toffs left, Toffs right)
+                public static bool operator >=(Toffs? left, Toffs? right)
                     => left is null ? right is null : left.CompareTo(right) >= 0;
 
-                public static bool operator ==(Toffs left, Toffs right)
+                public static bool operator ==(Toffs? left, Toffs? right)
                     => left?.Equals(right) ?? right is null;
 
-                public static bool operator !=(Toffs left, Toffs right)
+                public static bool operator !=(Toffs? left, Toffs? right)
                     => !(left == right);
 
+                #nullable restore
                 #endregion
             }
         }

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldTermStack.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldTermStack.cs
@@ -265,7 +265,7 @@ namespace Lucene.Net.Search.VectorHighlight
 
             public override bool Equals(object obj)
             {
-                if (this == obj)
+                if (ReferenceEquals(this, obj))
                 {
                     return true;
                 }
@@ -284,6 +284,29 @@ namespace Lucene.Net.Search.VectorHighlight
                 }
                 return true;
             }
+
+            #region Operator overrides
+            // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+            public static bool operator <(TermInfo left, TermInfo right)
+                => left is null ? right is not null : left.CompareTo(right) < 0;
+
+            public static bool operator <=(TermInfo left, TermInfo right)
+                => left is null || left.CompareTo(right) <= 0;
+
+            public static bool operator >(TermInfo left, TermInfo right)
+                => left is not null && left.CompareTo(right) > 0;
+
+            public static bool operator >=(TermInfo left, TermInfo right)
+                => left is null ? right is null : left.CompareTo(right) >= 0;
+
+            public static bool operator ==(TermInfo left, TermInfo right)
+                => left?.Equals(right) ?? right is null;
+
+            public static bool operator !=(TermInfo left, TermInfo right)
+                => !(left == right);
+
+            #endregion
         }
     }
 }

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldTermStack.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldTermStack.cs
@@ -286,26 +286,28 @@ namespace Lucene.Net.Search.VectorHighlight
             }
 
             #region Operator overrides
+            #nullable enable
             // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-            public static bool operator <(TermInfo left, TermInfo right)
+            public static bool operator <(TermInfo? left, TermInfo? right)
                 => left is null ? right is not null : left.CompareTo(right) < 0;
 
-            public static bool operator <=(TermInfo left, TermInfo right)
+            public static bool operator <=(TermInfo? left, TermInfo? right)
                 => left is null || left.CompareTo(right) <= 0;
 
-            public static bool operator >(TermInfo left, TermInfo right)
+            public static bool operator >(TermInfo? left, TermInfo? right)
                 => left is not null && left.CompareTo(right) > 0;
 
-            public static bool operator >=(TermInfo left, TermInfo right)
+            public static bool operator >=(TermInfo? left, TermInfo? right)
                 => left is null ? right is null : left.CompareTo(right) >= 0;
 
-            public static bool operator ==(TermInfo left, TermInfo right)
+            public static bool operator ==(TermInfo? left, TermInfo? right)
                 => left?.Equals(right) ?? right is null;
 
-            public static bool operator !=(TermInfo left, TermInfo right)
+            public static bool operator !=(TermInfo? left, TermInfo? right)
                 => !(left == right);
 
+            #nullable restore
             #endregion
         }
     }

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldTermStack.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldTermStack.cs
@@ -286,7 +286,7 @@ namespace Lucene.Net.Search.VectorHighlight
             }
 
             #region Operator overrides
-            #nullable enable
+#nullable enable
             // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
             public static bool operator <(TermInfo? left, TermInfo? right)
@@ -307,7 +307,7 @@ namespace Lucene.Net.Search.VectorHighlight
             public static bool operator !=(TermInfo? left, TermInfo? right)
                 => !(left == right);
 
-            #nullable restore
+#nullable restore
             #endregion
         }
     }

--- a/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
@@ -28,8 +28,8 @@ namespace Lucene.Net.QueryParsers.Surround.Query
     public abstract class SimpleTerm : SrndQuery, IDistanceSubQuery, IComparable<SimpleTerm>
     {
         protected SimpleTerm(bool quoted) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
-        { 
-            this.quoted = quoted; 
+        {
+            this.quoted = quoted;
         }
 
         private readonly bool quoted; // LUCENENET: marked readonly
@@ -115,5 +115,32 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         {
             return new SimpleTermRewriteQuery(this, fieldName, qf);
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+        // NOTE: The CompareTo method is marked as obsolete, but we still need to implement the comparison operators
+        // since this is public in 4.8. Suppressing the obsolete warning here.
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        public static bool operator <(SimpleTerm left, SimpleTerm right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(SimpleTerm left, SimpleTerm right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(SimpleTerm left, SimpleTerm right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(SimpleTerm left, SimpleTerm right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        public static bool operator ==(SimpleTerm left, SimpleTerm right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(SimpleTerm left, SimpleTerm right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
@@ -2,7 +2,7 @@
 using Lucene.Net.Index;
 using System;
 using System.Text;
-#pragma warning disable CS0660, CS0661 - CompareTo is deprecated, so skipping implementing equality members (lucenenet#683)
+#pragma warning disable CS0660, CS0661 // CompareTo is deprecated, so skipping implementing equality members (lucenenet#683)
 
 namespace Lucene.Net.QueryParsers.Surround.Query
 {

--- a/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
@@ -118,7 +118,7 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         }
 
         #region Operator overrides
-        #nullable enable
+#nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
         // NOTE: The CompareTo method is marked as obsolete, but we still need to implement the comparison operators
         // since this is public in 4.8. Suppressing the obsolete warning here.
@@ -143,7 +143,7 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         public static bool operator !=(SimpleTerm? left, SimpleTerm? right)
             => !(left == right);
 
-        #nullable restore
+#nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SimpleTerm.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.Index;
 using System;
 using System.Text;
+#pragma warning disable CS0660, CS0661 - CompareTo is deprecated, so skipping implementing equality members (lucenenet#683)
 
 namespace Lucene.Net.QueryParsers.Surround.Query
 {
@@ -117,30 +118,32 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         }
 
         #region Operator overrides
+        #nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
         // NOTE: The CompareTo method is marked as obsolete, but we still need to implement the comparison operators
         // since this is public in 4.8. Suppressing the obsolete warning here.
 
 #pragma warning disable CS0618 // Type or member is obsolete
-        public static bool operator <(SimpleTerm left, SimpleTerm right)
+        public static bool operator <(SimpleTerm? left, SimpleTerm? right)
             => left is null ? right is not null : left.CompareTo(right) < 0;
 
-        public static bool operator <=(SimpleTerm left, SimpleTerm right)
+        public static bool operator <=(SimpleTerm? left, SimpleTerm? right)
             => left is null || left.CompareTo(right) <= 0;
 
-        public static bool operator >(SimpleTerm left, SimpleTerm right)
+        public static bool operator >(SimpleTerm? left, SimpleTerm? right)
             => left is not null && left.CompareTo(right) > 0;
 
-        public static bool operator >=(SimpleTerm left, SimpleTerm right)
+        public static bool operator >=(SimpleTerm? left, SimpleTerm? right)
             => left is null ? right is null : left.CompareTo(right) >= 0;
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        public static bool operator ==(SimpleTerm left, SimpleTerm right)
+        public static bool operator ==(SimpleTerm? left, SimpleTerm? right)
             => left?.Equals(right) ?? right is null;
 
-        public static bool operator !=(SimpleTerm left, SimpleTerm right)
+        public static bool operator !=(SimpleTerm? left, SimpleTerm? right)
             => !(left == right);
 
+        #nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net.Spatial/Prefix/Tree/Cell.cs
+++ b/src/Lucene.Net.Spatial/Prefix/Tree/Cell.cs
@@ -28,13 +28,13 @@ namespace Lucene.Net.Spatial.Prefix.Tree
     /// <summary>
     /// Represents a grid cell. These are not necessarily thread-safe, although new
     /// Cell("") (world cell) must be.
-    /// 
+    ///
     /// @lucene.experimental
     /// </summary>
     public abstract class Cell : IComparable<Cell>
     {
         /// <summary>
-        /// LUCENENET specific - we need to set the SpatialPrefixTree before calling overridden 
+        /// LUCENENET specific - we need to set the SpatialPrefixTree before calling overridden
         /// members of this class, just in case those overridden members require it. This is
         /// not possible from the subclass because the constructor of the base class runs first.
         /// So we need to move the reference here and also set it before running the normal constructor
@@ -90,7 +90,7 @@ namespace Lucene.Net.Spatial.Prefix.Tree
             {
                 this.token = token.Substring(0, (token.Length - 1) - 0);
                 // LUCENENET specific - calling private instead of virtual to avoid initialization issues
-                SetLeafInternal(); 
+                SetLeafInternal();
             }
             if (Level == 0)
             {
@@ -178,8 +178,8 @@ namespace Lucene.Net.Spatial.Prefix.Tree
         public virtual bool IsLeaf => m_leaf;
 
         /// <summary>Note: not supported at level 0.
-        /// 
-        /// NOTE: When overriding this method, be aware that the constructor of this class calls 
+        ///
+        /// NOTE: When overriding this method, be aware that the constructor of this class calls
         /// a private method and not this virtual method. So if you need to override
         /// the behavior during the initialization, call your own private method from the constructor
         /// with whatever custom behavior you need.
@@ -232,7 +232,7 @@ namespace Lucene.Net.Spatial.Prefix.Tree
         //public Cell getParent();
         /// <summary>
         /// Like <see cref="GetSubCells()">GetSubCells()</see> but with the results filtered by a shape. If
-        /// that shape is a <see cref="IPoint"/> then it must call 
+        /// that shape is a <see cref="IPoint"/> then it must call
         /// <see cref="GetSubCell(IPoint)"/>. The returned cells
         /// should have <see cref="ShapeRel">ShapeRel</see> set to their relation with
         /// <paramref name="shapeFilter"/>. In addition, <see cref="IsLeaf"/>
@@ -337,5 +337,27 @@ namespace Lucene.Net.Spatial.Prefix.Tree
 
         #endregion
 
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(Cell? left, Cell? right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(Cell? left, Cell? right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(Cell? left, Cell? right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(Cell? left, Cell? right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(Cell? left, Cell? right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(Cell? left, Cell? right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
@@ -69,15 +69,13 @@ namespace Lucene.Net.Search.Suggest.Fst
             }
 
             // LUCENENET specific - per CS0660 and CS0661, we need to override Equals and GetHashCode
-            public override bool Equals(object obj) => ReferenceEquals(this, obj);
+            // ReSharper disable once BaseObjectEqualsIsObjectEquals
+            // ReSharper disable once RedundantOverriddenMember
+            public override bool Equals(object obj) => base.Equals(obj);
 
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    return (Utf8.GetHashCode() * 397) ^ Bucket;
-                }
-            }
+            // ReSharper disable once BaseObjectGetHashCodeCallInGetHashCode
+            // ReSharper disable once RedundantOverriddenMember
+            public override int GetHashCode() => base.GetHashCode();
 
             #region Operator overrides
             #nullable enable

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
@@ -67,6 +67,29 @@ namespace Lucene.Net.Search.Suggest.Fst
             {
                 return this.Utf8.CompareTo(o.Utf8);
             }
+
+            #region Operator overrides
+            // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+            public static bool operator <(Completion left, Completion right)
+                => left is null ? right is not null : left.CompareTo(right) < 0;
+
+            public static bool operator <=(Completion left, Completion right)
+                => left is null || left.CompareTo(right) <= 0;
+
+            public static bool operator >(Completion left, Completion right)
+                => left is not null && left.CompareTo(right) > 0;
+
+            public static bool operator >=(Completion left, Completion right)
+                => left is null ? right is null : left.CompareTo(right) >= 0;
+
+            public static bool operator ==(Completion left, Completion right)
+                => left?.Equals(right) ?? right is null;
+
+            public static bool operator !=(Completion left, Completion right)
+                => !(left == right);
+
+            #endregion
         }
 
         /// <summary>

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
@@ -78,7 +78,7 @@ namespace Lucene.Net.Search.Suggest.Fst
             public override int GetHashCode() => base.GetHashCode();
 
             #region Operator overrides
-            #nullable enable
+#nullable enable
             // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
             public static bool operator <(Completion? left, Completion? right)
@@ -99,7 +99,7 @@ namespace Lucene.Net.Search.Suggest.Fst
             public static bool operator !=(Completion? left, Completion? right)
                 => !(left == right);
 
-            #nullable restore
+#nullable restore
             #endregion
         }
 

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
@@ -46,10 +46,10 @@ namespace Lucene.Net.Search.Suggest.Fst
         {
             /// <summary>
             /// UTF-8 bytes of the suggestion </summary>
-            public BytesRef Utf8 { get; private set; }
+            public BytesRef Utf8 { get; }
             /// <summary>
             /// source bucket (weight) of the suggestion </summary>
-            public int Bucket { get; private set; }
+            public int Bucket { get; }
 
             internal Completion(BytesRef key, int bucket)
             {
@@ -68,27 +68,40 @@ namespace Lucene.Net.Search.Suggest.Fst
                 return this.Utf8.CompareTo(o.Utf8);
             }
 
+            // LUCENENET specific - per CS0660 and CS0661, we need to override Equals and GetHashCode
+            public override bool Equals(object obj) => ReferenceEquals(this, obj);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (Utf8.GetHashCode() * 397) ^ Bucket;
+                }
+            }
+
             #region Operator overrides
+            #nullable enable
             // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-            public static bool operator <(Completion left, Completion right)
+            public static bool operator <(Completion? left, Completion? right)
                 => left is null ? right is not null : left.CompareTo(right) < 0;
 
-            public static bool operator <=(Completion left, Completion right)
+            public static bool operator <=(Completion? left, Completion? right)
                 => left is null || left.CompareTo(right) <= 0;
 
-            public static bool operator >(Completion left, Completion right)
+            public static bool operator >(Completion? left, Completion? right)
                 => left is not null && left.CompareTo(right) > 0;
 
-            public static bool operator >=(Completion left, Completion right)
+            public static bool operator >=(Completion? left, Completion? right)
                 => left is null ? right is null : left.CompareTo(right) >= 0;
 
-            public static bool operator ==(Completion left, Completion right)
+            public static bool operator ==(Completion? left, Completion? right)
                 => left?.Equals(right) ?? right is null;
 
-            public static bool operator !=(Completion left, Completion right)
+            public static bool operator !=(Completion? left, Completion? right)
                 => !(left == right);
 
+            #nullable restore
             #endregion
         }
 

--- a/src/Lucene.Net.Suggest/Suggest/Lookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Lookup.cs
@@ -124,20 +124,13 @@ namespace Lucene.Net.Search.Suggest
             }
 
             // LUCENENET specific - per CS0660 and CS0661, we need to override Equals and GetHashCode
-            public override bool Equals(object obj) => ReferenceEquals(this, obj);
+            // ReSharper disable once BaseObjectEqualsIsObjectEquals
+            // ReSharper disable once RedundantOverriddenMember
+            public override bool Equals(object obj) => base.Equals(obj);
 
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    var hashCode = (Key != null ? Key.GetHashCode() : 0);
-                    hashCode = (hashCode * 397) ^ (HighlightKey != null ? HighlightKey.GetHashCode() : 0);
-                    hashCode = (hashCode * 397) ^ Value.GetHashCode();
-                    hashCode = (hashCode * 397) ^ (Payload != null ? Payload.GetHashCode() : 0);
-                    hashCode = (hashCode * 397) ^ (Contexts != null ? Contexts.GetHashCode() : 0);
-                    return hashCode;
-                }
-            }
+            // ReSharper disable once BaseObjectGetHashCodeCallInGetHashCode
+            // ReSharper disable once RedundantOverriddenMember
+            public override int GetHashCode() => base.GetHashCode();
 
             #region Operator overrides
             // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators

--- a/src/Lucene.Net.Suggest/Suggest/Lookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Lookup.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Search.Suggest
 
             /// <summary>
             /// Expert: custom Object to hold the result of a
-            /// highlighted suggestion. 
+            /// highlighted suggestion.
             /// </summary>
             public object HighlightKey { get; private set; }
 
@@ -122,6 +122,29 @@ namespace Lucene.Net.Search.Suggest
             {
                 return CHARSEQUENCE_COMPARER.Compare(Key, o.Key);
             }
+
+            #region Operator overrides
+            // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+            public static bool operator <(LookupResult left, LookupResult right)
+                => left is null ? right is not null : left.CompareTo(right) < 0;
+
+            public static bool operator <=(LookupResult left, LookupResult right)
+                => left is null || left.CompareTo(right) <= 0;
+
+            public static bool operator >(LookupResult left, LookupResult right)
+                => left is not null && left.CompareTo(right) > 0;
+
+            public static bool operator >=(LookupResult left, LookupResult right)
+                => left is null ? right is null : left.CompareTo(right) >= 0;
+
+            public static bool operator ==(LookupResult left, LookupResult right)
+                => left?.Equals(right) ?? right is null;
+
+            public static bool operator !=(LookupResult left, LookupResult right)
+                => !(left == right);
+
+            #endregion
         }
 
         /// <summary>
@@ -129,7 +152,7 @@ namespace Lucene.Net.Search.Suggest
         /// </summary>
         public static readonly IComparer<string> CHARSEQUENCE_COMPARER = new CharSequenceComparer();
 
-        // LUCENENET: It is no longer good practice to use binary serialization. 
+        // LUCENENET: It is no longer good practice to use binary serialization.
         // See: https://github.com/dotnet/corefx/issues/23584#issuecomment-325724568
 #if FEATURE_SERIALIZABLE
         [Serializable]
@@ -201,7 +224,7 @@ namespace Lucene.Net.Search.Suggest
         }
 
         /// <summary>
-        /// Sole constructor. (For invocation by subclass 
+        /// Sole constructor. (For invocation by subclass
         /// constructors, typically implicit.)
         /// </summary>
         protected Lookup() // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)

--- a/src/Lucene.Net.Suggest/Suggest/Lookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Lookup.cs
@@ -39,25 +39,25 @@ namespace Lucene.Net.Search.Suggest
         {
             /// <summary>
             /// the key's text </summary>
-            public string Key { get; private set; }
+            public string Key { get; }
 
             /// <summary>
             /// Expert: custom Object to hold the result of a
             /// highlighted suggestion.
             /// </summary>
-            public object HighlightKey { get; private set; }
+            public object HighlightKey { get; }
 
             /// <summary>
             /// the key's weight </summary>
-            public long Value { get; private set; }
+            public long Value { get; }
 
             /// <summary>
             /// the key's payload (null if not present) </summary>
-            public BytesRef Payload { get; private set; }
+            public BytesRef Payload { get; }
 
             /// <summary>
             /// the key's contexts (null if not present) </summary>
-            public IEnumerable<BytesRef> Contexts { get; private set; }
+            public IEnumerable<BytesRef> Contexts { get; }
 
             /// <summary>
             /// Create a new result from a key+weight pair.
@@ -121,6 +121,22 @@ namespace Lucene.Net.Search.Suggest
             public int CompareTo(LookupResult o)
             {
                 return CHARSEQUENCE_COMPARER.Compare(Key, o.Key);
+            }
+
+            // LUCENENET specific - per CS0660 and CS0661, we need to override Equals and GetHashCode
+            public override bool Equals(object obj) => ReferenceEquals(this, obj);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = (Key != null ? Key.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (HighlightKey != null ? HighlightKey.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ Value.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (Payload != null ? Payload.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Contexts != null ? Contexts.GetHashCode() : 0);
+                    return hashCode;
+                }
             }
 
             #region Operator overrides

--- a/src/Lucene.Net/Index/IndexCommit.cs
+++ b/src/Lucene.Net/Index/IndexCommit.cs
@@ -117,8 +117,8 @@ namespace Lucene.Net.Index
         public abstract long Generation { get; }
 
         /// <summary>
-        /// Returns userData, previously passed to 
-        /// <see cref="IndexWriter.SetCommitData(IDictionary{string, string})"/>} for this commit.  
+        /// Returns userData, previously passed to
+        /// <see cref="IndexWriter.SetCommitData(IDictionary{string, string})"/>} for this commit.
         /// The dictionary is <see cref="string"/> -> <see cref="string"/>.
         /// </summary>
         public abstract IDictionary<string, string> UserData { get; }
@@ -145,5 +145,28 @@ namespace Lucene.Net.Index
                 return 0;
             }
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(IndexCommit left, IndexCommit right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(IndexCommit left, IndexCommit right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(IndexCommit left, IndexCommit right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(IndexCommit left, IndexCommit right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(IndexCommit left, IndexCommit right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(IndexCommit left, IndexCommit right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net/Index/IndexCommit.cs
+++ b/src/Lucene.Net/Index/IndexCommit.cs
@@ -147,7 +147,7 @@ namespace Lucene.Net.Index
         }
 
         #region Operator overrides
-        #nullable enable
+#nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
         public static bool operator <(IndexCommit? left, IndexCommit? right)
@@ -168,7 +168,7 @@ namespace Lucene.Net.Index
         public static bool operator !=(IndexCommit? left, IndexCommit? right)
             => !(left == right);
 
-        #nullable restore
+#nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Index/IndexCommit.cs
+++ b/src/Lucene.Net/Index/IndexCommit.cs
@@ -147,26 +147,28 @@ namespace Lucene.Net.Index
         }
 
         #region Operator overrides
+        #nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-        public static bool operator <(IndexCommit left, IndexCommit right)
+        public static bool operator <(IndexCommit? left, IndexCommit? right)
             => left is null ? right is not null : left.CompareTo(right) < 0;
 
-        public static bool operator <=(IndexCommit left, IndexCommit right)
+        public static bool operator <=(IndexCommit? left, IndexCommit? right)
             => left is null || left.CompareTo(right) <= 0;
 
-        public static bool operator >(IndexCommit left, IndexCommit right)
+        public static bool operator >(IndexCommit? left, IndexCommit? right)
             => left is not null && left.CompareTo(right) > 0;
 
-        public static bool operator >=(IndexCommit left, IndexCommit right)
+        public static bool operator >=(IndexCommit? left, IndexCommit? right)
             => left is null ? right is null : left.CompareTo(right) >= 0;
 
-        public static bool operator ==(IndexCommit left, IndexCommit right)
+        public static bool operator ==(IndexCommit? left, IndexCommit? right)
             => left?.Equals(right) ?? right is null;
 
-        public static bool operator !=(IndexCommit left, IndexCommit right)
+        public static bool operator !=(IndexCommit? left, IndexCommit? right)
             => !(left == right);
 
+        #nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Index/Term.cs
+++ b/src/Lucene.Net/Index/Term.cs
@@ -191,7 +191,7 @@ namespace Lucene.Net.Index
         }
 
         #region Operator overrides
-        #nullable enable
+#nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
         public static bool operator <(Term? left, Term? right)
@@ -212,7 +212,7 @@ namespace Lucene.Net.Index
         public static bool operator !=(Term? left, Term? right)
             => !(left == right);
 
-        #nullable restore
+#nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Index/Term.cs
+++ b/src/Lucene.Net/Index/Term.cs
@@ -191,26 +191,28 @@ namespace Lucene.Net.Index
         }
 
         #region Operator overrides
+        #nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-        public static bool operator <(Term left, Term right)
+        public static bool operator <(Term? left, Term? right)
             => left is null ? right is not null : left.CompareTo(right) < 0;
 
-        public static bool operator <=(Term left, Term right)
+        public static bool operator <=(Term? left, Term? right)
             => left is null || left.CompareTo(right) <= 0;
 
-        public static bool operator >(Term left, Term right)
+        public static bool operator >(Term? left, Term? right)
             => left is not null && left.CompareTo(right) > 0;
 
-        public static bool operator >=(Term left, Term right)
+        public static bool operator >=(Term? left, Term? right)
             => left is null ? right is null : left.CompareTo(right) >= 0;
 
-        public static bool operator ==(Term left, Term right)
+        public static bool operator ==(Term? left, Term? right)
             => left?.Equals(right) ?? right is null;
 
-        public static bool operator !=(Term left, Term right)
+        public static bool operator !=(Term? left, Term? right)
             => !(left == right);
 
+        #nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Index/Term.cs
+++ b/src/Lucene.Net/Index/Term.cs
@@ -189,5 +189,28 @@ namespace Lucene.Net.Index
         {
             return Field + ":" + Text;
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(Term left, Term right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(Term left, Term right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(Term left, Term right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(Term left, Term right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(Term left, Term right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(Term left, Term right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -377,7 +377,7 @@ namespace Lucene.Net.Util.Automaton
         }
 
         #region Operator overrides
-        #nullable enable
+#nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
         public static bool operator <(State? left, State? right)
@@ -398,7 +398,7 @@ namespace Lucene.Net.Util.Automaton
         public static bool operator !=(State? left, State? right)
             => !(left == right);
 
-        #nullable restore
+#nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -376,26 +376,28 @@ namespace Lucene.Net.Util.Automaton
         }
 
         #region Operator overrides
+        #nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-        public static bool operator <(State left, State right)
+        public static bool operator <(State? left, State? right)
             => left is null ? right is not null : left.CompareTo(right) < 0;
 
-        public static bool operator <=(State left, State right)
+        public static bool operator <=(State? left, State? right)
             => left is null || left.CompareTo(right) <= 0;
 
-        public static bool operator >(State left, State right)
+        public static bool operator >(State? left, State? right)
             => left is not null && left.CompareTo(right) > 0;
 
-        public static bool operator >=(State left, State right)
+        public static bool operator >=(State? left, State? right)
             => left is null ? right is null : left.CompareTo(right) >= 0;
 
-        public static bool operator ==(State left, State right)
+        public static bool operator ==(State? left, State? right)
             => left is null ? right is null : ReferenceEquals(left, right);
 
-        public static bool operator !=(State left, State right)
+        public static bool operator !=(State? left, State? right)
             => !(left == right);
 
+        #nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -367,7 +367,8 @@ namespace Lucene.Net.Util.Automaton
         // IndexOutOfRangeExceptions when using FuzzyTermsEnum.
         // See GH-296.
         // Overriding here to prevent CS0660 warning due to defining the == operator.
-        public override bool Equals(object obj) => ReferenceEquals(this, obj);
+        // ReSharper disable once BaseObjectEqualsIsObjectEquals
+        public override bool Equals(object obj) => base.Equals(obj);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode()

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -360,17 +360,42 @@ namespace Lucene.Net.Util.Automaton
             return s.id - id;
         }
 
-        // LUCENENET NOTE: DO NOT IMPLEMENT Equals()!!!
+        // LUCENENET NOTE: DO NOT IMPLEMENT Equals() with structural equality!!!
         // Although it doesn't match GetHashCode(), checking for
         // reference equality is by design.
         // Implementing Equals() causes difficult to diagnose
         // IndexOutOfRangeExceptions when using FuzzyTermsEnum.
         // See GH-296.
+        // Overriding here to prevent CS0660 warning due to defining the == operator.
+        public override bool Equals(object obj) => ReferenceEquals(this, obj);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode()
         {
             return id;
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(State left, State right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(State left, State right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(State left, State right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(State left, State right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(State left, State right)
+            => left is null ? right is null : ReferenceEquals(left, right);
+
+        public static bool operator !=(State left, State right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -402,26 +402,28 @@ namespace Lucene.Net.Util
         }
 
         #region Operator overrides
+        #nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-        public static bool operator <(BytesRef left, BytesRef right)
+        public static bool operator <(BytesRef? left, BytesRef? right)
             => left is null ? right is not null : left.CompareTo(right) < 0;
 
-        public static bool operator <=(BytesRef left, BytesRef right)
+        public static bool operator <=(BytesRef? left, BytesRef? right)
             => left is null || left.CompareTo(right) <= 0;
 
-        public static bool operator >(BytesRef left, BytesRef right)
+        public static bool operator >(BytesRef? left, BytesRef? right)
             => left is not null && left.CompareTo(right) > 0;
 
-        public static bool operator >=(BytesRef left, BytesRef right)
+        public static bool operator >=(BytesRef? left, BytesRef? right)
             => left is null ? right is null : left.CompareTo(right) >= 0;
 
-        public static bool operator ==(BytesRef left, BytesRef right)
+        public static bool operator ==(BytesRef? left, BytesRef? right)
             => left?.Equals(right) ?? right is null;
 
-        public static bool operator !=(BytesRef left, BytesRef right)
+        public static bool operator !=(BytesRef? left, BytesRef? right)
             => !(left == right);
 
+        #nullable restore
         #endregion
     }
 

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -402,7 +402,7 @@ namespace Lucene.Net.Util
         }
 
         #region Operator overrides
-        #nullable enable
+#nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
         public static bool operator <(BytesRef? left, BytesRef? right)
@@ -423,7 +423,7 @@ namespace Lucene.Net.Util
         public static bool operator !=(BytesRef? left, BytesRef? right)
             => !(left == right);
 
-        #nullable restore
+#nullable restore
         #endregion
     }
 

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -400,6 +400,29 @@ namespace Lucene.Net.Util
             }
             return true;
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(BytesRef left, BytesRef right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(BytesRef left, BytesRef right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(BytesRef left, BytesRef right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(BytesRef left, BytesRef right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(BytesRef left, BytesRef right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(BytesRef left, BytesRef right)
+            => !(left == right);
+
+        #endregion
     }
 
     // LUCENENET: It is no longer good practice to use binary serialization.

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -445,7 +445,7 @@ namespace Lucene.Net.Util
         }
 
         #region Operator overrides
-        #nullable enable
+#nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
         public static bool operator <(CharsRef? left, CharsRef? right)
@@ -466,7 +466,7 @@ namespace Lucene.Net.Util
         public static bool operator !=(CharsRef? left, CharsRef? right)
             => !(left == right);
 
-        #nullable restore
+#nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -443,5 +443,28 @@ namespace Lucene.Net.Util
             }
             return true;
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(CharsRef left, CharsRef right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(CharsRef left, CharsRef right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(CharsRef left, CharsRef right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(CharsRef left, CharsRef right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(CharsRef left, CharsRef right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(CharsRef left, CharsRef right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -445,26 +445,28 @@ namespace Lucene.Net.Util
         }
 
         #region Operator overrides
+        #nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-        public static bool operator <(CharsRef left, CharsRef right)
+        public static bool operator <(CharsRef? left, CharsRef? right)
             => left is null ? right is not null : left.CompareTo(right) < 0;
 
-        public static bool operator <=(CharsRef left, CharsRef right)
+        public static bool operator <=(CharsRef? left, CharsRef? right)
             => left is null || left.CompareTo(right) <= 0;
 
-        public static bool operator >(CharsRef left, CharsRef right)
+        public static bool operator >(CharsRef? left, CharsRef? right)
             => left is not null && left.CompareTo(right) > 0;
 
-        public static bool operator >=(CharsRef left, CharsRef right)
+        public static bool operator >=(CharsRef? left, CharsRef? right)
             => left is null ? right is null : left.CompareTo(right) >= 0;
 
-        public static bool operator ==(CharsRef left, CharsRef right)
+        public static bool operator ==(CharsRef? left, CharsRef? right)
             => left?.Equals(right) ?? right is null;
 
-        public static bool operator !=(CharsRef left, CharsRef right)
+        public static bool operator !=(CharsRef? left, CharsRef? right)
             => !(left == right);
 
+        #nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Util/IntsRef.cs
+++ b/src/Lucene.Net/Util/IntsRef.cs
@@ -295,26 +295,28 @@ namespace Lucene.Net.Util
         }
 
         #region Operator overrides
+        #nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-        public static bool operator <(Int32sRef left, Int32sRef right)
+        public static bool operator <(Int32sRef? left, Int32sRef? right)
             => left is null ? right is not null : left.CompareTo(right) < 0;
 
-        public static bool operator <=(Int32sRef left, Int32sRef right)
+        public static bool operator <=(Int32sRef? left, Int32sRef? right)
             => left is null || left.CompareTo(right) <= 0;
 
-        public static bool operator >(Int32sRef left, Int32sRef right)
+        public static bool operator >(Int32sRef? left, Int32sRef? right)
             => left is not null && left.CompareTo(right) > 0;
 
-        public static bool operator >=(Int32sRef left, Int32sRef right)
+        public static bool operator >=(Int32sRef? left, Int32sRef? right)
             => left is null ? right is null : left.CompareTo(right) >= 0;
 
-        public static bool operator ==(Int32sRef left, Int32sRef right)
+        public static bool operator ==(Int32sRef? left, Int32sRef? right)
             => left?.Equals(right) ?? right is null;
 
-        public static bool operator !=(Int32sRef left, Int32sRef right)
+        public static bool operator !=(Int32sRef? left, Int32sRef? right)
             => !(left == right);
 
+        #nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Util/IntsRef.cs
+++ b/src/Lucene.Net/Util/IntsRef.cs
@@ -293,5 +293,28 @@ namespace Lucene.Net.Util
             }
             return true;
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(Int32sRef left, Int32sRef right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(Int32sRef left, Int32sRef right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(Int32sRef left, Int32sRef right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(Int32sRef left, Int32sRef right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(Int32sRef left, Int32sRef right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(Int32sRef left, Int32sRef right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net/Util/IntsRef.cs
+++ b/src/Lucene.Net/Util/IntsRef.cs
@@ -295,7 +295,7 @@ namespace Lucene.Net.Util
         }
 
         #region Operator overrides
-        #nullable enable
+#nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
         public static bool operator <(Int32sRef? left, Int32sRef? right)
@@ -316,7 +316,7 @@ namespace Lucene.Net.Util
         public static bool operator !=(Int32sRef? left, Int32sRef? right)
             => !(left == right);
 
-        #nullable restore
+#nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Util/LongsRef.cs
+++ b/src/Lucene.Net/Util/LongsRef.cs
@@ -294,26 +294,28 @@ namespace Lucene.Net.Util
         }
 
         #region Operator overrides
+        #nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-        public static bool operator <(Int64sRef left, Int64sRef right)
+        public static bool operator <(Int64sRef? left, Int64sRef? right)
             => left is null ? right is not null : left.CompareTo(right) < 0;
 
-        public static bool operator <=(Int64sRef left, Int64sRef right)
+        public static bool operator <=(Int64sRef? left, Int64sRef? right)
             => left is null || left.CompareTo(right) <= 0;
 
-        public static bool operator >(Int64sRef left, Int64sRef right)
+        public static bool operator >(Int64sRef? left, Int64sRef? right)
             => left is not null && left.CompareTo(right) > 0;
 
-        public static bool operator >=(Int64sRef left, Int64sRef right)
+        public static bool operator >=(Int64sRef? left, Int64sRef? right)
             => left is null ? right is null : left.CompareTo(right) >= 0;
 
-        public static bool operator ==(Int64sRef left, Int64sRef right)
+        public static bool operator ==(Int64sRef? left, Int64sRef? right)
             => left?.Equals(right) ?? right is null;
 
-        public static bool operator !=(Int64sRef left, Int64sRef right)
+        public static bool operator !=(Int64sRef? left, Int64sRef? right)
             => !(left == right);
 
+        #nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Util/LongsRef.cs
+++ b/src/Lucene.Net/Util/LongsRef.cs
@@ -294,7 +294,7 @@ namespace Lucene.Net.Util
         }
 
         #region Operator overrides
-        #nullable enable
+#nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
         public static bool operator <(Int64sRef? left, Int64sRef? right)
@@ -315,7 +315,7 @@ namespace Lucene.Net.Util
         public static bool operator !=(Int64sRef? left, Int64sRef? right)
             => !(left == right);
 
-        #nullable restore
+#nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Util/LongsRef.cs
+++ b/src/Lucene.Net/Util/LongsRef.cs
@@ -292,5 +292,28 @@ namespace Lucene.Net.Util
             }
             return true;
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(Int64sRef left, Int64sRef right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(Int64sRef left, Int64sRef right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(Int64sRef left, Int64sRef right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(Int64sRef left, Int64sRef right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(Int64sRef left, Int64sRef right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(Int64sRef left, Int64sRef right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net/Util/Mutable/MutableValue.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValue.cs
@@ -61,8 +61,8 @@ namespace Lucene.Net.Util.Mutable
         }
 
 
-        // LUCENENET specific implementation, for use with FunctionFirstPassGroupingCollector 
-        // (note that IComparable<T> does not inherit IComparable, so we need to explicitly 
+        // LUCENENET specific implementation, for use with FunctionFirstPassGroupingCollector
+        // (note that IComparable<T> does not inherit IComparable, so we need to explicitly
         // implement here in order to support IComparable)
         public virtual int CompareTo(object other)
         {
@@ -91,5 +91,28 @@ namespace Lucene.Net.Util.Mutable
         {
             return Exists ? ToObject().ToString() : "(null)";
         }
+
+        #region Operator overrides
+        // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
+
+        public static bool operator <(MutableValue left, MutableValue right)
+            => left is null ? right is not null : left.CompareTo(right) < 0;
+
+        public static bool operator <=(MutableValue left, MutableValue right)
+            => left is null || left.CompareTo(right) <= 0;
+
+        public static bool operator >(MutableValue left, MutableValue right)
+            => left is not null && left.CompareTo(right) > 0;
+
+        public static bool operator >=(MutableValue left, MutableValue right)
+            => left is null ? right is null : left.CompareTo(right) >= 0;
+
+        public static bool operator ==(MutableValue left, MutableValue right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(MutableValue left, MutableValue right)
+            => !(left == right);
+
+        #endregion
     }
 }

--- a/src/Lucene.Net/Util/Mutable/MutableValue.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValue.cs
@@ -93,7 +93,7 @@ namespace Lucene.Net.Util.Mutable
         }
 
         #region Operator overrides
-        #nullable enable
+#nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
         public static bool operator <(MutableValue? left, MutableValue? right)
@@ -114,7 +114,7 @@ namespace Lucene.Net.Util.Mutable
         public static bool operator !=(MutableValue? left, MutableValue? right)
             => !(left == right);
 
-        #nullable restore
+#nullable restore
         #endregion
     }
 }

--- a/src/Lucene.Net/Util/Mutable/MutableValue.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValue.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Util.Mutable
 
         public override bool Equals(object other)
         {
-            return (this.GetType() == other.GetType()) && this.EqualsSameType(other);
+            return this.GetType() == other?.GetType() && this.EqualsSameType(other);
         }
 
         public override abstract int GetHashCode();

--- a/src/Lucene.Net/Util/Mutable/MutableValue.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValue.cs
@@ -93,26 +93,28 @@ namespace Lucene.Net.Util.Mutable
         }
 
         #region Operator overrides
+        #nullable enable
         // LUCENENET specific - per csharpsquid:S1210, IComparable<T> should override comparison operators
 
-        public static bool operator <(MutableValue left, MutableValue right)
+        public static bool operator <(MutableValue? left, MutableValue? right)
             => left is null ? right is not null : left.CompareTo(right) < 0;
 
-        public static bool operator <=(MutableValue left, MutableValue right)
+        public static bool operator <=(MutableValue? left, MutableValue? right)
             => left is null || left.CompareTo(right) <= 0;
 
-        public static bool operator >(MutableValue left, MutableValue right)
+        public static bool operator >(MutableValue? left, MutableValue? right)
             => left is not null && left.CompareTo(right) > 0;
 
-        public static bool operator >=(MutableValue left, MutableValue right)
+        public static bool operator >=(MutableValue? left, MutableValue? right)
             => left is null ? right is null : left.CompareTo(right) >= 0;
 
-        public static bool operator ==(MutableValue left, MutableValue right)
+        public static bool operator ==(MutableValue? left, MutableValue? right)
             => left?.Equals(right) ?? right is null;
 
-        public static bool operator !=(MutableValue left, MutableValue right)
+        public static bool operator !=(MutableValue? left, MutableValue? right)
             => !(left == right);
 
+        #nullable restore
         #endregion
     }
 }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Add operator overrides for public IComparable types

Fixes #683

## Description

This is to resolve the Sonar warning about needing to override the comparison operators for any types that implement IComparable. We are only doing this here for the public types.

QualityQuery was missing Equals and GetHashCode, as well as had some possible NullReferenceExceptions, so those have been fixed as well.
