### PR TITLE
UnicodeUtil updates: TryUTF8toUTF16, ReadOnlySpan methods, #1024

### DIFF
--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
@@ -411,10 +411,10 @@ namespace Lucene.Net.Codecs.SimpleText
                     SimpleTextUtil.ReadLine(_input, _scratch);
                     try
                     {
-                        // LUCNENENET: .NET doesn't have a way to specify a pattern with integer, but all of the standard ones are built in.
+                        // LUCENENET: .NET doesn't have a way to specify a pattern with integer, but all of the standard ones are built in.
                         return int.Parse(_scratch.Utf8ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture) - 1;
                     }
-                    catch (Exception pe) when (pe.IsParseException())
+                    catch (Exception pe) when (pe.IsParseException() || pe.IsNumberFormatException())
                     {
                         var e = new CorruptIndexException($"failed to parse ord (resource={_input})", pe);
                         throw e;

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextUtil.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextUtil.cs
@@ -106,8 +106,9 @@ namespace Lucene.Net.Codecs.SimpleText
 
             if (StringHelper.StartsWith(scratch, CHECKSUM) == false)
             {
+                // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
                 throw new CorruptIndexException("SimpleText failure: expected checksum line but got " +
-                                                scratch.Utf8ToString() + " (resource=" + input + ")");
+                                                scratch.Utf8ToStringWithFallback() + " (resource=" + input + ")");
             }
             var actualChecksum =
                 (new BytesRef(scratch.Bytes, CHECKSUM.Length, scratch.Length - CHECKSUM.Length)).Utf8ToString();

--- a/src/Lucene.Net.Facet/SortedSet/DefaultSortedSetDocValuesReaderState.cs
+++ b/src/Lucene.Net.Facet/SortedSet/DefaultSortedSetDocValuesReaderState.cs
@@ -79,7 +79,8 @@ namespace Lucene.Net.Facet.SortedSet
                 string[] components = FacetsConfig.StringToPath(spare.Utf8ToString());
                 if (components.Length != 2)
                 {
-                    throw new ArgumentException("this class can only handle 2 level hierarchy (dim/value); got: " + Arrays.ToString(components) + " " + spare.Utf8ToString());
+                    // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
+                    throw new ArgumentException("this class can only handle 2 level hierarchy (dim/value); got: " + Arrays.ToString(components) + " " + spare.Utf8ToStringWithFallback());
                 }
                 if (!components[0].Equals(lastDim, StringComparison.Ordinal))
                 {

--- a/src/Lucene.Net.Grouping/AbstractGroupFacetCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractGroupFacetCollector.cs
@@ -278,7 +278,7 @@ namespace Lucene.Net.Search.Grouping
             public override string ToString()
             {
                 return "FacetEntry{" +
-                    "value=" + value.Utf8ToString() +
+                    "value=" + value.Utf8ToStringWithFallback() + // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
                     ", count=" + count +
                     '}';
             }

--- a/src/Lucene.Net.Join/TermsIncludingScoreQuery.cs
+++ b/src/Lucene.Net.Join/TermsIncludingScoreQuery.cs
@@ -314,7 +314,7 @@ namespace Lucene.Net.Search.Join
                 } while (docId != DocIdSetIterator.NO_MORE_DOCS);
 
                 return new ComplexExplanation(true, outerInstance._scores[outerInstance._ords[_scoreUpto]],
-                    "Score based on join value " + _termsEnum.Term.Utf8ToString());
+                    "Score based on join value " + _termsEnum.Term.Utf8ToStringWithFallback()); // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
             }
         }
 

--- a/src/Lucene.Net.Misc/Misc/TermStats.cs
+++ b/src/Lucene.Net.Misc/Misc/TermStats.cs
@@ -45,7 +45,8 @@ namespace Lucene.Net.Misc
 
         public override string ToString()
         {
-            return ("TermStats: Term=" + TermText.Utf8ToString() + " DocFreq=" + DocFreq + " TotalTermFreq=" + TotalTermFreq);
+            // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
+            return "TermStats: Term=" + TermText.Utf8ToStringWithFallback() + " DocFreq=" + DocFreq + " TotalTermFreq=" + TotalTermFreq;
         }
     }
 }

--- a/src/Lucene.Net.Queries/TermsFilter.cs
+++ b/src/Lucene.Net.Queries/TermsFilter.cs
@@ -319,7 +319,7 @@ namespace Lucene.Net.Queries
                     }
                     first = false;
                     builder.Append(current.field).Append(':');
-                    builder.Append(spare.Utf8ToString());
+                    builder.Append(spare.Utf8ToStringWithFallback()); // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
                 }
             }
 

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletion.cs
@@ -59,7 +59,8 @@ namespace Lucene.Net.Search.Suggest.Fst
 
             public override string ToString()
             {
-                return Utf8.Utf8ToString() + "/" + Bucket.ToString("0.0", CultureInfo.InvariantCulture);
+                // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
+                return Utf8.Utf8ToStringWithFallback() + "/" + Bucket.ToString("0.0", CultureInfo.InvariantCulture);
             }
 
             /// <seealso cref="BytesRef.CompareTo(object)"></seealso>

--- a/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
@@ -353,7 +353,7 @@ namespace Lucene.Net.Util
         public void TestTryUTF8toUTF16()
         {
             string unicode = TestUtil.RandomRealisticUnicodeString(Random);
-            var utf8 = new BytesRef(IOUtils.CHARSET_UTF_8.GetBytes(unicode));
+            var utf8 = new BytesRef(IOUtils.ENCODING_UTF_8_NO_BOM.GetBytes(unicode));
 
             bool success = UnicodeUtil.TryUTF8toUTF16(utf8, out var chars);
 

--- a/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
@@ -339,7 +339,7 @@ namespace Lucene.Net.Util
 
             if (shouldThrow)
             {
-                Assert.Throws<ParseException>(() => UnicodeUtil.UTF8toUTF16(invalidUtf8, scratch));
+                Assert.Throws<FormatException>(() => UnicodeUtil.UTF8toUTF16(invalidUtf8, scratch));
             }
             else
             {

--- a/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
@@ -326,5 +326,18 @@ namespace Lucene.Net.Util
                 Assert.AreEqual(cRef.ToString(), unicode);
             }
         }
+
+        [Test]
+        [LuceneNetSpecific] // this is a Lucene.NET specific method
+        public void TestTryUTF8toUTF16()
+        {
+            string unicode = TestUtil.RandomRealisticUnicodeString(Random);
+            var utf8 = new BytesRef(IOUtils.CHARSET_UTF_8.GetBytes(unicode));
+
+            bool success = UnicodeUtil.TryUTF8toUTF16(utf8, out var chars);
+
+            Assert.IsTrue(success);
+            Assert.AreEqual(unicode, chars?.ToString());
+        }
     }
 }

--- a/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
@@ -339,5 +339,17 @@ namespace Lucene.Net.Util
             Assert.IsTrue(success);
             Assert.AreEqual(unicode, chars?.ToString());
         }
+
+        [Test]
+        [LuceneNetSpecific] // this is a Lucene.NET specific method
+        public void TestUTF8toUTF16WithFallback()
+        {
+            byte[] invalidUtf8 = { 0x63, 0xc3 }; // Invalid ending UTF-8 sequence
+            var scratch = new CharsRef();
+
+            UnicodeUtil.UTF8toUTF16WithFallback(invalidUtf8, scratch);
+
+            Assert.AreEqual("c\ufffd", scratch.ToString());
+        }
     }
 }

--- a/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
+++ b/src/Lucene.Net/Codecs/BlockTreeTermsWriter.cs
@@ -440,7 +440,8 @@ namespace Lucene.Net.Codecs
 
             public override string ToString()
             {
-                return Term.Utf8ToString();
+                // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
+                return Term.Utf8ToStringWithFallback();
             }
         }
 
@@ -468,7 +469,8 @@ namespace Lucene.Net.Codecs
 
             public override string ToString()
             {
-                return $"BLOCK: {Prefix.Utf8ToString()}";
+                // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
+                return $"BLOCK: {Prefix.Utf8ToStringWithFallback()}";
             }
 
             #nullable enable

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
@@ -343,7 +343,8 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                 if (DEBUG_SURROGATES)
                 {
-                    Console.WriteLine("      try seek term=" + UnicodeUtil.ToHexString(term.Utf8ToString()));
+                    // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
+                    Console.WriteLine("      try seek term=" + UnicodeUtil.ToHexString(term.Utf8ToStringWithFallback()));
                 }
 
                 // Seek "back":
@@ -487,7 +488,8 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                     if (DEBUG_SURROGATES)
                     {
-                        Console.WriteLine("    seek to term=" + UnicodeUtil.ToHexString(scratchTerm.Utf8ToString()) + " " + scratchTerm.ToString());
+                        // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
+                        Console.WriteLine("    seek to term=" + UnicodeUtil.ToHexString(scratchTerm.Utf8ToStringWithFallback()) + " " + scratchTerm.ToString());
                     }
 
                     // TODO: more efficient seek?  can we simply swap
@@ -598,10 +600,11 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                 if (DEBUG_SURROGATES)
                 {
+                    // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
                     Console.WriteLine("  dance");
-                    Console.WriteLine("    prev=" + UnicodeUtil.ToHexString(prevTerm.Utf8ToString()));
+                    Console.WriteLine("    prev=" + UnicodeUtil.ToHexString(prevTerm.Utf8ToStringWithFallback()));
                     Console.WriteLine("         " + prevTerm.ToString());
-                    Console.WriteLine("    term=" + UnicodeUtil.ToHexString(scratchTerm.Utf8ToString()));
+                    Console.WriteLine("    term=" + UnicodeUtil.ToHexString(scratchTerm.Utf8ToStringWithFallback()));
                     Console.WriteLine("         " + scratchTerm.ToString());
                 }
 
@@ -678,7 +681,8 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                         if (DEBUG_SURROGATES)
                         {
-                            Console.WriteLine("    try seek 1 pos=" + upTo + " term=" + UnicodeUtil.ToHexString(scratchTerm.Utf8ToString()) + " " + scratchTerm.ToString() + " len=" + scratchTerm.Length);
+                            // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
+                            Console.WriteLine("    try seek 1 pos=" + upTo + " term=" + UnicodeUtil.ToHexString(scratchTerm.Utf8ToStringWithFallback()) + " " + scratchTerm.ToString() + " len=" + scratchTerm.Length);
                         }
 
                         // Seek "forward":
@@ -831,7 +835,8 @@ namespace Lucene.Net.Codecs.Lucene3x
             {
                 if (DEBUG_SURROGATES)
                 {
-                    Console.WriteLine("TE.seek target=" + UnicodeUtil.ToHexString(term.Utf8ToString()));
+                    // LUCENENET specific - use Utf8ToStringWithFallback() to handle invalid UTF-8 bytes
+                    Console.WriteLine("TE.seek target=" + UnicodeUtil.ToHexString(term.Utf8ToStringWithFallback()));
                 }
                 skipNext = false;
                 TermInfosReader tis = outerInstance.TermsDict;

--- a/src/Lucene.Net/Support/ObsoleteAPI/UnicodeUtil.cs
+++ b/src/Lucene.Net/Support/ObsoleteAPI/UnicodeUtil.cs
@@ -1,0 +1,175 @@
+using Lucene.Net.Support;
+using System;
+
+#nullable enable
+
+namespace Lucene.Net.Util
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /*
+     * Some of this code came from the excellent Unicode
+     * conversion examples from:
+     *
+     *   http://www.unicode.org/Public/PROGRAMS/CVTUTF
+     *
+     * Full Copyright for that code follows:
+    */
+
+    /*
+     * Copyright 2001-2004 Unicode, Inc.
+     *
+     * Disclaimer
+     *
+     * this source code is provided as is by Unicode, Inc. No claims are
+     * made as to fitness for any particular purpose. No warranties of any
+     * kind are expressed or implied. The recipient agrees to determine
+     * applicability of information provided. If this file has been
+     * purchased on magnetic or optical media from Unicode, Inc., the
+     * sole remedy for any claim will be exchange of defective media
+     * within 90 days of receipt.
+     *
+     * Limitations on Rights to Redistribute this Code
+     *
+     * Unicode, Inc. hereby grants the right to freely use the information
+     * supplied in this file in the creation of products supporting the
+     * Unicode Standard, and to make copies of this file in any form
+     * for internal or external distribution as long as this notice
+     * remains attached.
+     */
+
+    /*
+     * Additional code came from the IBM ICU library.
+     *
+     *  http://www.icu-project.org
+     *
+     * Full Copyright for that code follows.
+     */
+
+    /*
+     * Copyright (C) 1999-2010, International Business Machines
+     * Corporation and others.  All Rights Reserved.
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining a copy
+     * of this software and associated documentation files (the "Software"), to deal
+     * in the Software without restriction, including without limitation the rights
+     * to use, copy, modify, merge, publish, distribute, and/or sell copies of the
+     * Software, and to permit persons to whom the Software is furnished to do so,
+     * provided that the above copyright notice(s) and this permission notice appear
+     * in all copies of the Software and that both the above copyright notice(s) and
+     * this permission notice appear in supporting documentation.
+     *
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+     * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN this NOTICE BE
+     * LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR
+     * ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+     * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+     * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF this SOFTWARE.
+     *
+     * Except as contained in this notice, the name of a copyright holder shall not
+     * be used in advertising or otherwise to promote the sale, use or other
+     * dealings in this Software without prior written authorization of the
+     * copyright holder.
+     */
+
+    public static partial class UnicodeUtil
+    {
+        /// <summary>
+        /// Generates char array that represents the provided input code points.
+        /// <para/>
+        /// LUCENENET specific.
+        /// </summary>
+        /// <param name="codePoints"> The code array. </param>
+        /// <param name="offset"> The start of the text in the code point array. </param>
+        /// <param name="count"> The number of code points. </param>
+        /// <returns> a char array representing the code points between offset and count. </returns>
+        // LUCENENET NOTE: This code was originally in the NewString() method.
+        // It has been refactored from the original to remove the exception throw/catch and
+        // instead proactively resizes the array instead of relying on exceptions + copy operations
+        [Obsolete("Use NewString method instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static char[] ToCharArray(int[] codePoints, int offset, int count)
+        {
+            return ToCharArray(codePoints.AsSpan(offset), count);
+        }
+
+        /// <summary>
+        /// Generates char array that represents the provided input code points.
+        /// <para/>
+        /// LUCENENET specific.
+        /// </summary>
+        /// <param name="codePoints"> The code span. </param>
+        /// <param name="count"> The number of code points. </param>
+        /// <returns> a char array representing the code points between offset and count. </returns>
+        // LUCENENET NOTE: This code was originally in the NewString() method.
+        // It has been refactored from the original to remove the exception throw/catch and
+        // instead proactively resizes the array instead of relying on exceptions + copy operations
+        [Obsolete("Use NewString method instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static char[] ToCharArray(ReadOnlySpan<int> codePoints, int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), "count must be >= 0"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+            }
+            const int countThreshold = 1024; // If the number of chars exceeds this, we count them instead of allocating count * 2
+            // LUCENENET: as a first approximation, assume each codepoint
+            // is 2 characters (since it cannot be longer than this)
+            int arrayLength = count * 2;
+            // LUCENENET: if we go over the threshold, count the number of
+            // chars we will need so we can allocate the precise amount of memory
+            if (count > countThreshold)
+            {
+                arrayLength = 0;
+                for (int r = 0; r < count; ++r)
+                {
+                    arrayLength += codePoints[r] < 0x010000 ? 1 : 2;
+                }
+                if (arrayLength < 1)
+                {
+                    arrayLength = count * 2;
+                }
+            }
+            // Initialize our array to our exact or oversized length.
+            // It is now safe to assume we have enough space for all of the characters.
+            char[] chars = new char[arrayLength];
+            int w = 0;
+            for (int r = 0; r < count; ++r)
+            {
+                int cp = codePoints[r];
+                if (cp < 0 || cp > 0x10ffff)
+                {
+                    throw new ArgumentException($"Invalid code point: {cp}", nameof(codePoints));
+                }
+                if (cp < 0x010000)
+                {
+                    chars[w++] = (char)cp;
+                }
+                else
+                {
+                    chars[w++] = (char)(LEAD_SURROGATE_OFFSET_ + (cp >> LEAD_SURROGATE_SHIFT_));
+                    chars[w++] = (char)(TRAIL_SURROGATE_MIN_VALUE + (cp & TRAIL_SURROGATE_MASK_));
+                }
+            }
+
+            var result = new char[w];
+            Arrays.Copy(chars, result, w);
+            return result;
+        }
+    }
+}

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -248,9 +248,9 @@ namespace Lucene.Net.Util
         /// resulting <see cref="string"/>.
         /// </summary>
         /// <remarks>
-        /// LUCENENET specific version that does not throw exceptions,
-        /// primarily for use in ToString() and other methods that
-        /// should not throw exceptions.
+        /// LUCENENET specific version that does not throw exceptions on invalid UTF-8,
+        /// primarily for use in ToString() and other cases that should not throw exceptions,
+        /// such as when building a message for another exception.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string Utf8ToStringWithFallback()
@@ -604,11 +604,11 @@ namespace Lucene.Net.Util
             switch (format)
             {
                 case BytesRefFormat.UTF8:
-                    try
+                    if (bytesRef.TryUtf8ToString(out var utf8String))
                     {
-                        return bytesRef.Utf8ToString();
+                        return utf8String;
                     }
-                    catch (Exception e) when (e.IsIndexOutOfBoundsException())
+                    else
                     {
                         return bytesRef.ToString();
                     }

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -243,6 +243,26 @@ namespace Lucene.Net.Util
             return @ref.ToString();
         }
 
+        #nullable enable
+        /// <summary>
+        /// Tries to interpret the stored bytes as UTF8 bytes, returning the
+        /// resulting <see cref="string"/> as an output parameter <paramref name="result"/>.
+        /// </summary>
+        /// <param name="result">The resulting string output.</param>
+        /// <returns><c>true</c> if successful, <c>false</c> otherwise.</returns>
+        public bool TryUtf8ToString([NotNullWhen(true)] out string? result)
+        {
+            if (UnicodeUtil.TryUTF8toUTF16(bytes, Offset, Length, out CharsRef? @ref))
+            {
+                result = @ref.ToString();
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+        #nullable restore
+
         /// <summary>
         /// Returns hex encoded bytes, eg [0x6c 0x75 0x63 0x65 0x6e 0x65] </summary>
         public override string ToString()

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -243,6 +243,23 @@ namespace Lucene.Net.Util
             return @ref.ToString();
         }
 
+        /// <summary>
+        /// Interprets stored bytes as UTF8 bytes, returning the
+        /// resulting <see cref="string"/>.
+        /// </summary>
+        /// <remarks>
+        /// LUCENENET specific version that does not throw exceptions,
+        /// primarily for use in ToString() and other methods that
+        /// should not throw exceptions.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public string Utf8ToStringWithFallback()
+        {
+            CharsRef @ref = new CharsRef(Length);
+            UnicodeUtil.UTF8toUTF16WithFallback(bytes, Offset, Length, @ref);
+            return @ref.ToString();
+        }
+
         #nullable enable
         /// <summary>
         /// Tries to interpret the stored bytes as UTF8 bytes, returning the

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -1,7 +1,6 @@
 using J2N;
 using J2N.Text;
 using Lucene.Net.Diagnostics;
-using Lucene.Net.Support;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -887,7 +886,7 @@ namespace Lucene.Net.Util
         /// it doesn't provide enough space to hold the worst case of each byte becoming a UTF-16 codepoint.
         /// <para/>
         /// NOTE: Full characters are read, even if this reads past the length passed (and
-        /// can result in an <see cref="IndexOutOfRangeException"/> if invalid UTF-8 is passed).
+        /// can result in an <see cref="FormatException"/> if invalid UTF-8 is passed).
         /// Explicit checks for valid UTF-8 are not performed.
         /// </summary>
         /// <seealso cref="UTF8toUTF16(ReadOnlySpan{byte}, CharsRef)"/>
@@ -902,7 +901,7 @@ namespace Lucene.Net.Util
         /// it doesn't provide enough space to hold the worst case of each byte becoming a UTF-16 codepoint.
         /// <para/>
         /// NOTE: Full characters are read, even if this reads past the length passed (and
-        /// can result in an <see cref="IndexOutOfRangeException"/> if invalid UTF-8 is passed).
+        /// can result in an <see cref="FormatException"/> if invalid UTF-8 is passed).
         /// Explicit checks for valid UTF-8 are not performed.
         /// </summary>
         /// <remarks>
@@ -927,7 +926,7 @@ namespace Lucene.Net.Util
                 {
                     if (utf8.Length <= i)
                     {
-                        throw new ParseException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}", i - 1);
+                        throw new FormatException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}");
                     }
                     @out[out_offset++] = (char)(((b & 0x1f) << 6) + (utf8[i++] & 0x3f));
                 }
@@ -935,7 +934,7 @@ namespace Lucene.Net.Util
                 {
                     if (utf8.Length <= i + 1)
                     {
-                        throw new ParseException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}", i - 1);
+                        throw new FormatException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}");
                     }
                     @out[out_offset++] = (char)(((b & 0xf) << 12) + ((utf8[i] & 0x3f) << 6) + (utf8[i + 1] & 0x3f));
                     i += 2;
@@ -944,7 +943,7 @@ namespace Lucene.Net.Util
                 {
                     if (utf8.Length <= i + 2)
                     {
-                        throw new ParseException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}", i - 1);
+                        throw new FormatException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}");
                     }
                     if (Debugging.AssertsEnabled) Debugging.Assert(b < 0xf8, "b = 0x{0:x}", b);
                     int ch = ((b & 0x7) << 18) + ((utf8[i] & 0x3f) << 12) + ((utf8[i + 1] & 0x3f) << 6) + (utf8[i + 2] & 0x3f);

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -578,20 +578,20 @@ namespace Lucene.Net.Util
                             // Valid surrogate pair
                         }
                         else
-                            // Unmatched high surrogate
                         {
+                            // Unmatched high surrogate
                             return false;
                         }
                     }
                     else
-                        // Unmatched high surrogate
                     {
+                        // Unmatched high surrogate
                         return false;
                     }
                 }
                 else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END)
-                    // Unmatched low surrogate
                 {
+                    // Unmatched low surrogate
                     return false;
                 }
             }
@@ -617,20 +617,20 @@ namespace Lucene.Net.Util
                             // Valid surrogate pair
                         }
                         else
-                            // Unmatched high surrogate
                         {
+                            // Unmatched high surrogate
                             return false;
                         }
                     }
                     else
-                        // Unmatched high surrogate
                     {
+                        // Unmatched high surrogate
                         return false;
                     }
                 }
                 else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END)
-                    // Unmatched low surrogate
                 {
+                    // Unmatched low surrogate
                     return false;
                 }
             }
@@ -657,20 +657,20 @@ namespace Lucene.Net.Util
                             // Valid surrogate pair
                         }
                         else
-                            // Unmatched high surrogate
                         {
+                            // Unmatched high surrogate
                             return false;
                         }
                     }
                     else
-                        // Unmatched high surrogate
                     {
+                        // Unmatched high surrogate
                         return false;
                     }
                 }
                 else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END)
-                    // Unmatched low surrogate
                 {
+                    // Unmatched low surrogate
                     return false;
                 }
             }
@@ -706,8 +706,8 @@ namespace Lucene.Net.Util
                     }
                 }
                 else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END)
-                    // Unmatched low surrogate
                 {
+                    // Unmatched low surrogate
                     return false;
                 }
             }

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -812,7 +812,7 @@ namespace Lucene.Net.Util
         /// <param name="count"> The number of code points. </param>
         /// <returns> a String representing the code points between offset and count. </returns>
         /// <exception cref="ArgumentException"> If an invalid code point is encountered. </exception>
-        /// <exception cref="IndexOutOfRangeException"> If the offset or count are out of bounds. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If the offset or count are out of bounds. </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string NewString(int[] codePoints, int offset, int count)
         {

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -925,15 +925,27 @@ namespace Lucene.Net.Util
                 }
                 else if (b < 0xe0)
                 {
+                    if (utf8.Length <= i)
+                    {
+                        throw new ParseException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}", i - 1);
+                    }
                     @out[out_offset++] = (char)(((b & 0x1f) << 6) + (utf8[i++] & 0x3f));
                 }
                 else if (b < 0xf0)
                 {
+                    if (utf8.Length <= i + 1)
+                    {
+                        throw new ParseException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}", i - 1);
+                    }
                     @out[out_offset++] = (char)(((b & 0xf) << 12) + ((utf8[i] & 0x3f) << 6) + (utf8[i + 1] & 0x3f));
                     i += 2;
                 }
                 else
                 {
+                    if (utf8.Length <= i + 2)
+                    {
+                        throw new ParseException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}", i - 1);
+                    }
                     if (Debugging.AssertsEnabled) Debugging.Assert(b < 0xf8, "b = 0x{0:x}", b);
                     int ch = ((b & 0x7) << 18) + ((utf8[i] & 0x3f) << 12) + ((utf8[i + 1] & 0x3f) << 6) + (utf8[i + 2] & 0x3f);
                     i += 3;

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
+#nullable enable
 
 namespace Lucene.Net.Util
 {
@@ -108,7 +109,10 @@ namespace Lucene.Net.Util
         /// <para/>
         /// WARNING: this is not a valid UTF8 Term
         /// </summary>
-        public static readonly BytesRef BIG_TERM = new BytesRef(new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }); // TODO this is unrelated here find a better place for it
+        public static readonly BytesRef BIG_TERM = new BytesRef(new byte[]
+        {
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+        }); // TODO this is unrelated here find a better place for it
 
         public const int UNI_SUR_HIGH_START = 0xD800;
         public const int UNI_SUR_HIGH_END = 0xDBFF;
@@ -121,7 +125,8 @@ namespace Lucene.Net.Util
         private const long HALF_SHIFT = 10;
         private const long HALF_MASK = 0x3FFL;
 
-        private const int SURROGATE_OFFSET = Character.MinSupplementaryCodePoint - (UNI_SUR_HIGH_START << (int)HALF_SHIFT) - UNI_SUR_LOW_START;
+        private const int SURROGATE_OFFSET = Character.MinSupplementaryCodePoint -
+                                             (UNI_SUR_HIGH_START << (int)HALF_SHIFT) - UNI_SUR_LOW_START;
 
         /// <summary>
         /// Encode characters from a <see cref="ReadOnlySpan{T}"/> (with generic type argument <see cref="char"/>) <paramref name="source"/>, starting at
@@ -149,6 +154,7 @@ namespace Lucene.Net.Util
             {
                 @out = result.Bytes = new byte[maxLen];
             }
+
             result.Offset = 0;
 
             while (i < end)
@@ -189,6 +195,7 @@ namespace Lucene.Net.Util
                             continue;
                         }
                     }
+
                     // replace unpaired surrogate or out-of-order low surrogate
                     // with substitution character
                     @out[upto++] = 0xEF;
@@ -196,12 +203,13 @@ namespace Lucene.Net.Util
                     @out[upto++] = 0xBD;
                 }
             }
+
             //assert matches(source, offset, length, out, upto);
             result.Length = upto;
         }
 
         /// <summary>
-        /// Encode characters from a <see cref="ReadOnlySpan{T}"/> (with generic type argument <see cref="char"/>) <paramref name="source"/>, starting at
+        /// Encode characters from a <see cref="T:char[]"/> <paramref name="source"/>, starting at
         /// <paramref name="offset"/> for <paramref name="length"/> chars. After encoding, <c>result.Offset</c> will always be 0.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="result"/> is <c>null</c>.</exception>
@@ -213,6 +221,31 @@ namespace Lucene.Net.Util
         /// <paramref name="offset"/> and <paramref name="length"/> refer to a location outside of <paramref name="source"/>.
         /// </exception>
         // TODO: broken if incoming result.offset != 0
+        public static void UTF16toUTF8(char[] source, int offset, int length, BytesRef result)
+        {
+            // LUCENENET: Added guard clauses
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            UTF16toUTF8(source.AsSpan(), offset, length, result);
+        }
+
+        /// <summary>
+        /// Encode characters from a <see cref="ReadOnlySpan{T}"/> (with generic type argument <see cref="char"/>) <paramref name="source"/>, starting at
+        /// <paramref name="offset"/> for <paramref name="length"/> chars. After encoding, <c>result.Offset</c> will always be 0.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="result"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="offset"/> or <paramref name="length"/> is less than zero.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="offset"/> and <paramref name="length"/> refer to a location outside of <paramref name="source"/>.
+        /// </exception>
+        /// <remarks>
+        /// LUCENENET specific overload.
+        /// </remarks>
+        // TODO: broken if incoming result.offset != 0
         public static void UTF16toUTF8(ReadOnlySpan<char> source, int offset, int length, BytesRef result)
         {
             // LUCENENET: Added guard clauses
@@ -223,7 +256,8 @@ namespace Lucene.Net.Util
             if (length < 0)
                 throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
             if (offset > source.Length - length) // Checks for int overflow
-                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
+                throw new ArgumentOutOfRangeException(nameof(length),
+                    $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
 
             int upto = 0;
             int i = offset;
@@ -235,6 +269,7 @@ namespace Lucene.Net.Util
             {
                 @out = result.Bytes = new byte[maxLen];
             }
+
             result.Offset = 0;
 
             while (i < end)
@@ -275,6 +310,7 @@ namespace Lucene.Net.Util
                             continue;
                         }
                     }
+
                     // replace unpaired surrogate or out-of-order low surrogate
                     // with substitution character
                     @out[upto++] = 0xEF;
@@ -282,6 +318,7 @@ namespace Lucene.Net.Util
                     @out[upto++] = 0xBD;
                 }
             }
+
             //assert matches(source, offset, length, out, upto);
             result.Length = upto;
         }
@@ -311,7 +348,8 @@ namespace Lucene.Net.Util
             if (length < 0)
                 throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
             if (offset > source.Length - length) // Checks for int overflow
-                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
+                throw new ArgumentOutOfRangeException(nameof(length),
+                    $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
 
             int end = offset + length;
 
@@ -362,6 +400,7 @@ namespace Lucene.Net.Util
                             continue;
                         }
                     }
+
                     // replace unpaired surrogate or out-of-order low surrogate
                     // with substitution character
                     @out[upto++] = 0xEF;
@@ -369,6 +408,7 @@ namespace Lucene.Net.Util
                     @out[upto++] = 0xBD;
                 }
             }
+
             //assert matches(s, offset, length, out, upto);
             result.Length = upto;
         }
@@ -400,7 +440,8 @@ namespace Lucene.Net.Util
             if (length < 0)
                 throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
             if (offset > source.Length - length) // Checks for int overflow
-                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
+                throw new ArgumentOutOfRangeException(nameof(length),
+                    $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
 
             int end = offset + length;
 
@@ -451,6 +492,7 @@ namespace Lucene.Net.Util
                             continue;
                         }
                     }
+
                     // replace unpaired surrogate or out-of-order low surrogate
                     // with substitution character
                     @out[upto++] = 0xEF;
@@ -458,6 +500,7 @@ namespace Lucene.Net.Util
                     @out[upto++] = 0xBD;
                 }
             }
+
             //assert matches(s, offset, length, out, upto);
             result.Length = upto;
         }
@@ -535,19 +578,19 @@ namespace Lucene.Net.Util
                             // Valid surrogate pair
                         }
                         else
-                        // Unmatched high surrogate
+                            // Unmatched high surrogate
                         {
                             return false;
                         }
                     }
                     else
-                    // Unmatched high surrogate
+                        // Unmatched high surrogate
                     {
                         return false;
                     }
                 }
                 else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END)
-                // Unmatched low surrogate
+                    // Unmatched low surrogate
                 {
                     return false;
                 }
@@ -556,7 +599,8 @@ namespace Lucene.Net.Util
             return true;
         }
 
-        public static bool ValidUTF16String(string s) // LUCENENET specific overload because string doesn't implement ICharSequence
+        public static bool
+            ValidUTF16String(string s) // LUCENENET specific overload because string doesn't implement ICharSequence
         {
             int size = s.Length;
             for (int i = 0; i < size; i++)
@@ -573,19 +617,19 @@ namespace Lucene.Net.Util
                             // Valid surrogate pair
                         }
                         else
-                        // Unmatched high surrogate
+                            // Unmatched high surrogate
                         {
                             return false;
                         }
                     }
                     else
-                    // Unmatched high surrogate
+                        // Unmatched high surrogate
                     {
                         return false;
                     }
                 }
                 else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END)
-                // Unmatched low surrogate
+                    // Unmatched low surrogate
                 {
                     return false;
                 }
@@ -594,7 +638,9 @@ namespace Lucene.Net.Util
             return true;
         }
 
-        public static bool ValidUTF16String(StringBuilder s) // LUCENENET specific overload because StringBuilder doesn't implement ICharSequence
+        public static bool
+            ValidUTF16String(
+                StringBuilder s) // LUCENENET specific overload because StringBuilder doesn't implement ICharSequence
         {
             int size = s.Length;
             for (int i = 0; i < size; i++)
@@ -611,19 +657,19 @@ namespace Lucene.Net.Util
                             // Valid surrogate pair
                         }
                         else
-                        // Unmatched high surrogate
+                            // Unmatched high surrogate
                         {
                             return false;
                         }
                     }
                     else
-                    // Unmatched high surrogate
+                        // Unmatched high surrogate
                     {
                         return false;
                     }
                 }
                 else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END)
-                // Unmatched low surrogate
+                    // Unmatched low surrogate
                 {
                     return false;
                 }
@@ -631,6 +677,8 @@ namespace Lucene.Net.Util
 
             return true;
         }
+
+        public static bool ValidUTF16String(char[] s, int size) => ValidUTF16String(s.AsSpan(), size);
 
         public static bool ValidUTF16String(ReadOnlySpan<char> s, int size)
         {
@@ -658,7 +706,7 @@ namespace Lucene.Net.Util
                     }
                 }
                 else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END)
-                // Unmatched low surrogate
+                    // Unmatched low surrogate
                 {
                     return false;
                 }
@@ -676,10 +724,13 @@ namespace Lucene.Net.Util
         /* Map UTF-8 encoded prefix byte to sequence length.  -1 (0xFF)
          * means illegal prefix.  see RFC 2279 for details */
         internal static readonly int[] utf8CodeLength = LoadUTF8CodeLength();
-        private static int[] LoadUTF8CodeLength() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+
+        private static int[]
+            LoadUTF8CodeLength() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            int v = int.MinValue;
-            return new int[] {
+            const int v = int.MinValue;
+            return new int[]
+            {
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -720,12 +771,31 @@ namespace Lucene.Net.Util
             for (; pos < limit; codePointCount++)
             {
                 int v = bytes[pos] & 0xFF;
-                if (v <   /* 0xxx xxxx */ 0x80) { pos += 1; continue; }
-                if (v >=  /* 110x xxxx */ 0xc0)
+                if (v < /* 0xxx xxxx */ 0x80)
                 {
-                    if (v < /* 111x xxxx */ 0xe0) { pos += 2; continue; }
-                    if (v < /* 1111 xxxx */ 0xf0) { pos += 3; continue; }
-                    if (v < /* 1111 1xxx */ 0xf8) { pos += 4; continue; }
+                    pos += 1;
+                    continue;
+                }
+
+                if (v >= /* 110x xxxx */ 0xc0)
+                {
+                    if (v < /* 111x xxxx */ 0xe0)
+                    {
+                        pos += 2;
+                        continue;
+                    }
+
+                    if (v < /* 1111 xxxx */ 0xf0)
+                    {
+                        pos += 3;
+                        continue;
+                    }
+
+                    if (v < /* 1111 1xxx */ 0xf8)
+                    {
+                        pos += 4;
+                        continue;
+                    }
                     // fallthrough, consider 5 and 6 byte sequences invalid.
                 }
 
@@ -756,6 +826,7 @@ namespace Lucene.Net.Util
             {
                 utf32.Int32s = new int[utf8.Length];
             }
+
             int utf32Count = 0;
             int utf8Upto = utf8.Offset;
             int[] ints = utf32.Int32s;
@@ -795,6 +866,7 @@ namespace Lucene.Net.Util
                 {
                     v = v << 6 | bytes[utf8Upto++] & 63;
                 }
+
                 ints[utf32Count++] = v;
             }
 
@@ -824,7 +896,25 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Value that all lead surrogate starts with. </summary>
-        private const int LEAD_SURROGATE_OFFSET_ = LEAD_SURROGATE_MIN_VALUE - (SUPPLEMENTARY_MIN_VALUE >> LEAD_SURROGATE_SHIFT_);
+        private const int LEAD_SURROGATE_OFFSET_ =
+            LEAD_SURROGATE_MIN_VALUE - (SUPPLEMENTARY_MIN_VALUE >> LEAD_SURROGATE_SHIFT_);
+
+        /// <summary>
+        /// Cover JDK 1.5 API. Create a String from an array of <paramref name="codePoints"/>.
+        /// </summary>
+        /// <param name="codePoints"> The code point array. </param>
+        /// <param name="offset"> The start of the text in the code point array. </param>
+        /// <param name="count"> The number of code points. </param>
+        /// <returns> a String representing the code points between offset and count. </returns>
+        /// <exception cref="ArgumentException"> If an invalid code point is encountered. </exception>
+        /// <exception cref="IndexOutOfRangeException"> If the offset or count are out of bounds. </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string NewString(int[] codePoints, int offset, int count)
+        {
+            // LUCENENET: Character.ToString() was optimized to use the stack for arrays
+            // of codepoints 256 or less, so it performs better than using ToCharArray().
+            return Character.ToString(codePoints, offset, count);
+        }
 
         /// <summary>
         /// Cover JDK 1.5 API. Create a String from a span of <paramref name="codePoints"/>.
@@ -841,6 +931,23 @@ namespace Lucene.Net.Util
             // LUCENENET: Character.ToString() was optimized to use the stack for arrays
             // of codepoints 256 or less, so it performs better than using ToCharArray().
             return Character.ToString(codePoints, offset, count);
+        }
+
+        /// <summary>
+        /// Generates char array that represents the provided input code points.
+        /// <para/>
+        /// LUCENENET specific.
+        /// </summary>
+        /// <param name="codePoints"> The code array. </param>
+        /// <param name="offset"> The start of the text in the code point array. </param>
+        /// <param name="count"> The number of code points. </param>
+        /// <returns> a char array representing the code points between offset and count. </returns>
+        // LUCENENET NOTE: This code was originally in the NewString() method (above).
+        // It has been refactored from the original to remove the exception throw/catch and
+        // instead proactively resizes the array instead of relying on exceptions + copy operations
+        public static char[] ToCharArray(int[] codePoints, int offset, int count)
+        {
+            return ToCharArray(codePoints.AsSpan(), offset, count);
         }
 
         /// <summary>
@@ -950,6 +1057,20 @@ namespace Lucene.Net.Util
         }
 
         /// <summary>
+        /// Interprets the given byte array as UTF-8 and converts to UTF-16. The <see cref="CharsRef"/> will be extended if
+        /// it doesn't provide enough space to hold the worst case of each byte becoming a UTF-16 codepoint.
+        /// <para/>
+        /// NOTE: Full characters are read, even if this reads past the length passed (and
+        /// can result in an <see cref="IndexOutOfRangeException"/> if invalid UTF-8 is passed).
+        /// Explicit checks for valid UTF-8 are not performed.
+        /// </summary>
+        // TODO: broken if chars.offset != 0
+        public static void UTF8toUTF16(byte[] utf8, int offset, int length, CharsRef chars)
+        {
+            UTF8toUTF16(utf8.AsSpan(), offset, length, chars);
+        }
+
+        /// <summary>
         /// Interprets the given byte span as UTF-8 and converts to UTF-16. The <see cref="CharsRef"/> will be extended if
         /// it doesn't provide enough space to hold the worst case of each byte becoming a UTF-16 codepoint.
         /// <para/>
@@ -958,7 +1079,7 @@ namespace Lucene.Net.Util
         /// Explicit checks for valid UTF-8 are not performed.
         /// </summary>
         /// <remarks>
-        /// LUCENENET specific: This method uses <see cref="ReadOnlySpan{T}"/> (with generic type argument <see cref="byte"/>) instead of byte[].
+        /// LUCENENET specific overload.
         /// </remarks>
         // TODO: broken if chars.offset != 0
         public static void UTF8toUTF16(ReadOnlySpan<byte> utf8, int offset, int length, CharsRef chars)
@@ -1003,7 +1124,6 @@ namespace Lucene.Net.Util
             chars.Length = out_offset - chars.Offset;
         }
 
-        #nullable enable
         /// <summary>
         /// Tries to interpret the given byte span as UTF-8 and convert to UTF-16, providing the result in a new <see cref="CharsRef"/>.
         /// <para/>
@@ -1077,7 +1197,6 @@ namespace Lucene.Net.Util
             chars = result;
             return true;
         }
-        #nullable restore
 
         /// <summary>
         /// Utility method for <see cref="UTF8toUTF16(ReadOnlySpan{byte}, int, int, CharsRef)"/> </summary>
@@ -1085,7 +1204,15 @@ namespace Lucene.Net.Util
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UTF8toUTF16(BytesRef bytesRef, CharsRef chars)
         {
-            UTF8toUTF16(bytesRef.Bytes, bytesRef.Offset, bytesRef.Length, chars);
+            UTF8toUTF16(bytesRef.Bytes.AsSpan(), bytesRef.Offset, bytesRef.Length, chars);
+        }
+
+        /// <summary>
+        /// Utility method for <see cref="TryUTF8toUTF16(ReadOnlySpan{byte}, int, int, out CharsRef)"/> </summary>
+        /// <seealso cref="TryUTF8toUTF16(ReadOnlySpan{byte}, int, int, out CharsRef)"/>
+        public static bool TryUTF8toUTF16(BytesRef bytesRef, out CharsRef? chars)
+        {
+            return TryUTF8toUTF16(bytesRef.Bytes.AsSpan(), bytesRef.Offset, bytesRef.Length, out chars);
         }
     }
 }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Various improvements to the UnicodeUtil APIs

Fixes #1024

## Description

This PR includes several changes to the UnicodeUtil APIs:

- New TryUTF8toUTF16 method added that uses the Try-method pattern common in .NET, so that it will return false if there is an incomplete UTF-8 byte sequence at the end
- UTF8toUTF16 has been updated to throw a ParseException instead of IndexOutOfRangeException if there is an incomplete UTF-8 byte sequence at the end
- New UTF8toUTF16WithFallback method that is like UTF8toUTF16 but adds the U+FFFD character to the output if there is an incomplete UTF-8 byte sequence at the end, instead of throwing
- Moved ToCharArray to the ObsoleteAPI folder as a partial class, and marked for removal in the 4.8.0 RC
- Add ReadOnlySpan overloads where applicable
- Add TryUtf8ToString and Utf8ToStringWithFallback methods on BytesRef that call the respective methods in UnicodeUtil
- Update callers where it makes sense to use these methods, such as ToString and logging/exception formatting where it doesn't make sense to throw an exception on invalid UTF-8