### PR TITLE
Overhaul TokenStream ICloseable/IDisposable Patterns, #271

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PatternAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PatternAnalyzer.cs
@@ -436,9 +436,9 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 this.offsetAtt.SetOffset(finalOffset, finalOffset);
             }
 
-            protected override void DoClose()
+            public override void Close()
             {
-                base.DoClose();
+                base.Close();
                 this.initialized = false;
             }
 
@@ -570,9 +570,9 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 return stopWords != null && stopWords.Contains(text);
             }
 
-            protected override void DoClose()
+            public override void Close()
             {
-                base.DoClose();
+                base.Close();
                 this.str = null;
             }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PatternAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PatternAnalyzer.cs
@@ -436,13 +436,10 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 this.offsetAtt.SetOffset(finalOffset, finalOffset);
             }
 
-            protected override void Dispose(bool disposing)
+            protected override void DoClose()
             {
-                base.Dispose(disposing);
-                if (disposing)
-                {
-                    this.initialized = false;
-                }
+                base.DoClose();
+                this.initialized = false;
             }
 
             public override void Reset()
@@ -573,13 +570,10 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 return stopWords != null && stopWords.Contains(text);
             }
 
-            protected override void Dispose(bool disposing)
+            protected override void DoClose()
             {
-                base.Dispose(disposing);
-                if (disposing)
-                {
-                    this.str = null;
-                }
+                base.DoClose();
+                this.str = null;
             }
 
             public override void Reset()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAndSuffixAwareTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAndSuffixAwareTokenFilter.cs
@@ -21,15 +21,15 @@ namespace Lucene.Net.Analysis.Miscellaneous
     /// <summary>
     /// Links two <see cref="PrefixAwareTokenFilter"/>.
     /// <para/>
-    /// <b>NOTE:</b> This filter might not behave correctly if used with custom 
+    /// <b>NOTE:</b> This filter might not behave correctly if used with custom
     /// <see cref="Lucene.Net.Util.IAttribute"/>s, i.e. <see cref="Lucene.Net.Util.IAttribute"/>s other than
-    /// the ones located in Lucene.Net.Analysis.TokenAttributes. 
+    /// the ones located in Lucene.Net.Analysis.TokenAttributes.
     /// </summary>
     public class PrefixAndSuffixAwareTokenFilter : TokenStream
     {
         private readonly PrefixAwareTokenFilter suffix;
 
-        public PrefixAndSuffixAwareTokenFilter(TokenStream prefix, TokenStream input, TokenStream suffix) 
+        public PrefixAndSuffixAwareTokenFilter(TokenStream prefix, TokenStream input, TokenStream suffix)
             : base(suffix)
         {
             prefix = new PrefixAwareTokenFilterAnonymousClass(this, prefix, input);
@@ -40,7 +40,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
         {
             private readonly PrefixAndSuffixAwareTokenFilter outerInstance;
 
-            public PrefixAwareTokenFilterAnonymousClass(PrefixAndSuffixAwareTokenFilter outerInstance, TokenStream prefix, TokenStream input) 
+            public PrefixAwareTokenFilterAnonymousClass(PrefixAndSuffixAwareTokenFilter outerInstance, TokenStream prefix, TokenStream input)
                 : base(prefix, input)
             {
                 this.outerInstance = outerInstance;
@@ -56,7 +56,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
         {
             private readonly PrefixAndSuffixAwareTokenFilter outerInstance;
 
-            public PrefixAwareTokenFilterAnonymousClass2(PrefixAndSuffixAwareTokenFilter outerInstance, TokenStream prefix, TokenStream suffix) 
+            public PrefixAwareTokenFilterAnonymousClass2(PrefixAndSuffixAwareTokenFilter outerInstance, TokenStream prefix, TokenStream suffix)
                 : base(prefix, suffix)
             {
                 this.outerInstance = outerInstance;
@@ -90,13 +90,10 @@ namespace Lucene.Net.Analysis.Miscellaneous
             suffix.Reset();
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            if (disposing)
-            {
-                suffix.Dispose();
-            }
-            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
+            suffix.Close();
+            base.DoClose(); // LUCENENET: Added to ensure the base class is marked closed
         }
 
         public override void End()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAndSuffixAwareTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAndSuffixAwareTokenFilter.cs
@@ -90,10 +90,9 @@ namespace Lucene.Net.Analysis.Miscellaneous
             suffix.Reset();
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
             suffix.Close();
-            base.DoClose(); // LUCENENET: Added to ensure the base class is marked closed
         }
 
         public override void End()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAwareTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAwareTokenFilter.cs
@@ -24,10 +24,10 @@ namespace Lucene.Net.Analysis.Miscellaneous
     /// <summary>
     /// Joins two token streams and leaves the last token of the first stream available
     /// to be used when updating the token values in the second stream based on that token.
-    /// 
+    ///
     /// The default implementation adds last prefix token end offset to the suffix token start and end offsets.
     /// <para/>
-    /// <b>NOTE:</b> This filter might not behave correctly if used with custom 
+    /// <b>NOTE:</b> This filter might not behave correctly if used with custom
     /// <see cref="Lucene.Net.Util.IAttribute"/>s, i.e. <see cref="Lucene.Net.Util.IAttribute"/>s other than
     /// the ones located in Lucene.Net.Analysis.TokenAttributes.
     /// </summary>
@@ -175,14 +175,11 @@ namespace Lucene.Net.Analysis.Miscellaneous
             suffix.End();
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            if (disposing)
-            {
-                prefix.Dispose();
-                suffix.Dispose();
-            }
-            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
+            prefix.Close();
+            suffix.Close();
+            base.DoClose(); // LUCENENET specific - added to ensure the base class is marked as closed
         }
 
         public override void Reset()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAwareTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PrefixAwareTokenFilter.cs
@@ -175,11 +175,10 @@ namespace Lucene.Net.Analysis.Miscellaneous
             suffix.End();
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
             prefix.Close();
             suffix.Close();
-            base.DoClose(); // LUCENENET specific - added to ensure the base class is marked as closed
         }
 
         public override void Reset()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/ClassicTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/ClassicTokenizer.cs
@@ -25,22 +25,22 @@ namespace Lucene.Net.Analysis.Standard
 
     /// <summary>
     /// A grammar-based tokenizer constructed with JFlex (and then ported to .NET)
-    /// 
+    ///
     /// <para> This should be a good tokenizer for most European-language documents:
-    /// 
+    ///
     /// <list type="bullet">
-    ///     <item><description>Splits words at punctuation characters, removing punctuation. However, a 
+    ///     <item><description>Splits words at punctuation characters, removing punctuation. However, a
     ///         dot that's not followed by whitespace is considered part of a token.</description></item>
     ///     <item><description>Splits words at hyphens, unless there's a number in the token, in which case
     ///         the whole token is interpreted as a product number and is not split.</description></item>
     ///     <item><description>Recognizes email addresses and internet hostnames as one token.</description></item>
     /// </list>
-    /// 
+    ///
     /// </para>
     /// <para>Many applications have specific tokenizer needs.  If this tokenizer does
     /// not suit your application, please consider copying this source code
     /// directory to your project and maintaining your own grammar-based tokenizer.
-    /// 
+    ///
     /// <see cref="ClassicTokenizer"/> was named <see cref="StandardTokenizer"/> in Lucene versions prior to 3.1.
     /// As of 3.1, <see cref="StandardTokenizer"/> implements Unicode text segmentation,
     /// as specified by UAX#29.
@@ -83,7 +83,7 @@ namespace Lucene.Net.Analysis.Standard
 
         /// <summary>
         /// Set the max allowed token length.  Any token longer
-        ///  than this is skipped. 
+        ///  than this is skipped.
         /// </summary>
         public int MaxTokenLength
         {
@@ -103,7 +103,7 @@ namespace Lucene.Net.Analysis.Standard
         /// </summary>
         /// <param name="matchVersion"> lucene compatibility version </param>
         /// <param name="input"> The input reader
-        /// 
+        ///
         /// See http://issues.apache.org/jira/browse/LUCENE-1068 </param>
         public ClassicTokenizer(LuceneVersion matchVersion, Reader input)
             : base(input)
@@ -112,7 +112,7 @@ namespace Lucene.Net.Analysis.Standard
         }
 
         /// <summary>
-        /// Creates a new <see cref="ClassicTokenizer"/> with a given <see cref="AttributeSource.AttributeFactory"/> 
+        /// Creates a new <see cref="ClassicTokenizer"/> with a given <see cref="AttributeSource.AttributeFactory"/>
         /// </summary>
         public ClassicTokenizer(LuceneVersion matchVersion, AttributeFactory factory, Reader input)
             : base(factory, input)
@@ -135,7 +135,7 @@ namespace Lucene.Net.Analysis.Standard
         private IOffsetAttribute offsetAtt;
         private IPositionIncrementAttribute posIncrAtt;
         private ITypeAttribute typeAtt;
-        
+
         /*
          * (non-Javadoc)
          *
@@ -193,13 +193,10 @@ namespace Lucene.Net.Analysis.Standard
             posIncrAtt.PositionIncrement = posIncrAtt.PositionIncrement + skippedPositions;
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                scanner.YyReset(m_input);
-            }
+            base.DoClose();
+            scanner.YyReset(m_input);
         }
 
         public override void Reset()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/ClassicTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/ClassicTokenizer.cs
@@ -193,9 +193,9 @@ namespace Lucene.Net.Analysis.Standard
             posIncrAtt.PositionIncrement = posIncrAtt.PositionIncrement + skippedPositions;
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
-            base.DoClose();
+            base.Close();
             scanner.YyReset(m_input);
         }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/StandardTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/StandardTokenizer.cs
@@ -30,14 +30,14 @@ namespace Lucene.Net.Analysis.Standard
     /// A grammar-based tokenizer constructed with JFlex.
     /// <para>
     /// As of Lucene version 3.1, this class implements the Word Break rules from the
-    /// Unicode Text Segmentation algorithm, as specified in 
+    /// Unicode Text Segmentation algorithm, as specified in
     /// <a href="http://unicode.org/reports/tr29/">Unicode Standard Annex #29</a>.
     /// <p/>
     /// </para>
     /// <para>Many applications have specific tokenizer needs.  If this tokenizer does
     /// not suit your application, please consider copying this source code
     /// directory to your project and maintaining your own grammar-based tokenizer.
-    /// 
+    ///
     /// </para>
     /// <para>You must specify the required <see cref="LuceneVersion"/>
     /// compatibility when creating <see cref="StandardTokenizer"/>:
@@ -58,25 +58,25 @@ namespace Lucene.Net.Analysis.Standard
         private IStandardTokenizerInterface scanner;
 
         public const int ALPHANUM = 0;
-        /// @deprecated (3.1) 
+        /// @deprecated (3.1)
         [Obsolete("(3.1)")]
         public const int APOSTROPHE = 1;
-        /// @deprecated (3.1) 
+        /// @deprecated (3.1)
         [Obsolete("(3.1)")]
         public const int ACRONYM = 2;
-        /// @deprecated (3.1) 
+        /// @deprecated (3.1)
         [Obsolete("(3.1)")]
         public const int COMPANY = 3;
         public const int EMAIL = 4;
-        /// @deprecated (3.1) 
+        /// @deprecated (3.1)
         [Obsolete("(3.1)")]
         public const int HOST = 5;
         public const int NUM = 6;
-        /// @deprecated (3.1) 
+        /// @deprecated (3.1)
         [Obsolete("(3.1)")]
         public const int CJ = 7;
 
-        /// @deprecated (3.1) 
+        /// @deprecated (3.1)
         [Obsolete("(3.1)")]
         public const int ACRONYM_DEP = 8;
 
@@ -111,7 +111,7 @@ namespace Lucene.Net.Analysis.Standard
 
         /// <summary>
         /// Set the max allowed token length.  Any token longer
-        ///  than this is skipped. 
+        ///  than this is skipped.
         /// </summary>
         public int MaxTokenLength
         {
@@ -133,7 +133,7 @@ namespace Lucene.Net.Analysis.Standard
         /// </summary>
         /// <param name="matchVersion"> Lucene compatibility version - See <see cref="StandardTokenizer"/> </param>
         /// <param name="input"> The input reader
-        /// 
+        ///
         /// See http://issues.apache.org/jira/browse/LUCENE-1068 </param>
         public StandardTokenizer(LuceneVersion matchVersion, TextReader input)
             : base(input)
@@ -142,7 +142,7 @@ namespace Lucene.Net.Analysis.Standard
         }
 
         /// <summary>
-        /// Creates a new <see cref="StandardTokenizer"/> with a given <see cref="AttributeSource.AttributeFactory"/> 
+        /// Creates a new <see cref="StandardTokenizer"/> with a given <see cref="AttributeSource.AttributeFactory"/>
         /// </summary>
         public StandardTokenizer(LuceneVersion matchVersion, AttributeFactory factory, TextReader input)
             : base(factory, input)
@@ -248,13 +248,10 @@ namespace Lucene.Net.Analysis.Standard
             posIncrAtt.PositionIncrement = posIncrAtt.PositionIncrement + skippedPositions;
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                scanner.YyReset(m_input);
-            }
+            base.DoClose();
+            scanner.YyReset(m_input);
         }
 
         public override void Reset()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/StandardTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/StandardTokenizer.cs
@@ -248,9 +248,9 @@ namespace Lucene.Net.Analysis.Standard
             posIncrAtt.PositionIncrement = posIncrAtt.PositionIncrement + skippedPositions;
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
-            base.DoClose();
+            base.Close();
             scanner.YyReset(m_input);
         }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailTokenizer.cs
@@ -214,9 +214,9 @@ namespace Lucene.Net.Analysis.Standard
             posIncrAtt.PositionIncrement = posIncrAtt.PositionIncrement + skippedPositions;
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
-            base.DoClose();
+            base.Close();
             scanner.YyReset(m_input);
         }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Standard/UAX29URLEmailTokenizer.cs
@@ -28,9 +28,9 @@ namespace Lucene.Net.Analysis.Standard
      */
 
     /// <summary>
-    /// This class implements Word Break rules from the Unicode Text Segmentation 
+    /// This class implements Word Break rules from the Unicode Text Segmentation
     /// algorithm, as specified in                 `
-    /// <a href="http://unicode.org/reports/tr29/">Unicode Standard Annex #29</a> 
+    /// <a href="http://unicode.org/reports/tr29/">Unicode Standard Annex #29</a>
     /// URLs and email addresses are also tokenized according to the relevant RFCs.
     /// <para/>
     /// Tokens produced are of the following types:
@@ -89,7 +89,7 @@ namespace Lucene.Net.Analysis.Standard
 
         /// <summary>
         /// Set the max allowed token length.  Any token longer
-        ///  than this is skipped. 
+        ///  than this is skipped.
         /// </summary>
         public int MaxTokenLength
         {
@@ -214,13 +214,10 @@ namespace Lucene.Net.Analysis.Standard
             posIncrAtt.PositionIncrement = posIncrAtt.PositionIncrement + skippedPositions;
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                scanner.YyReset(m_input);
-            }
+            base.DoClose();
+            scanner.YyReset(m_input);
         }
 
         public override void Reset()

--- a/src/Lucene.Net.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizer.cs
@@ -319,9 +319,9 @@ namespace Lucene.Net.Analysis.Wikipedia
             offsetAtt.SetOffset(CorrectOffset(start), CorrectOffset(start + termAtt.Length));
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
-            base.DoClose();
+            base.Close();
             scanner.YyReset(m_input);
         }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizer.cs
@@ -319,13 +319,10 @@ namespace Lucene.Net.Analysis.Wikipedia
             offsetAtt.SetOffset(CorrectOffset(start), CorrectOffset(start + termAtt.Length));
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                scanner.YyReset(m_input);
-            }
+            base.DoClose();
+            scanner.YyReset(m_input);
         }
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
@@ -233,13 +233,10 @@ namespace Lucene.Net.Analysis.Ja
             set => this.dotOut = value;
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                buffer.Reset(m_input);
-            }
+            base.DoClose();
+            buffer.Reset(m_input);
         }
 
         public override void Reset()

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
@@ -233,9 +233,9 @@ namespace Lucene.Net.Analysis.Ja
             set => this.dotOut = value;
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
-            base.DoClose();
+            base.Close();
             buffer.Reset(m_input);
         }
 

--- a/src/Lucene.Net.Analysis.OpenNLP/OpenNLPLemmatizerFilter.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/OpenNLPLemmatizerFilter.cs
@@ -136,11 +136,11 @@ namespace Lucene.Net.Analysis.OpenNlp
         /// <remarks>
         /// LUCENENET specific
         /// </remarks>
-        protected override void DoClose()
+        public override void Close()
         {
             sentenceTokenAttrsIter?.Dispose();
             sentenceTokenAttrsIter = null;
-            base.DoClose();
+            base.Close();
         }
     }
 }

--- a/src/Lucene.Net.Analysis.OpenNLP/OpenNLPLemmatizerFilter.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/OpenNLPLemmatizerFilter.cs
@@ -133,24 +133,14 @@ namespace Lucene.Net.Analysis.OpenNlp
         /// Releases resources used by the <see cref="OpenNLPLemmatizerFilter"/> and
         /// if overridden in a derived class, optionally releases unmanaged resources.
         /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources;
-        /// <c>false</c> to release only unmanaged resources.</param>
-
-        // LUCENENET specific
-        protected override void Dispose(bool disposing)
+        /// <remarks>
+        /// LUCENENET specific
+        /// </remarks>
+        protected override void DoClose()
         {
-            try
-            {
-                if (disposing)
-                {
-                    sentenceTokenAttrsIter?.Dispose();
-                    sentenceTokenAttrsIter = null;
-                }
-            }
-            finally
-            {
-                base.Dispose(disposing);
-            }
+            sentenceTokenAttrsIter?.Dispose();
+            sentenceTokenAttrsIter = null;
+            base.DoClose();
         }
     }
 }

--- a/src/Lucene.Net.Analysis.OpenNLP/OpenNLPTokenizer.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/OpenNLPTokenizer.cs
@@ -67,14 +67,11 @@ namespace Lucene.Net.Analysis.OpenNlp
             this.offsetAtt = AddAttribute<IOffsetAttribute>();
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                termSpans = null;
-                termNum = sentenceStart = 0;
-            }
+            base.DoClose();
+            termSpans = null;
+            termNum = sentenceStart = 0;
         }
 
         protected override void SetNextSentence(int sentenceStart, int sentenceEnd)

--- a/src/Lucene.Net.Analysis.OpenNLP/OpenNLPTokenizer.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/OpenNLPTokenizer.cs
@@ -67,9 +67,9 @@ namespace Lucene.Net.Analysis.OpenNlp
             this.offsetAtt = AddAttribute<IOffsetAttribute>();
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
-            base.DoClose();
+            base.Close();
             termSpans = null;
             termNum = sentenceStart = 0;
         }

--- a/src/Lucene.Net.Analysis.SmartCn/HMMChineseTokenizer.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/HMMChineseTokenizer.cs
@@ -99,11 +99,11 @@ namespace Lucene.Net.Analysis.Cn.Smart
         /// <remarks>
         /// LUCENENET specific
         /// </remarks>
-        protected override void DoClose()
+        public override void Close()
         {
             tokens?.Dispose(); // LUCENENET specific - dispose tokens and set to null
             tokens = null;
-            base.DoClose();
+            base.Close();
         }
     }
 }

--- a/src/Lucene.Net.Analysis.SmartCn/HMMChineseTokenizer.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/HMMChineseTokenizer.cs
@@ -94,27 +94,16 @@ namespace Lucene.Net.Analysis.Cn.Smart
         }
 
         /// <summary>
-        /// Releases resources used by the <see cref="HMMChineseTokenizer"/> and
-        /// if overridden in a derived class, optionally releases unmanaged resources.
+        /// Releases resources used by the <see cref="HMMChineseTokenizer"/>.
         /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources;
-        /// <c>false</c> to release only unmanaged resources.</param>
-
-        // LUCENENET specific
-        protected override void Dispose(bool disposing)
+        /// <remarks>
+        /// LUCENENET specific
+        /// </remarks>
+        protected override void DoClose()
         {
-            try
-            {
-                if (disposing)
-                {
-                    tokens?.Dispose(); // LUCENENET specific - dispose tokens and set to null
-                    tokens = null;
-                }
-            }
-            finally
-            {
-                base.Dispose(disposing);
-            }
+            tokens?.Dispose(); // LUCENENET specific - dispose tokens and set to null
+            tokens = null;
+            base.DoClose();
         }
     }
 }

--- a/src/Lucene.Net.Analysis.SmartCn/WordTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/WordTokenFilter.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
                     // a new sentence is available: process it.
                     tokenBuffer = wordSegmenter.SegmentSentence(termAtt.ToString(), offsetAtt.StartOffset);
                     tokenIter = tokenBuffer.GetEnumerator();
-                    /* 
+                    /*
                      * it should not be possible to have a sentence with 0 words, check just in case.
                      * returning EOS isn't the best either, but its the behavior of the original code.
                      */
@@ -90,7 +90,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
 
             // WordTokenFilter must clear attributes, as it is creating new tokens.
             ClearAttributes();
-            // There are remaining tokens from the current sentence, return the next one. 
+            // There are remaining tokens from the current sentence, return the next one.
             SegToken nextWord = tokenIter.Current;
 
             termAtt.CopyBuffer(nextWord.CharArray, 0, nextWord.CharArray.Length);
@@ -114,27 +114,16 @@ namespace Lucene.Net.Analysis.Cn.Smart
         }
 
         /// <summary>
-        /// Releases resources used by the <see cref="WordTokenFilter"/> and
-        /// if overridden in a derived class, optionally releases unmanaged resources.
+        /// Releases resources used by the <see cref="WordTokenFilter"/>.
         /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources;
-        /// <c>false</c> to release only unmanaged resources.</param>
-
-        // LUCENENET specific
-        protected override void Dispose(bool disposing)
+        /// <remarks>
+        /// LUCENENET specific
+        /// </remarks>
+        protected override void DoClose()
         {
-            try
-            {
-                if (disposing)
-                {
-                    tokenIter?.Dispose(); // LUCENENET specific - dispose tokenIter and set to null
-                    tokenIter = null;
-                }
-            }
-            finally
-            {
-                base.Dispose(disposing);
-            }
+            tokenIter?.Dispose(); // LUCENENET specific - dispose tokenIter and set to null
+            tokenIter = null;
+            base.DoClose();
         }
     }
 }

--- a/src/Lucene.Net.Analysis.SmartCn/WordTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/WordTokenFilter.cs
@@ -119,11 +119,11 @@ namespace Lucene.Net.Analysis.Cn.Smart
         /// <remarks>
         /// LUCENENET specific
         /// </remarks>
-        protected override void DoClose()
+        public override void Close()
         {
             tokenIter?.Dispose(); // LUCENENET specific - dispose tokenIter and set to null
             tokenIter = null;
-            base.DoClose();
+            base.Close();
         }
     }
 }

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTokensTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTokensTask.cs
@@ -76,7 +76,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                     continue;
                 }
 
-                using TokenStream stream = field.GetTokenStream(analyzer);
+                TokenStream stream = field.GetTokenStream(analyzer);
                 // reset the TokenStream to the first token
                 stream.Reset();
 
@@ -87,6 +87,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                     tokenCount++;
                 }
                 stream.End();
+                stream.Close();
             }
             totalTokenCount += tokenCount;
             return tokenCount;

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTokensTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/ReadTokensTask.cs
@@ -77,17 +77,25 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 }
 
                 TokenStream stream = field.GetTokenStream(analyzer);
-                // reset the TokenStream to the first token
-                stream.Reset();
-
-                ITermToBytesRefAttribute termAtt = stream.GetAttribute<ITermToBytesRefAttribute>();
-                while (stream.IncrementToken())
+                // LUCENENET specific: wrap in try/finally block
+                try
                 {
-                    termAtt.FillBytesRef();
-                    tokenCount++;
+                    // reset the TokenStream to the first token
+                    stream.Reset();
+
+                    ITermToBytesRefAttribute termAtt = stream.GetAttribute<ITermToBytesRefAttribute>();
+                    while (stream.IncrementToken())
+                    {
+                        termAtt.FillBytesRef();
+                        tokenCount++;
+                    }
+
+                    stream.End();
                 }
-                stream.End();
-                stream.Close();
+                finally
+                {
+                    stream.Close();
+                }
             }
             totalTokenCount += tokenCount;
             return tokenCount;

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/SearchTravRetHighlightTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/SearchTravRetHighlightTask.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     /// Note: This task reuses the reader if it is already open.
     /// Otherwise a reader is opened at start and closed at the end.
     /// <para/>
-    /// Takes optional multivalued, comma separated param string as: 
+    /// Takes optional multivalued, comma separated param string as:
     /// <code>
     /// size[&lt;traversal size&gt;],highlight[&lt;int&gt;],maxFrags[&lt;int&gt;],mergeContiguous[&lt;boolean&gt;],fields[name1;name2;...]
     /// </code>
@@ -110,8 +110,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             public override int DoHighlight(IndexReader reader, int doc, string field, Document document, Analyzer analyzer, string text)
             {
                 TokenStream ts = TokenSources.GetAnyTokenStream(reader, doc, field, document, analyzer);
-                TextFragment[]
-                frag = highlighter.GetBestTextFragments(ts, text, outerInstance.m_mergeContiguous, outerInstance.m_maxFrags);
+                TextFragment[] frag = highlighter.GetBestTextFragments(ts, text, outerInstance.m_mergeContiguous, outerInstance.m_maxFrags);
                 return frag != null ? frag.Length : 0;
             }
         }

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -435,7 +435,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                     initializedReaderManager = false;
                 }
                 cache?.Dispose();
-                parentStream.Dispose(); // LUCENENET specific
+                parentStream.Close(); // LUCENENET specific
             }
             finally
             {

--- a/src/Lucene.Net.Highlighter/Highlight/Highlighter.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/Highlighter.cs
@@ -328,7 +328,7 @@ namespace Lucene.Net.Search.Highlight
                     try
                     {
                         tokenStream.End();
-                        tokenStream.Dispose();
+                        tokenStream.Close();
                     }
                     catch (Exception e) when (e.IsException())
                     {

--- a/src/Lucene.Net.Highlighter/PostingsHighlight/MultiTermHighlighting.cs
+++ b/src/Lucene.Net.Highlighter/PostingsHighlight/MultiTermHighlighting.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Search.PostingsHighlight
     internal class MultiTermHighlighting
     {
         /// <summary>
-        /// Extracts all <see cref="MultiTermQuery"/>s for <paramref name="field"/>, and returns equivalent 
+        /// Extracts all <see cref="MultiTermQuery"/>s for <paramref name="field"/>, and returns equivalent
         /// automata that will match terms.
         /// </summary>
         internal static CharacterRunAutomaton[] ExtractAutomata(Query query, string field)
@@ -279,7 +279,7 @@ namespace Lucene.Net.Search.PostingsHighlight
                         }
                     }
                     stream.End();
-                    stream.Dispose();
+                    stream.Close();
                     stream = null;
                 }
                 // exhausted

--- a/src/Lucene.Net.Memory/MemoryIndex.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.cs
@@ -288,7 +288,7 @@ namespace Lucene.Net.Index.Memory
         /// <typeparam name="T">The type of item in the collection.</typeparam>
         /// <remarks>
         /// LUCENENET specific - This class originally got an enumerator in the constructor and stored it to a field
-        /// that was never reset, which meant that it could not be reused (since most IEnumerator implementations can
+        /// that was never reset, which meant that it could not be reused (since many IEnumerator implementations can
         /// only be iterated once and throw on <see cref="System.Collections.IEnumerator.Reset()"/>). This class has
         /// been modified to initialize <see cref="iter"/> on <see cref="TokenStream.Reset()"/> instead, which allows
         /// it to be reused, per the TokenStream workflow contract of allowing <see cref="TokenStream.Reset()"/> after

--- a/src/Lucene.Net.Memory/MemoryIndex.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.cs
@@ -312,27 +312,16 @@ namespace Lucene.Net.Index.Memory
             }
 
             /// <summary>
-            /// Releases resources used by the <see cref="TokenStreamAnonymousClass{T}"/> and
-            /// if overridden in a derived class, optionally releases unmanaged resources.
+            /// Releases resources used by the <see cref="TokenStreamAnonymousClass{T}"/>.
             /// </summary>
-            /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources;
-            /// <c>false</c> to release only unmanaged resources.</param>
-
-            // LUCENENET specific
-            protected override void Dispose(bool disposing)
+            /// <remarks>
+            /// LUCENENET specific
+            /// </remarks>
+            protected override void DoClose()
             {
-                try
-                {
-                    if (disposing)
-                    {
-                        iter?.Dispose(); // LUCENENET specific - dispose iter and set to null
-                        iter = null;
-                    }
-                }
-                finally
-                {
-                    base.Dispose(disposing);
-                }
+                iter?.Dispose(); // LUCENENET specific - dispose iter and set to null
+                iter = null;
+                base.DoClose();
             }
         }
 

--- a/src/Lucene.Net.Memory/MemoryIndex.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.cs
@@ -317,11 +317,15 @@ namespace Lucene.Net.Index.Memory
             /// <remarks>
             /// LUCENENET specific
             /// </remarks>
-            protected override void DoClose()
+            protected override void Dispose(bool disposing)
             {
-                iter?.Dispose(); // LUCENENET specific - dispose iter and set to null
-                iter = null;
-                base.DoClose();
+                if (disposing)
+                {
+                    iter?.Dispose(); // LUCENENET specific - dispose iter and set to null, can't be reused
+                    iter = null;
+                }
+
+                base.Dispose(disposing);
             }
         }
 

--- a/src/Lucene.Net.Memory/MemoryIndex.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.cs
@@ -269,7 +269,8 @@ namespace Lucene.Net.Index.Memory
         /// </summary>
         /// <param name="keywords"> the keywords to generate tokens for </param>
         /// <returns> the corresponding token stream </returns>
-        public virtual TokenStream KeywordTokenStream<T>(ICollection<T> keywords)
+        // LUCENENET: renamed from keywordTokenStream
+        public virtual TokenStream GetKeywordTokenStream<T>(ICollection<T> keywords)
         {
             // TODO: deprecate & move this method into AnalyzerUtil?
             if (keywords is null)
@@ -282,7 +283,7 @@ namespace Lucene.Net.Index.Memory
 
         /// <summary>
         /// An anonymous implementation of <see cref="TokenStream"/> for
-        /// <see cref="KeywordTokenStream{T}(ICollection{T})"/>.
+        /// <see cref="MemoryIndex.GetKeywordTokenStream{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of item in the collection.</typeparam>
         /// <remarks>

--- a/src/Lucene.Net.Queries/Mlt/MoreLikeThis.cs
+++ b/src/Lucene.Net.Queries/Mlt/MoreLikeThis.cs
@@ -77,11 +77,11 @@ namespace Lucene.Net.Queries.Mlt
     /// <code>
     /// IndexReader ir = ...
     /// IndexSearcher is = ...
-    /// 
+    ///
     /// MoreLikeThis mlt = new MoreLikeThis(ir);
     /// TextReader target = ... // orig source of doc you want to find similarities to
     /// Query query = mlt.Like(target);
-    /// 
+    ///
     /// Hits hits = is.Search(query);
     /// // now the usual iteration thru 'hits' - the only thing to watch for is to make sure
     /// //you ignore the doc if it matches your 'target' document, as it should be similar to itself
@@ -192,7 +192,7 @@ namespace Lucene.Net.Queries.Mlt
         public static readonly int DEFAULT_MAX_QUERY_TERMS = 25;
 
         // LUCNENENET NOTE: The following fields were made into auto-implemented properties:
-        // analyzer, minTermFreq, minDocFreq, maxDocFreq, boost, 
+        // analyzer, minTermFreq, minDocFreq, maxDocFreq, boost,
         // fieldNames, maxNumTokensParsed, minWordLen, maxWordLen,
         // maxQueryTerms, similarity
 
@@ -250,7 +250,7 @@ namespace Lucene.Net.Queries.Mlt
 
         /// <summary>
         /// Gets or Sets an analyzer that will be used to parse source doc with. The default analyzer
-        /// is not set. An analyzer is not required for generating a query with the 
+        /// is not set. An analyzer is not required for generating a query with the
         /// <see cref="Like(int)"/> method, all other 'like' methods require an analyzer.
         /// </summary>
         public Analyzer Analyzer { get; set; }
@@ -299,7 +299,7 @@ namespace Lucene.Net.Queries.Mlt
 
         /// <summary>
         /// Gets or Sets the field names that will be used when generating the 'More Like This' query.
-        /// The default field names that will be used is <see cref="DEFAULT_FIELD_NAMES"/>. 
+        /// The default field names that will be used is <see cref="DEFAULT_FIELD_NAMES"/>.
         /// Set this to null for the field names to be determined at runtime from the <see cref="IndexReader"/>
         /// provided in the constructor.
         /// </summary>
@@ -617,7 +617,7 @@ namespace Lucene.Net.Queries.Mlt
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 

--- a/src/Lucene.Net.QueryParser/Analyzing/AnalyzingQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Analyzing/AnalyzingQueryParser.cs
@@ -39,14 +39,14 @@ namespace Lucene.Net.QueryParsers.Analyzing
     /// <c>?</c> don't get removed from the search terms.
     /// <para/>
     /// <b>Warning:</b> This class should only be used with analyzers that do not use stopwords
-    /// or that add tokens. Also, several stemming analyzers are inappropriate: for example, <see cref="Analysis.De.GermanAnalyzer"/>  
-    /// will turn <c>Häuser</c> into <c>hau</c>, but <c>H?user</c> will 
+    /// or that add tokens. Also, several stemming analyzers are inappropriate: for example, <see cref="Analysis.De.GermanAnalyzer"/>
+    /// will turn <c>Häuser</c> into <c>hau</c>, but <c>H?user</c> will
     /// become <c>h?user</c> when using this parser and thus no match would be found (i.e.
-    /// using this parser will be no improvement over QueryParser in such cases). 
+    /// using this parser will be no improvement over QueryParser in such cases).
     /// </summary>
     public class AnalyzingQueryParser : Classic.QueryParser
     {
-        // gobble escaped chars or find a wildcard character 
+        // gobble escaped chars or find a wildcard character
         private readonly Regex wildcardPattern = new Regex(@"(\\.)|([?*]+)", RegexOptions.Compiled);
 
         public AnalyzingQueryParser(LuceneVersion matchVersion, string field, Analyzer analyzer)
@@ -158,7 +158,7 @@ namespace Lucene.Net.QueryParsers.Analyzing
 
         /// <summary>
         /// Returns the analyzed form for the given chunk.
-        /// 
+        ///
         /// If the analyzer produces more than one output token from the given chunk,
         /// a ParseException is thrown.
         /// </summary>
@@ -219,7 +219,7 @@ namespace Lucene.Net.QueryParsers.Analyzing
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(stream);
+                IOUtils.CloseWhileHandlingException(stream);
             }
             return analyzed;
         }

--- a/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
@@ -623,7 +623,7 @@ namespace Lucene.Net.QueryParsers.Classic
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(source);
+                IOUtils.CloseWhileHandlingException(source);
             }
         }
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/AnalyzerQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/AnalyzerQueryNodeProcessor.cs
@@ -153,7 +153,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(source);
+                    IOUtils.CloseWhileHandlingException(source);
                 }
 
                 // rewind the buffer stream

--- a/src/Lucene.Net.QueryParser/Xml/Builders/LikeThisQueryBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Xml/Builders/LikeThisQueryBuilder.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.QueryParsers.Xml.Builders
                     }
                     finally
                     {
-                        IOUtils.DisposeWhileHandlingException(ts);
+                        IOUtils.CloseWhileHandlingException(ts);
                     }
                 }
             }

--- a/src/Lucene.Net.QueryParser/Xml/Builders/SpanOrTermsBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Xml/Builders/SpanOrTermsBuilder.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.QueryParsers.Xml.Builders
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
     }

--- a/src/Lucene.Net.QueryParser/Xml/Builders/TermsFilterBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Xml/Builders/TermsFilterBuilder.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.QueryParsers.Xml.Builders
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
             return new TermsFilter(fieldName, terms);
         }

--- a/src/Lucene.Net.QueryParser/Xml/Builders/TermsQueryBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Xml/Builders/TermsQueryBuilder.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.QueryParsers.Xml.Builders
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
 
             bq.Boost = DOMUtils.GetAttribute(e, "boost", 1.0f);

--- a/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
+++ b/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
@@ -273,7 +273,7 @@ namespace Lucene.Net.Sandbox.Queries
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 

--- a/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
+++ b/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
@@ -203,10 +203,14 @@ namespace Lucene.Net.Spatial.Prefix
             /// <remarks>
             /// LUCENENET specific
             /// </remarks>
-            protected override void DoClose()
+            protected override void Dispose(bool disposing)
             {
-                iter.Dispose(); // LUCENENET specific - dispose iter
-                base.DoClose();
+                if (disposing)
+                {
+                    iter.Dispose(); // LUCENENET specific - dispose iter, can't be reused above
+                }
+
+                base.Dispose(disposing);
             }
         }
 

--- a/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
+++ b/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
@@ -197,20 +197,10 @@ namespace Lucene.Net.Spatial.Prefix
                 return false;
             }
 
-            /// <summary>
-            /// Releases resources used by the <see cref="CellTokenStream"/>.
-            /// </summary>
-            /// <remarks>
-            /// LUCENENET specific
-            /// </remarks>
-            protected override void Dispose(bool disposing)
+            public override void Close()
             {
-                if (disposing)
-                {
-                    iter.Dispose(); // LUCENENET specific - dispose iter, can't be reused above
-                }
-
-                base.Dispose(disposing);
+                iter.Dispose();
+                base.Close();
             }
         }
 

--- a/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
+++ b/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
@@ -171,11 +171,11 @@ namespace Lucene.Net.Spatial.Prefix
         /// <see cref="TokenStream.Close()"/> will dispose of the enumerator, but it can be reinitialized by calling
         /// <see cref="TokenStream.Reset()"/> again.
         /// <para />
-        /// This implementation also expects that the enumerator will support <see cref="IEnumerator{T}.Reset()"/>
+        /// This implementation also expects that the enumerator will support <see cref="System.Collections.IEnumerator.Reset()"/>
         /// to avoid unnecessary allocations. Most BCL types in .NET support this, but custom implementations may not.
         /// For this reason, anyone that overrides
         /// <see cref="SpatialPrefixTree.GetCells(Spatial4n.Shapes.IShape?,int,bool,bool)"/> must make sure to return
-        /// an implementation of <c>IList&lt;Cell&gt;</c> that supports <see cref="IEnumerator{T}.Reset()"/>.
+        /// an implementation of <c>IList&lt;Cell&gt;</c> that supports <see cref="System.Collections.IEnumerator.Reset()"/>.
         /// </remarks>
         internal sealed class CellTokenStream : TokenStream
         {

--- a/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
+++ b/src/Lucene.Net.Spatial/Prefix/PrefixTreeStrategy.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Spatial.Prefix
     /// subclasses are <see cref="RecursivePrefixTreeStrategy">RecursivePrefixTreeStrategy</see> and
     /// <see cref="TermQueryPrefixTreeStrategy">TermQueryPrefixTreeStrategy</see>.  This strategy is most effective as a fast
     /// approximate spatial search filter.
-    /// 
+    ///
     /// <h4>Characteristics:</h4>
     /// <list type="bullet">
     /// <item><description>Can index any shape; however only
@@ -60,7 +60,7 @@ namespace Lucene.Net.Spatial.Prefix
     /// it doesn't scale to large numbers of points nor is it real-time-search
     /// friendly.</description></item>
     /// </list>
-    /// 
+    ///
     /// <h4>Implementation:</h4>
     /// The <see cref="SpatialPrefixTree"/>
     /// does most of the work, for example returning
@@ -198,26 +198,15 @@ namespace Lucene.Net.Spatial.Prefix
             }
 
             /// <summary>
-            /// Releases resources used by the <see cref="CellTokenStream"/> and
-            /// if overridden in a derived class, optionally releases unmanaged resources.
+            /// Releases resources used by the <see cref="CellTokenStream"/>.
             /// </summary>
-            /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources;
-            /// <c>false</c> to release only unmanaged resources.</param>
-
-            // LUCENENET specific
-            protected override void Dispose(bool disposing)
+            /// <remarks>
+            /// LUCENENET specific
+            /// </remarks>
+            protected override void DoClose()
             {
-                try
-                {
-                    if (disposing)
-                    {
-                        iter.Dispose(); // LUCENENET specific - dispose iter
-                    }
-                }
-                finally
-                {
-                    base.Dispose(disposing);
-                }
+                iter.Dispose(); // LUCENENET specific - dispose iter
+                base.DoClose();
             }
         }
 

--- a/src/Lucene.Net.Spatial/Prefix/Tree/SpatialPrefixTree.cs
+++ b/src/Lucene.Net.Spatial/Prefix/Tree/SpatialPrefixTree.cs
@@ -180,8 +180,8 @@ namespace Lucene.Net.Spatial.Prefix.Tree
         /// <see cref="GetCells(IPoint, int, bool)"/>.
         /// <para />
         /// LUCENENET NOTE: If overriding this method, make sure to return an implementation of
-        /// <c>IList&lt;Cell&gt;</c> whose <see cref="IList{T}.GetEnumerator()"/> returns an enumerator
-        /// that supports being <see cref="IEnumerator{T}.Reset"/> without throwing an exception.
+        /// <c>IList&lt;Cell&gt;</c> whose <see cref="IEnumerable{T}.GetEnumerator()"/> returns an enumerator
+        /// that supports being <see cref="System.Collections.IEnumerator.Reset()"/> without throwing an exception.
         /// Most common .NET collection types like <see cref="List{T}"/> and <c>Cell[]</c> support this.
         /// </remarks>
         /// <param name="shape">the shape</param>

--- a/src/Lucene.Net.Spatial/Prefix/Tree/SpatialPrefixTree.cs
+++ b/src/Lucene.Net.Spatial/Prefix/Tree/SpatialPrefixTree.cs
@@ -178,6 +178,11 @@ namespace Lucene.Net.Spatial.Prefix.Tree
         /// <para/>
         /// This implementation checks if shape is a <see cref="IPoint"/> and if so returns
         /// <see cref="GetCells(IPoint, int, bool)"/>.
+        /// <para />
+        /// LUCENENET NOTE: If overriding this method, make sure to return an implementation of
+        /// <c>IList&lt;Cell&gt;</c> whose <see cref="IList{T}.GetEnumerator()"/> returns an enumerator
+        /// that supports being <see cref="IEnumerator{T}.Reset"/> without throwing an exception.
+        /// Most common .NET collection types like <see cref="List{T}"/> and <c>Cell[]</c> support this.
         /// </remarks>
         /// <param name="shape">the shape</param>
         /// <param name="detailLevel">the maximum detail level to get cells for</param>

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -45,19 +45,19 @@ namespace Lucene.Net.Search.Suggest.Analyzing
     /// Analyzes the input text and then suggests matches based
     ///  on prefix matches to any tokens in the indexed text.
     ///  This also highlights the tokens that match.
-    /// 
+    ///
     ///  <para>This suggester supports payloads.  Matches are sorted only
     ///  by the suggest weight; it would be nice to support
     ///  blended score + weight sort in the future.  This means
     ///  this suggester best applies when there is a strong
     ///  a-priori ranking of all the suggestions.
-    /// 
+    ///
     /// </para>
     ///  <para>This suggester supports contexts, however the
     ///  contexts must be valid utf8 (arbitrary binary terms will
     ///  not work).
-    /// 
-    /// @lucene.experimental 
+    ///
+    /// @lucene.experimental
     /// </para>
     /// </summary>
 
@@ -71,13 +71,13 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
         /// <summary>
         /// Field name used for the indexed text, as a
-        /// <see cref="StringField"/>, for exact lookup. 
+        /// <see cref="StringField"/>, for exact lookup.
         /// </summary>
         protected const string EXACT_TEXT_FIELD_NAME = "exacttext";
 
         /// <summary>
         /// Field name used for the indexed context, as a
-        /// <see cref="StringField"/> and a <see cref="SortedSetDocValuesField"/>, for filtering. 
+        /// <see cref="StringField"/> and a <see cref="SortedSetDocValuesField"/>, for filtering.
         /// </summary>
         protected const string CONTEXTS_FIELD_NAME = "contexts";
 
@@ -104,7 +104,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
         /// <summary>
         /// Default minimum number of leading characters before
-        ///  PrefixQuery is used (4). 
+        ///  PrefixQuery is used (4).
         /// </summary>
         public const int DEFAULT_MIN_PREFIX_CHARS = 4;
 
@@ -114,11 +114,11 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
         /// <summary>
         /// Create a new instance, loading from a previously built
-        /// <see cref="AnalyzingInfixSuggester"/> directory, if it exists. 
+        /// <see cref="AnalyzingInfixSuggester"/> directory, if it exists.
         /// This directory must be
         /// private to the infix suggester (i.e., not an external
         /// Lucene index).  Note that <see cref="Dispose()"/>
-        /// will also dispose the provided directory. 
+        /// will also dispose the provided directory.
         /// </summary>
         public AnalyzingInfixSuggester(LuceneVersion matchVersion, Directory dir, Analyzer analyzer)
             : this(matchVersion, dir, analyzer, analyzer, DEFAULT_MIN_PREFIX_CHARS)
@@ -212,13 +212,13 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
         }
 
-        /// LUCENENET specific - moved IndexWriterConfig GetIndexWriterConfig to 
+        /// LUCENENET specific - moved IndexWriterConfig GetIndexWriterConfig to
         /// <see cref="AnalyzingInfixSuggesterIndexWriterConfigFactory"/> class
         /// to allow for customizing the index writer config.
 
         /// <summary>
-        /// Subclass can override to choose a specific 
-        /// <see cref="Directory"/> implementation. 
+        /// Subclass can override to choose a specific
+        /// <see cref="Directory"/> implementation.
         /// </summary>
         protected internal virtual Directory GetDirectory(DirectoryInfo path)
         {
@@ -365,11 +365,11 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// instead if you want to replace a previous suggestion.
         /// After adding or updating a batch of new suggestions,
         /// you must call <see cref="Refresh()"/> in the end in order to
-        /// see the suggestions in <see cref="DoLookup(string, IEnumerable{BytesRef}, int, bool, bool)"/> 
+        /// see the suggestions in <see cref="DoLookup(string, IEnumerable{BytesRef}, int, bool, bool)"/>
         /// </summary>
         public virtual void Add(BytesRef text, IEnumerable<BytesRef> contexts, long weight, BytesRef payload)
         {
-            EnsureOpen();    //LUCENENET specific -Support for LUCENE - 5889.       
+            EnsureOpen();    //LUCENENET specific -Support for LUCENE - 5889.
             writer.AddDocument(BuildDocument(text, contexts, weight, payload));
         }
 
@@ -377,10 +377,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// Updates a previous suggestion, matching the exact same
         /// text as before.  Use this to change the weight or
         /// payload of an already added suggstion.  If you know
-        /// this text is not already present you can use <see cref="Add"/> 
+        /// this text is not already present you can use <see cref="Add"/>
         /// instead.  After adding or updating a batch of
         /// new suggestions, you must call <see cref="Refresh()"/> in the
-        /// end in order to see the suggestions in <see cref="DoLookup(string, IEnumerable{BytesRef}, int, bool, bool)"/> 
+        /// end in order to see the suggestions in <see cref="DoLookup(string, IEnumerable{BytesRef}, int, bool, bool)"/>
         /// </summary>
         public virtual void Update(BytesRef text, IEnumerable<BytesRef> contexts, long weight, BytesRef payload)
         {
@@ -419,7 +419,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// <summary>
         /// Reopens the underlying searcher; it's best to "batch
         /// up" many additions/updates, and then call refresh
-        /// once in the end. 
+        /// once in the end.
         /// </summary>
         public virtual void Refresh()
         {
@@ -459,7 +459,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// <summary>
         /// This is called if the last token isn't ended
         /// (e.g. user did not type a space after it).  Return an
-        /// appropriate <see cref="Query"/> clause to add to the <see cref="BooleanQuery"/>. 
+        /// appropriate <see cref="Query"/> clause to add to the <see cref="BooleanQuery"/>.
         /// </summary>
         protected internal virtual Query GetLastTokenQuery(string token)
         {
@@ -475,7 +475,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// <summary>
         /// Retrieve suggestions, specifying whether all terms
         ///  must match (<paramref name="allTermsRequired"/>) and whether the hits
-        ///  should be highlighted (<paramref name="doHighlight"/>). 
+        ///  should be highlighted (<paramref name="doHighlight"/>).
         /// </summary>
         public virtual IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, int num, bool allTermsRequired, bool doHighlight)
         {
@@ -577,7 +577,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
 
             // TODO: we could allow blended sort here, combining
@@ -692,7 +692,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
         /// <summary>
         /// Subclass can override this to tweak the Query before
-        /// searching. 
+        /// searching.
         /// </summary>
         protected internal virtual Query FinishQuery(BooleanQuery bq, bool allTermsRequired)
         {
@@ -703,7 +703,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// Override this method to customize the Object
         /// representing a single highlighted suggestions; the
         /// result is set on each <see cref="Lookup.LookupResult.HighlightKey"/>
-        /// member. 
+        /// member.
         /// </summary>
         protected internal virtual object Highlight(string text, ICollection<string> matchedTokens, string prefixToken)
         {
@@ -752,7 +752,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
@@ -37,17 +37,17 @@ namespace Lucene.Net.Search.Suggest.Analyzing
     /// thing at lookup time.  This means lookup is based on the
     /// analyzed form while suggestions are still the surface
     /// form(s).
-    /// 
+    ///
     /// <para>
     /// This can result in powerful suggester functionality.  For
-    /// example, if you use an analyzer removing stop words, 
+    /// example, if you use an analyzer removing stop words,
     /// then the partial text "ghost chr..." could see the
     /// suggestion "The Ghost of Christmas Past". Note that
     /// position increments MUST NOT be preserved for this example
-    /// to work, so you should call the constructor with 
-    /// <see cref="preservePositionIncrements"/> parameter set to 
+    /// to work, so you should call the constructor with
+    /// <see cref="preservePositionIncrements"/> parameter set to
     /// false
-    /// 
+    ///
     /// </para>
     /// <para>
     /// If SynonymFilter is used to map wifi and wireless network to
@@ -55,35 +55,35 @@ namespace Lucene.Net.Search.Suggest.Analyzing
     /// "wifi router".  Token normalization like stemmers, accent
     /// removal, etc., would allow suggestions to ignore such
     /// variations.
-    /// 
+    ///
     /// </para>
     /// <para>
     /// When two matching suggestions have the same weight, they
     /// are tie-broken by the analyzed form.  If their analyzed
     /// form is the same then the order is undefined.
-    /// 
+    ///
     /// </para>
     /// <para>
     /// There are some limitations:
     /// <list type="number">
-    /// 
+    ///
     ///   <item><description> A lookup from a query like "net" in English won't
     ///        be any different than "net " (ie, user added a
     ///        trailing space) because analyzers don't reflect
     ///        when they've seen a token separator and when they
     ///        haven't.</description></item>
-    /// 
+    ///
     ///   <item><description> If you're using <see cref="Analysis.Core.StopFilter"/>, and the user will
     ///        type "fast apple", but so far all they've typed is
     ///        "fast a", again because the analyzer doesn't convey whether
     ///        it's seen a token separator after the "a",
     ///        <see cref="Analysis.Core.StopFilter"/> will remove that "a" causing
     ///        far more matches than you'd expect.</description></item>
-    /// 
+    ///
     ///   <item><description> Lookups with the empty string return no results
     ///        instead of all results.</description></item>
     /// </list>
-    /// 
+    ///
     /// @lucene.experimental
     /// </para>
     /// </summary>
@@ -122,19 +122,19 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
         /// <summary>
         /// Represents the separation between tokens, if
-        /// <see cref="SuggesterOptions.PRESERVE_SEP"/> was specified 
+        /// <see cref="SuggesterOptions.PRESERVE_SEP"/> was specified
         /// </summary>
         private const int SEP_LABEL = '\u001F';
 
         /// <summary>
         /// Marks end of the analyzed input and start of dedup
-        ///  byte. 
+        ///  byte.
         /// </summary>
         private const int END_BYTE = 0x0;
 
         /// <summary>
         /// Maximum number of dup surface forms (different surface
-        ///  forms for the same analyzed form). 
+        ///  forms for the same analyzed form).
         /// </summary>
         private readonly int maxSurfaceFormsPerAnalyzedForm;
 
@@ -142,14 +142,14 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// Maximum graph paths to index for a single analyzed
         ///  surface form.  This only matters if your analyzer
         ///  makes lots of alternate paths (e.g. contains
-        ///  SynonymFilter). 
+        ///  SynonymFilter).
         /// </summary>
         private readonly int maxGraphExpansions;
 
         /// <summary>
         /// Highest number of analyzed paths we saw for any single
         ///  input surface form.  For analyzers that never create
-        ///  graphs this will always be 1. 
+        ///  graphs this will always be 1.
         /// </summary>
         private int maxAnalyzedPathsForOneInput;
 
@@ -307,7 +307,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
         /// <summary>
         /// Used by subclass to change the lookup automaton, if
-        ///  necessary. 
+        ///  necessary.
         /// </summary>
         protected internal virtual Automaton ConvertAutomaton(Automaton a)
         {
@@ -969,7 +969,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
 
             ReplaceSep(automaton);
@@ -999,7 +999,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
 
             // TODO: we could use the end offset to "guess"

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
@@ -763,7 +763,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -986,10 +986,6 @@ namespace Lucene.Net.Analysis
                 // LUCENENET: We are doing this in the finally block to ensure it happens
                 // when there are exceptions thrown (such as when the assert fails).
                 ts.Close();
-
-                // ... and we dispose of it because it's the last use of the token stream
-                // before being reassigned below
-                ts.Dispose();
             }
 
             // verify reusing is "reproducable" and also get the normal tokenstream sanity checks
@@ -1047,7 +1043,6 @@ namespace Lucene.Net.Analysis
                         finally
                         {
                             ts.Close();
-                            ts.Dispose();
                         }
                     }
                     else if (evilness == 7)
@@ -1080,7 +1075,6 @@ namespace Lucene.Net.Analysis
                         finally
                         {
                             ts.Close();
-                            ts.Dispose();
                         }
                     }
                 }
@@ -1185,7 +1179,6 @@ namespace Lucene.Net.Analysis
             finally
             {
                 ts.Close();
-                ts.Dispose();
             }
 
             if (field != null)

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -559,7 +559,7 @@ namespace Lucene.Net.Analysis
             try
             {
                 ts = a.GetTokenStream("bogus", new StringReader(input));
-                Assert.Fail("Didn't get expected exception when Dispose() not called");
+                Assert.Fail("Didn't get expected exception when Close() not called");
             }
             catch (Exception expected) when (expected.IsIllegalStateException())
             {

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -986,6 +986,10 @@ namespace Lucene.Net.Analysis
                 // LUCENENET: We are doing this in the finally block to ensure it happens
                 // when there are exceptions thrown (such as when the assert fails).
                 ts.Close();
+
+                // ... and we dispose of it because it's the last use of the token stream
+                // before being reassigned below
+                ts.Dispose();
             }
 
             // verify reusing is "reproducable" and also get the normal tokenstream sanity checks
@@ -1043,6 +1047,7 @@ namespace Lucene.Net.Analysis
                         finally
                         {
                             ts.Close();
+                            ts.Dispose();
                         }
                     }
                     else if (evilness == 7)
@@ -1075,6 +1080,7 @@ namespace Lucene.Net.Analysis
                         finally
                         {
                             ts.Close();
+                            ts.Dispose();
                         }
                     }
                 }
@@ -1179,6 +1185,7 @@ namespace Lucene.Net.Analysis
             finally
             {
                 ts.Close();
+                ts.Dispose();
             }
 
             if (field != null)

--- a/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Analysis
 
         // LUCENENET: The all locales may are not available for collation.
         // LUCENENET: Removed this (only) reference to the ICU library, since it has a lot of data and we don't
-        // want to unnecessarily reference it in all test projects. 
+        // want to unnecessarily reference it in all test projects.
         //protected readonly string[] availableCollationLocales = RuleBasedCollator.GetAvailableCollationLocales().ToArray();
 
         /// <summary>
@@ -154,13 +154,13 @@ namespace Lucene.Net.Analysis
         //
         // TODO: this test is really fragile. there are already 3 different cases,
         // depending upon unicode version.
-        public virtual void TestCollationKeySort(Analyzer usAnalyzer, 
-                                                Analyzer franceAnalyzer, 
-                                                Analyzer swedenAnalyzer, 
-                                                Analyzer denmarkAnalyzer, 
-                                                string usResult, 
-                                                string frResult, 
-                                                string svResult, 
+        public virtual void TestCollationKeySort(Analyzer usAnalyzer,
+                                                Analyzer franceAnalyzer,
+                                                Analyzer swedenAnalyzer,
+                                                Analyzer denmarkAnalyzer,
+                                                string usResult,
+                                                string frResult,
+                                                string svResult,
                                                 string dkResult)
         {
             using Directory indexStore = NewDirectory();
@@ -272,7 +272,7 @@ namespace Lucene.Net.Analysis
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(priorException, ts);
+                    IOUtils.CloseWhileHandlingException(priorException, ts);
                 }
             }
 
@@ -329,7 +329,7 @@ namespace Lucene.Net.Analysis
                         }
                         finally
                         {
-                            IOUtils.DisposeWhileHandlingException(priorException, ts);
+                            IOUtils.CloseWhileHandlingException(priorException, ts);
                         }
                     }
                 }

--- a/src/Lucene.Net.TestFramework/Analysis/CrankyTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/CrankyTokenFilter.cs
@@ -69,15 +69,12 @@ namespace Lucene.Net.TestFramework.Analysis
             }
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            base.Dispose(disposing);
-            if (disposing)
+            base.DoClose();
+            if (thingToDo == 3 && random.nextBoolean())
             {
-                if (thingToDo == 3 && random.nextBoolean())
-                {
-                    throw new IOException("Fake IOException from TokenStream.Dispose(bool)");
-                }
+                throw new IOException("Fake IOException from TokenStream.DoClose()");
             }
         }
     }

--- a/src/Lucene.Net.TestFramework/Analysis/CrankyTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/CrankyTokenFilter.cs
@@ -69,9 +69,9 @@ namespace Lucene.Net.TestFramework.Analysis
             }
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
-            base.DoClose();
+            base.Close();
             if (thingToDo == 3 && random.nextBoolean())
             {
                 throw new IOException("Fake IOException from TokenStream.DoClose()");

--- a/src/Lucene.Net.TestFramework/Analysis/CrankyTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/CrankyTokenFilter.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.TestFramework.Analysis
             thingToDo = random.Next(100);
             if (thingToDo == 2 && random.nextBoolean())
             {
-                throw new IOException("Fake IOException from TokenStream.Reset()");
+                throw new IOException($"Fake IOException from {nameof(TokenStream)}.{nameof(TokenStream.Reset)}()");
             }
         }
 
@@ -74,7 +74,7 @@ namespace Lucene.Net.TestFramework.Analysis
             base.Close();
             if (thingToDo == 3 && random.nextBoolean())
             {
-                throw new IOException("Fake IOException from TokenStream.DoClose()");
+                throw new IOException($"Fake IOException from {nameof(TokenStream)}.{nameof(TokenStream.Close)}()");
             }
         }
     }

--- a/src/Lucene.Net.TestFramework/Analysis/MockGraphTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockGraphTokenFilter.cs
@@ -111,9 +111,9 @@ namespace Lucene.Net.Analysis
             this.random = new J2N.Randomizer(seed);
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
-            base.DoClose();
+            base.Close();
             this.random = null;
         }
 

--- a/src/Lucene.Net.TestFramework/Analysis/MockGraphTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockGraphTokenFilter.cs
@@ -111,13 +111,10 @@ namespace Lucene.Net.Analysis
             this.random = new J2N.Randomizer(seed);
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            if (disposing)
-            {
-                base.Dispose(disposing);
-                this.random = null;
-            }
+            base.DoClose();
+            this.random = null;
         }
 
         public override bool IncrementToken()

--- a/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
@@ -305,9 +305,9 @@ namespace Lucene.Net.Analysis
             streamState = State.RESET;
         }
 
-        protected override void DoClose()
+        public override void Close()
         {
-            base.DoClose();
+            base.Close();
             // in some exceptional cases (e.g. TestIndexWriterExceptions) a test can prematurely close()
             // these tests should disable this check, by default we check the normal workflow.
             // TODO: investigate the CachingTokenFilter "double-close"... for now we ignore this

--- a/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
@@ -311,13 +311,13 @@ namespace Lucene.Net.Analysis
             // in some exceptional cases (e.g. TestIndexWriterExceptions) a test can prematurely close()
             // these tests should disable this check, by default we check the normal workflow.
             // TODO: investigate the CachingTokenFilter "double-close"... for now we ignore this
-            if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.END || streamState == State.CLOSE,"Dispose() called in wrong state: {0}", streamState);
+            if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.END || streamState == State.CLOSE, "Close() called in wrong state: {0}", streamState);
             streamState = State.CLOSE;
         }
 
         internal override bool SetReaderTestPoint()
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.CLOSE,"SetReader() called in wrong state: {0}", streamState);
+            if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.CLOSE, "SetReader() called in wrong state: {0}", streamState);
             streamState = State.SETREADER;
             return true;
         }

--- a/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockTokenizer.cs
@@ -305,17 +305,14 @@ namespace Lucene.Net.Analysis
             streamState = State.RESET;
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                // in some exceptional cases (e.g. TestIndexWriterExceptions) a test can prematurely close()
-                // these tests should disable this check, by default we check the normal workflow.
-                // TODO: investigate the CachingTokenFilter "double-close"... for now we ignore this
-                if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.END || streamState == State.CLOSE,"Dispose() called in wrong state: {0}", streamState);
-                streamState = State.CLOSE;
-            }
+            base.DoClose();
+            // in some exceptional cases (e.g. TestIndexWriterExceptions) a test can prematurely close()
+            // these tests should disable this check, by default we check the normal workflow.
+            // TODO: investigate the CachingTokenFilter "double-close"... for now we ignore this
+            if (Debugging.AssertsEnabled) Debugging.Assert(!enableChecks || streamState == State.END || streamState == State.CLOSE,"Dispose() called in wrong state: {0}", streamState);
+            streamState = State.CLOSE;
         }
 
         internal override bool SetReaderTestPoint()

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cn/TestChineseTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Cn/TestChineseTokenizer.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Analysis.Cn
      * limitations under the License.
      */
 
-    /// @deprecated Remove this test when ChineseAnalyzer is removed. 
+    /// @deprecated Remove this test when ChineseAnalyzer is removed.
     [Obsolete("Remove this test when ChineseAnalyzer is removed.")]
     public class TestChineseTokenizer : BaseTokenStreamTestCase
     {
@@ -47,7 +47,7 @@ namespace Lucene.Net.Analysis.Cn
                 correctEndOffset++;
             }
             tokenizer.End();
-            tokenizer.Dispose();
+            tokenizer.Close();
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace Lucene.Net.Analysis.Cn
         /*
          * ChineseTokenizer tokenizes english similar to SimpleAnalyzer.
          * it will lowercase terms automatically.
-         * 
+         *
          * ChineseFilter has an english stopword list, it also removes any single character tokens.
          * the stopword list is case-sensitive.
          */

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Commongrams/CommonGramsFilterTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Commongrams/CommonGramsFilterTest.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Analysis.CommonGrams
             assertEquals("the", term.ToString());
             assertTrue(cgf.IncrementToken());
             assertEquals("the_s", term.ToString());
-            cgf.Dispose();
+            cgf.Close();
 
             wt.SetReader(new StringReader(input));
             cgf.Reset();
@@ -70,7 +70,7 @@ namespace Lucene.Net.Analysis.CommonGrams
             assertEquals("How_the", term.ToString());
             assertTrue(nsf.IncrementToken());
             assertEquals("the_s", term.ToString());
-            nsf.Dispose();
+            nsf.Close();
 
             wt.SetReader(new StringReader(input));
             nsf.Reset();
@@ -86,7 +86,7 @@ namespace Lucene.Net.Analysis.CommonGrams
         /// tokens/positions in)
         /// "foo bar the"=>"foo:1|bar:2,bar-the:2|the:3=> "foo" "bar-the" (2 tokens
         /// out)
-        /// 
+        ///
         /// </summary>
         [Test]
         public virtual void TestCommonGramsQueryFilter()

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Compound/TestCompoundWordTokenFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Compound/TestCompoundWordTokenFilter.cs
@@ -147,7 +147,7 @@ namespace Lucene.Net.Analysis.Compound
             assertTrue(tf.IncrementToken());
             assertEquals("Rind", termAtt.ToString());
             tf.End();
-            tf.Dispose();
+            tf.Close();
             wsTokenizer.SetReader(new StringReader("Rindfleischüberwachungsgesetz"));
             tf.Reset();
             assertTrue(tf.IncrementToken());

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
@@ -261,9 +261,9 @@ namespace Lucene.Net.Analysis.Core
                 Console.WriteLine(m_input.GetType().Name + ".end()");
             }
 
-            protected override void DoClose()
+            public override void Close()
             {
-                base.DoClose();
+                base.Close();
                 Console.WriteLine(m_input.GetType().Name + ".close()");
             }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
@@ -246,7 +246,7 @@ namespace Lucene.Net.Analysis.Core
             {
                 if (m_input.IncrementToken())
                 {
-                    Console.WriteLine(m_input.GetType().Name + "->" + this.ReflectAsString(false));
+                    Console.WriteLine($"{m_input.GetType().Name}->{this.ReflectAsString(false)}");
                     return true;
                 }
                 else
@@ -258,19 +258,19 @@ namespace Lucene.Net.Analysis.Core
             public override void End()
             {
                 base.End();
-                Console.WriteLine(m_input.GetType().Name + ".end()");
+                Console.WriteLine($"{m_input.GetType().Name}.{nameof(End)}()");
             }
 
             public override void Close()
             {
                 base.Close();
-                Console.WriteLine(m_input.GetType().Name + ".close()");
+                Console.WriteLine($"{m_input.GetType().Name}.{nameof(Close)}()");
             }
 
             public override void Reset()
             {
                 base.Reset();
-                Console.WriteLine(m_input.GetType().Name + ".reset()");
+                Console.WriteLine($"{m_input.GetType().Name}.{nameof(Reset)}()");
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestBugInSomething.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Analysis.Core
             {
                 reader = new MockCharFilter(reader, 0);
                 reader = new MappingCharFilter(map, reader);
-                return reader;            
+                return reader;
             });
             CheckAnalysisConsistency(Random, a, false, "wmgddzunizdomqyj");
         }
@@ -261,13 +261,10 @@ namespace Lucene.Net.Analysis.Core
                 Console.WriteLine(m_input.GetType().Name + ".end()");
             }
 
-            protected override void Dispose(bool disposing)
+            protected override void DoClose()
             {
-                base.Dispose(disposing);
-                if (disposing)
-                {
-                    Console.WriteLine(m_input.GetType().Name + ".close()");
-                }
+                base.DoClose();
+                Console.WriteLine(m_input.GetType().Name + ".close()");
             }
 
             public override void Reset()

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestDuelingAnalyzers.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestDuelingAnalyzers.cs
@@ -28,9 +28,9 @@ namespace Lucene.Net.Analysis.Core
      */
 
     /// <summary>
-    /// Compares MockTokenizer (which is simple with no optimizations) with equivalent 
+    /// Compares MockTokenizer (which is simple with no optimizations) with equivalent
     /// core tokenizers (that have optimizations like buffering).
-    /// 
+    ///
     /// Any tests here need to probably consider unicode version of the JRE (it could
     /// cause false fails).
     /// </summary>
@@ -195,8 +195,8 @@ namespace Lucene.Net.Analysis.Core
             left.End();
             right.End();
             assertEquals("wrong final offset for input: " + s, leftOffset.EndOffset, rightOffset.EndOffset);
-            left.Dispose();
-            right.Dispose();
+            left.Close();
+            right.Close();
         }
 
         // TODO: maybe push this out to TestUtil or LuceneTestCase and always use it instead?

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestKeywordAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestKeywordAnalyzer.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Analysis.Core
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(stream);
+                IOUtils.CloseWhileHandlingException(stream);
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -1150,7 +1150,7 @@ namespace Lucene.Net.Analysis.Core
         }
 
         [Test]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
+        //[AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
         public void TestRandomChains_()
         {
             int numIterations = AtLeast(20);
@@ -1177,7 +1177,7 @@ namespace Lucene.Net.Analysis.Core
 
         // we might regret this decision...
         [Test]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
+        //[AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
         public void TestRandomChainsWithLargeStrings()
         {
             int numIterations = AtLeast(20);

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -1150,7 +1150,7 @@ namespace Lucene.Net.Analysis.Core
         }
 
         [Test]
-        //[AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
+        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
         public void TestRandomChains_()
         {
             int numIterations = AtLeast(20);
@@ -1177,7 +1177,7 @@ namespace Lucene.Net.Analysis.Core
 
         // we might regret this decision...
         [Test]
-        //[AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
+        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
         public void TestRandomChainsWithLargeStrings()
         {
             int numIterations = AtLeast(20);

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopAnalyzer.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Analysis.Core
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(stream);
+                IOUtils.CloseWhileHandlingException(stream);
             }
         }
 
@@ -86,7 +86,7 @@ namespace Lucene.Net.Analysis.Core
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(stream);
+                IOUtils.CloseWhileHandlingException(stream);
             }
         }
 
@@ -116,7 +116,7 @@ namespace Lucene.Net.Analysis.Core
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(stream);
+                IOUtils.CloseWhileHandlingException(stream);
             }
         }
     }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestStopFilter.cs
@@ -151,7 +151,7 @@ namespace Lucene.Net.Analysis.Core
             }
             assertFalse(stpf.IncrementToken());
             stpf.End();
-            stpf.Dispose();
+            stpf.Close();
         }
 
         // print debug info depending on VERBOSE

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestTypeTokenFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestTypeTokenFilter.cs
@@ -76,7 +76,7 @@ namespace Lucene.Net.Analysis.Core
             reader = new StringReader(sb.ToString());
             typeTokenFilter =
 #pragma warning disable 612, 618
-                new TypeTokenFilter(LuceneVersion.LUCENE_43, 
+                new TypeTokenFilter(LuceneVersion.LUCENE_43,
 #pragma warning restore 612, 618
                     false, new StandardTokenizer(TEST_VERSION_CURRENT, reader), stopSet);
             TestPositons(typeTokenFilter);
@@ -96,7 +96,7 @@ namespace Lucene.Net.Analysis.Core
                 assertEquals("if position increment is enabled the positionIncrementAttribute value should be 3, otherwise 1", posIncrAtt.PositionIncrement, enablePositionIncrements ? 3 : 1);
             }
             stpf.End();
-            stpf.Dispose();
+            stpf.Close();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCodepointCountFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestCodepointCountFilter.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 stream.Reset();
                 assertEquals(expected, stream.IncrementToken());
                 stream.End();
-                stream.Dispose();
+                stream.Close();
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestEmptyTokenStream.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestEmptyTokenStream.cs
@@ -33,12 +33,12 @@ namespace Lucene.Net.Analysis.Miscellaneous
             ts.Reset();
             assertFalse(ts.IncrementToken());
             ts.End();
-            ts.Dispose();
+            ts.Close();
             // try again with reuse:
             ts.Reset();
             assertFalse(ts.IncrementToken());
             ts.End();
-            ts.Dispose();
+            ts.Close();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestPerFieldAnalyzerWrapper.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestPerFieldAnalyzerWrapper.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(tokenStream);
+                IOUtils.CloseWhileHandlingException(tokenStream);
             }
 
             tokenStream = analyzer.GetTokenStream("special", text);
@@ -69,7 +69,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(tokenStream);
+                IOUtils.CloseWhileHandlingException(tokenStream);
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Pattern/TestPatternTokenizer.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Analysis.Pattern
                 termAtt.SetEmpty().Append("bogusTerm");
             }
 
-            @in.Dispose();
+            @in.Close();
             return @out.ToString();
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Payloads/DelimitedPayloadTokenFilterTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Payloads/DelimitedPayloadTokenFilterTest.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Analysis.Payloads
             AssertTermEquals("dogs", filter, termAtt, payAtt, "NN".getBytes(Encoding.UTF8));
             assertFalse(filter.IncrementToken());
             filter.End();
-            filter.Dispose();
+            filter.Close();
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace Lucene.Net.Analysis.Payloads
             AssertTermEquals("dogs", filter, "NN".getBytes(Encoding.UTF8));
             assertFalse(filter.IncrementToken());
             filter.End();
-            filter.Dispose();
+            filter.Close();
         }
 
 
@@ -93,7 +93,7 @@ namespace Lucene.Net.Analysis.Payloads
             AssertTermEquals("dogs", filter, termAtt, payAtt, PayloadHelper.EncodeSingle(83.7f));
             assertFalse(filter.IncrementToken());
             filter.End();
-            filter.Dispose();
+            filter.Close();
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace Lucene.Net.Analysis.Payloads
             AssertTermEquals("dogs", filter, termAtt, payAtt, PayloadHelper.EncodeInt32(83));
             assertFalse(filter.IncrementToken());
             filter.End();
-            filter.Dispose();
+            filter.Close();
         }
 
         internal virtual void AssertTermEquals(string expected, TokenStream stream, byte[] expectPay)

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Payloads/TestDelimitedPayloadTokenFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Payloads/TestDelimitedPayloadTokenFilterFactory.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Analysis.Payloads
                 assertEquals(0.1f, payFloat, 0.0f);
             }
             stream.End();
-            stream.Dispose();
+            stream.Close();
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace Lucene.Net.Analysis.Payloads
                 assertEquals(0.1f, payFloat, 0.0f);
             }
             stream.End();
-            stream.Dispose();
+            stream.Close();
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Shingle/ShingleAnalyzerWrapperTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Shingle/ShingleAnalyzerWrapperTest.cs
@@ -110,7 +110,7 @@ namespace Lucene.Net.Analysis.Shingle
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
 
             ScoreDoc[] hits = searcher.Search(q, null, 1000).ScoreDocs;
@@ -143,7 +143,7 @@ namespace Lucene.Net.Analysis.Shingle
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
 
             ScoreDoc[] hits = searcher.Search(q, null, 1000).ScoreDocs;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
@@ -150,7 +150,7 @@ namespace Lucene.Net.Analysis.Synonym
                 }
             }
             tokensOut.End();
-            tokensOut.Dispose();
+            tokensOut.Close();
             if (Verbose)
             {
                 Console.WriteLine("  incr: END");
@@ -229,7 +229,7 @@ namespace Lucene.Net.Analysis.Synonym
             assertTrue(tokensIn.IncrementToken());
             assertFalse(tokensIn.IncrementToken());
             tokensIn.End();
-            tokensIn.Dispose();
+            tokensIn.Close();
 
             tokensOut = new SynonymFilter(tokensIn, b.Build(), true);
             termAtt = tokensOut.AddAttribute<ICharTermAttribute>();
@@ -482,7 +482,7 @@ namespace Lucene.Net.Analysis.Synonym
             assertTrue(tokensIn.IncrementToken());
             assertFalse(tokensIn.IncrementToken());
             tokensIn.End();
-            tokensIn.Dispose();
+            tokensIn.Close();
 
             tokensOut = new SynonymFilter(tokensIn, b.Build(), true);
             termAtt = tokensOut.AddAttribute<ICharTermAttribute>();
@@ -724,7 +724,7 @@ namespace Lucene.Net.Analysis.Synonym
             assertTrue(tokensIn.IncrementToken());
             assertFalse(tokensIn.IncrementToken());
             tokensIn.End();
-            tokensIn.Dispose();
+            tokensIn.Close();
 
             tokensOut = new SynonymFilter(tokensIn, b.Build(), true);
             termAtt = tokensOut.AddAttribute<ICharTermAttribute>();
@@ -861,7 +861,7 @@ namespace Lucene.Net.Analysis.Synonym
             assertTrue(tokensIn.IncrementToken());
             assertFalse(tokensIn.IncrementToken());
             tokensIn.End();
-            tokensIn.Dispose();
+            tokensIn.Close();
 
             tokensOut = new SynonymFilter(tokensIn, b.Build(), true);
             termAtt = tokensOut.AddAttribute<ICharTermAttribute>();

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Th/TestThaiAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Th/TestThaiAnalyzer.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Analysis.Th
 
     /// <summary>
     /// Test case for ThaiAnalyzer, modified from TestFrenchAnalyzer
-    /// 
+    ///
     /// </summary>
 
     public class TestThaiAnalyzer : BaseTokenStreamTestCase
@@ -74,7 +74,7 @@ namespace Lucene.Net.Analysis.Th
 
         /// <summary>
         /// Thai numeric tokens were typed as <ALPHANUM> instead of <NUM>. </summary>
-        /// @deprecated (3.1) testing backwards behavior 
+        /// @deprecated (3.1) testing backwards behavior
         [Test]
         [Obsolete("(3.1) testing backwards behavior")]
         public virtual void TestBuggyTokenType30()
@@ -82,7 +82,7 @@ namespace Lucene.Net.Analysis.Th
             AssertAnalyzesTo(new ThaiAnalyzer(LuceneVersion.LUCENE_30), "การที่ได้ต้องแสดงว่างานดี ๑๒๓", new string[] { "การ", "ที่", "ได้", "ต้อง", "แสดง", "ว่า", "งาน", "ดี", "๑๒๓" }, new string[] { "<ALPHANUM>", "<ALPHANUM>", "<ALPHANUM>", "<ALPHANUM>", "<ALPHANUM>", "<ALPHANUM>", "<ALPHANUM>", "<ALPHANUM>", "<ALPHANUM>" });
         }
 
-        /// @deprecated (3.1) testing backwards behavior 
+        /// @deprecated (3.1) testing backwards behavior
         [Test]
         [Obsolete("(3.1) testing backwards behavior")]
         public virtual void TestAnalyzer30()
@@ -166,7 +166,7 @@ namespace Lucene.Net.Analysis.Th
             AssertAnalyzesTo(analyzer, "บริษัทชื่อ XY&Z - คุยกับ xyz@demo.com", new string[] { "บริษัท", "ชื่อ", "xy", "z", "คุย", "กับ", "xyz", "demo.com" });
         }
 
-        /// @deprecated (3.1) for version back compat 
+        /// @deprecated (3.1) for version back compat
         [Test]
         [Obsolete("(3.1) for version back compat")]
         public virtual void TestReusableTokenStream30()
@@ -259,10 +259,10 @@ namespace Lucene.Net.Analysis.Th
             JCG.List<int> startOffsets = new JCG.List<int>();
             JCG.List<int> endOffsets = new JCG.List<int>();
 
-            TokenStream ts;
             TextReader reader = new StringReader(text);
+            TokenStream ts = analyzer.GetTokenStream("dummy", reader);
 
-            using (ts = analyzer.GetTokenStream("dummy", reader))
+            try
             {
                 bool isReset = false;
                 try
@@ -303,12 +303,19 @@ namespace Lucene.Net.Analysis.Th
                             // ignore
                         }
                     }
-                    ts.End(); // ts.end();
+
+                    ts.End();
                 }
-            } // ts.Dispose()
+            }
+            finally
+            {
+                ts.Close();
+            }
 
             reader = new StringReader(text);
-            using (ts = analyzer.GetTokenStream("dummy", reader))
+            ts = analyzer.GetTokenStream("dummy", reader);
+
+            try
             {
                 bool isReset = false;
                 try
@@ -346,11 +353,14 @@ namespace Lucene.Net.Analysis.Th
                             // ignore
                         }
                     }
-                    ts.End(); // ts.end();
+                    ts.End();
                 }
             }
-
-        } // ts.Dispose()
+            finally
+            {
+                ts.Close();
+            }
+        }
 
 
         /// <summary>
@@ -364,7 +374,7 @@ namespace Lucene.Net.Analysis.Th
 
         /// <summary>
         /// blast some random large strings through the analyzer </summary>
-        /// 
+        ///
         [Test]
         [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/269")] // LUCENENET TODO: this test occasionally fails
         public virtual void TestRandomHugeStrings()
@@ -383,7 +393,7 @@ namespace Lucene.Net.Analysis.Th
             // just consume
             TokenStream ts = analyzer.GetTokenStream("dummy", "ภาษาไทย");
             AssertTokenStreamContents(ts, new string[] { "ภาษา", "ไทย" });
-            // this consumer adds flagsAtt, which this analyzer does not use. 
+            // this consumer adds flagsAtt, which this analyzer does not use.
             ts = analyzer.GetTokenStream("dummy", "ภาษาไทย");
             ts.AddAttribute<IFlagsAttribute>();
             AssertTokenStreamContents(ts, new string[] { "ภาษา", "ไทย" });

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharTokenizers.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharTokenizers.cs
@@ -145,7 +145,7 @@ namespace Lucene.Net.Analysis.Util
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(ts);
+                    IOUtils.CloseWhileHandlingException(ts);
                 }
             }
             // just for fun
@@ -208,7 +208,7 @@ namespace Lucene.Net.Analysis.Util
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(ts);
+                    IOUtils.CloseWhileHandlingException(ts);
                 }
             }
             // just for fun

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestElision.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestElision.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Analysis.Util
                 tas.Add(termAtt.ToString());
             }
             filter.End();
-            filter.Dispose();
+            filter.Close();
             return tas;
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizerTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Wikipedia/WikipediaTokenizerTest.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Analysis.Wikipedia
 
     /// <summary>
     /// Basic Tests for <seealso cref="WikipediaTokenizer"/>
-    /// 
+    ///
     /// </summary>
     public class WikipediaTokenizerTest : BaseTokenStreamTestCase
     {
@@ -107,7 +107,7 @@ namespace Lucene.Net.Analysis.Wikipedia
                 assertEquals("flags " + i, expectedFlags[i], flagsAtt.Flags);
             }
             assertFalse(tf.IncrementToken());
-            tf.Dispose();
+            tf.Close();
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/Segmentation/TestICUTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/Segmentation/TestICUTokenizer.cs
@@ -157,7 +157,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         }
 
         [Test]
-        public void TestMyanmar() 
+        public void TestMyanmar()
         {
             AssertAnalyzesTo(a, "သက်ဝင်လှုပ်ရှားစေပြီး", new String[] { "သက်ဝင်", "လှုပ်ရှား", "စေ", "ပြီး" });
         }
@@ -339,17 +339,25 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         [Test]
         public void TestTokenAttributes()
         {
-            using TokenStream ts = a.GetTokenStream("dummy", "This is a test");
-            IScriptAttribute scriptAtt = ts.AddAttribute<IScriptAttribute>();
-            ts.Reset();
-            while (ts.IncrementToken())
+            TokenStream ts = a.GetTokenStream("dummy", "This is a test");
+            try
             {
-                assertEquals(UScript.Latin, scriptAtt.Code);
-                assertEquals(UScript.GetName(UScript.Latin), scriptAtt.GetName());
-                assertEquals(UScript.GetShortName(UScript.Latin), scriptAtt.GetShortName());
-                assertTrue(ts.ReflectAsString(false).Contains("script=Latin"));
+                IScriptAttribute scriptAtt = ts.AddAttribute<IScriptAttribute>();
+                ts.Reset();
+                while (ts.IncrementToken())
+                {
+                    assertEquals(UScript.Latin, scriptAtt.Code);
+                    assertEquals(UScript.GetName(UScript.Latin), scriptAtt.GetName());
+                    assertEquals(UScript.GetShortName(UScript.Latin), scriptAtt.GetShortName());
+                    assertTrue(ts.ReflectAsString(false).Contains("script=Latin"));
+                }
+
+                ts.End();
             }
-            ts.End();
+            finally
+            {
+                IOUtils.CloseWhileHandlingException(ts);
+            }
         }
 
         private sealed class ThreadAnonymousClass : ThreadJob

--- a/src/Lucene.Net.Tests.Analysis.ICU/Collation/TestICUCollationKeyFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Collation/TestICUCollationKeyFilterFactory.cs
@@ -46,8 +46,8 @@ namespace Lucene.Net.Collation
         [Test]
         public void TestBasicUsage()
         {
-            String turkishUpperCase = "I WİLL USE TURKİSH CASING";
-            String turkishLowerCase = "ı will use turkish casıng";
+            string turkishUpperCase = "I WİLL USE TURKİSH CASING";
+            string turkishLowerCase = "ı will use turkish casıng";
             TokenFilterFactory factory = tokenFilterFactory("ICUCollationKey",
                 "locale", "tr",
                 "strength", "primary");
@@ -64,8 +64,8 @@ namespace Lucene.Net.Collation
         [Test]
         public void TestNormalization()
         {
-            String turkishUpperCase = "I W\u0049\u0307LL USE TURKİSH CASING";
-            String turkishLowerCase = "ı will use turkish casıng";
+            string turkishUpperCase = "I W\u0049\u0307LL USE TURKİSH CASING";
+            string turkishLowerCase = "ı will use turkish casıng";
             TokenFilterFactory factory = tokenFilterFactory("ICUCollationKey",
             "locale", "tr",
             "strength", "primary",
@@ -83,8 +83,8 @@ namespace Lucene.Net.Collation
         [Test]
         public void TestSecondaryStrength()
         {
-            String upperCase = "TESTING";
-            String lowerCase = "testing";
+            string upperCase = "TESTING";
+            string lowerCase = "testing";
             TokenFilterFactory factory = tokenFilterFactory("ICUCollationKey",
                 "locale", "en",
                 "strength", "secondary",
@@ -98,13 +98,13 @@ namespace Lucene.Net.Collation
 
         /*
          * Setting alternate=shifted to shift whitespace, punctuation and symbols
-         * to quaternary level 
+         * to quaternary level
          */
         [Test]
         public void TestIgnorePunctuation()
         {
-            String withPunctuation = "foo-bar";
-            String withoutPunctuation = "foo bar";
+            string withPunctuation = "foo-bar";
+            string withoutPunctuation = "foo bar";
             TokenFilterFactory factory = tokenFilterFactory("ICUCollationKey",
                 "locale", "en",
                 "strength", "primary",
@@ -117,15 +117,15 @@ namespace Lucene.Net.Collation
         }
 
         /*
-         * Setting alternate=shifted and variableTop to shift whitespace, but not 
-         * punctuation or symbols, to quaternary level 
+         * Setting alternate=shifted and variableTop to shift whitespace, but not
+         * punctuation or symbols, to quaternary level
          */
         [Test]
         public void TestIgnoreWhitespace()
         {
-            String withSpace = "foo bar";
-            String withoutSpace = "foobar";
-            String withPunctuation = "foo-bar";
+            string withSpace = "foo bar";
+            string withoutSpace = "foobar";
+            string withPunctuation = "foo-bar";
             TokenFilterFactory factory = tokenFilterFactory("ICUCollationKey",
                 "locale", "en",
                 "strength", "primary",
@@ -151,8 +151,8 @@ namespace Lucene.Net.Collation
         [Test]
         public void TestNumerics()
         {
-            String nine = "foobar-9";
-            String ten = "foobar-10";
+            string nine = "foobar-9";
+            string ten = "foobar-10";
             TokenFilterFactory factory = tokenFilterFactory("ICUCollationKey",
                 "locale", "en",
                 "numeric", "true");
@@ -170,10 +170,10 @@ namespace Lucene.Net.Collation
         [Test]
         public void TestIgnoreAccentsButNotCase()
         {
-            String withAccents = "résumé";
-            String withoutAccents = "resume";
-            String withAccentsUpperCase = "Résumé";
-            String withoutAccentsUpperCase = "Resume";
+            string withAccents = "résumé";
+            string withoutAccents = "resume";
+            string withAccentsUpperCase = "Résumé";
+            string withoutAccentsUpperCase = "Resume";
             TokenFilterFactory factory = tokenFilterFactory("ICUCollationKey",
                 "locale", "en",
                 "strength", "primary",
@@ -205,8 +205,8 @@ namespace Lucene.Net.Collation
         [Test]
         public void TestUpperCaseFirst()
         {
-            String lower = "resume";
-            String upper = "Resume";
+            string lower = "resume";
+            string upper = "Resume";
             TokenFilterFactory factory = tokenFilterFactory("ICUCollationKey",
                 "locale", "en",
                 "strength", "tertiary",
@@ -230,7 +230,7 @@ namespace Lucene.Net.Collation
         {
             RuleBasedCollator baseCollator = (RuleBasedCollator)Collator.GetInstance(new UCultureInfo("de_DE"));
 
-            String DIN5007_2_tailorings =
+            string DIN5007_2_tailorings =
               "& ae , a\u0308 & AE , A\u0308" +
               "& oe , o\u0308 & OE , O\u0308" +
               "& ue , u\u0308 & UE , u\u0308";
@@ -238,12 +238,12 @@ namespace Lucene.Net.Collation
             RuleBasedCollator tailoredCollator = new RuleBasedCollator(baseCollator.GetRules() + DIN5007_2_tailorings);
             string tailoredRules = tailoredCollator.GetRules();
             //
-            // at this point, you would save these tailoredRules to a file, 
+            // at this point, you would save these tailoredRules to a file,
             // and use the custom parameter.
             //
-            String germanUmlaut = "Töne";
-            String germanOE = "Toene";
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            string germanUmlaut = "Töne";
+            string germanOE = "Toene";
+            IDictionary<string, string> args = new Dictionary<string, string>();
             args["custom"] = "rules.txt";
             args["strength"] = "primary";
             ICUCollationKeyFilterFactory factory = new ICUCollationKeyFilterFactory(args);
@@ -276,49 +276,49 @@ namespace Lucene.Net.Collation
             assertFalse(stream2.IncrementToken());
             stream1.End();
             stream2.End();
-            stream1.Dispose();
-            stream2.Dispose();
+            stream1.Close();
+            stream2.Close();
         }
 
         private class StringMockResourceLoader : IResourceLoader
         {
-            String text;
+            string text;
 
-            internal StringMockResourceLoader(String text)
+            internal StringMockResourceLoader(string text)
             {
                 this.text = text;
             }
 
-            public T NewInstance<T>(String cname)
+            public T NewInstance<T>(string cname)
             {
                 return default;
             }
 
-            public Type FindType(String cname)
+            public Type FindType(string cname)
             {
                 return null;
             }
 
-            public Stream OpenResource(String resource)
+            public Stream OpenResource(string resource)
             {
                 return new MemoryStream(Encoding.UTF8.GetBytes(text));
             }
         }
 
-        private TokenFilterFactory tokenFilterFactory(String name, params String[] keysAndValues)
+        private TokenFilterFactory tokenFilterFactory(string name, params string[] keysAndValues)
         {
             Type clazz = TokenFilterFactory.LookupClass(name);
             if (keysAndValues.Length % 2 == 1)
             {
                 throw new ArgumentException("invalid keysAndValues map");
             }
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<string, string> args = new Dictionary<string, string>();
             for (int i = 0; i < keysAndValues.Length; i += 2)
             {
-                String prev = args.Put(keysAndValues[i], keysAndValues[i + 1]);
+                string prev = args.Put(keysAndValues[i], keysAndValues[i + 1]);
                 assertNull("duplicate values for key: " + keysAndValues[i], prev);
             }
-            String previous = args.Put("luceneMatchVersion", TEST_VERSION_CURRENT.ToString());
+            string previous = args.Put("luceneMatchVersion", TEST_VERSION_CURRENT.ToString());
             assertNull("duplicate values for key: luceneMatchVersion", previous);
             TokenFilterFactory factory = null;
             try

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestExtendedMode.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestExtendedMode.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Analysis.Ja
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(ts);
+                    IOUtils.CloseWhileHandlingException(ts);
                 }
             }
         }

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseTokenizer.cs
@@ -94,7 +94,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             AssertAnalyzesTo(analyzerNormal,
                              "シニアソフトウェアエンジニア",
-                             new String[] { "シニアソフトウェアエンジニア" });
+                             new string[] { "シニアソフトウェアエンジニア" });
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             AssertAnalyzesTo(analyzerNoPunct, "本来は、貧困層の女性や子供に医療保護を提供するために創設された制度である、" +
                                  "アメリカ低所得者医療援助制度が、今日では、その予算の約３分の１を老人に費やしている。",
-             new String[] { "本来", "は",  "貧困", "層", "の", "女性", "や", "子供", "に", "医療", "保護", "を",
+             new string[] { "本来", "は",  "貧困", "層", "の", "女性", "や", "子供", "に", "医療", "保護", "を",
                     "提供", "する", "ため", "に", "創設", "さ", "れ", "た", "制度", "で", "ある",  "アメリカ",
                     "低", "所得", "者", "医療", "援助", "制度", "が",  "今日", "で", "は",  "その",
                     "予算", "の", "約", "３", "分の", "１", "を", "老人", "に", "費やし", "て", "いる" },
@@ -119,7 +119,7 @@ namespace Lucene.Net.Analysis.Ja
         public void TestDecomposition2()
         {
             AssertAnalyzesTo(analyzerNoPunct, "麻薬の密売は根こそぎ絶やさなければならない",
-              new String[] { "麻薬", "の", "密売", "は", "根こそぎ", "絶やさ", "なけれ", "ば", "なら", "ない" },
+              new string[] { "麻薬", "の", "密売", "は", "根こそぎ", "絶やさ", "なけれ", "ば", "なら", "ない" },
               new int[] { 0, 2, 3, 5, 6, 10, 13, 16, 17, 19 },
               new int[] { 2, 3, 5, 6, 10, 13, 16, 17, 19, 21 }
             );
@@ -129,7 +129,7 @@ namespace Lucene.Net.Analysis.Ja
         public void TestDecomposition3()
         {
             AssertAnalyzesTo(analyzerNoPunct, "魔女狩大将マシュー・ホプキンス。",
-              new String[] { "魔女", "狩", "大将", "マシュー", "ホプキンス" },
+              new string[] { "魔女", "狩", "大将", "マシュー", "ホプキンス" },
               new int[] { 0, 2, 3, 5, 10 },
               new int[] { 2, 3, 5, 9, 15 }
             );
@@ -139,7 +139,7 @@ namespace Lucene.Net.Analysis.Ja
         public void TestDecomposition4()
         {
             AssertAnalyzesTo(analyzer, "これは本ではない",
-              new String[] { "これ", "は", "本", "で", "は", "ない" },
+              new string[] { "これ", "は", "本", "で", "は", "ない" },
               new int[] { 0, 2, 3, 4, 5, 6 },
               new int[] { 2, 3, 4, 5, 6, 8 }
             );
@@ -163,7 +163,7 @@ namespace Lucene.Net.Analysis.Ja
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 
@@ -195,7 +195,7 @@ namespace Lucene.Net.Analysis.Ja
             */
 
             AssertAnalyzesTo(analyzerNoPunct, "魔女狩大将マシュー・ホプキンス。 魔女狩大将マシュー・ホプキンス。",
-              new String[] { "魔女", "狩", "大将", "マシュー", "ホプキンス", "魔女", "狩", "大将", "マシュー", "ホプキンス" },
+              new string[] { "魔女", "狩", "大将", "マシュー", "ホプキンス", "魔女", "狩", "大将", "マシュー", "ホプキンス" },
               new int[] { 0, 2, 3, 5, 10, 17, 19, 20, 22, 27 },
               new int[] { 2, 3, 5, 9, 15, 19, 20, 22, 26, 32 }
             );
@@ -239,7 +239,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             for (int i = 0; i < 100; i++)
             {
-                String s = TestUtil.RandomUnicodeString(Random, 10000);
+                string s = TestUtil.RandomUnicodeString(Random, 10000);
                 TokenStream ts = analyzer.GetTokenStream("foo", s);
                 try
                 {
@@ -251,7 +251,7 @@ namespace Lucene.Net.Analysis.Ja
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(ts);
+                    IOUtils.CloseWhileHandlingException(ts);
                 }
             }
         }
@@ -261,7 +261,7 @@ namespace Lucene.Net.Analysis.Ja
         public void TestSurrogates()
         {
             AssertAnalyzesTo(analyzer, "𩬅艱鍟䇹愯瀛",
-              new String[] { "𩬅", "艱", "鍟", "䇹", "愯", "瀛" });
+              new string[] { "𩬅", "艱", "鍟", "䇹", "愯", "瀛" });
         }
 
         /** random test ensuring we don't ever split supplementaries */
@@ -275,7 +275,7 @@ namespace Lucene.Net.Analysis.Ja
                 {
                     Console.WriteLine("\nTEST: iter=" + i);
                 }
-                String s = TestUtil.RandomUnicodeString(Random, 100);
+                string s = TestUtil.RandomUnicodeString(Random, 100);
                 TokenStream ts = analyzer.GetTokenStream("foo", s);
                 try
                 {
@@ -289,7 +289,7 @@ namespace Lucene.Net.Analysis.Ja
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(ts);
+                    IOUtils.CloseWhileHandlingException(ts);
                 }
             }
         }
@@ -306,7 +306,7 @@ namespace Lucene.Net.Analysis.Ja
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 
@@ -322,7 +322,7 @@ namespace Lucene.Net.Analysis.Ja
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 
@@ -332,14 +332,14 @@ namespace Lucene.Net.Analysis.Ja
         public void TestEnd()
         {
             AssertTokenStreamContents(analyzerNoPunct.GetTokenStream("foo", "これは本ではない"),
-                new String[] { "これ", "は", "本", "で", "は", "ない" },
+                new string[] { "これ", "は", "本", "で", "は", "ない" },
                 new int[] { 0, 2, 3, 4, 5, 6 },
                 new int[] { 2, 3, 4, 5, 6, 8 },
                 new int?(8)
             );
 
             AssertTokenStreamContents(analyzerNoPunct.GetTokenStream("foo", "これは本ではない    "),
-                new String[] { "これ", "は", "本", "で", "は", "ない" },
+                new string[] { "これ", "は", "本", "で", "は", "ない" },
                 new int[] { 0, 2, 3, 4, 5, 6, 8 },
                 new int[] { 2, 3, 4, 5, 6, 8, 9 },
                 new int?(12)
@@ -352,7 +352,7 @@ namespace Lucene.Net.Analysis.Ja
             // Not a great test because w/o userdict.txt the
             // segmentation is the same:
             AssertTokenStreamContents(analyzer.GetTokenStream("foo", "関西国際空港に行った"),
-                                      new String[] { "関西", "国際", "空港", "に", "行っ", "た" },
+                                      new string[] { "関西", "国際", "空港", "に", "行っ", "た" },
                                       new int[] { 0, 2, 4, 6, 7, 9 },
                                       new int[] { 2, 4, 6, 7, 9, 10 },
                                       new int?(10)
@@ -364,7 +364,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             // Better test: w/o userdict the segmentation is different:
             AssertTokenStreamContents(analyzer.GetTokenStream("foo", "朝青龍"),
-                                      new String[] { "朝青龍" },
+                                      new string[] { "朝青龍" },
                                       new int[] { 0 },
                                       new int[] { 3 },
                                       new int?(3)
@@ -376,7 +376,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             // Test entry that breaks into multiple tokens:
             AssertTokenStreamContents(analyzer.GetTokenStream("foo", "abcd"),
-                                      new String[] { "a", "b", "cd" },
+                                      new string[] { "a", "b", "cd" },
                                       new int[] { 0, 1, 2 },
                                       new int[] { 1, 2, 4 },
                                       new int?(4)
@@ -410,8 +410,8 @@ namespace Lucene.Net.Analysis.Ja
             //        "スペース", "ステーション", "に", "行き", "ます", "。",
             //        "うたがわしい", "。"
             //   };
-            String input = "スペースステーションに行きます。うたがわしい。";
-            String[]
+            string input = "スペースステーションに行きます。うたがわしい。";
+            string[]
             surfaceForms = {
                 "スペース", "ステーション", "に", "行き", "ます", "。",
                 "うたがわしい", "。"
@@ -435,8 +435,8 @@ namespace Lucene.Net.Analysis.Ja
             });
 
 
-            String input = "スペースステーションに行きます。うたがわしい。";
-            String[] surfaceForms = {
+            string input = "スペースステーションに行きます。うたがわしい。";
+            string[] surfaceForms = {
                 "スペース", "ステーション", "に", "行き", "ます", "。",
                 "うたがわしい", "。"
             };
@@ -448,14 +448,14 @@ namespace Lucene.Net.Analysis.Ja
             assertTrue(gv2.Finish().IndexOf("22.0", StringComparison.Ordinal) != -1);
         }
 
-        private void assertReadings(String input, params String[] readings)
+        private void assertReadings(string input, params string[] readings)
         {
             TokenStream ts = analyzer.GetTokenStream("ignored", input);
             try
             {
                 IReadingAttribute readingAtt = ts.AddAttribute<IReadingAttribute>();
                 ts.Reset();
-                foreach (String reading in readings)
+                foreach (string reading in readings)
                 {
                     assertTrue(ts.IncrementToken());
                     assertEquals(reading, readingAtt.GetReading());
@@ -465,18 +465,18 @@ namespace Lucene.Net.Analysis.Ja
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 
-        private void assertPronunciations(String input, params String[] pronunciations)
+        private void assertPronunciations(string input, params string[] pronunciations)
         {
             TokenStream ts = analyzer.GetTokenStream("ignored", input);
             try
             {
                 IReadingAttribute readingAtt = ts.AddAttribute<IReadingAttribute>();
                 ts.Reset();
-                foreach (String pronunciation in pronunciations)
+                foreach (string pronunciation in pronunciations)
                 {
                     assertTrue(ts.IncrementToken());
                     assertEquals(pronunciation, readingAtt.GetPronunciation());
@@ -486,18 +486,18 @@ namespace Lucene.Net.Analysis.Ja
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 
-        private void assertBaseForms(String input, params String[] baseForms)
+        private void assertBaseForms(string input, params string[] baseForms)
         {
             TokenStream ts = analyzer.GetTokenStream("ignored", input);
             try
             {
                 IBaseFormAttribute baseFormAtt = ts.AddAttribute<IBaseFormAttribute>();
                 ts.Reset();
-                foreach (String baseForm in baseForms)
+                foreach (string baseForm in baseForms)
                 {
                     assertTrue(ts.IncrementToken());
                     assertEquals(baseForm, baseFormAtt.GetBaseForm());
@@ -507,18 +507,18 @@ namespace Lucene.Net.Analysis.Ja
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 
-        private void assertInflectionTypes(String input, params String[] inflectionTypes)
+        private void assertInflectionTypes(string input, params string[] inflectionTypes)
         {
             TokenStream ts = analyzer.GetTokenStream("ignored", input);
             try
             {
                 IInflectionAttribute inflectionAtt = ts.AddAttribute<IInflectionAttribute>();
                 ts.Reset();
-                foreach (String inflectionType in inflectionTypes)
+                foreach (string inflectionType in inflectionTypes)
                 {
                     assertTrue(ts.IncrementToken());
                     assertEquals(inflectionType, inflectionAtt.GetInflectionType());
@@ -528,18 +528,18 @@ namespace Lucene.Net.Analysis.Ja
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 
-        private void assertInflectionForms(String input, params String[] inflectionForms)
+        private void assertInflectionForms(string input, params string[] inflectionForms)
         {
             TokenStream ts = analyzer.GetTokenStream("ignored", input);
             try
             {
                 IInflectionAttribute inflectionAtt = ts.AddAttribute<IInflectionAttribute>();
                 ts.Reset();
-                foreach (String inflectionForm in inflectionForms)
+                foreach (string inflectionForm in inflectionForms)
                 {
                     assertTrue(ts.IncrementToken());
                     assertEquals(inflectionForm, inflectionAtt.GetInflectionForm());
@@ -549,18 +549,18 @@ namespace Lucene.Net.Analysis.Ja
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 
-        private void assertPartsOfSpeech(String input, params String[] partsOfSpeech)
+        private void assertPartsOfSpeech(string input, params string[] partsOfSpeech)
         {
             TokenStream ts = analyzer.GetTokenStream("ignored", input);
             try
             {
                 IPartOfSpeechAttribute partOfSpeechAtt = ts.AddAttribute<IPartOfSpeechAttribute>();
                 ts.Reset();
-                foreach (String partOfSpeech in partsOfSpeech)
+                foreach (string partOfSpeech in partsOfSpeech)
                 {
                     assertTrue(ts.IncrementToken());
                     assertEquals(partOfSpeech, partOfSpeechAtt.GetPartOfSpeech());
@@ -570,7 +570,7 @@ namespace Lucene.Net.Analysis.Ja
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(ts);
+                IOUtils.CloseWhileHandlingException(ts);
             }
         }
 
@@ -695,14 +695,14 @@ namespace Lucene.Net.Analysis.Ja
         public void TestYabottai()
         {
             AssertAnalyzesTo(analyzer, "やぼったい",
-                             new String[] { "やぼったい" });
+                             new string[] { "やぼったい" });
         }
 
         [Test]
         public void TestTsukitosha()
         {
             AssertAnalyzesTo(analyzer, "突き通しゃ",
-                             new String[] { "突き通しゃ" });
+                             new string[] { "突き通しゃ" });
         }
 
         [Test]
@@ -770,7 +770,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             TextReader reader = new StreamReader(
                 this.GetType().getResourceAsStream("bocchan.utf-8"), Encoding.UTF8);
-            String line = reader.ReadLine();
+            string line = reader.ReadLine();
             reader.Dispose();
 
             if (Verbose)
@@ -801,10 +801,10 @@ namespace Lucene.Net.Analysis.Ja
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(ts);
+                    IOUtils.CloseWhileHandlingException(ts);
                 }
             }
-            String[] sentences = Regex.Split(line, "、|。").TrimEnd();
+            string[] sentences = Regex.Split(line, "、|。").TrimEnd();
             if (Verbose)
             {
                 Console.WriteLine("Total time : " + ((Time.NanoTime() / Time.MillisecondsPerNanosecond) - totalStart)); // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
@@ -813,7 +813,7 @@ namespace Lucene.Net.Analysis.Ja
             totalStart = Time.NanoTime() / Time.MillisecondsPerNanosecond; // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
             for (int i = 0; i < numIterations; i++)
             {
-                foreach (String sentence in sentences)
+                foreach (string sentence in sentences)
                 {
                     TokenStream ts = analyzer.GetTokenStream("ignored", sentence);
                     try
@@ -824,7 +824,7 @@ namespace Lucene.Net.Analysis.Ja
                     }
                     finally
                     {
-                        IOUtils.DisposeWhileHandlingException(ts);
+                        IOUtils.CloseWhileHandlingException(ts);
                     }
                 }
             }
@@ -838,7 +838,7 @@ namespace Lucene.Net.Analysis.Ja
         public void TestWithPunctuation()
         {
             AssertAnalyzesTo(analyzerNoPunct, "羽田。空港",
-                             new String[] { "羽田", "空港" },
+                             new string[] { "羽田", "空港" },
                              new int[] { 1, 1 });
         }
 
@@ -846,7 +846,7 @@ namespace Lucene.Net.Analysis.Ja
         public void TestCompoundOverPunctuation()
         {
             AssertAnalyzesToPositions(analyzerNoPunct, "dεε϶ϢϏΎϷΞͺ羽田",
-                                      new String[] { "d", "ε", "ε", "ϢϏΎϷΞͺ", "羽田" },
+                                      new string[] { "d", "ε", "ε", "ϢϏΎϷΞͺ", "羽田" },
                                       new int[] { 1, 1, 1, 1, 1 },
                                       new int[] { 1, 1, 1, 1, 1 });
         }
@@ -858,7 +858,7 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestEmptyBacktrace()
         {
-            String text = "";
+            string text = "";
 
             // since the max backtrace gap ({@link JapaneseTokenizer#MAX_BACKTRACE_GAP)
             // is set to 1024, we want the first 1023 characters to generate multiple paths
@@ -872,7 +872,7 @@ namespace Lucene.Net.Analysis.Ja
             // will end-up together
             text += "手紙";
 
-            IList<String> outputs = new List<String>();
+            IList<string> outputs = new List<string>();
             for (int i = 0; i < 511; i++)
             {
                 outputs.Add("ああ");

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPTokenizerFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPTokenizerFactory.cs
@@ -123,11 +123,11 @@ namespace Lucene.Net.Analysis.OpenNlp
             //ts.SetReader(new StringReader(SENTENCES));
 
             ts.Reset();
-            ts.Dispose();
+            ts.Close();
             ts.Reset();
             ts.SetReader(new StringReader(SENTENCES));
             AssertTokenStreamContents(ts, SENTENCES_punc);
-            ts.Dispose();
+            ts.Close();
             ts.Reset();
             ts.SetReader(new StringReader(SENTENCES));
             AssertTokenStreamContents(ts, SENTENCES_punc);

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/TestBeiderMorseFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/TestBeiderMorseFilter.cs
@@ -127,7 +127,7 @@ namespace Lucene.Net.Analysis.Phonetic
             }
             assertEquals(12, i);
             stream.End();
-            stream.Dispose();
+            stream.Close();
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/TestSmartChineseAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/TestSmartChineseAnalyzer.cs
@@ -273,7 +273,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(stream);
+                IOUtils.CloseWhileHandlingException(stream);
             }
         }
 
@@ -298,7 +298,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(stream);
+                IOUtils.CloseWhileHandlingException(stream);
             }
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Stempel/Pl/TestPolishAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Stempel/Pl/TestPolishAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Analysis.Util;
+using Lucene.Net.Attributes;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
@@ -82,6 +83,7 @@ namespace Lucene.Net.Analysis.Pl
         /// (although that behavior no longer throws an exception).
         /// </summary>
         [Test]
+        [LuceneNetSpecific]
         public void TestOutOfRange()
         {
             var a = new PolishAnalyzer(TEST_VERSION_CURRENT);

--- a/src/Lucene.Net.Tests.Analysis.Stempel/Pl/TestPolishAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Stempel/Pl/TestPolishAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Analysis.Util;
+using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.IO;
@@ -25,7 +26,7 @@ namespace Lucene.Net.Analysis.Pl
     public class TestPolishAnalyzer : BaseTokenStreamTestCase
     {
         /// <summary>
-        /// This test fails with NPE when the 
+        /// This test fails with NPE when the
         /// stopwords file is missing in classpath
         /// </summary>
         [Test]
@@ -71,13 +72,13 @@ namespace Lucene.Net.Analysis.Pl
         }
 
         /// <summary>
-        /// LUCENENET specific. The original Java implementation relied on String.subSequence(int, int) to throw an IndexOutOfBoundsException 
-        /// (in .NET, it would be string.SubString(int, int) and an ArgumentOutOfRangeException). 
-        /// However, the logic was corrected for .NET to test when the argument is negative and not 
+        /// LUCENENET specific. The original Java implementation relied on String.subSequence(int, int) to throw an IndexOutOfBoundsException
+        /// (in .NET, it would be string.SubString(int, int) and an ArgumentOutOfRangeException).
+        /// However, the logic was corrected for .NET to test when the argument is negative and not
         /// throw an exception, since exceptions are expensive and not meant for "normal"
         /// behavior in .NET. This test case was made trying to figure out that issue (since initially an IndexOutOfRangeException,
-        /// rather than ArgumentOutOfRangeException, was in the catch block which made the TestRandomStrings test fail). 
-        /// It will trigger the behavior that cause the second substring argument to be negative 
+        /// rather than ArgumentOutOfRangeException, was in the catch block which made the TestRandomStrings test fail).
+        /// It will trigger the behavior that cause the second substring argument to be negative
         /// (although that behavior no longer throws an exception).
         /// </summary>
         [Test]
@@ -87,14 +88,22 @@ namespace Lucene.Net.Analysis.Pl
             var text = "zyaolz 96619727 p";
             var reader = new StringReader(text);
             int remainder = 2;
-            using var ts = a.GetTokenStream("dummy", (TextReader)new MockCharFilter(reader, remainder));
-            ts.Reset();
+            var ts = a.GetTokenStream("dummy", (TextReader)new MockCharFilter(reader, remainder));
 
-            while (ts.IncrementToken())
+            try
             {
-            }
+                ts.Reset();
 
-            ts.End();
+                while (ts.IncrementToken())
+                {
+                }
+
+                ts.End();
+            }
+            finally
+            {
+                IOUtils.CloseWhileHandlingException(ts);
+            }
         }
     }
 }

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/CountingHighlighterTestTask.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/CountingHighlighterTestTask.cs
@@ -58,8 +58,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             public override int DoHighlight(IndexReader reader, int doc, string field, Document document, Analyzer analyzer, string text)
             {
                 TokenStream ts = TokenSources.GetAnyTokenStream(reader, doc, field, document, analyzer);
-                TextFragment[]
-                frag = highlighter.GetBestTextFragments(ts, text, outerInstance.m_mergeContiguous, outerInstance.m_maxFrags);
+                TextFragment[] frag = highlighter.GetBestTextFragments(ts, text, outerInstance.m_mergeContiguous, outerInstance.m_maxFrags);
                 numHighlightedResults += frag != null ? frag.Length : 0;
                 return frag != null ? frag.Length : 0;
             }
@@ -71,7 +70,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             return new BenchmarkHighlighterAnonymousClass(this, m_highlighter);
             //        return new BenchmarkHighlighter() {
             //  @Override
-            //  public int doHighlight(IndexReader reader, int doc, String field, Document document, Analyzer analyzer, String text) 
+            //  public int doHighlight(IndexReader reader, int doc, String field, Document document, Analyzer analyzer, String text)
             //    {
             //        TokenStream ts = TokenSources.GetAnyTokenStream(reader, doc, field, document, analyzer);
             //        TextFragment []

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/TestPerfTasksLogic.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/TestPerfTasksLogic.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestIndexAndSearchTasks()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "ResetSystemErase",
                 "CreateIndex",
                 "{ AddDoc } : 1000",
@@ -101,7 +101,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         [Test]
         public void TestTimedSearchTask()
         {
-            String[] algLines = {
+            string[] algLines = {
                 "log.step=100000",
                 "ResetSystemErase",
                 "CreateIndex",
@@ -125,7 +125,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         [Test]
         public void TestBGSearchTaskThreads()
         {
-            String[] algLines = {
+            string[] algLines = {
                 "log.time.step.msec = 100",
                 "log.step=100000",
                 "ResetSystemErase",
@@ -156,7 +156,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestHighlighting()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "doc.stored=true",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -196,7 +196,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestHighlightingTV()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "doc.stored=true",//doc storage is required in order to have text to highlight
                 "doc.term.vector=true",
                 "doc.term.vector.offsets=true",
@@ -238,7 +238,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestHighlightingNoTvNoStore()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "doc.stored=false",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -276,7 +276,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestExhaustContentSource()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.SingleDocSource, Lucene.Net.Benchmark",
                 "content.source.log.step=1",
@@ -319,7 +319,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestDocMakerThreadSafety()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.SortableSingleDocSource, Lucene.Net.Benchmark",
                 "doc.term.vector=false",
@@ -360,7 +360,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestParallelDocMaker()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -398,7 +398,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             int NUM_TRY_DOCS = 50;
 
             // Creates a line file with first 50 docs from SingleDocSource
-            String[] algLines1 = {
+            string[] algLines1 = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.SingleDocSource, Lucene.Net.Benchmark",
                 "content.source.forever=true",
@@ -414,7 +414,7 @@ namespace Lucene.Net.Benchmarks.ByTask
                 new StreamReader(
                     new FileStream(lineFile.FullName, FileMode.Open, FileAccess.Read), Encoding.UTF8);
             int numLines = 0;
-            String line;
+            string line;
             while ((line = r.ReadLine()) != null)
             {
                 if (numLines == 0 && line.StartsWith(WriteLineDocTask.FIELDS_HEADER_INDICATOR, StringComparison.Ordinal))
@@ -427,7 +427,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             assertEquals("did not see the right number of docs; should be " + NUM_TRY_DOCS + " but was " + numLines, NUM_TRY_DOCS, numLines);
 
             // Index the line docs
-            String[] algLines2 = {
+            string[] algLines2 = {
                 "# ----- properties ",
                 "analyzer=Lucene.Net.Analysis.Core.WhitespaceAnalyzer, Lucene.Net.Analysis.Common",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
@@ -470,7 +470,7 @@ namespace Lucene.Net.Benchmarks.ByTask
 
             // Read tokens from first NUM_DOCS docs from Reuters and
             // then build index from the same docs
-            String[] algLines1 = {
+            string[] algLines1 = {
                 "# ----- properties ",
                 "analyzer=Lucene.Net.Analysis.Core.WhitespaceAnalyzer, Lucene.Net.Analysis.Common",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
@@ -506,7 +506,7 @@ namespace Lucene.Net.Benchmarks.ByTask
 
             Fields fields = MultiFields.GetFields(reader);
 
-            foreach (String fieldName in fields)
+            foreach (string fieldName in fields)
             {
                 if (fieldName.Equals(DocMaker.ID_FIELD, StringComparison.Ordinal) || fieldName.Equals(DocMaker.DATE_MSEC_FIELD, StringComparison.Ordinal) || fieldName.Equals(DocMaker.TIME_SEC_FIELD, StringComparison.Ordinal))
                 {
@@ -541,7 +541,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestParallelExhausted()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -579,7 +579,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestExhaustedLooped()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -617,7 +617,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestCloseIndexFalse()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -666,7 +666,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestMergeScheduler()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -716,7 +716,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestMergePolicy()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -757,7 +757,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestIndexWriterSettings()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -804,7 +804,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestIndexingWithFacets()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -842,7 +842,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         public void TestForceMerge()
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -894,7 +894,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         private void doTestDisableCounting(bool disable)
         {
             // 1. alg definition (required in every "logic" test)
-            String[] algLines = disableCountingLines(disable);
+            string[] algLines = disableCountingLines(disable);
 
             // 2. execute the algorithm  (required in every "logic" test)
             Benchmark benchmark = execBenchmark(algLines);
@@ -904,7 +904,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             int nChecked = 0;
             foreach (TaskStats stats in benchmark.RunData.Points.TaskStats)
             {
-                String taskName = stats.Task.GetName();
+                string taskName = stats.Task.GetName();
                 if (taskName.Equals("Rounds", StringComparison.Ordinal))
                 {
                     assertEquals("Wrong total count!", 20 + 2 * n, stats.Count);
@@ -924,10 +924,10 @@ namespace Lucene.Net.Benchmarks.ByTask
             assertEquals("Missing some tasks to check!", 3, nChecked);
         }
 
-        private String[] disableCountingLines(bool disable)
+        private string[] disableCountingLines(bool disable)
         {
-            String dis = disable ? "-" : "";
-            return new String[] {
+            string dis = disable ? "-" : "";
+            return new string[] {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -983,9 +983,9 @@ namespace Lucene.Net.Benchmarks.ByTask
             assertEquals(new CultureInfo("nb-NO"/*, "NY"*/), benchmark.RunData.Locale);
         }
 
-        private String[] getLocaleConfig(String localeParam)
+        private string[] getLocaleConfig(string localeParam)
         {
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -1045,7 +1045,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             assertEqualCollation(expected, benchmark.RunData.Analyzer, "foobar");
         }
 
-        private void assertEqualCollation(Analyzer a1, Analyzer a2, String text)
+        private void assertEqualCollation(Analyzer a1, Analyzer a2, string text)
         {
             TokenStream ts1 = a1.GetTokenStream("bogus", text);
             TokenStream ts2 = a2.GetTokenStream("bogus", text);
@@ -1062,14 +1062,14 @@ namespace Lucene.Net.Benchmarks.ByTask
             assertEquals(bytes1, bytes2);
             assertFalse(ts1.IncrementToken());
             assertFalse(ts2.IncrementToken());
-            ts1.Dispose();
-            ts2.Dispose();
+            ts1.Close();
+            ts2.Close();
         }
 
-        private String[] getCollatorConfig(String localeParam,
-            String collationParam)
+        private string[] getCollatorConfig(string localeParam,
+            string collationParam)
         {
-            String[] algLines = {
+            string[] algLines = {
                 "# ----- properties ",
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
@@ -1095,15 +1095,15 @@ namespace Lucene.Net.Benchmarks.ByTask
         [Test]
         public void TestShingleAnalyzer()
         {
-            String text = "one,two,three, four five six";
+            string text = "one,two,three, four five six";
 
             // StandardTokenizer, maxShingleSize, and outputUnigrams
             Benchmark benchmark = execBenchmark(getAnalyzerFactoryConfig
                 ("shingle-analyzer", "StandardTokenizer,ShingleFilter"));
             benchmark.RunData.Analyzer.GetTokenStream
-                ("bogus", text).Dispose();
+                ("bogus", text).Close();
             BaseTokenStreamTestCase.AssertAnalyzesTo(benchmark.RunData.Analyzer, text,
-                                                     new String[] { "one", "one two", "two", "two three",
+                                                     new string[] { "one", "one two", "two", "two three",
                                                             "three", "three four", "four", "four five",
                                                             "five", "five six", "six" });
             // StandardTokenizer, maxShingleSize = 3, and outputUnigrams = false
@@ -1112,7 +1112,7 @@ namespace Lucene.Net.Benchmarks.ByTask
                   ("shingle-analyzer",
                    "StandardTokenizer,ShingleFilter(maxShingleSize:3,outputUnigrams:false)"));
             BaseTokenStreamTestCase.AssertAnalyzesTo(benchmark.RunData.Analyzer, text,
-                                                     new String[] { "one two", "one two three", "two three",
+                                                     new string[] { "one two", "one two three", "two three",
                                                             "two three four", "three four",
                                                             "three four five", "four five",
                                                             "four five six", "five six" });
@@ -1120,7 +1120,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             benchmark = execBenchmark
               (getAnalyzerFactoryConfig("shingle-analyzer", "WhitespaceTokenizer,ShingleFilter"));
             BaseTokenStreamTestCase.AssertAnalyzesTo(benchmark.RunData.Analyzer, text,
-                                                     new String[] { "one,two,three,", "one,two,three, four",
+                                                     new string[] { "one,two,three,", "one,two,three, four",
                                                             "four", "four five", "five", "five six",
                                                             "six" });
 
@@ -1130,13 +1130,13 @@ namespace Lucene.Net.Benchmarks.ByTask
                 ("shingle-factory",
                  "WhitespaceTokenizer,ShingleFilter(outputUnigrams:false,maxShingleSize:3)"));
             BaseTokenStreamTestCase.AssertAnalyzesTo(benchmark.RunData.Analyzer, text,
-                                                     new String[] { "one,two,three, four",
+                                                     new string[] { "one,two,three, four",
                                                             "one,two,three, four five",
                                                             "four five", "four five six",
                                                             "five six" });
         }
 
-        private String[] getAnalyzerFactoryConfig(String name, String @params)
+        private string[] getAnalyzerFactoryConfig(string name, string @params)
         {
             //String singleQuoteEscapedName = name.Replace("'", "\\\\'");
             //String[] algLines = {
@@ -1151,8 +1151,8 @@ namespace Lucene.Net.Benchmarks.ByTask
             //    "{ \"AddDocs\"  AddDoc > : * "
             //};
             //String singleQuoteEscapedName = name.Replace("'", @"\'");
-            String singleQuoteEscapedName = name.Replace("'", @"\'");
-            String[] algLines = {
+            string singleQuoteEscapedName = name.Replace("'", @"\'");
+            string[] algLines = {
                 "content.source=Lucene.Net.Benchmarks.ByTask.Feeds.LineDocSource, Lucene.Net.Benchmark",
                 "docs.file=" + getReuters20LinesFile(),
                 "work.dir=" + getWorkDir().FullName.Replace(@"\", "/"), // Fix Windows path
@@ -1169,7 +1169,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         [Test]
         public void TestAnalyzerFactory()
         {
-            String text = "Fortieth, Quarantième, Cuadragésimo";
+            string text = "Fortieth, Quarantième, Cuadragésimo";
             Benchmark benchmark = execBenchmark(getAnalyzerFactoryConfig
                 ("ascii folded, pattern replaced, standard tokenized, downcased, bigrammed.'analyzer'",
                  "positionIncrementGap:100,offsetGap:1111,"
@@ -1177,12 +1177,12 @@ namespace Lucene.Net.Benchmarks.ByTask
                  + "PatternReplaceCharFilterFactory(pattern:'e(\\\\\\\\S*)m',replacement:\"$1xxx$1\"),"
                  + "StandardTokenizer,LowerCaseFilter,NGramTokenFilter(minGramSize:2,maxGramSize:2)"));
             BaseTokenStreamTestCase.AssertAnalyzesTo(benchmark.RunData.Analyzer, text,
-                new String[] { "fo", "or", "rt", "ti", "ie", "et", "th",
+                new string[] { "fo", "or", "rt", "ti", "ie", "et", "th",
                        "qu", "ua", "ar", "ra", "an", "nt", "ti", "ix", "xx", "xx", "xe",
                        "cu", "ua", "ad", "dr", "ra", "ag", "gs", "si", "ix", "xx", "xx", "xs", "si", "io"});
         }
 
-        private String getReuters20LinesFile()
+        private string getReuters20LinesFile()
         {
             return getWorkDirResourcePath("reuters.first20.lines.txt");
         }

--- a/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
@@ -1305,6 +1305,7 @@ namespace Lucene.Net.Search.Highlight
                 for (int i = 0; i < hits.TotalHits; i++)
                 {
                     String text = searcher.Doc(hits.ScoreDocs[i].Doc).Get(FIELD_NAME);
+                    // TODO: #271 review disposable
                     TokenStream tokenStream = analyzer.GetTokenStream(FIELD_NAME, text);
 
                     Highlighter highlighter = instance.GetHighlighter(query, FIELD_NAME,

--- a/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
@@ -2159,12 +2159,12 @@ namespace Lucene.Net.Search.Highlight
         }
 
 
-        protected override void DoClose()
+        public override void Close()
         {
             this.realStream.Close();
             this.st?.Dispose();
             this.st = null;
-            base.DoClose();
+            base.Close();
         }
     }
 

--- a/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
@@ -2159,21 +2159,12 @@ namespace Lucene.Net.Search.Highlight
         }
 
 
-        protected override void Dispose(bool disposing)
+        protected override void DoClose()
         {
-            try
-            {
-                if (disposing)
-                {
-                    this.realStream.Dispose();
-                    this.st?.Dispose();
-                    this.st = null;
-                }
-            }
-            finally
-            {
-                base.Dispose(disposing);
-            }
+            this.realStream.Close();
+            this.st?.Dispose();
+            this.st = null;
+            base.DoClose();
         }
     }
 

--- a/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Highlight/HighlighterTest.cs
@@ -1305,7 +1305,7 @@ namespace Lucene.Net.Search.Highlight
                 for (int i = 0; i < hits.TotalHits; i++)
                 {
                     String text = searcher.Doc(hits.ScoreDocs[i].Doc).Get(FIELD_NAME);
-                    // TODO: #271 review disposable
+
                     TokenStream tokenStream = analyzer.GetTokenStream(FIELD_NAME, text);
 
                     Highlighter highlighter = instance.GetHighlighter(query, FIELD_NAME,
@@ -2162,10 +2162,10 @@ namespace Lucene.Net.Search.Highlight
 
         public override void Close()
         {
+            base.Close();
             this.realStream.Close();
             this.st?.Dispose();
             this.st = null;
-            base.Close();
         }
     }
 

--- a/src/Lucene.Net.Tests.Highlighter/VectorHighlight/AbstractTestCase.cs
+++ b/src/Lucene.Net.Tests.Highlighter/VectorHighlight/AbstractTestCase.cs
@@ -193,7 +193,7 @@ namespace Lucene.Net.Search.VectorHighlight
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(tokenStream);
+                IOUtils.CloseWhileHandlingException(tokenStream);
             }
 
             return bytesRefs;

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
@@ -117,7 +117,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         }
 
         /// <summary>
-        /// Used to return highlighted result; see 
+        /// Used to return highlighted result; see
         /// <see cref = "Lookup.LookupResult.HighlightKey" />
         /// </summary>
         private sealed class LookupHighlightFragment
@@ -201,7 +201,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(ts);
+                    IOUtils.CloseWhileHandlingException(ts);
                 }
             }
         }
@@ -445,7 +445,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         public void TestEmptyAtStart()
         {
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
-            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3);                       //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0              
+            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3);                       //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
             suggester.Build(new InputArrayEnumerator(new Input[0]));
             suggester.Add(new BytesRef("a penny saved is a penny earned"), null, 10, new BytesRef("foobaz"));
             suggester.Add(new BytesRef("lend me your ear"), null, 8, new BytesRef("foobar"));

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TestBaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TestBaseTokenStreamTestCase.cs
@@ -1,10 +1,13 @@
 ﻿using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Analysis.TokenAttributes.Extensions;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Attributes;
 using Lucene.Net.Util;
 using NUnit.Framework;
+using System;
+using System.IO;
 
 #nullable enable
 
@@ -62,7 +65,7 @@ namespace Lucene.Net.Analysis
         /// if it is called more than once, or if other operations are called after it is disposed.
         /// Code copied from <see cref="LowerCaseFilter"/>.
         /// </summary>
-        private class DisposeTrackingLowerCaseFilter : TokenFilter
+        private sealed class DisposeTrackingLowerCaseFilter : TokenFilter, IDisposable
         {
             private readonly CharacterUtils charUtils;
             private readonly ICharTermAttribute termAtt;
@@ -74,12 +77,11 @@ namespace Lucene.Net.Analysis
                 charUtils = CharacterUtils.GetInstance(matchVersion);
             }
 
-            protected override void Dispose(bool disposing)
+            public void Dispose()
             {
                 if (!IsDisposed)
                 {
                     IsDisposed = true;
-                    base.Dispose(disposing);
                 }
                 else
                 {
@@ -136,6 +138,418 @@ namespace Lucene.Net.Analysis
             }
 
             public bool IsDisposed { get; private set; }
+        }
+
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestTokenStream_Dispose_AllDisposable()
+        {
+            DisposableKeywordTokenizer? tokenizer = null;
+            DisposableTokenFilter? filter = null;
+            DisposableTokenFilter? filter2 = null;
+            DisposableTokenFilter? filter3 = null;
+
+            using (Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                tokenizer = new DisposableKeywordTokenizer(reader);
+                filter = new DisposableTokenFilter(tokenizer);
+                filter2 = new DisposableTokenFilter(filter);
+                filter3 = new DisposableTokenFilter(filter2);
+                return new TokenStreamComponents(tokenizer, filter3);
+            }))
+            {
+                CheckOneTerm(analyzer, "foo", "foo");
+                CheckOneTerm(analyzer, "bar", "bar");
+            }
+
+            Assert.AreEqual(1, tokenizer!.disposeCount);
+            Assert.AreEqual(1, filter!.disposeCount);
+            Assert.AreEqual(1, filter2!.disposeCount);
+            Assert.AreEqual(1, filter3!.disposeCount);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestTokenStream_Dispose_DisposableTokenizer_OneDisposableFilter()
+        {
+            DisposableKeywordTokenizer? tokenizer = null;
+            NonDisposableTokenFilter? filter = null;
+            DisposableTokenFilter? filter2 = null;
+            NonDisposableTokenFilter? filter3 = null;
+
+            using (Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                tokenizer = new DisposableKeywordTokenizer(reader);
+                filter = new NonDisposableTokenFilter(tokenizer);
+                filter2 = new DisposableTokenFilter(filter);
+                filter3 = new NonDisposableTokenFilter(filter2);
+                return new TokenStreamComponents(tokenizer, filter3);
+            }))
+            {
+                CheckOneTerm(analyzer, "foo", "foo");
+                CheckOneTerm(analyzer, "bar", "bar");
+            }
+
+            Assert.AreEqual(1, tokenizer!.disposeCount);
+            Assert.AreEqual(1, filter2!.disposeCount);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestTokenStream_Dispose_DisposableTokenizer_TwoDisposableFilters()
+        {
+            DisposableKeywordTokenizer? tokenizer = null;
+            NonDisposableTokenFilter? filter = null;
+            NonDisposableTokenFilter? filter2 = null;
+            DisposableTokenFilter? filter3 = null;
+            NonDisposableTokenFilter? filter4 = null;
+            DisposableTokenFilter? filter5 = null;
+
+            using (Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                tokenizer = new DisposableKeywordTokenizer(reader);
+                filter = new NonDisposableTokenFilter(tokenizer);
+                filter2 = new NonDisposableTokenFilter(filter);
+                filter3 = new DisposableTokenFilter(filter2);
+                filter4 = new NonDisposableTokenFilter(filter3);
+                filter5 = new DisposableTokenFilter(filter4);
+                return new TokenStreamComponents(tokenizer, filter5);
+            }))
+            {
+                CheckOneTerm(analyzer, "foo", "foo");
+                CheckOneTerm(analyzer, "bar", "bar");
+            }
+
+            Assert.AreEqual(1, tokenizer!.disposeCount);
+            Assert.AreEqual(1, filter3!.disposeCount);
+            Assert.AreEqual(1, filter5!.disposeCount);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestTokenStream_Dispose_NonDisposableTokenizer_OneDisposableFilter()
+        {
+            NonDisposableKeywordTokenizer? tokenizer = null;
+            NonDisposableTokenFilter? filter = null;
+            NonDisposableTokenFilter? filter2 = null;
+            DisposableTokenFilter? filter3 = null;
+
+            using (Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                tokenizer = new NonDisposableKeywordTokenizer(reader);
+                filter = new NonDisposableTokenFilter(tokenizer);
+                filter2 = new NonDisposableTokenFilter(filter);
+                filter3 = new DisposableTokenFilter(filter2);
+                return new TokenStreamComponents(tokenizer, filter3);
+            }))
+            {
+                CheckOneTerm(analyzer, "foo", "foo");
+                CheckOneTerm(analyzer, "bar", "bar");
+            }
+
+            Assert.AreEqual(1, filter3!.disposeCount);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestTokenStream_Dispose_NonDisposableTokenizer_TwoDisposableFilters()
+        {
+            NonDisposableKeywordTokenizer? tokenizer = null;
+            NonDisposableTokenFilter? filter = null;
+            NonDisposableTokenFilter? filter2 = null;
+            DisposableTokenFilter? filter3 = null;
+            NonDisposableTokenFilter? filter4 = null;
+            DisposableTokenFilter? filter5 = null;
+
+            using (Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                tokenizer = new NonDisposableKeywordTokenizer(reader);
+                filter = new NonDisposableTokenFilter(tokenizer);
+                filter2 = new NonDisposableTokenFilter(filter);
+                filter3 = new DisposableTokenFilter(filter2);
+                filter4 = new NonDisposableTokenFilter(filter3);
+                filter5 = new DisposableTokenFilter(filter4);
+                return new TokenStreamComponents(tokenizer, filter5);
+            }))
+            {
+                CheckOneTerm(analyzer, "foo", "foo");
+                CheckOneTerm(analyzer, "bar", "bar");
+            }
+
+            Assert.AreEqual(1, filter3!.disposeCount);
+            Assert.AreEqual(1, filter5!.disposeCount);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestTokenStream_DoubleDispose_NonDisposableTokenizer_TwoDisposableFilters()
+        {
+            NonDisposableKeywordTokenizer? tokenizer = null;
+            NonDisposableTokenFilter? filter = null;
+            NonDisposableTokenFilter? filter2 = null;
+            DisposableTokenFilter? filter3 = null;
+            NonDisposableTokenFilter? filter4 = null;
+            DisposableTokenFilter? filter5 = null;
+
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                tokenizer = new NonDisposableKeywordTokenizer(reader);
+                filter = new NonDisposableTokenFilter(tokenizer);
+                filter2 = new NonDisposableTokenFilter(filter);
+                filter3 = new DisposableTokenFilter(filter2);
+                filter4 = new NonDisposableTokenFilter(filter3);
+                filter5 = new DisposableTokenFilter(filter4);
+                return new TokenStreamComponents(tokenizer, filter5);
+            });
+            CheckOneTerm(analyzer, "foo", "foo");
+            CheckOneTerm(analyzer, "bar", "bar");
+
+            analyzer.Dispose();
+            analyzer.Dispose();
+
+            Assert.AreEqual(1, filter3!.disposeCount);
+            Assert.AreEqual(1, filter5!.disposeCount);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestTokenStream_ThrowOnDispose_NonDisposableTokenizer_TwoDisposableFilters()
+        {
+            NonDisposableKeywordTokenizer? tokenizer = null;
+            NonDisposableTokenFilter? filter = null;
+            NonDisposableTokenFilter? filter2 = null;
+            DisposableTokenFilter? filter3 = null;
+            NonDisposableTokenFilter? filter4 = null;
+            DisposableTokenFilter? filter5 = null;
+
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                tokenizer = new NonDisposableKeywordTokenizer(reader);
+                filter = new NonDisposableTokenFilter(tokenizer);
+                filter2 = new NonDisposableTokenFilter(filter);
+                filter3 = new DisposableTokenFilter(filter2, throwOnDispose: true);
+                filter4 = new NonDisposableTokenFilter(filter3);
+                filter5 = new DisposableTokenFilter(filter4, throwOnDispose: true);
+                return new TokenStreamComponents(tokenizer, filter5);
+            });
+            CheckOneTerm(analyzer, "foo", "foo");
+            CheckOneTerm(analyzer, "bar", "bar");
+
+            LuceneSystemException ex = Assert.Throws<LuceneSystemException>(analyzer.Dispose)!;
+            Assert.AreEqual(1, ex.GetSuppressed().Length);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestTokenStream_ThrowOnDispose_DisposableTokenizer_TwoDisposableFilters()
+        {
+            DisposableKeywordTokenizer? tokenizer = null;
+            NonDisposableTokenFilter? filter = null;
+            NonDisposableTokenFilter? filter2 = null;
+            DisposableTokenFilter? filter3 = null;
+            NonDisposableTokenFilter? filter4 = null;
+            DisposableTokenFilter? filter5 = null;
+
+            Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                tokenizer = new DisposableKeywordTokenizer(reader, throwOnDispose: true);
+                filter = new NonDisposableTokenFilter(tokenizer);
+                filter2 = new NonDisposableTokenFilter(filter);
+                filter3 = new DisposableTokenFilter(filter2, throwOnDispose: true);
+                filter4 = new NonDisposableTokenFilter(filter3);
+                filter5 = new DisposableTokenFilter(filter4, throwOnDispose: true);
+                return new TokenStreamComponents(tokenizer, filter5);
+            });
+            CheckOneTerm(analyzer, "foo", "foo");
+            CheckOneTerm(analyzer, "bar", "bar");
+
+            LuceneSystemException ex = Assert.Throws<LuceneSystemException>(analyzer.Dispose)!;
+            Assert.AreEqual(2, ex.GetSuppressed().Length);
+        }
+
+        private class PassThroughTokenFilter : TokenFilter
+        {
+            private readonly ICharTermAttribute termAtt;
+
+            public PassThroughTokenFilter(TokenStream input)
+                : base(input)
+            {
+                termAtt = AddAttribute<ICharTermAttribute>();
+            }
+
+            public override void Reset() => base.Reset();
+
+            public override sealed bool IncrementToken() => m_input.IncrementToken(); // Simply pass tokens through unchanged
+        }
+
+        private class DisposableTokenFilter : PassThroughTokenFilter, IDisposable
+        {
+            internal int disposeCount;
+            internal int closeCount;
+            private readonly bool throwOnDispose;
+
+            public DisposableTokenFilter(TokenStream input, bool throwOnDispose = false)
+                : base(input)
+            {
+                this.throwOnDispose = throwOnDispose;
+            }
+
+            public override void Close()
+            {
+                closeCount++;
+                base.Close();
+            }
+
+            public void Dispose()
+            {
+                disposeCount++;
+                if (throwOnDispose)
+                {
+                    throw RuntimeException.Create("disposal error");
+                }
+            }
+        }
+
+        private class NonDisposableTokenFilter : PassThroughTokenFilter
+        {
+            internal int closeCount;
+
+            public NonDisposableTokenFilter(TokenStream input)
+                : base(input)
+            {
+            }
+
+            public override void Close()
+            {
+                closeCount++;
+                base.Close();
+            }
+        }
+
+        private class BaseKeywordTokenizer : Tokenizer
+        {
+            private bool done = false;
+            private int finalOffset;
+            private readonly ICharTermAttribute termAtt;
+            private readonly IOffsetAttribute offsetAtt;
+
+            public BaseKeywordTokenizer(TextReader input)
+              : base(input)
+            {
+                termAtt = AddAttribute<ICharTermAttribute>();
+                offsetAtt = AddAttribute<IOffsetAttribute>();
+            }
+
+            public BaseKeywordTokenizer(AttributeFactory factory, TextReader input)
+                : base(factory, input)
+            {
+                termAtt = AddAttribute<ICharTermAttribute>();
+                offsetAtt = AddAttribute<IOffsetAttribute>();
+            }
+
+            public override sealed bool IncrementToken()
+            {
+                if (!done)
+                {
+                    ClearAttributes();
+                    done = true;
+                    int upto = 0;
+                    char[] buffer = termAtt.Buffer;
+                    while (true)
+                    {
+                        int length = m_input.Read(buffer, upto, buffer.Length - upto);
+                        if (length <= 0)
+                        {
+                            break;
+                        }
+                        upto += length;
+                        if (upto == buffer.Length)
+                        {
+                            buffer = termAtt.ResizeBuffer(1 + buffer.Length);
+                        }
+                    }
+                    termAtt.Length = upto;
+                    finalOffset = CorrectOffset(upto);
+                    offsetAtt.SetOffset(CorrectOffset(0), finalOffset);
+
+                    // **Ensure we emit at least one token (even if empty)**
+                    if (upto == 0)
+                    {
+                        termAtt.SetEmpty();
+                    }
+
+                    return true;
+                }
+                return false;
+            }
+
+            public override sealed void End()
+            {
+                base.End();
+                // set final offset 
+                offsetAtt.SetOffset(finalOffset, finalOffset);
+            }
+
+            public override void Reset()
+            {
+                base.Reset();
+                this.done = false;
+            }
+        }
+
+        private class DisposableKeywordTokenizer : BaseKeywordTokenizer, IDisposable
+        {
+            internal int disposeCount;
+            internal int closeCount;
+            private readonly bool throwOnDispose;
+
+            public DisposableKeywordTokenizer(TextReader input, bool throwOnDispose = false)
+              : base(input)
+            {
+                this.throwOnDispose = throwOnDispose;
+            }
+
+            public DisposableKeywordTokenizer(AttributeFactory factory, TextReader input)
+                : base(factory, input)
+            {
+            }
+
+            public override void Close()
+            {
+                closeCount++;
+                base.Close();
+            }
+
+            public void Dispose()
+            {
+                disposeCount++;
+                if (throwOnDispose)
+                {
+                    throw RuntimeException.Create("disposal error");
+                }
+            }
+        }
+
+        private class NonDisposableKeywordTokenizer : BaseKeywordTokenizer
+        {
+            internal int closeCount;
+
+            public NonDisposableKeywordTokenizer(TextReader input)
+              : base(input)
+            {
+            }
+
+            public NonDisposableKeywordTokenizer(AttributeFactory factory, TextReader input)
+                : base(factory, input)
+            {
+            }
+
+            public override void Close()
+            {
+                closeCount++;
+                base.Close();
+            }
         }
     }
 }

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TestBaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TestBaseTokenStreamTestCase.cs
@@ -1,0 +1,141 @@
+﻿using Lucene.Net.Analysis.Core;
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Analysis.Util;
+using Lucene.Net.Attributes;
+using Lucene.Net.Util;
+using NUnit.Framework;
+
+#nullable enable
+
+namespace Lucene.Net.Analysis
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Tests for <see cref="BaseTokenStreamTestCase"/>.
+    /// </summary>
+    [TestFixture]
+    public class TestBaseTokenStreamTestCase : BaseTokenStreamTestCase
+    {
+        [Test]
+        [LuceneNetSpecific] // lucenenet#271
+        public void TestTokenStreamNotUsedAfterDispose()
+        {
+            DisposeTrackingLowerCaseFilter? leakedReference = null;
+
+            using (var a = Analyzer.NewAnonymous((_, reader) =>
+                   {
+                       // copied from StandardAnalyzer, but purposefully leaking our dispose tracking reference
+                       var src = new StandardTokenizer(LuceneVersion.LUCENE_48, reader);
+                       src.MaxTokenLength = 255;
+                       TokenStream tok = new StandardFilter(LuceneVersion.LUCENE_48, src);
+                       tok = leakedReference = new DisposeTrackingLowerCaseFilter(LuceneVersion.LUCENE_48, tok);
+                       return new TokenStreamComponents(src, tok);
+                   }))
+            {
+                CheckAnalysisConsistency(Random, a, false, "This is a test to make sure dispose is called only once");
+            }
+
+            Assert.IsNotNull(leakedReference);
+            Assert.IsTrue(leakedReference!.IsDisposed, "Dispose was not called on the token stream");
+        }
+
+        /// <summary>
+        /// LUCENENET specific class for <see cref="TestBaseTokenStreamTestCase.TestTokenStreamNotUsedAfterDispose"/>
+        /// that tracks whether <see cref="TokenStream.Dispose()"/> was called, and throws an exception
+        /// if it is called more than once, or if other operations are called after it is disposed.
+        /// Code copied from <see cref="LowerCaseFilter"/>.
+        /// </summary>
+        private class DisposeTrackingLowerCaseFilter : TokenFilter
+        {
+            private readonly CharacterUtils charUtils;
+            private readonly ICharTermAttribute termAtt;
+
+            public DisposeTrackingLowerCaseFilter(LuceneVersion matchVersion, TokenStream @in)
+                : base(@in)
+            {
+                termAtt = AddAttribute<ICharTermAttribute>();
+                charUtils = CharacterUtils.GetInstance(matchVersion);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (!IsDisposed)
+                {
+                    IsDisposed = true;
+                    base.Dispose(disposing);
+                }
+                else
+                {
+                    throw new AssertionException("Dispose called more than once on TokenStream instance");
+                }
+            }
+
+            public override bool IncrementToken()
+            {
+                if (IsDisposed)
+                {
+                    throw new AssertionException("IncrementToken called after Dispose");
+                }
+
+                if (m_input.IncrementToken())
+                {
+                    charUtils.ToLower(termAtt.Buffer, 0, termAtt.Length);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public override void End()
+            {
+                if (IsDisposed)
+                {
+                    throw new AssertionException("End called after Dispose");
+                }
+
+                base.End();
+            }
+
+            public override void Reset()
+            {
+                if (IsDisposed)
+                {
+                    throw new AssertionException("Reset called after Dispose");
+                }
+
+                base.Reset();
+            }
+
+            public override void Close()
+            {
+                if (IsDisposed)
+                {
+                    throw new AssertionException("Close called after Dispose");
+                }
+
+                base.Close();
+            }
+
+            public bool IsDisposed { get; private set; }
+        }
+    }
+}

--- a/src/Lucene.Net.Tests.TestFramework/Analysis/TestMockAnalyzer.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Analysis/TestMockAnalyzer.cs
@@ -217,14 +217,26 @@ namespace Lucene.Net.Analysis
             String testString = "t";
 
             Analyzer analyzer = new MockAnalyzer(Random);
-            using (TokenStream stream = analyzer.GetTokenStream("dummy", testString))
+            Exception priorException = null;
+            TokenStream stream = analyzer.GetTokenStream("dummy", testString);
+
+            try
             {
                 stream.Reset();
                 while (stream.IncrementToken())
                 {
                     // consume
                 }
+
                 stream.End();
+            }
+            catch (Exception e)
+            {
+                priorException = e;
+            }
+            finally
+            {
+                IOUtils.CloseWhileHandlingException(priorException, stream);
             }
 
             AssertAnalyzesTo(analyzer, testString, new String[] { "t" });
@@ -269,13 +281,26 @@ namespace Lucene.Net.Analysis
                 StringReader reader = new StringReader(s);
                 MockCharFilter charfilter = new MockCharFilter(reader, 2);
                 MockAnalyzer analyzer = new MockAnalyzer(Random);
-                using TokenStream ts = analyzer.GetTokenStream("bogus", charfilter);
-                ts.Reset();
-                while (ts.IncrementToken())
+                Exception priorException = null;
+                TokenStream ts = analyzer.GetTokenStream("bogus", charfilter);
+                try
                 {
-                    ;
+                    ts.Reset();
+                    while (ts.IncrementToken())
+                    {
+                        ;
+                    }
+
+                    ts.End();
                 }
-                ts.End();
+                catch (Exception e)
+                {
+                    priorException = e;
+                }
+                finally
+                {
+                    IOUtils.CloseWhileHandlingException(priorException, ts);
+                }
             }
         }
 

--- a/src/Lucene.Net.Tests/Analysis/TestMockAnalyzer.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestMockAnalyzer.cs
@@ -263,7 +263,7 @@ namespace Lucene.Net.Analysis
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(priorException, stream);
+                IOUtils.CloseWhileHandlingException(priorException, stream);
             }
 
             AssertAnalyzesTo(analyzer, testString, new string[] { "t" });
@@ -327,7 +327,7 @@ namespace Lucene.Net.Analysis
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(priorException, ts);
+                    IOUtils.CloseWhileHandlingException(priorException, ts);
                 }
             }
         }

--- a/src/Lucene.Net.Tests/Analysis/TestNumericTokenStream.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestNumericTokenStream.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Analysis
         [Test]
         public virtual void TestLongStream()
         {
-            using NumericTokenStream stream = new NumericTokenStream().SetInt64Value(lvalue);
+            NumericTokenStream stream = new NumericTokenStream().SetInt64Value(lvalue);
             // use getAttribute to test if attributes really exist, if not an IAE will be throwed
             ITermToBytesRefAttribute bytesAtt = stream.GetAttribute<ITermToBytesRefAttribute>();
             ITypeAttribute typeAtt = stream.GetAttribute<ITypeAttribute>();
@@ -55,14 +55,13 @@ namespace Lucene.Net.Analysis
             }
             Assert.IsFalse(stream.IncrementToken(), "More tokens available");
             stream.End();
-            // LUCENENET specific - stream disposed above via using statement
-            // stream.Dispose();
+            stream.Close();
         }
 
         [Test]
         public virtual void TestIntStream()
         {
-            using NumericTokenStream stream = new NumericTokenStream().SetInt32Value(ivalue);
+            NumericTokenStream stream = new NumericTokenStream().SetInt32Value(ivalue);
             // use getAttribute to test if attributes really exist, if not an IAE will be throwed
             ITermToBytesRefAttribute bytesAtt = stream.GetAttribute<ITermToBytesRefAttribute>();
             ITypeAttribute typeAtt = stream.GetAttribute<ITypeAttribute>();
@@ -81,8 +80,7 @@ namespace Lucene.Net.Analysis
             }
             Assert.IsFalse(stream.IncrementToken(), "More tokens available");
             stream.End();
-            // LUCENENET specific - stream disposed above via using statement
-            // stream.Dispose();
+            stream.Close();
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Index/TestLongPostings.cs
+++ b/src/Lucene.Net.Tests/Index/TestLongPostings.cs
@@ -95,7 +95,7 @@ namespace Lucene.Net.Index
                 }
                 finally
                 {
-                    IOUtils.DisposeWhileHandlingException(priorException, ts);
+                    IOUtils.CloseWhileHandlingException(priorException, ts);
                 }
             }
         }

--- a/src/Lucene.Net.Tests/Index/TestPayloads.cs
+++ b/src/Lucene.Net.Tests/Index/TestPayloads.cs
@@ -597,12 +597,10 @@ namespace Lucene.Net.Index
                 return true;
             }
 
-            protected override void Dispose(bool disposing)
+            protected override void DoClose()
             {
-                if (disposing)
-                {
-                    pool.Release(payload);
-                }
+                pool.Release(payload);
+                base.DoClose();
             }
         }
 

--- a/src/Lucene.Net.Tests/Index/TestPayloads.cs
+++ b/src/Lucene.Net.Tests/Index/TestPayloads.cs
@@ -597,10 +597,9 @@ namespace Lucene.Net.Index
                 return true;
             }
 
-            protected override void DoClose()
+            public override void Close()
             {
                 pool.Release(payload);
-                base.DoClose();
             }
         }
 

--- a/src/Lucene.Net.Tests/Index/TestTermVectorsWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestTermVectorsWriter.cs
@@ -213,7 +213,7 @@ namespace Lucene.Net.Index
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(priorException, stream);
+                IOUtils.CloseWhileHandlingException(priorException, stream);
             }
             w.Dispose();
 

--- a/src/Lucene.Net.Tests/Search/TestPhraseQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestPhraseQuery.cs
@@ -678,7 +678,7 @@ namespace Lucene.Net.Search
                         }
                         finally
                         {
-                            IOUtils.DisposeWhileHandlingException(priorException, ts);
+                            IOUtils.CloseWhileHandlingException(priorException, ts);
                         }
                     }
                     else

--- a/src/Lucene.Net/Analysis/Analyzer.cs
+++ b/src/Lucene.Net/Analysis/Analyzer.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Analysis
     /// <para/>
     /// Simple example:
     /// <code>
-    /// Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) => 
+    /// Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
     /// {
     ///     Tokenizer source = new FooTokenizer(reader);
     ///     TokenStream filter = new FooFilter(source);
@@ -96,9 +96,9 @@ namespace Lucene.Net.Analysis
         /// <summary>
         /// Creates a new instance with the ability to specify the body of the <see cref="CreateComponents(string, TextReader)"/>
         /// method through the <paramref name="createComponents"/> parameter.
-        /// Simple example: 
+        /// Simple example:
         /// <code>
-        ///     var analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) => 
+        ///     var analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         ///     {
         ///         Tokenizer source = new FooTokenizer(reader);
         ///         TokenStream filter = new FooFilter(source);
@@ -110,8 +110,8 @@ namespace Lucene.Net.Analysis
         /// LUCENENET specific
         /// </summary>
         /// <param name="createComponents">
-        /// A delegate method that represents (is called by) the <see cref="CreateComponents(string, TextReader)"/> 
-        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and 
+        /// A delegate method that represents (is called by) the <see cref="CreateComponents(string, TextReader)"/>
+        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and
         /// returns the <see cref="TokenStreamComponents"/> for this analyzer.
         /// </param>
         /// <returns> A new <see cref="AnonymousAnalyzer"/> instance.</returns>
@@ -123,9 +123,9 @@ namespace Lucene.Net.Analysis
         /// <summary>
         /// Creates a new instance with the ability to specify the body of the <see cref="CreateComponents(string, TextReader)"/>
         /// method through the <paramref name="createComponents"/> parameter and allows the use of a <see cref="ReuseStrategy"/>.
-        /// Simple example: 
+        /// Simple example:
         /// <code>
-        ///     var analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) => 
+        ///     var analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         ///     {
         ///         Tokenizer source = new FooTokenizer(reader);
         ///         TokenStream filter = new FooFilter(source);
@@ -137,8 +137,8 @@ namespace Lucene.Net.Analysis
         /// LUCENENET specific
         /// </summary>
         /// <param name="createComponents">
-        /// An delegate method that represents (is called by) the <see cref="CreateComponents(string, TextReader)"/> 
-        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and 
+        /// An delegate method that represents (is called by) the <see cref="CreateComponents(string, TextReader)"/>
+        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and
         /// returns the <see cref="TokenStreamComponents"/> for this analyzer.
         /// </param>
         /// <param name="reuseStrategy">A custom <see cref="ReuseStrategy"/> instance.</param>
@@ -152,15 +152,15 @@ namespace Lucene.Net.Analysis
         /// Creates a new instance with the ability to specify the body of the <see cref="CreateComponents(string, TextReader)"/>
         /// method through the <paramref name="createComponents"/> parameter and the body of the <see cref="InitReader(string, TextReader)"/>
         /// method through the <paramref name="initReader"/> parameter.
-        /// Simple example: 
+        /// Simple example:
         /// <code>
-        ///     var analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) => 
+        ///     var analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         ///     {
         ///         Tokenizer source = new FooTokenizer(reader);
         ///         TokenStream filter = new FooFilter(source);
         ///         filter = new BarFilter(filter);
         ///         return new TokenStreamComponents(source, filter);
-        ///     }, initReader: (fieldName, reader) => 
+        ///     }, initReader: (fieldName, reader) =>
         ///     {
         ///         return new HTMLStripCharFilter(reader);
         ///     });
@@ -169,12 +169,12 @@ namespace Lucene.Net.Analysis
         /// LUCENENET specific
         /// </summary>
         /// <param name="createComponents">
-        /// A delegate method that represents (is called by) the <see cref="CreateComponents(string, TextReader)"/> 
-        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and 
+        /// A delegate method that represents (is called by) the <see cref="CreateComponents(string, TextReader)"/>
+        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and
         /// returns the <see cref="TokenStreamComponents"/> for this analyzer.
         /// </param>
         /// <param name="initReader">A delegate method that represents (is called by) the <see cref="InitReader(string, TextReader)"/>
-        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and 
+        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and
         /// returns the <see cref="TextReader"/> that can be modified or wrapped by the <paramref name="initReader"/> method.</param>
         /// <returns> A new <see cref="AnonymousAnalyzer"/> instance.</returns>
         public static Analyzer NewAnonymous(Func<string, TextReader, TokenStreamComponents> createComponents, Func<string, TextReader, TextReader> initReader)
@@ -186,15 +186,15 @@ namespace Lucene.Net.Analysis
         /// Creates a new instance with the ability to specify the body of the <see cref="CreateComponents(string, TextReader)"/>
         /// method through the <paramref name="createComponents"/> parameter, the body of the <see cref="InitReader(string, TextReader)"/>
         /// method through the <paramref name="initReader"/> parameter, and allows the use of a <see cref="ReuseStrategy"/>.
-        /// Simple example: 
+        /// Simple example:
         /// <code>
-        ///     var analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) => 
+        ///     var analyzer = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
         ///     {
         ///         Tokenizer source = new FooTokenizer(reader);
         ///         TokenStream filter = new FooFilter(source);
         ///         filter = new BarFilter(filter);
         ///         return new TokenStreamComponents(source, filter);
-        ///     }, initReader: (fieldName, reader) => 
+        ///     }, initReader: (fieldName, reader) =>
         ///     {
         ///         return new HTMLStripCharFilter(reader);
         ///     }, reuseStrategy);
@@ -203,12 +203,12 @@ namespace Lucene.Net.Analysis
         /// LUCENENET specific
         /// </summary>
         /// <param name="createComponents">
-        /// A delegate method that represents (is called by) the <see cref="CreateComponents(string, TextReader)"/> 
-        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and 
+        /// A delegate method that represents (is called by) the <see cref="CreateComponents(string, TextReader)"/>
+        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and
         /// returns the <see cref="TokenStreamComponents"/> for this analyzer.
         /// </param>
         /// <param name="initReader">A delegate method that represents (is called by) the <see cref="InitReader(string, TextReader)"/>
-        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and 
+        /// method. It accepts a <see cref="string"/> fieldName and a <see cref="TextReader"/> reader and
         /// returns the <see cref="TextReader"/> that can be modified or wrapped by the <paramref name="initReader"/> method.</param>
         /// <param name="reuseStrategy">A custom <see cref="ReuseStrategy"/> instance.</param>
         /// <returns> A new <see cref="AnonymousAnalyzer"/> instance.</returns>
@@ -275,7 +275,7 @@ namespace Lucene.Net.Analysis
         /// method will reuse the previously stored components after resetting them
         /// through <see cref="TokenStreamComponents.SetReader(TextReader)"/>.
         /// <para/>
-        /// <b>NOTE:</b> After calling this method, the consumer must follow the 
+        /// <b>NOTE:</b> After calling this method, the consumer must follow the
         /// workflow described in <see cref="Analysis.TokenStream"/> to properly consume its contents.
         /// See the <see cref="Lucene.Net.Analysis"/> namespace documentation for
         /// some examples demonstrating this.
@@ -360,7 +360,7 @@ namespace Lucene.Net.Analysis
         public ReuseStrategy Strategy => reuseStrategy;
 
         /// <summary>
-        /// Frees persistent resources used by this <see cref="Analyzer"/> 
+        /// Frees persistent resources used by this <see cref="Analyzer"/>
         /// </summary>
         public void Dispose()
         {
@@ -369,7 +369,7 @@ namespace Lucene.Net.Analysis
         }
 
         /// <summary>
-        /// Frees persistent resources used by this <see cref="Analyzer"/> 
+        /// Frees persistent resources used by this <see cref="Analyzer"/>
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
@@ -470,7 +470,7 @@ namespace Lucene.Net.Analysis
         /// LUCENENET specific helper class to mimick Java's ability to create anonymous classes.
         /// Clearly, the design of <see cref="Analyzer"/> took this feature of Java into consideration.
         /// Since it doesn't exist in .NET, we can use a delegate method to call the constructor of
-        /// this concrete instance to fake it (by calling an overload of 
+        /// this concrete instance to fake it (by calling an overload of
         /// <see cref="Analyzer.NewAnonymous(Func{string, TextReader, TokenStreamComponents})"/>).
         /// </summary>
         private class AnonymousAnalyzer : Analyzer

--- a/src/Lucene.Net/Analysis/CachingTokenFilter.cs
+++ b/src/Lucene.Net/Analysis/CachingTokenFilter.cs
@@ -102,27 +102,16 @@ namespace Lucene.Net.Analysis
         }
 
         /// <summary>
-        /// Releases resources used by the <see cref="CachingTokenFilter"/> and
-        /// if overridden in a derived class, optionally releases unmanaged resources.
+        /// Releases resources used by the <see cref="CachingTokenFilter"/>.
         /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources;
-        /// <c>false</c> to release only unmanaged resources.</param>
-
-        // LUCENENET specific
-        protected override void Dispose(bool disposing)
+        /// <remarks>
+        /// LUCENENET specific
+        /// </remarks>
+        protected override void DoClose()
         {
-            try
-            {
-                if (disposing)
-                {
-                    iterator?.Dispose();
-                    iterator = null;
-                }
-            }
-            finally
-            {
-                base.Dispose(disposing);
-            }
+            iterator?.Dispose();
+            iterator = null;
+            base.DoClose();
         }
     }
 }

--- a/src/Lucene.Net/Analysis/CachingTokenFilter.cs
+++ b/src/Lucene.Net/Analysis/CachingTokenFilter.cs
@@ -107,11 +107,11 @@ namespace Lucene.Net.Analysis
         /// <remarks>
         /// LUCENENET specific
         /// </remarks>
-        protected override void DoClose()
+        public override void Close()
         {
             iterator?.Dispose();
             iterator = null;
-            base.DoClose();
+            base.Close();
         }
     }
 }

--- a/src/Lucene.Net/Analysis/TokenFilter.cs
+++ b/src/Lucene.Net/Analysis/TokenFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace Lucene.Net.Analysis
 {
@@ -24,6 +25,13 @@ namespace Lucene.Net.Analysis
     /// <para/>
     /// This is an abstract class; subclasses must override <see cref="TokenStream.IncrementToken()"/>.
     /// </summary>
+    /// <remarks>
+    /// If <see cref="IDisposable"/> is implemented on a <see cref="TokenFilter"/> subclass,
+    /// a call to <see cref="Analyzer.Dispose()"/> will cascade the call to the <see cref="TokenFilter"/>
+    /// automatically. This allows for final teardown of components that are only designed to be disposed
+    /// once, since <see cref="Close()"/> may be called multiple times during a <see cref="TokenFilter"/>
+    /// instance lifetime.
+    /// </remarks>
     /// <seealso cref="TokenStream"/>
     public abstract class TokenFilter : TokenStream
     {

--- a/src/Lucene.Net/Analysis/TokenFilter.cs
+++ b/src/Lucene.Net/Analysis/TokenFilter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace Lucene.Net.Analysis
 {
@@ -29,11 +28,13 @@ namespace Lucene.Net.Analysis
     public abstract class TokenFilter : TokenStream
     {
         /// <summary>
-        /// The source of tokens for this filter. </summary>
+        /// The source of tokens for this filter.
+        /// </summary>
         protected readonly TokenStream m_input;
 
         /// <summary>
-        /// Construct a token stream filtering the given input. </summary>
+        /// Construct a token stream filtering the given input.
+        /// </summary>
         protected TokenFilter(TokenStream input)
             : base(input)
         {
@@ -41,24 +42,13 @@ namespace Lucene.Net.Analysis
         }
 
         /// <summary>
-        /// This method is called by the consumer after the last token has been
-        /// consumed, after <see cref="TokenStream.IncrementToken()"/> returned <c>false</c>
-        /// (using the new <see cref="TokenStream"/> API). Streams implementing the old API
-        /// should upgrade to use this feature.
-        /// <para/>
-        /// This method can be used to perform any end-of-stream operations, such as
-        /// setting the final offset of a stream. The final offset of a stream might
-        /// differ from the offset of the last token eg in case one or more whitespaces
-        /// followed after the last token, but a WhitespaceTokenizer was used.
-        /// <para/>
-        /// Additionally any skipped positions (such as those removed by a stopfilter)
-        /// can be applied to the position increment, or any adjustment of other
-        /// attributes where the end-of-stream value may be important.
-        /// <para/>
+        /// <inheritdoc cref="TokenStream.End()"/>
+        /// </summary>
+        /// <remarks>
         /// <b>NOTE:</b>
         /// The default implementation chains the call to the input TokenStream, so
         /// be sure to call <c>base.End()</c> first when overriding this method.
-        /// </summary>
+        /// </remarks>
         /// <exception cref="IOException"> If an I/O error occurs </exception>
         public override void End()
         {
@@ -66,35 +56,19 @@ namespace Lucene.Net.Analysis
         }
 
         /// <summary>
-        /// Releases resources associated with this stream.
-        /// <para/>
-        /// If you override this method, always call <c>base.Dispose(disposing)</c>, otherwise
-        /// some internal state will not be correctly reset (e.g., <see cref="Tokenizer"/> will
-        /// throw <see cref="InvalidOperationException"/> on reuse).
-        /// <para/>
-        /// <b>NOTE:</b>
-        /// The default implementation chains the call to the input TokenStream, so
-        /// be sure to call <c>base.Dispose(disposing)</c> when overriding this method.
+        /// <inheritdoc cref="TokenStream.DoClose()"/>
         /// </summary>
-        protected override void Dispose(bool disposing)
+        /// <remarks>
+        /// LUCENENET specific - overriding <see cref="TokenStream.DoClose()"/> instead of
+        /// <see cref="TokenStream.Close()"/> so that this is reused with <see cref="TokenStream.Dispose(bool)"/>.
+        /// </remarks>
+        protected override void DoClose()
         {
-            if (disposing)
-            {
-                m_input.Dispose();
-            }
-            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
+            m_input.Dispose();
         }
 
         /// <summary>
-        /// This method is called by a consumer before it begins consumption using
-        /// <see cref="TokenStream.IncrementToken()"/>.
-        /// <para/>
-        /// Resets this stream to a clean state. Stateful implementations must implement
-        /// this method so that they can be reused, just as if they had been created fresh.
-        /// <para/>
-        /// If you override this method, always call <c>base.Reset()</c>, otherwise
-        /// some internal state will not be correctly reset (e.g., <see cref="Tokenizer"/> will
-        /// throw <see cref="InvalidOperationException"/> on further usage).
+        /// <inheritdoc cref="TokenStream.Reset()"/>
         /// </summary>
         /// <remarks>
         /// <b>NOTE:</b>
@@ -104,6 +78,7 @@ namespace Lucene.Net.Analysis
         public override void Reset()
         {
             m_input.Reset();
+            base.Reset(); // LUCENENET specific - added to ensure base class is reset
         }
     }
 }

--- a/src/Lucene.Net/Analysis/TokenFilter.cs
+++ b/src/Lucene.Net/Analysis/TokenFilter.cs
@@ -56,15 +56,12 @@ namespace Lucene.Net.Analysis
         }
 
         /// <summary>
-        /// <inheritdoc cref="TokenStream.DoClose()"/>
+        /// <inheritdoc cref="TokenStream.Close()"/>
         /// </summary>
-        /// <remarks>
-        /// LUCENENET specific - overriding <see cref="TokenStream.DoClose()"/> instead of
-        /// <see cref="TokenStream.Close()"/> so that this is reused with <see cref="TokenStream.Dispose(bool)"/>.
-        /// </remarks>
-        protected override void DoClose()
+        public override void Close()
         {
-            m_input.Dispose();
+            m_input.Close();
+            base.Close();
         }
 
         /// <summary>
@@ -78,7 +75,6 @@ namespace Lucene.Net.Analysis
         public override void Reset()
         {
             m_input.Reset();
-            base.Reset(); // LUCENENET specific - added to ensure base class is reset
         }
     }
 }

--- a/src/Lucene.Net/Analysis/TokenFilter.cs
+++ b/src/Lucene.Net/Analysis/TokenFilter.cs
@@ -66,6 +66,11 @@ namespace Lucene.Net.Analysis
         /// <summary>
         /// <inheritdoc cref="TokenStream.Close()"/>
         /// </summary>
+        ///  <remarks>
+        /// <b>NOTE:</b>
+        /// The default implementation chains the call to the input <see cref="TokenStream"/>, so
+        /// be sure to call <c>base.Close()</c> first when overriding this method.
+        /// </remarks>
         public override void Close()
         {
             m_input.Close();

--- a/src/Lucene.Net/Analysis/TokenFilter.cs
+++ b/src/Lucene.Net/Analysis/TokenFilter.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Analysis
         /// </summary>
         /// <remarks>
         /// <b>NOTE:</b>
-        /// The default implementation chains the call to the input TokenStream, so
+        /// The default implementation chains the call to the input <see cref="TokenStream"/>, so
         /// be sure to call <c>base.End()</c> first when overriding this method.
         /// </remarks>
         /// <exception cref="IOException"> If an I/O error occurs </exception>

--- a/src/Lucene.Net/Analysis/TokenStream.cs
+++ b/src/Lucene.Net/Analysis/TokenStream.cs
@@ -37,13 +37,13 @@ namespace Lucene.Net.Analysis
     /// A new <see cref="TokenStream"/> API has been introduced with Lucene 2.9. this API
     /// has moved from being <see cref="Token"/>-based to <see cref="Util.IAttribute"/>-based. While
     /// <see cref="Token"/> still exists in 2.9 as a convenience class, the preferred way
-    /// to store the information of a <see cref="Token"/> is to use <see cref="System.Attribute"/>s.
+    /// to store the information of a <see cref="Token"/> is to use <see cref="Util.Attribute"/>s.
     /// <para/>
     /// <see cref="TokenStream"/> now extends <see cref="AttributeSource"/>, which provides
     /// access to all of the token <see cref="Util.IAttribute"/>s for the <see cref="TokenStream"/>.
-    /// Note that only one instance per <see cref="System.Attribute"/> is created and reused
+    /// Note that only one instance per <see cref="Util.Attribute"/> is created and reused
     /// for every token. This approach reduces object creation and allows local
-    /// caching of references to the <see cref="System.Attribute"/>s. See
+    /// caching of references to the <see cref="Util.Attribute"/>s. See
     /// <see cref="IncrementToken()"/> for further details.
     /// <para/>
     /// <b>The workflow of the new <see cref="TokenStream"/> API is as follows:</b>

--- a/src/Lucene.Net/Analysis/TokenStream.cs
+++ b/src/Lucene.Net/Analysis/TokenStream.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Index;
 using Lucene.Net.Util;
 using System;
 using System.IO;
@@ -77,7 +78,7 @@ namespace Lucene.Net.Analysis
     /// Therefore all non-abstract subclasses must be sealed or have at least a sealed
     /// implementation of <see cref="IncrementToken()"/>! This is checked when assertions are enabled.
     /// </summary>
-    public abstract class TokenStream : AttributeSource, ICloseable
+    public abstract class TokenStream : AttributeSource, ICloseable, IDisposable
     {
         /// <summary>
         /// A <see cref="TokenStream"/> using the default attribute factory.
@@ -110,7 +111,7 @@ namespace Lucene.Net.Analysis
         }
 
         /// <summary>
-        /// Consumers (i.e., <see cref="Index.IndexWriter"/>) use this method to advance the stream to
+        /// Consumers (i.e., <see cref="IndexWriter"/>) use this method to advance the stream to
         /// the next token. Implementing classes must implement this method and update
         /// the appropriate <see cref="Lucene.Net.Util.IAttribute"/>s with the attributes of the next
         /// token.
@@ -187,9 +188,27 @@ namespace Lucene.Net.Analysis
         /// </summary>
         /// <remarks>
         /// LUCENENET notes - this is intended to release resources in a way that allows the
-        /// object to be reused, so it is not the same as <see cref="IDisposable"/>.
+        /// object to be reused, so it is not the same as <see cref="Dispose()"/>.
         /// </remarks>
         public virtual void Close()
+        {
+        }
+
+        // LUCENENET specific - implementing proper dispose pattern
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases resources associated with this stream, in a way such that the stream is not reusable.
+        /// <para/>
+        /// If you override this method, always call <c>base.Dispose(disposing)</c>.
+        /// Also, ensure that your implementation is idempotent as it may be called multiple times.
+        /// </summary>
+        /// <seealso cref="TokenStreamComponents.Dispose()"/>
+        protected virtual void Dispose(bool disposing)
         {
         }
     }

--- a/src/Lucene.Net/Analysis/TokenStream.cs
+++ b/src/Lucene.Net/Analysis/TokenStream.cs
@@ -79,11 +79,14 @@ namespace Lucene.Net.Analysis
     /// implementation of <see cref="IncrementToken()"/>! This is checked when assertions are enabled.
     /// <para/>
     /// LUCENENET: <see cref="Close()"/> may be called multiple times upon reuse of the <see cref="Analyzer"/>.
-    /// If a <see cref="TokenStream"/> subclass implements <see cref="IDisposable"/>,
-    /// a call to <see cref="Analyzer.Dispose()"/> will be cascaded to the <see cref="TokenStream"/>
-    /// instance through <see cref="TokenStreamComponents"/>. This allows for final teardown of components
-    /// that are only designed to be disposed once.
     /// </summary>
+    /// <remarks>
+    /// If <see cref="IDisposable"/> is implemented on a <see cref="TokenStream"/> subclass,
+    /// a call to <see cref="Analyzer.Dispose()"/> will cascade the call to the <see cref="TokenStream"/>
+    /// automatically. This allows for final teardown of components that are only designed to be disposed
+    /// once, since <see cref="Close()"/> may be called multiple times during a <see cref="TokenStream"/>
+    /// instance lifetime.
+    /// </remarks>
     public abstract class TokenStream : AttributeSource, ICloseable
     {
         // LUCENENET specific - track disposable TokenStreams that are part of the current chain
@@ -215,8 +218,9 @@ namespace Lucene.Net.Analysis
         /// <remarks>
         /// LUCENENET NOTE: This is intended to release resources in a way that allows the
         /// instance to be reused, so it is not the same as <see cref="IDisposable.Dispose()"/>.
-        /// Implementing <see cref="IDisposable"/> on your <see cref="TokenStream"/> subclass will
-        /// cascade the call from <see cref="Analyzer.Dispose()"/> to your <see cref="TokenStream"/>
+        /// <para/>
+        /// Implementing <see cref="IDisposable"/> on a <see cref="TokenStream"/> subclass will
+        /// cascade the call from <see cref="Analyzer.Dispose()"/> to the <see cref="TokenStream"/>
         /// automatically.
         /// </remarks>
         public virtual void Close()
@@ -226,6 +230,9 @@ namespace Lucene.Net.Analysis
         /// <summary>
         /// LUCENENET: Disposes all tracked wrapped <see cref="TokenStream"/>s that implement <see cref="IDisposable"/>.
         /// </summary>
+        /// <remarks>
+        /// This is named <see cref="DoDispose()"/> to prevent shadowing from any subclasses that implement <see cref="IDisposable"/>.
+        /// </remarks>
         internal void DoDispose() => disposableTracker.Dispose();
 
         /// <summary>

--- a/src/Lucene.Net/Analysis/TokenStream.cs
+++ b/src/Lucene.Net/Analysis/TokenStream.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Analysis
             if (input is TokenStream ts)
             {
                 disposableTracker = ts.disposableTracker;
-                disposableTracker.MaybeRegisterForDisposal(this);
+                disposableTracker.RegisterForDisposalIfRequired(this);
             }
             else
             {
@@ -247,14 +247,14 @@ namespace Lucene.Net.Analysis
             /// <param name="obj">An object that may or may not implement <see cref="IDisposable"/>.</param>
             public DisposableTracker(object? obj)
             {
-                MaybeRegisterForDisposal(obj);
+                RegisterForDisposalIfRequired(obj);
             }
 
             /// <summary>
             /// Registers an object for disposal if it implements <see cref="IDisposable"/>.
             /// </summary>
             /// <param name="obj">An object that may or may not implement <see cref="IDisposable"/>.</param>
-            public void MaybeRegisterForDisposal(object? obj)
+            public void RegisterForDisposalIfRequired(object? obj)
             {
                 // Register in reverse order (ensures correct teardown order)
                 if (obj is IDisposable disposable)

--- a/src/Lucene.Net/Analysis/TokenStream.cs
+++ b/src/Lucene.Net/Analysis/TokenStream.cs
@@ -97,7 +97,7 @@ namespace Lucene.Net.Analysis
             // we are using a Roslyn code analyzer to ensure the rules are followed at compile time.
 
             // LUCENENET specific - track disposable TokenStreams that are part of the current chain
-            disposableTracker = new DisposableTracker(This);
+            disposableTracker = new DisposableTracker(this);
         }
 
         /// <summary>
@@ -113,11 +113,11 @@ namespace Lucene.Net.Analysis
             if (input is TokenStream ts)
             {
                 disposableTracker = ts.disposableTracker;
-                disposableTracker.MaybeRegisterForDisposal(This);
+                disposableTracker.MaybeRegisterForDisposal(this);
             }
             else
             {
-                disposableTracker = new DisposableTracker(This);
+                disposableTracker = new DisposableTracker(this);
             }
         }
 
@@ -132,14 +132,8 @@ namespace Lucene.Net.Analysis
             // we are using a Roslyn code analyzer to ensure the rules are followed at compile time.
 
             // LUCENENET specific - track disposable TokenStreams that are part of the current chain
-            disposableTracker = new DisposableTracker(This);
+            disposableTracker = new DisposableTracker(this);
         }
-
-        /// <summary>
-        /// LUCENENET: We cannot access <c>this</c> from the constructor, so this property is used
-        /// to cheat the compiler.
-        /// </summary>
-        private TokenStream This => this;
 
         /// <summary>
         /// Consumers (i.e., <see cref="IndexWriter"/>) use this method to advance the stream to

--- a/src/Lucene.Net/Analysis/TokenStream.cs
+++ b/src/Lucene.Net/Analysis/TokenStream.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Analysis
     ///         consuming the attributes after each call.</description></item>
     ///     <item><description>The consumer calls <see cref="End()"/> so that any end-of-stream operations
     ///         can be performed.</description></item>
-    ///     <item><description>The consumer calls <see cref="Dispose()"/> to release any resource when finished
+    ///     <item><description>The consumer calls <see cref="Close()"/> to release any resource when finished
     ///         using the <see cref="TokenStream"/>.</description></item>
     /// </list>
     /// To make sure that filters and consumers know which attributes are available,
@@ -77,7 +77,7 @@ namespace Lucene.Net.Analysis
     /// Therefore all non-abstract subclasses must be sealed or have at least a sealed
     /// implementation of <see cref="IncrementToken()"/>! This is checked when assertions are enabled.
     /// </summary>
-    public abstract class TokenStream : AttributeSource, ICloseable, IDisposable
+    public abstract class TokenStream : AttributeSource, ICloseable
     {
         /// <summary>
         /// A <see cref="TokenStream"/> using the default attribute factory.
@@ -187,33 +187,10 @@ namespace Lucene.Net.Analysis
         /// </summary>
         /// <remarks>
         /// LUCENENET notes - this is intended to release resources in a way that allows the
-        /// object to be reused, so it is not the same as <see cref="Dispose()"/>. If you need
-        /// to release resources that cannot be reused, override <see cref="Dispose(bool)"/> instead.
+        /// object to be reused, so it is not the same as <see cref="IDisposable"/>.
         /// </remarks>
         public virtual void Close()
         {
-        }
-
-        // LUCENENET specific - implementing proper dispose pattern
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Releases resources associated with this stream.
-        /// <para/>
-        /// If you override this method, always call <c>base.Dispose(disposing)</c>, otherwise
-        /// some internal state will not be correctly reset (e.g., <see cref="Tokenizer"/> will
-        /// throw <see cref="InvalidOperationException"/> on reuse).
-        /// </summary>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                Close();
-            }
         }
     }
 }

--- a/src/Lucene.Net/Analysis/TokenStream.cs
+++ b/src/Lucene.Net/Analysis/TokenStream.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+#nullable enable
 
 namespace Lucene.Net.Analysis
 {
@@ -237,14 +238,14 @@ namespace Lucene.Net.Analysis
         /// </summary>
         private sealed class DisposableTracker : IDisposable
         {
-            private LinkedList<IDisposable> disposables;
+            private LinkedList<IDisposable>? disposables;
 
             /// <summary>
             /// Initializes a new instance of <see cref="DisposableTracker"/> and registers the
             /// supplied <paramref name="obj"/> if it implements <see cref="IDisposable"/>.
             /// </summary>
             /// <param name="obj">An object that may or may not implement <see cref="IDisposable"/>.</param>
-            public DisposableTracker(object obj)
+            public DisposableTracker(object? obj)
             {
                 MaybeRegisterForDisposal(obj);
             }
@@ -253,7 +254,7 @@ namespace Lucene.Net.Analysis
             /// Registers an object for disposal if it implements <see cref="IDisposable"/>.
             /// </summary>
             /// <param name="obj">An object that may or may not implement <see cref="IDisposable"/>.</param>
-            public void MaybeRegisterForDisposal(object obj)
+            public void MaybeRegisterForDisposal(object? obj)
             {
                 // Register in reverse order (ensures correct teardown order)
                 if (obj is IDisposable disposable)

--- a/src/Lucene.Net/Analysis/TokenStream.cs
+++ b/src/Lucene.Net/Analysis/TokenStream.cs
@@ -79,9 +79,6 @@ namespace Lucene.Net.Analysis
     /// </summary>
     public abstract class TokenStream : AttributeSource, ICloseable, IDisposable
     {
-        private bool closed;
-        private bool disposed;
-
         /// <summary>
         /// A <see cref="TokenStream"/> using the default attribute factory.
         /// </summary>
@@ -179,7 +176,6 @@ namespace Lucene.Net.Analysis
         /// </summary>
         public virtual void Reset()
         {
-            closed = false; // LUCENENET specific - reset closed state to allow reuse
         }
 
         /// <summary>
@@ -190,28 +186,12 @@ namespace Lucene.Net.Analysis
         /// throw <see cref="InvalidOperationException"/> on reuse).
         /// </summary>
         /// <remarks>
-        /// LUCENENET specific - you probably don't want to override this method. Instead, override
-        /// <see cref="DoClose()"/> which is called by this method as well as <see cref="Dispose(bool)"/>.
+        /// LUCENENET notes - this is intended to release resources in a way that allows the
+        /// object to be reused, so it is not the same as <see cref="Dispose()"/>. If you need
+        /// to release resources that cannot be reused, override <see cref="Dispose(bool)"/> instead.
         /// </remarks>
         public virtual void Close()
         {
-            DoClose(); // LUCENENET specific - consolidated common close/dispose logic
-        }
-
-        /// <summary>
-        /// Releases resources associated with this stream, whether called from <see cref="Close()"/>
-        /// or <see cref="Dispose(bool)"/>.
-        /// <para />
-        /// If you override this method, always call <c>base.DoClose()</c>, otherwise
-        /// some internal state will not be correctly reset (e.g., <see cref="Tokenizer"/> will
-        /// throw <see cref="InvalidOperationException"/> on reuse).
-        /// </summary>
-        /// <remarks>
-        /// LUCENENET specific: This method was added to consolidate common close/dispose logic.
-        /// </remarks>
-        protected virtual void DoClose()
-        {
-            closed = true;
         }
 
         // LUCENENET specific - implementing proper dispose pattern
@@ -230,20 +210,10 @@ namespace Lucene.Net.Analysis
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposed)
-            {
-                return;
-            }
-
             if (disposing)
             {
-                if (!closed)
-                {
-                    DoClose();
-                }
+                Close();
             }
-
-            disposed = true;
         }
     }
 }

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -61,6 +61,11 @@ namespace Lucene.Net.Analysis
         /// <summary>
         /// <inheritdoc cref="TokenStream.Close()"/>
         /// </summary>
+        /// <remarks>
+        /// <b>NOTE:</b>
+        /// The default implementation closes the input Reader, so
+        /// be sure to call <c>super.close()</c> when overriding this method.
+        /// </remarks>
         public override void Close()
         {
             inputPending.Dispose(); // LUCENENET specific: call dispose on input pending

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -120,7 +120,7 @@ namespace Lucene.Net.Analysis
         {
             public override int Read(char[] cbuf, int off, int len)
             {
-                throw IllegalStateException.Create("TokenStream contract violation: Reset()/Dispose() call missing, "
+                throw IllegalStateException.Create("TokenStream contract violation: Reset()/Close() call missing, "
                     + "Reset() called multiple times, or subclass does not call base.Reset(). "
                     + "Please see the documentation of TokenStream class for more information about the correct consuming workflow.");
             }

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -70,8 +70,8 @@ namespace Lucene.Net.Analysis
         /// </summary>
         /// <remarks>
         /// <b>NOTE:</b>
-        /// The default implementation closes the input Reader, so
-        /// be sure to call <c>super.close()</c> when overriding this method.
+        /// The default implementation disposes the input <see cref="TextReader"/>, so
+        /// be sure to call <c>base.Close()</c> when overriding this method.
         /// </remarks>
         public override void Close()
         {

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -59,36 +59,16 @@ namespace Lucene.Net.Analysis
         }
 
         /// <summary>
-        /// <inheritdoc cref="TokenStream.DoClose()"/>
+        /// <inheritdoc cref="TokenStream.Close()"/>
         /// </summary>
-        /// <remarks>
-        /// LUCENENET specific - overriding <see cref="TokenStream.DoClose()"/> instead of
-        /// <see cref="TokenStream.Close()"/> so that this is reused with <see cref="TokenStream.Dispose(bool)"/>.
-        /// </remarks>
-        protected override void DoClose()
+        public override void Close()
         {
+            inputPending.Dispose(); // LUCENENET specific: call dispose on input pending
             m_input.Dispose();
             // LUCENE-2387: don't hold onto Reader after close, so
             // GC can reclaim
             inputPending = m_input = ILLEGAL_STATE_READER;
-            base.DoClose();
-        }
-
-        /// <summary>
-        /// <inheritdoc cref="TokenStream.Dispose(bool)"/>
-        /// </summary>
-        /// <remarks>
-        /// <b>NOTE:</b>
-        /// The default implementation closes the input <see cref="TextReader"/>, so
-        /// be sure to call <c>base.Dispose(disposing)</c> when overriding this method.
-        /// </remarks>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                inputPending.Dispose(); // LUCENENET specific: call dispose on input pending
-            }
-            base.Dispose(disposing); // LUCENENET specific - disposable pattern requires calling the base class implementation
+            base.Close();
         }
 
         /// <summary>

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -30,6 +30,13 @@ namespace Lucene.Net.Analysis
     /// call <see cref="Util.AttributeSource.ClearAttributes()"/> before
     /// setting attributes.
     /// </summary>
+    /// <remarks>
+    /// If <see cref="IDisposable"/> is implemented on a <see cref="Tokenizer"/> subclass,
+    /// a call to <see cref="Analyzer.Dispose()"/> will cascade the call to the <see cref="Tokenizer"/>
+    /// automatically. This allows for final teardown of components that are only designed to be disposed
+    /// once, since <see cref="Close()"/> may be called multiple times during a <see cref="Tokenizer"/>
+    /// instance lifetime.
+    /// </remarks>
     public abstract class Tokenizer : TokenStream
     {
         /// <summary>

--- a/src/Lucene.Net/Analysis/Tokenizer.cs
+++ b/src/Lucene.Net/Analysis/Tokenizer.cs
@@ -113,6 +113,14 @@ namespace Lucene.Net.Analysis
             if (Debugging.AssertsEnabled) Debugging.Assert(SetReaderTestPoint());
         }
 
+        /// <summary>
+        /// <inheritdoc cref="TokenStream.Reset()"/>
+        /// </summary>
+        /// <remarks>
+        /// <b>NOTE:</b>
+        /// The default implementation chains the call to the input <see cref="TokenStream"/>, so
+        /// be sure to call <c>base.Reset()</c> when overriding this method.
+        /// </remarks>
         public override void Reset()
         {
             base.Reset();

--- a/src/Lucene.Net/Document/Field.cs
+++ b/src/Lucene.Net/Document/Field.cs
@@ -35,8 +35,8 @@ namespace Lucene.Net.Documents
 
     /// <summary>
     /// Expert: directly create a field for a document.  Most
-    /// users should use one of the sugar subclasses: <see cref="Int32Field"/>, 
-    /// <see cref="Int64Field"/>, <see cref="SingleField"/>, <see cref="DoubleField"/>, 
+    /// users should use one of the sugar subclasses: <see cref="Int32Field"/>,
+    /// <see cref="Int64Field"/>, <see cref="SingleField"/>, <see cref="DoubleField"/>,
     /// <see cref="BinaryDocValuesField"/>, <see cref="NumericDocValuesField"/>,
     /// <see cref="SortedDocValuesField"/>, <see cref="StringField"/>,
     /// <see cref="TextField"/>, <see cref="StoredField"/>.
@@ -44,7 +44,7 @@ namespace Lucene.Net.Documents
     /// <para/> A field is a section of a <see cref="Document"/>. Each field has three
     /// parts: name, type and value. Values may be text
     /// (<see cref="string"/>, <see cref="TextReader"/> or pre-analyzed <see cref="TokenStream"/>), binary
-    /// (<see cref="T:byte[]"/>), or numeric (<see cref="int"/>, <see cref="long"/>, <see cref="float"/>, or <see cref="double"/>). 
+    /// (<see cref="T:byte[]"/>), or numeric (<see cref="int"/>, <see cref="long"/>, <see cref="float"/>, or <see cref="double"/>).
     /// Fields are optionally stored in the
     /// index, so that they may be returned with hits on the document.
     ///
@@ -72,7 +72,7 @@ namespace Lucene.Net.Documents
         private object fieldsData;
 
         /// <summary>
-        /// Field's value 
+        /// Field's value
         /// <para/>
         /// Setting this property will automatically set the backing field for the
         /// <see cref="NumericType"/> property.
@@ -320,7 +320,7 @@ namespace Lucene.Net.Documents
         /// <param name="provider">An object that supplies culture-specific formatting information. This parameter has no effect if this field is non-numeric.</param>
         /// <returns>The string representation of the value if it is either a <see cref="string"/> or numeric type.</returns>
         // LUCENENET specific overload.
-        public virtual string GetStringValue(IFormatProvider provider) 
+        public virtual string GetStringValue(IFormatProvider provider)
         {
             return GetStringValue(null, provider);
         }
@@ -333,7 +333,7 @@ namespace Lucene.Net.Documents
         /// <param name="format">A standard or custom numeric format string. This parameter has no effect if this field is non-numeric.</param>
         /// <returns>The string representation of the value if it is either a <see cref="string"/> or numeric type.</returns>
         // LUCENENET specific overload.
-        public virtual string GetStringValue(string format) 
+        public virtual string GetStringValue(string format)
         {
             return GetStringValue(format, null);
         }
@@ -411,7 +411,7 @@ namespace Lucene.Net.Documents
         }
 
         /// <summary>
-        /// Expert: change the value of this field. See 
+        /// Expert: change the value of this field. See
         /// <see cref="SetStringValue(string)"/>.
         /// </summary>
         public virtual void SetReaderValue(TextReader value)
@@ -532,7 +532,7 @@ namespace Lucene.Net.Documents
 
         // LUCENENET TODO: Add SetValue() overloads for each type?
         // Upside: Simpler API.
-        // Downside: Must be vigilant about what type is passed or the wrong overload will be called and will get a runtime exception. 
+        // Downside: Must be vigilant about what type is passed or the wrong overload will be called and will get a runtime exception.
 
         /// <summary>
         /// Expert: sets the token stream to be used for indexing and causes
@@ -602,15 +602,15 @@ namespace Lucene.Net.Documents
         /// <summary>
         /// Gets the <see cref="NumericFieldType"/> of the underlying value, or <see cref="NumericFieldType.NONE"/> if the value is not set or non-numeric.
         /// <para/>
-        /// Expert: The difference between this property and <see cref="FieldType.NumericType"/> is 
+        /// Expert: The difference between this property and <see cref="FieldType.NumericType"/> is
         /// this is represents the current state of the field (whether being written or read) and the
         /// <see cref="FieldType"/> property represents instructions on how the field will be written,
         /// but does not re-populate when reading back from an index (it is write-only).
         /// <para/>
-        /// In Java, the numeric type was determined by checking the type of  
+        /// In Java, the numeric type was determined by checking the type of
         /// <see cref="GetNumericValue()"/>. However, since there are no reference number
         /// types in .NET, using <see cref="GetNumericValue()"/> so will cause boxing/unboxing. It is
-        /// therefore recommended to use this property to check the underlying type and the corresponding 
+        /// therefore recommended to use this property to check the underlying type and the corresponding
         /// <c>Get*Value()</c> method to retrieve the value.
         /// <para/>
         /// NOTE: Since Lucene codecs do not support <see cref="NumericFieldType.BYTE"/> or <see cref="NumericFieldType.INT16"/>,
@@ -770,7 +770,7 @@ namespace Lucene.Net.Documents
         }
 
         /// <summary>
-        /// Prints a <see cref="Field"/> for human consumption. 
+        /// Prints a <see cref="Field"/> for human consumption.
         /// </summary>
         /// <param name="format">A standard or custom numeric format string. This parameter has no effect if this field is non-numeric.</param>
         // LUCENENET specific - method added for better .NET compatibility
@@ -954,12 +954,9 @@ namespace Lucene.Net.Documents
                 used = false;
             }
 
-            protected override void Dispose(bool disposing)
+            protected override void DoClose()
             {
-                if (disposing)
-                {
-                    value = null;
-                }
+                value = null;
             }
         }
 
@@ -985,7 +982,7 @@ namespace Lucene.Net.Documents
         //
 
         /// <summary>
-        /// Specifies whether and how a field should be indexed. 
+        /// Specifies whether and how a field should be indexed.
         /// </summary>
         [Obsolete("This is here only to ease transition from the pre-4.0 APIs.")]
         public enum Index
@@ -1035,13 +1032,13 @@ namespace Lucene.Net.Documents
         }
 
         /// <summary>
-        /// Specifies whether and how a field should have term vectors. 
+        /// Specifies whether and how a field should have term vectors.
         /// </summary>
         [Obsolete("This is here only to ease transition from the pre-4.0 APIs.")]
         public enum TermVector
         {
             /// <summary>
-            /// Do not store term vectors. 
+            /// Do not store term vectors.
             /// </summary>
             NO,
 
@@ -1197,7 +1194,7 @@ namespace Lucene.Net.Documents
         }
 
         /// <summary>
-        /// Create a tokenized and indexed field that is not stored, optionally with 
+        /// Create a tokenized and indexed field that is not stored, optionally with
         /// storing term vectors.  The <see cref="TextReader"/> is read only when the <see cref="Document"/> is added to the index,
         /// i.e. you may not close the <see cref="TextReader"/> until <see cref="IndexWriter.AddDocument(System.Collections.Generic.IEnumerable{IIndexableField})"/>
         /// has been called.
@@ -1229,7 +1226,7 @@ namespace Lucene.Net.Documents
         }
 
         /// <summary>
-        /// Create a tokenized and indexed field that is not stored, optionally with 
+        /// Create a tokenized and indexed field that is not stored, optionally with
         /// storing term vectors.  This is useful for pre-analyzed fields.
         /// The <see cref="TokenStream"/> is read only when the <see cref="Document"/> is added to the index,
         /// i.e. you may not close the <see cref="TokenStream"/> until <see cref="IndexWriter.AddDocument(System.Collections.Generic.IEnumerable{IIndexableField})"/>
@@ -1412,7 +1409,7 @@ namespace Lucene.Net.Documents
         }
 
         [Obsolete("This is here only to ease transition from the pre-4.0 APIs.")]
-        public static Field.Index ToIndex(bool indexed, bool analyzed, bool omitNorms) 
+        public static Field.Index ToIndex(bool indexed, bool analyzed, bool omitNorms)
         {
             // If it is not indexed nothing else matters
             if (!indexed)
@@ -1473,8 +1470,8 @@ namespace Lucene.Net.Documents
     // LUCENENET specific
     // Since we have more numeric types on Field than on FieldType,
     // a new enumeration was created for .NET. In Java, this type was
-    // determined by checking the data type of the Field.numericValue() 
-    // method. However, since the corresponding GetNumericValue() method 
+    // determined by checking the data type of the Field.numericValue()
+    // method. However, since the corresponding GetNumericValue() method
     // in .NET returns type object (which would result in boxing/unboxing),
     // this has been refactored to use an enumeration instead, which makes the
     // API easier to use.
@@ -1511,7 +1508,7 @@ namespace Lucene.Net.Documents
         SINGLE,
 
         /// <summary>
-        /// 64-bit double numeric type 
+        /// 64-bit double numeric type
         /// </summary>
         DOUBLE
     }

--- a/src/Lucene.Net/Document/Field.cs
+++ b/src/Lucene.Net/Document/Field.cs
@@ -954,7 +954,7 @@ namespace Lucene.Net.Documents
                 used = false;
             }
 
-            protected override void DoClose()
+            public override void Close()
             {
                 value = null;
             }

--- a/src/Lucene.Net/Index/DocInverterPerField.cs
+++ b/src/Lucene.Net/Index/DocInverterPerField.cs
@@ -223,11 +223,11 @@ namespace Lucene.Net.Index
                     {
                         if (!succeededInProcessingField)
                         {
-                            IOUtils.DisposeWhileHandlingException(stream);
+                            IOUtils.CloseWhileHandlingException(stream);
                         }
                         else
                         {
-                            stream.Dispose();
+                            stream.Close();
                         }
                         if (!succeededInProcessingField && docState.infoStream.IsEnabled("DW"))
                         {

--- a/src/Lucene.Net/Support/IO/ICloseable.cs
+++ b/src/Lucene.Net/Support/IO/ICloseable.cs
@@ -1,0 +1,35 @@
+namespace Lucene.Net.Support.IO
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Represents a source or destination of data that can be closed.
+    /// </summary>
+    /// <remarks>
+    /// LUCENENET specific - this interface is to be used when a class
+    /// is designed to be reusable after being closed, unlike IDisposable,
+    /// when the instance is no longer usable after being disposed.
+    /// </remarks>
+    public interface ICloseable
+    {
+        /// <summary>
+        /// Closes this object in a way that allows it to be reused.
+        /// </summary>
+        void Close();
+    }
+}

--- a/src/Lucene.Net/Support/Util/ICloseable.cs
+++ b/src/Lucene.Net/Support/Util/ICloseable.cs
@@ -1,4 +1,4 @@
-namespace Lucene.Net.Support.IO
+namespace Lucene.Net.Util
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Util/CloseableThreadLocal.cs
+++ b/src/Lucene.Net/Util/CloseableThreadLocal.cs
@@ -170,11 +170,16 @@ namespace Lucene.Net.Util
             if (copy is null)
                 return;
 
-            IOUtils.Dispose(copy.Values.OfType<IDisposable>());
-
-            Interlocked.Increment(ref globalVersion);
-            _disposed = true;
-            _values = null;
+            try
+            {
+                IOUtils.Dispose(copy.Values.OfType<IDisposable>());
+            }
+            finally
+            {
+                Interlocked.Increment(ref globalVersion);
+                _disposed = true;
+                _values = null;
+            }
         }
 
         private sealed class CurrentThreadState

--- a/src/Lucene.Net/Util/CloseableThreadLocal.cs
+++ b/src/Lucene.Net/Util/CloseableThreadLocal.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Util
     /// <para/>
     /// This class works around the issue by using an alternative approach than using <see cref="ThreadLocal{T}"/>.
     /// It keeps track of each thread's local and global state in order to later optimize garbage collection.
-    /// A complete explanation can be found at 
+    /// A complete explanation can be found at
     /// <a href="https://ayende.com/blog/189793-A/the-design-and-implementation-of-a-better-threadlocal-t">
     /// https://ayende.com/blog/189793-A/the-design-and-implementation-of-a-better-threadlocal-t</a>.
     /// <para/>
@@ -168,6 +168,21 @@ namespace Lucene.Net.Util
             copy = Interlocked.CompareExchange(ref _values, null, copy);
             if (copy is null)
                 return;
+
+            foreach (var value in copy.Values)
+            {
+                if (value is IDisposable disposable)
+                {
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+                }
+            }
 
             Interlocked.Increment(ref globalVersion);
             _disposed = true;

--- a/src/Lucene.Net/Util/CloseableThreadLocal.cs
+++ b/src/Lucene.Net/Util/CloseableThreadLocal.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using JCG = J2N.Collections.Generic;
@@ -169,20 +170,7 @@ namespace Lucene.Net.Util
             if (copy is null)
                 return;
 
-            foreach (var value in copy.Values)
-            {
-                if (value is IDisposable disposable)
-                {
-                    try
-                    {
-                        disposable.Dispose();
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
-                }
-            }
+            IOUtils.Dispose(copy.Values.OfType<IDisposable>());
 
             Interlocked.Increment(ref globalVersion);
             _disposed = true;

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -83,65 +83,60 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="priorException">  <c>null</c> or an exception that will be rethrown after method completion. </param>
         /// <param name="objects">         Objects to call <see cref="IDisposable.Dispose()"/> on. </param>
-        [Obsolete("Use DisposeWhileHandlingException(Exception, params IDisposable[]) instead.")]
-        public static void CloseWhileHandlingException(Exception priorException, params IDisposable[] objects)
+        public static void CloseWhileHandlingException(Exception priorException, params ICloseable[] objects)
         {
-            DisposeWhileHandlingException(priorException, objects);
+            CloseWhileHandlingException(priorException, objects);
         }
 
         /// <summary>
-        /// Disposes all given <see cref="IDisposable"/>s, suppressing all thrown exceptions. </summary>
-        /// <seealso cref="DisposeWhileHandlingException(Exception, IDisposable[])"/>
-        [Obsolete("Use DisposeWhileHandlingException(Exception, IEnumerable<IDisposable>) instead.")]
-        public static void CloseWhileHandlingException(Exception priorException, IEnumerable<IDisposable> objects)
+        /// Closes all given <see cref="ICloseable"/>s, suppressing all thrown exceptions.
+        /// </summary>
+        /// <seealso cref="CloseWhileHandlingException(Exception, ICloseable[])"/>
+        public static void CloseWhileHandlingException(Exception priorException, IEnumerable<ICloseable> objects)
         {
-            DisposeWhileHandlingException(priorException, objects);
+            CloseWhileHandlingException(priorException, objects);
         }
 
         /// <summary>
-        /// Disposes all given <see cref="IDisposable"/>s.  Some of the
-        /// <see cref="IDisposable"/>s may be <c>null</c>; they are
+        /// Closes all given <see cref="ICloseable"/>s.  Some of the
+        /// <see cref="ICloseable"/>s may be <c>null</c>; they are
         /// ignored.  After everything is closed, the method either
         /// throws the first exception it hit while closing, or
         /// completes normally if there were no exceptions.
         /// </summary>
-        /// <param name="objects">
-        ///          Objects to call <see cref="IDisposable.Dispose()"/> on </param>
-        [Obsolete("Use Dispose(params IDisposable[]) instead.")]
-        public static void Close(params IDisposable[] objects)
+        /// <param name="objects">Objects to call <see cref="ICloseable.Close()"/> on</param>
+        public static void Close(params ICloseable[] objects)
         {
-            Dispose(objects);
+            Close(objects);
         }
 
         /// <summary>
-        /// Disposes all given <see cref="IDisposable"/>s. </summary>
-        /// <seealso cref="Dispose(IDisposable[])"/>
-        [Obsolete("Use Dispose(IEnumerable<IDisposable>) instead.")]
-        public static void Close(IEnumerable<IDisposable> objects)
-        {
-            Dispose(objects);
-        }
-
-        /// <summary>
-        /// Disposes all given <see cref="IDisposable"/>s, suppressing all thrown exceptions.
-        /// Some of the <see cref="IDisposable"/>s may be <c>null</c>, they are ignored.
+        /// Closes all given <see cref="ICloseable"/>s.
         /// </summary>
-        /// <param name="objects">
-        ///          Objects to call <see cref="IDisposable.Dispose()"/> on </param>
-        [Obsolete("Use DisposeWhileHandlingException(params IDisposable[]) instead.")]
-        public static void CloseWhileHandlingException(params IDisposable[] objects)
+        /// <seealso cref="Close(ICloseable[])"/>
+        public static void Close(IEnumerable<ICloseable> objects)
         {
-            DisposeWhileHandlingException(objects);
+            Close(objects);
         }
 
         /// <summary>
-        /// Disposes all given <see cref="IDisposable"/>s, suppressing all thrown exceptions. </summary>
-        /// <seealso cref="DisposeWhileHandlingException(IEnumerable{IDisposable})"/>
-        /// <seealso cref="DisposeWhileHandlingException(IDisposable[])"/>
-        [Obsolete("Use DisposeWhileHandlingException(IEnumerable<IDisposable>) instead.")]
-        public static void CloseWhileHandlingException(IEnumerable<IDisposable> objects)
+        /// Closes all given <see cref="ICloseable"/>s, suppressing all thrown exceptions.
+        /// Some of the <see cref="ICloseable"/>s may be <c>null</c>, they are ignored.
+        /// </summary>
+        /// <param name="objects">Objects to call <see cref="ICloseable.Close()"/> on</param>
+        public static void CloseWhileHandlingException(params ICloseable[] objects)
         {
-            DisposeWhileHandlingException(objects);
+            CloseWhileHandlingException(objects);
+        }
+
+        /// <summary>
+        /// Closes all given <see cref="ICloseable"/>s, suppressing all thrown exceptions.
+        /// </summary>
+        /// <seealso cref="CloseWhileHandlingException(IEnumerable{ICloseable})"/>
+        /// <seealso cref="CloseWhileHandlingException(ICloseable[])"/>
+        public static void CloseWhileHandlingException(IEnumerable<ICloseable> objects)
+        {
+            CloseWhileHandlingException(objects);
         }
 
 

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -220,6 +220,7 @@ namespace Lucene.Net.Util
                 }
                 catch (Exception t) when (t.IsThrowable())
                 {
+                    // eat it
                 }
             }
         }
@@ -239,6 +240,7 @@ namespace Lucene.Net.Util
                 }
                 catch (Exception t) when (t.IsThrowable())
                 {
+                    // eat it
                 }
             }
         }

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -58,8 +58,66 @@ namespace Lucene.Net.Util
         public static readonly string UTF_8 = "UTF-8";
 
         /// <summary>
-        /// <para>Disposes all given <c>IDisposable</c>s, suppressing all thrown exceptions. Some of the <c>IDisposable</c>s
-        /// may be <c>null</c>, they are ignored. After everything is disposed, method either throws <paramref name="priorException"/>,
+        /// Closes all given <see cref="ICloseable"/>s.  Some of the
+        /// <see cref="ICloseable"/>s may be <c>null</c>; they are
+        /// ignored.  After everything is closed, the method either
+        /// throws the first exception it hit while closing, or
+        /// completes normally if there were no exceptions.
+        /// </summary>
+        /// <param name="objects">Objects to call <see cref="ICloseable.Close()"/> on</param>
+        public static void Close(params ICloseable[] objects)
+        {
+            Exception th = null;
+
+            foreach (ICloseable @object in objects)
+            {
+                try
+                {
+                    @object?.Close();
+                }
+                catch (Exception t) when (t.IsThrowable())
+                {
+                    AddSuppressed(th, t);
+                    if (th is null)
+                    {
+                        th = t;
+                    }
+                }
+            }
+
+            ReThrow(th);
+        }
+
+        /// <summary>
+        /// Closes all given <see cref="ICloseable"/>s.
+        /// </summary>
+        /// <seealso cref="Close(ICloseable[])"/>
+        public static void Close(IEnumerable<ICloseable> objects)
+        {
+            Exception th = null;
+
+            foreach (ICloseable @object in objects)
+            {
+                try
+                {
+                    @object?.Close();
+                }
+                catch (Exception t) when (t.IsThrowable())
+                {
+                    AddSuppressed(th, t);
+                    if (th is null)
+                    {
+                        th = t;
+                    }
+                }
+            }
+
+            ReThrow(th);
+        }
+
+        /// <summary>
+        /// <para>Closes all given <see cref="ICloseable">ICloseable</see>s, suppressing all thrown exceptions. Some of the <see cref="ICloseable">ICloseable</see>s
+        /// may be <c>null</c>, they are ignored. After everything is closed, method either throws <paramref name="priorException"/>,
         /// if one is supplied, or the first of suppressed exceptions, or completes normally.</para>
         /// <para>Sample usage:
         /// <code>
@@ -82,10 +140,10 @@ namespace Lucene.Net.Util
         /// </para>
         /// </summary>
         /// <param name="priorException">  <c>null</c> or an exception that will be rethrown after method completion. </param>
-        /// <param name="objects">         Objects to call <see cref="IDisposable.Dispose()"/> on. </param>
+        /// <param name="objects">         Objects to call <see cref="ICloseable.Close()"/> on. </param>
         public static void CloseWhileHandlingException(Exception priorException, params ICloseable[] objects)
         {
-            CloseWhileHandlingException(priorException, objects);
+            throw new NotImplementedException("TODO: determine if these are still needed, they don't exist upstream");
         }
 
         /// <summary>
@@ -94,29 +152,7 @@ namespace Lucene.Net.Util
         /// <seealso cref="CloseWhileHandlingException(Exception, ICloseable[])"/>
         public static void CloseWhileHandlingException(Exception priorException, IEnumerable<ICloseable> objects)
         {
-            CloseWhileHandlingException(priorException, objects);
-        }
-
-        /// <summary>
-        /// Closes all given <see cref="ICloseable"/>s.  Some of the
-        /// <see cref="ICloseable"/>s may be <c>null</c>; they are
-        /// ignored.  After everything is closed, the method either
-        /// throws the first exception it hit while closing, or
-        /// completes normally if there were no exceptions.
-        /// </summary>
-        /// <param name="objects">Objects to call <see cref="ICloseable.Close()"/> on</param>
-        public static void Close(params ICloseable[] objects)
-        {
-            Close(objects);
-        }
-
-        /// <summary>
-        /// Closes all given <see cref="ICloseable"/>s.
-        /// </summary>
-        /// <seealso cref="Close(ICloseable[])"/>
-        public static void Close(IEnumerable<ICloseable> objects)
-        {
-            Close(objects);
+            throw new NotImplementedException("TODO: determine if these are still needed, they don't exist upstream");
         }
 
         /// <summary>
@@ -126,7 +162,25 @@ namespace Lucene.Net.Util
         /// <param name="objects">Objects to call <see cref="ICloseable.Close()"/> on</param>
         public static void CloseWhileHandlingException(params ICloseable[] objects)
         {
-            CloseWhileHandlingException(objects);
+            Exception th = null;
+
+            foreach (ICloseable @object in objects)
+            {
+                try
+                {
+                    @object?.Close();
+                }
+                catch (Exception t) when (t.IsThrowable())
+                {
+                    AddSuppressed(th, t);
+                    if (th is null)
+                    {
+                        th = t;
+                    }
+                }
+            }
+
+            ReThrow(th);
         }
 
         /// <summary>
@@ -136,7 +190,25 @@ namespace Lucene.Net.Util
         /// <seealso cref="CloseWhileHandlingException(ICloseable[])"/>
         public static void CloseWhileHandlingException(IEnumerable<ICloseable> objects)
         {
-            CloseWhileHandlingException(objects);
+            Exception th = null;
+
+            foreach (ICloseable @object in objects)
+            {
+                try
+                {
+                    @object?.Close();
+                }
+                catch (Exception t) when (t.IsThrowable())
+                {
+                    AddSuppressed(th, t);
+                    if (th is null)
+                    {
+                        th = t;
+                    }
+                }
+            }
+
+            ReThrow(th);
         }
 
 

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -212,8 +212,6 @@ namespace Lucene.Net.Util
         /// <param name="objects">Objects to call <see cref="ICloseable.Close()"/> on</param>
         public static void CloseWhileHandlingException(params ICloseable[] objects)
         {
-            Exception th = null;
-
             foreach (ICloseable @object in objects)
             {
                 try
@@ -222,15 +220,8 @@ namespace Lucene.Net.Util
                 }
                 catch (Exception t) when (t.IsThrowable())
                 {
-                    AddSuppressed(th, t);
-                    if (th is null)
-                    {
-                        th = t;
-                    }
                 }
             }
-
-            ReThrow(th);
         }
 
         /// <summary>
@@ -240,8 +231,6 @@ namespace Lucene.Net.Util
         /// <seealso cref="CloseWhileHandlingException(ICloseable[])"/>
         public static void CloseWhileHandlingException(IEnumerable<ICloseable> objects)
         {
-            Exception th = null;
-
             foreach (ICloseable @object in objects)
             {
                 try
@@ -250,15 +239,8 @@ namespace Lucene.Net.Util
                 }
                 catch (Exception t) when (t.IsThrowable())
                 {
-                    AddSuppressed(th, t);
-                    if (th is null)
-                    {
-                        th = t;
-                    }
                 }
             }
-
-            ReThrow(th);
         }
 
 

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -143,7 +143,32 @@ namespace Lucene.Net.Util
         /// <param name="objects">         Objects to call <see cref="ICloseable.Close()"/> on. </param>
         public static void CloseWhileHandlingException(Exception priorException, params ICloseable[] objects)
         {
-            throw new NotImplementedException("TODO: determine if these are still needed, they don't exist upstream");
+            Exception th = null;
+
+            foreach (ICloseable @object in objects)
+            {
+                try
+                {
+                    @object?.Close();
+                }
+                catch (Exception t) when (t.IsThrowable())
+                {
+                    AddSuppressed(priorException ?? th, t);
+                    if (th is null)
+                    {
+                        th = t;
+                    }
+                }
+            }
+
+            if (priorException != null)
+            {
+                ExceptionDispatchInfo.Capture(priorException).Throw(); // LUCENENET: Rethrow to preserve stack details from the original throw
+            }
+            else
+            {
+                ReThrow(th);
+            }
         }
 
         /// <summary>
@@ -152,7 +177,32 @@ namespace Lucene.Net.Util
         /// <seealso cref="CloseWhileHandlingException(Exception, ICloseable[])"/>
         public static void CloseWhileHandlingException(Exception priorException, IEnumerable<ICloseable> objects)
         {
-            throw new NotImplementedException("TODO: determine if these are still needed, they don't exist upstream");
+            Exception th = null;
+
+            foreach (ICloseable @object in objects)
+            {
+                try
+                {
+                    @object?.Close();
+                }
+                catch (Exception t) when (t.IsThrowable())
+                {
+                    AddSuppressed(priorException ?? th, t);
+                    if (th is null)
+                    {
+                        th = t;
+                    }
+                }
+            }
+
+            if (priorException != null)
+            {
+                ExceptionDispatchInfo.Capture(priorException).Throw(); // LUCENENET: Rethrow to preserve stack details from the original throw
+            }
+            else
+            {
+                ReThrow(th);
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/QueryBuilder.cs
+++ b/src/Lucene.Net/Util/QueryBuilder.cs
@@ -250,7 +250,7 @@ namespace Lucene.Net.Util
             }
             finally
             {
-                IOUtils.DisposeWhileHandlingException(source);
+                IOUtils.CloseWhileHandlingException(source);
             }
 
             // rewind the buffer stream
@@ -439,7 +439,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Builds a new <see cref="BooleanQuery"/> instance.
         /// <para/>
-        /// This is intended for subclasses that wish to customize the generated queries. 
+        /// This is intended for subclasses that wish to customize the generated queries.
         /// </summary>
         /// <param name="disableCoord"> Disable coord. </param>
         /// <returns> New <see cref="BooleanQuery"/> instance. </returns>
@@ -452,7 +452,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Builds a new <see cref="TermQuery"/> instance.
         /// <para/>
-        /// This is intended for subclasses that wish to customize the generated queries. 
+        /// This is intended for subclasses that wish to customize the generated queries.
         /// </summary>
         /// <param name="term"> Term. </param>
         /// <returns> New <see cref="TermQuery"/> instance. </returns>
@@ -465,7 +465,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Builds a new <see cref="PhraseQuery"/> instance.
         /// <para/>
-        /// This is intended for subclasses that wish to customize the generated queries. 
+        /// This is intended for subclasses that wish to customize the generated queries.
         /// </summary>
         /// <returns> New <see cref="PhraseQuery"/> instance. </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -477,7 +477,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Builds a new <see cref="MultiPhraseQuery"/> instance.
         /// <para/>
-        /// This is intended for subclasses that wish to customize the generated queries. 
+        /// This is intended for subclasses that wish to customize the generated queries.
         /// </summary>
         /// <returns> New <see cref="MultiPhraseQuery"/> instance. </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Overhaul TokenStream ICloseable/IDisposable Patterns

Fixes #271

## Description

This pull request focuses on refactoring the codebase by replacing the `Dispose` method with the new `ICloseable` interface's `Close` method in all provided TokenStream implementations to make them reusable. None of the implementations in our codebase need a non-reusable cleanup method, however, in discussion in #271, it was determined that there are possible use cases in which a custom TokenStream implementation might need to have their instance Disposed when the owning Analyzer (with stored values set by a ReuseStrategy) is disposed, so we have retained the IDisposable pattern as well. This PR also ensures that those values are disposed by way of DisposableThreadLocal and TokenStreamComponents disposing of their values.