### PR TITLE
SWEEP: Avoid unnecessary FileInfo/DirectoryInfo allocations, #832

### DIFF
--- a/Lucene.Net.sln.DotSettings
+++ b/Lucene.Net.sln.DotSettings
@@ -1,4 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coord/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LUCENENET/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=stopword/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=stopwords/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=testsettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
@@ -127,9 +127,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <param name="filename"> the filename </param>
         /// <exception cref="IOException"> In case the parsing fails </exception>
         public virtual void LoadPatterns(string filename)
-        {
-            LoadPatterns(filename, Encoding.UTF8);
-        }
+            => LoadPatterns(filename, Encoding.UTF8);
 
         /// <summary>
         /// Read hyphenation patterns from an XML file.
@@ -149,9 +147,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <param name="f"> a <see cref="FileInfo"/> object representing the file </param>
         /// <exception cref="IOException"> In case the parsing fails </exception>
         public virtual void LoadPatterns(FileInfo f)
-        {
-            LoadPatterns(f, Encoding.UTF8);
-        }
+            => LoadPatterns(f.FullName, Encoding.UTF8);
 
         /// <summary>
         /// Read hyphenation patterns from an XML file.
@@ -160,10 +156,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <param name="encoding">The character encoding to use</param>
         /// <exception cref="IOException"> In case the parsing fails </exception>
         public virtual void LoadPatterns(FileInfo f, Encoding encoding)
-        {
-            var src = new FileStream(f.FullName, FileMode.Open, FileAccess.Read);
-            LoadPatterns(src, encoding);
-        }
+            => LoadPatterns(f.FullName, encoding);
 
         /// <summary>
         /// Read hyphenation patterns from an XML file.
@@ -171,9 +164,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <param name="source"> <see cref="Stream"/> input source for the file </param>
         /// <exception cref="IOException"> In case the parsing fails </exception>
         public virtual void LoadPatterns(Stream source)
-        {
-            LoadPatterns(source, Encoding.UTF8);
-        }
+            => LoadPatterns(source, Encoding.UTF8);
 
         /// <summary>
         /// Read hyphenation patterns from an XML file.

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
@@ -17,9 +17,9 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
      * The ASF licenses this file to You under the Apache License, Version 2.0
      * (the "License"); you may not use this file except in compliance with
      * the License.  You may obtain a copy of the License at
-     * 
+     *
      *      http://www.apache.org/licenses/LICENSE-2.0
-     * 
+     *
      * Unless required by applicable law or agreed to in writing, software
      * distributed under the License is distributed on an "AS IS" BASIS,
      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,7 +62,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
             hyphenChar = '-'; // default
         }
 
-        public PatternParser(IPatternConsumer consumer) 
+        public PatternParser(IPatternConsumer consumer)
             : this()
         {
             this.consumer = consumer;
@@ -80,9 +80,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <param name="path">The complete file path to be read.</param>
         /// <exception cref="IOException"> In case of an exception while parsing </exception>
         public virtual void Parse(string path)
-        {
-            Parse(path, Encoding.UTF8);
-        }
+            => Parse(path, Encoding.UTF8);
 
         /// <summary>
         /// Parses a hyphenation pattern file.
@@ -103,9 +101,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <param name="file">  a <see cref="FileInfo"/> object representing the file  </param>
         /// <exception cref="IOException"> In case of an exception while parsing </exception>
         public virtual void Parse(FileInfo file)
-        {
-            Parse(file, Encoding.UTF8);
-        }
+            => Parse(file.FullName, Encoding.UTF8);
 
         /// <summary>
         /// Parses a hyphenation pattern file.
@@ -114,12 +110,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <param name="encoding">The character encoding to use</param>
         /// <exception cref="IOException"> In case of an exception while parsing </exception>
         public virtual void Parse(FileInfo file, Encoding encoding)
-        {
-            var xmlReaderSettings = GetXmlReaderSettings();
-
-            using var src = XmlReader.Create(new StreamReader(file.OpenRead(), encoding), xmlReaderSettings);
-            Parse(src);
-        }
+            => Parse(file.FullName, encoding);
 
         /// <summary>
         /// Parses a hyphenation pattern file.
@@ -127,8 +118,8 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <param name="xmlStream">
         /// The stream containing the XML data.
         /// <para/>
-        /// The <see cref="PatternParser"/> scans the first bytes of the stream looking for a byte order mark 
-        /// or other sign of encoding. When encoding is determined, the encoding is used to continue reading 
+        /// The <see cref="PatternParser"/> scans the first bytes of the stream looking for a byte order mark
+        /// or other sign of encoding. When encoding is determined, the encoding is used to continue reading
         /// the stream, and processing continues parsing the input as a stream of (Unicode) characters.
         /// </param>
         /// <exception cref="IOException"> In case of an exception while parsing </exception>
@@ -396,9 +387,9 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <summary>
         /// Receive notification of the beginning of an element.
         /// <para/>
-        /// The Parser will invoke this method at the beginning of every element in the XML document; 
-        /// there will be a corresponding <see cref="EndElement"/> event for every <see cref="StartElement"/> event 
-        /// (even when the element is empty). All of the element's content will be reported, 
+        /// The Parser will invoke this method at the beginning of every element in the XML document;
+        /// there will be a corresponding <see cref="EndElement"/> event for every <see cref="StartElement"/> event
+        /// (even when the element is empty). All of the element's content will be reported,
         /// in order, before the corresponding endElement event.
         /// </summary>
         /// <param name="uri">the Namespace URI, or the empty string if the element has no Namespace URI or if Namespace processing is not being performed</param>
@@ -442,8 +433,8 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <summary>
         /// Receive notification of the end of an element.
         /// <para/>
-        /// The parser will invoke this method at the end of every element in the XML document; 
-        /// there will be a corresponding <see cref="StartElement"/> event for every 
+        /// The parser will invoke this method at the end of every element in the XML document;
+        /// there will be a corresponding <see cref="StartElement"/> event for every
         /// <see cref="EndElement"/> event (even when the element is empty).
         /// </summary>
         /// <param name="uri">the Namespace URI, or the empty string if the element has no Namespace URI or if Namespace processing is not being performed</param>
@@ -489,9 +480,9 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <summary>
         /// Receive notification of character data.
         /// <para/>
-        /// The Parser will call this method to report each chunk of character data. Parsers may 
-        /// return all contiguous character data in a single chunk, or they may split it into 
-        /// several chunks; however, all of the characters in any single event must come from 
+        /// The Parser will call this method to report each chunk of character data. Parsers may
+        /// return all contiguous character data in a single chunk, or they may split it into
+        /// several chunks; however, all of the characters in any single event must come from
         /// the same external entity so that the Locator provides useful information.
         /// <para/>
         /// The application must not attempt to read from the array outside of the specified range.

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/HyphenationCompoundWordTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/HyphenationCompoundWordTokenFilter.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Analysis.Compound
         private readonly HyphenationTree hyphenator;
 
         /// <summary>
-        /// Creates a new <see cref="HyphenationCompoundWordTokenFilter"/> instance. 
+        /// Creates a new <see cref="HyphenationCompoundWordTokenFilter"/> instance.
         /// </summary>
         /// <param name="matchVersion">
         ///          Lucene version to enable correct Unicode 4.0 behavior in the
@@ -59,9 +59,9 @@ namespace Lucene.Net.Analysis.Compound
         ///          the hyphenation pattern tree to use for hyphenation </param>
         /// <param name="dictionary">
         ///          the word dictionary to match against. </param>
-        public HyphenationCompoundWordTokenFilter(LuceneVersion matchVersion, TokenStream input, 
+        public HyphenationCompoundWordTokenFilter(LuceneVersion matchVersion, TokenStream input,
             HyphenationTree hyphenator, CharArraySet dictionary)
-            : this(matchVersion, input, hyphenator, dictionary, DEFAULT_MIN_WORD_SIZE, 
+            : this(matchVersion, input, hyphenator, dictionary, DEFAULT_MIN_WORD_SIZE,
                   DEFAULT_MIN_SUBWORD_SIZE, DEFAULT_MAX_SUBWORD_SIZE, false)
         {
         }
@@ -88,10 +88,10 @@ namespace Lucene.Net.Analysis.Compound
         ///          only subwords shorter than this get to the output stream </param>
         /// <param name="onlyLongestMatch">
         ///          Add only the longest matching subword to the stream </param>
-        public HyphenationCompoundWordTokenFilter(LuceneVersion matchVersion, TokenStream input, 
-            HyphenationTree hyphenator, CharArraySet dictionary, int minWordSize, int minSubwordSize, 
+        public HyphenationCompoundWordTokenFilter(LuceneVersion matchVersion, TokenStream input,
+            HyphenationTree hyphenator, CharArraySet dictionary, int minWordSize, int minSubwordSize,
             int maxSubwordSize, bool onlyLongestMatch)
-            : base(matchVersion, input, dictionary, minWordSize, minSubwordSize, maxSubwordSize, 
+            : base(matchVersion, input, dictionary, minWordSize, minSubwordSize, maxSubwordSize,
                   onlyLongestMatch)
         {
             this.hyphenator = hyphenator;
@@ -103,10 +103,10 @@ namespace Lucene.Net.Analysis.Compound
         /// Calls <see cref="HyphenationCompoundWordTokenFilter.HyphenationCompoundWordTokenFilter(LuceneVersion, TokenStream, HyphenationTree, CharArraySet, int, int, int, bool)"/>
         /// </para>
         /// </summary>
-        public HyphenationCompoundWordTokenFilter(LuceneVersion matchVersion, TokenStream input, 
-            HyphenationTree hyphenator, int minWordSize, int minSubwordSize, 
+        public HyphenationCompoundWordTokenFilter(LuceneVersion matchVersion, TokenStream input,
+            HyphenationTree hyphenator, int minWordSize, int minSubwordSize,
             int maxSubwordSize)
-            : this(matchVersion, input, hyphenator, null, minWordSize, minSubwordSize, 
+            : this(matchVersion, input, hyphenator, null, minWordSize, minSubwordSize,
                   maxSubwordSize, false)
         {
         }
@@ -117,9 +117,9 @@ namespace Lucene.Net.Analysis.Compound
         /// Calls <see cref="HyphenationCompoundWordTokenFilter.HyphenationCompoundWordTokenFilter(LuceneVersion, TokenStream, HyphenationTree, int, int, int)"/>
         /// </para>
         /// </summary>
-        public HyphenationCompoundWordTokenFilter(LuceneVersion matchVersion, TokenStream input, 
+        public HyphenationCompoundWordTokenFilter(LuceneVersion matchVersion, TokenStream input,
             HyphenationTree hyphenator)
-            : this(matchVersion, input, hyphenator, DEFAULT_MIN_WORD_SIZE, DEFAULT_MIN_SUBWORD_SIZE, 
+            : this(matchVersion, input, hyphenator, DEFAULT_MIN_WORD_SIZE, DEFAULT_MIN_SUBWORD_SIZE,
                   DEFAULT_MAX_SUBWORD_SIZE)
         {
         }
@@ -131,9 +131,7 @@ namespace Lucene.Net.Analysis.Compound
         /// <returns> An object representing the hyphenation patterns </returns>
         /// <exception cref="IOException"> If there is a low-level I/O error. </exception>
         public static HyphenationTree GetHyphenationTree(string hyphenationFilename)
-        {
-            return GetHyphenationTree(hyphenationFilename, Encoding.UTF8);
-        }
+            => GetHyphenationTree(hyphenationFilename, Encoding.UTF8);
 
         /// <summary>
         /// Create a hyphenator tree
@@ -143,9 +141,7 @@ namespace Lucene.Net.Analysis.Compound
         /// <returns> An object representing the hyphenation patterns </returns>
         /// <exception cref="IOException"> If there is a low-level I/O error. </exception>
         public static HyphenationTree GetHyphenationTree(string hyphenationFilename, Encoding encoding)
-        {
-            return GetHyphenationTree(new FileStream(hyphenationFilename, FileMode.Open, FileAccess.Read), encoding);
-        }
+            => GetHyphenationTree(new FileStream(hyphenationFilename, FileMode.Open, FileAccess.Read), encoding);
 
         /// <summary>
         /// Create a hyphenator tree
@@ -154,9 +150,7 @@ namespace Lucene.Net.Analysis.Compound
         /// <returns> An object representing the hyphenation patterns </returns>
         /// <exception cref="IOException"> If there is a low-level I/O error. </exception>
         public static HyphenationTree GetHyphenationTree(FileInfo hyphenationFile)
-        {
-            return GetHyphenationTree(hyphenationFile, Encoding.UTF8);
-        }
+            => GetHyphenationTree(hyphenationFile.FullName, Encoding.UTF8);
 
         /// <summary>
         /// Create a hyphenator tree
@@ -166,9 +160,7 @@ namespace Lucene.Net.Analysis.Compound
         /// <returns> An object representing the hyphenation patterns </returns>
         /// <exception cref="IOException"> If there is a low-level I/O error. </exception>
         public static HyphenationTree GetHyphenationTree(FileInfo hyphenationFile, Encoding encoding)
-        {
-            return GetHyphenationTree(new FileStream(hyphenationFile.FullName, FileMode.Open, FileAccess.Read), encoding);
-        }
+            => GetHyphenationTree(hyphenationFile.FullName, encoding);
 
         /// <summary>
         /// Create a hyphenator tree
@@ -177,9 +169,7 @@ namespace Lucene.Net.Analysis.Compound
         /// <returns> An object representing the hyphenation patterns </returns>
         /// <exception cref="IOException"> If there is a low-level I/O error. </exception>
         public static HyphenationTree GetHyphenationTree(Stream hyphenationSource)
-        {
-            return GetHyphenationTree(hyphenationSource, Encoding.UTF8);
-        }
+            => GetHyphenationTree(hyphenationSource, Encoding.UTF8);
 
         /// <summary>
         /// Create a hyphenator tree
@@ -227,7 +217,7 @@ namespace Lucene.Net.Analysis.Compound
                     // that are longer than minPartSize
                     if (partLength < this.m_minSubwordSize)
                     {
-                        // BOGUS/BROKEN/FUNKY/WACKO: somehow we have negative 'parts' according to the 
+                        // BOGUS/BROKEN/FUNKY/WACKO: somehow we have negative 'parts' according to the
                         // calculation above, and we rely upon minSubwordSize being >=0 to filter them out...
                         continue;
                     }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Core/StopAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Core/StopAnalyzer.cs
@@ -81,6 +81,19 @@ namespace Lucene.Net.Analysis.Core
         /// Builds an analyzer with the stop words from the given file. </summary>
         /// <seealso cref="WordlistLoader.GetWordSet(TextReader, LuceneVersion)"/>
         /// <param name="matchVersion"> See <see cref="LuceneVersion"/> </param>
+        /// <param name="stopwordsFileName"> File name to load stop words from  </param>
+        /// <remarks>
+        /// LUCENENET: This overload takes a string file name to avoid allocating a <see cref="FileInfo"/> object.
+        /// </remarks>
+        public StopAnalyzer(LuceneVersion matchVersion, string stopwordsFileName)
+            : this(matchVersion, LoadStopwordSet(stopwordsFileName, matchVersion))
+        {
+        }
+
+        /// <summary>
+        /// Builds an analyzer with the stop words from the given file. </summary>
+        /// <seealso cref="WordlistLoader.GetWordSet(TextReader, LuceneVersion)"/>
+        /// <param name="matchVersion"> See <see cref="LuceneVersion"/> </param>
         /// <param name="stopwordsFile"> File to load stop words from  </param>
         public StopAnalyzer(LuceneVersion matchVersion, FileInfo stopwordsFile)
             : this(matchVersion, LoadStopwordSet(stopwordsFile, matchVersion))

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/FilesystemResourceLoader.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/FilesystemResourceLoader.cs
@@ -1,6 +1,7 @@
 ﻿// Lucene version compatibility level 4.8.1
 using System;
 using System.IO;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Util
 {
@@ -25,12 +26,12 @@ namespace Lucene.Net.Analysis.Util
     /// Simple <see cref="IResourceLoader"/> that opens resource files
     /// from the local file system, optionally resolving against
     /// a base directory.
-    /// 
+    ///
     /// <para>This loader wraps a delegate <see cref="IResourceLoader"/>
     /// that is used to resolve all files, the current base directory
     /// does not contain. <see cref="NewInstance"/> is always resolved
     /// against the delegate, as an <see cref="T:System.Assembly"/> is needed.
-    /// 
+    ///
     /// </para>
     /// <para>You can chain several <see cref="FilesystemResourceLoader"/>s
     /// to allow lookup of files in more than one base directory.
@@ -38,7 +39,7 @@ namespace Lucene.Net.Analysis.Util
     /// </summary>
     public sealed class FilesystemResourceLoader : IResourceLoader
     {
-        private readonly DirectoryInfo baseDirectory;
+        private readonly string? baseDirectory; // LUCENENET specific: changed to use string directory name instead of allocating a DirectoryInfo (#832)
         private readonly IResourceLoader @delegate;
 
         /// <summary>
@@ -47,7 +48,7 @@ namespace Lucene.Net.Analysis.Util
         /// are delegated to context classloader.
         /// </summary>
         public FilesystemResourceLoader()
-            : this((DirectoryInfo)null)
+            : this((string?)null)
         {
         }
 
@@ -57,8 +58,19 @@ namespace Lucene.Net.Analysis.Util
         /// Files not found in file system and class lookups are delegated to context
         /// classloader.
         /// </summary>
-        public FilesystemResourceLoader(DirectoryInfo baseDirectory)
+        public FilesystemResourceLoader(string? baseDirectory)
             : this(baseDirectory, new ClasspathResourceLoader(typeof(FilesystemResourceLoader)))
+        {
+        }
+
+        /// <summary>
+        /// Creates a resource loader that resolves resources against the given
+        /// base directory (may be <c>null</c> to refer to CWD).
+        /// Files not found in file system and class lookups are delegated to context
+        /// classloader.
+        /// </summary>
+        public FilesystemResourceLoader(DirectoryInfo? baseDirectory)
+            : this(baseDirectory?.FullName, new ClasspathResourceLoader(typeof(FilesystemResourceLoader)))
         {
         }
 
@@ -68,11 +80,22 @@ namespace Lucene.Net.Analysis.Util
         /// Files not found in file system and class lookups are delegated
         /// to the given delegate <see cref="IResourceLoader"/>.
         /// </summary>
-        public FilesystemResourceLoader(DirectoryInfo baseDirectory, IResourceLoader @delegate)
+        public FilesystemResourceLoader(DirectoryInfo? baseDirectory, IResourceLoader @delegate)
+            : this(baseDirectory?.FullName, @delegate)
+        {
+        }
+
+        /// <summary>
+        /// Creates a resource loader that resolves resources against the given
+        /// base directory (may be <c>null</c> to refer to CWD).
+        /// Files not found in file system and class lookups are delegated
+        /// to the given delegate <see cref="IResourceLoader"/>.
+        /// </summary>
+        public FilesystemResourceLoader(string? baseDirectory, IResourceLoader @delegate)
         {
             // LUCENENET NOTE: If you call DirectoryInfo.Create() it doesn't set the DirectoryInfo.Exists
             // flag to true, so we use the Directory object to check the path explicitly.
-            if (!(baseDirectory is null) && !Directory.Exists(baseDirectory.FullName))
+            if (baseDirectory is not null && !Directory.Exists(baseDirectory))
             {
                 throw new ArgumentException("baseDirectory is not a directory or is null");
             }
@@ -89,12 +112,12 @@ namespace Lucene.Net.Analysis.Util
         {
             try
             {
-                FileInfo file = null;
+                string? file = null; // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
 
                 // First try absolute.
                 if (File.Exists(resource))
                 {
-                    file = new FileInfo(resource);
+                    file = resource;
                 }
                 else
                 {
@@ -102,22 +125,22 @@ namespace Lucene.Net.Analysis.Util
                     var fullPath = System.IO.Path.GetFullPath(resource);
                     if (File.Exists(fullPath))
                     {
-                        file = new FileInfo(fullPath);
+                        file = fullPath;
                     }
                     else if (baseDirectory != null)
                     {
                         // Try to combine with the base directory
-                        string based = System.IO.Path.Combine(baseDirectory.FullName, resource);
+                        string based = System.IO.Path.Combine(baseDirectory, resource);
                         if (File.Exists(based))
                         {
-                            file = new FileInfo(based);
+                            file = based;
                         }
                     }
                 }
 
                 if (file != null)
                 {
-                    return file.OpenRead();
+                    return new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read);
                 }
 
                 // Fallback on the inner resource loader (this could fail)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/StopwordAnalyzerBase.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/StopwordAnalyzerBase.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Analysis.Util
      */
 
     /// <summary>
-    /// Base class for <see cref="Analyzer"/>s that need to make use of stopword sets. 
+    /// Base class for <see cref="Analyzer"/>s that need to make use of stopword sets.
     /// </summary>
     public abstract class StopwordAnalyzerBase : Analyzer
     {
@@ -97,6 +97,35 @@ namespace Lucene.Net.Analysis.Util
 #pragma warning disable 612, 618
                     LuceneVersion.LUCENE_CURRENT, 16, ignoreCase));
 #pragma warning restore 612, 618
+            }
+            finally
+            {
+                IOUtils.Dispose(reader);
+            }
+        }
+
+        /// <summary>
+        /// Creates a <see cref="CharArraySet"/> from a file.
+        /// </summary>
+        /// <param name="stopwordsFileName">
+        ///          the stopwords file name to load
+        /// </param>
+        /// <param name="matchVersion">
+        ///          the Lucene version for cross version compatibility </param>
+        /// <returns> a <see cref="CharArraySet"/> containing the distinct stopwords from the given
+        ///         file </returns>
+        /// <exception cref="IOException">
+        ///           if loading the stopwords throws an <see cref="IOException"/> </exception>
+        /// <remarks>
+        /// LUCENENET: This overload takes a string file name to avoid allocating a <see cref="FileInfo"/> object.
+        /// </remarks>
+        protected static CharArraySet LoadStopwordSet(string stopwordsFileName, LuceneVersion matchVersion)
+        {
+            TextReader reader = null;
+            try
+            {
+                reader = IOUtils.GetDecodingReader(stopwordsFileName, Encoding.UTF8);
+                return WordlistLoader.GetWordSet(reader, matchVersion);
             }
             finally
             {

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/BinaryDictionary.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/BinaryDictionary.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Util;
 using System;
 using System.IO;
 using System.Security;
+using Directory = System.IO.Directory;
 
 namespace Lucene.Net.Analysis.Ja.Dict
 {
@@ -67,21 +68,21 @@ namespace Lucene.Net.Analysis.Ja.Dict
             // variable. If it is null or empty after this process, we need to
             // load the embedded files.
             string candidatePath = System.IO.Path.Combine(currentPath, DATA_SUBDIR);
-            if (System.IO.Directory.Exists(candidatePath))
+            if (Directory.Exists(candidatePath))
             {
                 return candidatePath;
             }
 
-            while (new DirectoryInfo(currentPath).Parent != null)
+            while (Directory.GetParent(currentPath) is { } parent) // LUCENENET: Reduce DirectoryInfo allocations by only getting parent once per iteration (#832)
             {
                 try
                 {
-                    candidatePath = System.IO.Path.Combine(new DirectoryInfo(currentPath).Parent.FullName, DATA_SUBDIR);
-                    if (System.IO.Directory.Exists(candidatePath))
+                    candidatePath = System.IO.Path.Combine(parent.FullName, DATA_SUBDIR);
+                    if (Directory.Exists(candidatePath))
                     {
                         return candidatePath;
                     }
-                    currentPath = new DirectoryInfo(currentPath).Parent.FullName;
+                    currentPath = parent.FullName;
                 }
                 catch (SecurityException)
                 {

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
@@ -53,9 +53,10 @@ namespace Lucene.Net.Analysis.Ja.Util
         public virtual TokenInfoDictionaryWriter Build(string dirname)
         {
             JCG.List<string> csvFiles = new JCG.List<string>();
-            foreach (FileInfo file in new DirectoryInfo(dirname).EnumerateFiles("*.csv"))
+            // LUCENENET specific: changed to use string file names instead of allocating a FileInfo (#832)
+            foreach (string file in Directory.EnumerateFiles(dirname, "*.csv"))
             {
-                csvFiles.Add(file.FullName);
+                csvFiles.Add(file);
             }
             csvFiles.Sort(StringComparer.Ordinal);
             return BuildDictionary(csvFiles);
@@ -159,10 +160,10 @@ namespace Lucene.Net.Analysis.Ja.Util
 
             return dictionary;
         }
-        
+
         /// <summary>
         /// IPADIC features
-        /// 
+        ///
         /// 0   - surface
         /// 1   - left cost
         /// 2   - right cost
@@ -171,9 +172,9 @@ namespace Lucene.Net.Analysis.Ja.Util
         /// 10  - base form
         /// 11  - reading
         /// 12  - pronounciation
-        /// 
+        ///
         /// UniDic features
-        /// 
+        ///
         /// 0   - surface
         /// 1   - left cost
         /// 2   - right cost

--- a/src/Lucene.Net.Analysis.SmartCn/AnalyzerProfile.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/AnalyzerProfile.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
     /// To place the files in an alternate location, set an environment variable named "smartcn.data.dir"
     /// with the name of the directory the "bigramdict.dct" and "coredict.dct" files can be located within.
     /// <para/>
-    /// The default "bigramdict.dct" and "coredict.dct" files can be found at: 
+    /// The default "bigramdict.dct" and "coredict.dct" files can be found at:
     /// <a href="https://issues.apache.org/jira/browse/LUCENE-1629">https://issues.apache.org/jira/browse/LUCENE-1629</a>.
     /// <para/>
     /// @lucene.experimental
@@ -51,7 +51,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
             Init();
         }
 
-        // LUCENENET specific - changed the logic here to leave the 
+        // LUCENENET specific - changed the logic here to leave the
         // ANALYSIS_DATA_DIR an empty string if it is not found. This
         // allows us to skip loading files from disk if there are no files
         // to load (and fixes LUCENE-1817 that prevents the on-disk files
@@ -79,19 +79,18 @@ namespace Lucene.Net.Analysis.Cn.Smart
                 ANALYSIS_DATA_DIR = candidatePath;
                 return;
             }
-            
 
             try
             {
-                while (new DirectoryInfo(currentPath).Parent != null)
+                while (Directory.GetParent(currentPath) is { } parent) // LUCENENET: Reduce DirectoryInfo allocations by only getting parent once per iteration (#832)
                 {
-                    candidatePath = System.IO.Path.Combine(new DirectoryInfo(currentPath).Parent.FullName, dirName);
+                    candidatePath = System.IO.Path.Combine(parent.FullName, dirName);
                     if (Directory.Exists(candidatePath))
                     {
                         ANALYSIS_DATA_DIR = candidatePath;
                         return;
                     }
-                    currentPath = new DirectoryInfo(currentPath).Parent.FullName;
+                    currentPath = parent.FullName;
                 }
             }
             catch (SecurityException)

--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/BigramDictionary.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/BigramDictionary.cs
@@ -93,8 +93,8 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
         {
             try
             {
-                using (Stream input = new FileStream(serialObj.FullName, FileMode.Open, FileAccess.Read))
-                    LoadFromInputStream(input);
+                using Stream input = new FileStream(serialObj.FullName, FileMode.Open, FileAccess.Read);
+                LoadFromInputStream(input);
                 return true;
             }
             catch (Exception e) when (e.IsException())

--- a/src/Lucene.Net.Benchmark/ByTask/Benchmark.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Benchmark.cs
@@ -129,14 +129,14 @@ namespace Lucene.Net.Benchmarks.ByTask
             }
 
             // verify input files
-            FileInfo algFile = new FileInfo(args[0]);
-            if (!algFile.Exists /*|| !algFile.isFile() ||!algFile.canRead()*/ )
+            string algFile = args[0]; // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+            if (!File.Exists(algFile) /*|| !algFile.isFile() ||!algFile.canRead()*/ )
             {
-                Console.WriteLine("cannot find/read algorithm file: " + algFile.FullName);
+                Console.WriteLine("cannot find/read algorithm file: " + algFile);
                 Environment.Exit(1);
             }
 
-            Console.WriteLine("Running algorithm from: " + algFile.FullName);
+            Console.WriteLine("Running algorithm from: " + algFile);
 
             Benchmark benchmark = null;
             try

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
@@ -225,7 +225,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
                     {
                         Stream localFileIS = outerInstance.@is;
                         if (localFileIS != null)
-                        { // null means fileIS was closed on us 
+                        { // null means fileIS was closed on us
                             try
                             {
                                 // To work around a bug in XERCES (XERCESJ-1257), we assume the XML is always UTF8, so we simply provide reader.
@@ -374,7 +374,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             return ELEMENTS.TryGetValue(elem, out int val) ? val : -1;
         }
 
-        private FileInfo file;
+        private string file; // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
         private bool keepImages = true;
         private Stream @is;
         private readonly Parser parser;
@@ -430,7 +430,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             string fileName = config.Get("docs.file", null);
             if (fileName != null)
             {
-                file = new FileInfo(fileName);
+                // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+                file = fileName;
             }
         }
     }

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/FileBasedQueryMaker.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/FileBasedQueryMaker.cs
@@ -65,12 +65,13 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             string fileName = m_config.Get("file.query.maker.file", null);
             if (fileName != null)
             {
-                FileInfo file = new FileInfo(fileName);
+                // LUCENENET: not used, preferring fileName overloads: FileInfo file = new FileInfo(fileName);
                 TextReader reader = null;
                 // note: we use a decoding reader, so if your queries are screwed up you know
-                if (file.Exists)
+                // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+                if (File.Exists(fileName))
                 {
-                    reader = IOUtils.GetDecodingReader(file, Encoding.UTF8);
+                    reader = IOUtils.GetDecodingReader(fileName, Encoding.UTF8);
                 }
                 else
                 {

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/LineDocSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/LineDocSource.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
     {
         // LUCENENET specific - de-nested LineParser, SimpleLineParser, HeaderLineParser
 
-        private FileInfo file;
+        private string file; // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
         private TextReader reader;
         private int readCount;
 
@@ -153,7 +153,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
                 }
             }
 
-            // if this the simple case,   
+            // if this the simple case,
             if (Arrays.Equals(header, WriteLineDocTask.DEFAULT_FIELDS))
             {
                 return new SimpleLineParser(header);
@@ -171,11 +171,10 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         {
             base.SetConfig(config);
             string fileName = config.Get("docs.file", null);
-            if (fileName is null)
-            {
-                throw new ArgumentException("docs.file must be set");
-            }
-            file = new FileInfo(fileName);
+
+            // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+            file = fileName ?? throw new ArgumentException("docs.file must be set");
+
             if (m_encoding is null)
             {
                 m_encoding = Encoding.UTF8;
@@ -189,7 +188,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         protected readonly string[] m_header;
 
         /// <summary>
-        /// Construct with the header 
+        /// Construct with the header
         /// </summary>
         /// <param name="header">header line found in the input file, or <c>null</c> if none.</param>
         protected LineParser(string[] header) // LUCENENET: CA1012: Abstract types should not have constructors (marked protected)
@@ -205,8 +204,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
 
     /// <summary>
     /// <see cref="LineParser"/> which ignores the header passed to its constructor
-    /// and assumes simply that field names and their order are the same 
-    /// as in <see cref="WriteLineDocTask.DEFAULT_FIELDS"/>. 
+    /// and assumes simply that field names and their order are the same
+    /// as in <see cref="WriteLineDocTask.DEFAULT_FIELDS"/>.
     /// </summary>
     public class SimpleLineParser : LineParser
     {
@@ -243,11 +242,11 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
     }
 
     /// <summary>
-    /// <see cref="LineParser"/> which sets field names and order by 
+    /// <see cref="LineParser"/> which sets field names and order by
     /// the header - any header - of the lines file.
     /// It is less efficient than <see cref="SimpleLineParser"/> but more powerful.
     /// </summary>
-    public class HeaderLineParser : LineParser 
+    public class HeaderLineParser : LineParser
     {
         private enum FieldName { NAME, TITLE, DATE, BODY, PROP }
         private readonly FieldName[] posToF;

--- a/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
@@ -103,7 +103,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             config,
             performReinit: true,
             logQueries: string.Equals(config?.Get("log.queries", "false") ?? "false", "true", StringComparison.OrdinalIgnoreCase))
-        {    
+        {
         }
 
         // LUCENENET specific - added performReinit parameter to allow subclasses to skip reinit
@@ -114,7 +114,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         protected PerfRunData(Config config, bool performReinit, bool logQueries)
         {
             this.config = config ?? throw new ArgumentNullException(nameof(config));
-            
+
             // analyzer (default is standard analyzer)
             analyzer = NewAnalyzerTask.CreateAnalyzer(config.Get("analyzer",
                 typeof(Lucene.Net.Analysis.Standard.StandardAnalyzer).AssemblyQualifiedName));
@@ -178,7 +178,7 @@ namespace Lucene.Net.Benchmarks.ByTask
             }
         }
 
-        // clean old stuff, reopen 
+        // clean old stuff, reopen
         public virtual void Reinit(bool eraseIndex)
         {
             // cleanup index
@@ -210,8 +210,8 @@ namespace Lucene.Net.Benchmarks.ByTask
         {
             if ("FSDirectory".Equals(config.Get(dirParam, "RAMDirectory"), StringComparison.Ordinal))
             {
-                DirectoryInfo workDir = new DirectoryInfo(config.Get("work.dir", "work"));
-                DirectoryInfo indexDir = new DirectoryInfo(System.IO.Path.Combine(workDir.FullName, dirName));
+                string workDir = config.Get("work.dir", "work"); // LUCENENET specific: changed to use string directory name instead of allocating a DirectoryInfo (#832)
+                DirectoryInfo indexDir = new DirectoryInfo(Path.Combine(workDir, dirName));
                 if (eraseIndex && indexDir.Exists)
                 {
                     FileUtils.FullyDelete(indexDir);
@@ -290,9 +290,9 @@ namespace Lucene.Net.Benchmarks.ByTask
 
         /// <summary>
         /// Set the taxonomy reader. Takes ownership of that taxonomy reader, that is,
-        /// internally performs taxoReader.IncRef() (If caller no longer needs that 
-        /// reader it should DecRef()/Dispose() it after calling this method, otherwise, 
-        /// the reader will remain open). 
+        /// internally performs taxoReader.IncRef() (If caller no longer needs that
+        /// reader it should DecRef()/Dispose() it after calling this method, otherwise,
+        /// the reader will remain open).
         /// </summary>
         /// <param name="taxoReader">The taxonomy reader to set.</param>
         public virtual void SetTaxonomyReader(TaxonomyReader taxoReader)
@@ -399,9 +399,9 @@ namespace Lucene.Net.Benchmarks.ByTask
 
         /// <summary>
         /// Set the index reader. Takes ownership of that index reader, that is,
-        /// internally performs indexReader.incRef() (If caller no longer needs that 
+        /// internally performs indexReader.incRef() (If caller no longer needs that
         /// reader it should decRef()/close() it after calling this method, otherwise,
-        /// the reader will remain open). 
+        /// the reader will remain open).
         /// </summary>
         /// <param name="indexReader">The indexReader to set.</param>
         public virtual void SetIndexReader(DirectoryReader indexReader)

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
@@ -487,7 +487,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 }
                 if (instance is IResourceLoaderAware resourceLoaderAware)
                 {
-                    DirectoryInfo baseDir = new DirectoryInfo(RunData.Config.Get("work.dir", "work"));
+                    string baseDir = RunData.Config.Get("work.dir", "work"); // LUCENENET specific: changed to use string directory name instead of allocating a DirectoryInfo (#832)
                     resourceLoaderAware.Inform(new FilesystemResourceLoader(baseDir));
                 }
                 if (typeof(CharFilterFactory).IsAssignableFrom(clazz))

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/CreateIndexTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/CreateIndexTask.cs
@@ -214,8 +214,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                 }
                 else
                 {
-                    FileInfo f = new FileInfo(infoStreamVal);
-                    iwc.SetInfoStream(new StreamWriter(new FileStream(f.FullName, FileMode.Create, FileAccess.Write), Encoding.GetEncoding(0)));
+                    // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+                    iwc.SetInfoStream(new StreamWriter(new FileStream(infoStreamVal, FileMode.Create, FileAccess.Write), Encoding.GetEncoding(0)));
                 }
             }
             IndexWriter writer = new IndexWriter(runData.Directory, iwc);

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteEnwikiLineDocTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteEnwikiLineDocTask.cs
@@ -26,9 +26,9 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
      */
 
     /// <summary>
-    /// A <see cref="WriteLineDocTask"/> which for Wikipedia input, will write category pages 
+    /// A <see cref="WriteLineDocTask"/> which for Wikipedia input, will write category pages
     /// to another file, while remaining pages will be written to the original file.
-    /// The categories file is derived from the original file, by adding a prefix "categories-". 
+    /// The categories file is derived from the original file, by adding a prefix "categories-".
     /// </summary>
     public class WriteEnwikiLineDocTask : WriteLineDocTask
     {
@@ -37,9 +37,18 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         public WriteEnwikiLineDocTask(PerfRunData runData)
                   : base(runData)
         {
-            Stream @out = StreamUtils.GetOutputStream(CategoriesLineFile(new FileInfo(m_fname)));
+            Stream @out = StreamUtils.GetOutputStream(CategoriesLineFile(m_fname)); // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
             categoryLineFileOut = new StreamWriter(@out, Encoding.UTF8);
             WriteHeader(categoryLineFileOut);
+        }
+
+        /// <summary>Compose categories line file out of original line file</summary>
+        // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+        public static string CategoriesLineFile(string fileName)
+        {
+            string dir = Path.GetDirectoryName(fileName);
+            string categoriesName = "categories-" + Path.GetFileName(fileName);
+            return dir is null ? categoriesName : Path.Combine(dir, categoriesName);
         }
 
         /// <summary>Compose categories line file out of original line file</summary>
@@ -47,7 +56,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         {
             DirectoryInfo dir = f.Directory;
             string categoriesName = "categories-" + f.Name;
-            return dir is null ? new FileInfo(categoriesName) : new FileInfo(System.IO.Path.Combine(dir.FullName, categoriesName));
+            return dir is null ? new FileInfo(categoriesName) : new FileInfo(Path.Combine(dir.FullName, categoriesName));
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteLineDocTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/WriteLineDocTask.cs
@@ -49,8 +49,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     ///     <item><term>line.file.out</term><description>the name of the file to write the output to. That parameter is mandatory. <b>NOTE:</b> the file is re-created.</description></item>
     ///     <item><term>line.fields</term><description>which fields should be written in each line. (optional, default: <see cref="DEFAULT_FIELDS"/>).</description></item>
     ///     <item><term>sufficient.fields</term><description>
-    ///         list of field names, separated by comma, which, 
-    ///         if all of them are missing, the document will be skipped. For example, to require 
+    ///         list of field names, separated by comma, which,
+    ///         if all of them are missing, the document will be skipped. For example, to require
     ///         that at least one of f1,f2 is not empty, specify: "f1,f2" in this field. To specify
     ///         that no field is required, i.e. that even empty docs should be emitted, specify <b>","</b>
     ///         (optional, default: <see cref="DEFAULT_SUFFICIENT_FIELDS"/>).
@@ -111,11 +111,11 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             {
                 throw new ArgumentException("line.file.out must be set");
             }
-            Stream @out = StreamUtils.GetOutputStream(new FileInfo(m_fname));
+            Stream @out = StreamUtils.GetOutputStream(m_fname); // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
             m_lineFileOut = new StreamWriter(@out, Encoding.UTF8);
             docMaker = runData.DocMaker;
 
-            // init fields 
+            // init fields
             string f2r = config.Get("line.fields", null);
             if (f2r is null)
             {

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/FileUtils.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/FileUtils.cs
@@ -27,19 +27,31 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
         /// <summary>
         /// Delete files and directories, even if non-empty.
         /// </summary>
-        /// <param name="dir">File or directory.</param>
+        /// <param name="dir">Directory to delete.</param>
         /// <returns><c>true</c> on success, <c>false</c> if no or part of files have been deleted.</returns>
         /// <exception cref="IOException">If there is a low-level I/O error.</exception>
-        public static bool FullyDelete(DirectoryInfo dir) 
+        public static bool FullyDelete(DirectoryInfo dir)
+            => FullyDelete(dir.FullName);
+
+        /// <summary>
+        /// Delete files and directories, even if non-empty.
+        /// </summary>
+        /// <param name="dirName">Directory path to delete.</param>
+        /// <returns><c>true</c> on success, <c>false</c> if no or part of files have been deleted.</returns>
+        /// <exception cref="IOException">If there is a low-level I/O error.</exception>
+        /// <remarks>
+        /// LUCENENET: This overload takes a string to avoid allocating a <see cref="DirectoryInfo"/> object.
+        /// </remarks>
+        public static bool FullyDelete(string dirName)
         {
             try
             {
-                Directory.Delete(dir.FullName, true);
+                Directory.Delete(dirName, true);
                 return true;
             }
             catch
             {
-                return !Directory.Exists(dir.FullName);
+                return !Directory.Exists(dirName);
             }
         }
     }

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/StreamUtils.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/StreamUtils.cs
@@ -47,25 +47,51 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
         /// based on the file name (e.g., if it ends with .bz2 or .bzip, return a
         /// 'bzip' <see cref="Stream"/>).
         /// </summary>
-        public static Stream GetInputStream(FileInfo file)
+        /// <remarks>
+        /// LUCENENET: This overload takes a string file name to avoid allocating a <see cref="FileInfo"/> object.
+        /// </remarks>
+        public static Stream GetInputStream(string fileName)
         {
             // First, create a FileInputStream, as this will be required by all types.
             // Wrap with BufferedInputStream for better performance
-            Stream @in = new FileStream(file.FullName, FileMode.Open, FileAccess.Read);
-            return GetFileType(file).GetInputStream(@in);
+            Stream @in = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+            return GetFileType(fileName).GetInputStream(@in);
         }
 
+        /// <summary>
+        /// Returns an <see cref="Stream"/> over the requested file. This method
+        /// attempts to identify the appropriate <see cref="Stream"/> instance to return
+        /// based on the file name (e.g., if it ends with .bz2 or .bzip, return a
+        /// 'bzip' <see cref="Stream"/>).
+        /// </summary>
+        public static Stream GetInputStream(FileInfo file)
+            => GetInputStream(file.FullName);
+
         /// <summary>Return the type of the file, or <c>null</c> if unknown.</summary>
-        private static FileType GetFileType(FileInfo file)
+        private static FileType GetFileType(string fileName)
         {
             FileType? type = null;
-            string fileName = file.Name;
             int idx = fileName.LastIndexOf('.');
             if (idx != -1)
             {
                 extensionToType.TryGetValue(fileName.Substring(idx).ToLowerInvariant(), out type);
             }
-            return type ?? FileType.PLAIN ;
+            return type ?? FileType.PLAIN;
+        }
+
+        /// <summary>
+        /// Returns an <see cref="Stream"/> over the requested file, identifying
+        /// the appropriate <see cref="Stream"/> instance similar to <see cref="GetInputStream(string)"/>.
+        /// </summary>
+        /// <remarks>
+        /// LUCENENET: This overload takes a string file name to avoid allocating a <see cref="FileInfo"/> object.
+        /// </remarks>
+        public static Stream GetOutputStream(string fileName)
+        {
+            // First, create a FileInputStream, as this will be required by all types.
+            // Wrap with BufferedInputStream for better performance
+            Stream os = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+            return GetFileType(fileName).GetOutputStream(os);
         }
 
         /// <summary>
@@ -73,12 +99,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
         /// the appropriate <see cref="Stream"/> instance similar to <see cref="GetInputStream(FileInfo)"/>.
         /// </summary>
         public static Stream GetOutputStream(FileInfo file)
-        {
-            // First, create a FileInputStream, as this will be required by all types.
-            // Wrap with BufferedInputStream for better performance
-            Stream os = new FileStream(file.FullName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
-            return GetFileType(file).GetOutputStream(os);
-        }
+            => GetOutputStream(file.FullName);
     }
 
     /// <summary>File format type.</summary>
@@ -109,7 +130,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
                 case FileType.BZIP2:
                     return new BZip2InputStream(input);
                 case FileType.GZIP:
-                    return new GZipStream(input, CompressionMode.Decompress); 
+                    return new GZipStream(input, CompressionMode.Decompress);
                 default:
                     return input;
             }

--- a/src/Lucene.Net.Benchmark/Quality/Trec/QueryDriver.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/QueryDriver.cs
@@ -69,10 +69,11 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
                 //Environment.Exit(1);
             }
 
-            FileInfo topicsFile = new FileInfo(args[0]);
-            FileInfo qrelsFile = new FileInfo(args[1]);
+            // LUCENENET specific: changed to use string file names instead of allocating a FileInfo (#832)
+            string topicsFile = args[0];
+            string qrelsFile = args[1];
             SubmissionReport submitLog = new SubmissionReport(new StreamWriter(new FileStream(args[2], FileMode.Create, FileAccess.Write), Encoding.UTF8 /* huh, no nio.Charset ctor? */), "lucene");
-            using Store.FSDirectory dir = Store.FSDirectory.Open(new DirectoryInfo(args[3]));
+            using Store.FSDirectory dir = Store.FSDirectory.Open(args[3]); // LUCENENET specific: changed to use string path instead of allocating a DirectoryInfo (#832)
             using IndexReader reader = DirectoryReader.Open(dir);
             string fieldSpec = args.Length == 5 ? args[4] : "T"; // default to Title-only if not specified.
             IndexSearcher searcher = new IndexSearcher(reader);

--- a/src/Lucene.Net.Misc/Index/CompoundFileExtractor.cs
+++ b/src/Lucene.Net.Misc/Index/CompoundFileExtractor.cs
@@ -98,15 +98,18 @@ namespace Lucene.Net.Index
 
             try
             {
-                FileInfo file = new FileInfo(filename);
-                string dirname = file.DirectoryName;
-                filename = file.Name;
+                // LUCENENET specific: changed to use string filename instead of allocating a FileInfo (#832)
+                string dirname = Path.GetDirectoryName(filename)
+                                 ?? throw new InvalidOperationException($"Could not determine directory name from filename: {filename}");
+
                 if (dirImpl is null)
                 {
-                    dir = FSDirectory.Open(new DirectoryInfo(dirname));
+                    dir = FSDirectory.Open(dirname);
                 }
                 else
                 {
+                    // LUCENENET NOTE: We need the DirectoryInfo instance here, as there's no benefit to using a string.
+                    // See comments on CommandLineUtil.NewFSDirectory(string, DirectoryInfo) for more information. (#832)
                     dir = CommandLineUtil.NewFSDirectory(dirImpl, new DirectoryInfo(dirname));
                 }
 

--- a/src/Lucene.Net.Misc/Index/IndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/IndexSplitter.cs
@@ -181,8 +181,9 @@ namespace Lucene.Net.Index
                 ICollection<string> files = infoPerCommit.GetFiles();
                 foreach (string srcName in files)
                 {
-                    FileInfo srcFile = new FileInfo(Path.Combine(dir.FullName, srcName));
-                    FileInfo destFile = new FileInfo(Path.Combine(destDir.FullName, srcName));
+                    // LUCENENET specific: changed to use string file names instead of allocating a FileInfo (#832)
+                    string srcFile = Path.Combine(dir.FullName, srcName);
+                    string destFile = Path.Combine(destDir.FullName, srcName);
                     CopyFile(srcFile, destFile);
                 }
             }
@@ -191,10 +192,11 @@ namespace Lucene.Net.Index
             // Console.WriteLine("destDir:"+destDir.getAbsolutePath());
         }
 
-        private static void CopyFile(FileInfo src, FileInfo dst)
+        // LUCENENET specific: changed to use string file names instead of allocating a FileInfo (#832)
+        private static void CopyFile(string src, string dst)
         {
-            using Stream @in = new FileStream(src.FullName, FileMode.Open, FileAccess.Read);
-            using Stream @out = new FileStream(dst.FullName, FileMode.OpenOrCreate, FileAccess.Write);
+            using Stream @in = new FileStream(src, FileMode.Open, FileAccess.Read);
+            using Stream @out = new FileStream(dst, FileMode.OpenOrCreate, FileAccess.Write);
             @in.CopyTo(@out);
         }
     }

--- a/src/Lucene.Net.Suggest/Spell/PlainTextDictionary.cs
+++ b/src/Lucene.Net.Suggest/Spell/PlainTextDictionary.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Search.Spell
 
     /// <summary>
     /// Dictionary represented by a text file.
-    /// 
+    ///
     /// <para/>Format allowed: 1 word per line:<para/>
     /// word1<para/>
     /// word2<para/>
@@ -34,8 +34,21 @@ namespace Lucene.Net.Search.Spell
     /// </summary>
     public class PlainTextDictionary : IDictionary
     {
-
         private readonly TextReader @in;
+
+        /// <summary>
+        /// Creates a dictionary based on a File.
+        /// <para>
+        /// NOTE: content is treated as UTF-8
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// LUCENENET: This overload takes a string to avoid having to allocate a <see cref="FileInfo"/> object.
+        /// </remarks>
+        public PlainTextDictionary(string fileName)
+        {
+            @in = IOUtils.GetDecodingReader(fileName, Encoding.UTF8);
+        }
 
         /// <summary>
         /// Creates a dictionary based on a File.

--- a/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellTernarySearchTrie.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) 2005 Bruno Martins
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
-// modification, are permitted provided that the following conditions 
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
 // are met:
-// 1. Redistributions of source code must retain the above copyright 
+// 1. Redistributions of source code must retain the above copyright
 //    notice, this list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright
 //    notice, this list of conditions and the following disclaimer in the
@@ -12,9 +12,9 @@
 // 3. Neither the name of the organization nor the names of its contributors
 //    may be used to endorse or promote products derived from this software
 //    without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 // ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
 // LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
@@ -46,13 +46,13 @@ namespace Lucene.Net.Search.Suggest.Jaspell
     /// tree with the speed of a digital search trie, and is therefore ideal for
     /// practical use in sorting and searching data.
     /// <para>
-    /// 
+    ///
     /// This data structure is faster than hashing for many typical search problems,
     /// and supports a broader range of useful problems and operations. Ternary
     /// searches are faster than hashing and more powerful, too.
     /// </para>
     /// <para>
-    /// 
+    ///
     /// The theory of ternary search trees was described at a symposium in 1997 (see
     /// "Fast Algorithms for Sorting and Searching Strings," by J.L. Bentley and R.
     /// Sedgewick, Proceedings of the 8th Annual ACM-SIAM Symposium on Discrete
@@ -131,14 +131,14 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// <param name="culture">The culture used for lowercasing.</param>
         /// <returns> A negative number, 0 or a positive number if the second char is
         ///         less, equal or greater. </returns>
-        ///         
+        ///
         private static int CompareCharsAlphabetically(char cCompare2, char cRef, CultureInfo culture)
         {
             var textInfo = culture.TextInfo;
             return textInfo.ToLower(cCompare2) - textInfo.ToLower(cRef);
         }
 
-        /* what follows is the original Jaspell code. 
+        /* what follows is the original Jaspell code.
         private static int compareCharsAlphabetically(int cCompare2, int cRef) {
         int cCompare = 0;
         if (cCompare2 >= 65) {
@@ -209,12 +209,11 @@ namespace Lucene.Net.Search.Suggest.Jaspell
             get => rootNode;
         }
 
-
         /// <summary>
         /// Constructs a Ternary Search Trie and loads data from a <see cref="FileInfo"/>
         /// into the Trie. The file is a normal text document, where each line is of
         /// the form word TAB float.
-        /// 
+        ///
         /// <para>Uses the culture of the current thread to lowercase words before comparing.</para>
         /// </summary>
         /// <param name="file">
@@ -222,7 +221,26 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// <exception cref="IOException">
         ///              A problem occured while reading the data. </exception>
         public JaspellTernarySearchTrie(FileInfo file)
-            : this(file, false, CultureInfo.CurrentCulture)
+            : this(file.FullName, false, CultureInfo.CurrentCulture)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a Ternary Search Trie and loads data from a given <paramref name="fileName"/>
+        /// into the Trie. The file is a normal text document, where each line is of
+        /// the form word TAB float.
+        ///
+        /// <para>Uses the culture of the current thread to lowercase words before comparing.</para>
+        /// </summary>
+        /// <param name="fileName">
+        ///          The file name with the data to load into the Trie. </param>
+        /// <exception cref="IOException">
+        ///              A problem occured while reading the data. </exception>
+        /// <remarks>
+        /// LUCENENET: This constructor overload takes a string <paramref name="fileName"/> to avoid having to allocate a <see cref="FileInfo"/> object.
+        /// </remarks>
+        public JaspellTernarySearchTrie(string fileName)
+            : this(fileName, false, CultureInfo.CurrentCulture)
         {
         }
 
@@ -230,7 +248,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// Constructs a Ternary Search Trie and loads data from a <see cref="FileInfo"/>
         /// into the Trie. The file is a normal text document, where each line is of
         /// the form word TAB float.
-        /// 
+        ///
         /// <para>Uses the supplied culture to lowercase words before comparing.</para>
         /// </summary>
         /// <param name="file">
@@ -239,15 +257,33 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// <exception cref="IOException">
         ///              A problem occured while reading the data. </exception>
         public JaspellTernarySearchTrie(FileInfo file, CultureInfo culture)
-            : this(file, false, culture)
-        {
-        }
+            : this(file.FullName, false, culture)
+        { }
+
+        /// <summary>
+        /// Constructs a Ternary Search Trie and loads data from a given <paramref name="fileName"/>
+        /// into the Trie. The file is a normal text document, where each line is of
+        /// the form word TAB float.
+        ///
+        /// <para>Uses the supplied culture to lowercase words before comparing.</para>
+        /// </summary>
+        /// <param name="fileName">
+        ///          The file name with the data to load into the Trie. </param>
+        /// <param name="culture">The culture used for lowercasing.</param>
+        /// <exception cref="IOException">
+        ///              A problem occured while reading the data. </exception>
+        /// <remarks>
+        /// LUCENENET: This constructor overload takes a string <paramref name="fileName"/> to avoid having to allocate a <see cref="FileInfo"/> object.
+        /// </remarks>
+        public JaspellTernarySearchTrie(string fileName, CultureInfo culture)
+            : this(fileName, false, culture)
+        { }
 
         /// <summary>
         /// Constructs a Ternary Search Trie and loads data from a <see cref="FileInfo"/>
         /// into the Trie. The file is a normal text document, where each line is of
         /// the form "word TAB float".
-        /// 
+        ///
         /// <para>Uses the culture of the current thread to lowercase words before comparing.</para>
         /// </summary>
         /// <param name="file">
@@ -258,14 +294,35 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// <exception cref="IOException">
         ///              A problem occured while reading the data. </exception>
         public JaspellTernarySearchTrie(FileInfo file, bool compression)
-            : this(file, compression, CultureInfo.CurrentCulture)
+            : this(file.FullName, compression, CultureInfo.CurrentCulture)
+        { }
+
+        /// <summary>
+        /// Constructs a Ternary Search Trie and loads data from a given <paramref name="fileName"/>
+        /// into the Trie. The file is a normal text document, where each line is of
+        /// the form "word TAB float".
+        ///
+        /// <para>Uses the culture of the current thread to lowercase words before comparing.</para>
+        /// </summary>
+        /// <param name="fileName">
+        ///          The file name with the data to load into the Trie. </param>
+        /// <param name="compression">
+        ///          If true, the file is compressed with the GZIP algorithm, and if
+        ///          false, the file is a normal text document. </param>
+        /// <exception cref="IOException">
+        ///              A problem occured while reading the data. </exception>
+        /// <remarks>
+        /// LUCENENET: This constructor overload takes a string <paramref name="fileName"/> to avoid having to allocate a <see cref="FileInfo"/> object.
+        /// </remarks>
+        public JaspellTernarySearchTrie(string fileName, bool compression)
+            : this(fileName, compression, CultureInfo.CurrentCulture)
         { }
 
         /// <summary>
         /// Constructs a Ternary Search Trie and loads data from a <see cref="FileInfo"/>
         /// into the Trie. The file is a normal text document, where each line is of
         /// the form "word TAB float".
-        /// 
+        ///
         /// <para>Uses the supplied culture to lowercase words before comparing.</para>
         /// <para>NOTE for subclasses: this constructor calls a virtual method, which could
         /// result in your override of it being called before the class is properly initialized.
@@ -281,14 +338,45 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// <param name="culture">The culture used for lowercasing.</param>
         /// <exception cref="IOException">
         ///              A problem occured while reading the data. </exception>
+        /// <remarks>
+        /// LUCENENET: This constructor overload takes a string <paramref name="fileName"/> to avoid having to allocate a <see cref="FileInfo"/> object.
+        /// </remarks>
+        public JaspellTernarySearchTrie(FileInfo file, bool compression, CultureInfo culture)
+            : this(file.FullName, compression, culture)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a Ternary Search Trie and loads data from a given <paramref name="fileName"/>
+        /// into the Trie. The file is a normal text document, where each line is of
+        /// the form "word TAB float".
+        ///
+        /// <para>Uses the supplied culture to lowercase words before comparing.</para>
+        /// <para>NOTE for subclasses: this constructor calls a virtual method, which could
+        /// result in your override of it being called before the class is properly initialized.
+        /// To overcome the issue, you could override <see cref="JaspellTernarySearchTrie(CultureInfo)"/>
+        /// constructor and then call the logic in a way that suits your needs.
+        /// </para>
+        /// </summary>
+        /// <param name="fileName">
+        ///          The file name with the data to load into the Trie. </param>
+        /// <param name="compression">
+        ///          If true, the file is compressed with the GZIP algorithm, and if
+        ///          false, the file is a normal text document. </param>
+        /// <param name="culture">The culture used for lowercasing.</param>
+        /// <exception cref="IOException">
+        ///              A problem occured while reading the data. </exception>
+        /// <remarks>
+        /// LUCENENET: This constructor overload takes a string <paramref name="fileName"/> to avoid having to allocate a <see cref="FileInfo"/> object.
+        /// </remarks>
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("CodeQuality", "S1699:Constructors should only call non-overridable methods", Justification = "This class gets deprecated and removed in later versions")]
-        public JaspellTernarySearchTrie(FileInfo file, bool compression, CultureInfo culture)
+        public JaspellTernarySearchTrie(string fileName, bool compression, CultureInfo culture)
             : this(culture)
         {
-            using TextReader @in = (compression) ?
-                IOUtils.GetDecodingReader(new GZipStream(new FileStream(file.FullName, FileMode.Open), CompressionMode.Decompress), Encoding.UTF8) :
-                IOUtils.GetDecodingReader(new FileStream(file.FullName, FileMode.Open), Encoding.UTF8);
+            using TextReader @in = compression ?
+                IOUtils.GetDecodingReader(new GZipStream(new FileStream(fileName, FileMode.Open), CompressionMode.Decompress), Encoding.UTF8) :
+                IOUtils.GetDecodingReader(new FileStream(fileName, FileMode.Open), Encoding.UTF8);
             string word;
             int pos;
             float occur, one = 1f;
@@ -379,13 +467,13 @@ namespace Lucene.Net.Search.Suggest.Jaspell
 
         /// <summary>
         /// Recursively visits each node to be deleted.
-        /// 
+        ///
         /// To delete a node, first set its data to null, then pass it into this
         /// method, then pass the node returned by this method into this method (make
         /// sure you don't delete the data of any of the nodes returned from this
         /// method!) and continue in this fashion until the node returned by this
         /// method is <c>null</c>.
-        /// 
+        ///
         /// The TSTNode instance returned by this method will be next node to be
         /// operated on by <see cref="DeleteNodeRecursion(TSTNode)"/> (This emulates recursive
         /// method call while avoiding the overhead normally associated with a
@@ -686,7 +774,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// If the <see cref="MatchAlmost(string, int)"/> method is called before the
         /// <see cref="MatchAlmostDiff"/> property has been called for the first time,
         /// then diff = 0.
-        /// 
+        ///
         /// </para>
         /// </summary>
         /// <param name="key">
@@ -706,7 +794,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// If the <see cref="MatchAlmost(string, int)"/> method is called before the
         /// <see cref="MatchAlmostDiff"/> property has been called for the first time,
         /// then diff = 0.
-        /// 
+        ///
         /// </para>
         /// </summary>
         /// <param name="key"> The target key. </param>
@@ -732,7 +820,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// <param name="matchAlmostResult2">
         ///          The results so far. </param>
         /// <param name="upTo">
-        ///          If true all keys having up to and including <see cref="MatchAlmostDiff"/> 
+        ///          If true all keys having up to and including <see cref="MatchAlmostDiff"/>
         ///          mismatched letters will be included in the result (including a key
         ///          that is exactly the same as the target string) otherwise keys will
         ///          be included in the result only if they have exactly
@@ -906,7 +994,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// <para>
         /// Arguments less than 0 will set the char difference to 0, and arguments
         /// greater than 3 will set the char difference to 3.
-        /// 
+        ///
         /// </para>
         /// </summary>
         public virtual int MatchAlmostDiff
@@ -945,7 +1033,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// <para>
         /// The number of keys returned is limited to numReturnValues. To get a list
         /// that isn't limited in size, set numReturnValues to -1.
-        /// 
+        ///
         /// </para>
         /// </summary>
         /// <param name="startNode">
@@ -965,7 +1053,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         /// Sorted keys will be appended to the end of the resulting <see cref="List{String}"/>.
         /// The result may be empty when this method is invoked, but may not be
         /// <c>null</c>.
-        /// 
+        ///
         /// </para>
         /// </summary>
         /// <param name="currentNode">

--- a/src/Lucene.Net.TestFramework/Support/Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/Lucene.Net.TestFramework/Support/Configuration/ConfigurationBuilderExtensions.cs
@@ -101,14 +101,14 @@ namespace Lucene.Net.Configuration
 
             try
             {
-                while (new DirectoryInfo(currentPath).Parent != null)
+                while (Directory.GetParent(currentPath) is { } parent) // LUCENENET: Reduce DirectoryInfo allocations by only getting parent once per iteration (#832)
                 {
-                    candidatePath = System.IO.Path.Combine(new DirectoryInfo(currentPath).Parent.FullName, fileName);
+                    candidatePath = Path.Combine(parent.FullName, fileName);
                     if (File.Exists(candidatePath))
                     {
                         locations.Push(candidatePath);
                     }
-                    currentPath = new DirectoryInfo(currentPath).Parent.FullName;
+                    currentPath = parent.FullName;
                 }
             }
             catch (SecurityException)

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/WriteEnwikiLineDocTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/WriteEnwikiLineDocTaskTest.cs
@@ -4,7 +4,6 @@ using Lucene.Net.Benchmarks.ByTask.Feeds;
 using Lucene.Net.Benchmarks.ByTask.Utils;
 using Lucene.Net.Documents;
 using NUnit.Framework;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -52,37 +51,40 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
 
         }
 
-        private PerfRunData createPerfRunData(FileInfo file, String docMakerName)
+        // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+        private PerfRunData createPerfRunData(string fileName, string docMakerName)
         {
             Dictionary<string, string> props = new Dictionary<string, string>();
             props["doc.maker"] = docMakerName;
-            props["line.file.out"] = file.FullName;
+            props["line.file.out"] = fileName;
             props["directory"] = "RAMDirectory"; // no accidental FS dir.
             Config config = new Config(props);
             return new PerfRunData(config);
         }
 
-        private void doReadTest(FileInfo file, String expTitle,
-                                String expDate, String expBody)
+        // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+        private void doReadTest(string fileName, string expTitle,
+                                string expDate, string expBody)
         {
-            doReadTest(2, file, expTitle, expDate, expBody);
-            FileInfo categoriesFile = WriteEnwikiLineDocTask.CategoriesLineFile(file);
+            doReadTest(2, fileName, expTitle, expDate, expBody);
+            string categoriesFile = WriteEnwikiLineDocTask.CategoriesLineFile(fileName);
             doReadTest(2, categoriesFile, "Category:" + expTitle, expDate, expBody);
         }
 
-        private void doReadTest(int n, FileInfo file, String expTitle, String expDate, String expBody)
+        // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+        private void doReadTest(int n, string fileName, string expTitle, string expDate, string expBody)
         {
-            Stream @in = new FileStream(file.FullName, FileMode.Open, FileAccess.Read);
+            Stream @in = new FileStream(fileName, FileMode.Open, FileAccess.Read);
             TextReader br = new StreamReader(@in, Encoding.UTF8);
             try
             {
-                String line = br.ReadLine();
+                string line = br.ReadLine();
                 WriteLineDocTaskTest.assertHeaderLine(line);
                 for (int i = 0; i < n; i++)
                 {
                     line = br.ReadLine();
                     assertNotNull(line);
-                    String[] parts = line.Split(WriteLineDocTask.SEP).TrimEnd();
+                    string[] parts = line.Split(WriteLineDocTask.SEP).TrimEnd();
                     int numExpParts = expBody is null ? 2 : 3;
                     assertEquals(numExpParts, parts.Length);
                     assertEquals(expTitle, parts[0]);
@@ -106,11 +108,12 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             // WriteLineDocTask replaced only \t characters w/ a space, since that's its
             // separator char. However, it didn't replace newline characters, which
             // resulted in errors in LineDocSource.
-            FileInfo file = new FileInfo(Path.Combine(getWorkDir().FullName, "two-lines-each.txt"));
+            // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
+            string file = Path.Combine(getWorkDir().FullName, "two-lines-each.txt");
             PerfRunData runData = createPerfRunData(file, typeof(WriteLineCategoryDocMaker).AssemblyQualifiedName);
             WriteLineDocTask wldt = new WriteEnwikiLineDocTask(runData);
             for (int i = 0; i < 4; i++)
-            { // four times so that each file should have 2 lines. 
+            { // four times so that each file should have 2 lines.
                 wldt.DoLogic();
             }
             wldt.Dispose();

--- a/src/Lucene.Net/Store/MMapDirectory.cs
+++ b/src/Lucene.Net/Store/MMapDirectory.cs
@@ -183,8 +183,8 @@ namespace Lucene.Net.Store
         public override IndexInput OpenInput(string name, IOContext context)
         {
             EnsureOpen();
-            var file = new FileInfo(Path.Combine(Directory.FullName, name));
-            var fc = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            var file = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
+            var fc = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return new MMapIndexInput(this, "MMapIndexInput(path=\"" + file + "\")", fc);
         }
 

--- a/src/Lucene.Net/Store/NIOFSDirectory.cs
+++ b/src/Lucene.Net/Store/NIOFSDirectory.cs
@@ -102,27 +102,27 @@ namespace Lucene.Net.Store
         public override IndexInput OpenInput(string name, IOContext context)
         {
             EnsureOpen();
-            var path = new FileInfo(Path.Combine(Directory.FullName, name));
-            var fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var path = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
+            var fc = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new NIOFSIndexInput("NIOFSIndexInput(path=\"" + path + "\")", fc, context);
         }
 
         public override IndexInputSlicer CreateSlicer(string name, IOContext context)
         {
             EnsureOpen();
-            var path = new FileInfo(Path.Combine(Directory.FullName, name));
-            var fc = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var path = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
+            var fc = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new IndexInputSlicerAnonymousClass(context, path, fc);
         }
 
         private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly IOContext context;
-            private readonly FileInfo path;
+            private readonly string path; // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
             private readonly FileStream descriptor;
             private int disposed = 0; // LUCENENET specific - allow double-dispose
 
-            public IndexInputSlicerAnonymousClass(IOContext context, FileInfo path, FileStream descriptor)
+            public IndexInputSlicerAnonymousClass(IOContext context, string path, FileStream descriptor)
             {
                 this.context = context;
                 this.path = path;
@@ -141,7 +141,7 @@ namespace Lucene.Net.Store
 
             public override IndexInput OpenSlice(string sliceDescription, long offset, long length)
             {
-                return new NIOFSIndexInput("NIOFSIndexInput(" + sliceDescription + " in path=\"" + path + "\" slice=" + offset + ":" + (offset + length) + ")", descriptor, offset, length, 
+                return new NIOFSIndexInput("NIOFSIndexInput(" + sliceDescription + " in path=\"" + path + "\" slice=" + offset + ":" + (offset + length) + ")", descriptor, offset, length,
                     BufferedIndexInput.GetBufferSize(context));
             }
 

--- a/src/Lucene.Net/Store/SimpleFSDirectory.cs
+++ b/src/Lucene.Net/Store/SimpleFSDirectory.cs
@@ -98,27 +98,27 @@ namespace Lucene.Net.Store
         public override IndexInput OpenInput(string name, IOContext context)
         {
             EnsureOpen();
-            var path = new FileInfo(Path.Combine(Directory.FullName, name));
-            var raf = new FileStream(path.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            return new SimpleFSIndexInput("SimpleFSIndexInput(path=\"" + path.FullName + "\")", raf, context);
+            var path = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
+            var raf = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            return new SimpleFSIndexInput("SimpleFSIndexInput(path=\"" + path + "\")", raf, context);
         }
 
         public override IndexInputSlicer CreateSlicer(string name, IOContext context)
         {
             EnsureOpen();
-            var file = new FileInfo(Path.Combine(Directory.FullName, name));
-            var descriptor = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            var file = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
+            var descriptor = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return new IndexInputSlicerAnonymousClass(context, file, descriptor);
         }
 
         private sealed class IndexInputSlicerAnonymousClass : IndexInputSlicer
         {
             private readonly IOContext context;
-            private readonly FileInfo file;
+            private readonly string file; // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
             private readonly FileStream descriptor;
             private int disposed = 0; // LUCENENET specific - allow double-dispose
 
-            public IndexInputSlicerAnonymousClass(IOContext context, FileInfo file, FileStream descriptor)
+            public IndexInputSlicerAnonymousClass(IOContext context, string file, FileStream descriptor)
             {
                 this.context = context;
                 this.file = file;
@@ -137,7 +137,7 @@ namespace Lucene.Net.Store
 
             public override IndexInput OpenSlice(string sliceDescription, long offset, long length)
             {
-                return new SimpleFSIndexInput("SimpleFSIndexInput(" + sliceDescription + " in path=\"" + file.FullName + "\" slice=" + offset + ":" + (offset + length) + ")", descriptor, offset, length, BufferedIndexInput.GetBufferSize(context));
+                return new SimpleFSIndexInput("SimpleFSIndexInput(" + sliceDescription + " in path=\"" + file + "\" slice=" + offset + ":" + (offset + length) + ")", descriptor, offset, length, BufferedIndexInput.GetBufferSize(context));
             }
 
             [Obsolete("Only for reading CFS files from 3.x indexes.")]

--- a/src/Lucene.Net/Store/SimpleFSLockFactory.cs
+++ b/src/Lucene.Net/Store/SimpleFSLockFactory.cs
@@ -22,8 +22,8 @@ namespace Lucene.Net.Store
      */
 
     /// <summary>
-    /// <para>Implements <see cref="LockFactory"/> using 
-    /// <see cref="File.WriteAllText(string, string, Encoding)"/> 
+    /// <para>Implements <see cref="LockFactory"/> using
+    /// <see cref="File.WriteAllText(string, string, Encoding)"/>
     /// (writes the file with UTF8 encoding and no byte order mark).</para>
     ///
     /// <para>Special care needs to be taken if you change the locking
@@ -36,7 +36,7 @@ namespace Lucene.Net.Store
     ///
     /// <para>If you suspect that this or any other <see cref="LockFactory"/> is
     /// not working properly in your environment, you can easily
-    /// test it by using <see cref="VerifyingLockFactory"/>, 
+    /// test it by using <see cref="VerifyingLockFactory"/>,
     /// <see cref="LockVerifyServer"/> and <see cref="LockStressTest"/>.</para>
     /// </summary>
     /// <seealso cref="LockFactory"/>
@@ -87,14 +87,14 @@ namespace Lucene.Net.Store
                 {
                     lockName = m_lockPrefix + "-" + lockName;
                 }
-                FileInfo lockFile = new FileInfo(Path.Combine(m_lockDir.FullName, lockName));
+                string lockFile = Path.Combine(m_lockDir.FullName, lockName); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
                 try
                 {
-                    lockFile.Delete();
+                    File.Delete(lockFile);
                 }
                 catch (Exception e)
                 {
-                    if (lockFile.Exists) // Delete failed and lockFile exists
+                    if (File.Exists(lockFile)) // Delete failed and lockFile exists
                         throw new IOException("Cannot delete " + lockFile, e); // LUCENENET specific: wrapped inner exception
                 }
             }
@@ -103,13 +103,13 @@ namespace Lucene.Net.Store
 
     internal class SimpleFSLock : Lock
     {
-        internal FileInfo lockFile;
+        internal string lockFile; // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
         internal DirectoryInfo lockDir;
 
         public SimpleFSLock(DirectoryInfo lockDir, string lockFileName)
         {
             this.lockDir = lockDir;
-            lockFile = new FileInfo(Path.Combine(lockDir.FullName, lockFileName));
+            lockFile = Path.Combine(lockDir.FullName, lockFileName);
         }
 
         public override bool Obtain()
@@ -134,16 +134,16 @@ namespace Lucene.Net.Store
             // LUCENENET: Since WriteAllText doesn't care if the file exists or not,
             // we need to make that check first. We create a new IOException "failure reason"
             // in this case to simulate what happens in Java
-            if (File.Exists(lockFile.FullName))
+            if (File.Exists(lockFile))
             {
-                FailureReason = new IOException(string.Format("lockFile '{0}' alredy exists.", lockFile.FullName));
+                FailureReason = new IOException($"lockFile '{lockFile}' already exists.");
                 return false;
             }
 
             try
             {
                 // Create the file, and close it immediately
-                File.WriteAllText(lockFile.FullName, string.Empty, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false) /* No BOM */);
+                File.WriteAllText(lockFile, string.Empty, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false) /* No BOM */);
                 return true;
             }
             catch (Exception e) // LUCENENET: Some of the exceptions that can happen are not IOException, so we catch everything
@@ -161,12 +161,12 @@ namespace Lucene.Net.Store
         {
             if (disposing)
             {
-                if (File.Exists(lockFile.FullName))
+                if (File.Exists(lockFile))
                 {
-                    File.Delete(lockFile.FullName);
+                    File.Delete(lockFile);
 
                     // If lockFile still exists, delete failed
-                    if (File.Exists(lockFile.FullName))
+                    if (File.Exists(lockFile))
                     {
                         throw new LockReleaseFailedException("failed to delete " + lockFile);
                     }
@@ -176,7 +176,7 @@ namespace Lucene.Net.Store
 
         public override bool IsLocked()
         {
-            return File.Exists(lockFile.FullName);
+            return File.Exists(lockFile);
         }
 
         public override string ToString()

--- a/src/Lucene.Net/Util/CommandLineUtil.cs
+++ b/src/Lucene.Net/Util/CommandLineUtil.cs
@@ -35,6 +35,8 @@ namespace Lucene.Net.Util
         /// <param name="clazzName"> The name of the <see cref="FSDirectory"/> class to load. </param>
         /// <param name="dir"> The <see cref="DirectoryInfo"/> to be used as parameter constructor. </param>
         /// <returns> The new <see cref="FSDirectory"/> instance </returns>
+        // LUCENENET NOTE: We do not benefit from creating a string overload here to avoid DirectoryInfo allocations,
+        // because the FSDirectory implementations that take string just convert it to a DirectoryInfo anyway. (#832)
         public static FSDirectory NewFSDirectory(string clazzName, DirectoryInfo dir)
         {
             try
@@ -43,21 +45,21 @@ namespace Lucene.Net.Util
 
                 // LUCENENET: In .NET, we get a null when the class is not found, so we need to throw here for compatibility
                 if (clazz is null)
-                    throw new ArgumentException(typeof(FSDirectory).Name + " implementation not found: " + clazzName);
+                    throw new ArgumentException(nameof(FSDirectory) + " implementation not found: " + clazzName);
 
                 return NewFSDirectory(clazz, dir);
             }
             catch (Exception e) when (e.IsClassNotFoundException())
             {
-                throw new ArgumentException(typeof(FSDirectory).Name + " implementation not found: " + clazzName, e);
+                throw new ArgumentException(nameof(FSDirectory) + " implementation not found: " + clazzName, e);
             }
             catch (Exception e) when (e.IsClassCastException())
             {
-                throw new ArgumentException(clazzName + " is not a " + typeof(FSDirectory).Name + " implementation", e);
+                throw new ArgumentException(clazzName + " is not a " + nameof(FSDirectory) + " implementation", e);
             }
             catch (Exception e) when (e.IsNoSuchMethodException())
             {
-                throw new ArgumentException(clazzName + " constructor with " + typeof(FileInfo).Name + " as parameter not found", e);
+                throw new ArgumentException(clazzName + " constructor with " + nameof(FileInfo) + " as parameter not found", e);
             }
             catch (Exception e)
             {
@@ -91,7 +93,7 @@ namespace Lucene.Net.Util
         {
             if (clazzName is null || clazzName.Trim().Length == 0)
             {
-                throw new ArgumentException("The " + typeof(FSDirectory).Name + " implementation cannot be null or empty");
+                throw new ArgumentException("The " + nameof(FSDirectory) + " implementation cannot be null or empty");
             }
 
             // LUCENENET specific: Changed to use char rather than string so we get StringComparison.Ordinal,
@@ -114,6 +116,8 @@ namespace Lucene.Net.Util
         /// <exception cref="MemberAccessException"> If the class is abstract or an interface. </exception>
         /// <exception cref="TypeLoadException"> If the constructor does not have public visibility. </exception>
         /// <exception cref="TargetInvocationException"> If the constructor throws an exception </exception>
+        // LUCENENET NOTE: We do not benefit from creating a string overload here to avoid DirectoryInfo allocations,
+        // because the FSDirectory implementations that take string just convert it to a DirectoryInfo anyway. (#832)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static FSDirectory NewFSDirectory(Type clazz, DirectoryInfo dir)
         {

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -567,10 +567,13 @@ namespace Lucene.Net.Util.Fst
         /// <summary>
         /// Writes an automaton to a file.
         /// </summary>
-        public void Save(FileInfo file)
+        /// <remarks>
+        /// LUCENENET: This overload takes a string file name to avoid allocating a <see cref="FileInfo"/> object.
+        /// </remarks>
+        public void Save(string fileName)
         {
             bool success = false;
-            var bs = file.OpenWrite();
+            var bs = new FileStream(fileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
             try
             {
                 Save(new OutputStreamDataOutput(bs));
@@ -588,6 +591,13 @@ namespace Lucene.Net.Util.Fst
                 }
             }
         }
+
+        /// <summary>
+        /// Writes an automaton to a file.
+        /// </summary>
+        /// <seealso cref="Save(string)"/>
+        public void Save(FileInfo file)
+            => Save(file.FullName);
 
         // LUCENENET NOTE: static Read<T>() was moved into the FST class
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lucene.Net/Util/IOUtils.cs
+++ b/src/Lucene.Net/Util/IOUtils.cs
@@ -377,6 +377,37 @@ namespace Lucene.Net.Util
         }
 
         /// <summary>
+        /// Opens a <see cref="TextReader"/> for the given <paramref name="fileName"/> using a <see cref="Encoding"/>.
+        /// Unlike Java's defaults this reader will throw an exception if your it detects
+        /// the read charset doesn't match the expected <see cref="Encoding"/>.
+        /// <para/>
+        /// Decoding readers are useful to load configuration files, stopword lists or synonym files
+        /// to detect character set problems. However, its not recommended to use as a common purpose
+        /// reader. </summary>
+        /// <param name="fileName"> The file name to open a reader on </param>
+        /// <param name="charSet"> The expected charset </param>
+        /// <returns> A reader to read the given file </returns>
+        public static TextReader GetDecodingReader(string fileName, Encoding charSet)
+        {
+            FileStream stream = null;
+            bool success = false;
+            try
+            {
+                stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+                TextReader reader = GetDecodingReader(stream, charSet);
+                success = true;
+                return reader;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    IOUtils.Dispose(stream);
+                }
+            }
+        }
+
+        /// <summary>
         /// Opens a <see cref="TextReader"/> for the given <see cref="FileInfo"/> using a <see cref="Encoding"/>.
         /// Unlike Java's defaults this reader will throw an exception if your it detects
         /// the read charset doesn't match the expected <see cref="Encoding"/>.


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Add string-based overloads to some methods that take FileInfo/DirectoryInfo to avoid unnecessary allocations

Fixes #832

## Description

See #832 for context. This makes changes to add and prefer string-based overloads for methods that take FileInfo and DirectoryInfo primarily just for the FullName property, to avoid unnecessary allocations.
