### PR TITLE
Convert Lucene volatile long/double values to Atomic counterparts, #1063

### DIFF
--- a/src/Lucene.Net.Replicator/LocalReplicator.cs
+++ b/src/Lucene.Net.Replicator/LocalReplicator.cs
@@ -99,13 +99,15 @@ namespace Lucene.Net.Replicator
             public SessionToken Session { get; private set; }
             public RefCountedRevision Revision { get; private set; }
 
-            private long lastAccessTime;
+            // LUCENENET: was volatile long in Lucene, but that is not valid in .NET
+            // Instead, we use AtomicInt64 to ensure atomicity.
+            private readonly AtomicInt64 lastAccessTime;
 
             public ReplicationSession(SessionToken session, RefCountedRevision revision)
             {
                 Session = session;
                 Revision = revision;
-                lastAccessTime = Stopwatch.GetTimestamp(); // LUCENENET: Use the most accurate timer to determine expiration
+                lastAccessTime = new AtomicInt64(Stopwatch.GetTimestamp()); // LUCENENET: Use the most accurate timer to determine expiration
             }
 
             public virtual bool IsExpired(long expirationThreshold)
@@ -115,7 +117,7 @@ namespace Lucene.Net.Replicator
 
             public virtual void MarkAccessed()
             {
-                lastAccessTime = Stopwatch.GetTimestamp(); // LUCENENET: Use the most accurate timer to determine expiration
+                lastAccessTime.Value = Stopwatch.GetTimestamp(); // LUCENENET: Use the most accurate timer to determine expiration
             }
         }
 

--- a/src/Lucene.Net.Tests._J-S/Lucene.Net.Tests._J-S.csproj
+++ b/src/Lucene.Net.Tests._J-S/Lucene.Net.Tests._J-S.csproj
@@ -22,7 +22,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(SolutionDir)TestTargetFramework.props" />
-  
+
   <PropertyGroup>
     <AssemblyTitle>Lucene.Net.Tests._J-S</AssemblyTitle>
     <RootNamespace>Lucene.Net</RootNamespace>
@@ -80,7 +80,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimeInformationPackageVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/src/Lucene.Net.Tests/Support/Threading/AtomicDoubleTest.cs
+++ b/src/Lucene.Net.Tests/Support/Threading/AtomicDoubleTest.cs
@@ -1,0 +1,255 @@
+using Lucene.Net.Support.Threading;
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace Lucene.Net.Threading
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// This is a modified copy of J2N's TestAtomicInt64,
+    /// modified to test <see cref="AtomicDouble"/>
+    /// </summary>
+    [TestFixture]
+    public class AtomicDoubleTest : LuceneTestCase
+    {
+        private const int LONG_DELAY_MS = 50 * 50;
+
+        /**
+         * fail with message "Unexpected exception"
+         */
+        public void unexpectedException()
+        {
+            fail("Unexpected exception");
+        }
+
+        /**
+         * constructor initializes to given value
+         */
+        [Test]
+        public void TestConstructor()
+        {
+            AtomicDouble ai = new AtomicDouble(1.0d);
+            assertEquals(1.0d, ai);
+        }
+
+        /**
+         * default constructed initializes to zero
+         */
+        [Test]
+        public void TestConstructor2()
+        {
+            AtomicDouble ai = new AtomicDouble();
+            assertEquals(0.0d, ai.Value);
+        }
+
+        /**
+         * get returns the last value set
+         */
+        [Test]
+        public void TestGetSet()
+        {
+            AtomicDouble ai = new AtomicDouble(1);
+            assertEquals(1.0d, ai);
+            ai.Value = 2.0d;
+            assertEquals(2.0d, ai);
+            ai.Value = -3.0d;
+            assertEquals(-3.0d, ai);
+
+        }
+
+        /**
+         * compareAndSet succeeds in changing value if equal to expected else fails
+         */
+        [Test]
+        public void TestCompareAndSet()
+        {
+            AtomicDouble ai = new AtomicDouble(1.0d);
+            assertTrue(ai.CompareAndSet(1.0d, 2.0d));
+            assertTrue(ai.CompareAndSet(2.0d, -4.0d));
+            assertEquals(-4.0d, ai.Value);
+            assertFalse(ai.CompareAndSet(-5.0d, 7.0d));
+            assertFalse(7.0d.Equals(ai.Value));
+            assertTrue(ai.CompareAndSet(-4.0d, 7.0d));
+            assertEquals(7.0d, ai.Value);
+        }
+
+        /**
+         * compareAndSet in one thread enables another waiting for value
+         * to succeed
+         */
+        [Test]
+        public void TestCompareAndSetInMultipleThreads()
+        {
+            AtomicDouble ai = new AtomicDouble(1.0d);
+            Thread t = new Thread(() =>
+            {
+                while (!ai.CompareAndSet(2.0d, 3.0d)) Thread.Yield();
+            });
+            try
+            {
+                t.Start();
+                assertTrue(ai.CompareAndSet(1.0d, 2.0d));
+                t.Join(LONG_DELAY_MS);
+                assertFalse(t.IsAlive);
+                assertEquals(ai.Value, 3.0d);
+            }
+            catch (Exception /*e*/)
+            {
+                unexpectedException();
+            }
+        }
+
+        //    /**
+        //     * repeated weakCompareAndSet succeeds in changing value when equal
+        //     * to expected
+        //     */
+        //[Test]
+        //    public void TestWeakCompareAndSet()
+        //{
+        //    AtomicDouble ai = new AtomicDouble(1);
+        //    while (!ai.WeakCompareAndSet(1, 2)) ;
+        //    while (!ai.WeakCompareAndSet(2, -4)) ;
+        //    assertEquals(-4, ai.Value);
+        //    while (!ai.WeakCompareAndSet(-4, 7)) ;
+        //    assertEquals(7, ai.Value);
+        //}
+
+        /**
+         * getAndSet returns previous value and sets to given value
+         */
+        [Test]
+        public void TestGetAndSet()
+        {
+            AtomicDouble ai = new AtomicDouble(1.0d);
+            assertEquals(1.0d, ai.GetAndSet(0.0d));
+            assertEquals(0.0d, ai.GetAndSet(-10.0d));
+            assertEquals(-10.0d, ai.GetAndSet(1.0d));
+        }
+
+#if FEATURE_SERIALIZABLE
+        /**
+         * a deserialized serialized atomic holds same value
+         */
+        [Test]
+        public void TestSerialization()
+        {
+            AtomicDouble l = new AtomicDouble();
+
+            try
+            {
+                l.Value = 22.0d;
+                AtomicDouble r = Clone(l);
+                assertEquals(l.Value, r.Value);
+            }
+            catch (Exception /*e*/)
+            {
+                unexpectedException();
+            }
+        }
+#endif
+
+        /**
+         * toString returns current value.
+         */
+        [Test]
+        public void TestToString()
+        {
+            AtomicDouble ai = new AtomicDouble();
+            for (double i = -12.0d; i < 6.0d; i += 1.0d)
+            {
+                ai.Value = i;
+                assertEquals(ai.ToString(), J2N.Numerics.Double.ToString(i));
+            }
+        }
+
+        /**
+         * intValue returns current value.
+         */
+        [Test]
+        public void TestIntValue()
+        {
+            AtomicDouble ai = new AtomicDouble();
+            for (double i = -12.0d; i < 6.0d; ++i)
+            {
+                ai.Value = i;
+                assertEquals((int)i, Convert.ToInt32(ai));
+            }
+        }
+
+
+        /**
+         * longValue returns current value.
+         */
+        [Test]
+        public void TestLongValue()
+        {
+            AtomicDouble ai = new AtomicDouble();
+            for (double i = -12.0d; i < 6.0d; ++i)
+            {
+                ai.Value = i;
+                assertEquals((long)i, Convert.ToInt64(ai));
+            }
+        }
+
+        /**
+         * floatValue returns current value.
+         */
+        [Test]
+        public void TestFloatValue()
+        {
+            AtomicDouble ai = new AtomicDouble();
+            for (double i = -12.0d; i < 6.0d; ++i)
+            {
+                ai.Value = i;
+                assertEquals((float)i, Convert.ToSingle(ai));
+            }
+        }
+
+        /**
+         * doubleValue returns current value.
+         */
+        [Test]
+        public void TestDoubleValue()
+        {
+            AtomicDouble ai = new AtomicDouble();
+            for (double i = -12.0d; i < 6.0d; ++i)
+            {
+                ai.Value = i;
+                assertEquals((double)i, Convert.ToDouble(ai));
+            }
+        }
+
+        /**
+        * doubleValue returns current value.
+        */
+        [Test]
+        public void TestComparisonOperators()
+        {
+            AtomicDouble ai = new AtomicDouble(6.0d);
+            assertTrue(5.0d < ai);
+            assertTrue(9.0d > ai);
+            assertTrue(ai > 4.0d);
+            assertTrue(ai < 7.0d);
+            assertFalse(ai < 6.0d);
+            assertTrue(ai <= 6.0d);
+        }
+    }
+}

--- a/src/Lucene.Net/Index/IndexWriterConfig.cs
+++ b/src/Lucene.Net/Index/IndexWriterConfig.cs
@@ -293,8 +293,8 @@ namespace Lucene.Net.Index
         // so must declare it new. See: http://stackoverflow.com/q/82437
         new public long WriteLockTimeout
         {
-            get => writeLockTimeout;
-            set => this.writeLockTimeout = value;
+            get => writeLockTimeout.Value;
+            set => writeLockTimeout.Value = value;
         }
 
         /// <summary>

--- a/src/Lucene.Net/Index/MergePolicy.cs
+++ b/src/Lucene.Net/Index/MergePolicy.cs
@@ -1,4 +1,5 @@
-﻿using Lucene.Net.Diagnostics;
+﻿using J2N.Threading.Atomic;
+using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
@@ -128,12 +129,17 @@ namespace Lucene.Net.Index
             }
             private int maxNumSegments = -1;
 
+            // LUCENENET NOTE: original was volatile, using AtomicInt64 instead.
+            // Also, we expose the value as a `long` property instead of exposing
+            // the AtomicInt64 object itself.
+            internal readonly AtomicInt64 estimatedMergeBytes = new AtomicInt64();
+
             /// <summary>
             /// Estimated size in bytes of the merged segment. </summary>
-            public long EstimatedMergeBytes { get; internal set; } // used by IndexWriter // LUCENENET NOTE: original was volatile, but long cannot be in .NET
+            public long EstimatedMergeBytes => estimatedMergeBytes.Value;
 
             // Sum of sizeInBytes of all SegmentInfos; set by IW.mergeInit
-            internal long totalMergeBytes; // LUCENENET NOTE: original was volatile, but long cannot be in .NET
+            internal readonly AtomicInt64 totalMergeBytes = new AtomicInt64(); // LUCENENET NOTE: original was volatile, using AtomicInt64 instead
 
             internal IList<SegmentReader> readers; // used by IndexWriter
 
@@ -413,7 +419,7 @@ namespace Lucene.Net.Index
             /// input total size. This is only set once the merge is
             /// initialized by <see cref="IndexWriter"/>.
             /// </summary>
-            public virtual long TotalBytesSize => totalMergeBytes;
+            public virtual long TotalBytesSize => totalMergeBytes.Value;
 
             /// <summary>
             /// Returns the total number of documents that are included with this merge.

--- a/src/Lucene.Net/Index/SegmentCommitInfo.cs
+++ b/src/Lucene.Net/Index/SegmentCommitInfo.cs
@@ -1,4 +1,5 @@
 ﻿using J2N.Collections.Generic.Extensions;
+using J2N.Threading.Atomic;
 using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
@@ -58,7 +59,7 @@ namespace Lucene.Net.Index
         // Track the per-generation updates files
         private readonly IDictionary<long, ISet<string>> genUpdatesFiles = new Dictionary<long, ISet<string>>();
 
-        private long sizeInBytes = -1; // LUCENENET NOTE: This was volatile in the original, but long cannot be volatile in .NET
+        private readonly AtomicInt64 sizeInBytes = new AtomicInt64(-1L); // LUCENENET NOTE: This was volatile in the original, using AtomicInt64 instead
 
         /// <summary>
         /// Sole constructor.
@@ -115,7 +116,7 @@ namespace Lucene.Net.Index
         {
             delGen = nextWriteDelGen;
             nextWriteDelGen = delGen + 1;
-            sizeInBytes = -1;
+            sizeInBytes.Value = -1;
         }
 
         /// <summary>
@@ -134,7 +135,7 @@ namespace Lucene.Net.Index
         {
             fieldInfosGen = nextWriteFieldInfosGen;
             nextWriteFieldInfosGen = fieldInfosGen + 1;
-            sizeInBytes = -1;
+            sizeInBytes.Value = -1;
         }
 
         /// <summary>
@@ -161,7 +162,7 @@ namespace Lucene.Net.Index
                 {
                     sum += Info.Dir.FileLength(fileName);
                 }
-                sizeInBytes = sum;
+                sizeInBytes.Value = sum;
             }
 
             return sizeInBytes;
@@ -198,7 +199,7 @@ namespace Lucene.Net.Index
         internal void SetBufferedDeletesGen(long value)
         {
             bufferedDeletesGen = value;
-            sizeInBytes = -1;
+            sizeInBytes.Value = -1;
         }
 
         /// <summary>

--- a/src/Lucene.Net/Search/ControlledRealTimeReopenThread.cs
+++ b/src/Lucene.Net/Search/ControlledRealTimeReopenThread.cs
@@ -50,8 +50,13 @@ namespace Lucene.Net.Search
         private readonly long targetMinStaleNS;
         private readonly TrackingIndexWriter writer;
         private volatile bool finish;
+
+        // LUCENENET note: these fields were originally volatile in Lucene,
+        // but since access to them is always done under a lock or with Interlocked,
+        // no need to make these AtomicInt64.
         private long waitingGen;
         private long searchingGen;
+
         private readonly AtomicInt64 refreshStartGen = new AtomicInt64();
         private readonly AtomicBoolean isDisposed = new AtomicBoolean(false);
 

--- a/src/Lucene.Net/Support/Threading/AtomicDouble.cs
+++ b/src/Lucene.Net/Support/Threading/AtomicDouble.cs
@@ -364,7 +364,7 @@ namespace Lucene.Net.Support.Threading
             if (a2 is null)
                 return false;
 
-            return a1.Equals(a2.Value);
+            return a2.Equals(a1);
         }
 
         /// <summary>
@@ -411,10 +411,12 @@ namespace Lucene.Net.Support.Threading
         /// <returns><c>true</c> if the given numbers are equal; otherwise, <c>false</c>.</returns>
         public static bool operator ==(double? a1, AtomicDouble? a2)
         {
-            if (!a1.HasValue)
+            if (a1 is null)
                 return a2 is null;
+            if (a2 is null)
+                return false;
 
-            return a1.GetValueOrDefault().Equals(a2.Value);
+            return a2.Equals(a1.Value);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Support/Threading/AtomicDouble.cs
+++ b/src/Lucene.Net/Support/Threading/AtomicDouble.cs
@@ -339,7 +339,7 @@ namespace Lucene.Net.Support.Threading
             if (a1 is null)
                 return false;
 
-            return a1.Value.Equals(a2);
+            return a1.Equals(a2);
         }
 
         /// <summary>
@@ -391,7 +391,7 @@ namespace Lucene.Net.Support.Threading
             if (a2 is null)
                 return false;
 
-            return a1.Value.Equals(a2.Value);
+            return a1.Equals(a2.Value);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Support/Threading/AtomicDouble.cs
+++ b/src/Lucene.Net/Support/Threading/AtomicDouble.cs
@@ -387,9 +387,11 @@ namespace Lucene.Net.Support.Threading
         public static bool operator ==(AtomicDouble? a1, double? a2)
         {
             if (a1 is null)
-                return !a2.HasValue;
+                return a2 is null;
+            if (a2 is null)
+                return false;
 
-            return a1.Value.Equals(a2.GetValueOrDefault());
+            return a1.Value.Equals(a2.Value);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Support/Threading/AtomicDouble.cs
+++ b/src/Lucene.Net/Support/Threading/AtomicDouble.cs
@@ -208,6 +208,26 @@ namespace Lucene.Net.Support.Threading
             return J2N.Numerics.Double.ToString(Value, format, provider);
         }
 
+        #region TryFormat
+
+        /// <summary>
+        /// Tries to format the value of the current double instance into the provided span of characters.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return J2N.Numerics.Double.TryFormat(Value, destination, out charsWritten, format, provider);
+        }
+
+        #endregion
+
         #region IConvertible Members
 
         /// <inheritdoc/>

--- a/src/Lucene.Net/Support/Threading/AtomicDouble.cs
+++ b/src/Lucene.Net/Support/Threading/AtomicDouble.cs
@@ -133,7 +133,7 @@ namespace Lucene.Net.Support.Threading
         public bool Equals(double other)
         {
             // NOTE: comparing long values rather than floating point comparison
-            return Interlocked.Read(ref value) == BitConversion.DoubleToRawInt64Bits(other));
+            return Interlocked.Read(ref value) == BitConversion.DoubleToRawInt64Bits(other);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Support/Threading/AtomicDouble.cs
+++ b/src/Lucene.Net/Support/Threading/AtomicDouble.cs
@@ -1,4 +1,4 @@
-#region Copyright 2010 by Apache Harmony, Licensed under the Apache License, Version 2.0
+﻿#region Copyright 2010 by Apache Harmony, Licensed under the Apache License, Version 2.0
 /*  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with
  *  this work for additional information regarding copyright ownership.
@@ -145,10 +145,10 @@ namespace Lucene.Net.Support.Threading
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="AtomicDouble"/>; otherwise, <c>false</c>.</returns>
         public override bool Equals(object? other)
         {
-            if (other is AtomicDouble ai)
-                return Equals(ai);
-            if (other is double i)
-                return Equals(i);
+            if (other is AtomicDouble ad)
+                return Equals(ad);
+            if (other is double d)
+                return Equals(d);
             return false;
         }
 
@@ -295,10 +295,10 @@ namespace Lucene.Net.Support.Threading
         /// <summary>
         /// Implicitly converts an <see cref="AtomicDouble"/> to a <see cref="double"/>.
         /// </summary>
-        /// <param name="atomicInt64">The <see cref="AtomicDouble"/> to convert.</param>
-        public static implicit operator double(AtomicDouble atomicInt64)
+        /// <param name="atomicDouble">The <see cref="AtomicDouble"/> to convert.</param>
+        public static implicit operator double(AtomicDouble atomicDouble)
         {
-            return atomicInt64.Value;
+            return atomicDouble.Value;
         }
 
         /// <summary>

--- a/src/Lucene.Net/Support/Threading/AtomicDouble.cs
+++ b/src/Lucene.Net/Support/Threading/AtomicDouble.cs
@@ -1,0 +1,413 @@
+#region Copyright 2010 by Apache Harmony, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using J2N;
+using J2N.Numerics;
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+#nullable enable
+
+namespace Lucene.Net.Support.Threading
+{
+    /// <summary>
+    /// A <see cref="double"/> value that may be updated atomically.
+    /// An <see cref="AtomicDouble"/> is used in applications such as atomically
+    /// stored and retrieved values, and cannot be used as a replacement
+    /// for a <see cref="System.Double"/>. However, this class does
+    /// implement implicit conversion to <see cref="double"/>, so it can
+    /// be utilized with language features, tools and utilities that deal
+    /// with numerical operations.
+    /// <para/>
+    /// NOTE: This is a modified version of <see cref="J2N.Threading.Atomic.AtomicInt64"/> to support <see cref="double"/> values.
+    /// It does not have the increment, decrement, and add methods because those operations are not atomic
+    /// due to the conversion to/from <see cref="long"/>.
+    /// </summary>
+#if FEATURE_SERIALIZABLE
+    [Serializable]
+#endif
+    [DebuggerDisplay("{Value}")]
+    internal class AtomicDouble : Number, IEquatable<AtomicDouble>, IEquatable<double>, IFormattable, IConvertible
+    {
+        private long value;
+
+        /// <summary>
+        /// Creates a new <see cref="AtomicDouble"/> with the default initial value, <c>0</c>.
+        /// </summary>
+        public AtomicDouble()
+            : this(0d)
+        { }
+
+        /// <summary>
+        /// Creates a new <see cref="AtomicDouble"/> with the given initial <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The initial value.</param>
+        public AtomicDouble(double value)
+        {
+            this.value = BitConversion.DoubleToInt64Bits(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the current value. Note that these operations can be done
+        /// implicitly by setting the <see cref="AtomicDouble"/> to a <see cref="double"/>.
+        /// <code>
+        /// AtomicDouble aDouble = new AtomicDouble(4.0);
+        /// double x = aDouble;
+        /// </code>
+        /// </summary>
+        /// <remarks>
+        /// Properties are inherently not atomic. Operators such as += and -= should not
+        /// be used on <see cref="Value"/> because they perform both a separate get and a set operation.
+        /// </remarks>
+        public double Value
+        {
+            get => BitConversion.Int64BitsToDouble(Interlocked.Read(ref this.value));
+            set => Interlocked.Exchange(ref this.value, BitConversion.DoubleToInt64Bits(value));
+        }
+
+        /// <summary>
+        /// Atomically sets to the given value and returns the old value.
+        /// </summary>
+        /// <param name="newValue">The new value.</param>
+        /// <returns>The previous value.</returns>
+        public double GetAndSet(double newValue)
+        {
+            return BitConversion.Int64BitsToDouble(Interlocked.Exchange(ref value, BitConversion.DoubleToInt64Bits(newValue)));
+        }
+
+        /// <summary>
+        /// Atomically sets the value to the given updated value
+        /// if the current value equals the expected value.
+        /// </summary>
+        /// <param name="expect">The expected value (the comparand).</param>
+        /// <param name="update">The new value that will be set if the current value equals the expected value.</param>
+        /// <returns><c>true</c> if successful. A <c>false</c> return value indicates that the actual value
+        /// was not equal to the expected value.</returns>
+        public bool CompareAndSet(double expect, double update)
+        {
+            long expectLong = BitConversion.DoubleToInt64Bits(expect);
+            long updateLong = BitConversion.DoubleToInt64Bits(update);
+            long rc = Interlocked.CompareExchange(ref value, updateLong, expectLong);
+            return rc == expectLong;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="AtomicDouble"/> is equal to the current <see cref="AtomicDouble"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="AtomicDouble"/> to compare with the current <see cref="AtomicDouble"/>.</param>
+        /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="AtomicDouble"/>; otherwise, <c>false</c>.</returns>
+        public bool Equals(AtomicDouble? other)
+        {
+            if (other is null)
+                return false;
+
+            // NOTE: comparing long values rather than floating point comparison
+            return value == other.value;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="double"/> is equal to the current <see cref="AtomicDouble"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="double"/> to compare with the current <see cref="AtomicDouble"/>.</param>
+        /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="AtomicDouble"/>; otherwise, <c>false</c>.</returns>
+        public bool Equals(double other)
+        {
+            // NOTE: comparing long values rather than floating point comparison
+            return value == BitConversion.DoubleToInt64Bits(other);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="AtomicDouble"/>.
+        /// <para/>
+        /// If <paramref name="other"/> is a <see cref="AtomicDouble"/>, the comparison is not done atomically.
+        /// </summary>
+        /// <param name="other">The <see cref="object"/> to compare with the current <see cref="AtomicDouble"/>.</param>
+        /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="AtomicDouble"/>; otherwise, <c>false</c>.</returns>
+        public override bool Equals(object? other)
+        {
+            if (other is AtomicDouble ai)
+                return Equals(ai);
+            if (other is double i)
+                return Equals(i);
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Converts the numeric value of this instance to its equivalent string representation.
+        /// </summary>
+        /// <returns>The string representation of the value of this instance, consisting of
+        /// a negative sign if the value is negative,
+        /// and a sequence of digits ranging from 0 to 9 with no leading zeroes.</returns>
+        public override string ToString()
+        {
+            return J2N.Numerics.Double.ToString(Value);
+        }
+
+        /// <summary>
+        /// Converts the numeric value of this instance to its equivalent string representation,
+        /// using the specified <paramref name="format"/>.
+        /// </summary>
+        /// <param name="format">A standard or custom numeric format string.</param>
+        /// <returns>The string representation of the value of this instance as specified
+        /// by <paramref name="format"/>.</returns>
+        public override string ToString(string? format)
+        {
+            return J2N.Numerics.Double.ToString(Value, format);
+        }
+
+        /// <summary>
+        /// Converts the numeric value of this instance to its equivalent string representation
+        /// using the specified culture-specific format information.
+        /// </summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <returns>The string representation of the value of this instance as specified by <paramref name="provider"/>.</returns>
+        public override string ToString(IFormatProvider? provider)
+        {
+            return J2N.Numerics.Double.ToString(Value, provider);
+        }
+
+        /// <summary>
+        /// Converts the numeric value of this instance to its equivalent string representation using the
+        /// specified format and culture-specific format information.
+        /// </summary>
+        /// <param name="format">A standard or custom numeric format string.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <returns>The string representation of the value of this instance as specified by
+        /// <paramref name="format"/> and <paramref name="provider"/>.</returns>
+        public override string ToString(string? format, IFormatProvider? provider)
+        {
+            return J2N.Numerics.Double.ToString(Value, format, provider);
+        }
+
+        #region IConvertible Members
+
+        /// <inheritdoc/>
+        public override byte ToByte()
+        {
+            return (byte)Value;
+        }
+
+        /// <inheritdoc/>
+        public override sbyte ToSByte()
+        {
+            return (sbyte)Value;
+        }
+
+        /// <inheritdoc/>
+        public override double ToDouble()
+        {
+            return Value;
+        }
+
+        /// <inheritdoc/>
+        public override float ToSingle()
+        {
+            return (float)Value;
+        }
+
+        /// <inheritdoc/>
+        public override int ToInt32()
+        {
+            return (int)Value;
+        }
+
+        /// <inheritdoc/>
+        public override long ToInt64()
+        {
+            return (long)Value;
+        }
+
+        /// <inheritdoc/>
+        public override short ToInt16()
+        {
+            return (short)Value;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="TypeCode"/> for value type <see cref="int"/>.
+        /// </summary>
+        /// <returns></returns>
+        public TypeCode GetTypeCode() => ((IConvertible)Value).GetTypeCode();
+
+        bool IConvertible.ToBoolean(IFormatProvider? provider) => Convert.ToBoolean(Value);
+
+        byte IConvertible.ToByte(IFormatProvider? provider) => Convert.ToByte(Value);
+
+        char IConvertible.ToChar(IFormatProvider? provider) => Convert.ToChar(Value);
+
+        DateTime IConvertible.ToDateTime(IFormatProvider? provider) => Convert.ToDateTime(Value);
+
+        decimal IConvertible.ToDecimal(IFormatProvider? provider) => Convert.ToDecimal(Value);
+
+        double IConvertible.ToDouble(IFormatProvider? provider) => Value;
+
+        short IConvertible.ToInt16(IFormatProvider? provider) => Convert.ToInt16(Value);
+
+        int IConvertible.ToInt32(IFormatProvider? provider) => Convert.ToInt32(Value);
+
+        long IConvertible.ToInt64(IFormatProvider? provider) => Convert.ToInt64(Value);
+
+        sbyte IConvertible.ToSByte(IFormatProvider? provider) => Convert.ToSByte(Value);
+
+        float IConvertible.ToSingle(IFormatProvider? provider) => Convert.ToSingle(Value);
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)Value).ToType(conversionType, provider);
+
+        ushort IConvertible.ToUInt16(IFormatProvider? provider) => Convert.ToUInt16(Value);
+
+        uint IConvertible.ToUInt32(IFormatProvider? provider) => Convert.ToUInt32(Value);
+
+        ulong IConvertible.ToUInt64(IFormatProvider? provider) => Convert.ToUInt64(Value);
+
+        #endregion IConvertible Members
+
+        #region Operator Overrides
+
+        /// <summary>
+        /// Implicitly converts an <see cref="AtomicDouble"/> to a <see cref="double"/>.
+        /// </summary>
+        /// <param name="atomicInt64">The <see cref="AtomicDouble"/> to convert.</param>
+        public static implicit operator double(AtomicDouble atomicInt64)
+        {
+            return atomicInt64.Value;
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value equality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are equal; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(AtomicDouble a1, AtomicDouble a2)
+        {
+            // NOTE: comparing long values rather than floating point comparison
+            return a1.value == a2.value;
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value inequality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are not equal; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(AtomicDouble a1, AtomicDouble a2)
+        {
+            return !(a1 == a2);
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value equality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are equal; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(AtomicDouble a1, double a2)
+        {
+            return a1.Value.Equals(a2);
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value inequality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are not equal; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(AtomicDouble a1, double a2)
+        {
+            return !(a1 == a2);
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value equality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are equal; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(double a1, AtomicDouble a2)
+        {
+            return a1.Equals(a2.Value);
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value inequality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are not equal; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(double a1, AtomicDouble a2)
+        {
+            return !(a1 == a2);
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value equality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are equal; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(AtomicDouble a1, double? a2)
+        {
+            return a1.Value.Equals(a2.GetValueOrDefault());
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value inequality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are not equal; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(AtomicDouble a1, double? a2)
+        {
+            return !(a1 == a2);
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value equality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are equal; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(double? a1, AtomicDouble a2)
+        {
+            return a1.GetValueOrDefault().Equals(a2.Value);
+        }
+
+        /// <summary>
+        /// Compares <paramref name="a1"/> and <paramref name="a2"/> for value inequality.
+        /// </summary>
+        /// <param name="a1">The first number.</param>
+        /// <param name="a2">The second number.</param>
+        /// <returns><c>true</c> if the given numbers are not equal; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(double? a1, AtomicDouble a2)
+        {
+            return !(a1 == a2);
+        }
+
+        #endregion Operator Overrides
+    }
+}


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Convert long/double values that are volatile in Lucene (but can't be in .NET) to AtomicInt64 or (new) AtomicDouble.

Fixes #1063

## Description

Since we can't use `volatile` on 64-bit values in .NET, this doesn't work for `long` or `double`. This PR changes `volatile long` fields to be `AtomicInt64` from J2N, as well as introduces a new internal `AtomicDouble` type in Support for those values, using bit conversion to/from long internally so that we can use Interlocked on it.
