### PR TITLE
SWEEP: Add unchecked to GetHashCode, #1065

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PatternAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PatternAnalyzer.cs
@@ -277,12 +277,15 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 return 1303507063;
             }
 
-            int h = 1;
-            h = 31 * h + pattern.ToString().GetHashCode();
-            h = 31 * h + (int)pattern.Options;
-            h = 31 * h + (toLowerCase ? 1231 : 1237);
-            h = 31 * h + (stopWords != null ? stopWords.GetHashCode() : 0);
-            return h;
+            unchecked
+            {
+                int h = 1;
+                h = 31 * h + pattern.ToString().GetHashCode();
+                h = 31 * h + (int)pattern.Options;
+                h = 31 * h + (toLowerCase ? 1231 : 1237);
+                h = 31 * h + (stopWords != null ? stopWords.GetHashCode() : 0);
+                return h;
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -1800,18 +1800,23 @@ namespace Lucene.Net.Analysis.Util
         /// <returns></returns>
         public override int GetHashCode()
         {
-            const int PRIME = 31; // arbitrary prime
-            int hash = PRIME;
-            using (var iter = GetEnumerator())
+            unchecked
             {
-                while (iter.MoveNext())
+                const int PRIME = 31; // arbitrary prime
+                int hash = PRIME;
+                using (var iter = GetEnumerator())
                 {
-                    hash = (hash * PRIME) ^ iter.CurrentKeyString.GetHashCode();
-                    TValue? value = iter.CurrentValue;
-                    hash = (hash * PRIME) ^ (value is null ? 0 : JCG.EqualityComparer<TValue>.Default.GetHashCode(value));
+                    while (iter.MoveNext())
+                    {
+                        hash = (hash * PRIME) ^ iter.CurrentKeyString.GetHashCode();
+                        TValue? value = iter.CurrentValue;
+                        hash = (hash * PRIME) ^
+                               (value is null ? 0 : JCG.EqualityComparer<TValue>.Default.GetHashCode(value));
+                    }
                 }
+
+                return hash;
             }
-            return hash;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1832,16 +1837,22 @@ namespace Lucene.Net.Analysis.Util
             {
                 for (int i = startIndex; i < stop;)
                 {
-                    int codePointAt = charUtils.CodePointAt(text, i, stop);
-                    code = code * 31 + Character.ToLower(codePointAt, CultureInfo.InvariantCulture); // LUCENENET specific - need to use invariant culture to match Java
-                    i += Character.CharCount(codePointAt);
+                    unchecked
+                    {
+                        int codePointAt = charUtils.CodePointAt(text, i, stop);
+                        code = code * 31 + Character.ToLower(codePointAt, CultureInfo.InvariantCulture); // LUCENENET specific - need to use invariant culture to match Java
+                        i += Character.CharCount(codePointAt);
+                    }
                 }
             }
             else
             {
                 for (int i = startIndex; i < stop; i++)
                 {
-                    code = code * 31 + text[i];
+                    unchecked
+                    {
+                        code = code * 31 + text[i];
+                    }
                 }
             }
             return code;
@@ -1859,16 +1870,22 @@ namespace Lucene.Net.Analysis.Util
             {
                 for (int i = 0; i < length;)
                 {
-                    int codePointAt = charUtils.CodePointAt(text, i);
-                    code = code * 31 + Character.ToLower(codePointAt, CultureInfo.InvariantCulture); // LUCENENET specific - need to use invariant culture to match Java
-                    i += Character.CharCount(codePointAt);
+                    unchecked
+                    {
+                        int codePointAt = charUtils.CodePointAt(text, i);
+                        code = code * 31 + Character.ToLower(codePointAt, CultureInfo.InvariantCulture); // LUCENENET specific - need to use invariant culture to match Java
+                        i += Character.CharCount(codePointAt);
+                    }
                 }
             }
             else
             {
                 for (int i = 0; i < length; i++)
                 {
-                    code = code * 31 + text[i];
+                    unchecked
+                    {
+                        code = code * 31 + text[i];
+                    }
                 }
             }
             return code;
@@ -1886,16 +1903,22 @@ namespace Lucene.Net.Analysis.Util
             {
                 for (int i = 0; i < length;)
                 {
-                    int codePointAt = charUtils.CodePointAt(text, i);
-                    code = code * 31 + Character.ToLower(codePointAt, CultureInfo.InvariantCulture); // LUCENENET specific - need to use invariant culture to match Java
-                    i += Character.CharCount(codePointAt);
+                    unchecked
+                    {
+                        int codePointAt = charUtils.CodePointAt(text, i);
+                        code = code * 31 + Character.ToLower(codePointAt, CultureInfo.InvariantCulture); // LUCENENET specific - need to use invariant culture to match Java
+                        i += Character.CharCount(codePointAt);
+                    }
                 }
             }
             else
             {
                 for (int i = 0; i < length; i++)
                 {
-                    code = code * 31 + text[i];
+                    unchecked
+                    {
+                        code = code * 31 + text[i];
+                    }
                 }
             }
             return code;

--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/PathNode.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/PathNode.cs
@@ -48,13 +48,16 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
         /// </summary>
         public override int GetHashCode()
         {
-            int prime = 31;
-            int result = 1;
-            result = prime * result + PreNode;
-            long temp;
-            temp = J2N.BitConversion.DoubleToInt64Bits(Weight);
-            result = prime * result + (int)(temp ^ (temp >>> 32));
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + PreNode;
+                long temp;
+                temp = J2N.BitConversion.DoubleToInt64Bits(Weight);
+                result = prime * result + (int)(temp ^ (temp >>> 32));
+                return result;
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegToken.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegToken.cs
@@ -83,18 +83,21 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
         /// </summary>
         public override int GetHashCode()
         {
-            int prime = 31;
-            int result = 1;
-            for (int i = 0; i < CharArray.Length; i++)
+            unchecked
             {
-                result = prime * result + CharArray[i];
+                const int prime = 31;
+                int result = 1;
+                for (int i = 0; i < CharArray.Length; i++)
+                {
+                    result = prime * result + CharArray[i];
+                }
+                result = prime * result + EndOffset;
+                result = prime * result + Index;
+                result = prime * result + StartOffset;
+                result = prime * result + Weight;
+                result = prime * result + (int)WordType;
+                return result;
             }
-            result = prime * result + EndOffset;
-            result = prime * result + Index;
-            result = prime * result + StartOffset;
-            result = prime * result + Weight;
-            result = prime * result + (int)WordType;
-            return result;
         }
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegTokenPair.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegTokenPair.cs
@@ -55,18 +55,21 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
         /// </summary>
         public override int GetHashCode()
         {
-            int prime = 31;
-            int result = 1;
-            for (int i = 0; i < CharArray.Length; i++)
+            unchecked
             {
-                result = prime * result + CharArray[i];
+                const int prime = 31;
+                int result = 1;
+                for (int i = 0; i < CharArray.Length; i++)
+                {
+                    result = prime * result + CharArray[i];
+                }
+                result = prime * result + From;
+                result = prime * result + To;
+                long temp;
+                temp = J2N.BitConversion.DoubleToInt64Bits(Weight);
+                result = prime * result + (int)(temp ^ (temp >>> 32));
+                return result;
             }
-            result = prime * result + From;
-            result = prime * result + To;
-            long temp;
-            temp = J2N.BitConversion.DoubleToInt64Bits(Weight);
-            result = prime * result + (int)(temp ^ (temp >>> 32));
-            return result;
         }
 
         /// <summary>

--- a/src/Lucene.Net.Codecs/BlockTerms/BlockTermsReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/BlockTermsReader.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Codecs.BlockTerms
 
     /// <summary>
     /// Handles a terms dict, but decouples all details of
-    /// doc/freqs/positions reading to an instance of 
+    /// doc/freqs/positions reading to an instance of
     /// <see cref="PostingsReaderBase"/>.  This class is reusable for
     /// codecs that use a different format for
     /// docs/freqs/positions (though codecs are also free to
@@ -36,7 +36,7 @@ namespace Lucene.Net.Codecs.BlockTerms
     /// <para/>
     /// This class also interacts with an instance of
     /// <see cref="TermsIndexReaderBase"/>, to abstract away the specific
-    /// implementation of the terms dict index. 
+    /// implementation of the terms dict index.
     /// <para/>
     /// @lucene.experimental
     /// </summary>
@@ -90,7 +90,10 @@ namespace Lucene.Net.Codecs.BlockTerms
 
             public override int GetHashCode()
             {
-                return Field.GetHashCode() * 31 + Term.GetHashCode();
+                unchecked
+                {
+                    return Field.GetHashCode() * 31 + Term.GetHashCode();
+                }
             }
         }
 
@@ -372,7 +375,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 /// the terms data from that"; eg FuzzyTermsEnum will
                 /// (usually) just immediately call seek again if we
                 /// return NOT_FOUND so it's a waste for us to fill in
-                /// the term that was actually NOT_FOUND 
+                /// the term that was actually NOT_FOUND
                 /// </remarks>
                 public override SeekStatus SeekCeil(BytesRef target)
                 {
@@ -876,7 +879,7 @@ namespace Lucene.Net.Codecs.BlockTerms
                 // Does initial decode of next block of terms; this
                 // doesn't actually decode the docFreq, totalTermFreq,
                 // postings details (frq/prx offset, etc.) metadata;
-                // it just loads them as byte[] blobs which are then      
+                // it just loads them as byte[] blobs which are then
                 // decoded on-demand if the metadata is ever requested
                 // for any term in this block.  This enables terms-only
                 // intensive consumes (eg certain MTQs, respelling) to

--- a/src/Lucene.Net.Codecs/Memory/FSTTermOutputs.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermOutputs.cs
@@ -73,26 +73,29 @@ namespace Lucene.Net.Codecs.Memory
             // aren't NO_OUTPUTs.
             public override int GetHashCode()
             {
-                var hash = 0;
-                if (longs != null)
+                unchecked
                 {
-                    var end = longs.Length;
-                    for (var i = 0; i < end; i++)
+                    var hash = 0;
+                    if (longs != null)
                     {
-                        hash -= (int) longs[i];
+                        var end = longs.Length;
+                        for (var i = 0; i < end; i++)
+                        {
+                            hash -= (int) longs[i];
+                        }
                     }
-                }
-                if (bytes != null)
-                {
-                    hash = -hash;
-                    var end = bytes.Length;
-                    for (var i = 0; i < end; i++)
+                    if (bytes != null)
                     {
-                        hash += bytes[i];
+                        hash = -hash;
+                        var end = bytes.Length;
+                        for (var i = 0; i < end; i++)
+                        {
+                            hash += bytes[i];
+                        }
                     }
+                    hash += (int) (docFreq + totalTermFreq);
+                    return hash;
                 }
-                hash += (int) (docFreq + totalTermFreq);
-                return hash;
             }
 
             public override bool Equals(object other)

--- a/src/Lucene.Net.Expressions/ExpressionSortField.cs
+++ b/src/Lucene.Net.Expressions/ExpressionSortField.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Expressions
     {
         private readonly ExpressionValueSource source;
 
-        internal ExpressionSortField(string name, ExpressionValueSource source, bool reverse) 
+        internal ExpressionSortField(string name, ExpressionValueSource source, bool reverse)
             : base(name, SortFieldType.CUSTOM, reverse)
         {
             this.source = source;
@@ -40,10 +40,13 @@ namespace Lucene.Net.Expressions
 
         public override int GetHashCode()
         {
-            int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + ((source is null) ? 0 : source.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (source is null ? 0 : source.GetHashCode());
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Expressions/ExpressionValueSource.cs
+++ b/src/Lucene.Net.Expressions/ExpressionValueSource.cs
@@ -120,12 +120,15 @@ namespace Lucene.Net.Expressions
 
         public override int GetHashCode()
         {
-            int prime = 31;
-            int result = 1;
-            result = prime * result + ((expression is null) ? 0 : expression.GetHashCode());
-            result = prime * result + (needsScores ? 1231 : 1237);
-            result = prime * result + Arrays.GetHashCode(variables);
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + (expression is null ? 0 : expression.GetHashCode());
+                result = prime * result + (needsScores ? 1231 : 1237);
+                result = prime * result + Arrays.GetHashCode(variables);
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Facet/DrillDownQuery.cs
+++ b/src/Lucene.Net.Facet/DrillDownQuery.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Facet
     /// <para/>
     /// Collection initializer note: To create and populate a <see cref="DrillDownQuery"/>
     /// in a single statement, you can use the following example as a guide:
-    /// 
+    ///
     /// <code>
     /// var drillDownQuery = new DrillDownQuery(config)
     /// {
@@ -129,9 +129,9 @@ namespace Lucene.Net.Facet
         }
 
         /// <summary>
-        /// Creates a new <see cref="DrillDownQuery"/> without a base query, 
+        /// Creates a new <see cref="DrillDownQuery"/> without a base query,
         /// to perform a pure browsing query (equivalent to using
-        /// <see cref="MatchAllDocsQuery"/> as base). 
+        /// <see cref="MatchAllDocsQuery"/> as base).
         /// </summary>
         public DrillDownQuery(FacetsConfig config)
             : this(config, null)
@@ -142,7 +142,7 @@ namespace Lucene.Net.Facet
         /// Creates a new <see cref="DrillDownQuery"/> over the given base query. Can be
         /// <c>null</c>, in which case the result <see cref="Query"/> from
         /// <see cref="Rewrite(IndexReader)"/> will be a pure browsing query, filtering on
-        /// the added categories only. 
+        /// the added categories only.
         /// </summary>
         public DrillDownQuery(FacetsConfig config, Query baseQuery)
         {
@@ -156,7 +156,7 @@ namespace Lucene.Net.Facet
 
         /// <summary>
         /// Merges (ORs) a new path into an existing AND'd
-        /// clause. 
+        /// clause.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void Merge(string dim, string[] path)
@@ -188,7 +188,7 @@ namespace Lucene.Net.Facet
         /// Adds one dimension of drill downs; if you pass the same
         /// dimension more than once it is OR'd with the previous
         /// cofnstraints on that dimension, and all dimensions are
-        /// AND'd against each other and the base query. 
+        /// AND'd against each other and the base query.
         /// </summary>
         public void Add(string dim, params string[] path)
         {
@@ -210,7 +210,7 @@ namespace Lucene.Net.Facet
         /// <summary>
         /// Expert: add a custom drill-down subQuery.  Use this
         /// when you have a separate way to drill-down on the
-        /// dimension than the indexed facet ordinals. 
+        /// dimension than the indexed facet ordinals.
         /// </summary>
         public void Add(string dim, Query subQuery)
         {
@@ -232,7 +232,7 @@ namespace Lucene.Net.Facet
 
         /// <summary>
         /// Expert: add a custom drill-down Filter, e.g. when
-        /// drilling down after range faceting. 
+        /// drilling down after range faceting.
         /// </summary>
         public void Add(string dim, Filter subFilter)
         {
@@ -281,9 +281,12 @@ namespace Lucene.Net.Facet
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            return prime * result + query.GetHashCode();
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                return prime * result + query.GetHashCode();
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Facet/DrillSidewaysQuery.cs
+++ b/src/Lucene.Net.Facet/DrillSidewaysQuery.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Facet
 
     /// <summary>
     /// Only purpose is to punch through and return a
-    /// <see cref="DrillSidewaysScorer"/> 
+    /// <see cref="DrillSidewaysScorer"/>
     /// </summary>
     internal class DrillSidewaysQuery : Query
     {
@@ -243,13 +243,16 @@ namespace Lucene.Net.Facet
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + ((baseQuery is null) ? 0 : baseQuery.GetHashCode());
-            result = prime * result + ((drillDownCollector is null) ? 0 : drillDownCollector.GetHashCode());
-            result = prime * result + Arrays.GetHashCode(drillDownQueries);
-            result = prime * result + Arrays.GetHashCode(drillSidewaysCollectors);
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (baseQuery is null ? 0 : baseQuery.GetHashCode());
+                result = prime * result + (drillDownCollector is null ? 0 : drillDownCollector.GetHashCode());
+                result = prime * result + Arrays.GetHashCode(drillDownQueries);
+                result = prime * result + Arrays.GetHashCode(drillSidewaysCollectors);
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Facet/FacetResult.cs
+++ b/src/Lucene.Net.Facet/FacetResult.cs
@@ -40,12 +40,12 @@ namespace Lucene.Net.Facet
         /// </summary>
         [WritableArray]
         [SuppressMessage("Microsoft.Performance", "CA1819", Justification = "Lucene's design requires some writable array properties")]
-        public string[] Path { get; private set; } 
+        public string[] Path { get; private set; }
 
         /// <summary>
         /// Total value for this path (sum of all child counts, or
         /// sum of all child values), even those not included in
-        /// the topN. 
+        /// the topN.
         /// </summary>
         public float Value { get; private set; }
 
@@ -67,7 +67,7 @@ namespace Lucene.Net.Facet
         public Type TypeOfValue { get; private set; }
 
         /// <summary>
-        /// Constructor for <see cref="float"/> <paramref name="value"/>. Makes the <see cref="ToString()"/> method 
+        /// Constructor for <see cref="float"/> <paramref name="value"/>. Makes the <see cref="ToString()"/> method
         /// print the <paramref name="value"/> as a <see cref="float"/> with at least 1 number after the decimal.
         /// </summary>
         public FacetResult(string dim, string[] path, float value, LabelAndValue[] labelValues, int childCount)
@@ -81,7 +81,7 @@ namespace Lucene.Net.Facet
         }
 
         /// <summary>
-        /// Constructor for <see cref="int"/> <paramref name="value"/>. Makes the <see cref="ToString()"/> method 
+        /// Constructor for <see cref="int"/> <paramref name="value"/>. Makes the <see cref="ToString()"/> method
         /// print the <paramref name="value"/> as an <see cref="int"/> with no decimal.
         /// </summary>
         public FacetResult(string dim, string[] path, int value, LabelAndValue[] labelValues, int childCount)
@@ -151,12 +151,15 @@ namespace Lucene.Net.Facet
 
         public override int GetHashCode()
         {
-            int hashCode = Value.GetHashCode() + 31 * ChildCount;
-            foreach (LabelAndValue labelValue in LabelValues)
+            unchecked
             {
-                hashCode = labelValue.GetHashCode() + 31 * hashCode;
+                int hashCode = Value.GetHashCode() + 31 * ChildCount;
+                foreach (LabelAndValue labelValue in LabelValues)
+                {
+                    hashCode = labelValue.GetHashCode() + 31 * hashCode;
+                }
+                return hashCode;
             }
-            return hashCode;
         }
     }
 }

--- a/src/Lucene.Net.Facet/LabelAndValue.cs
+++ b/src/Lucene.Net.Facet/LabelAndValue.cs
@@ -24,7 +24,7 @@ namespace Lucene.Net.Facet
 
     /// <summary>
     /// Single label and its value, usually contained in a
-    /// <see cref="FacetResult"/>. 
+    /// <see cref="FacetResult"/>.
     /// </summary>
     public sealed class LabelAndValue : IFormattable
     {
@@ -42,7 +42,7 @@ namespace Lucene.Net.Facet
         public Type TypeOfValue { get; private set; }
 
         /// <summary>
-        /// Constructor for <see cref="float"/> <paramref name="value"/>. Makes the <see cref="ToString()"/> method 
+        /// Constructor for <see cref="float"/> <paramref name="value"/>. Makes the <see cref="ToString()"/> method
         /// print the <paramref name="value"/> as a <see cref="float"/> with at least 1 number after the decimal.
         /// </summary>
         public LabelAndValue(string label, float value)
@@ -53,7 +53,7 @@ namespace Lucene.Net.Facet
         }
 
         /// <summary>
-        /// Constructor for <see cref="int"/> <paramref name="value"/>. Makes the <see cref="ToString()"/> method 
+        /// Constructor for <see cref="int"/> <paramref name="value"/>. Makes the <see cref="ToString()"/> method
         /// print the <paramref name="value"/> as an <see cref="int"/> with no decimal.
         /// </summary>
         public LabelAndValue(string label, int value)
@@ -101,7 +101,10 @@ namespace Lucene.Net.Facet
 
         public override int GetHashCode()
         {
-            return Label.GetHashCode() + 1439 * Value.GetHashCode();
+            unchecked
+            {
+                return Label.GetHashCode() + 1439 * Value.GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Facet.Taxonomy
     /// <summary>
     /// Holds a sequence of string components, specifying the hierarchical name of a
     /// category.
-    /// 
+    ///
     /// @lucene.experimental
     /// </summary>
     public class CategoryPath : IComparable<CategoryPath>
@@ -185,7 +185,7 @@ namespace Lucene.Net.Facet.Taxonomy
         /// Copies the path components to the given <see cref="T:char[]"/>, starting at index
         /// <paramref name="start"/>. <paramref name="delimiter"/> is copied between the path components.
         /// Returns the number of chars copied.
-        /// 
+        ///
         /// <para>
         /// <b>NOTE:</b> this method relies on the array being large enough to hold the
         /// components and separators - the amount of needed space can be calculated
@@ -250,7 +250,10 @@ namespace Lucene.Net.Facet.Taxonomy
             int hash = Length;
             for (int i = 0; i < Length; i++)
             {
-                hash = hash * 31 + Components[i].GetHashCode();
+                unchecked
+                {
+                    hash = hash * 31 + Components[i].GetHashCode();
+                }
             }
             return hash;
         }

--- a/src/Lucene.Net.Facet/Taxonomy/FacetLabel.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/FacetLabel.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Facet.Taxonomy
     /// <summary>
     /// Holds a sequence of string components, specifying the hierarchical name of a
     /// category.
-    /// 
+    ///
     /// @lucene.internal
     /// </summary>
     public class FacetLabel : IComparable<FacetLabel>
@@ -174,8 +174,11 @@ namespace Lucene.Net.Facet.Taxonomy
             int hash = Length;
             for (int i = 0; i < Length; i++)
             {
-                // LUCENENET specific: Use CharSequenceComparer to get the same value as StringCharSequence.GetHashCode()
-                hash = hash * 31 + CharSequenceComparer.Ordinal.GetHashCode(Components[i]);
+                unchecked
+                {
+                    // LUCENENET specific: Use CharSequenceComparer to get the same value as StringCharSequence.GetHashCode()
+                    hash = hash * 31 + CharSequenceComparer.Ordinal.GetHashCode(Components[i]);
+                }
             }
             return hash;
         }
@@ -183,7 +186,7 @@ namespace Lucene.Net.Facet.Taxonomy
         /// <summary>
         /// Calculate a 64-bit hash function for this path.  This
         /// is necessary for <see cref="NameHashInt32CacheLru"/> (the
-        /// default cache impl for <see cref="LruTaxonomyWriterCache"/>) 
+        /// default cache impl for <see cref="LruTaxonomyWriterCache"/>)
         /// to reduce the chance of "silent but deadly" collisions.
         /// <para/>
         /// NOTE: This was longHashCode() in Lucene

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
@@ -599,8 +599,11 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 var chars = b.chars;
                 for (int i = indexInBlock; i < end; i++)
                 {
-                    // Hash code calculation from J2N/Apache Harmony
-                    hash = chars[i] + ((hash << 5) - hash);
+                    unchecked
+                    {
+                        // Hash code calculation from J2N/Apache Harmony
+                        hash = chars[i] + ((hash << 5) - hash);
+                    }
                 }
                 remaining -= numToCheck;
                 indexInBlock = 0; // 2nd+ iterations read from start of the block

--- a/src/Lucene.Net.Grouping/AbstractGroupFacetCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractGroupFacetCollector.cs
@@ -267,9 +267,12 @@ namespace Lucene.Net.Search.Grouping
 
             public override int GetHashCode()
             {
-                int result = value.GetHashCode();
-                result = 31 * result + count;
-                return result;
+                unchecked
+                {
+                    int result = value.GetHashCode();
+                    result = 31 * result + count;
+                    return result;
+                }
             }
 
             public override string ToString()

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldPhraseList.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldPhraseList.cs
@@ -431,13 +431,16 @@ namespace Lucene.Net.Search.VectorHighlight
 
             public override int GetHashCode()
             {
-                int prime = 31;
-                int result = 1;
-                result = prime * result + StartOffset;
-                result = prime * result + EndOffset;
-                long b = J2N.BitConversion.DoubleToInt64Bits(Boost);
-                result = prime * result + (int)(b ^ (b >>> 32));
-                return result;
+                unchecked
+                {
+                    const int prime = 31;
+                    int result = 1;
+                    result = prime * result + StartOffset;
+                    result = prime * result + EndOffset;
+                    long b = J2N.BitConversion.DoubleToInt64Bits(Boost);
+                    result = prime * result + (int)(b ^ (b >>> 32));
+                    return result;
+                }
             }
 
             public override bool Equals(object obj)
@@ -528,11 +531,14 @@ namespace Lucene.Net.Search.VectorHighlight
 
                 public override int GetHashCode()
                 {
-                    int prime = 31;
-                    int result = 1;
-                    result = prime * result + StartOffset;
-                    result = prime * result + EndOffset;
-                    return result;
+                    unchecked
+                    {
+                        const int prime = 31;
+                        int result = 1;
+                        result = prime * result + StartOffset;
+                        result = prime * result + EndOffset;
+                        return result;
+                    }
                 }
 
                 public override bool Equals(object obj)

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldTermStack.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldTermStack.cs
@@ -257,10 +257,13 @@ namespace Lucene.Net.Search.VectorHighlight
 
             public override int GetHashCode()
             {
-                int prime = 31;
-                int result = 1;
-                result = prime * result + position;
-                return result;
+                unchecked
+                {
+                    const int prime = 31;
+                    int result = 1;
+                    result = prime * result + position;
+                    return result;
+                }
             }
 
             public override bool Equals(object obj)

--- a/src/Lucene.Net.Join/TermsQuery.cs
+++ b/src/Lucene.Net.Join/TermsQuery.cs
@@ -25,7 +25,7 @@ namespace Lucene.Net.Search.Join
     /// <summary>
     /// A query that has an array of terms from a specific field. This query will match documents have one or more terms in
     /// the specified field that match with the terms specified in the array.
-    /// 
+    ///
     /// @lucene.experimental
     /// </summary>
     internal class TermsQuery : MultiTermQuery
@@ -35,12 +35,12 @@ namespace Lucene.Net.Search.Join
         private readonly Query _fromQuery; // Used for equals() only
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="field">The field that should contain terms that are specified in the previous parameter.</param>
         /// <param name="fromQuery"></param>
         /// <param name="terms">The terms that matching documents should have. The terms must be sorted by natural order.</param>
-        internal TermsQuery(string field, Query fromQuery, BytesRefHash terms) 
+        internal TermsQuery(string field, Query fromQuery, BytesRefHash terms)
             : base(field)
         {
             _fromQuery = fromQuery;
@@ -89,10 +89,13 @@ namespace Lucene.Net.Search.Join
 
         public override int GetHashCode()
         {
-            int prime = 31;
-            int result = base.GetHashCode();
-            result += prime * _fromQuery.GetHashCode();
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result += prime * _fromQuery.GetHashCode();
+                return result;
+            }
         }
 
         private class SeekingTermSetTermsEnum : FilteredTermsEnum
@@ -108,7 +111,7 @@ namespace Lucene.Net.Search.Join
             private BytesRef _seekTerm;
             private int _upto;
 
-            internal SeekingTermSetTermsEnum(TermsEnum tenum, BytesRefHash terms, int[] ords) 
+            internal SeekingTermSetTermsEnum(TermsEnum tenum, BytesRefHash terms, int[] ords)
                 : base(tenum)
             {
                 this.terms = terms;
@@ -125,7 +128,7 @@ namespace Lucene.Net.Search.Join
                 _seekTerm = null;
                 return temp;
             }
-            
+
             protected override AcceptStatus Accept(BytesRef term)
             {
                 if (_comparer.Compare(term, _lastTerm) > 0)

--- a/src/Lucene.Net.Misc/Util/Fst/UpToTwoPositiveIntOutputs.cs
+++ b/src/Lucene.Net.Misc/Util/Fst/UpToTwoPositiveIntOutputs.cs
@@ -96,7 +96,10 @@ namespace Lucene.Net.Util.Fst
 
             public override int GetHashCode()
             {
-                return (int)((first ^ (first >>> 32)) ^ (second ^ (second >> 32)));
+                unchecked
+                {
+                    return (int)((first ^ (first >>> 32)) ^ (second ^ (second >> 32)));
+                }
             }
         }
 

--- a/src/Lucene.Net.Queries/BoostingQuery.cs
+++ b/src/Lucene.Net.Queries/BoostingQuery.cs
@@ -23,18 +23,18 @@ namespace Lucene.Net.Queries
 
 
     /// <summary>
-    /// The <see cref="BoostingQuery"/> class can be used to effectively demote results that match a given query. 
-    /// Unlike the "NOT" clause, this still selects documents that contain undesirable terms, 
+    /// The <see cref="BoostingQuery"/> class can be used to effectively demote results that match a given query.
+    /// Unlike the "NOT" clause, this still selects documents that contain undesirable terms,
     /// but reduces their overall score:
     /// <code>
     ///     Query balancedQuery = new BoostingQuery(positiveQuery, negativeQuery, 0.01f);
     /// </code>
-    /// In this scenario the positiveQuery contains the mandatory, desirable criteria which is used to 
-    /// select all matching documents, and the negativeQuery contains the undesirable elements which 
-    /// are simply used to lessen the scores. Documents that match the negativeQuery have their score 
-    /// multiplied by the supplied "boost" parameter, so this should be less than 1 to achieve a 
+    /// In this scenario the positiveQuery contains the mandatory, desirable criteria which is used to
+    /// select all matching documents, and the negativeQuery contains the undesirable elements which
+    /// are simply used to lessen the scores. Documents that match the negativeQuery have their score
+    /// multiplied by the supplied "boost" parameter, so this should be less than 1 to achieve a
     /// demoting effect
-    /// 
+    ///
     /// This code was originally made available here: <c>[WWW] http://marc.theaimsgroup.com/?l=lucene-user&amp;m=108058407130459&amp;w=2 </c>
     /// and is documented here: <c>http://wiki.apache.org/lucene-java/CommunityContributions</c>
     /// </summary>
@@ -106,12 +106,15 @@ namespace Lucene.Net.Queries
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(boost);
-            result = prime * result + ((context is null) ? 0 : context.GetHashCode());
-            result = prime * result + ((match is null) ? 0 : match.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(boost);
+                result = prime * result + ((context is null) ? 0 : context.GetHashCode());
+                result = prime * result + ((match is null) ? 0 : match.GetHashCode());
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Queries/CommonTermsQuery.cs
+++ b/src/Lucene.Net.Queries/CommonTermsQuery.cs
@@ -58,10 +58,10 @@ namespace Lucene.Net.Queries
     /// <para/>
     /// Collection initializer note: To create and populate a <see cref="CommonTermsQuery"/>
     /// in a single statement, you can use the following example as a guide:
-    /// 
+    ///
     /// <code>
     /// var query = new CommonTermsQuery() {
-    ///     new Term("field", "microsoft"), 
+    ///     new Term("field", "microsoft"),
     ///     new Term("field", "office")
     /// };
     /// </code>
@@ -316,7 +316,7 @@ namespace Lucene.Net.Queries
         /// part. This method accepts a float value in the range [0..1) as a fraction
         /// of the actual query terms in the low frequent clause or a number
         /// <tt>&gt;=1</tt> as an absolut number of clauses that need to match.
-        /// 
+        ///
         /// <para>
         /// By default no optional clauses are necessary for a match (unless there are
         /// no required clauses). If this method is used, then the specified number of
@@ -336,7 +336,7 @@ namespace Lucene.Net.Queries
         /// part. This method accepts a float value in the range [0..1) as a fraction
         /// of the actual query terms in the low frequent clause or a number
         /// <tt>&gt;=1</tt> as an absolut number of clauses that need to match.
-        /// 
+        ///
         /// <para>
         /// By default no optional clauses are necessary for a match (unless there are
         /// no required clauses). If this method is used, then the specified number of
@@ -394,19 +394,22 @@ namespace Lucene.Net.Queries
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + (m_disableCoord ? 1231 : 1237);
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_highFreqBoost);
-            result = prime * result + /*((highFreqOccur is null) ? 0 :*/ m_highFreqOccur.GetHashCode()/*)*/;
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_lowFreqBoost);
-            result = prime * result + /*((lowFreqOccur is null) ? 0 :*/ m_lowFreqOccur.GetHashCode()/*)*/;
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_maxTermFrequency);
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_lowFreqMinNrShouldMatch);
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_highFreqMinNrShouldMatch);
-            // LUCENENET specific: use structural equality comparison
-            result = prime * result + ((m_terms is null) ? 0 : JCG.ListEqualityComparer<Term>.Default.GetHashCode(m_terms));
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (m_disableCoord ? 1231 : 1237);
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_highFreqBoost);
+                result = prime * result + /*((highFreqOccur is null) ? 0 :*/ m_highFreqOccur.GetHashCode()/*)*/;
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_lowFreqBoost);
+                result = prime * result + /*((lowFreqOccur is null) ? 0 :*/ m_lowFreqOccur.GetHashCode()/*)*/;
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_maxTermFrequency);
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_lowFreqMinNrShouldMatch);
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(m_highFreqMinNrShouldMatch);
+                // LUCENENET specific: use structural equality comparison
+                result = prime * result + (m_terms is null ? 0 : JCG.ListEqualityComparer<Term>.Default.GetHashCode(m_terms));
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Queries/CustomScoreQuery.cs
+++ b/src/Lucene.Net.Queries/CustomScoreQuery.cs
@@ -1,4 +1,5 @@
 ﻿// Lucene version compatibility level 4.8.1
+
 using Lucene.Net.Index;
 using Lucene.Net.Queries.Function;
 using Lucene.Net.Search;
@@ -181,8 +182,11 @@ namespace Lucene.Net.Queries
         /// Returns a hash code value for this object. </summary>
         public override int GetHashCode()
         {
-            return (this.GetType().GetHashCode() + subQuery.GetHashCode() + Arrays.GetHashCode(scoringQueries)) ^
-                   J2N.BitConversion.SingleToInt32Bits(Boost) ^ (strict ? 1234 : 4321);
+            unchecked
+            {
+                return (this.GetType().GetHashCode() + subQuery.GetHashCode() + Arrays.GetHashCode(scoringQueries)) ^
+                       J2N.BitConversion.SingleToInt32Bits(Boost) ^ (strict ? 1234 : 4321);
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net.Queries/Function/BoostedQuery.cs
+++ b/src/Lucene.Net.Queries/Function/BoostedQuery.cs
@@ -217,12 +217,15 @@ namespace Lucene.Net.Queries.Function
 
         public override int GetHashCode()
         {
-            int h = q.GetHashCode();
-            h ^= (h << 17) | (h >>> 16);
-            h += boostVal.GetHashCode();
-            h ^= (h << 8) | (h >>> 25);
-            h += J2N.BitConversion.SingleToInt32Bits(Boost);
-            return h;
+            unchecked
+            {
+                int h = q.GetHashCode();
+                h ^= (h << 17) | (h >>> 16);
+                h += boostVal.GetHashCode();
+                h ^= (h << 8) | (h >>> 25);
+                h += J2N.BitConversion.SingleToInt32Bits(Boost);
+                return h;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/FunctionQuery.cs
+++ b/src/Lucene.Net.Queries/Function/FunctionQuery.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Queries.Function
     /// <summary>
     /// Returns a score for each document based on a <see cref="Function.ValueSource"/>,
     /// often some function of the value of a field.
-    /// 
+    ///
     /// <b>Note: This API is experimental and may change in non backward-compatible ways in the future</b>
     /// </summary>
     public class FunctionQuery : Query
@@ -203,7 +203,7 @@ namespace Lucene.Net.Queries.Function
         {
             if (o is null) return false;
             if (!(o is FunctionQuery other)) return false;
-            return Boost == other.Boost 
+            return Boost == other.Boost
                 && func.Equals(other.func);
         }
 
@@ -212,7 +212,10 @@ namespace Lucene.Net.Queries.Function
         /// </summary>
         public override int GetHashCode()
         {
-            return func.GetHashCode() * 31 + J2N.BitConversion.SingleToInt32Bits(Boost);
+            unchecked
+            {
+                return func.GetHashCode() * 31 + J2N.BitConversion.SingleToInt32Bits(Boost);
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/ByteFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ByteFieldSource.cs
@@ -23,7 +23,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
      * See the License for the specific language governing permissions and
      * limitations under the License.
      */
-    
+
     /// <summary>
     /// Obtains <see cref="int"/> field values from the <see cref="Search.FieldCache"/>
     /// using <see cref="IFieldCache.GetInt32s(AtomicReader, string, FieldCache.IInt32Parser, bool)"/>
@@ -137,9 +137,12 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = parser is null ? typeof(sbyte?).GetHashCode() : parser.GetType().GetHashCode();
-            h += base.GetHashCode();
-            return h;
+            unchecked
+            {
+                int h = parser is null ? typeof(sbyte?).GetHashCode() : parser.GetType().GetHashCode();
+                h += base.GetHashCode();
+                return h;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/ConstValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ConstValueSource.cs
@@ -99,7 +99,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return J2N.BitConversion.SingleToInt32Bits(constant) * 31;
+            unchecked
+            {
+                return J2N.BitConversion.SingleToInt32Bits(constant) * 31;
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/DocFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DocFreqValueSource.cs
@@ -184,7 +184,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return this.GetType().GetHashCode() + m_indexedField.GetHashCode() * 29 + m_indexedBytes.GetHashCode();
+            unchecked
+            {
+                return this.GetType().GetHashCode() + m_indexedField.GetHashCode() * 29 + m_indexedBytes.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/DoubleFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DoubleFieldSource.cs
@@ -100,9 +100,12 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = m_parser is null ? typeof(double).GetHashCode() : m_parser.GetType().GetHashCode();
-            h += base.GetHashCode();
-            return h;
+            unchecked
+            {
+                int h = m_parser is null ? typeof(double).GetHashCode() : m_parser.GetType().GetHashCode();
+                h += base.GetHashCode();
+                return h;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/DualFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DualFloatFunction.cs
@@ -94,12 +94,15 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = m_a.GetHashCode();
-            h ^= (h << 13) | (h >>> 20);
-            h += m_b.GetHashCode();
-            h ^= (h << 23) | (h >>> 10);
-            h += Name.GetHashCode();
-            return h;
+            unchecked
+            {
+                int h = m_a.GetHashCode();
+                h ^= (h << 13) | (h >>> 20);
+                h += m_b.GetHashCode();
+                h ^= (h << 23) | (h >>> 10);
+                h += Name.GetHashCode();
+                return h;
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/EnumFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/EnumFieldSource.cs
@@ -267,13 +267,16 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int result = base.GetHashCode();
-            result = 31 * result + parser.GetHashCode();
-            // LUCENENET specific: must use DictionaryEqualityComparer.GetHashCode() to ensure values
-            // contained within the dictionaries are compared for equality
-            result = 31 * result + JCG.DictionaryEqualityComparer<int, string>.Default.GetHashCode(enumIntToStringMap);
-            result = 31 * result + JCG.DictionaryEqualityComparer<string, int>.Default.GetHashCode(enumStringToIntMap);
-            return result;
+            unchecked
+            {
+                int result = base.GetHashCode();
+                result = 31 * result + parser.GetHashCode();
+                // LUCENENET specific: must use DictionaryEqualityComparer.GetHashCode() to ensure values
+                // contained within the dictionaries are compared for equality
+                result = 31 * result + JCG.DictionaryEqualityComparer<int, string>.Default.GetHashCode(enumIntToStringMap);
+                result = 31 * result + JCG.DictionaryEqualityComparer<string, int>.Default.GetHashCode(enumStringToIntMap);
+                return result;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/FieldCacheSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/FieldCacheSource.cs
@@ -53,7 +53,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return m_cache.GetHashCode() + m_field.GetHashCode();
+            unchecked
+            {
+                return m_cache.GetHashCode() + m_field.GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/FloatFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/FloatFieldSource.cs
@@ -107,9 +107,12 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = m_parser is null ? typeof(float).GetHashCode() : m_parser.GetType().GetHashCode();
-            h += base.GetHashCode();
-            return h;
+            unchecked
+            {
+                int h = m_parser is null ? typeof(float).GetHashCode() : m_parser.GetType().GetHashCode();
+                h += base.GetHashCode();
+                return h;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/IfFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/IfFunction.cs
@@ -149,10 +149,13 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = ifSource.GetHashCode();
-            h = h * 31 + trueSource.GetHashCode();
-            h = h * 31 + falseSource.GetHashCode();
-            return h;
+            unchecked
+            {
+                int h = ifSource.GetHashCode();
+                h = h * 31 + trueSource.GetHashCode();
+                h = h * 31 + falseSource.GetHashCode();
+                return h;
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/IntFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/IntFieldSource.cs
@@ -147,9 +147,12 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = parser is null ? typeof(int).GetHashCode() : parser.GetType().GetHashCode();
-            h += base.GetHashCode();
-            return h;
+            unchecked
+            {
+                int h = parser is null ? typeof(int).GetHashCode() : parser.GetType().GetHashCode();
+                h += base.GetHashCode();
+                return h;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/JoinDocFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/JoinDocFreqValueSource.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
     /// <summary>
     /// Use a field value and find the Document Frequency within another field.
-    /// 
+    ///
     /// @since solr 4.0
     /// </summary>
     public class JoinDocFreqValueSource : FieldCacheSource
@@ -113,7 +113,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return m_qfield.GetHashCode() + base.GetHashCode();
+            unchecked
+            {
+                return m_qfield.GetHashCode() + base.GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/LinearFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LinearFloatFunction.cs
@@ -92,11 +92,14 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = J2N.BitConversion.SingleToInt32Bits(m_slope);
-            h = (h >>> 2) | (h << 30);
-            h += J2N.BitConversion.SingleToInt32Bits(m_intercept);
-            h ^= (h << 14) | (h >>> 19);
-            return h + m_source.GetHashCode();
+            unchecked
+            {
+                int h = J2N.BitConversion.SingleToInt32Bits(m_slope);
+                h = (h >>> 2) | (h << 30);
+                h += J2N.BitConversion.SingleToInt32Bits(m_intercept);
+                h ^= (h << 14) | (h >>> 19);
+                return h + m_source.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/LiteralValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LiteralValueSource.cs
@@ -95,7 +95,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
         public static readonly int hash = typeof(LiteralValueSource).GetHashCode();
         public override int GetHashCode()
         {
-            return hash + m_str.GetHashCode();
+            unchecked
+            {
+                return hash + m_str.GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/LongFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LongFieldSource.cs
@@ -167,9 +167,12 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = m_parser is null ? this.GetType().GetHashCode() : m_parser.GetType().GetHashCode();
-            h += base.GetHashCode();
-            return h;
+            unchecked
+            {
+                int h = m_parser is null ? this.GetType().GetHashCode() : m_parser.GetType().GetHashCode();
+                h += base.GetHashCode();
+                return h;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/MultiBoolFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/MultiBoolFunction.cs
@@ -116,8 +116,11 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            // LUCENENET specific: use structural equality comparison
-            return JCG.ListEqualityComparer<ValueSource>.Default.GetHashCode(m_sources) + Name.GetHashCode();
+            unchecked
+            {
+                // LUCENENET specific: use structural equality comparison
+                return JCG.ListEqualityComparer<ValueSource>.Default.GetHashCode(m_sources) + Name.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/MultiFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/MultiFloatFunction.cs
@@ -129,7 +129,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return Arrays.GetHashCode(m_sources) + Name.GetHashCode();
+            unchecked
+            {
+                return Arrays.GetHashCode(m_sources) + Name.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/MultiFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/MultiFunction.cs
@@ -127,8 +127,11 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            // LUCENENET specific: use structural equality comparison
-            return JCG.ListEqualityComparer<ValueSource>.Default.GetHashCode(m_sources) + Name.GetHashCode();
+            unchecked
+            {
+                // LUCENENET specific: use structural equality comparison
+                return JCG.ListEqualityComparer<ValueSource>.Default.GetHashCode(m_sources) + Name.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/NormValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/NormValueSource.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
     /// <para/>
     /// Note that the configured Similarity for the field must be
     /// a subclass of <see cref="TFIDFSimilarity"/>
-    /// @lucene.internal 
+    /// @lucene.internal
     /// </summary>
     public class NormValueSource : ValueSource
     {
@@ -104,7 +104,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return this.GetType().GetHashCode() + m_field.GetHashCode();
+            unchecked
+            {
+                return this.GetType().GetHashCode() + m_field.GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/OrdFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/OrdFieldSource.cs
@@ -124,7 +124,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return hcode + m_field.GetHashCode();
+            unchecked
+            {
+                return hcode + m_field.GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/QueryValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/QueryValueSource.cs
@@ -58,7 +58,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return q.GetHashCode() * 29;
+            unchecked
+            {
+                return q.GetHashCode() * 29;
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/RangeMapFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/RangeMapFloatFunction.cs
@@ -110,17 +110,20 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = m_source.GetHashCode();
-            h ^= (h << 10) | (h >>> 23);
-            h += J2N.BitConversion.SingleToInt32Bits(m_min);
-            h ^= (h << 14) | (h >>> 19);
-            h += J2N.BitConversion.SingleToInt32Bits(m_max);
-            h += m_target.GetHashCode();
-            if (m_defaultVal != null)
+            unchecked
             {
-                h += m_defaultVal.GetHashCode();
+                int h = m_source.GetHashCode();
+                h ^= (h << 10) | (h >>> 23);
+                h += J2N.BitConversion.SingleToInt32Bits(m_min);
+                h ^= (h << 14) | (h >>> 19);
+                h += J2N.BitConversion.SingleToInt32Bits(m_max);
+                h += m_target.GetHashCode();
+                if (m_defaultVal != null)
+                {
+                    h += m_defaultVal.GetHashCode();
+                }
+                return h;
             }
-            return h;
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/ReciprocalFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ReciprocalFloatFunction.cs
@@ -109,9 +109,12 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = J2N.BitConversion.SingleToInt32Bits(m_a) + J2N.BitConversion.SingleToInt32Bits(m_m);
-            h ^= (h << 13) | (h >>> 20);
-            return h + (J2N.BitConversion.SingleToInt32Bits(m_b)) + m_source.GetHashCode();
+            unchecked
+            {
+                int h = J2N.BitConversion.SingleToInt32Bits(m_a) + J2N.BitConversion.SingleToInt32Bits(m_m);
+                h ^= (h << 13) | (h >>> 20);
+                return h + (J2N.BitConversion.SingleToInt32Bits(m_b)) + m_source.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/ReverseOrdFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ReverseOrdFieldSource.cs
@@ -106,7 +106,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
         private static readonly int hcode = typeof(ReverseOrdFieldSource).GetHashCode();
         public override int GetHashCode()
         {
-            return hcode + field.GetHashCode();
+            unchecked
+            {
+                return hcode + field.GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/ScaleFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ScaleFloatFunction.cs
@@ -151,7 +151,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             public override string ToString(int doc)
             {
                 // LUCENENET specific - changed formatting to ensure the same culture is used for each value.
-                return string.Format(CultureInfo.InvariantCulture, "scale({0},toMin={1},toMax={2},fromMin={3})", 
+                return string.Format(CultureInfo.InvariantCulture, "scale({0},toMin={1},toMax={2},fromMin={3})",
                     vals.ToString(doc),
                     outerInstance.m_min,
                     outerInstance.m_max,
@@ -166,12 +166,15 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            int h = J2N.BitConversion.SingleToInt32Bits(m_min);
-            h = h * 29;
-            h += J2N.BitConversion.SingleToInt32Bits(m_max);
-            h = h * 29;
-            h += m_source.GetHashCode();
-            return h;
+            unchecked
+            {
+                int h = J2N.BitConversion.SingleToInt32Bits(m_min);
+                h = h * 29;
+                h += J2N.BitConversion.SingleToInt32Bits(m_max);
+                h = h * 29;
+                h += m_source.GetHashCode();
+                return h;
+            }
         }
 
         public override bool Equals(object o)
@@ -179,7 +182,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             if (!(o is ScaleSingleFunction other))
                 return false;
             return J2N.BitConversion.SingleToInt32Bits(this.m_min) == J2N.BitConversion.SingleToInt32Bits(other.m_min)
-                && J2N.BitConversion.SingleToInt32Bits(this.m_max) == J2N.BitConversion.SingleToInt32Bits(other.m_max) 
+                && J2N.BitConversion.SingleToInt32Bits(this.m_max) == J2N.BitConversion.SingleToInt32Bits(other.m_max)
                 && this.m_source.Equals(other.m_source);
         }
     }

--- a/src/Lucene.Net.Queries/Function/ValueSources/ShortFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ShortFieldSource.cs
@@ -126,16 +126,19 @@ namespace Lucene.Net.Queries.Function.ValueSources
         {
             if (!(o is Int16FieldSource other))
                 return false;
-            return base.Equals(other) 
-                && (parser is null ? other.parser is null : 
+            return base.Equals(other)
+                && (parser is null ? other.parser is null :
                 parser.GetType() == other.parser.GetType());
         }
 
         public override int GetHashCode()
         {
-            var h = parser is null ? typeof(short).GetHashCode() : parser.GetType().GetHashCode();
-            h += base.GetHashCode();
-            return h;
+            unchecked
+            {
+                var h = parser is null ? typeof(short).GetHashCode() : parser.GetType().GetHashCode();
+                h += base.GetHashCode();
+                return h;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Queries/Function/ValueSources/SimpleBoolFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/SimpleBoolFunction.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
     /// <summary>
     /// <see cref="BoolFunction"/> implementation which applies an extendible <see cref="bool"/>
     /// function to the values of a single wrapped <see cref="ValueSource"/>.
-    /// 
+    ///
     /// Functions this can be used for include whether a field has a value or not,
     /// or inverting the <see cref="bool"/> value of the wrapped <see cref="ValueSource"/>.
     /// </summary>
@@ -79,7 +79,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return m_source.GetHashCode() + Name.GetHashCode();
+            unchecked
+            {
+                return m_source.GetHashCode() + Name.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/SingleFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/SingleFunction.cs
@@ -45,14 +45,17 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return m_source.GetHashCode() + Name.GetHashCode();
+            unchecked
+            {
+                return m_source.GetHashCode() + Name.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)
         {
             if (!(o is SingularFunction other))
                 return false;
-            return Name.Equals(other.Name, StringComparison.Ordinal) 
+            return Name.Equals(other.Name, StringComparison.Ordinal)
                 && m_source.Equals(other.m_source);
         }
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/SumTotalTermFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/SumTotalTermFreqValueSource.cs
@@ -27,7 +27,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
     /// <summary>
     /// <see cref="SumTotalTermFreqValueSource"/> returns the number of tokens.
     /// (sum of term freqs across all documents, across all terms).
-    /// Returns -1 if frequencies were omitted for the field, or if 
+    /// Returns -1 if frequencies were omitted for the field, or if
     /// the codec doesn't support this statistic.
     /// @lucene.internal
     /// </summary>
@@ -103,7 +103,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return this.GetType().GetHashCode() + m_indexedField.GetHashCode();
+            unchecked
+            {
+                return this.GetType().GetHashCode() + m_indexedField.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Function/ValueSources/TotalTermFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/TotalTermFreqValueSource.cs
@@ -26,9 +26,9 @@ namespace Lucene.Net.Queries.Function.ValueSources
      */
 
     /// <summary>
-    /// <see cref="TotalTermFreqValueSource"/> returns the total term freq 
+    /// <see cref="TotalTermFreqValueSource"/> returns the total term freq
     /// (sum of term freqs across all documents).
-    /// Returns -1 if frequencies were omitted for the field, or if 
+    /// Returns -1 if frequencies were omitted for the field, or if
     /// the codec doesn't support this statistic.
     /// @lucene.internal
     /// </summary>
@@ -100,7 +100,10 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override int GetHashCode()
         {
-            return this.GetType().GetHashCode() + m_indexedField.GetHashCode() * 29 + m_indexedBytes.GetHashCode();
+            unchecked
+            {
+                return this.GetType().GetHashCode() + m_indexedField.GetHashCode() * 29 + m_indexedBytes.GetHashCode();
+            }
         }
 
         public override bool Equals(object o)

--- a/src/Lucene.Net.Queries/Mlt/MoreLikeThisQuery.cs
+++ b/src/Lucene.Net.Queries/Mlt/MoreLikeThisQuery.cs
@@ -139,19 +139,22 @@ namespace Lucene.Net.Queries.Mlt
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + ((analyzer is null) ? 0 : analyzer.GetHashCode());
-            result = prime * result + ((fieldName is null) ? 0 : fieldName.GetHashCode());
-            result = prime * result + ((likeText is null) ? 0 : likeText.GetHashCode());
-            result = prime * result + maxQueryTerms;
-            result = prime * result + minDocFreq;
-            result = prime * result + minTermFrequency;
-            result = prime * result + Arrays.GetHashCode(moreLikeFields);
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(percentTermsToMatch);
-            // LUCENENET specific: use structural equality comparison
-            result = prime * result + ((stopWords is null) ? 0 : JCG.SetEqualityComparer<string>.Default.GetHashCode(stopWords));
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (analyzer is null ? 0 : analyzer.GetHashCode());
+                result = prime * result + (fieldName is null ? 0 : fieldName.GetHashCode());
+                result = prime * result + (likeText is null ? 0 : likeText.GetHashCode());
+                result = prime * result + maxQueryTerms;
+                result = prime * result + minDocFreq;
+                result = prime * result + minTermFrequency;
+                result = prime * result + Arrays.GetHashCode(moreLikeFields);
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(percentTermsToMatch);
+                // LUCENENET specific: use structural equality comparison
+                result = prime * result + (stopWords is null ? 0 : JCG.SetEqualityComparer<string>.Default.GetHashCode(stopWords));
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Queries/TermsFilter.cs
+++ b/src/Lucene.Net.Queries/TermsFilter.cs
@@ -343,12 +343,15 @@ namespace Lucene.Net.Queries
 
             public override int GetHashCode()
             {
-                const int prime = 31;
-                int result = 1;
-                result = prime * result + ((field is null) ? 0 : field.GetHashCode());
-                result = prime * result + end;
-                result = prime * result + start;
-                return result;
+                unchecked
+                {
+                    const int prime = 31;
+                    int result = 1;
+                    result = prime * result + ((field is null) ? 0 : field.GetHashCode());
+                    result = prime * result + end;
+                    result = prime * result + start;
+                    return result;
+                }
             }
 
             public override bool Equals(object obj)

--- a/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
@@ -419,16 +419,19 @@ namespace Lucene.Net.QueryParsers.ComplexPhrase
 
             public override int GetHashCode()
             {
-                int prime = 31;
-                int result = base.GetHashCode();
-                result = prime * result + ((field is null) ? 0 : field.GetHashCode());
-                result = prime
-                    * result
-                    + ((phrasedQueryStringContents is null) ? 0
-                        : phrasedQueryStringContents.GetHashCode());
-                result = prime * result + slopFactor;
-                result = prime * result + (inOrder ? 1 : 0);
-                return result;
+                unchecked
+                {
+                    const int prime = 31;
+                    int result = base.GetHashCode();
+                    result = prime * result + (field is null ? 0 : field.GetHashCode());
+                    result = prime
+                        * result
+                        + (phrasedQueryStringContents is null ? 0
+                            : phrasedQueryStringContents.GetHashCode());
+                    result = prime * result + slopFactor;
+                    result = prime * result + (inOrder ? 1 : 0);
+                    return result;
+                }
             }
 
             public override bool Equals(object obj)

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumericConfig.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/NumericConfig.cs
@@ -103,12 +103,15 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
         /// </summary>
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + this.precisionStep.GetHashCode();
-            result = prime * result + this.type.GetHashCode();
-            result = prime * result + this.format.GetHashCode();
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + this.precisionStep.GetHashCode();
+                result = prime * result + this.type.GetHashCode();
+                result = prime * result + this.format.GetHashCode();
+                return result;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Sandbox/Queries/DuplicateFilter.cs
+++ b/src/Lucene.Net.Sandbox/Queries/DuplicateFilter.cs
@@ -195,11 +195,14 @@ namespace Lucene.Net.Sandbox.Queries
 
         public override int GetHashCode()
         {
-            int hash = 217;
-            hash = 31 * hash + keepMode.GetHashCode();
-            hash = 31 * hash + processingMode.GetHashCode();
-            hash = 31 * hash + fieldName.GetHashCode();
-            return hash;
+            unchecked
+            {
+                int hash = 217;
+                hash = 31 * hash + keepMode.GetHashCode();
+                hash = 31 * hash + processingMode.GetHashCode();
+                hash = 31 * hash + fieldName.GetHashCode();
+                return hash;
+            }
         }
 
         public ProcessingMode ProcessingMode

--- a/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
+++ b/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
@@ -61,14 +61,17 @@ namespace Lucene.Net.Sandbox.Queries
 
         public override int GetHashCode()
         {
-            int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + ((analyzer is null) ? 0 : analyzer.GetHashCode());
-            result = prime * result
-                + ((fieldVals is null) ? 0 : fieldVals.GetHashCode());
-            result = prime * result + (ignoreTF ? 1231 : 1237);
-            result = prime * result + maxNumTerms;
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (analyzer is null ? 0 : analyzer.GetHashCode());
+                result = prime * result
+                    + (fieldVals is null ? 0 : fieldVals.GetHashCode());
+                result = prime * result + (ignoreTF ? 1231 : 1237);
+                result = prime * result + maxNumTerms;
+                return result;
+            }
         }
 
         public override bool Equals(object obj)
@@ -133,15 +136,18 @@ namespace Lucene.Net.Sandbox.Queries
 
             public override int GetHashCode()
             {
-                int prime = 31;
-                int result = 1;
-                result = prime * result
-                    + ((fieldName is null) ? 0 : fieldName.GetHashCode());
-                result = prime * result + J2N.BitConversion.SingleToInt32Bits(minSimilarity);
-                result = prime * result + prefixLength;
-                result = prime * result
-                    + ((queryString is null) ? 0 : queryString.GetHashCode());
-                return result;
+                unchecked
+                {
+                    const int prime = 31;
+                    int result = 1;
+                    result = prime * result
+                        + (fieldName is null ? 0 : fieldName.GetHashCode());
+                    result = prime * result + J2N.BitConversion.SingleToInt32Bits(minSimilarity);
+                    result = prime * result + prefixLength;
+                    result = prime * result
+                        + (queryString is null ? 0 : queryString.GetHashCode());
+                    return result;
+                }
             }
 
             public override bool Equals(object obj)

--- a/src/Lucene.Net.Sandbox/Queries/SlowFuzzyQuery.cs
+++ b/src/Lucene.Net.Sandbox/Queries/SlowFuzzyQuery.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Sandbox.Queries
         protected Term m_term;
 
         /// <summary>
-        /// Create a new <see cref="SlowFuzzyQuery"/> that will match terms with a similarity 
+        /// Create a new <see cref="SlowFuzzyQuery"/> that will match terms with a similarity
         /// of at least <paramref name="minimumSimilarity"/> to <paramref name="term"/>.
         /// If a <paramref name="prefixLength"/> &gt; 0 is specified, a common prefix
         /// of that length is also required.
@@ -173,12 +173,15 @@ namespace Lucene.Net.Sandbox.Queries
 
         public override int GetHashCode()
         {
-            int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(minimumSimilarity);
-            result = prime * result + prefixLength;
-            result = prime * result + ((m_term is null) ? 0 : m_term.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(minimumSimilarity);
+                result = prime * result + prefixLength;
+                result = prime * result + (m_term is null ? 0 : m_term.GetHashCode());
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Sandbox/Queries/SortedSetSortField.cs
+++ b/src/Lucene.Net.Sandbox/Queries/SortedSetSortField.cs
@@ -94,7 +94,10 @@ namespace Lucene.Net.Sandbox.Queries
 
         public override int GetHashCode()
         {
-            return 31 * base.GetHashCode() + selector.GetHashCode();
+            unchecked
+            {
+                return 31 * base.GetHashCode() + selector.GetHashCode();
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Spatial/DisjointSpatialFilter.cs
+++ b/src/Lucene.Net.Spatial/DisjointSpatialFilter.cs
@@ -89,9 +89,12 @@ namespace Lucene.Net.Spatial
 
         public override int GetHashCode()
         {
-            int result = field is null ? 0 : field.GetHashCode();
-            result = 31 * result + intersectsFilter.GetHashCode();
-            return result;
+            unchecked
+            {
+                int result = field is null ? 0 : field.GetHashCode();
+                result = 31 * result + intersectsFilter.GetHashCode();
+                return result;
+            }
         }
 
         /// <exception cref="IOException"></exception>
@@ -129,7 +132,7 @@ namespace Lucene.Net.Spatial
                     docsWithField = null;//all docs
                 }
             }
-            
+
             //not so much a chain but a way to conveniently invert the Filter
             DocIdSet docIdSet = new ChainedFilter(new Filter[] { intersectsFilter }, ChainedFilter.ANDNOT).GetDocIdSet(context, acceptDocs);
             return BitsFilteredDocIdSet.Wrap(docIdSet, docsWithField);

--- a/src/Lucene.Net.Spatial/Prefix/AbstractPrefixTreeFilter.cs
+++ b/src/Lucene.Net.Spatial/Prefix/AbstractPrefixTreeFilter.cs
@@ -73,10 +73,13 @@ namespace Lucene.Net.Spatial.Prefix
 
         public override int GetHashCode()
         {
-            int result = m_queryShape.GetHashCode();
-            result = 31 * result + m_fieldName.GetHashCode();
-            result = 31 * result + m_detailLevel;
-            return result;
+            unchecked
+            {
+                int result = m_queryShape.GetHashCode();
+                result = 31 * result + m_fieldName.GetHashCode();
+                result = 31 * result + m_detailLevel;
+                return result;
+            }
         }
 
         // LUCENENET specific - de-nested BaseTermsEnumTraverser

--- a/src/Lucene.Net.Spatial/Prefix/ContainsPrefixTreeFilter.cs
+++ b/src/Lucene.Net.Spatial/Prefix/ContainsPrefixTreeFilter.cs
@@ -62,7 +62,10 @@ namespace Lucene.Net.Spatial.Prefix
 
         public override int GetHashCode()
         {
-            return base.GetHashCode() + (m_multiOverlappingIndexedShapes ? 1 : 0);
+            unchecked
+            {
+                return base.GetHashCode() + (m_multiOverlappingIndexedShapes ? 1 : 0);
+            }
         }
 
         public override DocIdSet? GetDocIdSet(AtomicReaderContext context, IBits acceptDocs)

--- a/src/Lucene.Net.Spatial/Prefix/IntersectsPrefixTreeFilter.cs
+++ b/src/Lucene.Net.Spatial/Prefix/IntersectsPrefixTreeFilter.cs
@@ -28,14 +28,14 @@ namespace Lucene.Net.Spatial.Prefix
     /// <summary>
     /// A Filter matching documents that have an <see cref="SpatialRelation.INTERSECTS"/>
     /// (i.e. not DISTINCT) relationship with a provided query shape.
-    /// 
+    ///
     /// @lucene.internal
     /// </summary>
     public class IntersectsPrefixTreeFilter : AbstractVisitingPrefixTreeFilter
     {
         private readonly bool hasIndexedLeaves;
 
-        public IntersectsPrefixTreeFilter(IShape queryShape, string fieldName, 
+        public IntersectsPrefixTreeFilter(IShape queryShape, string fieldName,
                                           SpatialPrefixTree grid, int detailLevel,
                                           int prefixGridScanLevel, bool hasIndexedLeaves)
             : base(queryShape, fieldName, grid, detailLevel, prefixGridScanLevel)
@@ -49,7 +49,7 @@ namespace Lucene.Net.Spatial.Prefix
         }
 
         /// <summary>
-        /// LUCENENET specific: need to override GetHashCode to 
+        /// LUCENENET specific: need to override GetHashCode to
         /// prevent a compiler warning and realistically, the hash code
         /// should work similarly to Equals.
         /// </summary>

--- a/src/Lucene.Net.Spatial/Util/DistanceToShapeValueSource.cs
+++ b/src/Lucene.Net.Spatial/Util/DistanceToShapeValueSource.cs
@@ -127,13 +127,16 @@ namespace Lucene.Net.Spatial.Util
 
         public override int GetHashCode()
         {
-            int result;
-            long temp;
-            result = shapeValueSource.GetHashCode();
-            result = 31 * result + queryPoint.GetHashCode();
-            temp = J2N.BitConversion.DoubleToInt64Bits(multiplier);
-            result = 31 * result + (int)(temp ^ (temp >>> 32));
-            return result;
+            unchecked
+            {
+                int result;
+                long temp;
+                result = shapeValueSource.GetHashCode();
+                result = 31 * result + queryPoint.GetHashCode();
+                temp = J2N.BitConversion.DoubleToInt64Bits(multiplier);
+                result = 31 * result + (int)(temp ^ (temp >>> 32));
+                return result;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Spatial/Util/ShapePredicateValueSource.cs
+++ b/src/Lucene.Net.Spatial/Util/ShapePredicateValueSource.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Spatial.Util
         private readonly IShape queryShape;//the right hand side (constant)
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="shapeValueSource">
         /// Must yield <see cref="IShape"/> instances from it's ObjectVal(doc). If null
@@ -119,10 +119,13 @@ namespace Lucene.Net.Spatial.Util
 
         public override int GetHashCode()
         {
-            int result = shapeValueSource.GetHashCode();
-            result = 31 * result + op.GetHashCode();
-            result = 31 * result + queryShape.GetHashCode();
-            return result;
+            unchecked
+            {
+                int result = shapeValueSource.GetHashCode();
+                result = 31 * result + op.GetHashCode();
+                result = 31 * result + queryShape.GetHashCode();
+                return result;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Suggest/Spell/DirectSpellChecker.cs
+++ b/src/Lucene.Net.Suggest/Spell/DirectSpellChecker.cs
@@ -553,10 +553,13 @@ namespace Lucene.Net.Search.Spell
 
             public override int GetHashCode()
             {
-                const int prime = 31;
-                int result = 1;
-                result = prime * result + ((Term is null) ? 0 : Term.GetHashCode());
-                return result;
+                unchecked
+                {
+                    const int prime = 31;
+                    int result = 1;
+                    result = prime * result + ((Term is null) ? 0 : Term.GetHashCode());
+                    return result;
+                }
             }
 
             public override bool Equals(object obj)

--- a/src/Lucene.Net.Suggest/Spell/JaroWinklerDistance.cs
+++ b/src/Lucene.Net.Suggest/Spell/JaroWinklerDistance.cs
@@ -125,7 +125,7 @@ namespace Lucene.Net.Search.Spell
 
         /// <summary>
         /// Gets or sets the threshold used to determine when Winkler bonus should be used.
-        /// The default value is 0.7. Set to a negative value to get the Jaro distance. 
+        /// The default value is 0.7. Set to a negative value to get the Jaro distance.
         /// </summary>
         public virtual float Threshold
         {
@@ -136,7 +136,10 @@ namespace Lucene.Net.Search.Spell
 
         public override int GetHashCode()
         {
-            return 113 * J2N.BitConversion.SingleToInt32Bits(threshold) * this.GetType().GetHashCode();
+            unchecked
+            {
+                return 113 * J2N.BitConversion.SingleToInt32Bits(threshold) * this.GetType().GetHashCode();
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Suggest/Spell/LevensteinDistance.cs
+++ b/src/Lucene.Net.Suggest/Spell/LevensteinDistance.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Search.Spell
                of the current cost count being calculated).  (Note that the arrays aren't really
                copied anymore, just switched...this is clearly much better than cloning an array
                or doing a System.arraycopy() each time  through the outer loop.)
-               
+
                Effectively, the difference between the two implementations is this one does not
                cause an out of memory condition when calculating the LD over two very large strings.
              */
@@ -120,7 +120,10 @@ namespace Lucene.Net.Search.Spell
 
         public override int GetHashCode()
         {
-            return 163 * this.GetType().GetHashCode();
+            unchecked
+            {
+                return 163 * this.GetType().GetHashCode();
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.Suggest/Spell/NGramDistance.cs
+++ b/src/Lucene.Net.Suggest/Spell/NGramDistance.cs
@@ -20,16 +20,16 @@ namespace Lucene.Net.Search.Spell
      */
 
     /// <summary>
-    /// N-Gram version of edit distance based on paper by Grzegorz Kondrak, 
-    /// "N-gram similarity and distance". Proceedings of the Twelfth International 
-    /// Conference on String Processing and Information Retrieval (SPIRE 2005), pp. 115-126, 
-    /// Buenos Aires, Argentina, November 2005. 
+    /// N-Gram version of edit distance based on paper by Grzegorz Kondrak,
+    /// "N-gram similarity and distance". Proceedings of the Twelfth International
+    /// Conference on String Processing and Information Retrieval (SPIRE 2005), pp. 115-126,
+    /// Buenos Aires, Argentina, November 2005.
     /// <a href="http://www.cs.ualberta.ca/~kondrak/papers/spire05.pdf">http://www.cs.ualberta.ca/~kondrak/papers/spire05.pdf</a>
-    /// 
+    ///
     /// This implementation uses the position-based optimization to compute partial
-    /// matches of n-gram sub-strings and adds a null-character prefix of size n-1 
-    /// so that the first character is contained in the same number of n-grams as 
-    /// a middle character.  Null-character prefix matches are discounted so that 
+    /// matches of n-gram sub-strings and adds a null-character prefix of size n-1
+    /// so that the first character is contained in the same number of n-grams as
+    /// a middle character.  Null-character prefix matches are discounted so that
     /// strings with no matching characters will return a distance of 0.
     /// </summary>
     public class NGramDistance : IStringDistance
@@ -115,7 +115,7 @@ namespace Lucene.Net.Search.Spell
 
             for (j = 1; j <= tl; j++)
             {
-                //construct t_j n-gram 
+                //construct t_j n-gram
                 if (j < n)
                 {
                     for (int ti = 0; ti < n - j; ti++)
@@ -165,7 +165,10 @@ namespace Lucene.Net.Search.Spell
 
         public override int GetHashCode()
         {
-            return 1427 * n * this.GetType().GetHashCode();
+            unchecked
+            {
+                return 1427 * n * this.GetType().GetHashCode();
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -216,7 +216,10 @@ namespace Lucene.Net.Index
 
             public override int GetHashCode()
             {
-                return start + 31 * end;
+                unchecked
+                {
+                    return start + 31 * end;
+                }
             }
 
             public override void CopyTo(IAttribute target) // LUCENENET specific - intentionally expanding target to use IAttribute rather than Attribute

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Search
     /// <summary>
     /// Thrown when the lease for a searcher has expired.
     /// </summary>
-    // LUCENENET: It is no longer good practice to use binary serialization. 
+    // LUCENENET: It is no longer good practice to use binary serialization.
     // See: https://github.com/dotnet/corefx/issues/23584#issuecomment-325724568
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
     [Serializable]
@@ -96,7 +96,10 @@ namespace Lucene.Net.Search
 
             public override int GetHashCode()
             {
-                return (int)(version * nodeID + field.GetHashCode());
+                unchecked
+                {
+                    return (int)(version * nodeID + field.GetHashCode());
+                }
             }
 
             public override bool Equals(object other)
@@ -132,7 +135,10 @@ namespace Lucene.Net.Search
 
             public override int GetHashCode()
             {
-                return (int)(version * nodeID + term.GetHashCode());
+                unchecked
+                {
+                    return (int)(version * nodeID + term.GetHashCode());
+                }
             }
 
             public override bool Equals(object other)

--- a/src/Lucene.Net/Analysis/Token.cs
+++ b/src/Lucene.Net/Analysis/Token.cs
@@ -417,20 +417,23 @@ namespace Lucene.Net.Analysis
 
         public override int GetHashCode()
         {
-            int code = base.GetHashCode();
-            code = code * 31 + startOffset;
-            code = code * 31 + endOffset;
-            code = code * 31 + flags;
-            code = code * 31 + positionIncrement;
-            if (type != null)
+            unchecked
             {
-                code = code * 31 + type.GetHashCode();
+                int code = base.GetHashCode();
+                code = code * 31 + startOffset;
+                code = code * 31 + endOffset;
+                code = code * 31 + flags;
+                code = code * 31 + positionIncrement;
+                if (type != null)
+                {
+                    code = code * 31 + type.GetHashCode();
+                }
+                if (payload != null)
+                {
+                    code = code * 31 + payload.GetHashCode();
+                }
+                return code;
             }
-            if (payload != null)
-            {
-                code = code * 31 + payload.GetHashCode();
-            }
-            return code;
         }
 
         // like clear() but doesn't clear termBuffer/text

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
@@ -380,9 +380,12 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
         public override int GetHashCode()
         {
-            int code = termLength;
-            code = code * 31 + ArrayUtil.GetHashCode(termBuffer, 0, termLength);
-            return code;
+            unchecked
+            {
+                int code = termLength;
+                code = code * 31 + ArrayUtil.GetHashCode(termBuffer, 0, termLength);
+                return code;
+            }
         }
 
         public override void Clear()

--- a/src/Lucene.Net/Analysis/TokenAttributes/OffsetAttributeImpl.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/OffsetAttributeImpl.cs
@@ -81,9 +81,12 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
         public override int GetHashCode()
         {
-            int code = startOffset;
-            code = code * 31 + endOffset;
-            return code;
+            unchecked
+            {
+                int code = startOffset;
+                code = code * 31 + endOffset;
+                return code;
+            }
         }
 
         public override void CopyTo(IAttribute target) // LUCENENET specific - intentionally expanding target to use IAttribute rather than Attribute

--- a/src/Lucene.Net/Index/IndexCommit.cs
+++ b/src/Lucene.Net/Index/IndexCommit.cs
@@ -107,7 +107,10 @@ namespace Lucene.Net.Index
 
         public override int GetHashCode()
         {
-            return Directory.GetHashCode() + Generation.GetHashCode();
+            unchecked
+            {
+                return Directory.GetHashCode() + Generation.GetHashCode();
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net/Index/SegmentInfo.cs
+++ b/src/Lucene.Net/Index/SegmentInfo.cs
@@ -238,7 +238,10 @@ namespace Lucene.Net.Index
 
         public override int GetHashCode()
         {
-            return Dir.GetHashCode() + Name.GetHashCode();
+            unchecked
+            {
+                return Dir.GetHashCode() + Name.GetHashCode();
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net/Index/Term.cs
+++ b/src/Lucene.Net/Index/Term.cs
@@ -115,11 +115,14 @@ namespace Lucene.Net.Index
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + ((Field is null) ? 0 : Field.GetHashCode());
-            result = prime * result + ((Bytes is null) ? 0 : Bytes.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + (Field is null ? 0 : Field.GetHashCode());
+                result = prime * result + (Bytes is null ? 0 : Bytes.GetHashCode());
+                return result;
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net/Search/AutomatonQuery.cs
+++ b/src/Lucene.Net/Search/AutomatonQuery.cs
@@ -80,11 +80,14 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + m_compiled.GetHashCode();
-            result = prime * result + ((m_term is null) ? 0 : m_term.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + m_compiled.GetHashCode();
+                result = prime * result + ((m_term is null) ? 0 : m_term.GetHashCode());
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/BooleanQuery.cs
+++ b/src/Lucene.Net/Search/BooleanQuery.cs
@@ -46,22 +46,22 @@ namespace Lucene.Net.Search
     /// <para/>
     /// Collection initializer note: To create and populate a <see cref="BooleanQuery"/>
     /// in a single statement, you can use the following example as a guide:
-    /// 
+    ///
     /// <code>
     /// var booleanQuery = new BooleanQuery() {
     ///     { new WildcardQuery(new Term("field2", "foobar")), Occur.SHOULD },
     ///     { new MultiPhraseQuery() {
-    ///         new Term("field", "microsoft"), 
+    ///         new Term("field", "microsoft"),
     ///         new Term("field", "office")
     ///     }, Occur.SHOULD }
     /// };
-    /// 
+    ///
     /// // or
-    /// 
+    ///
     /// var booleanQuery = new BooleanQuery() {
     ///     new BooleanClause(new WildcardQuery(new Term("field2", "foobar")), Occur.SHOULD),
     ///     new BooleanClause(new MultiPhraseQuery() {
-    ///         new Term("field", "microsoft"), 
+    ///         new Term("field", "microsoft"),
     ///         new Term("field", "office")
     ///     }, Occur.SHOULD)
     /// };
@@ -72,12 +72,12 @@ namespace Lucene.Net.Search
         private static int maxClauseCount = 1024;
 
         /// <summary>
-        /// Thrown when an attempt is made to add more than 
+        /// Thrown when an attempt is made to add more than
         /// <see cref="MaxClauseCount"/> clauses. This typically happens if
         /// a <see cref="PrefixQuery"/>, <see cref="FuzzyQuery"/>, <see cref="WildcardQuery"/>, or <see cref="TermRangeQuery"/>
         /// is expanded to many terms during search.
         /// </summary>
-        // LUCENENET: It is no longer good practice to use binary serialization. 
+        // LUCENENET: It is no longer good practice to use binary serialization.
         // See: https://github.com/dotnet/corefx/issues/23584#issuecomment-325724568
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
         [Serializable]
@@ -107,7 +107,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Return the maximum number of clauses permitted, 1024 by default.
-        /// Attempts to add more than the permitted number of clauses cause 
+        /// Attempts to add more than the permitted number of clauses cause
         /// <see cref="TooManyClausesException"/> to be thrown. </summary>
         public static int MaxClauseCount
         {
@@ -137,7 +137,7 @@ namespace Lucene.Net.Search
         /// <para/>
         /// <see cref="Similarity.Coord(int,int)"/> may be disabled in scoring, as
         /// appropriate. For example, this score factor does not make sense for most
-        /// automatically generated queries, like <see cref="WildcardQuery"/> and 
+        /// automatically generated queries, like <see cref="WildcardQuery"/> and
         /// <see cref="FuzzyQuery"/>.
         /// </summary>
         /// <param name="disableCoord"> Disables <see cref="Similarity.Coord(int,int)"/> in scoring. </param>
@@ -694,8 +694,11 @@ namespace Lucene.Net.Search
         /// Returns a hash code value for this object. </summary>
         public override int GetHashCode()
         {
-            return BitConversion.SingleToInt32Bits(Boost) ^ clauses.GetHashCode()
-                + MinimumNumberShouldMatch + (disableCoord ? 17 : 0);
+            unchecked
+            {
+                return BitConversion.SingleToInt32Bits(Boost) ^ clauses.GetHashCode()
+                    + MinimumNumberShouldMatch + (disableCoord ? 17 : 0);
+            }
         }
     }
 }

--- a/src/Lucene.Net/Search/ConstantScoreAutoRewrite.cs
+++ b/src/Lucene.Net/Search/ConstantScoreAutoRewrite.cs
@@ -36,13 +36,13 @@ namespace Lucene.Net.Search
     /// A rewrite method that tries to pick the best
     /// constant-score rewrite method based on term and
     /// document counts from the query.  If both the number of
-    /// terms and documents is small enough, then 
+    /// terms and documents is small enough, then
     /// <see cref="MultiTermQuery.CONSTANT_SCORE_BOOLEAN_QUERY_REWRITE"/> is used.
     /// Otherwise, <see cref="MultiTermQuery.CONSTANT_SCORE_FILTER_REWRITE"/> is
     /// used.
     /// </summary>
-    // LUCENENET specific: made this class public. In Lucene there was a derived class 
-    // with the same name that was nested within MultiTermQuery, but in .NET it is 
+    // LUCENENET specific: made this class public. In Lucene there was a derived class
+    // with the same name that was nested within MultiTermQuery, but in .NET it is
     // more intuitive if our classes are not nested.
     public class ConstantScoreAutoRewrite : TermCollectingRewrite<BooleanQuery>
     {
@@ -64,7 +64,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// If the number of terms in this query is equal to or
-        /// larger than this setting then 
+        /// larger than this setting then
         /// <see cref="MultiTermQuery.CONSTANT_SCORE_FILTER_REWRITE"/> is used.
         /// </summary>
         public virtual int TermCountCutoff
@@ -77,7 +77,7 @@ namespace Lucene.Net.Search
         /// If the number of documents to be visited in the
         /// postings exceeds this specified percentage of the
         /// <see cref="Index.IndexReader.MaxDoc"/> for the index, then
-        /// <see cref="MultiTermQuery.CONSTANT_SCORE_FILTER_REWRITE"/> is used. 
+        /// <see cref="MultiTermQuery.CONSTANT_SCORE_FILTER_REWRITE"/> is used.
         /// Value may be 0.0 to 100.0.
         /// </summary>
         public virtual double DocCountPercent
@@ -183,8 +183,11 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            const int prime = 1279;
-            return (int)(prime * termCountCutoff + J2N.BitConversion.DoubleToInt64Bits(docCountPercent));
+            unchecked
+            {
+                const int prime = 1279;
+                return (int)(prime * termCountCutoff + J2N.BitConversion.DoubleToInt64Bits(docCountPercent));
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/ConstantScoreQuery.cs
+++ b/src/Lucene.Net/Search/ConstantScoreQuery.cs
@@ -267,7 +267,7 @@ namespace Lucene.Net.Search
                     this.outerInstance = outerInstance;
                     this.collector = collector;
                 }
-                
+
                 public void SetScorer(Scorer scorer)
                 {
                     // we must wrap again here, but using the value passed in as parameter:
@@ -371,7 +371,10 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            return 31 * base.GetHashCode() + (m_query ?? (object)m_filter).GetHashCode();
+            unchecked
+            {
+                return 31 * base.GetHashCode() + (m_query ?? (object)m_filter).GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
+++ b/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
@@ -48,10 +48,10 @@ namespace Lucene.Net.Search
     /// <para/>
     /// Collection initializer note: To create and populate a <see cref="DisjunctionMaxQuery"/>
     /// in a single statement, you can use the following example as a guide:
-    /// 
+    ///
     /// <code>
     /// var disjunctionMaxQuery = new DisjunctionMaxQuery(0.1f) {
-    ///     new TermQuery(new Term("field1", "albino")), 
+    ///     new TermQuery(new Term("field1", "albino")),
     ///     new TermQuery(new Term("field2", "elephant"))
     /// };
     /// </code>
@@ -99,9 +99,9 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Add a collection of disjuncts to this disjunction
-        /// via <see cref="T:IEnumerable{Query}"/> 
+        /// via <see cref="T:IEnumerable{Query}"/>
         ///
-        /// NOTE: When overriding this method, be aware that the constructor of this class calls 
+        /// NOTE: When overriding this method, be aware that the constructor of this class calls
         /// a private method and not this virtual method. So if you need to override
         /// the behavior during the initialization, call your own private method from the constructor
         /// with whatever custom behavior you need.
@@ -377,9 +377,12 @@ namespace Lucene.Net.Search
         /// <returns> the hash code </returns>
         public override int GetHashCode()
         {
-            return J2N.BitConversion.SingleToInt32Bits(Boost) 
-                + J2N.BitConversion.SingleToInt32Bits(tieBreakerMultiplier) 
-                + disjuncts.GetHashCode();
+            unchecked
+            {
+                return J2N.BitConversion.SingleToInt32Bits(Boost)
+                       + J2N.BitConversion.SingleToInt32Bits(tieBreakerMultiplier)
+                       + disjuncts.GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net/Search/FieldValueFilter.cs
+++ b/src/Lucene.Net/Search/FieldValueFilter.cs
@@ -99,11 +99,14 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + ((field is null) ? 0 : field.GetHashCode());
-            result = prime * result + (negate ? 1231 : 1237);
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + (field is null ? 0 : field.GetHashCode());
+                result = prime * result + (negate ? 1231 : 1237);
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/FilteredQuery.cs
+++ b/src/Lucene.Net/Search/FilteredQuery.cs
@@ -452,11 +452,14 @@ namespace Lucene.Net.Search
         /// Returns a hash code value for this object. </summary>
         public override int GetHashCode()
         {
-            int hash = base.GetHashCode();
-            hash = hash * 31 + strategy.GetHashCode();
-            hash = hash * 31 + query.GetHashCode();
-            hash = hash * 31 + filter.GetHashCode();
-            return hash;
+            unchecked
+            {
+                int hash = base.GetHashCode();
+                hash = hash * 31 + strategy.GetHashCode();
+                hash = hash * 31 + query.GetHashCode();
+                hash = hash * 31 + filter.GetHashCode();
+                return hash;
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net/Search/FuzzyQuery.cs
+++ b/src/Lucene.Net/Search/FuzzyQuery.cs
@@ -178,14 +178,17 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + maxEdits;
-            result = prime * result + prefixLength;
-            result = prime * result + maxExpansions;
-            result = prime * result + (transpositions ? 0 : 1);
-            result = prime * result + ((term is null) ? 0 : term.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + maxEdits;
+                result = prime * result + prefixLength;
+                result = prime * result + maxExpansions;
+                result = prime * result + (transpositions ? 0 : 1);
+                result = prime * result + ((term is null) ? 0 : term.GetHashCode());
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/MultiTermQuery.cs
+++ b/src/Lucene.Net/Search/MultiTermQuery.cs
@@ -319,15 +319,18 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(Boost);
-            result = prime * result + m_rewriteMethod.GetHashCode();
-            if (m_field != null)
+            unchecked
             {
-                result = prime * result + m_field.GetHashCode();
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(Boost);
+                result = prime * result + m_rewriteMethod.GetHashCode();
+                if (m_field != null)
+                {
+                    result = prime * result + m_field.GetHashCode();
+                }
+                return result;
             }
-            return result;
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/NumericRangeQuery.cs
+++ b/src/Lucene.Net/Search/NumericRangeQuery.cs
@@ -249,17 +249,20 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            int hash = base.GetHashCode();
-            hash += precisionStep ^ 0x64365465;
-            if (min != null)
+            unchecked
             {
-                hash += min.GetHashCode() ^ 0x14fa55fb;
+                int hash = base.GetHashCode();
+                hash += precisionStep ^ 0x64365465;
+                if (min != null)
+                {
+                    hash += min.GetHashCode() ^ 0x14fa55fb;
+                }
+                if (max != null)
+                {
+                    hash += max.GetHashCode() ^ 0x733fa5fe;
+                }
+                return hash + (minInclusive.GetHashCode() ^ 0x14fa55fb) + (maxInclusive.GetHashCode() ^ 0x733fa5fe);
             }
-            if (max != null)
-            {
-                hash += max.GetHashCode() ^ 0x733fa5fe;
-            }
-            return hash + (minInclusive.GetHashCode() ^ 0x14fa55fb) + (maxInclusive.GetHashCode() ^ 0x733fa5fe);
         }
 
         // members (package private, to be also fast accessible by NumericRangeTermEnum)

--- a/src/Lucene.Net/Search/Payloads/AveragePayloadFunction.cs
+++ b/src/Lucene.Net/Search/Payloads/AveragePayloadFunction.cs
@@ -36,10 +36,13 @@ namespace Lucene.Net.Search.Payloads
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + this.GetType().GetHashCode();
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + this.GetType().GetHashCode();
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/Payloads/MaxPayloadFunction.cs
+++ b/src/Lucene.Net/Search/Payloads/MaxPayloadFunction.cs
@@ -45,10 +45,13 @@ namespace Lucene.Net.Search.Payloads
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + this.GetType().GetHashCode();
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + this.GetType().GetHashCode();
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/Payloads/MinPayloadFunction.cs
+++ b/src/Lucene.Net/Search/Payloads/MinPayloadFunction.cs
@@ -43,10 +43,13 @@ namespace Lucene.Net.Search.Payloads
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + this.GetType().GetHashCode();
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + this.GetType().GetHashCode();
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/Payloads/PayloadNearQuery.cs
+++ b/src/Lucene.Net/Search/Payloads/PayloadNearQuery.cs
@@ -109,11 +109,14 @@ namespace Lucene.Net.Search.Payloads
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + ((m_fieldName is null) ? 0 : m_fieldName.GetHashCode());
-            result = prime * result + ((m_function is null) ? 0 : m_function.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (m_fieldName is null ? 0 : m_fieldName.GetHashCode());
+                result = prime * result + (m_function is null ? 0 : m_function.GetHashCode());
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/Payloads/PayloadTermQuery.cs
+++ b/src/Lucene.Net/Search/Payloads/PayloadTermQuery.cs
@@ -225,11 +225,14 @@ namespace Lucene.Net.Search.Payloads
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + ((m_function is null) ? 0 : m_function.GetHashCode());
-            result = prime * result + (includeSpanScore ? 1231 : 1237);
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (m_function is null ? 0 : m_function.GetHashCode());
+                result = prime * result + (includeSpanScore ? 1231 : 1237);
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/PhraseQuery.cs
+++ b/src/Lucene.Net/Search/PhraseQuery.cs
@@ -52,10 +52,10 @@ namespace Lucene.Net.Search
     /// <para/>
     /// Collection initializer note: To create and populate a <see cref="PhraseQuery"/>
     /// in a single statement, you can use the following example as a guide:
-    /// 
+    ///
     /// <code>
     /// var phraseQuery = new PhraseQuery() {
-    ///     new Term("field", "microsoft"), 
+    ///     new Term("field", "microsoft"),
     ///     new Term("field", "office")
     /// };
     /// </code>
@@ -251,15 +251,18 @@ namespace Lucene.Net.Search
 
             public override int GetHashCode()
             {
-                const int prime = 31;
-                int result = 1;
-                result = prime * result + docFreq;
-                result = prime * result + position;
-                for (int i = 0; i < nTerms; i++)
+                unchecked
                 {
-                    result = prime * result + terms[i].GetHashCode();
+                    const int prime = 31;
+                    int result = 1;
+                    result = prime * result + docFreq;
+                    result = prime * result + position;
+                    for (int i = 0; i < nTerms; i++)
+                    {
+                        result = prime * result + terms[i].GetHashCode();
+                    }
+                    return result;
                 }
-                return result;
             }
 
             public override bool Equals(object obj)
@@ -300,7 +303,7 @@ namespace Lucene.Net.Search
             internal readonly Similarity similarity;
             internal readonly Similarity.SimWeight stats;
 
-            
+
             internal TermContext[] states;
 
             public PhraseWeight(PhraseQuery outerInstance, IndexSearcher searcher)
@@ -506,9 +509,9 @@ namespace Lucene.Net.Search
             }
             PhraseQuery other = (PhraseQuery)o;
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
-            return (NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost)) 
-                && (this.slop == other.slop) 
-                && this.terms.Equals(other.terms) 
+            return (NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost))
+                && (this.slop == other.slop)
+                && this.terms.Equals(other.terms)
                 && this.positions.Equals(other.positions);
         }
 
@@ -516,9 +519,9 @@ namespace Lucene.Net.Search
         /// Returns a hash code value for this object. </summary>
         public override int GetHashCode()
         {
-            return J2N.BitConversion.SingleToInt32Bits(Boost) 
-                ^ slop 
-                ^ terms.GetHashCode() 
+            return J2N.BitConversion.SingleToInt32Bits(Boost)
+                ^ slop
+                ^ terms.GetHashCode()
                 ^ positions.GetHashCode();
         }
 

--- a/src/Lucene.Net/Search/PrefixQuery.cs
+++ b/src/Lucene.Net/Search/PrefixQuery.cs
@@ -80,10 +80,13 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + ((_prefix is null) ? 0 : _prefix.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (_prefix is null ? 0 : _prefix.GetHashCode());
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/Query.cs
+++ b/src/Lucene.Net/Search/Query.cs
@@ -116,10 +116,13 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + J2N.BitConversion.SingleToInt32Bits(Boost);
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + J2N.BitConversion.SingleToInt32Bits(Boost);
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/Sort.cs
+++ b/src/Lucene.Net/Search/Sort.cs
@@ -142,7 +142,7 @@ namespace Lucene.Net.Search
         /// <summary>
         /// Sets the sort to the given criteria.
         ///
-        /// NOTE: When overriding this method, be aware that the constructor of this class calls 
+        /// NOTE: When overriding this method, be aware that the constructor of this class calls
         /// a private method and not this virtual method. So if you need to override
         /// the behavior during the initialization, call your own private method from the constructor
         /// with whatever custom behavior you need.
@@ -152,7 +152,7 @@ namespace Lucene.Net.Search
         /// <summary>
         /// Sets the sort to the given criteria in succession.
         ///
-        /// NOTE: When overriding this method, be aware that the constructor of this class calls 
+        /// NOTE: When overriding this method, be aware that the constructor of this class calls
         /// a private method and not this virtual method. So if you need to override
         /// the behavior during the initialization, call your own private method from the constructor
         /// with whatever custom behavior you need.
@@ -233,7 +233,10 @@ namespace Lucene.Net.Search
         /// Returns a hash code value for this object. </summary>
         public override int GetHashCode()
         {
-            return 0x45aaf665 + Arrays.GetHashCode(fields);
+            unchecked
+            {
+                return 0x45aaf665 + Arrays.GetHashCode(fields);
+            }
         }
 
         /// <summary>

--- a/src/Lucene.Net/Search/SortField.cs
+++ b/src/Lucene.Net/Search/SortField.cs
@@ -406,16 +406,19 @@ namespace Lucene.Net.Search
         /// </summary>
         public override int GetHashCode()
         {
-            int hash = (int)(type.GetHashCode() ^ 0x346565dd + reverse.GetHashCode() ^ 0xaf5998bb);
-            if (field != null)
+            unchecked
             {
-                hash += (int)(field.GetHashCode() ^ 0xff5685dd);
+                int hash = (int)(type.GetHashCode() ^ 0x346565dd + reverse.GetHashCode() ^ 0xaf5998bb);
+                if (field != null)
+                {
+                    hash += (int)(field.GetHashCode() ^ 0xff5685dd);
+                }
+                if (comparerSource != null)
+                {
+                    hash += comparerSource.GetHashCode();
+                }
+                return hash;
             }
-            if (comparerSource != null)
-            {
-                hash += comparerSource.GetHashCode();
-            }
-            return hash;
         }
 
         private IComparer<BytesRef> bytesComparer = BytesRef.UTF8SortedAsUnicodeComparer;

--- a/src/Lucene.Net/Search/Spans/SpanMultiTermQueryWrapper.cs
+++ b/src/Lucene.Net/Search/Spans/SpanMultiTermQueryWrapper.cs
@@ -125,10 +125,13 @@ namespace Lucene.Net.Search.Spans
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + m_query.GetHashCode();
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + m_query.GetHashCode();
+                return result;
+            }
         }
 
         public override bool Equals(object obj)
@@ -255,7 +258,10 @@ namespace Lucene.Net.Search.Spans
 
             public override int GetHashCode()
             {
-                return 31 * @delegate.GetHashCode();
+                unchecked
+                {
+                    return 31 * @delegate.GetHashCode();
+                }
             }
 
             public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/Spans/SpanNearQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanNearQuery.cs
@@ -215,16 +215,19 @@ namespace Lucene.Net.Search.Spans
 
         public override int GetHashCode()
         {
-            int result;
-            result = JCG.ListEqualityComparer<SpanQuery>.Default.GetHashCode(m_clauses);
-            // Mix bits before folding in things like boost, since it could cancel the
-            // last element of clauses.  this particular mix also serves to
-            // differentiate SpanNearQuery hashcodes from others.
-            result ^= (result << 14) | (result >>> 19); // reversible
-            result += J2N.BitConversion.SingleToRawInt32Bits(Boost);
-            result += m_slop;
-            result ^= (m_inOrder ? unchecked((int)0x99AFD3BD) : 0);
-            return result;
+            unchecked
+            {
+                int result;
+                result = JCG.ListEqualityComparer<SpanQuery>.Default.GetHashCode(m_clauses);
+                // Mix bits before folding in things like boost, since it could cancel the
+                // last element of clauses.  this particular mix also serves to
+                // differentiate SpanNearQuery hashcodes from others.
+                result ^= (result << 14) | (result >>> 19); // reversible
+                result += J2N.BitConversion.SingleToRawInt32Bits(Boost);
+                result += m_slop;
+                result ^= (m_inOrder ? unchecked((int)0x99AFD3BD) : 0);
+                return result;
+            }
         }
     }
 }

--- a/src/Lucene.Net/Search/Spans/SpanTermQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanTermQuery.cs
@@ -74,10 +74,13 @@ namespace Lucene.Net.Search.Spans
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + ((m_term is null) ? 0 : m_term.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (m_term is null ? 0 : m_term.GetHashCode());
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/TermRangeQuery.cs
+++ b/src/Lucene.Net/Search/TermRangeQuery.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Search
     /// A <see cref="Query"/> that matches documents within an range of terms.
     ///
     /// <para/>This query matches the documents looking for terms that fall into the
-    /// supplied range according to 
+    /// supplied range according to
     /// <see cref="byte.CompareTo(byte)"/>. It is not intended
     /// for numerical ranges; use <see cref="NumericRangeQuery"/> instead.
     ///
@@ -143,13 +143,16 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = base.GetHashCode();
-            result = prime * result + (includeLower ? 1231 : 1237);
-            result = prime * result + (includeUpper ? 1231 : 1237);
-            result = prime * result + ((lowerTerm is null) ? 0 : lowerTerm.GetHashCode());
-            result = prime * result + ((upperTerm is null) ? 0 : upperTerm.GetHashCode());
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = base.GetHashCode();
+                result = prime * result + (includeLower ? 1231 : 1237);
+                result = prime * result + (includeUpper ? 1231 : 1237);
+                result = prime * result + ((lowerTerm is null) ? 0 : lowerTerm.GetHashCode());
+                result = prime * result + ((upperTerm is null) ? 0 : upperTerm.GetHashCode());
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Search/TopTermsRewrite.cs
+++ b/src/Lucene.Net/Search/TopTermsRewrite.cs
@@ -218,7 +218,10 @@ namespace Lucene.Net.Search
 
         public override int GetHashCode()
         {
-            return 31 * size;
+            unchecked
+            {
+                return 31 * size;
+            }
         }
 
         public override bool Equals(object obj)
@@ -251,7 +254,7 @@ namespace Lucene.Net.Search
             if (Debugging.AssertsEnabled) Debugging.Assert(st1.TermComp == st2.TermComp, "term comparer should not change between segments");
             return st1.TermComp.Compare(st1.Bytes, st2.Bytes);
         });
-        
+
         internal sealed class ScoreTerm : IComparable<ScoreTerm>
         {
             public IComparer<BytesRef> TermComp { get; private set; }

--- a/src/Lucene.Net/Store/FlushInfo.cs
+++ b/src/Lucene.Net/Store/FlushInfo.cs
@@ -41,11 +41,14 @@
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + (int)(EstimatedSegmentSize ^ (EstimatedSegmentSize >>> 32));
-            result = prime * result + NumDocs;
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + (int)(EstimatedSegmentSize ^ (EstimatedSegmentSize >>> 32));
+                result = prime * result + NumDocs;
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Store/IOContext.cs
+++ b/src/Lucene.Net/Store/IOContext.cs
@@ -119,13 +119,16 @@ namespace Lucene.Net.Store
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + /*((Context is null) ? 0 :*/ Context.GetHashCode()/*)*/; // LUCENENET NOTE: Enum can never be null in .NET
-            result = prime * result + ((FlushInfo is null) ? 0 : FlushInfo.GetHashCode());
-            result = prime * result + ((MergeInfo is null) ? 0 : MergeInfo.GetHashCode());
-            result = prime * result + (ReadOnce ? 1231 : 1237);
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + /*((Context is null) ? 0 :*/ Context.GetHashCode()/*)*/; // LUCENENET NOTE: Enum can never be null in .NET
+                result = prime * result + (FlushInfo is null ? 0 : FlushInfo.GetHashCode());
+                result = prime * result + (MergeInfo is null ? 0 : MergeInfo.GetHashCode());
+                result = prime * result + (ReadOnce ? 1231 : 1237);
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Store/MergeInfo.cs
+++ b/src/Lucene.Net/Store/MergeInfo.cs
@@ -47,14 +47,17 @@
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result
-                + (int)(EstimatedMergeBytes ^ (EstimatedMergeBytes >>> 32));
-            result = prime * result + (IsExternal ? 1231 : 1237);
-            result = prime * result + MergeMaxNumSegments;
-            result = prime * result + TotalDocCount;
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result
+                         + (int)(EstimatedMergeBytes ^ (EstimatedMergeBytes >>> 32));
+                result = prime * result + (IsExternal ? 1231 : 1237);
+                result = prime * result + MergeMaxNumSegments;
+                result = prime * result + TotalDocCount;
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Util/ArrayUtil.cs
+++ b/src/Lucene.Net/Util/ArrayUtil.cs
@@ -64,7 +64,7 @@ namespace Lucene.Net.Util
         }
 
         /// <summary>
-        /// Parses a char array into an <see cref="int"/>. 
+        /// Parses a char array into an <see cref="int"/>.
         /// <para/>
         /// NOTE: This was parseInt() in Lucene
         /// </summary>
@@ -638,12 +638,15 @@ namespace Lucene.Net.Util
         /// </summary>
         public static int GetHashCode(char[] array, int start, int end)
         {
-            int code = 0;
-            for (int i = end - 1; i >= start; i--)
+            unchecked
             {
-                code = code * 31 + array[i];
+                int code = 0;
+                for (int i = end - 1; i >= start; i--)
+                {
+                    code = code * 31 + array[i];
+                }
+                return code;
             }
-            return code;
         }
 
         /// <summary>
@@ -652,12 +655,15 @@ namespace Lucene.Net.Util
         /// </summary>
         public static int GetHashCode(byte[] array, int start, int end)
         {
-            int code = 0;
-            for (int i = end - 1; i >= start; i--)
+            unchecked
             {
-                code = code * 31 + array[i];
+                int code = 0;
+                for (int i = end - 1; i >= start; i--)
+                {
+                    code = code * 31 + array[i];
+                }
+                return code;
             }
-            return code;
         }
 
         // Since Arrays.equals doesn't implement offsets for equals
@@ -773,7 +779,7 @@ namespace Lucene.Net.Util
             return false;
         }
 
-        // LUCENENET: The toIntArray() method was only here to convert Integer[] to int[] in Java, but is not necessary when dealing with 
+        // LUCENENET: The toIntArray() method was only here to convert Integer[] to int[] in Java, but is not necessary when dealing with
 
         /// <summary>
         /// NOTE: This was toIntArray() in Lucene

--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -396,9 +396,9 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// The caller must pass in an interface type that extends <see cref="IAttribute"/>.
-        /// This method first checks if an instance of the corresponding class is 
+        /// This method first checks if an instance of the corresponding class is
         /// already in this <see cref="AttributeSource"/> and returns it. Otherwise a
-        /// new instance is created, added to this <see cref="AttributeSource"/> and returned. 
+        /// new instance is created, added to this <see cref="AttributeSource"/> and returned.
         /// </summary>
         public T AddAttribute<T>()
             where T : IAttribute
@@ -532,12 +532,15 @@ namespace Lucene.Net.Util
 
         public override int GetHashCode()
         {
-            int code = 0;
-            for (State state = GetCurrentState(); state != null; state = state.next)
+            unchecked
             {
-                code = code * 31 + state.attribute.GetHashCode();
+                int code = 0;
+                for (State state = GetCurrentState(); state != null; state = state.next)
+                {
+                    code = code * 31 + state.attribute.GetHashCode();
+                }
+                return code;
             }
-            return code;
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Util/Automaton/Automaton.cs
+++ b/src/Lucene.Net/Util/Automaton/Automaton.cs
@@ -646,7 +646,10 @@ namespace Lucene.Net.Util.Automaton
             visited.Add(this.initial);
             while (worklist.TryDequeue(out State current))
             {
-                hash = 31 * hash + current.accept.GetHashCode();
+                unchecked
+                {
+                    hash = 31 * hash + current.accept.GetHashCode();
+                }
 
                 Transition[] t1 = transitions[current.number];
 
@@ -654,8 +657,11 @@ namespace Lucene.Net.Util.Automaton
                 {
                     int min1 = t1[n1].min, max1 = t1[n1].max;
 
-                    hash = 31 * hash + min1.GetHashCode();
-                    hash = 31 * hash + max1.GetHashCode();
+                    unchecked
+                    {
+                        hash = 31 * hash + min1.GetHashCode();
+                        hash = 31 * hash + max1.GetHashCode();
+                    }
 
                     State next = t1[n1].to;
                     if (!visited.Contains(next))

--- a/src/Lucene.Net/Util/Automaton/CompiledAutomaton.cs
+++ b/src/Lucene.Net/Util/Automaton/CompiledAutomaton.cs
@@ -452,12 +452,15 @@ namespace Lucene.Net.Util.Automaton
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + ((RunAutomaton is null) ? 0 : RunAutomaton.GetHashCode());
-            result = prime * result + ((Term is null) ? 0 : Term.GetHashCode());
-            result = prime * result + Type.GetHashCode(); //((Type is null) ? 0 : Type.GetHashCode()); // LUCENENET NOTE: Enum cannot be null in .NET
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + (RunAutomaton is null ? 0 : RunAutomaton.GetHashCode());
+                result = prime * result + (Term is null ? 0 : Term.GetHashCode());
+                result = prime * result + Type.GetHashCode(); //((Type is null) ? 0 : Type.GetHashCode()); // LUCENENET NOTE: Enum cannot be null in .NET
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
+++ b/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
@@ -98,26 +98,29 @@ namespace Lucene.Net.Util.Automaton
             /// </summary>
             public override int GetHashCode()
             {
-                int hash = is_final ? 1 : 0;
-
-                hash ^= hash * 31 + this.labels.Length;
-                foreach (int c in this.labels)
+                unchecked
                 {
-                    hash ^= hash * 31 + c;
-                }
+                    int hash = is_final ? 1 : 0;
 
-                /*
-                 * Compare the right-language of this state using reference-identity of
-                 * outgoing states. this is possible because states are interned (stored
-                 * in registry) and traversed in post-order, so any outgoing transitions
-                 * are already interned.
-                 */
-                foreach (State s in this.states)
-                {
-                    hash ^= s.GetHashCode();
-                }
+                    hash ^= hash * 31 + this.labels.Length;
+                    foreach (int c in this.labels)
+                    {
+                        hash ^= hash * 31 + c;
+                    }
 
-                return hash;
+                    /*
+                     * Compare the right-language of this state using reference-identity of
+                     * outgoing states. this is possible because states are interned (stored
+                     * in registry) and traversed in post-order, so any outgoing transitions
+                     * are already interned.
+                     */
+                    foreach (State s in this.states)
+                    {
+                        hash ^= s.GetHashCode();
+                    }
+
+                    return hash;
+                }
             }
 
             /// <summary>

--- a/src/Lucene.Net/Util/Automaton/RunAutomaton.cs
+++ b/src/Lucene.Net/Util/Automaton/RunAutomaton.cs
@@ -216,13 +216,16 @@ namespace Lucene.Net.Util.Automaton
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 1;
-            result = prime * result + m_initial;
-            result = prime * result + _maxInterval;
-            result = prime * result + _points.Length;
-            result = prime * result + _size;
-            return result;
+            unchecked
+            {
+                const int prime = 31;
+                int result = 1;
+                result = prime * result + m_initial;
+                result = prime * result + _maxInterval;
+                result = prime * result + _points.Length;
+                result = prime * result + _size;
+                return result;
+            }
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Util/Automaton/StatePair.cs
+++ b/src/Lucene.Net/Util/Automaton/StatePair.cs
@@ -97,7 +97,10 @@ namespace Lucene.Net.Util.Automaton
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode()
         {
-            return s1.GetHashCode() + s2.GetHashCode();
+            unchecked
+            {
+                return s1.GetHashCode() + s2.GetHashCode();
+            }
         }
     }
 }

--- a/src/Lucene.Net/Util/Automaton/Transition.cs
+++ b/src/Lucene.Net/Util/Automaton/Transition.cs
@@ -128,7 +128,10 @@ namespace Lucene.Net.Util.Automaton
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode()
         {
-            return min * 2 + max * 3;
+            unchecked
+            {
+                return min * 2 + max * 3;
+            }
         }
 
         /// <summary>
@@ -252,7 +255,7 @@ namespace Lucene.Net.Util.Automaton
                 return 0;
             }
         }
-        
+
         // LUCENENET NOTE: Renamed to follow convention of static fields/constants
         public static readonly IComparer<Transition> COMPARE_BY_DEST_THEN_MIN_MAX = new CompareByDestThenMinMaxSingle();
 

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -122,14 +122,17 @@ namespace Lucene.Net.Util
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 0;
-            int end = Offset + Length;
-            for (int i = Offset; i < end; i++)
+            unchecked
             {
-                result = prime * result + chars[i];
+                const int prime = 31;
+                int result = 0;
+                int end = Offset + Length;
+                for (int i = Offset; i < end; i++)
+                {
+                    result = prime * result + chars[i];
+                }
+                return result;
             }
-            return result;
         }
 
         public override bool Equals(object other)

--- a/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
+++ b/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
@@ -343,7 +343,10 @@ namespace Lucene.Net.Util
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override int GetHashCode()
             {
-                return RuntimeHelpers.GetHashCode(readerKey) * FieldName.GetHashCode();
+                unchecked
+                {
+                    return RuntimeHelpers.GetHashCode(readerKey) * FieldName.GetHashCode();
+                }
             }
 
             public override bool Equals(object that)

--- a/src/Lucene.Net/Util/FixedBitSet.cs
+++ b/src/Lucene.Net/Util/FixedBitSet.cs
@@ -724,15 +724,18 @@ namespace Lucene.Net.Util
 
         public override int GetHashCode()
         {
-            long h = 0;
-            for (int i = numWords; --i >= 0; )
+            unchecked
             {
-                h ^= bits[i];
-                h = (h << 1) | (h >>> 63); // rotate left
+                long h = 0;
+                for (int i = numWords; --i >= 0; )
+                {
+                    h ^= bits[i];
+                    h = (h << 1) | (h >>> 63); // rotate left
+                }
+                // fold leftmost bits into right and add a constant to prevent
+                // empty sets from returning 0, which is too common.
+                return (int)((h >> 32) ^ h) + unchecked((int)0x98761234);
             }
-            // fold leftmost bits into right and add a constant to prevent
-            // empty sets from returning 0, which is too common.
-            return (int)((h >> 32) ^ h) + unchecked((int)0x98761234);
         }
     }
 }

--- a/src/Lucene.Net/Util/FixedBitSet.cs
+++ b/src/Lucene.Net/Util/FixedBitSet.cs
@@ -734,7 +734,7 @@ namespace Lucene.Net.Util
                 }
                 // fold leftmost bits into right and add a constant to prevent
                 // empty sets from returning 0, which is too common.
-                return (int)((h >> 32) ^ h) + unchecked((int)0x98761234);
+                return (int)((h >> 32) ^ h) + (int)0x98761234;
             }
         }
     }

--- a/src/Lucene.Net/Util/Fst/PairOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/PairOutputs.cs
@@ -58,7 +58,10 @@ namespace Lucene.Net.Util.Fst
 
             public override int GetHashCode()
             {
-                return Output1.GetHashCode() + Output2.GetHashCode();
+                unchecked
+                {
+                    return Output1.GetHashCode() + Output2.GetHashCode();
+                }
             }
         }
 

--- a/src/Lucene.Net/Util/IntsRef.cs
+++ b/src/Lucene.Net/Util/IntsRef.cs
@@ -112,14 +112,17 @@ namespace Lucene.Net.Util
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 0;
-            int end = Offset + Length;
-            for (int i = Offset; i < end; i++)
+            unchecked
             {
-                result = prime * result + ints[i];
+                const int prime = 31;
+                int result = 0;
+                int end = Offset + Length;
+                for (int i = Offset; i < end; i++)
+                {
+                    result = prime * result + ints[i];
+                }
+                return result;
             }
-            return result;
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Util/LongBitSet.cs
+++ b/src/Lucene.Net/Util/LongBitSet.cs
@@ -452,15 +452,18 @@ namespace Lucene.Net.Util
 
         public override int GetHashCode()
         {
-            long h = 0;
-            for (int i = numWords; --i >= 0; )
+            unchecked
             {
-                h ^= bits[i];
-                h = (h << 1) | (h >>> 63); // rotate left
+                long h = 0;
+                for (int i = numWords; --i >= 0; )
+                {
+                    h ^= bits[i];
+                    h = (h << 1) | (h >>> 63); // rotate left
+                }
+                // fold leftmost bits into right and add a constant to prevent
+                // empty sets from returning 0, which is too common.
+                return (int)((h >> 32) ^ h) + unchecked((int)0x98761234);
             }
-            // fold leftmost bits into right and add a constant to prevent
-            // empty sets from returning 0, which is too common.
-            return (int)((h >> 32) ^ h) + unchecked((int)0x98761234);
         }
     }
 }

--- a/src/Lucene.Net/Util/LongBitSet.cs
+++ b/src/Lucene.Net/Util/LongBitSet.cs
@@ -462,7 +462,7 @@ namespace Lucene.Net.Util
                 }
                 // fold leftmost bits into right and add a constant to prevent
                 // empty sets from returning 0, which is too common.
-                return (int)((h >> 32) ^ h) + unchecked((int)0x98761234);
+                return (int)((h >> 32) ^ h) + (int)0x98761234;
             }
         }
     }

--- a/src/Lucene.Net/Util/LongsRef.cs
+++ b/src/Lucene.Net/Util/LongsRef.cs
@@ -112,14 +112,17 @@ namespace Lucene.Net.Util
 
         public override int GetHashCode()
         {
-            const int prime = 31;
-            int result = 0;
-            long end = Offset + Length;
-            for (int i = Offset; i < end; i++)
+            unchecked
             {
-                result = prime * result + (int)(longs[i] ^ (longs[i] >>> 32));
+                const int prime = 31;
+                int result = 0;
+                long end = Offset + Length;
+                for (int i = Offset; i < end; i++)
+                {
+                    result = prime * result + (int)(longs[i] ^ (longs[i] >>> 32));
+                }
+                return result;
             }
-            return result;
         }
 
         public override bool Equals(object obj)

--- a/src/Lucene.Net/Util/Mutable/MutableValueDouble.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValueDouble.cs
@@ -82,8 +82,11 @@ namespace Lucene.Net.Util.Mutable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode()
         {
-            long x = J2N.BitConversion.DoubleToInt64Bits(Value);
-            return (int)x + (int)(x >>> 32);
+            unchecked
+            {
+                long x = J2N.BitConversion.DoubleToInt64Bits(Value);
+                return (int)x + (int)(x >>> 32);
+            }
         }
     }
 }

--- a/src/Lucene.Net/Util/Mutable/MutableValueLong.cs
+++ b/src/Lucene.Net/Util/Mutable/MutableValueLong.cs
@@ -81,7 +81,10 @@ namespace Lucene.Net.Util.Mutable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode()
         {
-            return (int)Value + (int)(Value >> 32);
+            unchecked
+            {
+                return (int)Value + (int)(Value >> 32);
+            }
         }
     }
 }

--- a/src/Lucene.Net/Util/OpenBitSet.cs
+++ b/src/Lucene.Net/Util/OpenBitSet.cs
@@ -1104,17 +1104,20 @@ namespace Lucene.Net.Util
 
         public override int GetHashCode()
         {
-            // Start with a zero hash and use a mix that results in zero if the input is zero.
-            // this effectively truncates trailing zeros without an explicit check.
-            long h = 0;
-            for (int i = m_bits.Length; --i >= 0; )
+            unchecked
             {
-                h ^= m_bits[i];
-                h = (h << 1) | (h >>> 63); // rotate left
+                // Start with a zero hash and use a mix that results in zero if the input is zero.
+                // this effectively truncates trailing zeros without an explicit check.
+                long h = 0;
+                for (int i = m_bits.Length; --i >= 0; )
+                {
+                    h ^= m_bits[i];
+                    h = (h << 1) | (h >>> 63); // rotate left
+                }
+                // fold leftmost bits into right and add a constant to prevent
+                // empty sets from returning 0, which is too common.
+                return (int)((h >> 32) ^ h) + unchecked((int)0x98761234);
             }
-            // fold leftmost bits into right and add a constant to prevent
-            // empty sets from returning 0, which is too common.
-            return (int)((h >> 32) ^ h) + unchecked((int)0x98761234);
         }
     }
 }

--- a/src/Lucene.Net/Util/OpenBitSet.cs
+++ b/src/Lucene.Net/Util/OpenBitSet.cs
@@ -1116,7 +1116,7 @@ namespace Lucene.Net.Util
                 }
                 // fold leftmost bits into right and add a constant to prevent
                 // empty sets from returning 0, which is too common.
-                return (int)((h >> 32) ^ h) + unchecked((int)0x98761234);
+                return (int)((h >> 32) ^ h) + (int)0x98761234;
             }
         }
     }

--- a/src/Lucene.Net/Util/Packed/EliasFanoEncoder.cs
+++ b/src/Lucene.Net/Util/Packed/EliasFanoEncoder.cs
@@ -393,10 +393,13 @@ namespace Lucene.Net.Util.Packed
 
         public override int GetHashCode()
         {
-            int h = ((int)(31 * (numValues + 7 * (numEncoded + 5 * (numLowBits + 3 * (numIndexEntries + 11 * indexInterval))))))
-                ^ Arrays.GetHashCode(upperLongs)
-                ^ Arrays.GetHashCode(lowerLongs);
-            return h;
+            unchecked
+            {
+                int h = ((int)(31 * (numValues + 7 * (numEncoded + 5 * (numLowBits + 3 * (numIndexEntries + 11 * indexInterval))))))
+                        ^ Arrays.GetHashCode(upperLongs)
+                        ^ Arrays.GetHashCode(lowerLongs);
+                return h;
+            }
         }
     }
 }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Adds `unchecked` to all GetHashCode implementations where it is applicable

Fixes #1065

## Description

GetHashCode should not throw an exception on overflow. This PR adds `unchecked` blocks to all GetHashCode implementations that do addition or multiplication that could overflow.

During review, it was determined that GetHashCode methods that return constants, simply delegate GetHashCode to another object, or solely do bitwise xor operations do not need `unchecked` added. 