### PR TITLE
BREAKING: Replace SetOnce Get/Set with Value, #1069

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/MockRandomMergePolicy.cs
+++ b/src/Lucene.Net.TestFramework/Index/MockRandomMergePolicy.cs
@@ -47,7 +47,8 @@ namespace Lucene.Net.Index
             int numSegments/* = segmentInfos.Count*/; // LUCENENET: IDE0059: Remove unnecessary value assignment
 
             JCG.List<SegmentCommitInfo> segments = new JCG.List<SegmentCommitInfo>();
-            ICollection<SegmentCommitInfo> merging = base.m_writer.Get().MergingSegments;
+            ICollection<SegmentCommitInfo> merging = base.m_writer.Value?.MergingSegments
+                ?? throw new InvalidOperationException("The writer has not been initialized"); // LUCENENET specific - throw exception if writer is null
 
             foreach (SegmentCommitInfo sipc in segmentInfos.Segments)
             {

--- a/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
@@ -2877,7 +2877,7 @@ namespace Lucene.Net.Index
             SetOnce<IndexWriter> iwRef = new SetOnce<IndexWriter>();
             iwc.SetInfoStream(new TestPointInfoStream(iwc.InfoStream, new TestPointAnonymousClass(iwRef)));
             IndexWriter evilWriter = new IndexWriter(dir, iwc);
-            iwRef.Set(evilWriter);
+            iwRef.Value = evilWriter;
             for (int i = 0; i < 1000; i++)
             {
                 AddDoc(evilWriter);
@@ -2905,11 +2905,11 @@ namespace Lucene.Net.Index
             {
                 if ("startCommitMerge".Equals(message, StringComparison.Ordinal))
                 {
-                    iwRef.Get().KeepFullyDeletedSegments = false;
+                    iwRef.Value!.KeepFullyDeletedSegments = false;
                 }
                 else if ("startMergeInit".Equals(message, StringComparison.Ordinal))
                 {
-                    iwRef.Get().KeepFullyDeletedSegments = true;
+                    iwRef.Value!.KeepFullyDeletedSegments = true;
                 }
             }
         }

--- a/src/Lucene.Net.Tests/Util/TestSetOnce.cs
+++ b/src/Lucene.Net.Tests/Util/TestSetOnce.cs
@@ -56,7 +56,7 @@ namespace Lucene.Net.Util
                 try
                 {
                     Sleep(RAND.Next(10)); // sleep for a short time
-                    set.Set(new Integer(Convert.ToInt32(Name.Substring(2), CultureInfo.InvariantCulture)));
+                    set.Value = new Integer(Convert.ToInt32(Name.Substring(2), CultureInfo.InvariantCulture));
                     success = true;
                 }
                 catch (Exception e) when (e.IsInterruptedException())
@@ -76,24 +76,24 @@ namespace Lucene.Net.Util
         public virtual void TestEmptyCtor()
         {
             SetOnce<Integer> set = new SetOnce<Integer>();
-            Assert.IsNull(set.Get());
+            Assert.IsNull(set.Value);
         }
 
         [Test]
         public virtual void TestSettingCtor()
         {
             SetOnce<Integer> set = new SetOnce<Integer>(new Integer(5));
-            Assert.AreEqual(5, set.Get().value);
-            Assert.Throws<AlreadySetException>(() => set.Set(new Integer(7)));
+            Assert.AreEqual(5, set.Value?.value);
+            Assert.Throws<AlreadySetException>(() => set.Value = new Integer(7));
         }
 
         [Test]
         public virtual void TestSetOnce_mem()
         {
             SetOnce<Integer> set = new SetOnce<Integer>();
-            set.Set(new Integer(5));
-            Assert.AreEqual(5, set.Get().value);
-            Assert.Throws<AlreadySetException>(() => set.Set(new Integer(7)));
+            set.Value = new Integer(5);
+            Assert.AreEqual(5, set.Value.value);
+            Assert.Throws<AlreadySetException>(() => set.Value = new Integer(7));
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace Lucene.Net.Util
                 if (t.success)
                 {
                     int expectedVal = Convert.ToInt32(t.Name.Substring(2));
-                    Assert.AreEqual(expectedVal, t.set.Get().value, "thread " + t.Name);
+                    Assert.AreEqual(expectedVal, t.set.Value?.value, "thread " + t.Name);
                 }
             }
         }

--- a/src/Lucene.Net/Index/IndexWriterConfig.cs
+++ b/src/Lucene.Net/Index/IndexWriterConfig.cs
@@ -150,7 +150,7 @@ namespace Lucene.Net.Index
         ///           if this config is already attached to a writer. </exception>
         internal IndexWriterConfig SetIndexWriter(IndexWriter writer)
         {
-            this.writer.Set(writer);
+            this.writer.Value = writer;
             return this;
         }
 

--- a/src/Lucene.Net/Index/MergePolicy.cs
+++ b/src/Lucene.Net/Index/MergePolicy.cs
@@ -658,7 +658,7 @@ namespace Lucene.Net.Index
         /// <seealso cref="SetOnce{T}"/>
         public virtual void SetIndexWriter(IndexWriter writer)
         {
-            this.m_writer.Set(writer);
+            this.m_writer.Value = writer;
         }
 
         /// <summary>
@@ -754,7 +754,8 @@ namespace Lucene.Net.Index
         protected virtual long Size(SegmentCommitInfo info)
         {
             long byteSize = info.GetSizeInBytes();
-            int delCount = m_writer.Get().NumDeletedDocs(info);
+            int delCount = m_writer.Value?.NumDeletedDocs(info)
+                ?? throw new InvalidOperationException("The writer has not been initialized"); // LUCENENET specific - throw exception if writer is null
             double delRatio = (info.Info.DocCount <= 0 ? 0.0f : ((float)delCount / (float)info.Info.DocCount));
             if (Debugging.AssertsEnabled) Debugging.Assert(delRatio <= 1.0);
             return (info.Info.DocCount <= 0 ? byteSize : (long)(byteSize * (1.0 - delRatio)));
@@ -767,7 +768,7 @@ namespace Lucene.Net.Index
         /// </summary>
         protected bool IsMerged(SegmentInfos infos, SegmentCommitInfo info)
         {
-            IndexWriter w = m_writer.Get();
+            IndexWriter w = m_writer.Value;
             if (Debugging.AssertsEnabled) Debugging.Assert(w != null);
             bool hasDeletions = w.NumDeletedDocs(info) > 0;
             return !hasDeletions

--- a/src/Lucene.Net/Index/UpgradeIndexMergePolicy.cs
+++ b/src/Lucene.Net/Index/UpgradeIndexMergePolicy.cs
@@ -175,13 +175,13 @@ namespace Lucene.Net.Index
 
         private bool Verbose()
         {
-            IndexWriter w = m_writer.Get();
+            IndexWriter w = m_writer.Value;
             return w != null && w.infoStream.IsEnabled("UPGMP");
         }
 
         private void Message(string message)
         {
-            m_writer.Get().infoStream.Message("UPGMP", message);
+            m_writer.Value?.infoStream.Message("UPGMP", message);
         }
     }
 }

--- a/src/Lucene.Net/Support/ObsoleteAPI/SetOnce.cs
+++ b/src/Lucene.Net/Support/ObsoleteAPI/SetOnce.cs
@@ -1,0 +1,43 @@
+using System;
+#nullable enable
+
+namespace Lucene.Net.Util
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public partial class SetOnce<T>
+    {
+        /// <summary>
+        /// Sets the given object. If the object has already been set, an exception is thrown.
+        /// </summary>
+        [Obsolete("Use Value property instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public void Set(T? obj)
+        {
+            Value = obj;
+        }
+
+        /// <summary>
+        /// Returns the object set by <see cref="Set(T)"/> or <see cref="Value"/>.
+        /// </summary>
+        [Obsolete("Use Value property instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public T? Get()
+        {
+            return Value;
+        }
+    }
+}


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Replaces Get and Set on the `SetOnce<T>` type with a new `Value` property, marks old methods as deprecated for removal.

Fixes #1069

## Description

In addition to the above, this also enables nullable in the file, and adds more meaningful exceptions in cases where otherwise it could possibly throw a NRE.
