### PR TITLE
Dispose of some disposables, #265, #615

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -295,7 +295,7 @@ namespace Lucene.Net.Analysis.Hunspell
                 [""] = 0
             };
 
-            var reader = new StreamReader(affixStream, decoder);
+            using var reader = new StreamReader(affixStream, decoder); // LUCENENET specific - CA2000: Use using pattern to ensure reader is disposed
             string line; // LUCENENET: Removed unnecessary null assignment
             int lineNumber = 0;
             while ((line = reader.ReadLine()) != null)
@@ -910,7 +910,7 @@ namespace Lucene.Net.Analysis.Hunspell
             {
                 foreach (Stream dictionary in dictionaries)
                 {
-                    var lines = new StreamReader(dictionary, decoder);
+                    using var lines = new StreamReader(dictionary, decoder); // LUCENENET specific - CA2000: Use using pattern to ensure reader is disposed
                     string line = lines.ReadLine(); // first line is number of entries (approximately, sometimes)
 
                     while ((line = lines.ReadLine()) != null)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymMap.cs
@@ -348,6 +348,9 @@ namespace Lucene.Net.Analysis.Synonym
             /// <summary>
             /// Parse the given input, adding synonyms to the inherited <see cref="Builder"/>. </summary>
             /// <param name="in"> The input to parse </param>
+            /// <remarks>
+            /// LUCENENET NOTE: Implementations are expected to dispose of the <paramref name="in"/> parameter.
+            /// </remarks>
             public abstract void Parse(TextReader @in);
 
             /// <summary>

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/BinaryDictionary.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/BinaryDictionary.cs
@@ -101,7 +101,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
             ByteBuffer buffer; // LUCENENET: IDE0059: Remove unnecessary value assignment
 
             using (Stream mapIS = GetResource(TARGETMAP_FILENAME_SUFFIX))
-            using (var @in = new InputStreamDataInput(mapIS)) // LUCENENET: CA2000: Use using statement
+            using (var @in = new InputStreamDataInput(mapIS, leaveOpen: true)) // LUCENENET: CA2000: Use using statement
             {
                 CodecUtil.CheckHeader(@in, TARGETMAP_HEADER, VERSION, VERSION);
                 targetMap = new int[@in.ReadVInt32()];
@@ -124,7 +124,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
             }
 
             using (Stream posIS = GetResource(POSDICT_FILENAME_SUFFIX))
-            using (var @in = new InputStreamDataInput(posIS)) // LUCENENET: CA2000: Use using statement
+            using (var @in = new InputStreamDataInput(posIS, leaveOpen: true)) // LUCENENET: CA2000: Use using statement
             {
                 CodecUtil.CheckHeader(@in, POSDICT_HEADER, VERSION, VERSION);
                 int posSize = @in.ReadVInt32();
@@ -152,7 +152,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
 
             using (Stream dictIS = GetResource(DICT_FILENAME_SUFFIX))
             // no buffering here, as we load in one large buffer
-            using (var @in = new InputStreamDataInput(dictIS)) // LUCENENET: CA2000: Use using statement
+            using (var @in = new InputStreamDataInput(dictIS, leaveOpen: true)) // LUCENENET: CA2000: Use using statement
             {
                 CodecUtil.CheckHeader(@in, DICT_HEADER, VERSION, VERSION);
                 int size = @in.ReadVInt32();

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/BinaryDictionary.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/BinaryDictionary.cs
@@ -101,8 +101,8 @@ namespace Lucene.Net.Analysis.Ja.Dict
             ByteBuffer buffer; // LUCENENET: IDE0059: Remove unnecessary value assignment
 
             using (Stream mapIS = GetResource(TARGETMAP_FILENAME_SUFFIX))
+            using (var @in = new InputStreamDataInput(mapIS)) // LUCENENET: CA2000: Use using statement
             {
-                DataInput @in = new InputStreamDataInput(mapIS);
                 CodecUtil.CheckHeader(@in, TARGETMAP_HEADER, VERSION, VERSION);
                 targetMap = new int[@in.ReadVInt32()];
                 targetMapOffsets = new int[@in.ReadVInt32()];
@@ -124,8 +124,8 @@ namespace Lucene.Net.Analysis.Ja.Dict
             }
 
             using (Stream posIS = GetResource(POSDICT_FILENAME_SUFFIX))
+            using (var @in = new InputStreamDataInput(posIS)) // LUCENENET: CA2000: Use using statement
             {
-                DataInput @in = new InputStreamDataInput(posIS);
                 CodecUtil.CheckHeader(@in, POSDICT_HEADER, VERSION, VERSION);
                 int posSize = @in.ReadVInt32();
                 posDict = new string[posSize];
@@ -151,9 +151,9 @@ namespace Lucene.Net.Analysis.Ja.Dict
             ByteBuffer tmpBuffer;
 
             using (Stream dictIS = GetResource(DICT_FILENAME_SUFFIX))
+            // no buffering here, as we load in one large buffer
+            using (var @in = new InputStreamDataInput(dictIS)) // LUCENENET: CA2000: Use using statement
             {
-                // no buffering here, as we load in one large buffer
-                DataInput @in = new InputStreamDataInput(dictIS);
                 CodecUtil.CheckHeader(@in, DICT_HEADER, VERSION, VERSION);
                 int size = @in.ReadVInt32();
                 tmpBuffer = ByteBuffer.Allocate(size); // AllocateDirect..?

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/CharacterDefinition.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/CharacterDefinition.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
         private CharacterDefinition()
         {
             using Stream @is = BinaryDictionary.GetTypeResource(GetType(), FILENAME_SUFFIX);
-            DataInput @in = new InputStreamDataInput(@is);
+            using var @in = new InputStreamDataInput(@is); // LUCENENET: CA2000: Use using statement
             CodecUtil.CheckHeader(@in, HEADER, VERSION, VERSION);
             @in.ReadBytes(characterCategoryMap, 0, characterCategoryMap.Length);
             for (int i = 0; i < CLASS_COUNT; i++)

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/CharacterDefinition.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/CharacterDefinition.cs
@@ -61,7 +61,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
         private CharacterDefinition()
         {
             using Stream @is = BinaryDictionary.GetTypeResource(GetType(), FILENAME_SUFFIX);
-            using var @in = new InputStreamDataInput(@is); // LUCENENET: CA2000: Use using statement
+            using var @in = new InputStreamDataInput(@is, leaveOpen: true); // LUCENENET: CA2000: Use using statement
             CodecUtil.CheckHeader(@in, HEADER, VERSION, VERSION);
             @in.ReadBytes(characterCategoryMap, 0, characterCategoryMap.Length);
             for (int i = 0; i < CLASS_COUNT; i++)

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/ConnectionCosts.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/ConnectionCosts.cs
@@ -39,8 +39,8 @@ namespace Lucene.Net.Analysis.Ja.Dict
             short[][] costs = null;
 
             using (Stream @is = BinaryDictionary.GetTypeResource(GetType(), FILENAME_SUFFIX))
+            using (var @in = new InputStreamDataInput(@is)) // LUCENENET: CA2000: Use using statement
             {
-                DataInput @in = new InputStreamDataInput(@is);
                 CodecUtil.CheckHeader(@in, HEADER, VERSION, VERSION);
                 int forwardSize = @in.ReadVInt32();
                 int backwardSize = @in.ReadVInt32();

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/ConnectionCosts.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/ConnectionCosts.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
             short[][] costs = null;
 
             using (Stream @is = BinaryDictionary.GetTypeResource(GetType(), FILENAME_SUFFIX))
-            using (var @in = new InputStreamDataInput(@is)) // LUCENENET: CA2000: Use using statement
+            using (var @in = new InputStreamDataInput(@is, leaveOpen: true)) // LUCENENET: CA2000: Use using statement
             {
                 CodecUtil.CheckHeader(@in, HEADER, VERSION, VERSION);
                 int forwardSize = @in.ReadVInt32();

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/BinaryDictionaryWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/BinaryDictionaryWriter.cs
@@ -298,7 +298,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filename));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
+            using var @out = new OutputStreamDataOutput(os, leaveOpen: true); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, BinaryDictionary.TARGETMAP_HEADER, BinaryDictionary.VERSION);
 
             int numSourceIds = lastSourceId + 1;
@@ -328,7 +328,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filename));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
+            using var @out = new OutputStreamDataOutput(os, leaveOpen: true); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, BinaryDictionary.POSDICT_HEADER, BinaryDictionary.VERSION);
             @out.WriteVInt32(posDict.Count);
             foreach (string s in posDict)
@@ -355,7 +355,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filename));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
+            using var @out = new OutputStreamDataOutput(os, leaveOpen: true); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, BinaryDictionary.DICT_HEADER, BinaryDictionary.VERSION);
             @out.WriteVInt32(m_buffer.Position);
 

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/BinaryDictionaryWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/BinaryDictionaryWriter.cs
@@ -298,7 +298,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filename));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            DataOutput @out = new OutputStreamDataOutput(os);
+            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, BinaryDictionary.TARGETMAP_HEADER, BinaryDictionary.VERSION);
 
             int numSourceIds = lastSourceId + 1;
@@ -328,7 +328,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filename));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            DataOutput @out = new OutputStreamDataOutput(os);
+            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, BinaryDictionary.POSDICT_HEADER, BinaryDictionary.VERSION);
             @out.WriteVInt32(posDict.Count);
             foreach (string s in posDict)
@@ -355,7 +355,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filename));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            DataOutput @out = new OutputStreamDataOutput(os);
+            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, BinaryDictionary.DICT_HEADER, BinaryDictionary.VERSION);
             @out.WriteVInt32(m_buffer.Position);
 

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/CharacterDefinitionWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/CharacterDefinitionWriter.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(baseDir));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            DataOutput @out = new OutputStreamDataOutput(os);
+            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, CharacterDefinition.HEADER, CharacterDefinition.VERSION);
             @out.WriteBytes(characterCategoryMap, 0, characterCategoryMap.Length);
             for (int i = 0; i < CharacterDefinition.CLASS_COUNT; i++)

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/CharacterDefinitionWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/CharacterDefinitionWriter.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(baseDir));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
+            using var @out = new OutputStreamDataOutput(os, leaveOpen: true); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, CharacterDefinition.HEADER, CharacterDefinition.VERSION);
             @out.WriteBytes(characterCategoryMap, 0, characterCategoryMap.Length);
             for (int i = 0; i < CharacterDefinition.CLASS_COUNT; i++)

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsBuilder.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Analysis.Ja.Util
         public static ConnectionCostsWriter Build(string filename)
         {
             using Stream inputStream = new FileStream(filename, FileMode.Open, FileAccess.Read);
-            using StreamReader streamReader = new StreamReader(inputStream, Encoding.ASCII); // LUCENENET: CA2000: Use using statement
+            using StreamReader streamReader = new StreamReader(inputStream, Encoding.ASCII, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true); // LUCENENET: CA2000: Use using statement
 
             string line = streamReader.ReadLine();
             string[] dimensions = whiteSpaceRegex.Split(line).TrimEnd();

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsBuilder.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Analysis.Ja.Util
         public static ConnectionCostsWriter Build(string filename)
         {
             using Stream inputStream = new FileStream(filename, FileMode.Open, FileAccess.Read);
-            StreamReader streamReader = new StreamReader(inputStream, Encoding.ASCII);
+            using StreamReader streamReader = new StreamReader(inputStream, Encoding.ASCII); // LUCENENET: CA2000: Use using statement
 
             string line = streamReader.ReadLine();
             string[] dimensions = whiteSpaceRegex.Split(line).TrimEnd();

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsWriter.cs
@@ -54,11 +54,11 @@ namespace Lucene.Net.Analysis.Ja.Util
             // LUCENENET specific: we don't need to do a "classpath" output directory, since we
             // are changing the implementation to read files dynamically instead of making the
             // user recompile with the new files.
-            string filename = System.IO.Path.Combine(baseDir, typeof(ConnectionCosts).Name + CharacterDefinition.FILENAME_SUFFIX);
+            string filename = System.IO.Path.Combine(baseDir, nameof(ConnectionCosts) + CharacterDefinition.FILENAME_SUFFIX);
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filename));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            DataOutput @out = new OutputStreamDataOutput(os);
+            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, ConnectionCosts.HEADER, ConnectionCosts.VERSION);
             @out.WriteVInt32(forwardSize);
             @out.WriteVInt32(backwardSize);

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsWriter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/ConnectionCostsWriter.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             //new File(filename).getParentFile().mkdirs();
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filename));
             using Stream os = new FileStream(filename, FileMode.Create, FileAccess.Write);
-            using var @out = new OutputStreamDataOutput(os); // LUCENENET: CA2000: Use using statement
+            using var @out = new OutputStreamDataOutput(os, leaveOpen: true); // LUCENENET: CA2000: Use using statement
             CodecUtil.WriteHeader(@out, ConnectionCosts.HEADER, ConnectionCosts.VERSION);
             @out.WriteVInt32(forwardSize);
             @out.WriteVInt32(backwardSize);

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             {
                 using Stream inputStream = new FileStream(file, FileMode.Open, FileAccess.Read);
                 Encoding decoder = Encoding.GetEncoding(encoding);
-                using TextReader reader = new StreamReader(inputStream, decoder); // LUCENENET: CA2000: Use using statement
+                using TextReader reader = new StreamReader(inputStream, decoder, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true); // LUCENENET: CA2000: Use using statement
 
                 string line = null;
                 while ((line = reader.ReadLine()) != null)
@@ -159,10 +159,10 @@ namespace Lucene.Net.Analysis.Ja.Util
 
             return dictionary;
         }
-        
+
         /// <summary>
         /// IPADIC features
-        /// 
+        ///
         /// 0   - surface
         /// 1   - left cost
         /// 2   - right cost
@@ -171,9 +171,9 @@ namespace Lucene.Net.Analysis.Ja.Util
         /// 10  - base form
         /// 11  - reading
         /// 12  - pronounciation
-        /// 
+        ///
         /// UniDic features
-        /// 
+        ///
         /// 0   - surface
         /// 1   - left cost
         /// 2   - right cost

--- a/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Tools/TokenInfoDictionaryBuilder.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Analysis.Ja.Util
             {
                 using Stream inputStream = new FileStream(file, FileMode.Open, FileAccess.Read);
                 Encoding decoder = Encoding.GetEncoding(encoding);
-                TextReader reader = new StreamReader(inputStream, decoder);
+                using TextReader reader = new StreamReader(inputStream, decoder); // LUCENENET: CA2000: Use using statement
 
                 string line = null;
                 while ((line = reader.ReadLine()) != null)

--- a/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
@@ -401,7 +401,7 @@ namespace Lucene.Net.Codecs.Memory
                 Int32ArrayWriter scratch = new Int32ArrayWriter();
 
                 // Used for payloads, if any:
-                RAMOutputStream ros = new RAMOutputStream();
+                using RAMOutputStream ros = new RAMOutputStream(); // LUCENENET specific - dispose when done
 
                 // if (DEBUG) {
                 //   System.out.println("\nLOAD terms seg=" + state.segmentInfo.name + " field=" + field + " hasOffsets=" + hasOffsets + " hasFreq=" + hasFreq + " hasPos=" + hasPos + " hasPayloads=" + hasPayloads);

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -1170,8 +1170,9 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
                 }
                 AddDone(); // in case this wasn't previously called
 
-                var ifs = new FileStream(tmpfile, FileMode.OpenOrCreate, FileAccess.Read);
-                using (var @in = new InputStreamDataInput(ifs))
+                // LUCENENET specific - dispose of resources
+                using (var ifs = new FileStream(tmpfile, FileMode.OpenOrCreate, FileAccess.Read))
+                using (var @in = new InputStreamDataInput(ifs, leaveOpen: true))
                 {
                     map = new int[@in.ReadInt32()];
                     // NOTE: The current code assumes here that the map is complete,

--- a/src/Lucene.Net.Misc/Index/IndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/IndexSplitter.cs
@@ -167,7 +167,7 @@ namespace Lucene.Net.Index
         public virtual void Split(DirectoryInfo destDir, ICollection<string> segs) // LUCENENET specific - changed to ICollection to reduce copy operations
         {
             destDir.Create();
-            FSDirectory destFSDir = FSDirectory.Open(destDir);
+            using FSDirectory destFSDir = FSDirectory.Open(destDir); // LUCENENET specific - CA2000: dispose of destFSDir when finished
             SegmentInfos destInfos = new SegmentInfos();
             destInfos.Counter = Infos.Counter;
             foreach (string n in segs)

--- a/src/Lucene.Net.Misc/Index/MultiPassIndexSplitter.cs
+++ b/src/Lucene.Net.Misc/Index/MultiPassIndexSplitter.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Index
             // wrap a potentially read-only input
             // this way we don't have to preserve original deletions because neither
             // deleteDocument(int) or undeleteAll() is applied to the wrapped input index.
-            FakeDeleteIndexReader input = new FakeDeleteIndexReader(@in);
+            using FakeDeleteIndexReader input = new FakeDeleteIndexReader(@in); // LUCENENET: CA2000: Dispose FakeDeleteIndexReader
             int maxDoc = input.MaxDoc;
             int partLen = maxDoc / numParts;
             for (int i = 0; i < numParts; i++)

--- a/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
+++ b/src/Lucene.Net.Misc/Misc/GetTermInfo.cs
@@ -50,31 +50,37 @@ namespace Lucene.Net.Misc
         /// <exception cref="ArgumentException">Thrown if the incorrect number of arguments are provided</exception>
         public static void Main(string[] args)
         {
-
-            FSDirectory dir; // LUCENENET: IDE0059: Remove unnecessary value assignment
-            string inputStr; // LUCENENET: IDE0059: Remove unnecessary value assignment
-            string field; // LUCENENET: IDE0059: Remove unnecessary value assignment
-
-            if (args.Length == 3)
+            // LUCENENET specific - CA2000: dispose of directory when finished
+            FSDirectory dir = null;
+            try
             {
-                dir = FSDirectory.Open(new DirectoryInfo(args[0]));
-                field = args[1];
-                inputStr = args[2];
-            }
-            else
-            {
-                // LUCENENET specific - our wrapper console shows the correct usage
-                throw new ArgumentException("GetTermInfo requires 3 arguments", nameof(args));
-                //Usage();
-                //Environment.Exit(1);
-            }
+                string inputStr; // LUCENENET: IDE0059: Remove unnecessary value assignment
+                string field; // LUCENENET: IDE0059: Remove unnecessary value assignment
+                if (args.Length == 3)
+                {
+                    dir = FSDirectory.Open(new DirectoryInfo(args[0]));
+                    field = args[1];
+                    inputStr = args[2];
+                }
+                else
+                {
+                    // LUCENENET specific - our wrapper console shows the correct usage
+                    throw new ArgumentException("GetTermInfo requires 3 arguments", nameof(args));
+                    //Usage();
+                    //Environment.Exit(1);
+                }
 
-            TermInfo(dir, new Term(field, inputStr));
+                TermInfo(dir, new Term(field, inputStr));
+            }
+            finally
+            {
+                dir?.Dispose();
+            }
         }
 
         public static void TermInfo(Store.Directory dir, Term term)
         {
-            IndexReader reader = DirectoryReader.Open(dir);
+            using IndexReader reader = DirectoryReader.Open(dir);
             Console.WriteLine("{0}:{1} \t totalTF = {2:#,##0} \t doc freq = {3:#,##0} \n", term.Field, term.Text, reader.TotalTermFreq(term), reader.DocFreq(term));
         }
 

--- a/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
+++ b/src/Lucene.Net.Misc/Misc/HighFreqTerms.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Misc
                 //Environment.Exit(1);
             }
 
-            Store.Directory dir = FSDirectory.Open(new DirectoryInfo(args[0]));
+            using Store.Directory dir = FSDirectory.Open(new DirectoryInfo(args[0]));
 
             IComparer<TermStats> comparer = DocFreqComparer.Default;
 

--- a/src/Lucene.Net.Spatial/Query/SpatialArgsParser.cs
+++ b/src/Lucene.Net.Spatial/Query/SpatialArgsParser.cs
@@ -181,7 +181,7 @@ namespace Lucene.Net.Spatial.Queries
                 throw new ArgumentNullException(nameof(body));
 
             var map = new Dictionary<string, string>();
-            StringTokenizer st = new StringTokenizer(body, " \n\t");
+            using StringTokenizer st = new StringTokenizer(body, " \n\t");
 
             while (st.MoveNext())
             {

--- a/src/Lucene.Net.Suggest/Suggest/Lookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Lookup.cs
@@ -274,14 +274,14 @@ namespace Lucene.Net.Search.Suggest
         /// </summary>
         public virtual bool Store(Stream output)
         {
-            DataOutput dataOut = new OutputStreamDataOutput(output);
+            var dataOut = new OutputStreamDataOutput(output, leaveOpen: true);
             try
             {
                 return Store(dataOut);
             }
             finally
             {
-                IOUtils.Dispose(output);
+                IOUtils.Dispose(dataOut, output); // LUCENENET specific - dispose of dataOut
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -704,7 +704,7 @@ namespace Lucene.Net.Search
             {
                 try
                 {
-                    using LineFileDocs docs = new LineFileDocs(Random, DefaultCodecSupportsDocValues);
+                    LineFileDocs docs = new LineFileDocs(Random, DefaultCodecSupportsDocValues);
                     int numDocs = 0;
                     while (J2N.Time.NanoTime() < outerInstance.endTimeNanos)
                     {

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -704,7 +704,7 @@ namespace Lucene.Net.Search
             {
                 try
                 {
-                    LineFileDocs docs = new LineFileDocs(Random, DefaultCodecSupportsDocValues);
+                    using LineFileDocs docs = new LineFileDocs(Random, DefaultCodecSupportsDocValues);
                     int numDocs = 0;
                     while (J2N.Time.NanoTime() < outerInstance.endTimeNanos)
                     {

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Convenience method unzipping <paramref name="zipFileStream"/> into <paramref name="destDir"/>, cleaning up
-        /// <paramref name="destDir"/> first. 
+        /// <paramref name="destDir"/> first.
         /// </summary>
         public static void Unzip(Stream zipFileStream, DirectoryInfo destDir)
         {
@@ -180,7 +180,7 @@ namespace Lucene.Net.Util
             {
                 if (LuceneTestCase.UseInfoStream)
                 {
-                    checker.FlushInfoStream(); 
+                    checker.FlushInfoStream();
                     Console.WriteLine(bos.ToString());
                 }
                 return indexStatus;
@@ -203,7 +203,7 @@ namespace Lucene.Net.Util
         {
             // LUCENENET: dispose the StreamWriter and ByteArrayOutputStream when done
             using ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
-            using StreamWriter infoStream = new StreamWriter(bos, Encoding.UTF8);
+            using StreamWriter infoStream = new StreamWriter(bos, Encoding.UTF8, leaveOpen: true, bufferSize: 1024);
 
             reader.CheckIntegrity();
             CheckIndex.Status.FieldNormStatus fieldNormStatus = Index.CheckIndex.TestFieldNorms(reader, infoStream);
@@ -592,8 +592,8 @@ namespace Lucene.Net.Util
         public static bool FieldSupportsHugeBinaryDocValues(string field)
         {
             string dvFormat = GetDocValuesFormat(field);
-            if (dvFormat.Equals("Lucene40", StringComparison.Ordinal) 
-                || dvFormat.Equals("Lucene42", StringComparison.Ordinal) 
+            if (dvFormat.Equals("Lucene40", StringComparison.Ordinal)
+                || dvFormat.Equals("Lucene42", StringComparison.Ordinal)
                 || dvFormat.Equals("Memory", StringComparison.Ordinal))
             {
                 return false;
@@ -869,7 +869,7 @@ namespace Lucene.Net.Util
         /// Returns a valid (compiling) <see cref="Regex"/> instance with random stuff inside. Be careful
         /// when applying random patterns to longer strings as certain types of patterns
         /// may explode into exponential times in backtracking implementations (such as Java's).
-        /// </summary>        
+        /// </summary>
         public static Regex RandomRegex(Random random) // LUCENENET specific - renamed from RandomPattern()
         {
             return RandomizedTesting.Generators.RandomExtensions.NextRegex(random); // LUCENENET: Moved general random data generation to RandomizedTesting.Generators

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -201,8 +201,9 @@ namespace Lucene.Net.Util
 
         public static void CheckReader(AtomicReader reader, bool crossCheckTermVectors)
         {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
-            StreamWriter infoStream = new StreamWriter(bos, Encoding.UTF8);
+            // LUCENENET: dispose the StreamWriter and ByteArrayOutputStream when done
+            using ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
+            using StreamWriter infoStream = new StreamWriter(bos, Encoding.UTF8);
 
             reader.CheckIntegrity();
             CheckIndex.Status.FieldNormStatus fieldNormStatus = Index.CheckIndex.TestFieldNorms(reader, infoStream);

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Fst/LargeInputFST.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Fst/LargeInputFST.cs
@@ -32,30 +32,31 @@ namespace Lucene.Net.Search.Suggest.Fst
         // LUCENENET specific - renaming from Main() because we must only have 1 entry point.
         // Not sure why this utility is in a test project anyway - this seems like something that should
         // be in Lucene.Net.Suggest so we can put it into the lucene-cli tool.
-        public static void Main2(string[] args) 
+        public static void Main2(string[] args)
         {
             FileInfo input = new FileInfo("/home/dweiss/tmp/shuffled.dict");
 
-            int buckets = 20;
-            int shareMaxTail = 10;
+            const int buckets = 20;
+            const int shareMaxTail = 10;
 
             ExternalRefSorter sorter = new ExternalRefSorter(new OfflineSorter());
             FSTCompletionBuilder builder = new FSTCompletionBuilder(buckets, sorter, shareMaxTail);
 
-            TextReader reader =
-                new StreamReader(
-                    new FileStream(input.FullName, FileMode.Open), Encoding.UTF8);
-
-            BytesRef scratch = new BytesRef();
-            string line;
-            int count = 0;
-            while ((line = reader.ReadLine()) != null)
+            // LUCENENET specific - dispose of fileStream and reader when done
+            using (FileStream fileStream = new FileStream(input.FullName, FileMode.Open))
+            using (TextReader reader = new StreamReader(fileStream, Encoding.UTF8))
             {
-                scratch.CopyChars(line);
-                builder.Add(scratch, count % buckets);
-                if ((count++ % 100000) == 0)
+                BytesRef scratch = new BytesRef();
+                string line;
+                int count = 0;
+                while ((line = reader.ReadLine()) != null)
                 {
-                    Console.WriteLine("Line: " + count);
+                    scratch.CopyChars(line);
+                    builder.Add(scratch, count % buckets);
+                    if ((count++ % 100000) == 0)
+                    {
+                        Console.WriteLine("Line: " + count);
+                    }
                 }
             }
 

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Fst/LargeInputFST.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Fst/LargeInputFST.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Search.Suggest.Fst
 
             // LUCENENET specific - dispose of fileStream and reader when done
             using (FileStream fileStream = new FileStream(input.FullName, FileMode.Open))
-            using (TextReader reader = new StreamReader(fileStream, Encoding.UTF8, leaveOpen: true))
+            using (TextReader reader = new StreamReader(fileStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true))
             {
                 BytesRef scratch = new BytesRef();
                 string line;

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Fst/LargeInputFST.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Fst/LargeInputFST.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Search.Suggest.Fst
 
             // LUCENENET specific - dispose of fileStream and reader when done
             using (FileStream fileStream = new FileStream(input.FullName, FileMode.Open))
-            using (TextReader reader = new StreamReader(fileStream, Encoding.UTF8))
+            using (TextReader reader = new StreamReader(fileStream, Encoding.UTF8, leaveOpen: true))
             {
                 BytesRef scratch = new BytesRef();
                 string line;

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
@@ -384,7 +384,7 @@ namespace Lucene.Net.Codecs.Lucene45
                 long startFP = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 // currently, we have to store the delta from expected for every 1/nth term
                 // we could avoid this, but its not much and less overall RAM than the previous approach!
-                RAMOutputStream addressBuffer = new RAMOutputStream();
+                using RAMOutputStream addressBuffer = new RAMOutputStream();
                 MonotonicBlockPackedWriter termAddresses = new MonotonicBlockPackedWriter(addressBuffer, BLOCK_SIZE);
                 BytesRef lastTerm = new BytesRef();
                 long count = 0;

--- a/src/Lucene.Net/Index/FlushPolicy.cs
+++ b/src/Lucene.Net/Index/FlushPolicy.cs
@@ -121,7 +121,7 @@ namespace Lucene.Net.Index
             // the dwpt which needs to be flushed eventually
             ThreadState maxRamUsingThreadState = perThreadState;
             if (Debugging.AssertsEnabled) Debugging.Assert(!perThreadState.flushPending, "DWPT should have flushed");
-            IEnumerator<ThreadState> activePerThreadsIterator = control.AllActiveThreadStates();
+            using IEnumerator<ThreadState> activePerThreadsIterator = control.AllActiveThreadStates();
             while (activePerThreadsIterator.MoveNext())
             {
                 ThreadState next = activePerThreadsIterator.Current;

--- a/src/Lucene.Net/Store/InputStreamDataInput.cs
+++ b/src/Lucene.Net/Store/InputStreamDataInput.cs
@@ -27,11 +27,31 @@ namespace Lucene.Net.Store
     public class InputStreamDataInput : DataInput, IDisposable
     {
         private readonly Stream _is;
-        private int disposed = 0; // LUCENENET specific - allow double-dispose
+        private int disposed; // LUCENENET specific - allow double-dispose
+        private readonly bool leaveOpen; // LUCENENET specific - added to allow the stream to be left open
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="InputStreamDataInput"/> with the specified <paramref name="is"/> (input stream).
+        /// </summary>
+        /// <param name="is">The input stream to read from.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="is"/> is <c>null</c>.</exception>
         public InputStreamDataInput(Stream @is)
         {
             this._is = @is ?? throw new ArgumentNullException(nameof(@is)); // LUCENENET specific - added null guard clause
+        }
+
+        /// <inheritdoc cref="InputStreamDataInput(Stream)"/>
+        /// <summary>
+        /// Initializes a new instance of <see cref="InputStreamDataInput"/> with the specified <paramref name="is"/> (input stream) and <paramref name="leaveOpen"/> flag.
+        /// </summary>
+        /// <param name="leaveOpen">If <c>true</c>, the stream will not be disposed when this instance is disposed.</param>
+        /// <remarks>
+        /// LUCENENET specific - added to allow the stream to be left open.
+        /// </remarks>
+        public InputStreamDataInput(Stream @is, bool leaveOpen)
+            : this(@is)
+        {
+            this.leaveOpen = leaveOpen;
         }
 
         public override byte ReadByte()
@@ -71,7 +91,10 @@ namespace Lucene.Net.Store
 
             if (disposing)
             {
-                _is.Dispose();
+                if (!leaveOpen)
+                {
+                    _is.Dispose();
+                }
             }
         }
     }

--- a/src/Lucene.Net/Store/LockStressTest.cs
+++ b/src/Lucene.Net/Store/LockStressTest.cs
@@ -144,8 +144,8 @@ namespace Lucene.Net.Store
             socket.Connect(verifierHost, verifierPort);
 
             using Stream stream = new NetworkStream(socket);
-            BinaryReader intReader = new BinaryReader(stream);
-            BinaryWriter intWriter = new BinaryWriter(stream);
+            using BinaryReader intReader = new BinaryReader(stream);
+            using BinaryWriter intWriter = new BinaryWriter(stream);
 
             intWriter.Write(myID);
             stream.Flush();

--- a/src/Lucene.Net/Store/LockStressTest.cs
+++ b/src/Lucene.Net/Store/LockStressTest.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 using Console = Lucene.Net.Util.SystemConsole;
 
@@ -144,8 +145,8 @@ namespace Lucene.Net.Store
             socket.Connect(verifierHost, verifierPort);
 
             using Stream stream = new NetworkStream(socket);
-            using BinaryReader intReader = new BinaryReader(stream);
-            using BinaryWriter intWriter = new BinaryWriter(stream);
+            using BinaryReader intReader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+            using BinaryWriter intWriter = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
 
             intWriter.Write(myID);
             stream.Flush();

--- a/src/Lucene.Net/Store/LockVerifyServer.cs
+++ b/src/Lucene.Net/Store/LockVerifyServer.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 using Console = Lucene.Net.Util.SystemConsole;
 
@@ -134,8 +135,8 @@ namespace Lucene.Net.Store
             public override void Run()
             {
                 using Stream stream = new NetworkStream(cs);
-                using BinaryReader intReader = new BinaryReader(stream);
-                using BinaryWriter intWriter = new BinaryWriter(stream);
+                using BinaryReader intReader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+                using BinaryWriter intWriter = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
                 try
                 {
                     int id = intReader.ReadInt32();

--- a/src/Lucene.Net/Store/LockVerifyServer.cs
+++ b/src/Lucene.Net/Store/LockVerifyServer.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Store
             object localLock = new object();
             int[] lockedID = new int[1];
             lockedID[0] = -1;
-            CountdownEvent startingGun = new CountdownEvent(1);
+            using CountdownEvent startingGun = new CountdownEvent(1); // LUCENENET specific - dispose when finished
             ThreadJob[] threads = new ThreadJob[maxClients];
 
             for (int count = 0; count < maxClients; count++)
@@ -134,8 +134,8 @@ namespace Lucene.Net.Store
             public override void Run()
             {
                 using Stream stream = new NetworkStream(cs);
-                BinaryReader intReader = new BinaryReader(stream);
-                BinaryWriter intWriter = new BinaryWriter(stream);
+                using BinaryReader intReader = new BinaryReader(stream);
+                using BinaryWriter intWriter = new BinaryWriter(stream);
                 try
                 {
                     int id = intReader.ReadInt32();

--- a/src/Lucene.Net/Store/OutputStreamDataOutput.cs
+++ b/src/Lucene.Net/Store/OutputStreamDataOutput.cs
@@ -27,11 +27,31 @@ namespace Lucene.Net.Store
     public class OutputStreamDataOutput : DataOutput, IDisposable
     {
         private readonly Stream _os;
-        private int disposed = 0; // LUCENENET specific - allow double-dispose
+        private int disposed; // LUCENENET specific - allow double-dispose
+        private readonly bool leaveOpen; // LUCENENET specific - added to allow the stream to be left open
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="OutputStreamDataOutput"/> with the specified <paramref name="os"/> (output stream).
+        /// </summary>
+        /// <param name="os">The output stream to write to.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="os"/> is <c>null</c>.</exception>
         public OutputStreamDataOutput(Stream os)
         {
             this._os = os ?? throw new ArgumentNullException(nameof(os)); // LUCENENET specific - added null guard clause
+        }
+
+        /// <inheritdoc cref="OutputStreamDataOutput(Stream)"/>
+        /// <summary>
+        /// Initializes a new instance of <see cref="OutputStreamDataOutput"/> with the specified <paramref name="os"/> (output stream) and <paramref name="leaveOpen"/> flag.
+        /// </summary>
+        /// <param name="leaveOpen">If <c>true</c>, the stream will not be disposed when this instance is disposed.</param>
+        /// <remarks>
+        /// LUCENENET specific - added to allow the stream to be left open.
+        /// </remarks>
+        public OutputStreamDataOutput(Stream os, bool leaveOpen)
+            : this(os)
+        {
+            this.leaveOpen = leaveOpen;
         }
 
         public override void WriteByte(byte b)
@@ -66,7 +86,10 @@ namespace Lucene.Net.Store
 
             if (disposing)
             {
-                _os.Dispose();
+                if (!leaveOpen)
+                {
+                    _os.Dispose();
+                }
             }
         }
     }

--- a/src/Lucene.Net/Util/Constants.cs
+++ b/src/Lucene.Net/Util/Constants.cs
@@ -178,9 +178,10 @@ namespace Lucene.Net.Util
         {
             const string subkey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\";
 
-            // As an alternative, if you know the computers you will query are running .NET Framework 4.5 
+            // As an alternative, if you know the computers you will query are running .NET Framework 4.5
             // or later, you can use:
-            using RegistryKey ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32).OpenSubKey(subkey);
+            using RegistryKey baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
+            using RegistryKey ndpKey = baseKey.OpenSubKey(subkey);
             object releaseValue;
             if (ndpKey != null && (releaseValue = ndpKey.GetValue("Release")) != null)
             {

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -511,7 +511,7 @@ namespace Lucene.Net.Util.Fst
                 @out.WriteByte(1);
 
                 // Serialize empty-string output:
-                var ros = new RAMOutputStream();
+                using var ros = new RAMOutputStream();
                 Outputs.WriteFinalOutput(emptyOutput, ros);
 
                 var emptyOutputBytes = new byte[(int)ros.Position]; // LUCENENET specific: Renamed from getFilePointer() to match FileStream


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Disposes of some IDisposable objects that are not properly cleaned up.

Fixes #615
Partial #265

## Description

This adds `using` statements to clean up some disposable objects where it's possible to do so, after a review of our codebase with CA2000 code analysis warnings on, where the objects were determined to not "leak" via fields, return values, or the like. This also fixes two FileStream leaks in demo code, #615.

Note that CA2000 is _way_ too noisy to leave on, as there are literally hundreds of "violations" that would make our code a mess with `#pragma` suppressions. The Java upstream code is perhaps a little loose with keeping track of ICloseable lifetimes, but we have to match that in most cases. The cases fixed here were just ones where the object lifetime did not escape the method and it was safe to do so. 