### PR TITLE
Simplify IndexReader constructor, #919

### DIFF
--- a/src/Lucene.Net/Index/IndexReader.cs
+++ b/src/Lucene.Net/Index/IndexReader.cs
@@ -85,10 +85,11 @@ namespace Lucene.Net.Index
 
         private protected IndexReader() // LUCENENET: Changed from internal to private protected
         {
-            if (!(this is CompositeReader || this is AtomicReader))
-            {
-                throw Error.Create("IndexReader should never be directly extended, subclass AtomicReader or CompositeReader instead.");
-            }
+            // LUCENENET NOTE: this is enforced by the compiler in .NET due to `private protected`, so we don't need to check it here.
+            // if (!(this is CompositeReader || this is AtomicReader))
+            // {
+            //     throw Error.Create("IndexReader should never be directly extended, subclass AtomicReader or CompositeReader instead.");
+            // }
         }
 
 #if !FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Simplify IndexReader constructor.

Fixes #919

## Description

This removes the type check in the IndexReader constructor that ensures that only CompositeReader and AtomicReader are allowed subtypes. This is not needed since in C# we can use the `private protected` modifier to ensure that no outside classes can subtype this. This removes the need for the runtime check in the constructor, which will mildly improve performance. A comment was left explaining the divergence with the original commented-out code.