### PR TITLE
SWEEP: Use pattern matching, #667

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
@@ -30868,7 +30868,7 @@ namespace Lucene.Net.Analysis.CharFilters
         /// <returns></returns>
         private static BufferedCharFilter GetBufferedReader(TextReader reader)
         {
-            return (reader is BufferedCharFilter) ? (BufferedCharFilter)reader : new BufferedCharFilter(reader);
+            return reader as BufferedCharFilter ?? new BufferedCharFilter(reader);
         }
 
         public override int Read()

--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/MappingCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/MappingCharFilter.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Analysis.CharFilters
 
         /// <summary>
         /// Default constructor that takes a <see cref="TextReader"/>. </summary>
-        public MappingCharFilter(NormalizeCharMap normMap, TextReader @in) 
+        public MappingCharFilter(NormalizeCharMap normMap, TextReader @in)
             : base(@in)
         {
             //LUCENENET support to reset the reader.
@@ -79,20 +79,20 @@ namespace Lucene.Net.Analysis.CharFilters
 
         /// <summary>
         /// LUCENENET: Copied this method from the <see cref="WordlistLoader"/> class - this class requires readers
-        /// with a Reset() method (which .NET readers don't support). So, we use the <see cref="BufferedCharFilter"/> 
-        /// (which is similar to Java BufferedReader) as a wrapper for whatever reader the user passes 
+        /// with a Reset() method (which .NET readers don't support). So, we use the <see cref="BufferedCharFilter"/>
+        /// (which is similar to Java BufferedReader) as a wrapper for whatever reader the user passes
         /// (unless it is already a <see cref="BufferedCharFilter"/>).
         /// </summary>
         /// <param name="reader"></param>
         /// <returns></returns>
         private static BufferedCharFilter GetBufferedReader(TextReader reader)
         {
-            return (reader is BufferedCharFilter) ? (BufferedCharFilter)reader : new BufferedCharFilter(reader);
+            return reader as BufferedCharFilter ?? new BufferedCharFilter(reader);
         }
 
         public override void Reset()
         {
-            // LUCENENET: reset the BufferedCharFilter. 
+            // LUCENENET: reset the BufferedCharFilter.
             _input.Reset();
             buffer.Reset(_input);
             replacement = null;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
@@ -477,9 +477,9 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
                     object o = hw[i];
                     // j = index(sw) = letterindex(word)?
                     // result[k] = corresponding index(w)
-                    if (o is string)
+                    if (o is string os)
                     {
-                        j += ((string)o).Length;
+                        j += os.Length;
                         if (j >= remainCharCount && j < (len - pushCharCount))
                         {
                             result[k++] = j + iIgnoreAtBeginning;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
@@ -17,9 +17,9 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
      * The ASF licenses this file to You under the Apache License, Version 2.0
      * (the "License"); you may not use this file except in compliance with
      * the License.  You may obtain a copy of the License at
-     * 
+     *
      *      http://www.apache.org/licenses/LICENSE-2.0
-     * 
+     *
      * Unless required by applicable law or agreed to in writing, software
      * distributed under the License is distributed on an "AS IS" BASIS,
      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,7 +62,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
             hyphenChar = '-'; // default
         }
 
-        public PatternParser(IPatternConsumer consumer) 
+        public PatternParser(IPatternConsumer consumer)
             : this()
         {
             this.consumer = consumer;
@@ -127,8 +127,8 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <param name="xmlStream">
         /// The stream containing the XML data.
         /// <para/>
-        /// The <see cref="PatternParser"/> scans the first bytes of the stream looking for a byte order mark 
-        /// or other sign of encoding. When encoding is determined, the encoding is used to continue reading 
+        /// The <see cref="PatternParser"/> scans the first bytes of the stream looking for a byte order mark
+        /// or other sign of encoding. When encoding is determined, the encoding is used to continue reading
         /// the stream, and processing continues parsing the input as a stream of (Unicode) characters.
         /// </param>
         /// <exception cref="IOException"> In case of an exception while parsing </exception>
@@ -294,9 +294,8 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
             for (int i = 0; i < ex.Count; i++)
             {
                 object item = ex[i];
-                if (item is string)
+                if (item is string str)
                 {
-                    string str = (string)item;
                     StringBuilder buf = new StringBuilder();
                     for (int j = 0; j < str.Length; j++)
                     {
@@ -335,9 +334,9 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
             for (int i = 0; i < ex.Count; i++)
             {
                 object item = ex[i];
-                if (item is string)
+                if (item is string str)
                 {
-                    res.Append((string)item);
+                    res.Append(str);
                 }
                 else
                 {
@@ -396,9 +395,9 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <summary>
         /// Receive notification of the beginning of an element.
         /// <para/>
-        /// The Parser will invoke this method at the beginning of every element in the XML document; 
-        /// there will be a corresponding <see cref="EndElement"/> event for every <see cref="StartElement"/> event 
-        /// (even when the element is empty). All of the element's content will be reported, 
+        /// The Parser will invoke this method at the beginning of every element in the XML document;
+        /// there will be a corresponding <see cref="EndElement"/> event for every <see cref="StartElement"/> event
+        /// (even when the element is empty). All of the element's content will be reported,
         /// in order, before the corresponding endElement event.
         /// </summary>
         /// <param name="uri">the Namespace URI, or the empty string if the element has no Namespace URI or if Namespace processing is not being performed</param>
@@ -442,8 +441,8 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <summary>
         /// Receive notification of the end of an element.
         /// <para/>
-        /// The parser will invoke this method at the end of every element in the XML document; 
-        /// there will be a corresponding <see cref="StartElement"/> event for every 
+        /// The parser will invoke this method at the end of every element in the XML document;
+        /// there will be a corresponding <see cref="StartElement"/> event for every
         /// <see cref="EndElement"/> event (even when the element is empty).
         /// </summary>
         /// <param name="uri">the Namespace URI, or the empty string if the element has no Namespace URI or if Namespace processing is not being performed</param>
@@ -489,9 +488,9 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// <summary>
         /// Receive notification of character data.
         /// <para/>
-        /// The Parser will call this method to report each chunk of character data. Parsers may 
-        /// return all contiguous character data in a single chunk, or they may split it into 
-        /// several chunks; however, all of the characters in any single event must come from 
+        /// The Parser will call this method to report each chunk of character data. Parsers may
+        /// return all contiguous character data in a single chunk, or they may split it into
+        /// several chunks; however, all of the characters in any single event must come from
         /// the same external entity so that the Locator provides useful information.
         /// <para/>
         /// The application must not attempt to read from the array outside of the specified range.

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -2713,7 +2713,7 @@ namespace Lucene.Net.Analysis.Util
             }
             else
             {
-                if (!(array is object[] objects))
+                if (array is not object[] objects)
                 {
                     throw new ArgumentException(SR.Argument_InvalidArrayType);
                 }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/FilesystemResourceLoader.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/FilesystemResourceLoader.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Analysis.Util
         {
             // LUCENENET NOTE: If you call DirectoryInfo.Create() it doesn't set the DirectoryInfo.Exists
             // flag to true, so we use the Directory object to check the path explicitly.
-            if (!(baseDirectory is null) && !Directory.Exists(baseDirectory.FullName))
+            if (baseDirectory is not null && !Directory.Exists(baseDirectory.FullName))
             {
                 throw new ArgumentException("baseDirectory is not a directory or is null");
             }

--- a/src/Lucene.Net.Analysis.Phonetic/Language/DaitchMokotoffSoundex.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/DaitchMokotoffSoundex.cs
@@ -100,12 +100,12 @@ namespace Lucene.Net.Analysis.Phonetic.Language
                 {
                     return true;
                 }
-                if (!(other is Branch))
+                if (other is not Branch branch)
                 {
                     return false;
                 }
 
-                return ToString().Equals(((Branch)other).ToString(), StringComparison.Ordinal);
+                return ToString().Equals(branch.ToString(), StringComparison.Ordinal);
             }
 
             /// <summary>

--- a/src/Lucene.Net.Benchmark/Support/TagSoup/Parser.cs
+++ b/src/Lucene.Net.Benchmark/Support/TagSoup/Parser.cs
@@ -525,7 +525,7 @@ namespace TagSoup
                 {
                     i = GetInputStream(publicId, systemId);
                 }
-                if (!(i is BufferedStream))
+                if (i is not BufferedStream)
                 {
                     i = new BufferedStream(i);
                 }

--- a/src/Lucene.Net.Codecs/Bloom/BloomFilteringPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Bloom/BloomFilteringPostingsFormat.cs
@@ -233,7 +233,7 @@ namespace Lucene.Net.Codecs.Bloom
 
                 public override TermsEnum GetEnumerator(TermsEnum reuse)
                 {
-                    if (!(reuse is null) && reuse is BloomFilteredTermsEnum bfte && bfte.filter == _filter)
+                    if (reuse is not null && reuse is BloomFilteredTermsEnum bfte && bfte.filter == _filter)
                     {
                         // recycle the existing BloomFilteredTermsEnum by asking the delegate
                         // to recycle its contained TermsEnum

--- a/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
@@ -799,7 +799,7 @@ namespace Lucene.Net.Codecs.Memory
 
             public override TermsEnum GetEnumerator(TermsEnum reuse)
             {
-                if (!(reuse is DirectTermsEnum termsEnum) || !termsEnum.CanReuse(terms))
+                if (reuse is not DirectTermsEnum termsEnum || !termsEnum.CanReuse(terms))
                     termsEnum = new DirectTermsEnum(this);
 
                 termsEnum.Reset();

--- a/src/Lucene.Net.Codecs/Memory/FSTTermOutputs.cs
+++ b/src/Lucene.Net.Codecs/Memory/FSTTermOutputs.cs
@@ -103,10 +103,9 @@ namespace Lucene.Net.Codecs.Memory
                 if (other == this)
                     return true;
 
-                if (!(other is TermData))
+                if (other is not TermData _other)
                     return false;
 
-                var _other = (TermData) other;
                 return StatsEqual(this, _other) && Int64sEqual(this, _other) && BytesEqual(this, _other);
             }
         }

--- a/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
@@ -808,7 +808,7 @@ namespace Lucene.Net.Codecs.Memory
             {
                 DecodeMetaData();
 
-                if (reuse is null || !(reuse is FSTDocsEnum docsEnum) || !docsEnum.CanReuse(field.IndexOptions, field.HasPayloads))
+                if (reuse is null || reuse is not FSTDocsEnum docsEnum || !docsEnum.CanReuse(field.IndexOptions, field.HasPayloads))
                     docsEnum = new FSTDocsEnum(field.IndexOptions, field.HasPayloads);
 
                 return docsEnum.Reset(this.postingsSpare, liveDocs, docFreq);
@@ -823,7 +823,7 @@ namespace Lucene.Net.Codecs.Memory
                     return null;
                 }
                 DecodeMetaData();
-                if (reuse is null || !(reuse is FSTDocsAndPositionsEnum docsAndPositionsEnum) || !docsAndPositionsEnum.CanReuse(field.HasPayloads, hasOffsets))
+                if (reuse is null || reuse is not FSTDocsAndPositionsEnum docsAndPositionsEnum || !docsAndPositionsEnum.CanReuse(field.HasPayloads, hasOffsets))
                     docsAndPositionsEnum = new FSTDocsAndPositionsEnum(field.HasPayloads, hasOffsets);
 
                 //System.out.println("D&P reset this=" + this);

--- a/src/Lucene.Net.Codecs/Pulsing/PulsingPostingsReader.cs
+++ b/src/Lucene.Net.Codecs/Pulsing/PulsingPostingsReader.cs
@@ -253,7 +253,7 @@ namespace Lucene.Net.Codecs.Pulsing
                 return postings.Reset(liveDocs, termState2);
             }
 
-            if (!(reuse is PulsingDocsEnum))
+            if (reuse is not PulsingDocsEnum)
                 return _wrappedPostingsReader.Docs(field, termState2.WrappedTermState, liveDocs, reuse, flags);
 
             var wrapped = _wrappedPostingsReader.Docs(field, termState2.WrappedTermState, liveDocs,
@@ -299,7 +299,7 @@ namespace Lucene.Net.Codecs.Pulsing
                 return postings.Reset(liveDocs, termState2);
             }
 
-            if (!(reuse is PulsingDocsAndPositionsEnum))
+            if (reuse is not PulsingDocsAndPositionsEnum)
                 return _wrappedPostingsReader.DocsAndPositions(field, termState2.WrappedTermState, liveDocs, reuse,
                     flags);
 

--- a/src/Lucene.Net.Codecs/Sep/SepPostingsReader.cs
+++ b/src/Lucene.Net.Codecs/Sep/SepPostingsReader.cs
@@ -245,7 +245,7 @@ namespace Lucene.Net.Codecs.Sep
             // If you are using ParellelReader, and pass in a
             // reused DocsAndPositionsEnum, it could have come
             // from another reader also using sep codec
-            if (reuse is null || !(reuse is SepDocsEnum docsEnum) || docsEnum.startDocIn != docIn)
+            if (reuse is null || reuse is not SepDocsEnum docsEnum || docsEnum.startDocIn != docIn)
                 docsEnum = new SepDocsEnum(this);
 
             return docsEnum.Init(fieldInfo, termState_, liveDocs);
@@ -260,7 +260,7 @@ namespace Lucene.Net.Codecs.Sep
             // If you are using ParellelReader, and pass in a
             // reused DocsAndPositionsEnum, it could have come
             // from another reader also using sep codec
-            if (reuse is null || !(reuse is SepDocsAndPositionsEnum postingsEnum) || postingsEnum.startDocIn != docIn)
+            if (reuse is null || reuse is not SepDocsAndPositionsEnum postingsEnum || postingsEnum.startDocIn != docIn)
                 postingsEnum = new SepDocsAndPositionsEnum(this);
 
             return postingsEnum.Init(fieldInfo, termState_, liveDocs);

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
@@ -208,7 +208,7 @@ namespace Lucene.Net.Codecs.SimpleText
 
             public override DocsEnum Docs(IBits liveDocs, DocsEnum reuse, DocsFlags flags)
             {
-                if (reuse is null || !(reuse is SimpleTextDocsEnum docsEnum) || !docsEnum.CanReuse(outerInstance.input))
+                if (reuse is null || reuse is not SimpleTextDocsEnum docsEnum || !docsEnum.CanReuse(outerInstance.input))
                     docsEnum = new SimpleTextDocsEnum(outerInstance);
 
                 return docsEnum.Reset(docsStart, liveDocs, indexOptions == IndexOptions.DOCS_ONLY, docFreq);
@@ -223,7 +223,7 @@ namespace Lucene.Net.Codecs.SimpleText
                     return null;
                 }
 
-                if (reuse is null || !(reuse is SimpleTextDocsAndPositionsEnum docsAndPositionsEnum) || !docsAndPositionsEnum.CanReuse(outerInstance.input))
+                if (reuse is null || reuse is not SimpleTextDocsAndPositionsEnum docsAndPositionsEnum || !docsAndPositionsEnum.CanReuse(outerInstance.input))
                     docsAndPositionsEnum = new SimpleTextDocsAndPositionsEnum(outerInstance);
 
                 return docsAndPositionsEnum.Reset(docsStart, liveDocs, indexOptions, docFreq);

--- a/src/Lucene.Net.Facet/DrillDownQuery.cs
+++ b/src/Lucene.Net.Facet/DrillDownQuery.cs
@@ -291,12 +291,11 @@ namespace Lucene.Net.Facet
 
         public override bool Equals(object obj)
         {
-            if (!(obj is DrillDownQuery))
+            if (obj is not DrillDownQuery other)
             {
                 return false;
             }
 
-            DrillDownQuery other = (DrillDownQuery)obj;
             return query.Equals(other.query) && base.Equals(other);
         }
 

--- a/src/Lucene.Net.Facet/FacetsCollector.cs
+++ b/src/Lucene.Net.Facet/FacetsCollector.cs
@@ -325,7 +325,7 @@ namespace Lucene.Net.Facet
 
             if (sort != null)
             {
-                if (after != null && !(after is FieldDoc))
+                if (after != null && after is not FieldDoc)
                 {
                     // TODO: if we fix type safety of TopFieldDocs we can
                     // remove this

--- a/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
@@ -349,7 +349,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
         public static bool operator <(CategoryPath left, CategoryPath right)
         {
-            return left is null ? !(right is null) : left.CompareTo(right) < 0;
+            return left is null ? right is not null : left.CompareTo(right) < 0;
         }
 
         public static bool operator <=(CategoryPath left, CategoryPath right)
@@ -359,7 +359,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
         public static bool operator >(CategoryPath left, CategoryPath right)
         {
-            return !(left is null) && left.CompareTo(right) > 0;
+            return left is not null && left.CompareTo(right) > 0;
         }
 
         public static bool operator >=(CategoryPath left, CategoryPath right)

--- a/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/CategoryPath.cs
@@ -217,12 +217,11 @@ namespace Lucene.Net.Facet.Taxonomy
 
         public override bool Equals(object obj)
         {
-            if (!(obj is CategoryPath))
+            if (obj is not CategoryPath other)
             {
                 return false;
             }
 
-            CategoryPath other = (CategoryPath)obj;
             if (Length != other.Length)
             {
                 return false; // not same length, cannot be equal

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -237,7 +237,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             // verify (to some extent) that merge policy in effect would preserve category docids
             if (indexWriter != null)
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(!(indexWriter.Config.MergePolicy is TieredMergePolicy), "for preserving category docids, merging none-adjacent segments is not allowed");
+                if (Debugging.AssertsEnabled) Debugging.Assert(indexWriter.Config.MergePolicy is not TieredMergePolicy, "for preserving category docids, merging none-adjacent segments is not allowed");
             }
 
             // after we opened the writer, and the index is locked, it's safe to check

--- a/src/Lucene.Net.Facet/Taxonomy/FacetLabel.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/FacetLabel.cs
@@ -141,12 +141,11 @@ namespace Lucene.Net.Facet.Taxonomy
 
         public override bool Equals(object obj)
         {
-            if (!(obj is FacetLabel))
+            if (obj is not FacetLabel other)
             {
                 return false;
             }
 
-            FacetLabel other = (FacetLabel)obj;
             if (Length != other.Length)
             {
                 return false; // not same length, cannot be equal

--- a/src/Lucene.Net.Facet/Taxonomy/FacetLabel.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/FacetLabel.cs
@@ -252,7 +252,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
         public static bool operator <(FacetLabel left, FacetLabel right)
         {
-            return left is null ? !(right is null) : left.CompareTo(right) < 0;
+            return left is null ? right is not null : left.CompareTo(right) < 0;
         }
 
         public static bool operator <=(FacetLabel left, FacetLabel right)
@@ -262,7 +262,7 @@ namespace Lucene.Net.Facet.Taxonomy
 
         public static bool operator >(FacetLabel left, FacetLabel right)
         {
-            return !(left is null) && left.CompareTo(right) > 0;
+            return left is not null && left.CompareTo(right) > 0;
         }
 
         public static bool operator >=(FacetLabel left, FacetLabel right)

--- a/src/Lucene.Net.Highlighter/Highlight/WeightedSpanTermExtractor.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/WeightedSpanTermExtractor.cs
@@ -372,7 +372,7 @@ namespace Lucene.Net.Search.Highlight
         {
             if (internalReader is null)
             {
-                if (wrapToCaching && !(tokenStream is CachingTokenFilter))
+                if (wrapToCaching && tokenStream is not CachingTokenFilter)
                 {
                     tokenStream = new CachingTokenFilter(new OffsetLimitTokenFilter(tokenStream, maxDocCharsToAnalyze));
                     cachedTokenStream = true;

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldQuery.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldQuery.cs
@@ -175,10 +175,10 @@ namespace Lucene.Net.Search.VectorHighlight
 
         /// <summary>
         /// Create expandQueries from <paramref name="flatQueries"/>.
-        /// 
+        ///
         /// <code>
         /// expandQueries := flatQueries + overlapped phrase queries
-        /// 
+        ///
         /// ex1) flatQueries={a,b,c}
         ///     => expandQueries={a,b,c}
         /// ex2) flatQueries={a,"b c","c d"}
@@ -200,13 +200,13 @@ namespace Lucene.Net.Search.VectorHighlight
                     i++;
                 }
                 expandQueries.Add(query);
-                if (!(query is PhraseQuery)) continue;
+                if (query is not PhraseQuery pq) continue;
                 using IEnumerator<Query> j = flatQueries.GetEnumerator();
                 while (j.MoveNext())
                 {
                     Query qj = j.Current;
-                    if (!(qj is PhraseQuery)) continue;
-                    CheckOverlap(expandQueries, (PhraseQuery)query, (PhraseQuery)qj);
+                    if (qj is not PhraseQuery pqj) continue;
+                    CheckOverlap(expandQueries, pq, pqj);
                 }
             }
 
@@ -228,7 +228,7 @@ namespace Lucene.Net.Search.VectorHighlight
 
         /// <summary>
         /// Check if <see cref="PhraseQuery"/> A and B have overlapped part.
-        /// 
+        ///
         /// <code>
         /// ex1) A="a b", B="b c" => overlap; expandQueries={"a b c"}
         /// ex2) A="b c", B="a b" => overlap; expandQueries={"a b c"}
@@ -247,7 +247,7 @@ namespace Lucene.Net.Search.VectorHighlight
 
         /// <summary>
         /// Check if src and dest have overlapped part and if it is, create <see cref="PhraseQuery"/>s and add <paramref name="expandQueries"/>.
-        /// 
+        ///
         /// <code>
         /// ex1) src="a b", dest="c d"       => no overlap
         /// ex2) src="a b", dest="a b c"     => no overlap
@@ -328,7 +328,7 @@ namespace Lucene.Net.Search.VectorHighlight
 
         /// <summary>
         /// Save the set of terms in the queries to <see cref="termSetMap"/>.
-        /// 
+        ///
         /// <code>
         /// ex1) q=name:john
         ///      - fieldMatch==true

--- a/src/Lucene.Net.Join/Support/ToChildBlockJoinQuery.cs
+++ b/src/Lucene.Net.Join/Support/ToChildBlockJoinQuery.cs
@@ -135,12 +135,12 @@ namespace Lucene.Net.Join
                     // No matches
                     return null;
                 }
-                if (!(parents is FixedBitSet))
+                if (parents is not FixedBitSet fixedBitSet)
                 {
                     throw IllegalStateException.Create("parentFilter must return FixedBitSet; got " + parents);
                 }
 
-                return new ToChildBlockJoinScorer(this, parentScorer, (FixedBitSet)parents, _doScores, acceptDocs);
+                return new ToChildBlockJoinScorer(this, parentScorer, fixedBitSet, _doScores, acceptDocs);
             }
 
             public override Explanation Explain(AtomicReaderContext reader, int doc)

--- a/src/Lucene.Net.Join/Support/ToParentBlockJoinQuery.cs
+++ b/src/Lucene.Net.Join/Support/ToParentBlockJoinQuery.cs
@@ -29,44 +29,44 @@ namespace Lucene.Net.Join
     /// <summary>
     /// This query requires that you index
     /// children and parent docs as a single block, using the
-    /// <see cref="IndexWriter.AddDocuments(IEnumerable{IEnumerable{IIndexableField}}, Analysis.Analyzer)"/> 
+    /// <see cref="IndexWriter.AddDocuments(IEnumerable{IEnumerable{IIndexableField}}, Analysis.Analyzer)"/>
     /// or <see cref="IndexWriter.UpdateDocuments(Term, IEnumerable{IEnumerable{IIndexableField}}, Analysis.Analyzer)"/>
     /// API.  In each block, the
     /// child documents must appear first, ending with the parent
     /// document.  At search time you provide a <see cref="Filter"/>
     /// identifying the parents, however this <see cref="Filter"/> must provide
     /// an <see cref="FixedBitSet"/> per sub-reader.
-    /// 
+    ///
     /// <para>Once the block index is built, use this query to wrap
     /// any sub-query matching only child docs and join matches in that
     /// child document space up to the parent document space.
     /// You can then use this <see cref="Query"/> as a clause with
     /// other queries in the parent document space.</para>
-    /// 
+    ///
     /// <para>See <see cref="ToChildBlockJoinQuery"/> if you need to join
     /// in the reverse order.</para>
-    /// 
+    ///
     /// <para>The child documents must be orthogonal to the parent
     /// documents: the wrapped child query must never
     /// return a parent document.</para>
-    /// 
+    ///
     /// <para>If you'd like to retrieve <see cref="Lucene.Net.Search.Grouping.ITopGroups{T}"/> for the
     /// resulting query, use the <see cref="ToParentBlockJoinCollector"/>.
     /// Note that this is not necessary, ie, if you simply want
     /// to collect the parent documents and don't need to see
     /// which child documents matched under that parent, then
     /// you can use any collector.</para>
-    /// 
+    ///
     /// <para><b>NOTE</b>: If the overall query contains parent-only
     /// matches, for example you OR a parent-only query with a
     /// joined child-only query, then the resulting collected documents
     /// will be correct, however the <see cref="Lucene.Net.Search.Grouping.ITopGroups{T}"/> you get
     /// from <see cref="ToParentBlockJoinCollector"/> will not contain every
     /// child for parents that had matched.</para>
-    /// 
+    ///
     /// <para>See <a href="http://lucene.apache.org/core/4_8_0/join/">http://lucene.apache.org/core/4_8_0/join/</a> for an
     /// overview. </para>
-    /// 
+    ///
     /// @lucene.experimental
     /// </summary>
     [Obsolete("Use Lucene.Net.Search.Join.ToParentBlockJoinQuery instead. This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -174,12 +174,12 @@ namespace Lucene.Net.Join
                     // No matches
                     return null;
                 }
-                if (!(parents is FixedBitSet))
+                if (parents is not FixedBitSet fixedBitSet)
                 {
                     throw IllegalStateException.Create("parentFilter must return FixedBitSet; got " + parents);
                 }
 
-                return new BlockJoinScorer(this, childScorer, (FixedBitSet)parents, firstChildDoc, scoreMode, acceptDocs);
+                return new BlockJoinScorer(this, childScorer, fixedBitSet, firstChildDoc, scoreMode, acceptDocs);
             }
 
             public override Explanation Explain(AtomicReaderContext context, int doc)

--- a/src/Lucene.Net.Join/ToChildBlockJoinQuery.cs
+++ b/src/Lucene.Net.Join/ToChildBlockJoinQuery.cs
@@ -133,12 +133,12 @@ namespace Lucene.Net.Search.Join
                     // No matches
                     return null;
                 }
-                if (!(parents is FixedBitSet))
+                if (parents is not FixedBitSet fixedBitSet)
                 {
                     throw IllegalStateException.Create("parentFilter must return FixedBitSet; got " + parents);
                 }
 
-                return new ToChildBlockJoinScorer(this, parentScorer, (FixedBitSet)parents, _doScores, acceptDocs);
+                return new ToChildBlockJoinScorer(this, parentScorer, fixedBitSet, _doScores, acceptDocs);
             }
 
             public override Explanation Explain(AtomicReaderContext reader, int doc)

--- a/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
@@ -322,7 +322,7 @@ namespace Lucene.Net.Index.Memory
 
                 public override DocsEnum Docs(IBits liveDocs, DocsEnum reuse, DocsFlags flags)
                 {
-                    if (reuse is null || !(reuse is MemoryDocsEnum toReuse))
+                    if (reuse is null || reuse is not MemoryDocsEnum toReuse)
                         toReuse = new MemoryDocsEnum();
 
                     return toReuse.Reset(liveDocs, info.sliceArray.freq[info.sortedTerms[termUpto]]);
@@ -330,7 +330,7 @@ namespace Lucene.Net.Index.Memory
 
                 public override DocsAndPositionsEnum DocsAndPositions(IBits liveDocs, DocsAndPositionsEnum reuse, DocsAndPositionsFlags flags)
                 {
-                    if (reuse is null || !(reuse is MemoryDocsAndPositionsEnum toReuse))
+                    if (reuse is null || reuse is not MemoryDocsAndPositionsEnum toReuse)
                         toReuse = new MemoryDocsAndPositionsEnum(outerInstance);
 
                     int ord = info.sortedTerms[termUpto];

--- a/src/Lucene.Net.Misc/Index/Sorter/BlockJoinComparatorSource.cs
+++ b/src/Lucene.Net.Misc/Index/Sorter/BlockJoinComparatorSource.cs
@@ -176,11 +176,11 @@ namespace Lucene.Net.Index.Sorter
                 {
                     throw IllegalStateException.Create("AtomicReader " + context.AtomicReader + " contains no parents!");
                 }
-                if (!(parents is FixedBitSet))
+                if (parents is not FixedBitSet fixedBitSet)
                 {
                     throw IllegalStateException.Create("parentFilter must return FixedBitSet; got " + parents);
                 }
-                parentBits = (FixedBitSet)parents;
+                parentBits = fixedBitSet;
                 for (int i = 0; i < parentComparers.Length; i++)
                 {
                     parentComparers[i] = parentComparers[i].SetNextReader(context);

--- a/src/Lucene.Net.Misc/Index/Sorter/SortingAtomicReader.cs
+++ b/src/Lucene.Net.Misc/Index/Sorter/SortingAtomicReader.cs
@@ -463,11 +463,11 @@ namespace Lucene.Net.Index.Sorter
             // for testing
             internal virtual bool Reused(DocsEnum other)
             {
-                if (other is null || !(other is SortingDocsEnum))
+                if (other is not SortingDocsEnum sortingDocsEnum)
                 {
                     return false;
                 }
-                return docs == ((SortingDocsEnum)other).docs;
+                return docs == sortingDocsEnum.docs;
             }
 
             public override int Advance(int target)
@@ -635,11 +635,11 @@ namespace Lucene.Net.Index.Sorter
             // for testing
             internal virtual bool Reused(DocsAndPositionsEnum other)
             {
-                if (other is null || !(other is SortingDocsAndPositionsEnum))
+                if (other is not SortingDocsAndPositionsEnum sortingEnum)
                 {
                     return false;
                 }
-                return docs == ((SortingDocsAndPositionsEnum)other).docs;
+                return docs == sortingEnum.docs;
             }
 
             private void AddPositions(DocsAndPositionsEnum @in, IndexOutput @out)

--- a/src/Lucene.Net.Misc/Util/Fst/ListOfOutputs.cs
+++ b/src/Lucene.Net.Misc/Util/Fst/ListOfOutputs.cs
@@ -88,8 +88,8 @@ namespace Lucene.Net.Util.Fst
 
         public override object Add(object prefix, object output)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(!(prefix is IList));
-            if (!(output is IList outputList))
+            if (Debugging.AssertsEnabled) Debugging.Assert(prefix is not IList);
+            if (output is not IList outputList)
             {
                 return outputs.Add((T)prefix, (T)output);
             }
@@ -106,13 +106,13 @@ namespace Lucene.Net.Util.Fst
 
         public override void Write(object output, DataOutput @out)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(!(output is IList));
+            if (Debugging.AssertsEnabled) Debugging.Assert(output is not IList);
             outputs.Write((T)output, @out);
         }
 
         public override void WriteFinalOutput(object output, DataOutput @out)
         {
-            if (!(output is IList outputList))
+            if (output is not IList outputList)
             {
                 @out.WriteVInt32(1);
                 outputs.Write((T)output, @out);
@@ -154,7 +154,7 @@ namespace Lucene.Net.Util.Fst
 
         public override string OutputToString(object output)
         {
-            if (!(output is IList outputList))
+            if (output is not IList outputList)
             {
                 return outputs.OutputToString((T)output);
             }
@@ -180,7 +180,7 @@ namespace Lucene.Net.Util.Fst
         public override object Merge(object first, object second)
         {
             IList<T> outputList = new JCG.List<T>();
-            if (!(first is IList firstList))
+            if (first is not IList firstList)
             {
                 outputList.Add((T)first);
             }
@@ -191,7 +191,7 @@ namespace Lucene.Net.Util.Fst
                     outputList.Add((T)value);
                 }
             }
-            if (!(second is IList secondList))
+            if (second is not IList secondList)
             {
                 outputList.Add((T)second);
             }
@@ -214,7 +214,7 @@ namespace Lucene.Net.Util.Fst
 
         public IList<T> AsList(object output)
         {
-            if (!(output is IList<T> outputList))
+            if (output is not IList<T> outputList)
             {
                 return new JCG.List<T>(1) { (T)output };
             }

--- a/src/Lucene.Net.Queries/FilterClause.cs
+++ b/src/Lucene.Net.Queries/FilterClause.cs
@@ -58,7 +58,7 @@ namespace Lucene.Net.Queries
                 return true;
             }
 
-            if (!(o is FilterClause other))
+            if (o is not FilterClause other)
             {
                 return false;
             }

--- a/src/Lucene.Net.Queries/Function/FunctionQuery.cs
+++ b/src/Lucene.Net.Queries/Function/FunctionQuery.cs
@@ -202,7 +202,7 @@ namespace Lucene.Net.Queries.Function
         public override bool Equals(object o)
         {
             if (o is null) return false;
-            if (!(o is FunctionQuery other)) return false;
+            if (o is not FunctionQuery other) return false;
             return Boost == other.Boost
                 && func.Equals(other.func);
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/ByteFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ByteFieldSource.cs
@@ -131,7 +131,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
         public override bool Equals(object o)
         {
             if (o is null) return false;
-            if (!(o is ByteFieldSource other)) return false;
+            if (o is not ByteFieldSource other) return false;
             return base.Equals(other) && (this.parser is null ? other.parser is null : this.parser.GetType() == other.parser.GetType());
         }
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/ConstValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ConstValueSource.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is ConstValueSource other))
+            if (o is not ConstValueSource other)
             {
                 return false;
             }

--- a/src/Lucene.Net.Queries/Function/ValueSources/DoubleConstValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DoubleConstValueSource.cs
@@ -112,7 +112,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is DoubleConstValueSource other))
+            if (o is not DoubleConstValueSource other)
             {
                 return false;
             }

--- a/src/Lucene.Net.Queries/Function/ValueSources/DoubleFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DoubleFieldSource.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is DoubleFieldSource other))
+            if (o is not DoubleFieldSource other)
             {
                 return false;
             }

--- a/src/Lucene.Net.Queries/Function/ValueSources/DualFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/DualFloatFunction.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is DualSingleFunction other))
+            if (o is not DualSingleFunction other)
             {
                 return false;
             }

--- a/src/Lucene.Net.Queries/Function/ValueSources/FieldCacheSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/FieldCacheSource.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
         public override bool Equals(object o)
         {
             if (o is null) return false;
-            if (!(o is FieldCacheSource other)) return false;
+            if (o is not FieldCacheSource other) return false;
             return m_field.Equals(other.m_field, StringComparison.Ordinal) && m_cache == other.m_cache;
         }
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/FloatFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/FloatFieldSource.cs
@@ -100,7 +100,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is SingleFieldSource other))
+            if (o is not SingleFieldSource other)
                 return false;
             return base.Equals(other) && (this.m_parser is null ? other.m_parser is null : this.m_parser.GetType() == other.m_parser.GetType());
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/IfFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/IfFunction.cs
@@ -160,7 +160,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is IfFunction other))
+            if (o is not IfFunction other)
                 return false;
             return ifSource.Equals(other.ifSource) && trueSource.Equals(other.trueSource) && falseSource.Equals(other.falseSource);
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/IntFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/IntFieldSource.cs
@@ -140,7 +140,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is Int32FieldSource other))
+            if (o is not Int32FieldSource other)
                 return false;
             return base.Equals(other) && (this.parser is null ? other.parser is null : this.parser.GetType() == other.parser.GetType());
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/JoinDocFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/JoinDocFreqValueSource.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is JoinDocFreqValueSource other))
+            if (o is not JoinDocFreqValueSource other)
                 return false;
             if (!m_qfield.Equals(other.m_qfield, StringComparison.Ordinal))
             {

--- a/src/Lucene.Net.Queries/Function/ValueSources/LinearFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LinearFloatFunction.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is LinearSingleFunction other))
+            if (o is not LinearSingleFunction other)
                 return false;
             return this.m_slope == other.m_slope && this.m_intercept == other.m_intercept && this.m_source.Equals(other.m_source);
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/LiteralValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LiteralValueSource.cs
@@ -86,7 +86,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             {
                 return true;
             }
-            if (!(o is LiteralValueSource that))
+            if (o is not LiteralValueSource that)
                 return false;
             return m_str.Equals(that.m_str, StringComparison.Ordinal);
 

--- a/src/Lucene.Net.Queries/Function/ValueSources/LongFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/LongFieldSource.cs
@@ -160,7 +160,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             {
                 return false;
             }
-            if (!(o is Int64FieldSource other))
+            if (o is not Int64FieldSource other)
                 return false;
             return base.Equals(other) && (this.m_parser is null ? other.m_parser is null : this.m_parser.GetType() == other.m_parser.GetType());
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/MultiBoolFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/MultiBoolFunction.cs
@@ -129,7 +129,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             {
                 return false;
             }
-            if (!(o is MultiBoolFunction other))
+            if (o is not MultiBoolFunction other)
                 return false;
 
             // LUCENENET specific: use structural equality comparison

--- a/src/Lucene.Net.Queries/Function/ValueSources/MultiFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/MultiFloatFunction.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             {
                 return false;
             }
-            if (!(o is MultiSingleFunction other))
+            if (o is not MultiSingleFunction other)
                 return false;
             return Name.Equals(other.Name, StringComparison.Ordinal) && Arrays.Equals(this.m_sources, other.m_sources);
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/QueryValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/QueryValueSource.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is QueryValueSource other))
+            if (o is not QueryValueSource other)
                 return false;
             return this.q.Equals(other.q) && this.defVal == other.defVal;
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/RangeMapFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/RangeMapFloatFunction.cs
@@ -128,7 +128,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is RangeMapSingleFunction other))
+            if (o is not RangeMapSingleFunction other)
                 return false;
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
             return J2N.BitConversion.SingleToInt32Bits(this.m_min) == J2N.BitConversion.SingleToInt32Bits(other.m_min)

--- a/src/Lucene.Net.Queries/Function/ValueSources/ReciprocalFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ReciprocalFloatFunction.cs
@@ -119,7 +119,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is ReciprocalSingleFunction other))
+            if (o is not ReciprocalSingleFunction other)
                 return false;
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
             return J2N.BitConversion.SingleToInt32Bits(this.m_m) == J2N.BitConversion.SingleToInt32Bits(other.m_m)

--- a/src/Lucene.Net.Queries/Function/ValueSources/ReverseOrdFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ReverseOrdFieldSource.cs
@@ -98,7 +98,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is ReverseOrdFieldSource other))
+            if (o is not ReverseOrdFieldSource other)
                 return false;
             return this.field.Equals(other.field, StringComparison.Ordinal);
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/ScaleFloatFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ScaleFloatFunction.cs
@@ -179,7 +179,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is ScaleSingleFunction other))
+            if (o is not ScaleSingleFunction other)
                 return false;
             return J2N.BitConversion.SingleToInt32Bits(this.m_min) == J2N.BitConversion.SingleToInt32Bits(other.m_min)
                 && J2N.BitConversion.SingleToInt32Bits(this.m_max) == J2N.BitConversion.SingleToInt32Bits(other.m_max)

--- a/src/Lucene.Net.Queries/Function/ValueSources/ShortFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ShortFieldSource.cs
@@ -124,7 +124,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is Int16FieldSource other))
+            if (o is not Int16FieldSource other)
                 return false;
             return base.Equals(other)
                 && (parser is null ? other.parser is null :

--- a/src/Lucene.Net.Queries/Function/ValueSources/SimpleBoolFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/SimpleBoolFunction.cs
@@ -87,7 +87,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is SimpleBoolFunction other))
+            if (o is not SimpleBoolFunction other)
                 return false;
             return this.m_source.Equals(other.m_source);
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/SingleFunction.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/SingleFunction.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is SingularFunction other))
+            if (o is not SingularFunction other)
                 return false;
             return Name.Equals(other.Name, StringComparison.Ordinal)
                 && m_source.Equals(other.m_source);

--- a/src/Lucene.Net.Queries/Function/ValueSources/SumTotalTermFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/SumTotalTermFreqValueSource.cs
@@ -111,7 +111,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is SumTotalTermFreqValueSource other))
+            if (o is not SumTotalTermFreqValueSource other)
                 return false;
             return this.m_indexedField.Equals(other.m_indexedField, StringComparison.Ordinal);
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/TotalTermFreqValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/TotalTermFreqValueSource.cs
@@ -108,7 +108,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
 
         public override bool Equals(object o)
         {
-            if (!(o is TotalTermFreqValueSource other))
+            if (o is not TotalTermFreqValueSource other)
                 return false;
             return this.m_indexedField.Equals(other.m_indexedField, StringComparison.Ordinal) && this.m_indexedBytes.Equals(other.m_indexedBytes);
         }

--- a/src/Lucene.Net.Queries/Function/ValueSources/VectorValueSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/VectorValueSource.cs
@@ -273,7 +273,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
             if (this == o)
                 return true;
 
-            if (!(o is VectorValueSource that))
+            if (o is not VectorValueSource that)
                 return false;
 
             // LUCENENET specific: use structural equality comparison

--- a/src/Lucene.Net.QueryParser/Classic/MultiFieldQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/Classic/MultiFieldQueryParser.cs
@@ -284,7 +284,7 @@ namespace Lucene.Net.QueryParsers.Classic
             {
                 QueryParser qp = new QueryParser(matchVersion, fields[i], analyzer);
                 Query q = qp.Parse(queries[i]);
-                if (q != null && (!(q is BooleanQuery booleanQuery) || booleanQuery.Clauses.Count > 0))
+                if (q != null && (q is not BooleanQuery booleanQuery || booleanQuery.Clauses.Count > 0))
                 {
                     bQuery.Add(q, Occur.SHOULD);
                 }
@@ -340,7 +340,7 @@ namespace Lucene.Net.QueryParsers.Classic
             {
                 QueryParser qp = new QueryParser(matchVersion, fields[i], analyzer);
                 Query q = qp.Parse(query);
-                if (q != null && (!(q is BooleanQuery booleanQuery) || booleanQuery.Clauses.Count > 0))
+                if (q != null && (q is not BooleanQuery booleanQuery || booleanQuery.Clauses.Count > 0))
                 {
                     bQuery.Add(q, flags[i]);
                 }
@@ -394,7 +394,7 @@ namespace Lucene.Net.QueryParsers.Classic
             {
                 QueryParser qp = new QueryParser(matchVersion, fields[i], analyzer);
                 Query q = qp.Parse(queries[i]);
-                if (q != null && (!(q is BooleanQuery booleanQuery) || booleanQuery.Clauses.Count > 0))
+                if (q != null && (q is not BooleanQuery booleanQuery || booleanQuery.Clauses.Count > 0))
                 {
                     bQuery.Add(q, flags[i]);
                 }

--- a/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
@@ -264,14 +264,14 @@ namespace Lucene.Net.QueryParsers.ComplexPhrase
                 // clauses can be complex
                 // Booleans e.g. nots and ors etc
                 int numNegatives = 0;
-                if (!(contents is BooleanQuery))
+                if (contents is not BooleanQuery bq)
                 {
                     throw new ArgumentException("Unknown query type \""
                         + contents.GetType().Name
                         + "\" found in phrase query string \"" + phrasedQueryStringContents
                         + "\"");
                 }
-                BooleanQuery bq = (BooleanQuery)contents;
+
                 BooleanClause[] bclauses = bq.GetClauses();
                 SpanQuery[] allSpanClauses = new SpanQuery[bclauses.Length];
                 // For all clauses e.g. one* two~

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Builders/QueryTreeBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Builders/QueryTreeBuilder.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Builders
             {
                 IQueryBuilder<TQuery> builder = GetBuilder(node);
 
-                if (!(builder is QueryTreeBuilder<TQuery>))
+                if (builder is not QueryTreeBuilder<TQuery>)
                 {
                     IList<IQueryNode> children = node.GetChildren();
 

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Processors/NoChildOptimizationQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Processors/NoChildOptimizationQueryNodeProcessor.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Processors
                 {
                     foreach (IQueryNode child in children)
                     {
-                        if (!(child is DeletedQueryNode))
+                        if (child is not DeletedQueryNode)
                         {
                             return node;
                         }

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Processors/RemoveDeletedQueryNodesProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Processors/RemoveDeletedQueryNodesProcessor.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Processors
             queryTree = base.Process(queryTree);
 
             if (queryTree is DeletedQueryNode
-                && !(queryTree is MatchNoDocsQueryNode))
+                && queryTree is not MatchNoDocsQueryNode)
             {
                 return new MatchNoDocsQueryNode();
             }
@@ -63,7 +63,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Processors
                     foreach (var child in children)
                     {
 
-                        if (!(child is DeletedQueryNode))
+                        if (child is not DeletedQueryNode)
                         {
                             removeBoolean = false;
                             break;

--- a/src/Lucene.Net.QueryParser/Flexible/Precedence/Processors/BooleanModifiersQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Precedence/Processors/BooleanModifiersQueryNodeProcessor.cs
@@ -77,7 +77,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence.Processors
                 node.Set(this.childrenBuffer);
             }
             else if (this.usingAnd && node is BooleanQueryNode
-                && !(node is OrQueryNode))
+                && node is not OrQueryNode)
             {
                 this.childrenBuffer.Clear();
                 IList<IQueryNode> children = node.GetChildren();
@@ -96,7 +96,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Precedence.Processors
         private static IQueryNode ApplyModifier(IQueryNode node, Modifier mod) // LUCENENET: CA1822: Mark members as static
         {
             // check if modifier is not already defined and is default
-            if (!(node is ModifierQueryNode modNode))
+            if (node is not ModifierQueryNode modNode)
             {
                 return new ModifierQueryNode(node, mod);
             }

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Builders/MatchAllDocsQueryNodeBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Builders/MatchAllDocsQueryNodeBuilder.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Builders
         public virtual Query Build(IQueryNode queryNode)
         {
             // validates node
-            if (!(queryNode is MatchAllDocsQueryNode))
+            if (queryNode is not MatchAllDocsQueryNode)
             {
                 // LUCENENET: Factored out NLS/Message/IMessage so end users can optionally utilize the built-in .NET localization.
                 throw new QueryNodeException(string.Format(

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Builders/MatchNoDocsQueryNodeBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Builders/MatchNoDocsQueryNodeBuilder.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Builders
         public virtual Query Build(IQueryNode queryNode)
         {
             // validates node
-            if (!(queryNode is MatchNoDocsQueryNode))
+            if (queryNode is not MatchNoDocsQueryNode)
             {
                 // LUCENENET: Factored out NLS/Message/IMessage so end users can optionally utilize the built-in .NET localization.
                 throw new QueryNodeException(string.Format(

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/AnalyzerQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/AnalyzerQueryNodeProcessor.cs
@@ -98,10 +98,10 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
         protected override IQueryNode PostProcessNode(IQueryNode node)
         {
             if (node is ITextableQueryNode
-                && !(node is WildcardQueryNode)
-                && !(node is FuzzyQueryNode)
-                && !(node is RegexpQueryNode)
-                && !(node.Parent is IRangeQueryNode))
+                && node is not WildcardQueryNode
+                && node is not FuzzyQueryNode
+                && node is not RegexpQueryNode
+                && node.Parent is not IRangeQueryNode)
             {
                 FieldQueryNode fieldNode = ((FieldQueryNode)node);
                 string text = fieldNode.GetTextAsString();
@@ -190,9 +190,9 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
 
                     return fieldNode;
                 }
-                else if (severalTokensAtSamePosition || !(node is QuotedFieldQueryNode))
+                else if (severalTokensAtSamePosition || node is not QuotedFieldQueryNode)
                 {
-                    if (positionCount == 1 || !(node is QuotedFieldQueryNode))
+                    if (positionCount == 1 || node is not QuotedFieldQueryNode)
                     {
                         // no phrase query:
 
@@ -241,7 +241,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                                 }
                                 if (posIncrAtt != null && posIncrAtt.PositionIncrement == 0)
                                 {
-                                    if (!(currentQuery is BooleanQueryNode))
+                                    if (currentQuery is not BooleanQueryNode)
                                     {
                                         IQueryNode t = currentQuery;
                                         currentQuery = new StandardBooleanQueryNode(Collections.EmptyList<IQueryNode>(), true);

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/BooleanQuery2ModifierNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/BooleanQuery2ModifierNodeProcessor.cs
@@ -170,7 +170,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
         private static IQueryNode ApplyModifier(IQueryNode node, Modifier mod) // LUCENENET: CA1822: Mark members as static
         {
             // check if modifier is not already defined and is default
-            if (!(node is ModifierQueryNode modNode))
+            if (node is not ModifierQueryNode modNode)
             {
                 return new BooleanModifierNode(node, mod);
             }

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/BoostQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/BoostQueryNodeProcessor.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
         protected override IQueryNode PostProcessNode(IQueryNode node)
         {
             if (node is IFieldableNode fieldNode &&
-                (node.Parent is null || !(node.Parent is IFieldableNode)))
+                (node.Parent is null || node.Parent is not IFieldableNode))
             {
                 QueryConfigHandler config = GetQueryConfigHandler();
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/GroupQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/GroupQueryNodeProcessor.cs
@@ -193,7 +193,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                     this.latestNodeVerified = true;
                 }
             }
-            else if (!(node is BooleanQueryNode))
+            else if (node is not BooleanQueryNode)
             {
                 this.queryNodeList.Add(ApplyModifier(node, node.Parent));
                 this.latestNodeVerified = false;

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/NumericQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/NumericQueryNodeProcessor.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
         protected override IQueryNode PostProcessNode(IQueryNode node)
         {
             if (node is FieldQueryNode fieldNode
-                && !(node.Parent is IRangeQueryNode))
+                && node.Parent is not IRangeQueryNode)
             {
                 QueryConfigHandler config = GetQueryConfigHandler();
 

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/OpenRangeQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/OpenRangeQueryNodeProcessor.cs
@@ -44,13 +44,13 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
                 ICharSequence upperText = upperNode.Text;
 
                 if (OPEN_RANGE_TOKEN.Equals(upperNode.GetTextAsString(), StringComparison.Ordinal)
-                    && (!(upperText is UnescapedCharSequence unescapedUpperText) || !unescapedUpperText.WasEscaped(0)))
+                    && (upperText is not UnescapedCharSequence unescapedUpperText || !unescapedUpperText.WasEscaped(0)))
                 {
                     upperText = "".AsCharSequence();
                 }
 
                 if (OPEN_RANGE_TOKEN.Equals(lowerNode.GetTextAsString(), StringComparison.Ordinal)
-                    && (!(lowerText is UnescapedCharSequence unescapedLowerText) || !unescapedLowerText.WasEscaped(0)))
+                    && (lowerText is not UnescapedCharSequence unescapedLowerText || !unescapedLowerText.WasEscaped(0)))
                 {
                     lowerText = "".AsCharSequence();
                 }

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/PhraseSlopQueryNodeProcessor.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Processors/PhraseSlopQueryNodeProcessor.cs
@@ -39,8 +39,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Processors
         {
             if (node is SlopQueryNode phraseSlopNode)
             {
-                if (!(phraseSlopNode.GetChild() is TokenizedPhraseQueryNode)
-                    && !(phraseSlopNode.GetChild() is MultiPhraseQueryNode))
+                if (phraseSlopNode.GetChild() is not TokenizedPhraseQueryNode
+                    && phraseSlopNode.GetChild() is not MultiPhraseQueryNode)
                 {
                     return phraseSlopNode.GetChild();
                 }

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/QueryParserUtil.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/QueryParserUtil.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                 Query q = qp.Parse(queries[i], fields[i]);
 
                 if (q != null && // q never null, just being defensive
-                    (!(q is BooleanQuery booleanQuery) || booleanQuery.Clauses.Count > 0))
+                    (q is not BooleanQuery booleanQuery || booleanQuery.Clauses.Count > 0))
                 {
                     bQuery.Add(q, Occur.SHOULD);
                 }
@@ -126,7 +126,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                 Query q = qp.Parse(query, fields[i]);
 
                 if (q != null && // q never null, just being defensive
-                    (!(q is BooleanQuery booleanQuery) || booleanQuery.Clauses.Count > 0))
+                    (q is not BooleanQuery booleanQuery || booleanQuery.Clauses.Count > 0))
                 {
                     bQuery.Add(q, flags[i]);
                 }
@@ -187,7 +187,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
                 Query q = qp.Parse(queries[i], fields[i]);
 
                 if (q != null && // q never null, just being defensive
-                    (!(q is BooleanQuery booleanQuery) || booleanQuery.Clauses.Count > 0))
+                    (q is not BooleanQuery booleanQuery || booleanQuery.Clauses.Count > 0))
                 {
                     bQuery.Add(q, flags[i]);
                 }

--- a/src/Lucene.Net.QueryParser/Surround/Query/BasicQueryFactory.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/BasicQueryFactory.cs
@@ -107,9 +107,9 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         /// </summary>
         public override bool Equals(object obj)
         {
-            if (obj is not BasicQueryFactory bqf)
+            if (obj is not BasicQueryFactory other)
                 return false;
-            return AtMax == bqf.AtMax;
+            return AtMax == other.AtMax;
         }
     }
 }

--- a/src/Lucene.Net.QueryParser/Surround/Query/BasicQueryFactory.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/BasicQueryFactory.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.QueryParsers.Surround.Query
      // The basic queries are TermQuery and SpanTermQuery.
      // An exception can be thrown when too many of these are used.
      // SpanTermQuery and TermQuery use IndexReader.termEnum(Term), which causes the buffer usage.
-     
+
      // Use this class to limit the buffer usage for reading terms from an index.
      // Default is 1024, the same as the max. number of subqueries for a BooleanQuery.
 
@@ -107,10 +107,9 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         /// </summary>
         public override bool Equals(object obj)
         {
-            if (!(obj is BasicQueryFactory))
+            if (obj is not BasicQueryFactory bqf)
                 return false;
-            BasicQueryFactory other = (BasicQueryFactory)obj;
-            return AtMax == other.AtMax;
+            return AtMax == bqf.AtMax;
         }
     }
 }

--- a/src/Lucene.Net.QueryParser/Surround/Query/SpanNearClauseFactory.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Query/SpanNearClauseFactory.cs
@@ -105,9 +105,9 @@ namespace Lucene.Net.QueryParsers.Surround.Query
         {
             if (q == SrndQuery.TheEmptyLcnQuery)
                 return;
-            if (!(q is SpanQuery))
+            if (q is not SpanQuery sq)
                 throw AssertionError.Create("Expected SpanQuery: " + q.ToString(FieldName));
-            AddSpanQueryWeighted((SpanQuery)q, q.Boost);
+            AddSpanQueryWeighted(sq, sq.Boost);
         }
 
         public virtual SpanQuery MakeSpanClause()

--- a/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
+++ b/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
@@ -127,7 +127,7 @@ namespace Lucene.Net.Replicator
             if (other is null)
                 throw new ArgumentNullException(nameof(other));
 
-            if (!(other is IndexAndTaxonomyRevision itr))
+            if (other is not IndexAndTaxonomyRevision itr)
                 throw new ArgumentException($"Cannot compare IndexAndTaxonomyRevision to a {other.GetType()}", nameof(other));
 
             int cmp = indexCommit.CompareTo(itr.indexCommit);

--- a/src/Lucene.Net.Spatial/Prefix/AbstractVisitingPrefixTreeFilter.cs
+++ b/src/Lucene.Net.Spatial/Prefix/AbstractVisitingPrefixTreeFilter.cs
@@ -331,7 +331,7 @@ namespace Lucene.Net.Spatial.Prefix
         {
             // LUCENENET specific - on the first loop, we need to check for null,
             // but on each subsequent loop, we can use the result of MoveNext()
-            if (!(thisTerm is null) && StringHelper.StartsWith(thisTerm, curVNodeTerm)) //TODO refactor to use method on curVNode.cell
+            if (thisTerm is not null && StringHelper.StartsWith(thisTerm, curVNodeTerm)) //TODO refactor to use method on curVNode.cell
             {
                 // LUCENENET specific - added guard clause for m_termsEnum
                 if (m_termsEnum is null)

--- a/src/Lucene.Net.Spatial/Prefix/Tree/Cell.cs
+++ b/src/Lucene.Net.Spatial/Prefix/Tree/Cell.cs
@@ -321,7 +321,7 @@ namespace Lucene.Net.Spatial.Prefix.Tree
 
         public override bool Equals(object? obj)
         {
-            return !(obj is null || !(obj is Cell cell)) &&
+            return !(obj is null || obj is not Cell cell) &&
                 TokenString.Equals(cell.TokenString, StringComparison.Ordinal);
         }
 

--- a/src/Lucene.Net.Spatial/Util/CachingDoubleValueSource.cs
+++ b/src/Lucene.Net.Spatial/Util/CachingDoubleValueSource.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Spatial.Util
         public override bool Equals(object? o)
         {
             if (this == o) return true;
-            if (o is null || !(o is CachingDoubleValueSource that)) return false;
+            if (o is null || o is not CachingDoubleValueSource that) return false;
             if (m_source != null ? !m_source.Equals(that.m_source) : that.m_source != null) return false;
 
             return true;

--- a/src/Lucene.Net.Spatial/Util/ShapeFieldCacheDistanceValueSource.cs
+++ b/src/Lucene.Net.Spatial/Util/ShapeFieldCacheDistanceValueSource.cs
@@ -118,7 +118,7 @@ namespace Lucene.Net.Spatial.Util
             if (this == o) return true;
             if (o is null || GetType() != o.GetType()) return false;
 
-            if (!(o is ShapeFieldCacheDistanceValueSource that)) return false;
+            if (o is not ShapeFieldCacheDistanceValueSource that) return false;
             if (!ctx.Equals(that.ctx)) return false;
             if (!from.Equals(that.from)) return false;
             if (!provider.Equals(that.provider)) return false;

--- a/src/Lucene.Net.Spatial/Vector/DistanceValueSource.cs
+++ b/src/Lucene.Net.Spatial/Vector/DistanceValueSource.cs
@@ -132,7 +132,7 @@ namespace Lucene.Net.Spatial.Vector
             if (this == o) return true;
             if (o is null || GetType() != o.GetType()) return false;
 
-            if (!(o is DistanceValueSource that)) return false;
+            if (o is not DistanceValueSource that) return false;
 
             if (!from.Equals(that.from)) return false;
             if (!strategy.Equals(that.strategy)) return false;

--- a/src/Lucene.Net.Spatial/Vector/PointVectorStrategy.cs
+++ b/src/Lucene.Net.Spatial/Vector/PointVectorStrategy.cs
@@ -29,7 +29,7 @@ namespace Lucene.Net.Spatial.Vector
     /// <summary>
     /// Simple <see cref="SpatialStrategy"/> which represents Points in two numeric <see cref="DoubleField"/>s.
     /// The Strategy's best feature is decent distance sort.
-    /// 
+    ///
     /// <h4>Characteristics:</h4>
     /// <list type="bullet">
     ///     <item><description>Only indexes points; just one per field value.</description></item>
@@ -38,7 +38,7 @@ namespace Lucene.Net.Spatial.Vector
     ///     <item><description>Uses the FieldCache for <see cref="SpatialStrategy.MakeDistanceValueSource(IPoint)"/> and for
     ///     searching with a Circle.</description></item>
     /// </list>
-    /// 
+    ///
     /// <h4>Implementation:</h4>
     /// This is a simple Strategy.  Search works with <see cref="NumericRangeQuery"/>s on
     /// an x &amp; y pair of fields.  A Circle query does the same bbox query but adds a
@@ -150,10 +150,9 @@ namespace Lucene.Net.Spatial.Vector
             }
 
             IShape shape = args.Shape;
-            if (shape is IRectangle)
+            if (shape is IRectangle bboxRect)
             {
-                var bbox = (IRectangle)shape;
-                return new ConstantScoreQuery(MakeWithin(bbox));
+                return new ConstantScoreQuery(MakeWithin(bboxRect));
             }
             else if (shape is ICircle circle)
             {

--- a/src/Lucene.Net.Suggest/Spell/HighFrequencyDictionary.cs
+++ b/src/Lucene.Net.Suggest/Spell/HighFrequencyDictionary.cs
@@ -92,7 +92,7 @@ namespace Lucene.Net.Search.Spell
 
             public bool MoveNext()
             {
-                if (!(termsEnum is null))
+                if (termsEnum is not null)
                 {
                     while (termsEnum.MoveNext())
                     {

--- a/src/Lucene.Net.TestFramework/Index/AssertingAtomicReader.cs
+++ b/src/Lucene.Net.TestFramework/Index/AssertingAtomicReader.cs
@@ -75,7 +75,7 @@ namespace Lucene.Net.Index
         {
             // TODO: should we give this thing a random to be super-evil,
             // and randomly *not* unwrap?
-            if (!(reuse is null) && reuse is AssertingAtomicReader.AssertingTermsEnum reusable)
+            if (reuse is not null && reuse is AssertingAtomicReader.AssertingTermsEnum reusable)
             {
                 reuse = reusable.m_input;
             }

--- a/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
+++ b/src/Lucene.Net.TestFramework/Index/RandomIndexWriter.cs
@@ -119,7 +119,7 @@ namespace Lucene.Net.Index
 
             // Make sure we sometimes test indices that don't get
             // any forced merges:
-            doRandomForceMerge = !(c.MergePolicy is NoMergePolicy) && r.NextBoolean();
+            doRandomForceMerge = c.MergePolicy is not NoMergePolicy && r.NextBoolean();
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Search/AssertingQuery.cs
+++ b/src/Lucene.Net.TestFramework/Search/AssertingQuery.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Search
         public override bool Equals(object obj)
         {
             if (obj is null) return false;
-            if (!(obj is AssertingQuery that)) return false;
+            if (obj is not AssertingQuery that) return false;
             return this.@in.Equals(that.@in);
         }
 

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -104,12 +104,10 @@ namespace Lucene.Net.Search
 
             public override bool Equals(object other)
             {
-                if (!(other is FieldAndShardVersion))
+                if (other is not FieldAndShardVersion other_)
                 {
                     return false;
                 }
-
-                FieldAndShardVersion other_ = (FieldAndShardVersion)other;
 
                 return field.Equals(other_.field, StringComparison.Ordinal) && version == other_.version && nodeID == other_.nodeID;
             }
@@ -143,12 +141,10 @@ namespace Lucene.Net.Search
 
             public override bool Equals(object other)
             {
-                if (!(other is TermAndShardVersion))
+                if (other is not TermAndShardVersion other_)
                 {
                     return false;
                 }
-
-                TermAndShardVersion other_ = (TermAndShardVersion)other;
 
                 return term.Equals(other_.term) && version == other_.version && nodeID == other_.nodeID;
             }

--- a/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
@@ -890,7 +890,7 @@ namespace Lucene.Net.Store
             // this test backdoors the directory via the filesystem. so it must be an FSDir (for now)
             // TODO: figure a way to test this better/clean it up. E.g. we should be testing for FileSwitchDir,
             // if it's using two FSdirs and so on
-            if (!(fsdir is FSDirectory))
+            if (fsdir is not FSDirectory)
             {
                 AssumeTrue("test only works for FSDirectory subclasses", false);
                 return;

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -723,7 +723,7 @@ namespace Lucene.Net.Store
                 openFilesForWrite.Add(name);
 
                 // throttling REALLY slows down tests, so don't do it very often for SOMETIMES.
-                if (throttling == Throttling.ALWAYS || (throttling == Throttling.SOMETIMES && randomState.Next(50) == 0) && !(m_input is RateLimitedDirectoryWrapper))
+                if (throttling == Throttling.ALWAYS || (throttling == Throttling.SOMETIMES && randomState.Next(50) == 0) && m_input is not RateLimitedDirectoryWrapper)
                 {
                     if (LuceneTestCase.Verbose)
                     {

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -194,7 +194,7 @@ namespace Lucene.Net.Store
 
         /// <summary>
         /// If set to true (the default), when we throw random
-        /// <see cref="IOException"/> on <see cref="OpenInput(string, IOContext)"/> or 
+        /// <see cref="IOException"/> on <see cref="OpenInput(string, IOContext)"/> or
         /// <see cref="CreateOutput(string, IOContext)"/>, we may
         /// sometimes throw <see cref="FileNotFoundException"/>.
         /// </summary>
@@ -848,12 +848,12 @@ namespace Lucene.Net.Store
             UninterruptableMonitor.Enter(this);
             try
             {
-                if (!(m_input is RAMDirectory))
+                if (m_input is not RAMDirectory ramDirectory)
                 {
                     return GetSizeInBytes();
                 }
                 long size = 0;
-                foreach (RAMFile file in ((RAMDirectory)m_input).m_fileMap.Values)
+                foreach (RAMFile file in ramDirectory.m_fileMap.Values)
                 {
                     size += file.GetSizeInBytes();
                 }
@@ -877,12 +877,12 @@ namespace Lucene.Net.Store
             UninterruptableMonitor.Enter(this);
             try
             {
-                if (!(m_input is RAMDirectory))
+                if (m_input is not RAMDirectory ramDirectory)
                 {
                     return GetSizeInBytes();
                 }
                 long size = 0;
-                foreach (RAMFile file in ((RAMDirectory)m_input).m_fileMap.Values)
+                foreach (RAMFile file in ramDirectory.m_fileMap.Values)
                 {
                     size += file.Length;
                 }
@@ -1028,7 +1028,7 @@ namespace Lucene.Net.Store
                                                     if (Debugging.AssertsEnabled) Debugging.Assert(pendingDeletions.Contains(s));
                                                     if (LuceneTestCase.Verbose)
                                                     {
-                                                        Console.WriteLine("MDW: Unreferenced check: Ignoring referenced file: " + s + " " + 
+                                                        Console.WriteLine("MDW: Unreferenced check: Ignoring referenced file: " + s + " " +
                                                             "from " + file + " that we could not delete.");
                                                     }
                                                     startSet.Add(s);
@@ -1538,7 +1538,7 @@ namespace Lucene.Net.Store
     /// Use this when throwing fake <see cref="IOException"/>,
     /// e.g. from <see cref="Failure"/>.
     /// </summary>
-    // LUCENENET: It is no longer good practice to use binary serialization. 
+    // LUCENENET: It is no longer good practice to use binary serialization.
     // See: https://github.com/dotnet/corefx/issues/23584#issuecomment-325724568
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
     [Serializable]

--- a/src/Lucene.Net.TestFramework/Support/ExceptionHandling/ExceptionExtensions.cs
+++ b/src/Lucene.Net.TestFramework/Support/ExceptionHandling/ExceptionExtensions.cs
@@ -57,8 +57,8 @@ namespace Lucene.Net
             if (e is null || e.IsError() || e.IsAlwaysIgnored()) return false;
 
             return e is ArgumentException &&
-                !(e is ArgumentNullException) &&     // Corresponds to NullPointerException, so we don't catch it here.
-                !(e is ArgumentOutOfRangeException); // Corresponds to IndexOutOfBoundsException (and subclasses), so we don't catch it here.
+                e is not ArgumentNullException &&     // Corresponds to NullPointerException, so we don't catch it here.
+                e is not ArgumentOutOfRangeException; // Corresponds to IndexOutOfBoundsException (and subclasses), so we don't catch it here.
         }
     }
 }

--- a/src/Lucene.Net.TestFramework/Support/JavaCompatibility/SystemTypesHelpers.cs
+++ b/src/Lucene.Net.TestFramework/Support/JavaCompatibility/SystemTypesHelpers.cs
@@ -47,11 +47,11 @@ namespace Lucene.Net
             // LUCENENET: We compensate for the fact that
             // .NET doesn't have reliable results from ToString
             // by defaulting the behavior to return a concatenated
-            // list of the contents of enumerables rather than the 
+            // list of the contents of enumerables rather than the
             // .NET type name (similar to the way Java behaves).
             // Unless of course we already have a string (which
             // implements IEnumerable so we need skip it).
-            if (obj is IEnumerable && !(obj is string))
+            if (obj is IEnumerable list and not string)
             {
                 string result = obj.ToString();
                 // Assume that this is a default call to object.ToString()
@@ -63,7 +63,6 @@ namespace Lucene.Net
 
                 // If this is the default text, replace it with
                 // the contents of the enumerable as Java would.
-                IEnumerable list = obj as IEnumerable;
                 StringBuilder sb = new StringBuilder();
                 bool isArray = obj.GetType().IsArray;
                 sb.Append(isArray ? "{" : "[");

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1914,7 +1914,7 @@ namespace Lucene.Net.Util
                 {
                     r = SlowCompositeReaderWrapper.Wrap(r);
                 }
-                else if ((r is CompositeReader) && !(r is FCInvisibleMultiReader))
+                else if ((r is CompositeReader) && r is not FCInvisibleMultiReader)
                 {
                     // prevent cache insanity caused by e.g. ParallelCompositeReader, to fix we wrap one more time:
                     r = new FCInvisibleMultiReader(r);

--- a/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/ExceptionScanningTestCase.cs
+++ b/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/ExceptionScanningTestCase.cs
@@ -133,7 +133,7 @@ namespace Lucene.Net.Support.ExceptionHandling
             };
 
             // Special case - this doesn't exist on .NET Framework, so we only add it if not null
-            if (!(DebugAssertExceptionType is null))
+            if (DebugAssertExceptionType is not null)
             {
                 result.Add(DebugAssertExceptionType);                 // Corresponds to Java's AssertionError
             }
@@ -384,41 +384,41 @@ namespace Lucene.Net.Support.ExceptionHandling
             };
 
             // .NET Core 3.0 + only
-            if (!(SwitchExpressionExceptionType is null))
+            if (SwitchExpressionExceptionType is not null)
             {
                 result.Add(SwitchExpressionExceptionType);
             }
 
             // .NET Framework only
-            if (!(RemotingExceptionType is null))
+            if (RemotingExceptionType is not null)
             {
                 result.Add(RemotingExceptionType);
             }
-            if (!(RemotingTimeoutExceptionType is null))
+            if (RemotingTimeoutExceptionType is not null)
             {
                 result.Add(RemotingTimeoutExceptionType);
             }
-            if (!(RemotingServerExceptionType is null))
+            if (RemotingServerExceptionType is not null)
             {
                 result.Add(RemotingServerExceptionType);
             }
-            if (!(CryptographicUnexpectedOperationExceptionType is null))
+            if (CryptographicUnexpectedOperationExceptionType is not null)
             {
                 result.Add(CryptographicUnexpectedOperationExceptionType);
             }
-            if (!(HostProtectionExceptionType is null))
+            if (HostProtectionExceptionType is not null)
             {
                 result.Add(HostProtectionExceptionType);
             }
-            if (!(PolicyExceptionType is null))
+            if (PolicyExceptionType is not null)
             {
                 result.Add(PolicyExceptionType);
             }
-            if (!(IdentityNotMappedExceptionType is null))
+            if (IdentityNotMappedExceptionType is not null)
             {
                 result.Add(IdentityNotMappedExceptionType);
             }
-            if (!(XmlSyntaxExceptionType is null))
+            if (XmlSyntaxExceptionType is not null)
             {
                 result.Add(XmlSyntaxExceptionType);
             }
@@ -468,7 +468,7 @@ namespace Lucene.Net.Support.ExceptionHandling
             };
 
             // Special case - this doesn't exist on .NET Framework, so we only add it if not null
-            if (!(DebugAssertExceptionType is null))
+            if (DebugAssertExceptionType is not null)
             {
                 result[DebugAssertExceptionType] = (exceptionType, message) =>
                 {
@@ -480,7 +480,7 @@ namespace Lucene.Net.Support.ExceptionHandling
                 };
             }
 
-            if (!(MetadataExceptionType is null))
+            if (MetadataExceptionType is not null)
             {
                 result[MetadataExceptionType] = (exceptionType, message) =>
                 {
@@ -492,7 +492,7 @@ namespace Lucene.Net.Support.ExceptionHandling
                 };
             }
 
-            if (!(CrossAppDomainMarshaledExceptionType is null))
+            if (CrossAppDomainMarshaledExceptionType is not null)
             {
                 result[CrossAppDomainMarshaledExceptionType] = (exceptionType, message) =>
                 {

--- a/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/TestExceptionExtensions.cs
+++ b/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/TestExceptionExtensions.cs
@@ -390,7 +390,7 @@ namespace Lucene.Net.Support.ExceptionHandling
                     Assert.Pass($"Expected: Caught exception {e.GetType().FullName}");
                 }
             }
-            catch (Exception e) when (!(e is NUnit.Framework.SuccessException))
+            catch (Exception e) when (e is not NUnit.Framework.SuccessException)
             {
                 // not expected
                 Assert.Fail($"Exception thrown when expected to be caught: {e.GetType().FullName}");
@@ -418,7 +418,7 @@ namespace Lucene.Net.Support.ExceptionHandling
                     Assert.Fail($"Exception caught when expected to be thrown: {e.GetType().FullName}");
                 }
             }
-            catch (Exception e) when (!(e is NUnit.Framework.AssertionException))
+            catch (Exception e) when (e is not NUnit.Framework.AssertionException)
             {
                 // expected
                 Assert.Pass($"Expected: Did not catch exception {e.GetType().FullName}");

--- a/src/Lucene.Net.Tests.Analysis.ICU/Collation/TestICUCollationKeyFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Collation/TestICUCollationKeyFilterFactory.cs
@@ -98,7 +98,7 @@ namespace Lucene.Net.Collation
 
         /*
          * Setting alternate=shifted to shift whitespace, punctuation and symbols
-         * to quaternary level 
+         * to quaternary level
          */
         [Test]
         public void TestIgnorePunctuation()
@@ -117,8 +117,8 @@ namespace Lucene.Net.Collation
         }
 
         /*
-         * Setting alternate=shifted and variableTop to shift whitespace, but not 
-         * punctuation or symbols, to quaternary level 
+         * Setting alternate=shifted and variableTop to shift whitespace, but not
+         * punctuation or symbols, to quaternary level
          */
         [Test]
         public void TestIgnoreWhitespace()
@@ -238,7 +238,7 @@ namespace Lucene.Net.Collation
             RuleBasedCollator tailoredCollator = new RuleBasedCollator(baseCollator.GetRules() + DIN5007_2_tailorings);
             string tailoredRules = tailoredCollator.GetRules();
             //
-            // at this point, you would save these tailoredRules to a file, 
+            // at this point, you would save these tailoredRules to a file,
             // and use the custom parameter.
             //
             String germanUmlaut = "Töne";
@@ -338,9 +338,9 @@ namespace Lucene.Net.Collation
                     throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
                 }
             }
-            if (factory is IResourceLoaderAware)
+            if (factory is IResourceLoaderAware resourceLoaderAware)
             {
-                ((IResourceLoaderAware)factory).Inform(new ClasspathResourceLoader(GetType()));
+                resourceLoaderAware.Inform(new ClasspathResourceLoader(GetType()));
             }
             return factory;
         }

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/TestPerfTasksParse.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/TestPerfTasksParse.cs
@@ -59,10 +59,10 @@ namespace Lucene.Net.Benchmarks.ByTask
                 {
                     foundAdd = true;
                 }
-                if (task is TaskSequence)
+                if (task is TaskSequence taskSequence)
                 {
-                    assertEquals("repetions should be 1000 for " + parsedTasks, 1000, ((TaskSequence)task).Repetitions);
-                    assertTrue("sequence for " + parsedTasks + " should be parallel!", ((TaskSequence)task).IsParallel);
+                    assertEquals("repetions should be 1000 for " + parsedTasks, 1000, taskSequence.Repetitions);
+                    assertTrue("sequence for " + parsedTasks + " should be parallel!", taskSequence.IsParallel);
                 }
                 assertTrue("Task " + taskStr + " was not found in " + alg.toString(), foundAdd);
             }
@@ -84,10 +84,10 @@ namespace Lucene.Net.Benchmarks.ByTask
                 {
                     foundAdd = true;
                 }
-                if (task is TaskSequence)
+                if (task is TaskSequence taskSequence)
                 {
-                    assertEquals("repetions should be 1000 for " + parsedTasks, 1000, ((TaskSequence)task).Repetitions);
-                    assertFalse("sequence for " + parsedTasks + " should be sequential!", ((TaskSequence)task).IsParallel);
+                    assertEquals("repetions should be 1000 for " + parsedTasks, 1000, taskSequence.Repetitions);
+                    assertFalse("sequence for " + parsedTasks + " should be sequential!", taskSequence.IsParallel);
                 }
                 assertTrue("Task " + taskStr + " was not found in " + alg.toString(), foundAdd);
             }

--- a/src/Lucene.Net.Tests.Highlighter/Highlight/Custom/HighlightCustomQueryTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/Highlight/Custom/HighlightCustomQueryTest.cs
@@ -31,12 +31,12 @@ namespace Lucene.Net.Search.Highlight.Custom
     /// </summary>
     public class HighlightCustomQueryTest : LuceneTestCase
     {
-        private static readonly String FIELD_NAME = "contents";
+        private static readonly string FIELD_NAME = "contents";
 
         [Test]
         public void TestHighlightCustomQuery()
         {
-            String s1 = "I call our world Flatland, not because we call it so,";
+            string s1 = "I call our world Flatland, not because we call it so,";
 
             // Verify that a query against the default field results in text being
             // highlighted
@@ -44,8 +44,8 @@ namespace Lucene.Net.Search.Highlight.Custom
 
             CustomQuery q = new CustomQuery(new Term(FIELD_NAME, "world"));
 
-            String expected = "I call our <B>world</B> Flatland, not because we call it so,";
-            String observed = highlightField(q, "SOME_FIELD_NAME", s1);
+            string expected = "I call our <B>world</B> Flatland, not because we call it so,";
+            string observed = highlightField(q, "SOME_FIELD_NAME", s1);
             if (Verbose)
                 Console.WriteLine("Expected: \"" + expected + "\n" + "Observed: \""
                     + observed);
@@ -75,8 +75,8 @@ namespace Lucene.Net.Search.Highlight.Custom
          * This method intended for use with
          * <tt>testHighlightingWithDefaultField()</tt>
          */
-        private String highlightField(Query query, String fieldName,
-            String text)
+        private string highlightField(Query query, string fieldName,
+            string text)
         {
             TokenStream tokenStream = new MockAnalyzer(Random, MockTokenizer.SIMPLE,
                 true, MockTokenFilter.ENGLISH_STOPSET).GetTokenStream(fieldName, text);
@@ -86,7 +86,7 @@ namespace Lucene.Net.Search.Highlight.Custom
             Highlighter highlighter = new Highlighter(formatter, scorer);
             highlighter.TextFragmenter = (new SimpleFragmenter(int.MaxValue));
 
-            String rv = highlighter.GetBestFragments(tokenStream, text, 1,
+            string rv = highlighter.GetBestFragments(tokenStream, text, 1,
                 "(FIELD TEXT TRUNCATED)");
             return rv.Length == 0 ? text : rv;
         }
@@ -99,33 +99,31 @@ namespace Lucene.Net.Search.Highlight.Custom
             {
             }
 
-            public MyWeightedSpanTermExtractor(String defaultField)
+            public MyWeightedSpanTermExtractor(string defaultField)
                             : base(defaultField)
             {
             }
 
-
             protected override void ExtractUnknownQuery(Query query,
-                IDictionary<String, WeightedSpanTerm> terms)
+                IDictionary<string, WeightedSpanTerm> terms)
             {
-                if (query is CustomQuery)
+                if (query is CustomQuery cq)
                 {
-                    ExtractWeightedTerms(terms, new TermQuery(((CustomQuery)query).term));
+                    ExtractWeightedTerms(terms, new TermQuery(cq.term));
                 }
             }
-
         }
 
         public class MyQueryScorer : QueryScorer
         {
 
-            public MyQueryScorer(Query query, String field, String defaultField)
+            public MyQueryScorer(Query query, string field, string defaultField)
                         : base(query, field, defaultField)
             {
             }
 
 
-            protected override WeightedSpanTermExtractor NewTermExtractor(String defaultField)
+            protected override WeightedSpanTermExtractor NewTermExtractor(string defaultField)
             {
                 return defaultField is null ? new MyWeightedSpanTermExtractor()
                     : new MyWeightedSpanTermExtractor(defaultField);
@@ -143,7 +141,7 @@ namespace Lucene.Net.Search.Highlight.Custom
                 this.term = term;
             }
 
-            public override String ToString(String field)
+            public override string ToString(string field)
             {
                 return new TermQuery(term).ToString(field);
             }
@@ -162,7 +160,7 @@ namespace Lucene.Net.Search.Highlight.Custom
                 return result;
             }
 
-            public override bool Equals(Object obj)
+            public override bool Equals(object obj)
             {
                 if (this == obj)
                     return true;

--- a/src/Lucene.Net.Tests.Join/Support/TestBlockJoin.cs
+++ b/src/Lucene.Net.Tests.Join/Support/TestBlockJoin.cs
@@ -245,7 +245,7 @@ namespace Lucene.Net.Tests.Join
 
             MultiTermQuery qc = NumericRangeQuery.NewInt32Range("year", 2007, 2007, true, true);
             // Hacky: this causes the query to need 2 rewrite
-            // iterations: 
+            // iterations:
             qc.MultiTermRewriteMethod = MultiTermQuery.CONSTANT_SCORE_BOOLEAN_QUERY_REWRITE;
 
             Filter parentsFilter = new FixedBitSetCachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("docType", "resume"))));
@@ -807,9 +807,9 @@ namespace Lucene.Net.Tests.Join
                             Console.Write("    ");
                             foreach (object o in fd.Fields)
                             {
-                                if (o is BytesRef)
+                                if (o is BytesRef bytesRef)
                                 {
-                                    Console.Write(((BytesRef)o).Utf8ToString() + " ");
+                                    Console.Write(bytesRef.Utf8ToString() + " ");
                                 }
                                 else
                                 {
@@ -855,9 +855,9 @@ namespace Lucene.Net.Tests.Join
                                 Console.Write("  ");
                                 foreach (object o in group.GroupSortValues)
                                 {
-                                    if (o is BytesRef)
+                                    if (o is BytesRef bytesRef)
                                     {
-                                        Console.Write(((BytesRef)o).Utf8ToString() + " ");
+                                        Console.Write(bytesRef.Utf8ToString() + " ");
                                     }
                                     else
                                     {

--- a/src/Lucene.Net.Tests.Join/TestBlockJoin.cs
+++ b/src/Lucene.Net.Tests.Join/TestBlockJoin.cs
@@ -243,7 +243,7 @@ namespace Lucene.Net.Search.Join
 
             MultiTermQuery qc = NumericRangeQuery.NewInt32Range("year", 2007, 2007, true, true);
             // Hacky: this causes the query to need 2 rewrite
-            // iterations: 
+            // iterations:
             qc.MultiTermRewriteMethod = MultiTermQuery.CONSTANT_SCORE_BOOLEAN_QUERY_REWRITE;
 
             Filter parentsFilter = new FixedBitSetCachingWrapperFilter(new QueryWrapperFilter(new TermQuery(new Term("docType", "resume"))));
@@ -271,7 +271,7 @@ namespace Lucene.Net.Search.Join
             r.Dispose();
             dir.Dispose();
         }
-        
+
         protected QueryWrapperFilter Skill(string skill)
         {
             return new QueryWrapperFilter(new TermQuery(new Term("skill", skill)));
@@ -358,7 +358,7 @@ namespace Lucene.Net.Search.Join
             r.Dispose();
             dir.Dispose();
         }
-        
+
         private void AddSkillless(RandomIndexWriter w)
         {
             if (Random.NextBoolean())
@@ -366,7 +366,7 @@ namespace Lucene.Net.Search.Join
                 w.AddDocument(MakeResume("Skillless", Random.NextBoolean() ? "United Kingdom" : "United States"));
             }
         }
-        
+
         private Document GetParentDoc(IndexReader reader, Filter parents, int childDocID)
         {
             IList<AtomicReaderContext> leaves = reader.Leaves;
@@ -805,9 +805,9 @@ namespace Lucene.Net.Search.Join
                             Console.Write("    ");
                             foreach (object o in fd.Fields)
                             {
-                                if (o is BytesRef)
+                                if (o is BytesRef bytesRef)
                                 {
-                                    Console.Write(((BytesRef)o).Utf8ToString() + " ");
+                                    Console.Write(bytesRef.Utf8ToString() + " ");
                                 }
                                 else
                                 {
@@ -853,9 +853,9 @@ namespace Lucene.Net.Search.Join
                                 Console.Write("  ");
                                 foreach (object o in group.GroupSortValues)
                                 {
-                                    if (o is BytesRef)
+                                    if (o is BytesRef bytesRef)
                                     {
-                                        Console.Write(((BytesRef)o).Utf8ToString() + " ");
+                                        Console.Write(bytesRef.Utf8ToString() + " ");
                                     }
                                     else
                                     {
@@ -1063,7 +1063,7 @@ namespace Lucene.Net.Search.Join
             dir.Dispose();
             joinDir.Dispose();
         }
-        
+
         private void CompareChildHits(IndexReader r, IndexReader joinR, TopDocs results, TopDocs joinResults)
         {
             assertEquals(results.TotalHits, joinResults.TotalHits);
@@ -1087,7 +1087,7 @@ namespace Lucene.Net.Search.Join
                 assertArrayEquals(hit0.Fields, joinHit0.Fields);
             }
         }
-        
+
         private void CompareHits(IndexReader r, IndexReader joinR, TopDocs results, ITopGroups<int> joinResults)
         {
             // results is 'complete'; joinResults is a subset

--- a/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/Sorter/SorterTestBase.cs
@@ -267,9 +267,9 @@ namespace Lucene.Net.Index.Sorter
             // test advance()
             DocsAndPositionsEnum reuse = sortedPositions;
             sortedPositions = termsEnum.DocsAndPositions(null, reuse);
-            if (sortedPositions is SortingAtomicReader.SortingDocsAndPositionsEnum)
+            if (sortedPositions is SortingAtomicReader.SortingDocsAndPositionsEnum positionsEnum)
             {
-                assertTrue(((SortingAtomicReader.SortingDocsAndPositionsEnum)sortedPositions).Reused(reuse)); // make sure reuse worked
+                assertTrue(positionsEnum.Reused(reuse)); // make sure reuse worked
             }
             doc = 0;
             while ((doc = sortedPositions.Advance(doc + TestUtil.NextInt32(Random, 1, 5))) != DocIdSetIterator.NO_MORE_DOCS)
@@ -345,9 +345,9 @@ namespace Lucene.Net.Index.Sorter
 
             DocsEnum reuse = docs;
             docs = termsEnum.Docs(mappedLiveDocs, reuse);
-            if (docs is SortingAtomicReader.SortingDocsEnum)
+            if (docs is SortingAtomicReader.SortingDocsEnum sortingDocsEnum)
             {
-                assertTrue(((SortingAtomicReader.SortingDocsEnum)docs).Reused(reuse)); // make sure reuse worked
+                assertTrue(sortingDocsEnum.Reused(reuse)); // make sure reuse worked
             }
             doc = -1;
             prev = -1;

--- a/src/Lucene.Net.Tests.Misc/Index/TestIndexSplitter.cs
+++ b/src/Lucene.Net.Tests.Misc/Index/TestIndexSplitter.cs
@@ -35,9 +35,9 @@ namespace Lucene.Net.Index
             Store.Directory fsDir = NewFSDirectory(dir);
             // IndexSplitter.split makes its own commit directly with SIPC/SegmentInfos,
             // so the unreferenced files are expected.
-            if (fsDir is MockDirectoryWrapper)
+            if (fsDir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)fsDir).AssertNoUnreferencedFilesOnDispose = (false);
+                mockDirectoryWrapper.AssertNoUnreferencedFilesOnDispose = (false);
             }
 
             MergePolicy mergePolicy = new LogByteSizeMergePolicy();

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Spans/SpansValidatorQueryNodeProcessor.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Spans/SpansValidatorQueryNodeProcessor.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Spans
 
         protected override IQueryNode PreProcessNode(IQueryNode node)
         {
-            if (!((node is BooleanQueryNode && !(node is AndQueryNode)) || node
+            if (!((node is BooleanQueryNode && node is not AndQueryNode) || node
                 .GetType() == typeof(FieldQueryNode)))
             {
                 // LUCENENET: Factored out NLS/Message/IMessage so end users can optionally utilize the built-in .NET localization.

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Spans/UniqueFieldAttributeImpl.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Spans/UniqueFieldAttributeImpl.cs
@@ -49,24 +49,21 @@ namespace Lucene.Net.QueryParsers.Flexible.Spans
 
         public override void CopyTo(IAttribute target)
         {
-
-            if (!(target is UniqueFieldAttribute))
+            if (target is not UniqueFieldAttribute uniqueFieldAttr)
             {
                 throw new ArgumentException(
                     "cannot copy the values from attribute UniqueFieldAttribute to an instance of "
                         + target.GetType().Name);
             }
 
-            UniqueFieldAttribute uniqueFieldAttr = (UniqueFieldAttribute)target;
             uniqueFieldAttr.uniqueField = uniqueField.toString();
         }
 
         public override bool Equals(object other)
         {
-            if (other is UniqueFieldAttribute)
+            if (other is UniqueFieldAttribute uniqueFieldAttr)
             {
-
-                return ((UniqueFieldAttribute)other).uniqueField
+                return uniqueFieldAttr.uniqueField
                     .Equals(this.uniqueField, System.StringComparison.Ordinal);
             }
 

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Spans/UniqueFieldQueryNodeProcessor.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Spans/UniqueFieldQueryNodeProcessor.cs
@@ -40,10 +40,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Spans
 
         protected override IQueryNode PreProcessNode(IQueryNode node)
         {
-            if (node is IFieldableNode)
+            if (node is IFieldableNode fieldNode)
             {
-                IFieldableNode fieldNode = (IFieldableNode)node;
-
                 QueryConfigHandler queryConfig = GetQueryConfigHandler();
 
                 if (queryConfig is null)

--- a/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
+++ b/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
@@ -197,11 +197,11 @@ namespace Lucene.Net.Spatial.Prefix
             if (shape != null)
             {
                 IList<IShape> shapes;
-                if (shape is ShapePair)
+                if (shape is ShapePair shapePair)
                 {
                     shapes = new JCG.List<IShape>(2);
-                    shapes.Add(((ShapePair)shape).shape1);
-                    shapes.Add(((ShapePair)shape).shape2);
+                    shapes.Add(shapePair.shape1);
+                    shapes.Add(shapePair.shape2);
                 }
                 else
                 {
@@ -412,9 +412,8 @@ namespace Lucene.Net.Spatial.Prefix
         {
             if (snapMe is null)
                 return null;
-            if (snapMe is ShapePair)
+            if (snapMe is ShapePair me)
             {
-                ShapePair me = (ShapePair)snapMe;
                 return new ShapePair(gridSnap(me.shape1), gridSnap(me.shape2), me.biasContainsThenWithin, ctx, ctx2D);
             }
             if (snapMe is IPoint)

--- a/src/Lucene.Net.Tests/Index/Test2BBinaryDocValues.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BBinaryDocValues.cs
@@ -45,9 +45,9 @@ namespace Lucene.Net.Index
         public virtual void TestFixedBinary()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BFixedBinary"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
 
             IndexWriter w = new IndexWriter(dir,
@@ -112,9 +112,9 @@ namespace Lucene.Net.Index
         public virtual void TestVariableBinary()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BVariableBinary"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
 
             IndexWriter w = new IndexWriter(dir,

--- a/src/Lucene.Net.Tests/Index/Test2BNumericDocValues.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BNumericDocValues.cs
@@ -43,9 +43,9 @@ namespace Lucene.Net.Index
         public virtual void TestNumerics()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BNumerics"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
 
             IndexWriter w = new IndexWriter(dir,

--- a/src/Lucene.Net.Tests/Index/Test2BPositions.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BPositions.cs
@@ -49,9 +49,9 @@ namespace Lucene.Net.Index
         public virtual void Test()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BPositions"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
 
             IndexWriter w = new IndexWriter(dir,
@@ -63,10 +63,10 @@ namespace Lucene.Net.Index
                 .SetOpenMode(OpenMode.CREATE));
 
             MergePolicy mp = w.Config.MergePolicy;
-            if (mp is LogByteSizeMergePolicy)
+            if (mp is LogByteSizeMergePolicy logByteSizeMergePolicy)
             {
                 // 1 petabyte:
-                ((LogByteSizeMergePolicy)mp).MaxMergeMB = 1024 * 1024 * 1024;
+                logByteSizeMergePolicy.MaxMergeMB = 1024 * 1024 * 1024;
             }
 
             Document doc = new Document();

--- a/src/Lucene.Net.Tests/Index/Test2BPostings.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BPostings.cs
@@ -49,9 +49,9 @@ namespace Lucene.Net.Index
         public virtual void Test()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BPostings"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
 
             var iwc = new IndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
@@ -64,10 +64,10 @@ namespace Lucene.Net.Index
             IndexWriter w = new IndexWriter(dir, iwc);
 
             MergePolicy mp = w.Config.MergePolicy;
-            if (mp is LogByteSizeMergePolicy)
+            if (mp is LogByteSizeMergePolicy logByteSizeMergePolicy)
             {
                 // 1 petabyte:
-                ((LogByteSizeMergePolicy)mp).MaxMergeMB = 1024 * 1024 * 1024;
+                logByteSizeMergePolicy.MaxMergeMB = 1024 * 1024 * 1024;
             }
 
             Document doc = new Document();

--- a/src/Lucene.Net.Tests/Index/Test2BPostingsBytes.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BPostingsBytes.cs
@@ -53,9 +53,9 @@ namespace Lucene.Net.Index
         public virtual void Test()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BPostingsBytes1"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
 
             IndexWriter w = new IndexWriter(dir,
@@ -67,10 +67,10 @@ namespace Lucene.Net.Index
                 .SetOpenMode(OpenMode.CREATE));
 
             MergePolicy mp = w.Config.MergePolicy;
-            if (mp is LogByteSizeMergePolicy)
+            if (mp is LogByteSizeMergePolicy logByteSizeMergePolicy)
             {
                 // 1 petabyte:
-                ((LogByteSizeMergePolicy)mp).MaxMergeMB = 1024 * 1024 * 1024;
+                logByteSizeMergePolicy.MaxMergeMB = 1024 * 1024 * 1024;
             }
 
             Document doc = new Document();
@@ -102,9 +102,9 @@ namespace Lucene.Net.Index
             Arrays.Fill(subReaders, oneThousand);
             MultiReader mr = new MultiReader(subReaders);
             BaseDirectoryWrapper dir2 = NewFSDirectory(CreateTempDir("2BPostingsBytes2"));
-            if (dir2 is MockDirectoryWrapper)
+            if (dir2 is MockDirectoryWrapper mockDirectoryWrapper2)
             {
-                ((MockDirectoryWrapper)dir2).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper2.Throttling = Throttling.NEVER;
             }
             IndexWriter w2 = new IndexWriter(dir2,
                 new IndexWriterConfig(TEST_VERSION_CURRENT, null));
@@ -118,9 +118,9 @@ namespace Lucene.Net.Index
             Arrays.Fill(subReaders, oneMillion);
             mr = new MultiReader(subReaders);
             BaseDirectoryWrapper dir3 = NewFSDirectory(CreateTempDir("2BPostingsBytes3"));
-            if (dir3 is MockDirectoryWrapper)
+            if (dir3 is MockDirectoryWrapper mockDirectoryWrapper3)
             {
-                ((MockDirectoryWrapper)dir3).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper3.Throttling = Throttling.NEVER;
             }
             IndexWriter w3 = new IndexWriter(dir3,
                 new IndexWriterConfig(TEST_VERSION_CURRENT, null));

--- a/src/Lucene.Net.Tests/Index/Test2BSortedDocValues.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BSortedDocValues.cs
@@ -43,9 +43,9 @@ namespace Lucene.Net.Index
         public virtual void TestFixedSorted()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BFixedSorted"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
 
             IndexWriter w = new IndexWriter(dir,
@@ -106,9 +106,9 @@ namespace Lucene.Net.Index
         public virtual void Test2BOrds()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BOrds"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
 
             IndexWriter w = new IndexWriter(dir,

--- a/src/Lucene.Net.Tests/Index/Test2BTerms.cs
+++ b/src/Lucene.Net.Tests/Index/Test2BTerms.cs
@@ -180,9 +180,9 @@ namespace Lucene.Net.Index
 
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("2BTerms"));
             //MockDirectoryWrapper dir = NewFSDirectory(new File("/p/lucene/indices/2bindex"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
             dir.CheckIndexOnDispose = false; // don't double-checkindex
 
@@ -197,10 +197,10 @@ namespace Lucene.Net.Index
                    .SetOpenMode(OpenMode.CREATE));
 
                 MergePolicy mp = w.Config.MergePolicy;
-                if (mp is LogByteSizeMergePolicy)
+                if (mp is LogByteSizeMergePolicy logByteSizeMergePolicy)
                 {
                     // 1 petabyte:
-                    ((LogByteSizeMergePolicy)mp).MaxMergeMB = 1024 * 1024 * 1024;
+                    logByteSizeMergePolicy.MaxMergeMB = 1024 * 1024 * 1024;
                 }
 
                 Document doc = new Document();

--- a/src/Lucene.Net.Tests/Index/Test4GBStoredFields.cs
+++ b/src/Lucene.Net.Tests/Index/Test4GBStoredFields.cs
@@ -64,10 +64,10 @@ namespace Lucene.Net.Index
                 .SetOpenMode(OpenMode.CREATE));
 
             MergePolicy mp = w.Config.MergePolicy;
-            if (mp is LogByteSizeMergePolicy)
+            if (mp is LogByteSizeMergePolicy logByteSizeMergePolicy)
             {
                 // 1 petabyte:
-                ((LogByteSizeMergePolicy)mp).MaxMergeMB = 1024 * 1024 * 1024;
+                logByteSizeMergePolicy.MaxMergeMB = 1024 * 1024 * 1024;
             }
 
             Document doc = new Document();

--- a/src/Lucene.Net.Tests/Index/TestConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net.Tests/Index/TestConcurrentMergeScheduler.cs
@@ -398,9 +398,9 @@ namespace Lucene.Net.Index
         public virtual void TestTotalBytesSize()
         {
             Directory d = NewDirectory();
-            if (d is MockDirectoryWrapper)
+            if (d is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)d).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
             IndexWriterConfig iwc = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));
             iwc.SetMaxBufferedDocs(5);

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
@@ -679,11 +679,11 @@ namespace Lucene.Net.Index
         {
             Assert.AreEqual(0, reader.RefCount);
 
-            if (checkSubReaders && reader is CompositeReader)
+            if (checkSubReaders && reader is CompositeReader compositeReader)
             {
                 // we cannot use reader context here, as reader is
                 // already closed and calling getTopReaderContext() throws AlreadyClosed!
-                IList<IndexReader> subReaders = ((CompositeReader)reader).GetSequentialSubReaders();
+                IList<IndexReader> subReaders = compositeReader.GetSequentialSubReaders();
                 foreach (IndexReader r in subReaders)
                 {
                     AssertReaderClosed(r, checkSubReaders);

--- a/src/Lucene.Net.Tests/Index/TestForceMergeForever.cs
+++ b/src/Lucene.Net.Tests/Index/TestForceMergeForever.cs
@@ -79,13 +79,13 @@ namespace Lucene.Net.Index
             }
             MergePolicy mp = w.Config.MergePolicy;
             int mergeAtOnce = 1 + w.segmentInfos.Count;
-            if (mp is TieredMergePolicy)
+            if (mp is TieredMergePolicy tieredMergePolicy)
             {
-                ((TieredMergePolicy)mp).MaxMergeAtOnce = mergeAtOnce;
+                tieredMergePolicy.MaxMergeAtOnce = mergeAtOnce;
             }
-            else if (mp is LogMergePolicy)
+            else if (mp is LogMergePolicy logMergePolicy)
             {
-                ((LogMergePolicy)mp).MergeFactor = mergeAtOnce;
+                logMergePolicy.MergeFactor = mergeAtOnce;
             }
             else
             {

--- a/src/Lucene.Net.Tests/Index/TestIndexFileDeleter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexFileDeleter.cs
@@ -48,9 +48,9 @@ namespace Lucene.Net.Index
         public virtual void TestDeleteLeftoverFiles()
         {
             Directory dir = NewDirectory();
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).PreventDoubleWrite = false;
+                mockDirectoryWrapper.PreventDoubleWrite = false;
             }
 
             MergePolicy mergePolicy = NewLogMergePolicy(true, 10);

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterCommit.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterCommit.cs
@@ -160,9 +160,9 @@ namespace Lucene.Net.Index
 
             // On abort, writer in fact may write to the same
             // segments_N file:
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).PreventDoubleWrite = false;
+                mockDirectoryWrapper.PreventDoubleWrite = false;
             }
 
             for (int i = 0; i < 12; i++)
@@ -291,9 +291,9 @@ namespace Lucene.Net.Index
             // Must disable throwing exc on double-write: this
             // test uses IW.rollback which easily results in
             // writing to same file more than once
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).PreventDoubleWrite = false;
+                mockDirectoryWrapper.PreventDoubleWrite = false;
             }
             IndexWriter writer = new IndexWriter(
                 dir,
@@ -638,9 +638,9 @@ namespace Lucene.Net.Index
         public virtual void TestPrepareCommitRollback()
         {
             Directory dir = NewDirectory();
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).PreventDoubleWrite = false;
+                mockDirectoryWrapper.PreventDoubleWrite = false;
             }
 
             IndexWriter writer = new IndexWriter(

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -1468,9 +1468,9 @@ namespace Lucene.Net.Index
         public virtual void TestSimulatedCrashedWriter()
         {
             Directory dir = NewDirectory();
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).PreventDoubleWrite = false;
+                mockDirectoryWrapper.PreventDoubleWrite = false;
             }
 
             IndexWriter writer = null;
@@ -2116,11 +2116,10 @@ namespace Lucene.Net.Index
                 {
                     IndexWriterConfig iwc = NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random));
                     IMergeScheduler ms = iwc.MergeScheduler;
-                    if (ms is IConcurrentMergeScheduler)
+                    if (ms is IConcurrentMergeScheduler cms)
                     {
                         IConcurrentMergeScheduler suppressFakeIOE = new ConcurrentMergeSchedulerAnonymousClass();
 
-                        IConcurrentMergeScheduler cms = (IConcurrentMergeScheduler)ms;
                         suppressFakeIOE.SetMaxMergesAndThreads(cms.MaxMergeCount, cms.MaxThreadCount);
                         suppressFakeIOE.SetMergeThreadPriority(cms.MergeThreadPriority);
                         iwc.SetMergeScheduler(suppressFakeIOE);

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnDiskFull.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnDiskFull.cs
@@ -77,12 +77,12 @@ namespace Lucene.Net.Index
                     dir.MaxSizeInBytes = diskFree;
                     IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)));
                     IMergeScheduler ms = writer.Config.MergeScheduler;
-                    if (ms is IConcurrentMergeScheduler)
+                    if (ms is IConcurrentMergeScheduler concurrentMergeScheduler)
                     {
                         // this test intentionally produces exceptions
                         // in the threads that CMS launches; we don't
                         // want to pollute test output with these.
-                        ((IConcurrentMergeScheduler)ms).SetSuppressExceptions();
+                        concurrentMergeScheduler.SetSuppressExceptions();
                     }
 
                     bool hitError = false;
@@ -304,18 +304,18 @@ namespace Lucene.Net.Index
                     IMergeScheduler ms = indWriter.Config.MergeScheduler;
                     for (int x = 0; x < 2; x++)
                     {
-                        if (ms is IConcurrentMergeScheduler)
+                        if (ms is IConcurrentMergeScheduler concurrentMergeScheduler)
                         // this test intentionally produces exceptions
                         // in the threads that CMS launches; we don't
                         // want to pollute test output with these.
                         {
                             if (0 == x)
                             {
-                                ((IConcurrentMergeScheduler)ms).SetSuppressExceptions();
+                                concurrentMergeScheduler.SetSuppressExceptions();
                             }
                             else
                             {
-                                ((IConcurrentMergeScheduler)ms).ClearSuppressExceptions();
+                                concurrentMergeScheduler.ClearSuppressExceptions();
                             }
                         }
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOutOfFileDescriptors.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOutOfFileDescriptors.cs
@@ -72,9 +72,9 @@ namespace Lucene.Net.Index
                         iwc.SetInfoStream(new TextWriterInfoStream(Console.Out));
                     }
                     var ms = iwc.MergeScheduler;
-                    if (ms is IConcurrentMergeScheduler)
+                    if (ms is IConcurrentMergeScheduler concurrentMergeScheduler)
                     {
-                        ((IConcurrentMergeScheduler)ms).SetSuppressExceptions();
+                        concurrentMergeScheduler.SetSuppressExceptions();
                     }
                     w = new IndexWriter(dir, iwc);
                     if (r != null && Random.Next(5) == 3)

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
@@ -924,9 +924,9 @@ namespace Lucene.Net.Index
 
             Assert.AreEqual(0, excs.Count);
             r.Dispose();
-            if (dir1 is MockDirectoryWrapper)
+            if (dir1 is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ICollection<string> openDeletedFiles = ((MockDirectoryWrapper)dir1).GetOpenDeletedFiles();
+                ICollection<string> openDeletedFiles = mockDirectoryWrapper.GetOpenDeletedFiles();
                 Assert.AreEqual(0, openDeletedFiles.Count, "openDeleted=" + openDeletedFiles);
             }
 
@@ -970,9 +970,9 @@ namespace Lucene.Net.Index
 
         private Directory GetAssertNoDeletesDirectory(Directory directory)
         {
-            if (directory is MockDirectoryWrapper)
+            if (directory is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)directory).AssertNoDeleteOpenFile = true;
+                mockDirectoryWrapper.AssertNoDeleteOpenFile = true;
             }
             return directory;
         }

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
@@ -637,9 +637,9 @@ namespace Lucene.Net.Index
         public virtual void TestRollbackAndCommitWithThreads()
         {
             BaseDirectoryWrapper d = NewDirectory();
-            if (d is MockDirectoryWrapper)
+            if (d is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)d).PreventDoubleWrite = false;
+                mockDirectoryWrapper.PreventDoubleWrite = false;
             }
 
             int threadCount = TestUtil.NextInt32(Random, 2, 6);

--- a/src/Lucene.Net.Tests/Index/TestNeverDelete.cs
+++ b/src/Lucene.Net.Tests/Index/TestNeverDelete.cs
@@ -52,9 +52,9 @@ namespace Lucene.Net.Index
             // We want to "see" files removed if Lucene removed
             // them.  this is still worth running on Windows since
             // some files the IR opens and closes.
-            if (d is MockDirectoryWrapper)
+            if (d is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)d).NoDeleteOpenFile = false;
+                mockDirectoryWrapper.NoDeleteOpenFile = false;
             }
             RandomIndexWriter w = new RandomIndexWriter(Random, d, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random)).SetIndexDeletionPolicy(NoDeletionPolicy.INSTANCE));
             w.IndexWriter.Config.SetMaxBufferedDocs(TestUtil.NextInt32(Random, 5, 30));

--- a/src/Lucene.Net.Tests/Search/TestConstantScoreQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestConstantScoreQuery.cs
@@ -84,10 +84,9 @@ namespace Lucene.Net.Search
             {
                 this.scorer = scorer;
                 Assert.AreEqual(scorerClassName, scorer.GetType().Name, "Scorer is implemented by wrong class");
-                if (innerScorerClassName != null && scorer is ConstantScoreQuery.ConstantScorer)
+                if (innerScorerClassName != null && scorer is ConstantScoreQuery.ConstantScorer constantScorer)
                 {
-                    ConstantScoreQuery.ConstantScorer innerScorer = (ConstantScoreQuery.ConstantScorer)scorer;
-                    Assert.AreEqual(innerScorerClassName, innerScorer.docIdSetIterator.GetType().Name, "inner Scorer is implemented by wrong class");
+                    Assert.AreEqual(innerScorerClassName, constantScorer.docIdSetIterator.GetType().Name, "inner Scorer is implemented by wrong class");
                 }
             }
 

--- a/src/Lucene.Net.Tests/Search/TestFilteredQuery.cs
+++ b/src/Lucene.Net.Tests/Search/TestFilteredQuery.cs
@@ -408,11 +408,11 @@ namespace Lucene.Net.Search
             // check the class and boosts of rewritten query
             Query rewritten = searcher.Rewrite(fq);
             Assert.IsTrue(clazz.IsInstanceOfType(rewritten), "is not instance of " + clazz.Name);
-            if (rewritten is FilteredQuery)
+            if (rewritten is FilteredQuery rewrittenFq)
             {
-                Assert.AreEqual(boost, rewritten.Boost, 1E-5f);
-                Assert.AreEqual(innerBoost, ((FilteredQuery)rewritten).Query.Boost, 1E-5f);
-                Assert.AreEqual(fq.Strategy, ((FilteredQuery)rewritten).Strategy);
+                Assert.AreEqual(boost, rewrittenFq.Boost, 1E-5f);
+                Assert.AreEqual(innerBoost, rewrittenFq.Query.Boost, 1E-5f);
+                Assert.AreEqual(fq.Strategy, rewrittenFq.Strategy);
             }
             else
             {

--- a/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
+++ b/src/Lucene.Net.Tests/Search/TestMultiTermQueryRewrites.cs
@@ -98,10 +98,10 @@ namespace Lucene.Net.Search
 
         private Query ExtractInnerQuery(Query q)
         {
-            if (q is ConstantScoreQuery)
+            if (q is ConstantScoreQuery constantScoreQuery)
             {
                 // wrapped as ConstantScoreQuery
-                q = ((ConstantScoreQuery)q).Query;
+                q = constantScoreQuery.Query;
             }
             return q;
         }

--- a/src/Lucene.Net.Tests/Search/TestSearchAfter.cs
+++ b/src/Lucene.Net.Tests/Search/TestSearchAfter.cs
@@ -381,10 +381,10 @@ namespace Lucene.Net.Search
                 }
                 Assert.AreEqual(sd1.Doc, sd2.Doc);
                 Assert.AreEqual(sd1.Score, sd2.Score, 0f);
-                if (sd1 is FieldDoc)
+                if (sd1 is FieldDoc fieldDoc)
                 {
                     Assert.IsTrue(sd2 is FieldDoc);
-                    Assert.AreEqual(((FieldDoc)sd1).Fields, ((FieldDoc)sd2).Fields);
+                    Assert.AreEqual(fieldDoc.Fields, ((FieldDoc)sd2).Fields);
                 }
             }
         }

--- a/src/Lucene.Net.Tests/Search/TestTopDocsMerge.cs
+++ b/src/Lucene.Net.Tests/Search/TestTopDocsMerge.cs
@@ -177,11 +177,11 @@ namespace Lucene.Net.Search
             ShardSearcher[] subSearchers;
             int[] docStarts;
 
-            if (ctx is AtomicReaderContext)
+            if (ctx is AtomicReaderContext atomicReaderContext)
             {
                 subSearchers = new ShardSearcher[1];
                 docStarts = new int[1];
-                subSearchers[0] = new ShardSearcher((AtomicReaderContext)ctx, ctx);
+                subSearchers[0] = new ShardSearcher(atomicReaderContext, ctx);
                 docStarts[0] = 0;
             }
             else

--- a/src/Lucene.Net.Tests/Store/TestDirectory.cs
+++ b/src/Lucene.Net.Tests/Store/TestDirectory.cs
@@ -90,9 +90,9 @@ namespace Lucene.Net.Store
         {
             BaseDirectoryWrapper dir = NewDirectory();
             dir.CheckIndexOnDispose = false; // we arent making an index
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER; // makes this test really slow
+                mockDirectoryWrapper.Throttling = Throttling.NEVER; // makes this test really slow
             }
 
             if (Verbose)

--- a/src/Lucene.Net.Tests/Util/Packed/TestPackedInts.cs
+++ b/src/Lucene.Net.Tests/Util/Packed/TestPackedInts.cs
@@ -1361,7 +1361,7 @@ namespace Lucene.Net.Util.Packed
                     }
                     Assert.AreEqual(i, it.Ord);
                 }
-                assertEquals(fp, @in is ByteArrayDataInput ? ((ByteArrayDataInput)@in).Position : ((IndexInput)@in).Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                assertEquals(fp, @in is ByteArrayDataInput input1 ? input1.Position : ((IndexInput)@in).Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 try
                 {
                     it.Next();
@@ -1372,9 +1372,9 @@ namespace Lucene.Net.Util.Packed
                     // OK
                 }
 
-                if (@in is ByteArrayDataInput)
+                if (@in is ByteArrayDataInput input2)
                 {
-                    ((ByteArrayDataInput)@in).Position = 0;
+                    input2.Position = 0;
                 }
                 else
                 {
@@ -1398,7 +1398,7 @@ namespace Lucene.Net.Util.Packed
                         ++k;
                     }
                 }
-                assertEquals(fp, @in is ByteArrayDataInput ? ((ByteArrayDataInput)@in).Position : (((IndexInput)@in).Position)); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+                assertEquals(fp, @in is ByteArrayDataInput input3 ? input3.Position : ((IndexInput)@in).Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
                 try
                 {
                     it2.Skip(1);

--- a/src/Lucene.Net.Tests/Util/Test2BPagedBytes.cs
+++ b/src/Lucene.Net.Tests/Util/Test2BPagedBytes.cs
@@ -41,9 +41,9 @@ namespace Lucene.Net.Util
         public virtual void Test()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("test2BPagedBytes"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
             PagedBytes pb = new PagedBytes(15);
             IndexOutput dataOutput = dir.CreateOutput("foo", IOContext.DEFAULT);

--- a/src/Lucene.Net.Tests/Util/TestDoubleBarrelLRUCache.cs
+++ b/src/Lucene.Net.Tests/Util/TestDoubleBarrelLRUCache.cs
@@ -183,8 +183,8 @@ namespace Lucene.Net.Util
             public override bool Equals(object other)
             {
                 // LUCENENET: Additional type check not present in Java code
-                if (other is CloneableObject)
-                    return this.value.Equals(((CloneableObject) other).value);
+                if (other is CloneableObject cloneableObject)
+                    return this.value.Equals(cloneableObject.value);
                 else
                     return false;
             }

--- a/src/Lucene.Net.Tests/Util/TestPagedBytes.cs
+++ b/src/Lucene.Net.Tests/Util/TestPagedBytes.cs
@@ -45,9 +45,9 @@ namespace Lucene.Net.Util
             for (int iter = 0; iter < 5 * RandomMultiplier; iter++)
             {
                 BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("testOverflow"));
-                if (dir is MockDirectoryWrapper)
+                if (dir is MockDirectoryWrapper mockDirectoryWrapper)
                 {
-                    ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                    mockDirectoryWrapper.Throttling = Throttling.NEVER;
                 }
                 int blockBits = TestUtil.NextInt32(random, 1, 20);
                 int blockSize = 1 << blockBits;
@@ -186,9 +186,9 @@ namespace Lucene.Net.Util
         public virtual void TestOverflow()
         {
             BaseDirectoryWrapper dir = NewFSDirectory(CreateTempDir("testOverflow"));
-            if (dir is MockDirectoryWrapper)
+            if (dir is MockDirectoryWrapper mockDirectoryWrapper)
             {
-                ((MockDirectoryWrapper)dir).Throttling = Throttling.NEVER;
+                mockDirectoryWrapper.Throttling = Throttling.NEVER;
             }
             int blockBits = TestUtil.NextInt32(Random, 14, 28);
             int blockSize = 1 << blockBits;

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsReader.cs
@@ -778,7 +778,7 @@ namespace Lucene.Net.Codecs.Compressing
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override TermsEnum GetEnumerator(TermsEnum reuse)
             {
-                if (reuse is null || !(reuse is TVTermsEnum termsEnum))
+                if (reuse is null || reuse is not TVTermsEnum termsEnum)
                     termsEnum = new TVTermsEnum();
 
                 termsEnum.Reset(numTerms, flags, prefixLengths, suffixLengths, termFreqs, positionIndex, positions, startOffsets, lengths, payloadIndex, payloadBytes, new ByteArrayDataInput(termBytes.Bytes, termBytes.Offset, termBytes.Length));
@@ -922,7 +922,7 @@ namespace Lucene.Net.Codecs.Compressing
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override sealed DocsEnum Docs(IBits liveDocs, DocsEnum reuse, DocsFlags flags)
             {
-                if (reuse is null || !(reuse is TVDocsEnum docsEnum))
+                if (reuse is null || reuse is not TVDocsEnum docsEnum)
                     docsEnum = new TVDocsEnum();
 
                 docsEnum.Reset(liveDocs, termFreqs[ord], positionIndex[ord], positions, startOffsets, lengths, payloads, payloadIndex);

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -388,7 +388,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override TermsEnum GetEnumerator(TermsEnum reuse)
             {
-                if (reuse is null || !(reuse is TVTermsEnum termsEnum) || !termsEnum.CanReuse(outerInstance.tvf))
+                if (reuse is null || reuse is not TVTermsEnum termsEnum || !termsEnum.CanReuse(outerInstance.tvf))
                     termsEnum = new TVTermsEnum(outerInstance);
 
                 termsEnum.Reset(numTerms, tvfFPStart, storePositions, storeOffsets, unicodeSortOrder);
@@ -588,7 +588,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override DocsEnum Docs(IBits liveDocs, DocsEnum reuse, DocsFlags flags) // ignored
             {
-                if (reuse is null || !(reuse is TVDocsEnum docsEnum))
+                if (reuse is null || reuse is not TVDocsEnum docsEnum)
                     docsEnum = new TVDocsEnum();
 
                 docsEnum.Reset(liveDocs, termAndPostings[currentTerm]);
@@ -603,7 +603,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                     return null;
                 }
 
-                if (reuse is null || !(reuse is TVDocsAndPositionsEnum docsAndPositionsEnum))
+                if (reuse is null || reuse is not TVDocsAndPositionsEnum docsAndPositionsEnum)
                     docsAndPositionsEnum = new TVDocsAndPositionsEnum();
 
                 docsAndPositionsEnum.Reset(liveDocs, termAndPostings[currentTerm]);

--- a/src/Lucene.Net/Codecs/Lucene40/BitVector.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/BitVector.cs
@@ -262,7 +262,7 @@ namespace Lucene.Net.Codecs.Lucene40
         /// </summary>
         public void Write(Directory d, string name, IOContext context)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(!(d is CompoundFileDirectory));
+            if (Debugging.AssertsEnabled) Debugging.Assert(d is not CompoundFileDirectory);
             IndexOutput output = d.CreateOutput(name, context);
             try
             {

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40PostingsReader.cs
@@ -269,7 +269,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 // If you are using ParellelReader, and pass in a
                 // reused DocsEnum, it could have come from another
                 // reader also using standard codec
-                if (reuse is null || !(reuse is SegmentFullPositionsEnum docsEnum) || docsEnum.startFreqIn != freqIn)
+                if (reuse is null || reuse is not SegmentFullPositionsEnum docsEnum || docsEnum.startFreqIn != freqIn)
                     docsEnum = new SegmentFullPositionsEnum(this, freqIn, proxIn);
 
                 return docsEnum.Reset(fieldInfo, (StandardTermState)termState, liveDocs);
@@ -279,7 +279,7 @@ namespace Lucene.Net.Codecs.Lucene40
                 // If you are using ParellelReader, and pass in a
                 // reused DocsEnum, it could have come from another
                 // reader also using standard codec
-                if (reuse is null || !(reuse is SegmentDocsAndPositionsEnum docsEnum) || docsEnum.startFreqIn != freqIn)
+                if (reuse is null || reuse is not SegmentDocsAndPositionsEnum docsEnum || docsEnum.startFreqIn != freqIn)
                     docsEnum = new SegmentDocsAndPositionsEnum(this, freqIn, proxIn);
 
                 return docsEnum.Reset(fieldInfo, (StandardTermState)termState, liveDocs);

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
@@ -352,7 +352,7 @@ namespace Lucene.Net.Codecs.Lucene40
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override TermsEnum GetEnumerator(TermsEnum reuse)
             {
-                if (reuse is null || !(reuse is TVTermsEnum termsEnum) || !termsEnum.CanReuse(outerInstance.tvf))
+                if (reuse is null || reuse is not TVTermsEnum termsEnum || !termsEnum.CanReuse(outerInstance.tvf))
                     termsEnum = new TVTermsEnum(outerInstance);
 
                 termsEnum.Reset(numTerms, tvfFPStart, storePositions, storeOffsets, storePayloads);
@@ -562,7 +562,7 @@ namespace Lucene.Net.Codecs.Lucene40
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public override DocsEnum Docs(IBits liveDocs, DocsEnum reuse, DocsFlags flags) // ignored
             {
-                if (reuse is null || !(reuse is TVDocsEnum docsEnum))
+                if (reuse is null || reuse is not TVDocsEnum docsEnum)
                     docsEnum = new TVDocsEnum();
 
                 docsEnum.Reset(liveDocs, freq);
@@ -577,7 +577,7 @@ namespace Lucene.Net.Codecs.Lucene40
                     return null;
                 }
 
-                if (reuse is null || !(reuse is TVDocsAndPositionsEnum docsAndPositionsEnum))
+                if (reuse is null || reuse is not TVDocsAndPositionsEnum docsAndPositionsEnum)
                     docsAndPositionsEnum = new TVDocsAndPositionsEnum();
 
                 docsAndPositionsEnum.Reset(liveDocs, positions, startOffsets, endOffsets, payloadOffsets, payloadData);

--- a/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene41/Lucene41PostingsReader.cs
@@ -242,7 +242,7 @@ namespace Lucene.Net.Codecs.Lucene41
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override DocsEnum Docs(FieldInfo fieldInfo, BlockTermState termState, IBits liveDocs, DocsEnum reuse, DocsFlags flags)
         {
-            if (reuse is null || !(reuse is BlockDocsEnum docsEnum) || !docsEnum.CanReuse(docIn, fieldInfo))
+            if (reuse is null || reuse is not BlockDocsEnum docsEnum || !docsEnum.CanReuse(docIn, fieldInfo))
                 docsEnum = new BlockDocsEnum(this, fieldInfo);
 
             return docsEnum.Reset(liveDocs, (Lucene41PostingsWriter.Int32BlockTermState)termState, flags);
@@ -258,14 +258,14 @@ namespace Lucene.Net.Codecs.Lucene41
 
             if ((!indexHasOffsets || (flags & DocsAndPositionsFlags.OFFSETS) == 0) && (!indexHasPayloads || (flags & DocsAndPositionsFlags.PAYLOADS) == 0))
             {
-                if (reuse is null || !(reuse is BlockDocsAndPositionsEnum docsAndPositionsEnum) || !docsAndPositionsEnum.CanReuse(docIn, fieldInfo))
+                if (reuse is null || reuse is not BlockDocsAndPositionsEnum docsAndPositionsEnum || !docsAndPositionsEnum.CanReuse(docIn, fieldInfo))
                     docsAndPositionsEnum = new BlockDocsAndPositionsEnum(this, fieldInfo);
 
                 return docsAndPositionsEnum.Reset(liveDocs, (Lucene41PostingsWriter.Int32BlockTermState)termState);
             }
             else
             {
-                if (reuse is null || !(reuse is EverythingEnum everythingEnum) || !everythingEnum.CanReuse(docIn, fieldInfo))
+                if (reuse is null || reuse is not EverythingEnum everythingEnum || !everythingEnum.CanReuse(docIn, fieldInfo))
                     everythingEnum = new EverythingEnum(this, fieldInfo);
 
                 return everythingEnum.Reset(liveDocs, (Lucene41PostingsWriter.Int32BlockTermState)termState, flags);

--- a/src/Lucene.Net/Document/Field.cs
+++ b/src/Lucene.Net/Document/Field.cs
@@ -403,7 +403,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public virtual void SetStringValue(string value)
         {
-            if (!(FieldsData is string))
+            if (FieldsData is not string)
             {
                 throw new ArgumentException("cannot change value type from " + FieldsData.GetType().Name + " to string");
             }
@@ -416,7 +416,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public virtual void SetReaderValue(TextReader value)
         {
-            if (!(FieldsData is TextReader))
+            if (FieldsData is not TextReader)
             {
                 throw new ArgumentException("cannot change value type from " + FieldsData.GetType().Name + " to TextReader");
             }
@@ -432,7 +432,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public virtual void SetBytesValue(BytesRef value)
         {
-            if (!(FieldsData is BytesRef))
+            if (FieldsData is not BytesRef)
             {
                 throw new ArgumentException("cannot change value type from " + FieldsData.GetType().Name + " to BytesRef");
             }
@@ -458,7 +458,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public virtual void SetByteValue(byte value)
         {
-            if (!(FieldsData is Byte))
+            if (FieldsData is not Byte)
             {
                 throw new ArgumentException("cannot change value type from " + FieldsData.GetType().Name + " to Byte");
             }
@@ -471,7 +471,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public virtual void SetInt16Value(short value) // LUCENENET specific: Renamed from SetShortValue to follow .NET conventions
         {
-            if (!(FieldsData is Int16))
+            if (FieldsData is not Int16)
             {
                 throw new ArgumentException("cannot change value type from " + FieldsData.GetType().Name + " to Short");
             }
@@ -484,7 +484,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public virtual void SetInt32Value(int value) // LUCENENET specific: Renamed from SetIntValue to follow .NET conventions
         {
-            if (!(FieldsData is Int32))
+            if (FieldsData is not Int32)
             {
                 throw new ArgumentException("cannot change value type from " + FieldsData.GetType().Name + " to Integer");
             }
@@ -497,7 +497,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public virtual void SetInt64Value(long value) // LUCENENET specific: Renamed from SetLongValue to follow .NET conventions
         {
-            if (!(FieldsData is Int64))
+            if (FieldsData is not Int64)
             {
                 throw new ArgumentException("cannot change value type from " + FieldsData.GetType().Name + " to Long");
             }
@@ -510,7 +510,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public virtual void SetSingleValue(float value) // LUCENENET specific: Renamed from SetFloatValue to follow .NET conventions
         {
-            if (!(FieldsData is Single))
+            if (FieldsData is not Single)
             {
                 throw new ArgumentException("cannot change value type from " + FieldsData.GetType().Name + " to Float");
             }
@@ -523,7 +523,7 @@ namespace Lucene.Net.Documents
         /// </summary>
         public virtual void SetDoubleValue(double value)
         {
-            if (!(FieldsData is Double))
+            if (FieldsData is not Double)
             {
                 throw new ArgumentException("cannot change value type from " + FieldsData.GetType().Name + " to Double");
             }
@@ -877,7 +877,7 @@ namespace Lucene.Net.Documents
                 {
                     throw new ArgumentException("Non-Tokenized Fields must have a String value");
                 }
-                if (!(internalTokenStream is StringTokenStream))
+                if (internalTokenStream is not StringTokenStream)
                 {
                     // lazy init the TokenStream as it is heavy to instantiate
                     // (attributes,...) if not needed (stored field loading)

--- a/src/Lucene.Net/Index/CheckIndex.cs
+++ b/src/Lucene.Net/Index/CheckIndex.cs
@@ -1218,7 +1218,7 @@ namespace Lucene.Net.Index
                                 lastPos = pos;
                                 BytesRef payload = postings.GetPayload();
                                 // LUCENENET specific - restructured to reduce number of checks in production
-                                if (!(payload is null))
+                                if (payload is not null)
                                 {
                                     if (Debugging.AssertsEnabled) Debugging.Assert(payload.IsValid());
                                     if (payload.Length < 1)

--- a/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
@@ -728,7 +728,7 @@ namespace Lucene.Net.Index
                 catch (Exception exc) when (exc.IsThrowable())
                 {
                     // Ignore the exception if it was due to abort:
-                    if (!(exc is MergePolicy.MergeAbortedException))
+                    if (exc is not MergePolicy.MergeAbortedException)
                     {
                         //System.out.println(Thread.currentThread().getName() + ": CMS: exc");
                         //exc.printStackTrace(System.out);

--- a/src/Lucene.Net/Index/MultiTermsEnum.cs
+++ b/src/Lucene.Net/Index/MultiTermsEnum.cs
@@ -389,7 +389,7 @@ namespace Lucene.Net.Index
             if (queue.Count > 0)
             {
                 PullTop();
-                return !(current is null);
+                return current is not null;
             }
             else
             {
@@ -441,7 +441,7 @@ namespace Lucene.Net.Index
         {
             // Can only reuse if incoming enum is also a MultiDocsEnum
             // ... and was previously created w/ this MultiTermsEnum:
-            if (reuse is null || !(reuse is MultiDocsEnum docsEnum) || !docsEnum.CanReuse(this))
+            if (reuse is null || reuse is not MultiDocsEnum docsEnum || !docsEnum.CanReuse(this))
                 docsEnum = new MultiDocsEnum(this, subs.Length);
 
             int upto = 0;
@@ -511,7 +511,7 @@ namespace Lucene.Net.Index
         {
             // Can only reuse if incoming enum is also a MultiDocsAndPositionsEnum
             // ... and was previously created w/ this MultiTermsEnum:
-            if (reuse is null || !(reuse is MultiDocsAndPositionsEnum docsAndPositionsEnum) || !docsAndPositionsEnum.CanReuse(this))
+            if (reuse is null || reuse is not MultiDocsAndPositionsEnum docsAndPositionsEnum || !docsAndPositionsEnum.CanReuse(this))
 
                 docsAndPositionsEnum = new MultiDocsAndPositionsEnum(this, subs.Length);
 

--- a/src/Lucene.Net/Index/SegmentCoreReaders.cs
+++ b/src/Lucene.Net/Index/SegmentCoreReaders.cs
@@ -166,7 +166,7 @@ namespace Lucene.Net.Index
 
             IDictionary<string, object> normFields = normsLocal.Value;
 
-            if (!normFields.TryGetValue(fi.Name, out object ret) || !(ret is NumericDocValues norms))
+            if (!normFields.TryGetValue(fi.Name, out object ret) || ret is not NumericDocValues norms)
             {
                 norms = normsProducer.GetNumeric(fi);
                 normFields[fi.Name] = norms;

--- a/src/Lucene.Net/Index/SegmentInfo.cs
+++ b/src/Lucene.Net/Index/SegmentInfo.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Index
         /// </summary>
         public SegmentInfo(Directory dir, string version, string name, int docCount, bool isCompoundFile, Codec codec, IDictionary<string, string> diagnostics, IDictionary<string, string> attributes)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(!(dir is TrackingDirectoryWrapper));
+            if (Debugging.AssertsEnabled) Debugging.Assert(dir is not TrackingDirectoryWrapper);
             this.Dir = dir;
             this.version = version;
             this.Name = name;

--- a/src/Lucene.Net/Index/SegmentReader.cs
+++ b/src/Lucene.Net/Index/SegmentReader.cs
@@ -458,7 +458,7 @@ namespace Lucene.Net.Index
 
             IDictionary<string, object> dvFields = docValuesLocal.Value;
 
-            if (!dvFields.TryGetValue(field, out object dvsDummy) || !(dvsDummy is NumericDocValues dvs))
+            if (!dvFields.TryGetValue(field, out object dvsDummy) || dvsDummy is not NumericDocValues dvs)
             {
                 dvProducersByField.TryGetValue(field, out DocValuesProducer dvProducer);
                 if (Debugging.AssertsEnabled) Debugging.Assert(dvProducer != null);
@@ -508,7 +508,7 @@ namespace Lucene.Net.Index
 
             IDictionary<string, object> dvFields = docValuesLocal.Value;
 
-            if (!dvFields.TryGetValue(field, out object ret) || !(ret is BinaryDocValues dvs))
+            if (!dvFields.TryGetValue(field, out object ret) || ret is not BinaryDocValues dvs)
             {
                 dvProducersByField.TryGetValue(field, out DocValuesProducer dvProducer);
                 if (Debugging.AssertsEnabled) Debugging.Assert(dvProducer != null);
@@ -530,7 +530,7 @@ namespace Lucene.Net.Index
 
             IDictionary<string, object> dvFields = docValuesLocal.Value;
 
-            if (!dvFields.TryGetValue(field, out object ret) || !(ret is SortedDocValues dvs))
+            if (!dvFields.TryGetValue(field, out object ret) || ret is not SortedDocValues dvs)
             {
                 dvProducersByField.TryGetValue(field, out DocValuesProducer dvProducer);
                 if (Debugging.AssertsEnabled) Debugging.Assert(dvProducer != null);
@@ -552,7 +552,7 @@ namespace Lucene.Net.Index
 
             IDictionary<string, object> dvFields = docValuesLocal.Value;
 
-            if (!dvFields.TryGetValue(field, out object ret) || !(ret is SortedSetDocValues dvs))
+            if (!dvFields.TryGetValue(field, out object ret) || ret is not SortedSetDocValues dvs)
             {
                 dvProducersByField.TryGetValue(field, out DocValuesProducer dvProducer);
                 if (Debugging.AssertsEnabled) Debugging.Assert(dvProducer != null);

--- a/src/Lucene.Net/Search/BooleanQuery.cs
+++ b/src/Lucene.Net/Search/BooleanQuery.cs
@@ -678,11 +678,11 @@ namespace Lucene.Net.Search
         /// Returns <c>true</c> if <paramref name="o"/> is equal to this. </summary>
         public override bool Equals(object o)
         {
-            if (!(o is BooleanQuery))
+            if (o is not BooleanQuery other)
             {
                 return false;
             }
-            BooleanQuery other = (BooleanQuery)o;
+
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
             return NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost)
                 && this.clauses.Equals(other.clauses)

--- a/src/Lucene.Net/Search/CachingWrapperFilter.cs
+++ b/src/Lucene.Net/Search/CachingWrapperFilter.cs
@@ -156,7 +156,7 @@ namespace Lucene.Net.Search
         public override bool Equals(object o)
         {
             if (o is null) return false;
-            if (!(o is CachingWrapperFilter other)) return false;
+            if (o is not CachingWrapperFilter other) return false;
             return filter.Equals(other.filter);
         }
 

--- a/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
+++ b/src/Lucene.Net/Search/DisjunctionMaxQuery.cs
@@ -361,11 +361,11 @@ namespace Lucene.Net.Search
         /// <returns> <c>true</c> if <paramref name="o"/> is a <see cref="DisjunctionMaxQuery"/> with the same boost and the same subqueries, in the same order, as us </returns>
         public override bool Equals(object o)
         {
-            if (!(o is DisjunctionMaxQuery))
+            if (o is not DisjunctionMaxQuery other)
             {
                 return false;
             }
-            DisjunctionMaxQuery other = (DisjunctionMaxQuery)o;
+
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
             return NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost)
                 && NumericUtils.SingleToSortableInt32(this.tieBreakerMultiplier) == NumericUtils.SingleToSortableInt32(other.tieBreakerMultiplier)

--- a/src/Lucene.Net/Search/DocTermOrdsRangeFilter.cs
+++ b/src/Lucene.Net/Search/DocTermOrdsRangeFilter.cs
@@ -162,11 +162,10 @@ namespace Lucene.Net.Search
             {
                 return true;
             }
-            if (!(o is DocTermOrdsRangeFilter))
+            if (o is not DocTermOrdsRangeFilter other)
             {
                 return false;
             }
-            DocTermOrdsRangeFilter other = (DocTermOrdsRangeFilter)o;
 
             if (!this.field.Equals(other.field, StringComparison.Ordinal) || this.includeLower != other.includeLower || this.includeUpper != other.includeUpper)
             {

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -394,10 +394,10 @@ namespace Lucene.Net.Search
                             // Only check if key.custom (the parser) is
                             // non-null; else, we check twice for a single
                             // call to FieldCache.getXXX
-                            if (!(key.Custom is null) && !(wrapper is null))
+                            if (key.Custom is not null && wrapper is not null)
                             {
                                 TextWriter infoStream = wrapper.InfoStream;
-                                if (!(infoStream is null))
+                                if (infoStream is not null)
                                 {
                                     PrintNewInsanity(infoStream, progress.Value);
                                 }

--- a/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
+++ b/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
@@ -742,11 +742,10 @@ namespace Lucene.Net.Search
             {
                 return true;
             }
-            if (!(o is FieldCacheRangeFilter<T>))
+            if (o is not FieldCacheRangeFilter<T> other)
             {
                 return false;
             }
-            FieldCacheRangeFilter<T> other = (FieldCacheRangeFilter<T>)o;
 
             if (!this.field.Equals(other.field, StringComparison.Ordinal) || this.includeLower != other.includeLower || this.includeUpper != other.includeUpper)
             {

--- a/src/Lucene.Net/Search/FieldComparator.cs
+++ b/src/Lucene.Net/Search/FieldComparator.cs
@@ -1001,7 +1001,7 @@ namespace Lucene.Net.Search
                 // wrap with a ScoreCachingWrappingScorer so that successive calls to
                 // score() will not incur score computation over and
                 // over again.
-                if (!(scorer is ScoreCachingWrappingScorer))
+                if (scorer is not ScoreCachingWrappingScorer)
                 {
                     this.scorer = new ScoreCachingWrappingScorer(scorer);
                 }

--- a/src/Lucene.Net/Search/FuzzyTermsEnum.cs
+++ b/src/Lucene.Net/Search/FuzzyTermsEnum.cs
@@ -77,7 +77,7 @@ namespace Lucene.Net.Search
 
         protected readonly int m_termLength;
 
-        protected int m_maxEdits; 
+        protected int m_maxEdits;
         protected readonly bool m_raw;
 
         protected readonly Terms m_terms;
@@ -487,11 +487,11 @@ namespace Lucene.Net.Search
                 {
                     return true;
                 }
-                if (!(other is LevenshteinAutomataAttribute))
+                if (other is not LevenshteinAutomataAttribute laa)
                 {
                     return false;
                 }
-                return automata.Equals(((LevenshteinAutomataAttribute)other).automata);
+                return automata.Equals(laa.automata);
             }
 
             public override void CopyTo(IAttribute target) // LUCENENET specific - intentionally expanding target to use IAttribute rather than Attribute

--- a/src/Lucene.Net/Search/MatchAllDocsQuery.cs
+++ b/src/Lucene.Net/Search/MatchAllDocsQuery.cs
@@ -152,11 +152,11 @@ namespace Lucene.Net.Search
 
         public override bool Equals(object o)
         {
-            if (!(o is MatchAllDocsQuery))
+            if (o is not MatchAllDocsQuery other)
             {
                 return false;
             }
-            MatchAllDocsQuery other = (MatchAllDocsQuery)o;
+
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
             return NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost);
         }

--- a/src/Lucene.Net/Search/MultiPhraseQuery.cs
+++ b/src/Lucene.Net/Search/MultiPhraseQuery.cs
@@ -57,10 +57,10 @@ namespace Lucene.Net.Search
     /// <para/>
     /// Collection initializer note: To create and populate a <see cref="MultiPhraseQuery"/>
     /// in a single statement, you can use the following example as a guide:
-    /// 
+    ///
     /// <code>
     /// var multiPhraseQuery = new MultiPhraseQuery() {
-    ///     new Term("field", "microsoft"), 
+    ///     new Term("field", "microsoft"),
     ///     new Term("field", "office")
     /// };
     /// </code>
@@ -182,7 +182,7 @@ namespace Lucene.Net.Search
             private readonly MultiPhraseQuery outerInstance;
 
             private readonly Similarity similarity;
-            private readonly Similarity.SimWeight stats; 
+            private readonly Similarity.SimWeight stats;
             private readonly IDictionary<Term, TermContext> termContexts = new Dictionary<Term, TermContext>();
 
             public MultiPhraseWeight(MultiPhraseQuery outerInstance, IndexSearcher searcher)
@@ -440,11 +440,11 @@ namespace Lucene.Net.Search
         /// Returns <c>true</c> if <paramref name="o"/> is equal to this. </summary>
         public override bool Equals(object o)
         {
-            if (!(o is MultiPhraseQuery))
+            if (o is not MultiPhraseQuery other)
             {
                 return false;
             }
-            MultiPhraseQuery other = (MultiPhraseQuery)o;
+
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
             return NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost)
                 && this.slop == other.slop
@@ -457,10 +457,10 @@ namespace Lucene.Net.Search
         public override int GetHashCode()
         {
             //If this doesn't work hash all elements of positions. This was used to reduce time overhead
-            return J2N.BitConversion.SingleToInt32Bits(Boost) 
-                ^ slop 
-                ^ TermArraysHashCode() 
-                ^ ((positions.Count == 0) ? 0 : positions.GetHashCode() 
+            return J2N.BitConversion.SingleToInt32Bits(Boost)
+                ^ slop
+                ^ TermArraysHashCode()
+                ^ ((positions.Count == 0) ? 0 : positions.GetHashCode()
                 ^ 0x4AC65113);
         }
 
@@ -470,7 +470,7 @@ namespace Lucene.Net.Search
             int hashCode = 1;
             foreach (Term[] termArray in termArrays)
             {
-                hashCode = 31 * hashCode 
+                hashCode = 31 * hashCode
                     + (termArray is null ? 0 : Arrays.GetHashCode(termArray));
             }
             return hashCode;

--- a/src/Lucene.Net/Search/NGramPhraseQuery.cs
+++ b/src/Lucene.Net/Search/NGramPhraseQuery.cs
@@ -31,10 +31,10 @@ namespace Lucene.Net.Search
     /// <para/>
     /// Collection initializer note: To create and populate a <see cref="PhraseQuery"/>
     /// in a single statement, you can use the following example as a guide:
-    /// 
+    ///
     /// <code>
     /// var phraseQuery = new NGramPhraseQuery(2) {
-    ///     new Term("field", "ABCD"), 
+    ///     new Term("field", "ABCD"),
     ///     new Term("field", "EFGH")
     /// };
     /// </code>
@@ -105,11 +105,11 @@ namespace Lucene.Net.Search
         /// Returns <c>true</c> if <paramref name="o"/> is equal to this. </summary>
         public override bool Equals(object o)
         {
-            if (!(o is NGramPhraseQuery))
+            if (o is not NGramPhraseQuery other)
             {
                 return false;
             }
-            NGramPhraseQuery other = (NGramPhraseQuery)o;
+
             if (this.n != other.n)
             {
                 return false;
@@ -121,10 +121,10 @@ namespace Lucene.Net.Search
         /// Returns a hash code value for this object. </summary>
         public override int GetHashCode()
         {
-            return J2N.BitConversion.SingleToInt32Bits(Boost) 
-                ^ Slop 
-                ^ ArrayEqualityComparer<Term>.OneDimensional.GetHashCode(GetTerms()) 
-                ^ ArrayEqualityComparer<int>.OneDimensional.GetHashCode(GetPositions()) 
+            return J2N.BitConversion.SingleToInt32Bits(Boost)
+                ^ Slop
+                ^ ArrayEqualityComparer<Term>.OneDimensional.GetHashCode(GetTerms())
+                ^ ArrayEqualityComparer<int>.OneDimensional.GetHashCode(GetPositions())
                 ^ n;
         }
     }

--- a/src/Lucene.Net/Search/PhraseQuery.cs
+++ b/src/Lucene.Net/Search/PhraseQuery.cs
@@ -503,14 +503,14 @@ namespace Lucene.Net.Search
         /// Returns <c>true</c> if <paramref name="o"/> is equal to this. </summary>
         public override bool Equals(object o)
         {
-            if (!(o is PhraseQuery))
+            if (o is not PhraseQuery other)
             {
                 return false;
             }
-            PhraseQuery other = (PhraseQuery)o;
+
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
-            return (NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost))
-                && (this.slop == other.slop)
+            return NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost)
+                && this.slop == other.slop
                 && this.terms.Equals(other.terms)
                 && this.positions.Equals(other.positions);
         }

--- a/src/Lucene.Net/Search/QueryWrapperFilter.cs
+++ b/src/Lucene.Net/Search/QueryWrapperFilter.cs
@@ -84,11 +84,11 @@ namespace Lucene.Net.Search
 
         public override bool Equals(object o)
         {
-            if (!(o is QueryWrapperFilter))
+            if (o is not QueryWrapperFilter other)
             {
                 return false;
             }
-            return this.query.Equals(((QueryWrapperFilter)o).query);
+            return this.query.Equals(other.query);
         }
 
         public override int GetHashCode()

--- a/src/Lucene.Net/Search/ReferenceManager.cs
+++ b/src/Lucene.Net/Search/ReferenceManager.cs
@@ -326,7 +326,7 @@ namespace Lucene.Net.Search
         /// <exception cref="IOException"> If the release operation on the given resource throws an <see cref="IOException"/> </exception>
         public void Release(G reference)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(!(reference is null));
+            if (Debugging.AssertsEnabled) Debugging.Assert(reference is not null);
             DecRef(reference);
         }
 

--- a/src/Lucene.Net/Search/Sort.cs
+++ b/src/Lucene.Net/Search/Sort.cs
@@ -221,11 +221,11 @@ namespace Lucene.Net.Search
             {
                 return true;
             }
-            if (!(o is Sort))
+            if (o is not Sort other)
             {
                 return false;
             }
-            Sort other = (Sort)o;
+
             return Arrays.Equals(this.fields, other.fields);
         }
 

--- a/src/Lucene.Net/Search/SortField.cs
+++ b/src/Lucene.Net/Search/SortField.cs
@@ -386,15 +386,15 @@ namespace Lucene.Net.Search
             {
                 return true;
             }
-            if (!(o is SortField))
+            if (o is not SortField other)
             {
                 return false;
             }
-            SortField other = (SortField)o;
-            return (StringHelper.Equals(other.field, this.field)
-                && other.type == this.type
-                && other.reverse == this.reverse
-                && (other.comparerSource is null ? this.comparerSource is null : other.comparerSource.Equals(this.comparerSource)));
+
+            return StringHelper.Equals(other.field, this.field)
+                   && other.type == this.type
+                   && other.reverse == this.reverse
+                   && (other.comparerSource is null ? this.comparerSource is null : other.comparerSource.Equals(this.comparerSource));
         }
 
         /// <summary>

--- a/src/Lucene.Net/Search/Spans/FieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net/Search/Spans/FieldMaskingSpanQuery.cs
@@ -140,15 +140,15 @@ namespace Lucene.Net.Search.Spans
 
         public override bool Equals(object o)
         {
-            if (!(o is FieldMaskingSpanQuery))
+            if (o is not FieldMaskingSpanQuery other)
             {
                 return false;
             }
-            FieldMaskingSpanQuery other = (FieldMaskingSpanQuery)o;
+
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
-            return (this.Field.Equals(other.Field, StringComparison.Ordinal)
-                && (NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost))
-                && this.MaskedQuery.Equals(other.MaskedQuery));
+            return this.Field.Equals(other.Field, StringComparison.Ordinal)
+                   && NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost)
+                   && this.MaskedQuery.Equals(other.MaskedQuery);
         }
 
         public override int GetHashCode()

--- a/src/Lucene.Net/Search/Spans/SpanFirstQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanFirstQuery.cs
@@ -82,12 +82,11 @@ namespace Lucene.Net.Search.Spans
             {
                 return true;
             }
-            if (!(o is SpanFirstQuery))
+            if (o is not SpanFirstQuery other)
             {
                 return false;
             }
 
-            SpanFirstQuery other = (SpanFirstQuery)o;
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
             return this.m_end == other.m_end
                 && this.m_match.Equals(other.m_match)

--- a/src/Lucene.Net/Search/Spans/SpanMultiTermQueryWrapper.cs
+++ b/src/Lucene.Net/Search/Spans/SpanMultiTermQueryWrapper.cs
@@ -78,7 +78,7 @@ namespace Lucene.Net.Search.Spans
             get
             {
                 MultiTermQuery.RewriteMethod m = m_query.MultiTermRewriteMethod;
-                if (!(m is SpanRewriteMethod spanRewriteMethod))
+                if (m is not SpanRewriteMethod spanRewriteMethod)
                 {
                     throw UnsupportedOperationException.Create("You can only use SpanMultiTermQueryWrapper with a suitable SpanRewriteMethod.");
                 }
@@ -115,7 +115,7 @@ namespace Lucene.Net.Search.Spans
         public override Query Rewrite(IndexReader reader)
         {
             Query q = m_query.Rewrite(reader);
-            if (!(q is SpanQuery))
+            if (q is not SpanQuery)
             {
                 throw UnsupportedOperationException.Create("You can only use SpanMultiTermQueryWrapper with a suitable SpanRewriteMethod.");
             }

--- a/src/Lucene.Net/Search/Spans/SpanNearPayloadCheckQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanNearPayloadCheckQuery.cs
@@ -124,7 +124,7 @@ namespace Lucene.Net.Search.Spans
             {
                 return true;
             }
-            if (!(o is SpanNearPayloadCheckQuery other))
+            if (o is not SpanNearPayloadCheckQuery other)
             {
                 return false;
             }

--- a/src/Lucene.Net/Search/Spans/SpanNearQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanNearQuery.cs
@@ -191,7 +191,7 @@ namespace Lucene.Net.Search.Spans
             {
                 return true;
             }
-            if (!(o is SpanNearQuery spanNearQuery))
+            if (o is not SpanNearQuery spanNearQuery)
             {
                 return false;
             }

--- a/src/Lucene.Net/Search/Spans/SpanPayloadCheckQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanPayloadCheckQuery.cs
@@ -127,12 +127,11 @@ namespace Lucene.Net.Search.Spans
             {
                 return true;
             }
-            if (!(o is SpanPayloadCheckQuery))
+            if (o is not SpanPayloadCheckQuery other)
             {
                 return false;
             }
 
-            SpanPayloadCheckQuery other = (SpanPayloadCheckQuery)o;
             // LUCENENET NOTE: Need to use the structural equality comparer to compare equality of all contained values
             return payloadEqualityComparer.Equals(this.m_payloadToMatch, other.m_payloadToMatch)
                 && this.m_match.Equals(other.m_match)

--- a/src/Lucene.Net/Search/Spans/SpanPositionRangeQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanPositionRangeQuery.cs
@@ -87,12 +87,11 @@ namespace Lucene.Net.Search.Spans
             {
                 return true;
             }
-            if (!(o is SpanPositionRangeQuery))
+            if (o is not SpanPositionRangeQuery other)
             {
                 return false;
             }
 
-            SpanPositionRangeQuery other = (SpanPositionRangeQuery)o;
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
             return this.m_end == other.m_end
                 && this.m_start == other.m_start

--- a/src/Lucene.Net/Search/TermQuery.cs
+++ b/src/Lucene.Net/Search/TermQuery.cs
@@ -226,13 +226,13 @@ namespace Lucene.Net.Search
         /// Returns <c>true</c> if <paramref name="o"/> is equal to this. </summary>
         public override bool Equals(object o)
         {
-            if (!(o is TermQuery))
+            if (o is not TermQuery other)
             {
                 return false;
             }
-            TermQuery other = (TermQuery)o;
+
             // LUCENENET specific - compare bits rather than using equality operators to prevent these comparisons from failing in x86 in .NET Framework with optimizations enabled
-            return (NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost))
+            return NumericUtils.SingleToSortableInt32(this.Boost) == NumericUtils.SingleToSortableInt32(other.Boost)
                 && this.term.Equals(other.term);
         }
 

--- a/src/Lucene.Net/Search/TopDocs.cs
+++ b/src/Lucene.Net/Search/TopDocs.cs
@@ -217,11 +217,11 @@ namespace Lucene.Net.Search
                         for (int hitIDX = 0; hitIDX < shard.Length; hitIDX++)
                         {
                             ScoreDoc sd = shard[hitIDX];
-                            if (!(sd is FieldDoc))
+                            if (sd is not FieldDoc fd)
                             {
                                 throw new ArgumentException("shard " + shardIDX + " was not sorted by the provided Sort (expected FieldDoc but got ScoreDoc)");
                             }
-                            FieldDoc fd = (FieldDoc)sd;
+
                             if (fd.Fields is null)
                             {
                                 throw new ArgumentException("shard " + shardIDX + " did not set sort field values (FieldDoc.fields is null); you must pass fillFields=true to IndexSearcher.search on each shard");

--- a/src/Lucene.Net/Store/CompoundFileDirectory.cs
+++ b/src/Lucene.Net/Store/CompoundFileDirectory.cs
@@ -122,7 +122,7 @@ namespace Lucene.Net.Store
             }
             else
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(!(directory is CompoundFileDirectory),"compound file inside of compound file: {0}", fileName);
+                if (Debugging.AssertsEnabled) Debugging.Assert(directory is not CompoundFileDirectory,"compound file inside of compound file: {0}", fileName);
                 this.entries = SENTINEL;
                 this.IsOpen = true;
                 writer = new CompoundFileWriter(directory, fileName);

--- a/src/Lucene.Net/Support/ExceptionHandling/ExceptionExtensions.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/ExceptionExtensions.cs
@@ -47,8 +47,8 @@ namespace Lucene
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsAlwaysIgnored(this Exception e)
         {
-            return (!(NUnitSuccessExceptionType is null) && NUnitSuccessExceptionType.IsAssignableFrom(e.GetType())) ||
-                (!(NUnitInvalidPlatformException is null) && NUnitInvalidPlatformException.IsAssignableFrom(e.GetType()));
+            return (NUnitSuccessExceptionType is not null && NUnitSuccessExceptionType.IsAssignableFrom(e.GetType())) ||
+                (NUnitInvalidPlatformException is not null && NUnitInvalidPlatformException.IsAssignableFrom(e.GetType()));
         }
 
         /// <summary>
@@ -79,10 +79,10 @@ namespace Lucene
             if (e is null || e.IsAlwaysIgnored()) return false;
 
             return e is AssertionException ||
-                (!(DebugAssertExceptionType is null) && DebugAssertExceptionType.IsAssignableFrom(e.GetType())) ||
+                (DebugAssertExceptionType is not null && DebugAssertExceptionType.IsAssignableFrom(e.GetType())) ||
                 // Ignore NUnit exceptions (in tests)
-                (!(NUnitAssertionExceptionType is null) && NUnitAssertionExceptionType.IsAssignableFrom(e.GetType())) ||
-                (!(NUnitMultipleAssertExceptionType is null) && NUnitMultipleAssertExceptionType.IsAssignableFrom(e.GetType()));
+                (NUnitAssertionExceptionType is not null && NUnitAssertionExceptionType.IsAssignableFrom(e.GetType())) ||
+                (NUnitMultipleAssertExceptionType is not null && NUnitMultipleAssertExceptionType.IsAssignableFrom(e.GetType()));
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace Lucene
         {
             if (e is null || e.IsAlwaysIgnored() ||
                 // Exclude InconclusiveException - AssumptionViolatedException derives from RuntimeException in Java so it is not an Error type
-                (!(NUnitInconclusiveExceptionType is null) && NUnitInconclusiveExceptionType.IsAssignableFrom(e.GetType()))
+                (NUnitInconclusiveExceptionType is not null && NUnitInconclusiveExceptionType.IsAssignableFrom(e.GetType()))
                 ) return false;
 
             return
@@ -108,9 +108,9 @@ namespace Lucene
                 // e.IsNoClassDefFoundError() || // NOTE: These are technically errors, but they overlap other exception types in .NET. Since Lucene always catches this at the source, we can ignore here.
                 e is StackOverflowException || // Not catchable in .NET unless we throw it, but mainly here just for documentation purposes
                 // Ignore .NET debug assert statements (only valid when test framework is attached)
-                (!(DebugAssertExceptionType is null) && DebugAssertExceptionType.IsAssignableFrom(e.GetType())) ||
+                (DebugAssertExceptionType is not null && DebugAssertExceptionType.IsAssignableFrom(e.GetType())) ||
                 // Ignore NUnit exceptions (in tests)
-                (!(NUnitResultStateExceptionType is null) && NUnitResultStateExceptionType.IsAssignableFrom(e.GetType()));
+                (NUnitResultStateExceptionType is not null && NUnitResultStateExceptionType.IsAssignableFrom(e.GetType()));
         }
 
         /// <summary>
@@ -574,7 +574,7 @@ namespace Lucene
         public static bool IsIllegalStateException(this Exception e)
         {
             return e is InvalidOperationException &&
-                !(e is ObjectDisposedException); // In .NET, ObjectDisposedException subclases InvalidOperationException, but Lucene decided to use IOException for AlreadyClosedException
+                e is not ObjectDisposedException; // In .NET, ObjectDisposedException subclases InvalidOperationException, but Lucene decided to use IOException for AlreadyClosedException
         }
 
         /// <summary>

--- a/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
@@ -196,7 +196,7 @@ namespace Lucene.Net.Index
                 {
                     ae.Handle(ex =>
                     {
-                        if (!(ex is OperationCanceledException))
+                        if (ex is not OperationCanceledException)
                         {
                             HandleMergeException(ex);
                             return true;
@@ -330,7 +330,7 @@ namespace Lucene.Net.Index
 
         private void OnMergeThreadCompleted(object sender, EventArgs e)
         {
-            if (!(sender is MergeThread mergeThread))
+            if (sender is not MergeThread mergeThread)
             {
                 return;
             }
@@ -604,7 +604,7 @@ namespace Lucene.Net.Index
                 catch (Exception exc)
                 {
                     // Ignore the exception if it was due to abort:
-                    if (!(exc is MergePolicy.MergeAbortedException))
+                    if (exc is not MergePolicy.MergeAbortedException)
                     {
                         //System.out.println(Thread.currentThread().getName() + ": CMS: exc");
                         //exc.printStackTrace(System.out)
@@ -649,7 +649,7 @@ namespace Lucene.Net.Index
 
             public override bool Equals(object obj)
             {
-                if (!(obj is MergeThread compared)
+                if (obj is not MergeThread compared
                     || (Instance is null && compared.Instance != null)
                     || (Instance != null && compared.Instance is null))
                 {

--- a/src/Lucene.Net/Support/Util/Events/EventSubscription.cs
+++ b/src/Lucene.Net/Support/Util/Events/EventSubscription.cs
@@ -43,7 +43,7 @@ namespace Lucene.Net.Util.Events
         {
             if (actionReference == null)
                 throw new ArgumentNullException(nameof(actionReference));
-            if (!(actionReference.Target is Action))
+            if (actionReference.Target is not System.Action)
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidDelegateRerefenceTypeException, typeof(Action).FullName), nameof(actionReference));
 
             _actionReference = actionReference;
@@ -125,12 +125,12 @@ namespace Lucene.Net.Util.Events
         {
             if (actionReference == null)
                 throw new ArgumentNullException(nameof(actionReference));
-            if (!(actionReference.Target is Action<TPayload>))
+            if (actionReference.Target is not Action<TPayload>)
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidDelegateRerefenceTypeException, typeof(Action<TPayload>).FullName), nameof(actionReference));
 
             if (filterReference == null)
                 throw new ArgumentNullException(nameof(filterReference));
-            if (!(filterReference.Target is Predicate<TPayload>))
+            if (filterReference.Target is not Predicate<TPayload>)
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidDelegateRerefenceTypeException, typeof(Predicate<TPayload>).FullName), nameof(filterReference));
 
             _actionReference = actionReference;

--- a/src/Lucene.Net/Util/Automaton/SortedIntSet.cs
+++ b/src/Lucene.Net/Util/Automaton/SortedIntSet.cs
@@ -221,7 +221,7 @@ namespace Lucene.Net.Util.Automaton
             {
                 return false;
             }
-            if (!(obj is SortedInt32Set other)) // LUCENENET specific - don't compare against FrozenInt32Set
+            if (obj is not SortedInt32Set other) // LUCENENET specific - don't compare against FrozenInt32Set
             {
                 return false;
             }

--- a/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
+++ b/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
@@ -351,14 +351,13 @@ namespace Lucene.Net.Util
 
             public override bool Equals(object that)
             {
-                if (!(that is ReaderField))
+                if (that is not ReaderField other)
                 {
                     return false;
                 }
 
-                ReaderField other = (ReaderField)that;
-                return (object.ReferenceEquals(this.readerKey, other.readerKey)
-                    && this.FieldName.Equals(other.FieldName, StringComparison.Ordinal));
+                return ReferenceEquals(this.readerKey, other.readerKey)
+                       && this.FieldName.Equals(other.FieldName, StringComparison.Ordinal);
             }
 
             public override string ToString()

--- a/src/Lucene.Net/Util/FixedBitSet.cs
+++ b/src/Lucene.Net/Util/FixedBitSet.cs
@@ -710,11 +710,11 @@ namespace Lucene.Net.Util
             {
                 return true;
             }
-            if (!(o is FixedBitSet))
+            if (o is not FixedBitSet other)
             {
                 return false;
             }
-            var other = (FixedBitSet)o;
+
             if (numBits != other.Length)
             {
                 return false;

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -490,7 +490,7 @@ namespace Lucene.Net.Util.Fst
             {
                 throw IllegalStateException.Create("cannot save an FST pre-packed FST; it must first be packed");
             }
-            if (packed && !(nodeRefToAddress is PackedInt32s.Mutable))
+            if (packed && nodeRefToAddress is not PackedInt32s.Mutable)
             {
                 throw IllegalStateException.Create("cannot save a FST which has been loaded from disk ");
             }

--- a/src/Lucene.Net/Util/LongBitSet.cs
+++ b/src/Lucene.Net/Util/LongBitSet.cs
@@ -438,11 +438,11 @@ namespace Lucene.Net.Util
             {
                 return true;
             }
-            if (!(o is Int64BitSet))
+            if (o is not Int64BitSet other)
             {
                 return false;
             }
-            Int64BitSet other = (Int64BitSet)o;
+
             if (numBits != other.Length)
             {
                 return false;

--- a/src/Lucene.Net/Util/OpenBitSet.cs
+++ b/src/Lucene.Net/Util/OpenBitSet.cs
@@ -1065,12 +1065,11 @@ namespace Lucene.Net.Util
             {
                 return true;
             }
-            if (!(o is OpenBitSet))
+            if (o is not OpenBitSet b)
             {
                 return false;
             }
             OpenBitSet a;
-            OpenBitSet b = (OpenBitSet)o;
             // make a the larger set.
             if (b.m_wlen > this.m_wlen)
             {

--- a/src/Lucene.Net/Util/Packed/EliasFanoEncoder.cs
+++ b/src/Lucene.Net/Util/Packed/EliasFanoEncoder.cs
@@ -376,17 +376,17 @@ namespace Lucene.Net.Util.Packed
 
         public override bool Equals(object other)
         {
-            if (!(other is EliasFanoEncoder))
+            if (other is not EliasFanoEncoder oefs)
             {
                 return false;
             }
-            EliasFanoEncoder oefs = (EliasFanoEncoder)other;
+
             // no equality needed for upperBound
-            return (this.numValues == oefs.numValues)
-                && (this.numEncoded == oefs.numEncoded)
-                && (this.numLowBits == oefs.numLowBits)
-                && (this.numIndexEntries == oefs.numIndexEntries)
-                && (this.indexInterval == oefs.indexInterval)
+            return this.numValues == oefs.numValues
+                && this.numEncoded == oefs.numEncoded
+                && this.numLowBits == oefs.numLowBits
+                && this.numIndexEntries == oefs.numIndexEntries
+                && this.indexInterval == oefs.indexInterval
                 && Arrays.Equals(this.upperLongs, oefs.upperLongs)
                 && Arrays.Equals(this.lowerLongs, oefs.lowerLongs); // no need to check index content
         }

--- a/src/Lucene.Net/Util/QueryBuilder.cs
+++ b/src/Lucene.Net/Util/QueryBuilder.cs
@@ -324,7 +324,7 @@ namespace Lucene.Net.Util
                                 }
                                 if (posIncrAtt != null && posIncrAtt.PositionIncrement == 0)
                                 {
-                                    if (!(currentQuery is BooleanQuery))
+                                    if (currentQuery is not BooleanQuery)
                                     {
                                         Query t = currentQuery;
                                         currentQuery = NewBooleanQuery(true);


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Uses pattern matching instead of type-check-and-cast, and uses negated pattern matching where applicable.

Fixes #667

## Description

See #667 for details, plus a sweep of using negated pattern matching.
