### PR TITLE
SWEEP: Replace IndexOutOfRangeException with ArgumentOutOfRangeException except for indexer use, #1023

### DIFF
--- a/src/Lucene.Net.Benchmark/Support/Sax/Ext/Attributes2.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/Ext/Attributes2.cs
@@ -41,7 +41,7 @@ namespace Sax.Ext
         /// </summary>
         /// <param name="index">The attribute index (zero-based).</param>
         /// <returns>true if the attribute was declared in the DTD, false otherwise.</returns>
-        /// <exception cref="IndexOutOfRangeException">When the supplied index does not identify an attribute.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">When the supplied index does not identify an attribute.</exception>
         bool IsDeclared(int index);
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Sax.Ext
         /// </summary>
         /// <param name="index">The attribute index (zero-based).</param>
         /// <returns>true if the value was found in the XML text, false if the value was provided by DTD defaulting.</returns>
-        /// <exception cref="IndexOutOfRangeException">When the supplied index does not identify an attribute.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">When the supplied index does not identify an attribute.</exception>
         bool IsSpecified(int index);
 
         /// <summary>

--- a/src/Lucene.Net.Benchmark/Support/Sax/Ext/Attributes2Impl.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/Ext/Attributes2Impl.cs
@@ -74,8 +74,10 @@ namespace Sax.Ext
         public bool IsDeclared(int index)
         {
             if (index < 0 || index >= Length)
-                throw new IndexOutOfRangeException(
-                "No attribute at index: " + index);
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), $"No attribute at index: {index}");
+            }
+
             return declared[index];
         }
 
@@ -114,12 +116,14 @@ namespace Sax.Ext
         /// </summary>
         /// <param name="index">The attribute index (zero-based).</param>
         /// <returns>current flag value</returns>
-        /// <exception cref="IndexOutOfRangeException">When the supplied index does not identify an attribute.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">When the supplied index does not identify an attribute.</exception>
         public bool IsSpecified(int index)
         {
             if (index < 0 || index >= Length)
-                throw new IndexOutOfRangeException(
-                "No attribute at index: " + index);
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), $"No attribute at index: {index}");
+            }
+
             return specified[index];
         }
 
@@ -128,7 +132,7 @@ namespace Sax.Ext
         /// </summary>
         /// <param name="uri">The Namespace URI, or the empty string if the name has no Namespace URI.</param>
         /// <param name="localName">The attribute's local name.</param>
-        /// <returns>current flag value</returns>      
+        /// <returns>current flag value</returns>
         /// <exception cref="ArgumentException">When the supplied names do not identify an attribute.</exception>
         public bool IsSpecified(string uri, string localName)
         {
@@ -146,7 +150,7 @@ namespace Sax.Ext
         /// </summary>
         /// <param name="qName">The XML qualified (prefixed) name.</param>
         /// <returns>current flag value</returns>
-        /// <exception cref="ArgumentException">When the supplied name does not identify an attribute.</exception>          
+        /// <exception cref="ArgumentException">When the supplied name does not identify an attribute.</exception>
         public bool IsSpecified(string qName)
         {
             int index = GetIndex(qName);
@@ -253,12 +257,14 @@ namespace Sax.Ext
         /// </summary>
         /// <param name="index">The index of the attribute (zero-based).</param>
         /// <param name="value">The desired flag value.</param>
-        /// <exception cref="IndexOutOfRangeException">When the supplied index does not identify an attribute.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">When the supplied index does not identify an attribute.</exception>
         public virtual void SetDeclared(int index, bool value)
         {
             if (index < 0 || index >= Length)
-                throw new IndexOutOfRangeException(
-                "No attribute at index: " + index);
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), $"No attribute at index: {index}");
+            }
+
             declared[index] = value;
         }
 
@@ -269,12 +275,14 @@ namespace Sax.Ext
         /// </summary>
         /// <param name="index">The index of the attribute (zero-based).</param>
         /// <param name="value">The desired flag value.</param>
-        /// <exception cref="IndexOutOfRangeException">When the supplied index does not identify an attribute.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">When the supplied index does not identify an attribute.</exception>
         public virtual void SetSpecified(int index, bool value)
         {
             if (index < 0 || index >= Length)
-                throw new IndexOutOfRangeException(
-                "No attribute at index: " + index);
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), $"No attribute at index: {index}");
+            }
+
             specified[index] = value;
         }
     }

--- a/src/Lucene.Net.Benchmark/Support/Sax/Helpers/AttributesImpl.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/Helpers/AttributesImpl.cs
@@ -30,9 +30,9 @@ namespace Sax.Helpers
     /// <item><description>to construct or modify an Attributes object in a SAX2 driver or filter.</description></item>
     /// </list>
     /// <para/>
-    /// This class replaces the now-deprecated SAX1 AttributeListImpl 
+    /// This class replaces the now-deprecated SAX1 AttributeListImpl
     /// class; in addition to supporting the updated Attributes
-    /// interface rather than the deprecated IAttributeList 
+    /// interface rather than the deprecated IAttributeList
     /// interface, it also includes a much more efficient
     /// implementation using a single array rather than a set of Vectors.
     /// </remarks>
@@ -322,7 +322,7 @@ namespace Sax.Helpers
         /// Clear the attribute list for reuse.
         /// <para/>
         /// Note that little memory is freed by this call:
-        /// the current array is kept so it can be 
+        /// the current array is kept so it can be
         /// reused.
         /// </summary>
         public virtual void Clear()
@@ -391,7 +391,7 @@ namespace Sax.Helpers
 
         /// <summary>
         /// Set an attribute in the list.
-        /// 
+        ///
         /// <para/>For the sake of speed, this method does no checking
         /// for name conflicts or well-formedness: such checks are the
         /// responsibility of the application.
@@ -406,9 +406,9 @@ namespace Sax.Helpers
         /// if qualified names are not available.</param>
         /// <param name="type">The attribute type as a string.</param>
         /// <param name="value">The attribute value.</param>
-        /// <exception cref="IndexOutOfRangeException">When the
+        /// <exception cref="ArgumentOutOfRangeException">When the
         /// supplied index does not point to an attribute
-        /// in the list.</exception>    
+        /// in the list.</exception>
         public virtual void SetAttribute(int index, string uri, string localName,
                       string qName, string type, string value)
         {
@@ -430,7 +430,7 @@ namespace Sax.Helpers
         /// Remove an attribute from the list.
         /// </summary>
         /// <param name="index">The index of the attribute (zero-based).</param>
-        /// <exception cref="IndexOutOfRangeException">When the supplied index does not point to an attribute in the list.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">When the supplied index does not point to an attribute in the list.</exception>
         public virtual void RemoveAttribute(int index)
         {
             if (index >= 0 && index < length)
@@ -460,9 +460,9 @@ namespace Sax.Helpers
         /// <param name="index">The index of the attribute (zero-based).</param>
         /// <param name="uri">The attribute's Namespace URI, or the empty
         /// string for none.</param>
-        /// <exception cref="IndexOutOfRangeException">When the
+        /// <exception cref="ArgumentOutOfRangeException">When the
         /// supplied index does not point to an attribute
-        /// in the list.</exception>      
+        /// in the list.</exception>
         public virtual void SetURI(int index, string uri)
         {
             if (index >= 0 && index < length)
@@ -481,9 +481,9 @@ namespace Sax.Helpers
         /// <param name="index">The index of the attribute (zero-based).</param>
         /// <param name="localName">The attribute's local name, or the empty
         /// string for none.</param>
-        /// <exception cref="IndexOutOfRangeException">When the
+        /// <exception cref="ArgumentOutOfRangeException">When the
         /// supplied index does not point to an attribute
-        /// in the list.</exception>         
+        /// in the list.</exception>
         public virtual void SetLocalName(int index, string localName)
         {
             if (index >= 0 && index < length)
@@ -502,9 +502,9 @@ namespace Sax.Helpers
         /// <param name="index">The index of the attribute (zero-based).</param>
         /// <param name="qName">The attribute's qualified name, or the empty
         /// string for none.</param>
-        /// <exception cref="IndexOutOfRangeException">When the
+        /// <exception cref="ArgumentOutOfRangeException">When the
         /// supplied index does not point to an attribute
-        /// in the list.</exception>    
+        /// in the list.</exception>
         public virtual void SetQName(int index, string qName)
         {
             if (index >= 0 && index < length)
@@ -522,9 +522,9 @@ namespace Sax.Helpers
         /// </summary>
         /// <param name="index">The index of the attribute (zero-based).</param>
         /// <param name="type">The attribute's type.</param>
-        /// <exception cref="IndexOutOfRangeException">When the
+        /// <exception cref="ArgumentOutOfRangeException">When the
         /// supplied index does not point to an attribute
-        /// in the list.</exception>         
+        /// in the list.</exception>
         public virtual void SetType(int index, string type)
         {
             if (index >= 0 && index < length)
@@ -542,9 +542,9 @@ namespace Sax.Helpers
         /// </summary>
         /// <param name="index">The index of the attribute (zero-based).</param>
         /// <param name="value">The attribute's value.</param>
-        /// <exception cref="IndexOutOfRangeException">When the
+        /// <exception cref="ArgumentOutOfRangeException">When the
         /// supplied index does not point to an attribute
-        /// in the list.</exception>   
+        /// in the list.</exception>
         public virtual void SetValue(int index, string value)
         {
             if (index >= 0 && index < length)
@@ -601,12 +601,12 @@ namespace Sax.Helpers
         /// Report a bad array index in a manipulator.
         /// </summary>
         /// <param name="index">The index to report.</param>
-        /// <exception cref="IndexOutOfRangeException">Always.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Always.</exception>
+        [DoesNotReturn]
         private static void BadIndex(int index) // LUCENENET: CA1822: Mark members as static
         {
-            string msg =
-                "Attempt to modify attribute at illegal index: " + index;
-            throw new IndexOutOfRangeException(msg);
+            string msg = $"Attempt to modify attribute at illegal index: {index}";
+            throw new ArgumentOutOfRangeException(nameof(index), msg);
         }
 
 

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
@@ -178,8 +178,10 @@ namespace Lucene.Net.Codecs.SimpleText
                 try
                 {
                     if (docId < 0 || docId >= _outerInstance.maxDoc)
-                        throw new IndexOutOfRangeException("docID must be 0 .. " + (_outerInstance.maxDoc - 1) +
-                                                           "; got " + docId);
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(docId),
+                            $"docID must be 0 .. {_outerInstance.maxDoc - 1}; got {docId}");
+                    }
 
                     _input.Seek(_field.DataStartFilePointer + (1 + _field.Pattern.Length + 2) * docId);
                     SimpleTextUtil.ReadLine(_input, _scratch);
@@ -273,8 +275,10 @@ namespace Lucene.Net.Codecs.SimpleText
                 try
                 {
                     if (docId < 0 || docId >= _outerInstance.maxDoc)
-                        throw new IndexOutOfRangeException("docID must be 0 .. " + (_outerInstance.maxDoc - 1) +
-                                                           "; got " + docId);
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(docId),
+                            $"docID must be 0 .. {_outerInstance.maxDoc - 1}; got {docId}");
+                    }
 
                     _input.Seek(_field.DataStartFilePointer + (9 + _field.Pattern.Length + _field.MaxLength + 2) * docId);
                     SimpleTextUtil.ReadLine(_input, _scratch);
@@ -396,8 +400,8 @@ namespace Lucene.Net.Codecs.SimpleText
             {
                 if (docId < 0 || docId >= _outerInstance.maxDoc)
                 {
-                    throw new IndexOutOfRangeException("docID must be 0 .. " + (_outerInstance.maxDoc - 1) + "; got " +
-                                                       docId);
+                    throw new ArgumentOutOfRangeException(nameof(docId),
+                        $"docID must be 0 .. {_outerInstance.maxDoc - 1}; got {docId}");
                 }
 
                 try
@@ -428,8 +432,10 @@ namespace Lucene.Net.Codecs.SimpleText
                 {
                     if (ord < 0 || ord >= _field.NumValues)
                     {
-                        throw new IndexOutOfRangeException($"ord must be 0 .. {(_field.NumValues - 1)}; got {ord}");
+                        throw new ArgumentOutOfRangeException(nameof(ord),
+                            $"ord must be 0 .. {_field.NumValues - 1}; got {ord}");
                     }
+
                     _input.Seek(_field.DataStartFilePointer + ord * (9 + _field.Pattern.Length + _field.MaxLength));
                     SimpleTextUtil.ReadLine(_input, _scratch);
                     // LUCENENET specific - use wrapper BytesRefFormatter struct to defer building the string unless string.Format() is called
@@ -505,8 +511,10 @@ namespace Lucene.Net.Codecs.SimpleText
             public override void SetDocument(int docID)
             {
                 if (docID < 0 || docID >= _outerInstance.maxDoc)
-                    throw new IndexOutOfRangeException("docID must be 0 .. " + (_outerInstance.maxDoc - 1) + "; got " +
-                                                        docID);
+                {
+                    throw new ArgumentOutOfRangeException(nameof(docID),
+                        $"docID must be 0 .. {_outerInstance.maxDoc - 1}; got {docID}");
+                }
 
                 try
                 {
@@ -529,7 +537,8 @@ namespace Lucene.Net.Codecs.SimpleText
                 {
                     if (ord < 0 || ord >= _field.NumValues)
                     {
-                        throw new IndexOutOfRangeException("ord must be 0 .. " + (_field.NumValues - 1) + "; got " + ord);
+                        throw new ArgumentOutOfRangeException(nameof(ord),
+                            $"ord must be 0 .. {_field.NumValues - 1}; got {ord}");
                     }
 
                     _input.Seek(_field.DataStartFilePointer + ord * (9 + _field.Pattern.Length + _field.MaxLength));

--- a/src/Lucene.Net.Memory/MemoryIndexNormDocValues.cs
+++ b/src/Lucene.Net.Memory/MemoryIndexNormDocValues.cs
@@ -19,13 +19,14 @@ namespace Lucene.Net.Index.Memory
      * limitations under the License.
      */
 
-    /// 
+    ///
     /// <summary>
     /// @lucene.internal
     /// </summary>
     internal class MemoryIndexNormDocValues : NumericDocValues
     {
         private readonly long value;
+
         public MemoryIndexNormDocValues(long value)
         {
             this.value = value;
@@ -35,7 +36,7 @@ namespace Lucene.Net.Index.Memory
         {
             if (docID != 0)
             {
-                throw new IndexOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(docID));
             }
             else
             {

--- a/src/Lucene.Net/Codecs/Lucene40/BitVector.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/BitVector.cs
@@ -97,8 +97,9 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             if (bit >= size)
             {
-                throw new IndexOutOfRangeException("bit=" + bit + " size=" + size);
+                throw new ArgumentOutOfRangeException(nameof(bit), $"bit={bit} size={size}");
             }
+
             bits[bit >> 3] |= (byte)(1 << (bit & 7));
             count = -1;
         }
@@ -111,8 +112,9 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             if (bit >= size)
             {
-                throw new IndexOutOfRangeException("bit=" + bit + " size=" + size);
+                throw new ArgumentOutOfRangeException(nameof(bit), $"bit={bit} size={size}");
             }
+
             int pos = bit >> 3;
             int v = bits[pos];
             int flag = 1 << (bit & 7);
@@ -139,8 +141,9 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             if (bit >= size)
             {
-                throw new IndexOutOfRangeException(bit.ToString());
+                throw new ArgumentOutOfRangeException(nameof(bit), bit.ToString());
             }
+
             bits[bit >> 3] &= (byte)(~(1 << (bit & 7)));
             count = -1;
         }
@@ -149,8 +152,9 @@ namespace Lucene.Net.Codecs.Lucene40
         {
             if (bit >= size)
             {
-                throw new IndexOutOfRangeException(bit.ToString());
+                throw new ArgumentOutOfRangeException(nameof(bit), bit.ToString());
             }
+
             int pos = bit >> 3;
             int v = bits[pos];
             int flag = 1 << (bit & 7);

--- a/src/Lucene.Net/Index/DocValues.cs
+++ b/src/Lucene.Net/Index/DocValues.cs
@@ -101,14 +101,14 @@ namespace Lucene.Net.Index
 
             public override void LookupOrd(long ord, BytesRef result)
             {
-                throw new IndexOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(ord));
             }
 
             public override long ValueCount => 0;
 
             public override long OrdAt(int index)
             {
-                throw new IndexOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
             public override int Cardinality => 0;

--- a/src/Lucene.Net/Index/SegmentReader.cs
+++ b/src/Lucene.Net/Index/SegmentReader.cs
@@ -309,7 +309,7 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// Expert: retrieve thread-private 
+        /// Expert: retrieve thread-private
         /// <see cref="StoredFieldsReader"/>
         /// <para/>
         /// @lucene.internal
@@ -376,7 +376,8 @@ namespace Lucene.Net.Index
         {
             if (docID < 0 || docID >= MaxDoc)
             {
-                throw new IndexOutOfRangeException("docID must be >= 0 and < maxDoc=" + MaxDoc + " (got docID=" + docID + ")");
+                throw new ArgumentOutOfRangeException(nameof(docID),
+                    $"docID must be >= 0 and < maxDoc={MaxDoc} (got docID={docID})");
             }
         }
 
@@ -590,10 +591,10 @@ namespace Lucene.Net.Index
         /// <para/>
         /// @lucene.experimental
         /// </summary>
-        public interface ICoreDisposedListener 
+        public interface ICoreDisposedListener
         {
             /// <summary>
-            /// Invoked when the shared core of the original 
+            /// Invoked when the shared core of the original
             /// <see cref="SegmentReader"/> has disposed.
             /// </summary>
             void OnDispose(object ownerCoreCacheKey);

--- a/src/Lucene.Net/Support/ExceptionHandling/ExceptionExtensions.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/ExceptionExtensions.cs
@@ -137,7 +137,7 @@ namespace Lucene
         /// Used to check whether <paramref name="e"/> corresponds to a RuntimeException
         /// in Java. RuntimeException in Java indicates an unchecked exception. Unchecked
         /// exceptions don't force the developer to make a decision whether to handle or re-throw
-        /// the excption, it can safely be ignored and allowed to propagate.
+        /// the exception, it can safely be ignored and allowed to propagate.
         /// </summary>
         /// <param name="e">This exception.</param>
         /// <returns><c>true</c> if <paramref name="e"/> corresponds to a RuntimeException type
@@ -152,7 +152,7 @@ namespace Lucene
                 // Some Java errors derive from SystemException in .NET, but we don't want to include them here
                 e.IsError() ||
 
-                // .NET made IOException a SystemExcpetion, but those should not be included here
+                // .NET made IOException a SystemException, but those should not be included here
                 e.IsIOException() ||
 
                 // .NET made System.Threading.ThreadInterruptedException a SystemException, but we need to ignore it
@@ -160,7 +160,7 @@ namespace Lucene
                 e is System.Threading.ThreadInterruptedException ||
 
                 // ObjectDisposedException is a special case because in Lucene the AlreadyClosedException derived
-                // from IOException and was therefore a checked excpetion type.
+                // from IOException and was therefore a checked exception type.
                 e is ObjectDisposedException ||
 
                 // These seem to correspond closely to java.lang.ReflectiveOperationException, which are not derived from RuntimeException
@@ -172,9 +172,9 @@ namespace Lucene
                 return false;
             }
 
-            // Known implemetnations of IRuntimeException
+            // Known implementations of IRuntimeException
 
-            // LuceneExcpetion
+            // LuceneException
             // BytesRefHash.MaxBytesLengthExceededException
             // CollectionTerminatedException
             // TimeLimitingCollector.TimeExceededException
@@ -229,8 +229,8 @@ namespace Lucene
         {
             if (e is null || e.IsAlwaysIgnored()) return false;
 
-            return e is ArgumentOutOfRangeException ||
-                e is IndexOutOfRangeException;
+            return e is ArgumentOutOfRangeException
+                or IndexOutOfRangeException;
         }
 
         /// <summary>
@@ -245,8 +245,8 @@ namespace Lucene
         {
             if (e is null || e.IsAlwaysIgnored()) return false;
 
-            return e is ArgumentOutOfRangeException ||
-                e is IndexOutOfRangeException;
+            return e is ArgumentOutOfRangeException
+                or IndexOutOfRangeException;
         }
 
         /// <summary>
@@ -261,13 +261,13 @@ namespace Lucene
         {
             if (e is null || e.IsAlwaysIgnored()) return false;
 
-            return e is ArgumentOutOfRangeException ||
-                e is IndexOutOfRangeException;
+            return e is ArgumentOutOfRangeException
+                or IndexOutOfRangeException;
         }
 
         /// <summary>
         /// Used to check whether <paramref name="e"/> corresponds to a NoSuchFileException
-        /// or a FileNotFoundExcpetion in Java.
+        /// or a FileNotFoundException in Java.
         /// <para/>
         /// NOTE: In Java, there is no distinction between file and directory, and FileNotFoundException is thrown
         /// in either case. Therefore, this handler also catches <see cref="System.IO.DirectoryNotFoundException"/>.
@@ -278,11 +278,11 @@ namespace Lucene
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsNoSuchFileExceptionOrFileNotFoundException(this Exception e)
         {
-            return e is FileNotFoundException ||
-                // Java doesn't have an equivalent to DirectoryNotFoundExcption, but
+            return e is FileNotFoundException
+                // Java doesn't have an equivalent to DirectoryNotFoundException, but
                 // Lucene added one that subclassed java.io.FileNotFoundException
                 // that we didn't add to the .NET port.
-                e is DirectoryNotFoundException;
+                or DirectoryNotFoundException;
         }
 
         /// <summary>
@@ -305,7 +305,7 @@ namespace Lucene
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsParseException(this Exception e)
         {
-            // LUCENNET: Added this exception in J2N to cover this case because it is not a RuntimeException
+            // LUCENENET: Added this exception in J2N to cover this case because it is not a RuntimeException
             // which makes it different from NumberFormatException in Java and FormatException in .NET.
             return e is ParseException;
         }
@@ -348,8 +348,8 @@ namespace Lucene
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsIllegalAccessException(this Exception e)
         {
-            return e is MemberAccessException ||
-                e is TypeAccessException;
+            return e is MemberAccessException
+                or TypeAccessException;
         }
 
         /// <summary>
@@ -385,8 +385,8 @@ namespace Lucene
         {
             if (e is null || e.IsAlwaysIgnored()) return false;
 
-            return e is ArgumentNullException ||
-                e is NullReferenceException; // LUCENENET TODO: These could be real problems where excptions can be prevevented that our catch blocks are hiding
+            return e is ArgumentNullException
+                or NullReferenceException; // LUCENENET TODO: These could be real problems where exceptions can be prevented that our catch blocks are hiding
         }
 
         /// <summary>
@@ -407,10 +407,10 @@ namespace Lucene
             // described in the javadoc that the class might not be created when using Activator.CreateInstance().
             // The TestFactories class also seems to rule out that this is supposed to catch TargetInvocationException
             // or security exceptions such as MemberAccessException or TypeAccessException.
-            return e is MissingMethodException ||
-                e is TypeLoadException ||
-                e is ReflectionTypeLoadException ||
-                e is TypeInitializationException; // May happen due to a class initializer that throws an uncaught exception.
+            return e is MissingMethodException
+                or TypeLoadException
+                or ReflectionTypeLoadException
+                or TypeInitializationException; // May happen due to a class initializer that throws an uncaught exception.
         }
 
         /// <summary>
@@ -438,8 +438,8 @@ namespace Lucene
         {
             // According to the docs, this maps to 2 potential exceptions:
             // https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding?view=net-5.0
-            return e is ArgumentException ||
-                e is PlatformNotSupportedException;
+            return e is ArgumentException
+                or PlatformNotSupportedException;
         }
 
         /// <summary>
@@ -573,8 +573,8 @@ namespace Lucene
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsIllegalStateException(this Exception e)
         {
-            return e is InvalidOperationException &&
-                e is not ObjectDisposedException; // In .NET, ObjectDisposedException subclases InvalidOperationException, but Lucene decided to use IOException for AlreadyClosedException
+            return e is InvalidOperationException
+                and not ObjectDisposedException; // In .NET, ObjectDisposedException subclases InvalidOperationException, but Lucene decided to use IOException for AlreadyClosedException
         }
 
         /// <summary>
@@ -591,7 +591,7 @@ namespace Lucene
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsStackOverflowError(this Exception e)
         {
-            return e is StackOverflowException; // Uncatchable in .NET core, be sure to use with 
+            return e is StackOverflowException; // Uncatchable in .NET core, be sure to use with
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/BytesRefArray.cs
+++ b/src/Lucene.Net/Util/BytesRefArray.cs
@@ -105,7 +105,8 @@ namespace Lucene.Net.Util
                 pool.ReadBytes(offset, spare.Bytes, spare.Offset, spare.Length);
                 return spare;
             }
-            throw new IndexOutOfRangeException("index " + index + " must be less than the size: " + lastElement);
+
+            throw new ArgumentOutOfRangeException(nameof(index), $"index {index} must be less than the size: {lastElement}");
         }
 
         private int[] Sort(IComparer<BytesRef> comp)

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -835,7 +835,7 @@ namespace Lucene.Net.Util
         /// <param name="count"> The number of code points. </param>
         /// <returns> a String representing the code points between offset and count. </returns>
         /// <exception cref="ArgumentException"> If an invalid code point is encountered. </exception>
-        /// <exception cref="IndexOutOfRangeException"> If the offset or count are out of bounds. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If the offset or count are out of bounds. </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string NewString(int[] codePoints, int offset, int count)
         {


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Replaces IndexOutOfRangeException use with ArgumentOutOfRangeException when thrown from a method rather than an indexer.

Fixes #1023 

## Description

It is not correct in .NET to use IndexOutOfRangeException to throw exceptions from a non-indexer method when an argument is out of range, even if that argument is named `index`; that is what ArgumentOutOfRangeException is for. Additionally, this has the added benefit of having the `paramName` set to know which argument is out of range.