### PR TITLE
Finish [SuppressTempFileChecks] attribute functionality, #898

### DIFF
--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -937,10 +937,6 @@ namespace Lucene.Net.Util
 
             if (result.ResultState == ResultState.Failure || result.ResultState == ResultState.Error)
             {
-                // LUCENENET specific - Track that at least one test in the suite failed.
-                // LUCENENET TODO: finish implementation of RuleChains so this is not needed (#1088)
-                SuiteFailureMarker = false;
-
                 string message =
                     $$"""
                       {{result.Message}}


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Finishes implementation of the `[SuppressTempFileChecks]` attribute functionality.

Fixes #898

## Description

This attribute will cause the tear down logic to swallow any exceptions when cleaning up temporary files after the tests run. No tests actually need this attribute, but theoretically it is possible that a TestFramework user might want this. 

This also fixes an issue where the previous code was treating _all_ tests as if it had this attribute, and was not throwing if removing the temporary files failed. This change will make our tests more reliable by ensuring they fail if temp file handles are held during cleanup.

I'm also open to removing this attribute, since none of our tests need it and latest Lucene doesn't use it internally either. It could be viewed as a bad practice to just ignore these files being held too long.