### PR TITLE
Lucene.Net.TestFramework: Improved error handling and test reporting

### DIFF
--- a/.build/azure-templates/publish-test-results.yml
+++ b/.build/azure-templates/publish-test-results.yml
@@ -54,7 +54,6 @@ steps:
         $reader = [System.Xml.XmlReader]::Create($testResultsFileName)
         try {
             $countersFound = $false
-            $stdOutFound = $false
             $crashed = $false
             $inRunInfos = $false
             while ($reader.Read()) {
@@ -68,17 +67,6 @@ steps:
                         # Report a running total of failures
                         $totalFailures = ([int]$env:TOTALFAILURES + [int]$failed).ToString()
                         Write-Host "##vso[task.setvariable variable=TotalFailures;]$totalFailures"
-                        $countersFound = $true
-                    }
-                    if (!$stdOutFound -and $reader.Name -eq 'StdOut') {
-                        # Test for specific error messages - we may need to adjust this, as needed
-                        $innerXml = $reader.ReadInnerXml()
-                        if ($innerXml -and ($innerXml.Contains('[ERROR]'))) {
-                            Write-Host "##vso[task.setvariable variable=StdOutFailure;]true"
-                            # Report all of the test projects that had stdout failures
-                            $stdOutFailureRuns = "$env:STDOUTFAILURERUNS,$testProjectName".TrimStart(',')
-                            Write-Host "##vso[task.setvariable variable=StdOutFailureRuns;]$stdOutFailureRuns"
-                        }
                         $countersFound = $true
                     }
                     # Report a crash of the test runner
@@ -97,6 +85,13 @@ steps:
                             # Report all of the test projects that crashed
                             $crashedRuns = "$env:CRASHEDRUNS,$testProjectName".TrimStart(',')
                             Write-Host "##vso[task.setvariable variable=CrashedRuns;]$crashedRuns"
+                            $crashed = $true
+                        }
+                        if ($innerXml -and ($innerXml.Contains('[ERROR]'))) {
+                            Write-Host "##vso[task.setvariable variable=StdOutFailure;]true"
+                            # Report all of the test projects that had stdout failures
+                            $stdOutFailureRuns = "$env:STDOUTFAILURERUNS,$testProjectName".TrimStart(',')
+                            Write-Host "##vso[task.setvariable variable=StdOutFailureRuns;]$stdOutFailureRuns"
                             $crashed = $true
                         }
                     }

--- a/.build/azure-templates/publish-test-results.yml
+++ b/.build/azure-templates/publish-test-results.yml
@@ -102,6 +102,34 @@ steps:
     Write-Host "##vso[task.setvariable variable=TestResultsFileExists;]$testResultsFileExists"
   displayName: 'Parse Test Results File'
 
+- pwsh: |
+    $testProjectName = "${{ parameters.testProjectName }}"
+    $testStdErrFileName = "$(Build.ArtifactStagingDirectory)/${{ parameters.testResultsArtifactName }}/${{ parameters.osName }}/${{ parameters.framework }}/${{ parameters.vsTestPlatform }}/$testProjectName/dotnet-test-error.log"
+    $testStdErrFileExists = Test-Path $testStdErrFileName
+    if ($testStdErrFileExists) {
+        $fileLength = (Get-Item $testStdErrFileName).Length
+        if ($fileLength -gt 0) {
+            $stream = [System.IO.StreamReader]::new($testStdErrFileName)
+            try {
+                while (-not $stream.EndOfStream) {
+                    $line = $stream.ReadLine()
+                    if ($line -match "Test Run Failed" -or $line -match "\[ERROR\]") {
+                        Write-Host "##vso[task.setvariable variable=StdErrFailure;]true"
+                        # Report all of the test projects that had stderr failures
+                        $stderrFailureRuns = "$env:STDERRFAILURERUNS,$testProjectName".TrimStart(',')
+                        Write-Host "##vso[task.setvariable variable=StdErrFailureRuns;]$stderrFailureRuns"
+                        break # No need to continue reading after detecting a failure
+                    }
+                }
+            } finally {
+                $stream.Dispose()
+            }
+        }
+    } else {
+        Write-Host "WARNING: File not found: $testStdErrFileName"
+    }
+  displayName: 'Parse StdErr File'
+
 - task: PublishTestResults@2
   displayName: 'Publish Test Results ${{ parameters.testProjectName }},${{ parameters.framework }},${{ parameters.vsTestPlatform }}'
   inputs:

--- a/.build/azure-templates/publish-test-results.yml
+++ b/.build/azure-templates/publish-test-results.yml
@@ -54,6 +54,7 @@ steps:
         $reader = [System.Xml.XmlReader]::Create($testResultsFileName)
         try {
             $countersFound = $false
+            $stdOutFound = $false
             $crashed = $false
             $inRunInfos = $false
             while ($reader.Read()) {
@@ -67,6 +68,17 @@ steps:
                         # Report a running total of failures
                         $totalFailures = ([int]$env:TOTALFAILURES + [int]$failed).ToString()
                         Write-Host "##vso[task.setvariable variable=TotalFailures;]$totalFailures"
+                        $countersFound = $true
+                    }
+                    if (!$stdOutFound -and $reader.Name -eq 'StdOut') {
+                        # Test for specific error messages - we may need to adjust this, as needed
+                        $innerXml = $reader.ReadInnerXml()
+                        if ($innerXml -and ($innerXml.Contains('[ERROR]'))) {
+                            Write-Host "##vso[task.setvariable variable=StdOutFailure;]true"
+                            # Report all of the test projects that had stdout failures
+                            $stdOutFailureRuns = "$env:STDOUTFAILURERUNS,$testProjectName".TrimStart(',')
+                            Write-Host "##vso[task.setvariable variable=StdOutFailureRuns;]$stdOutFailureRuns"
+                        }
                         $countersFound = $true
                     }
                     # Report a crash of the test runner
@@ -116,8 +128,8 @@ steps:
                     if ($line -match "Test Run Failed" -or $line -match "\[ERROR\]") {
                         Write-Host "##vso[task.setvariable variable=StdErrFailure;]true"
                         # Report all of the test projects that had stderr failures
-                        $stderrFailureRuns = "$env:STDERRFAILURERUNS,$testProjectName".TrimStart(',')
-                        Write-Host "##vso[task.setvariable variable=StdErrFailureRuns;]$stderrFailureRuns"
+                        $stdErrFailureRuns = "$env:STDERRFAILURERUNS,$testProjectName".TrimStart(',')
+                        Write-Host "##vso[task.setvariable variable=StdErrFailureRuns;]$stdErrFailureRuns"
                         break # No need to continue reading after detecting a failure
                     }
                 }

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -310,6 +310,11 @@ steps:
         Write-Host "##vso[task.logissue type=error;]Test run failed due to too many failed tests. Maximum failures allowed: $maximumAllowedFailures, total failures: $($env:TOTALFAILURES)."
         $failed = $true
     }
+    if ([int]$maximumAllowedFailures -eq 0 -and $env:STDERRFAILURE -eq 'true') {
+        $runsExpanded = "$($env:STDERRFAILURERUNS)" -replace ',',"`r`n"
+        Write-Host "##vso[task.logissue type=error;]StdErr file(s) indicate test failures. Review the testresults artifacts for details. (click here to view the projects that failed)`r`n$runsExpanded"
+        $failed = $true
+    }
     if ($failed) {
         Write-Host "##vso[task.complete result=Failed;]"
     }

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -315,6 +315,11 @@ steps:
         Write-Host "##vso[task.logissue type=error;]StdErr file(s) indicate test failures. Review the testresults artifacts for details. (click here to view the projects that failed)`r`n$runsExpanded"
         $failed = $true
     }
+    if ([int]$maximumAllowedFailures -eq 0 -and $env:STDOUTFAILURE -eq 'true') {
+        $runsExpanded = "$($env:STDOUTFAILURERUNS)" -replace ',',"`r`n"
+        Write-Host "##vso[task.logissue type=error;]StdOut file(s) indicate test failures. Review the testresults artifacts for details. (click here to view the projects that failed)`r`n$runsExpanded"
+        $failed = $true
+    }
     if ($failed) {
         Write-Host "##vso[task.complete result=Failed;]"
     }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,7 @@ name: 'vNext$(rev:.r)' # Format for build number (will be overridden)
 # Verbose: 'false' (Optional - set to true for verbose logging output)
 # Multiplier: '1' (Optional - the number of iterations to multiply applicable tests by)
 # DisplayFullName: 'true' (Optional - set to 'false' to display only the test name instead of the full name with class and method)
+# FailOnTestFixtureOneTimeSetUpError: 'true' (Optional - set to 'false' to allow tests to pass if the test fixture (class) has a OneTimeSetUp failure.)
 
 # RunX86Tests: 'false' (Optional - set to 'true' to enable x86 tests)
 
@@ -162,6 +163,7 @@ stages:
         $directory = if ($env:Directory -eq $null) { 'random' } else { $env:Directory }
         $verbose = if ($env:Verbose -eq 'true') { 'true' } else { 'false' }
         $multiplier = if ($env:Multiplier -eq $null) { '1' } else { $env:Multiplier }
+        $failOnTestFixtureOneTimeSetUpError = if ($env.FailOnTestFixtureOneTimeSetUpError -eq 'false') { 'false' } else { 'true' }
         $fileText = "{`n`t" +
             """assert"": ""$assert"",`n`t" +
             """tests"": {`n`t`t" +
@@ -174,7 +176,8 @@ stages:
                 """postingsformat"": ""$postingsFormat"",`n`t`t" +
                 """directory"": ""$directory"",`n`t`t" +
                 """verbose"": ""$verbose"",`n`t`t" +
-                """multiplier"": ""$multiplier""`n`t" +
+                """multiplier"": ""$multiplier"",`n`t`t" +
+                """failontestfixtureonetimesetuperror"": ""$failOnTestFixtureOneTimeSetUpError""`n`t" +
             "}`n" +
         "}"
         Out-File -filePath "$(Build.ArtifactStagingDirectory)/$(TestSettingsFileName)" -encoding UTF8 -inputObject $fileText

--- a/src/Lucene.Net.TestFramework/Search/RandomSimilarityProvider.cs
+++ b/src/Lucene.Net.TestFramework/Search/RandomSimilarityProvider.cs
@@ -36,12 +36,12 @@ namespace Lucene.Net.Search
     /// </summary>
     public class RandomSimilarityProvider : PerFieldSimilarityWrapper
     {
-        internal readonly DefaultSimilarity defaultSim = new DefaultSimilarity();
-        internal readonly IList<Similarity> knownSims;
-        internal IDictionary<string, Similarity> previousMappings = new Dictionary<string, Similarity>();
-        internal readonly int perFieldSeed;
-        internal readonly int coordType; // 0 = no coord, 1 = coord, 2 = crazy coord
-        internal readonly bool shouldQueryNorm;
+        private readonly DefaultSimilarity defaultSim = new DefaultSimilarity();
+        private readonly IList<Similarity> knownSims;
+        private readonly JCG.Dictionary<string, Similarity> previousMappings = new JCG.Dictionary<string, Similarity>();
+        private readonly int perFieldSeed;
+        private readonly int coordType; // 0 = no coord, 1 = coord, 2 = crazy coord
+        private readonly bool shouldQueryNorm;
 
         public RandomSimilarityProvider(Random random)
         {
@@ -162,7 +162,7 @@ namespace Lucene.Net.Search
                 else
                     sb.Append("crazy");
                 sb.Append("): ");
-                sb.AppendFormat(J2N.Text.StringFormatter.InvariantCulture, "{0}", previousMappings);
+                sb.Append(previousMappings);
                 return sb.ToString();
             }
             finally

--- a/src/Lucene.Net.TestFramework/Support/Util/LuceneTestCase.SetUpFixture.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LuceneTestCase.SetUpFixture.cs
@@ -70,7 +70,6 @@ namespace Lucene.Net.Util
             [OneTimeSetUp]
             public void OneTimeSetUpWrapper()
             {
-                //var fixture = TestExecutionContext.CurrentContext.CurrentTest;
                 if (stackCount.GetAndIncrement() == 0)
                 {
                     // Set up for assembly

--- a/src/Lucene.Net.TestFramework/Support/Util/TestExtensions.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/TestExtensions.cs
@@ -1,0 +1,90 @@
+﻿using NUnit.Framework.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+#nullable enable
+
+namespace Lucene.Net.Util
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Extensions to <see cref="Test"/>.
+    /// </summary>
+    internal static class TestExtensions
+    {
+        /// <summary>
+        /// Mark the test and all descendents as Invalid (not runnable) specifying a reason and an exception.
+        /// </summary>
+        /// <param name="test">This <see cref="Test"/>.</param>
+        /// <param name="reason">The reason the test is not runnable</param>
+        /// <exception cref="ArgumentNullException"><paramref name="test"/> or <paramref name="reason"/> is <c>null</c>.</exception>
+        public static void MakeAllInvalid(this Test test, string reason)
+            => MakeAllInvalidInternal(test, null, reason);
+
+        /// <summary>
+        /// Mark the test and all descendents as Invalid (not runnable) specifying a reason and an exception.
+        /// </summary>
+        /// <param name="test">This <see cref="Test"/>.</param>
+        /// <param name="exception">The exception that was the cause.</param>
+        /// <param name="reason">The reason the test is not runnable</param>
+        /// <exception cref="ArgumentNullException"><paramref name="test"/>, <paramref name="exception"/> or <paramref name="reason"/> is <c>null</c>.</exception>
+        public static void MakeAllInvalid(this Test test, Exception exception, string reason)
+        {
+            if (exception is null)
+                throw new ArgumentNullException(nameof(exception));
+            MakeAllInvalidInternal(test, exception, reason);
+        }
+
+        private static void MakeAllInvalidInternal(this Test test, Exception? exception, string reason)
+        {
+            if (test is null)
+                throw new ArgumentNullException(nameof(test));
+            if (reason is null)
+                throw new ArgumentNullException(nameof(reason));
+
+            if (exception is null)
+                test.MakeInvalid(reason);
+            else
+                test.MakeInvalid(exception, reason);
+
+            if (test.HasChildren)
+            {
+                var stack = new Stack<Test>(test.Tests.OfType<Test>());
+
+                while (stack.Count > 0)
+                {
+                    var currentTest = stack.Pop();
+                    if (exception is null)
+                        currentTest.MakeInvalid(reason);
+                    else
+                        currentTest.MakeInvalid(exception, reason);
+
+                    // Add children to the stack if they exist
+                    if (currentTest.HasChildren)
+                    {
+                        foreach (var child in currentTest.Tests.OfType<Test>())
+                        {
+                            stack.Push(child);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -886,12 +886,6 @@ namespace Lucene.Net.Util
         // Suite and test case setup/ cleanup.
         // -----------------------------------------------------------------
 
-        // LUCENENET specific: Temporary storage for random selections so they
-        // can be set once per OneTimeSetUp and reused multiple times in SetUp
-        // where they are written to the output.
-        private string codecType;
-        private string similarityName;
-
         /// <summary>
         /// For subclasses to override. Overrides must call <c>base.SetUp()</c>.
         /// </summary>
@@ -900,48 +894,6 @@ namespace Lucene.Net.Util
         {
             // LUCENENET TODO: Not sure how to convert these
             //ParentChainCallRule.SetupCalled = true;
-
-            // LUCENENET: Printing out randomized context regardless
-            // of whether verbose is enabled (since we need it for debugging,
-            // but the verbose output can crash tests).
-            Console.Write("RandomSeed: ");
-            Console.WriteLine(RandomizedContext.CurrentContext.RandomSeedAsHex);
-
-            Console.Write("Culture: ");
-            Console.WriteLine(ClassEnvRule.locale.Name);
-
-            Console.Write("Time Zone: ");
-            Console.WriteLine(ClassEnvRule.timeZone.DisplayName);
-
-            Console.Write("Default Codec: ");
-            Console.Write(ClassEnvRule.codec.Name);
-            Console.Write(" (");
-            Console.Write(codecType);
-            Console.WriteLine(")");
-
-            Console.Write("Default Similarity: ");
-            Console.WriteLine(similarityName);
-
-            Console.Write("Nightly: ");
-            Console.WriteLine(TestNightly);
-
-            Console.Write("Weekly: ");
-            Console.WriteLine(TestWeekly);
-
-            Console.Write("Slow: ");
-            Console.WriteLine(TestSlow);
-
-            Console.Write("Awaits Fix: ");
-            Console.WriteLine(TestAwaitsFix);
-
-            Console.Write("Directory: ");
-            Console.WriteLine(TestDirectory);
-
-            Console.Write("Verbose: ");
-            Console.WriteLine(Verbose);
-
-            Console.Write("Random Multiplier: ");
-            Console.WriteLine(RandomMultiplier);
         }
 
         /// <summary>
@@ -994,6 +946,26 @@ namespace Lucene.Net.Util
                         }
                       }
 
+                      Fixture Test Values
+                      =================
+
+                       Random Seed:           {{RandomizedContext.CurrentContext.RandomSeedAsHex}}
+                       Culture:               {{ClassEnvRule.locale.Name}}
+                       Time Zone:             {{ClassEnvRule.timeZone.DisplayName}}
+                       Default Codec:         {{ClassEnvRule.codec.Name}} ({{ClassEnvRule.codec.GetType().Name}})
+                       Default Similarity:    {{ClassEnvRule.similarity}}
+
+                      System Properties
+                      =================
+
+                       Nightly:               {{TestNightly}}
+                       Weekly:                {{TestWeekly}}
+                       Slow:                  {{TestSlow}}
+                       Awaits Fix:            {{TestAwaitsFix}}
+                       Directory:             {{TestDirectory}}
+                       Verbose:               {{Verbose}}
+                       Random Multiplier:     {{RandomMultiplier}}
+
                       """;
 
                 result.SetResult(result.ResultState, message, result.StackTrace);
@@ -1014,10 +986,6 @@ namespace Lucene.Net.Util
             try
             {
                 ClassEnvRule.Before();
-
-                // LUCENENET: Generate the info once so it can be printed out for each test
-                codecType = ClassEnvRule.codec.GetType().Name;
-                similarityName = ClassEnvRule.similarity.ToString();
             }
             catch (Exception ex)
             {

--- a/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/TestExceptionExtensions.cs
+++ b/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/TestExceptionExtensions.cs
@@ -387,7 +387,7 @@ namespace Lucene.Net.Support.ExceptionHandling
                 catch (Exception e) when (extensionMethodExpression(e))
                 {
                     // expected
-                    Assert.Pass($"Expected: Caught exception {e.GetType().FullName}");
+                    Assert.Pass();
                 }
             }
             catch (Exception e) when (e is not NUnit.Framework.SuccessException)
@@ -410,7 +410,8 @@ namespace Lucene.Net.Support.ExceptionHandling
                     // Special case - need to suppress this from being thrown to the outer catch
                     // or we will get a false failure
                     Assert.IsFalse(extensionMethodExpression(e));
-                    Assert.Pass($"Expected: Did not catch exception {e.GetType().FullName}");
+                    // expected
+                    Assert.Pass();
                 }
                 catch (Exception e) when (extensionMethodExpression(e))
                 {
@@ -421,7 +422,7 @@ namespace Lucene.Net.Support.ExceptionHandling
             catch (Exception e) when (e is not NUnit.Framework.AssertionException)
             {
                 // expected
-                Assert.Pass($"Expected: Did not catch exception {e.GetType().FullName}");
+                Assert.Pass();
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Improved error handling and test reporting

## Description

This fixes several concerns regarding output during testing:

1. The details of the random test configuration are now output only if the test fails and will appear in the test message directly. This used to be where they appeared in older versions of NUnit and this restores that functionality.
2. Exceptions that were being called in `LuceneTestCase.OneTimeStartUp()` and `LuceneTestCase.OneTimeTearDown()` were not very visible because NUnit doesn't fail the test when they occur there. This changes it from re-throwing exceptions with an additional message to logging to the output. It goes to stderr in all cases except in `OneTimeTearDown()` where something is redirecting it to stdout. Either way, this changes the ADO pipeline to fail the build so we can avoid shipping the test framework with bugs in these methods.
3. Adds a system property named `tests:failontestfixtureonetimesetuperror` that can be used to cause the test framework to fail all of the tests when there is an error in `OneTimeSetUp()`. We may need to revisit this because there are asserts thrown here that users are supposed to see when dependency injection for codecs is not setup correctly.
4. Removes all messages from the `Assert.Pass()` method because this bloats the size of the test logs with no benefit.