### PR TITLE
IDisposable Pattern Cleanup and fix TestDictionary.TestResourceCleanup, #265

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -910,7 +910,8 @@ namespace Lucene.Net.Analysis.Hunspell
             {
                 foreach (Stream dictionary in dictionaries)
                 {
-                    using var lines = new StreamReader(dictionary, decoder); // LUCENENET specific - CA2000: Use using pattern to ensure reader is disposed
+                    // LUCENENET specific - CA2000: Use using pattern to ensure reader is disposed, although we want to leave the dictionary stream open. See: TestDictionary.TestResourceCleanup
+                    using var lines = new StreamReader(dictionary, decoder, detectEncodingFromByteOrderMarks: true, bufferSize: -1, leaveOpen: true);
                     string line = lines.ReadLine(); // first line is number of entries (approximately, sometimes)
 
                     while ((line = lines.ReadLine()) != null)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -911,7 +911,7 @@ namespace Lucene.Net.Analysis.Hunspell
                 foreach (Stream dictionary in dictionaries)
                 {
                     // LUCENENET specific - CA2000: Use using pattern to ensure reader is disposed, although we want to leave the dictionary stream open. See: TestDictionary.TestResourceCleanup
-                    using var lines = new StreamReader(dictionary, decoder, detectEncodingFromByteOrderMarks: true, bufferSize: -1, leaveOpen: true);
+                    using var lines = new StreamReader(dictionary, decoder, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
                     string line = lines.ReadLine(); // first line is number of entries (approximately, sometimes)
 
                     while ((line = lines.ReadLine()) != null)

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
@@ -376,7 +376,7 @@ namespace Lucene.Net.Codecs.Lucene42
         }
 
         // per-document vint-encoded byte[]
-        internal class SortedSetEnumerator : IEnumerator<BytesRef>
+        internal sealed class SortedSetEnumerator : IEnumerator<BytesRef>
         {
             internal byte[] buffer = new byte[10];
             internal ByteArrayDataOutput @out = new ByteArrayDataOutput();
@@ -426,7 +426,7 @@ namespace Lucene.Net.Codecs.Lucene42
             object IEnumerator.Current => Current;
 
             // encodes count values to buffer
-            internal virtual void EncodeValues(int count)
+            internal void EncodeValues(int count)
             {
                 @out.Reset(buffer);
                 long lastOrd = 0;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestDictionary.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Hunspell/TestDictionary.cs
@@ -156,7 +156,7 @@ namespace Lucene.Net.Analysis.Hunspell
                 set => @delegate.Position = value;
             }
 
-            public CloseCheckInputStream(TestDictionary outerInstance, System.IO.Stream @delegate) 
+            public CloseCheckInputStream(TestDictionary outerInstance, System.IO.Stream @delegate)
             {
                 this.@delegate = @delegate;
                 this.outerInstance = outerInstance;
@@ -164,16 +164,9 @@ namespace Lucene.Net.Analysis.Hunspell
 
             protected override void Dispose(bool disposing)
             {
+                disposed = true;
                 @delegate.Dispose();
             }
-
-
-            new public void Dispose()
-            {
-                this.disposed = true;
-                base.Dispose();
-            }
-            
 
             public virtual bool Disposed => this.disposed;
 
@@ -209,7 +202,7 @@ namespace Lucene.Net.Analysis.Hunspell
             CloseCheckInputStream affixStream = new CloseCheckInputStream(this, this.GetType().getResourceAsStream("compressed.aff"));
             CloseCheckInputStream dictStream = new CloseCheckInputStream(this, this.GetType().getResourceAsStream("compressed.dic"));
 
-            new Dictionary(affixStream, dictStream);
+            _ = new Dictionary(affixStream, dictStream);
 
             assertFalse(affixStream.Disposed);
             assertFalse(dictStream.Disposed);


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Some minor cleanup of IDisposable pattern implementations, and a bug fix.

Fixes #265

## Description

I did a review of all implementations of `IDisposable.Dispose()` to ensure they follow the [Dispose Pattern](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/dispose-pattern) correctly, and someone had clearly already done all of the hard work here: it was nearly all done right. There were a couple cases that I fixed in this PR:

- Lucene42DocValuesConsumer.SortedSetEnumerator did not implement the pattern correctly, but it also is an internal type with no subclasses, so this was made `sealed`.
- Hunspell's TestDictionary.CloseCheckInputStream had a curious shadowing of Dispose that was causing it to not work correctly, and this exposed a bug: the stream wrapper was getting disposed of in Hunspell.Dictionary, when it is expected to not be disposed of. The shadowed Dispose method was never called, even if the Dictionary code actually did dispose of the wrapper. This created a false negative, where the test thought it wasn't disposed of when it actually was. This PR fixes that by removing the shadowing Dispose method, marking `this.disposed` in the actual Dispose pattern override method so that it's properly marked when called virtually, and leaving the stream open in the Dictionary.ReadDictionaryFiles method to match Java's behavior (and the expected behavior per the unit test).  
