### PR TITLE
Added DisposeAfterSuite/DisposeAfterTest feature to test framework

### DIFF
--- a/src/Lucene.Net.TestFramework/Support/Util/DisposableResourceInfo.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/DisposableResourceInfo.cs
@@ -9,6 +9,23 @@ using System.Threading.Tasks;
 
 namespace Lucene.Net.Util
 {
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
     /// <summary>
     /// Allocation information (Thread, allocation stack) for tracking disposable
     /// resources.

--- a/src/Lucene.Net.TestFramework/Support/Util/DisposableResourceInfo.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/DisposableResourceInfo.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+#nullable enable
+
+namespace Lucene.Net.Util
+{
+    /// <summary>
+    /// Allocation information (Thread, allocation stack) for tracking disposable
+    /// resources.
+    /// </summary>
+    internal sealed class DisposableResourceInfo // From randomizedtesing
+    {
+        private readonly IDisposable resource;
+        private readonly LifecycleScope scope;
+        private readonly StackTrace stackTrace;
+        private readonly string? threadName;
+
+        public DisposableResourceInfo(IDisposable resource, LifecycleScope scope, string? threadName, StackTrace stackTrace)
+        {
+            Debug.Assert(resource != null);
+
+            this.resource = resource!;
+            this.scope = scope;
+            this.stackTrace = stackTrace;
+            this.threadName = threadName;
+        }
+
+        public IDisposable Resource => resource;
+
+        public StackTrace StackTrace => stackTrace;
+
+        public LifecycleScope Scope => scope;
+
+        public string? ThreadName => threadName;
+    }
+}

--- a/src/Lucene.Net.TestFramework/Support/Util/LifecycleScope.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LifecycleScope.cs
@@ -9,7 +9,7 @@ namespace Lucene.Net.Util
     /// <summary>
     /// Lifecycle stages for tracking resources.
     /// </summary>
-    public enum LifecycleScope // From randomizedtesing
+    internal enum LifecycleScope // From randomizedtesing
     {
         /// <summary>
         /// A single test case.

--- a/src/Lucene.Net.TestFramework/Support/Util/LifecycleScope.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LifecycleScope.cs
@@ -6,6 +6,23 @@ using System.Threading.Tasks;
 
 namespace Lucene.Net.Util
 {
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
     /// <summary>
     /// Lifecycle stages for tracking resources.
     /// </summary>

--- a/src/Lucene.Net.TestFramework/Support/Util/LifecycleScope.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LifecycleScope.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lucene.Net.Util
+{
+    /// <summary>
+    /// Lifecycle stages for tracking resources.
+    /// </summary>
+    public enum LifecycleScope // From randomizedtesing
+    {
+        /// <summary>
+        /// A single test case.
+        /// </summary>
+        TEST,
+
+        /// <summary>
+        /// A single suite (class).
+        /// </summary>
+        SUITE
+    }
+}

--- a/src/Lucene.Net.TestFramework/Support/Util/RandomizedContext.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/RandomizedContext.cs
@@ -204,8 +204,8 @@ namespace Lucene.Net.Util
             UninterruptableMonitor.Enter(contextLock);
             try
             {
-                resources = disposableResources;
-                disposableResources = null;
+                resources = disposableResources; // Set the resources to a local variable
+                disposableResources = null; // Set disposableResources field to null so our local list will go out of scope when we are done
             }
             finally
             {
@@ -245,7 +245,7 @@ namespace Lucene.Net.Util
                     ExceptionDispatchInfo.Capture(th).Throw(); // LUCENENET: Rethrow to preserve stack details from the original throw
                 }
             }
-        } // toDispose goes out of scope here - no need to Clear().
+        } // resources goes out of scope here - no need to Clear().
 
         /// <summary>
         /// Prints a stack trace of the <paramref name="exception"/> to the destination <see cref="TextWriter"/>.

--- a/src/Lucene.Net.TestFramework/Support/Util/RandomizedContext.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/RandomizedContext.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Util
         private readonly Test currentTest;
         private readonly Assembly currentTestAssembly;
         private readonly long randomSeed;
-        private readonly string randomSeedAsHex;
+        private volatile string? randomSeedAsString;
         private readonly long testSeed;
 
         /// <summary>
@@ -71,7 +71,6 @@ namespace Lucene.Net.Util
             this.currentTest = currentTest ?? throw new ArgumentNullException(nameof(currentTest));
             this.currentTestAssembly = currentTestAssembly ?? throw new ArgumentNullException(nameof(currentTestAssembly));
             this.randomSeed = randomSeed;
-            this.randomSeedAsHex = SeedUtils.FormatSeed(randomSeed);
             this.testSeed = testSeed;
             this.randomGenerator = new ThreadLocal<Random>(() => new J2N.Randomizer(this.testSeed));
         }
@@ -84,7 +83,7 @@ namespace Lucene.Net.Util
         /// <summary>
         /// Gets the initial seed as a hexadecimal string for display/configuration purposes.
         /// </summary>
-        public string RandomSeedAsHex => randomSeedAsHex;
+        public string RandomSeedAsString => randomSeedAsString ??= SeedUtils.FormatSeed(randomSeed);
 
         /// <summary>
         /// The current test for this context.

--- a/src/Lucene.Net.TestFramework/Support/Util/TestExtensions.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/TestExtensions.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework.Internal;
+﻿using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,6 +29,61 @@ namespace Lucene.Net.Util
     /// </summary>
     internal static class TestExtensions
     {
+        /// <summary>
+        /// Retrieves the <see cref="RandomizedContext"/> instance for a given <see cref="Test"/>.
+        /// <para/>
+        /// 
+        /// </summary>
+        /// <param name="test"></param>
+        /// <returns>The <see cref="RandomizedContext"/>. If the <paramref name="test"/> is <c>null</c>
+        /// or doesn't have a <see cref="RandomizedContext"/>
+        /// (it doesn't belong to our framework), then the return value is <c>null</c>.</returns>
+        public static RandomizedContext? GetRandomizedContext(this Test? test)
+        {
+            if (test is null)
+                return null;
+
+            if (test.Properties.ContainsKey(RandomizedContext.RandomizedContextPropertyName))
+                return (RandomizedContext?)test.Properties.Get(RandomizedContext.RandomizedContextPropertyName);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Determines if the current <paramref name="test"/> is a
+        /// type of runnable test (for example, a [Test] or [TestCase()] as
+        /// opposed to a class or other container).
+        /// </summary>
+        /// <param name="test">This <see cref="Test"/>.</param>
+        /// <returns><c>true</c> if the current <paramref name="test"/> is a
+        /// type of runnable test; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="test"/> is <c>null</c>.</exception>
+        public static bool IsTest(this ITest test)
+        {
+            if (test is null)
+                throw new ArgumentNullException(nameof(test));
+            if (test is Test t)
+                return !t.IsSuite;
+            return false;
+        }
+
+        /// <summary>
+        /// Determines if the current <paramref name="test"/> is a
+        /// test class (as opposed to a runnable test).
+        /// </summary>
+        /// <param name="test">This <see cref="Test"/>.</param>
+        /// <returns><c>true</c> if the current <paramref name="test"/> is a
+        /// test class; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static bool IsTestClass(this ITest test)
+        {
+            if (test is null)
+                throw new ArgumentNullException(nameof(test));
+            if (test is Test t)
+                return t.IsSuite && t.TypeInfo is not null;
+            return false;
+        }
+
         /// <summary>
         /// Mark the test and all descendents as Invalid (not runnable) specifying a reason and an exception.
         /// </summary>

--- a/src/Lucene.Net.TestFramework/Util/CloseableDirectory.cs
+++ b/src/Lucene.Net.TestFramework/Util/CloseableDirectory.cs
@@ -1,15 +1,11 @@
-#if TESTFRAMEWORK
-// LUCENENET NOTE: This is incomplete
+﻿using Lucene.Net.Store;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using System;
 
 namespace Lucene.Net.Util
 {
-
-    using NUnit.Framework;
-    using System;
-    using BaseDirectoryWrapper = Lucene.Net.Store.BaseDirectoryWrapper;
-    using MockDirectoryWrapper = Lucene.Net.Store.MockDirectoryWrapper;
-    //using Assert = org.junit.Assert;
-
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
      * contributor license agreements.  See the NOTICE file distributed with
@@ -30,36 +26,36 @@ namespace Lucene.Net.Util
     /// <summary>
     /// Attempts to close a <seealso cref="BaseDirectoryWrapper"/>.
     /// </summary>
-    /// <seealso> cref= LuceneTestCase#newDirectory(java.util.Random) </seealso>
-    internal sealed class IDisposableDirectory : IDisposable
+    /// <seealso cref="LuceneTestCase.NewDirectory(Random)"/>
+    internal sealed class DisposableDirectory : IDisposable
     {
-      private readonly BaseDirectoryWrapper Dir;
-      private readonly TestRuleMarkFailure FailureMarker;
+        private readonly BaseDirectoryWrapper dir;
 
-      public IDisposableDirectory(BaseDirectoryWrapper dir, TestRuleMarkFailure failureMarker)
-      {
-        this.Dir = dir;
-        this.FailureMarker = failureMarker;
-      }
+        public DisposableDirectory(BaseDirectoryWrapper dir)
+        {
+            this.dir = dir ?? throw new ArgumentNullException(nameof(dir));
+        }
 
-      public void Dispose()
-      {
-        // We only attempt to check open/closed state if there were no other test
-        // failures.
-        try
+        public void Dispose()
         {
-          if (FailureMarker.WasSuccessful() && Dir.Open)
-          {
-            Assert.Fail("Directory not closed: " + Dir);
-          }
+            // We only attempt to check open/closed state if there were no other test
+            // failures.
+            try
+            {
+                //if (FailureMarker.WasSuccessful() && dir.Open)
+                // LUCENENET NOTE: Outcome is context sensitive and only exists after a test run.
+                ResultState outcome = TestContext.CurrentContext.Result.Outcome;
+                if (outcome != ResultState.Failure && outcome != ResultState.Inconclusive && dir.IsOpen)
+                {
+                    Assert.Fail($"Directory not disposed: {dir}");
+                }
+            }
+            finally
+            {
+                // TODO: perform real close of the delegate: LUCENE-4058
+                // dir.Dispose();
+            }
         }
-        finally
-        {
-          // TODO: perform real close of the delegate: LUCENE-4058
-          // dir.close();
-        }
-      }
     }
 
 }
-#endif

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1022,7 +1022,7 @@ namespace Lucene.Net.Util
             catch (Exception ex)
             {
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
-                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during ClassEnvRule.After():\n{ex}");
+                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during ClassEnvRule.After() in {GetType().FullName}:\n{ex}");
             }
             try
             {
@@ -1031,7 +1031,7 @@ namespace Lucene.Net.Util
             catch (Exception ex)
             {
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
-                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during CleanupTemporaryFiles():\n{ex}");
+                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during CleanupTemporaryFiles() in {GetType().FullName}:\n{ex}");
             }
 
             // LUCENENET: DisposeAfterSuite runs last
@@ -1042,7 +1042,7 @@ namespace Lucene.Net.Util
             catch (Exception ex)
             {
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
-                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during RandomizedContext.DisposeResources():\n{ex}");
+                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during RandomizedContext.DisposeResources() in {GetType().FullName}:\n{ex}");
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -742,11 +742,11 @@ namespace Lucene.Net.Util
         /// </summary>
         internal static TestRuleSetupAndRestoreClassEnv ClassEnvRule { get; } = new TestRuleSetupAndRestoreClassEnv();
 
-        // LUCENENET TODO: Implement these rules
-        /// <summary>
-        /// Suite failure marker (any error in the test or suite scope).
-        /// </summary>
-        public static /*TestRuleMarkFailure*/ bool SuiteFailureMarker = true; // Means: was successful
+        // LUCENENET: Removed SuiteFailureMarker and TestFailureMarker because they are used for functionality that
+        // is redundant with NUnit.Framework.Internal.TestExecutionContext.CurrentContext.CurrentResult
+        //
+        // wasSuccessful() is the same as ResultState != ResultState.Error
+        // hadFailures() is the same as ResultState == ResultState.Error
 
         ///// <summary>
         ///// Ignore tests after hitting a designated number of initial failures. This
@@ -862,9 +862,11 @@ namespace Lucene.Net.Util
         /////// Save test thread and name. </summary>
         ////private TestRuleThreadAndTestName threadAndTestNameRule = new TestRuleThreadAndTestName();
 
-        /////// <summary>
-        /////// Taint suite result with individual test failures. </summary>
-        ////private TestRuleMarkFailure testFailureMarker = new TestRuleMarkFailure(SuiteFailureMarker);*/
+        // LUCENENET: Removed SuiteFailureMarker and TestFailureMarker because they are used for functionality that
+        // is redundant with NUnit.Framework.Internal.TestExecutionContext.CurrentContext.CurrentResult
+        //
+        // wasSuccessful() is the same as ResultState != ResultState.Error
+        // hadFailures() is the same as ResultState == ResultState.Error
 
         /////// <summary>
         /////// this controls how individual test rules are nested. It is important that
@@ -904,7 +906,6 @@ namespace Lucene.Net.Util
             /* LUCENENET TODO: Not sure how to convert these
                 ParentChainCallRule.TeardownCalled = true;
                 */
-
             TestResult result = TestExecutionContext.CurrentContext.CurrentResult;
 
             if (result.ResultState == ResultState.Failure || result.ResultState == ResultState.Error)
@@ -969,6 +970,9 @@ namespace Lucene.Net.Util
 
                 result.SetResult(result.ResultState, message, result.StackTrace);
             }
+
+            // LUCENENET: DisposeAfterTest runs last
+            RandomizedContext.CurrentContext.DisposeResources();
         }
 
         /// <summary>
@@ -1029,6 +1033,17 @@ namespace Lucene.Net.Util
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
                 NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during CleanupTemporaryFiles():\n{ex}");
             }
+
+            // LUCENENET: DisposeAfterSuite runs last
+            try
+            {
+                RandomizedContext.CurrentContext.DisposeResources();
+            }
+            catch (Exception ex)
+            {
+                // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
+                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during RandomizedContext.DisposeResources():\n{ex}");
+            }
         }
 
         // -----------------------------------------------------------------
@@ -1067,25 +1082,31 @@ namespace Lucene.Net.Util
             }
         }
 
-        /////// <summary>
-        /////// Registers a <see cref="IDisposable"/> resource that should be closed after the test
-        /////// completes.
-        /////// </summary>
-        /////// <returns> <c>resource</c> (for call chaining). </returns>
-        /////*public static T CloseAfterTest<T>(T resource)
-        ////{
-        ////    return RandomizedContext.Current.CloseAtEnd(resource, LifecycleScope.TEST);
-        ////}*/
+        /// <summary>
+        /// Registers a <see cref="IDisposable"/> resource that should be closed after the test
+        /// completes.
+        /// </summary>
+        /// <returns> <c>resource</c> (for call chaining). </returns>
+        public static T DisposeAfterTest<T>(T resource) where T : IDisposable
+        {
+            return RandomizedContext.CurrentContext.DisposeAtEnd(resource, LifecycleScope.TEST);
+        }
 
-        /////// <summary>
-        /////// Registers a <see cref="IDisposable"/> resource that should be closed after the suite
-        /////// completes.
-        /////// </summary>
-        /////// <returns> <c>resource</c> (for call chaining). </returns>
-        /////*public static T CloseAfterSuite<T>(T resource)
-        ////{
-        ////    return RandomizedContext.Current.CloseAtEnd(resource, LifecycleScope.SUITE);
-        ////}*/
+        /// <summary>
+        /// Registers a <see cref="IDisposable"/> resource that should be closed after the suite
+        /// completes.
+        /// </summary>
+        /// <returns> <c>resource</c> (for call chaining). </returns>
+        /// <remarks>
+        /// Due to limitations of NUnit, any exceptions or assertions raised
+        /// from the <paramref name="resource"/> will not be respected. However, if
+        /// you want to detect a failure, do note that the message from either one
+        /// will be printed to StdOut.
+        /// </remarks>
+        public static T DisposeAfterSuite<T>(T resource) where T : IDisposable
+        {
+            return RandomizedContext.CurrentContext.DisposeAtEnd(resource, LifecycleScope.SUITE);
+        }
 
         /// <summary>
         /// Gets the current type being tested.
@@ -1693,7 +1714,7 @@ namespace Lucene.Net.Util
             if (bare)
             {
                 BaseDirectoryWrapper @base = new BaseDirectoryWrapper(directory);
-                // LUCENENET TODO: CloseAfterSuite(new DisposableDirectory(@base, SuiteFailureMarker));
+                DisposeAfterSuite(new DisposableDirectory(@base /*, SuiteFailureMarker*/));
                 return @base;
             }
             else
@@ -1701,7 +1722,7 @@ namespace Lucene.Net.Util
                 MockDirectoryWrapper mock = new MockDirectoryWrapper(random, directory);
 
                 mock.Throttling = TestThrottling;
-                // LUCENENET TODO: CloseAfterSuite(new DisposableDirectory(mock, SuiteFailureMarker));
+                DisposeAfterSuite(new DisposableDirectory(mock /*, SuiteFailureMarker*/));
                 return mock;
             }
         }
@@ -3123,7 +3144,8 @@ namespace Lucene.Net.Util
             // Only check and throw an IOException on un-removable files if the test
             // was successful. Otherwise just report the path of temporary files
             // and leave them there.
-            if (LuceneTestCase.SuiteFailureMarker /*.WasSuccessful()*/)
+            //if (LuceneTestCase.SuiteFailureMarker.WasSuccessful)
+            if (TestExecutionContext.CurrentContext.CurrentResult.ResultState != ResultState.Failure)
             {
                 try
                 {

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -920,7 +920,7 @@ namespace Lucene.Net.Util
 
                        Apply the following assembly-level attributes:
 
-                      [assembly: Lucene.Net.Util.RandomSeed("{{RandomizedContext.CurrentContext.RandomSeedAsHex}}")]
+                      [assembly: Lucene.Net.Util.RandomSeed("{{RandomizedContext.CurrentContext.RandomSeedAsString}}")]
                       [assembly: NUnit.Framework.SetCulture("{{Thread.CurrentThread.CurrentCulture.Name}}")]
 
                       Option 2:
@@ -929,7 +929,7 @@ namespace Lucene.Net.Util
 
                       <RunSettings>
                         <TestRunParameters>
-                          <Parameter name="tests:seed" value="{{RandomizedContext.CurrentContext.RandomSeedAsHex}}" />
+                          <Parameter name="tests:seed" value="{{RandomizedContext.CurrentContext.RandomSeedAsString}}" />
                           <Parameter name="tests:culture" value="{{Thread.CurrentThread.CurrentCulture.Name}}" />
                         </TestRunParameters>
                       </RunSettings>
@@ -940,7 +940,7 @@ namespace Lucene.Net.Util
 
                       {
                         "tests": {
-                           "seed": "{{RandomizedContext.CurrentContext.RandomSeedAsHex}}",
+                           "seed": "{{RandomizedContext.CurrentContext.RandomSeedAsString}}",
                            "culture": "{{Thread.CurrentThread.CurrentCulture.Name}}"
                         }
                       }
@@ -948,7 +948,7 @@ namespace Lucene.Net.Util
                       Fixture Test Values
                       =================
 
-                       Random Seed:           {{RandomizedContext.CurrentContext.RandomSeedAsHex}}
+                       Random Seed:           {{RandomizedContext.CurrentContext.RandomSeedAsString}}
                        Culture:               {{ClassEnvRule.locale.Name}}
                        Time Zone:             {{ClassEnvRule.timeZone.DisplayName}}
                        Default Codec:         {{ClassEnvRule.codec.Name}} ({{ClassEnvRule.codec.GetType().Name}})

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using static Lucene.Net.Search.FieldCache;
@@ -972,7 +973,16 @@ namespace Lucene.Net.Util
             }
 
             // LUCENENET: DisposeAfterTest runs last
-            RandomizedContext.CurrentContext.DisposeResources();
+            try
+            {
+                RandomizedContext.CurrentContext.DisposeResources();
+            }
+            catch (Exception ex) when (ex.IsThrowable())
+            {
+                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] An exception occurred during TearDown:");
+                RandomizedContext.PrintStackTrace(ex, NUnit.Framework.TestContext.Error);
+                ExceptionDispatchInfo.Capture(ex).Throw();
+            }
         }
 
         /// <summary>
@@ -990,7 +1000,7 @@ namespace Lucene.Net.Util
             {
                 ClassEnvRule.Before();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex.IsThrowable())
             {
                 // This is a bug in the test framework that should be fixed and/or reported if it occurs.
                 if (FailOnTestFixtureOneTimeSetUpError)
@@ -1019,7 +1029,7 @@ namespace Lucene.Net.Util
             {
                 ClassEnvRule.After();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex.IsThrowable())
             {
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
                 NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during ClassEnvRule.After() in {GetType().FullName}:\n{ex}");
@@ -1028,7 +1038,7 @@ namespace Lucene.Net.Util
             {
                 CleanupTemporaryFiles();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex.IsThrowable())
             {
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
                 NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during CleanupTemporaryFiles() in {GetType().FullName}:\n{ex}");
@@ -1039,10 +1049,11 @@ namespace Lucene.Net.Util
             {
                 RandomizedContext.CurrentContext.DisposeResources();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex.IsThrowable())
             {
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
-                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during RandomizedContext.DisposeResources() in {GetType().FullName}:\n{ex}");
+                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during RandomizedContext.DisposeResources() in {GetType().FullName}:");
+                RandomizedContext.PrintStackTrace(ex, NUnit.Framework.TestContext.Error);
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -22,10 +22,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using static Lucene.Net.Search.FieldCache;
@@ -981,7 +979,7 @@ namespace Lucene.Net.Util
             {
                 NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] An exception occurred during TearDown:");
                 RandomizedContext.PrintStackTrace(ex, NUnit.Framework.TestContext.Error);
-                ExceptionDispatchInfo.Capture(ex).Throw();
+                throw; // LUCENENET: Throw to preserve stack details of original throw.
             }
         }
 
@@ -1054,6 +1052,7 @@ namespace Lucene.Net.Util
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
                 NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during RandomizedContext.DisposeResources() in {GetType().FullName}:");
                 RandomizedContext.PrintStackTrace(ex, NUnit.Framework.TestContext.Error);
+                throw; // LUCENENET: Throw to preserve stack details of original throw.
             }
         }
 

--- a/src/Lucene.Net.TestFramework/Util/TestRuleMarkFailure.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleMarkFailure.cs
@@ -1,155 +1,30 @@
-﻿#if TESTFRAMEWORK
-// LUCENENET NOTE: This is incomplete
-using System;
-using System.Collections.Generic;
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-namespace Lucene.Net.Util
-{
-
-
-    /*using AssumptionViolatedException = org.junit.@internal.AssumptionViolatedException;
-    using TestRule = org.junit.rules.TestRule;
-    using Description = org.junit.runner.Description;
-    using Statement = org.junit.runners.model.Statement;*/
-
-    /*
-     * Licensed to the Apache Software Foundation (ASF) under one or more
-     * contributor license agreements.  See the NOTICE file distributed with
-     * this work for additional information regarding copyright ownership.
-     * The ASF licenses this file to You under the Apache License, Version 2.0
-     * (the "License"); you may not use this file except in compliance with
-     * the License.  You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-
-    /// <summary>
-    /// A rule for marking failed tests and suites.
-    /// </summary>
-    public sealed class TestRuleMarkFailure : TestRule
-    {
-      private readonly TestRuleMarkFailure[] Chained;
-      private volatile bool Failures;
-
-      public TestRuleMarkFailure(params TestRuleMarkFailure[] chained)
-      {
-        this.Chained = chained;
-      }
-
-      public override Statement Apply(Statement s, Description d)
-      {
-        return new StatementAnonymousClass(this, s);
-      }
-
-      private sealed class StatementAnonymousClass : Statement
-      {
-          private readonly TestRuleMarkFailure OuterInstance;
-
-          private Statement s;
-
-          public StatementAnonymousClass(TestRuleMarkFailure outerInstance, Statement s)
-          {
-              this.OuterInstance = outerInstance;
-              this.s = s;
-          }
-
-          public override void Evaluate()
-          {
-            // Clear status at start.
-            OuterInstance.Failures = false;
-
-            try
-            {
-              s.evaluate();
-            }
-            catch (Exception t)
-            {
-              if (!IsAssumption(t))
-              {
-                outerInstance.MarkFailed();
-              }
-              throw t;
-            }
-          }
-      }
-
-      /// <summary>
-      /// Is a given exception (or a MultipleFailureException) an 
-      /// <seealso cref="AssumptionViolatedException"/>?
-      /// </summary>
-      public static bool IsAssumption(Exception t)
-      {
-        foreach (Exception t2 in ExpandFromMultiple(t))
-        {
-          if (!(t2 is AssumptionViolatedException))
-          {
-            return false;
-          }
-        }
-        return true;
-      }
-
-      /// <summary>
-      /// Expand from multi-exception wrappers.
-      /// </summary>
-      private static IList<Exception> ExpandFromMultiple(Exception t)
-      {
-        return ExpandFromMultiple(t, new JCG.List<Exception>());
-      }
-
-      /// <summary>
-      /// Internal recursive routine. </summary>
-      private static IList<Exception> ExpandFromMultiple(Exception t, IList<Exception> list)
-      {
-        if (t is org.junit.runners.model.MultipleFailureException)
-        {
-          foreach (Exception sub in ((org.junit.runners.model.MultipleFailureException) t).Failures)
-          {
-            ExpandFromMultiple(sub, list);
-          }
-        }
-        else
-        {
-          list.Add(t);
-        }
-
-        return list;
-      }
-
-      /// <summary>
-      /// Taints this object and any chained as having failures.
-      /// </summary>
-      public void MarkFailed()
-      {
-        Failures = true;
-        foreach (TestRuleMarkFailure next in Chained)
-        {
-          next.MarkFailed();
-        }
-      }
-
-      /// <summary>
-      /// Check if this object had any marked failures.
-      /// </summary>
-      public bool HadFailures()
-      {
-        return Failures;
-      }
-
-      /// <summary>
-      /// Check if this object was successful (the opposite of <seealso cref="#hadFailures()"/>). 
-      /// </summary>
-      public bool WasSuccessful()
-      {
-        return !HadFailures();
-      }
-    }
-
-}
-#endif
+// LUCENENET NOTE: This class was not ported because it is not required (and problematic) in .NET.
+//
+// NUnit tracks test result in NUnit.Framework.Internal.TestExectionContext.CurrentContext.TestResult.ResultState
+// and NUnit.Framework.TestContext.CurrentContext.Result.Outcome. It is much more comprehensive than checking for exceptions because
+// in NUnit failures aren't always exceptions and success may throw an exception. Furthermore, these are context sensitive so
+// so it is more understandable to have them in a global context than to try to track the state of both the test and the class result
+// elsewhere. NUnit also does it in a threadsafe way, so skipping this is one thing less to change if we ever try to run tests in
+// parallel in the future. When inside of a test, it is possible to check the class-level by doing a recursive call on
+// NUnit.Framework.Internal.TestExectionContext.CurrentContext.CurrentTest.Parent and checking to see whether it is a class using
+// our TestExtensions.IsTestClass() extension method. Once the class abstraction has been located, simply read the result
+// in NUnit.Framework.Internal.TestExectionContext.CurrentContext.TestResult.ResultState. Users have access to this state
+// already, so there is no need for us to add custom properties to LuceneTestCase to try to read it because that muddies the
+// fact that this state is context sensitive.

--- a/src/Lucene.Net.Tests.Grouping/TestGroupingExtra.cs
+++ b/src/Lucene.Net.Tests.Grouping/TestGroupingExtra.cs
@@ -60,11 +60,11 @@ namespace Lucene.Net.Search.Grouping
         {
             string[,] carData = GetCarData();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
             int carCount = carData.GetLength(0);
             Document doc = new Document();
@@ -88,7 +88,7 @@ namespace Lucene.Net.Search.Grouping
             groupingSearch.SetFillSortFields(true);
             groupingSearch.SetCachingInMB(10, cacheScores: true);
 
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query matchAllQuery = new MatchAllDocsQuery();
             ITopGroups<BytesRef> topGroups = groupingSearch.SearchByField(searcher, matchAllQuery, groupOffset: 0, groupLimit: 3);
@@ -154,11 +154,11 @@ namespace Lucene.Net.Search.Grouping
         {
             int[,] numericData = GetNumbers();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
 
             //Normally we can not group on a Int32Field when using fieldCache because the Int32Field is stored
@@ -198,7 +198,7 @@ namespace Lucene.Net.Search.Grouping
             groupingSearch.SetGroupSort(new Sort(new SortField("major", SortFieldType.INT32)));
             groupingSearch.SetSortWithinGroup(new Sort(new SortField("minor", SortFieldType.INT32)));
 
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query matchAllQuery = new MatchAllDocsQuery();
             ITopGroups<MutableValueStr> topGroups = groupingSearch.SearchByFunction<MutableValueStr>(searcher, matchAllQuery, groupOffset: 0, groupLimit: 10);
@@ -266,11 +266,11 @@ namespace Lucene.Net.Search.Grouping
         {
             string[,] carData = GetCarData();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
             int carCount = carData.GetLength(0);
             Document doc = new Document();
@@ -292,7 +292,7 @@ namespace Lucene.Net.Search.Grouping
             groupingSearch.SetFillSortFields(true);
             groupingSearch.SetCachingInMB(10, cacheScores: true);
 
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query matchAllQuery = new MatchAllDocsQuery();
             ITopGroups<object> topGroups = groupingSearch.Search(searcher, matchAllQuery, groupOffset: 0, groupLimit: 3);
@@ -359,11 +359,11 @@ namespace Lucene.Net.Search.Grouping
         {
             string[,] carData = GetCarData();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
             int carCount = carData.GetLength(0);
             Document doc = new Document();
@@ -387,7 +387,7 @@ namespace Lucene.Net.Search.Grouping
             groupingSearch.SetFillSortFields(true);
             groupingSearch.SetCachingInMB(10, cacheScores: true);
 
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query matchAllQuery = new MatchAllDocsQuery();
             ITopGroups<object> topGroups = groupingSearch.Search(searcher, matchAllQuery, groupOffset: 0, groupLimit: 3);
@@ -454,11 +454,11 @@ namespace Lucene.Net.Search.Grouping
         {
             int[,] numericData = GetNumbers();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
             //Normally we can not group on a Int32Field when using fieldCache because the Int32Field is stored
             //as a 8 term trie structure by default.  But by specifying int.MaxValue as the NumericPrecisionStep
@@ -496,7 +496,7 @@ namespace Lucene.Net.Search.Grouping
             groupingSearch.SetGroupSort(new Sort(new SortField("major", SortFieldType.INT32)));
             groupingSearch.SetSortWithinGroup(new Sort(new SortField("minor", SortFieldType.INT32)));
 
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query matchAllQuery = new MatchAllDocsQuery();
             ITopGroups<BytesRef> topGroups = groupingSearch.Search<BytesRef>(searcher, matchAllQuery, groupOffset: 0, groupLimit: 10);
@@ -563,11 +563,11 @@ namespace Lucene.Net.Search.Grouping
         {
             int[,] numericData = GetNumbers();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
 
             //Normally we can not group on a Int32Field when using fieldCache because the Int32Field is stored
@@ -607,7 +607,7 @@ namespace Lucene.Net.Search.Grouping
             groupingSearch.SetGroupSort(new Sort(new SortField("major", SortFieldType.INT32)));
             groupingSearch.SetSortWithinGroup(new Sort(new SortField("minor", SortFieldType.INT32)));
 
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query matchAllQuery = new MatchAllDocsQuery();
             ITopGroups<MutableValue> topGroups = groupingSearch.Search<MutableValue>(searcher, matchAllQuery, groupOffset: 0, groupLimit: 10);
@@ -674,11 +674,11 @@ namespace Lucene.Net.Search.Grouping
         {
             int[,] numericData = GetNumbers();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
 
             int rowCount = numericData.GetLength(0);
@@ -702,7 +702,7 @@ namespace Lucene.Net.Search.Grouping
             groupingSearch.SetGroupSort(new Sort(new SortField("major", SortFieldType.INT32)));
             groupingSearch.SetSortWithinGroup(new Sort(new SortField("minor", SortFieldType.INT32)));
 
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query matchAllQuery = new MatchAllDocsQuery();
 
@@ -769,11 +769,11 @@ namespace Lucene.Net.Search.Grouping
         {
             int[,] numericData = GetNumbers();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
             int rowCount = numericData.GetLength(0);
             Document doc = new Document();
@@ -796,7 +796,7 @@ namespace Lucene.Net.Search.Grouping
             groupingSearch.SetGroupSort(new Sort(new SortField("major", SortFieldType.INT32)));
             groupingSearch.SetSortWithinGroup(new Sort(new SortField("minor", SortFieldType.INT32)));
 
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query matchAllQuery = new MatchAllDocsQuery();
 
@@ -860,11 +860,11 @@ namespace Lucene.Net.Search.Grouping
         {
             string[,] carData = GetCarData();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
             int carCount = carData.GetLength(0);
             Document doc = new Document();
@@ -883,7 +883,7 @@ namespace Lucene.Net.Search.Grouping
 
 
             //Begin work to do grouping search manually without use of GroupingSearch class.
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query query = new MatchAllDocsQuery();
             Filter filter = null;
@@ -973,11 +973,11 @@ namespace Lucene.Net.Search.Grouping
         {
             int[,] numericData = GetNumbers();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
             //Normally we can not group on a Int32Field because it's stored as a 8 term trie structure
             //by default.  But by specifying int.MaxValue as the NumericPrecisionStep we force the inverted
@@ -1010,7 +1010,7 @@ namespace Lucene.Net.Search.Grouping
 
 
             //Begin work to do grouping search manually without use of GroupingSearch class.
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query query = new MatchAllDocsQuery();
             Filter filter = null;
@@ -1096,11 +1096,11 @@ namespace Lucene.Net.Search.Grouping
         {
             int[,] numericData = GetNumbers();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
             //Normally we can not group on a Int32Field because it's stored as a 8 term trie structure
             //by default.  But by specifying int.MaxValue as the NumericPrecisionStep we force the inverted
@@ -1133,7 +1133,7 @@ namespace Lucene.Net.Search.Grouping
 
 
             //Begin work to do grouping search manually without use of GroupingSearch class.
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query query = new MatchAllDocsQuery();
             Filter filter = null;
@@ -1224,11 +1224,11 @@ namespace Lucene.Net.Search.Grouping
         {
             int[,] numericData = GetNumbers();
 
-            Directory indexDir = NewDirectory();
+            using Directory indexDir = NewDirectory();
             Analyzer standardAnalyzer = new StandardAnalyzer(TEST_VERSION_CURRENT);
 
             IndexWriterConfig indexConfig = new IndexWriterConfig(TEST_VERSION_CURRENT, standardAnalyzer);
-            IndexWriter writer = new IndexWriter(indexDir, indexConfig);
+            using IndexWriter writer = new IndexWriter(indexDir, indexConfig);
 
             int rowCount = numericData.GetLength(0);
             Document doc = new Document();
@@ -1246,7 +1246,7 @@ namespace Lucene.Net.Search.Grouping
 
 
             //Begin work to do grouping search manually without use of GroupingSearch class.
-            IndexReader reader = writer.GetReader(applyAllDeletes: true);
+            using IndexReader reader = writer.GetReader(applyAllDeletes: true);
             IndexSearcher searcher = new IndexSearcher(reader);
             Query query = new MatchAllDocsQuery();
             Filter filter = null;

--- a/src/Lucene.Net.Tests.TestFramework/Support/TestApiConsistency.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Support/TestApiConsistency.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Tests.TestFramework
         [TestCase(typeof(Lucene.Net.RandomExtensions))]
         public override void TestPrivateFieldNames(Type typeFromTargetAssembly)
         {
-            base.TestPrivateFieldNames(typeFromTargetAssembly, @"ApiScanTestBase|TestUtil\.MaxRecursionBound|Assert\.FailureFormat|Lucene\.Net\.Util\.RandomizedContext\.RandomizedContextPropertyName|Lucene\.Net\.Util\.DefaultNamespaceTypeWrapper\.AllMembers|^Lucene\.Net\.Store\.BaseDirectoryWrapper\.(?:True|False)");
+            base.TestPrivateFieldNames(typeFromTargetAssembly, @"ApiScanTestBase|TestUtil\.MaxRecursionBound|Assert\.FailureFormat|Lucene\.Net\.Util\.RandomizedContext|Lucene\.Net\.Util\.DefaultNamespaceTypeWrapper\.AllMembers|^Lucene\.Net\.Store\.BaseDirectoryWrapper\.(?:True|False)");
         }
 
         [Test, LuceneNetSpecific]

--- a/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
@@ -63,6 +63,7 @@ namespace Lucene.Net.Util.Fst
     using Terms = Lucene.Net.Index.Terms;
     using TermsEnum = Lucene.Net.Index.TermsEnum;
 
+    [SuppressTempFileChecks] // LUCENENET TODO: There is a problem with cleaning up the LineDocsFile in TestRealTerms(). Ignoring for now, but we should figure this out.
     [SuppressCodecs("SimpleText", "Memory", "Direct")]
     [Slow]
     [TestFixture]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Added DisposeAfterSuite/DisposeAfterTest feature to test framework

Fixes #1094

## Description

This adds the `LuceneTestCase.DisposeAfterTest()` and `LuceneTestCase.DisposeAfterSuite()` methods to the test framework that exist in Lucene 4.8.0.

It also removes the `LuceneTestCase.SuiteFailureMarker` property that wasn't implemented. NUnit already tracks the result state of the tests in `NUnit.Framework.Internal.TestExectionContext.CurrentContext.TestResult.ResultState` and `NUnit.Framework.TestContext.CurrentContext.Result.Outcome` in a context-sensitive and thread safe manner, so there is no need to reinvent the wheel with this. For the same reason, we don't need the `TestFailureMarker` property or `TestRuleMarkFailure` class, which are all part of this feature.

The new feature also revealed that there were some directories that were not being disposed in `Lucene.Net.Tests.Grouping` which were also addressed.

For some reason `TestFsts.TestRealTerms()` does not reliably cleanup its line file docs temp file on Windows, so this adds the `[SuppressTempFileChecks]` attribute to suppress the issue when it happens (for now). At some point we should have a look at this, but it is not a blocker for the release.
