### PR TITLE
Remove unnecessary NoInlining, #931

### DIFF
--- a/src/Lucene.Net.Facet/DrillDownQuery.cs
+++ b/src/Lucene.Net.Facet/DrillDownQuery.cs
@@ -158,7 +158,6 @@ namespace Lucene.Net.Facet
         /// Merges (ORs) a new path into an existing AND'd
         /// clause.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void Merge(string dim, string[] path)
         {
             int index = 0;

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -3087,7 +3087,6 @@ namespace Lucene.Net.Util
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         protected string GetFullMethodName([CallerMemberName] string memberName = "")
         {
             return $"{this.GetType().Name}+{memberName}";

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -696,7 +696,10 @@ namespace Lucene.Net.Index
                 {
                     // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                     // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                    bool sawAppend = StackTraceHelper.DoesStackTraceContainMethod(nameof(FreqProxTermsWriterPerField), "Flush");
+                    // LUCENENET NOTE: This code seems incorrect in Lucene, as it checks for "Flush" regardless of type in the sawFlush case,
+                    // which will always be true if the first case is true. The name of the variable implies it checking for "Append"
+                    // but that is not a method on FreqProxTermsWriterPerField.
+                    bool sawAppend = StackTraceHelper.DoesStackTraceContainMethod(nameof(FreqProxTermsWriterPerField), nameof(FreqProxTermsWriterPerField.Flush));
                     bool sawFlush = StackTraceHelper.DoesStackTraceContainMethod("Flush");
 
                     if (sawAppend && sawFlush && count++ >= 30)
@@ -1017,7 +1020,7 @@ namespace Lucene.Net.Index
                 {
                     // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                     // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                    bool foundMethod = StackTraceHelper.DoesStackTraceContainMethod(nameof(MockDirectoryWrapper), "Sync");
+                    bool foundMethod = StackTraceHelper.DoesStackTraceContainMethod(nameof(MockDirectoryWrapper), nameof(MockDirectoryWrapper.Sync));
 
                     if (m_doFail && foundMethod)
                     {
@@ -1088,8 +1091,8 @@ namespace Lucene.Net.Index
         {
             internal bool failOnCommit, failOnDeleteFile;
             internal readonly bool dontFailDuringGlobalFieldMap;
-            internal const string PREPARE_STAGE = "PrepareCommit";
-            internal const string FINISH_STAGE = "FinishCommit";
+            internal const string PREPARE_STAGE = nameof(SegmentInfos.PrepareCommit);
+            internal const string FINISH_STAGE = nameof(SegmentInfos.FinishCommit);
             internal readonly string stage;
 
             public FailOnlyInCommit(bool dontFailDuringGlobalFieldMap, string stage)
@@ -1103,7 +1106,8 @@ namespace Lucene.Net.Index
                 // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
                 bool isCommit = StackTraceHelper.DoesStackTraceContainMethod(nameof(SegmentInfos), stage);
-                bool isDelete = StackTraceHelper.DoesStackTraceContainMethod(nameof(MockDirectoryWrapper), "DeleteFile");
+                bool isDelete = StackTraceHelper.DoesStackTraceContainMethod(nameof(MockDirectoryWrapper), nameof(MockDirectoryWrapper.DeleteFile));
+                // LUCENENET NOTE: this method does not appear to exist anywhere, and is likely always false. It certainly doesn't exist on SegmentInfos.
                 bool isInGlobalFieldMap = StackTraceHelper.DoesStackTraceContainMethod(nameof(SegmentInfos), "WriteGlobalFieldMap");
 
                 if (isInGlobalFieldMap && dontFailDuringGlobalFieldMap)
@@ -1618,8 +1622,8 @@ namespace Lucene.Net.Index
 
         private class FailOnTermVectors : Failure
         {
-            internal const string INIT_STAGE = "InitTermVectorsWriter";
-            internal const string AFTER_INIT_STAGE = "FinishDocument";
+            internal const string INIT_STAGE = nameof(TermVectorsConsumer.InitTermVectorsWriter);
+            internal const string AFTER_INIT_STAGE = nameof(TermVectorsConsumer.FinishDocument);
             internal const string EXC_MSG = "FOTV";
             internal readonly string stage;
 

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterOnDiskFull.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterOnDiskFull.cs
@@ -573,7 +573,7 @@ namespace Lucene.Net.Index
 
                 // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                if (StackTraceHelper.DoesStackTraceContainMethod(nameof(SegmentMerger), "MergeTerms") && !didFail1)
+                if (StackTraceHelper.DoesStackTraceContainMethod(nameof(SegmentMerger), nameof(SegmentMerger.MergeTerms)) && !didFail1)
                 {
                     didFail1 = true;
                     throw new IOException("fake disk full during mergeTerms");
@@ -581,7 +581,7 @@ namespace Lucene.Net.Index
 
                 // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                if (StackTraceHelper.DoesStackTraceContainMethod(nameof(LiveDocsFormat), "WriteLiveDocs") && !didFail2)
+                if (StackTraceHelper.DoesStackTraceContainMethod(nameof(LiveDocsFormat), nameof(LiveDocsFormat.WriteLiveDocs)) && !didFail2)
                 {
                     didFail2 = true;
                     throw new IOException("fake disk full while writing LiveDocs");

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
@@ -502,7 +502,7 @@ namespace Lucene.Net.Index
                 {
                     // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                     // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                    if (StackTraceHelper.DoesStackTraceContainMethod(nameof(DocFieldProcessor), "Flush"))
+                    if (StackTraceHelper.DoesStackTraceContainMethod(nameof(DocFieldProcessor), nameof(DocFieldProcessor.Flush)))
                     {
                         if (onlyOnce)
                         {

--- a/src/Lucene.Net.Tests/Index/TestPersistentSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestPersistentSnapshotDeletionPolicy.cs
@@ -161,7 +161,7 @@ namespace Lucene.Net.Index
             {
                 // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                if (StackTraceHelper.DoesStackTraceContainMethod(nameof(PersistentSnapshotDeletionPolicy), "Persist"))
+                if (StackTraceHelper.DoesStackTraceContainMethod(nameof(PersistentSnapshotDeletionPolicy), nameof(PersistentSnapshotDeletionPolicy.Persist)))
                 {
                     throw new IOException("now fail on purpose");
                 }

--- a/src/Lucene.Net/Codecs/LiveDocsFormat.cs
+++ b/src/Lucene.Net/Codecs/LiveDocsFormat.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs
 {
@@ -54,11 +53,10 @@ namespace Lucene.Net.Codecs
         public abstract IBits ReadLiveDocs(Directory dir, SegmentCommitInfo info, IOContext context);
 
         /// <summary>
-        /// Persist live docs bits.  Use 
+        /// Persist live docs bits.  Use
         /// <see cref="SegmentCommitInfo.NextDelGen"/> to determine the
         /// generation of the deletes file you should write to.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void WriteLiveDocs(IMutableBits bits, Directory dir, SegmentCommitInfo info, int newDelCount, IOContext context);
 
         /// <summary>

--- a/src/Lucene.Net/Codecs/StoredFieldsWriter.cs
+++ b/src/Lucene.Net/Codecs/StoredFieldsWriter.cs
@@ -65,7 +65,6 @@ namespace Lucene.Net.Codecs
 
         /// <summary>
         /// Called when a document and all its fields have been added. </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public virtual void FinishDocument()
         {
         }
@@ -78,7 +77,6 @@ namespace Lucene.Net.Codecs
         /// Aborts writing entirely, implementation should remove
         /// any partially-written files, etc.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Abort();
 
         /// <summary>
@@ -132,7 +130,7 @@ namespace Lucene.Net.Codecs
         }
 
         /// <summary>
-        /// Sugar method for <see cref="StartDocument(int)"/> + <see cref="WriteField(FieldInfo, IIndexableField)"/> 
+        /// Sugar method for <see cref="StartDocument(int)"/> + <see cref="WriteField(FieldInfo, IIndexableField)"/>
         /// for every stored field in the document. </summary>
         protected void AddDocument<T1>(IEnumerable<T1> doc, FieldInfos fieldInfos) where T1 : Lucene.Net.Index.IIndexableField
         {

--- a/src/Lucene.Net/Codecs/TermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/TermVectorsWriter.cs
@@ -80,7 +80,6 @@ namespace Lucene.Net.Codecs
 
         /// <summary>
         /// Called after a doc and all its fields have been added. </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public virtual void FinishDocument()
         {
         }
@@ -119,7 +118,6 @@ namespace Lucene.Net.Codecs
         /// Aborts writing entirely, implementation should remove
         /// any partially-written files, etc.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Abort();
 
         /// <summary>

--- a/src/Lucene.Net/Index/BinaryDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/BinaryDocValuesWriter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
@@ -131,7 +130,6 @@ namespace Lucene.Net.Index
             dvConsumer.AddBinaryField(fieldInfo, GetBytesIterator(maxDoc));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
         }

--- a/src/Lucene.Net/Index/DocConsumer.cs
+++ b/src/Lucene.Net/Index/DocConsumer.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Lucene.Net.Index
 {
     /*
@@ -23,13 +21,10 @@ namespace Lucene.Net.Index
     {
         public abstract void ProcessDocument(FieldInfos.Builder fieldInfos);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void FinishDocument();
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Flush(SegmentWriteState state);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Abort();
     }
 }

--- a/src/Lucene.Net/Index/DocFieldConsumer.cs
+++ b/src/Lucene.Net/Index/DocFieldConsumer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -26,19 +25,16 @@ namespace Lucene.Net.Index
         /// Called when <see cref="DocumentsWriterPerThread"/> decides to create a new
         /// segment
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void Flush(IDictionary<string, DocFieldConsumerPerField> fieldsToFlush, SegmentWriteState state);
 
         /// <summary>
         /// Called when an aborting exception is hit </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void Abort();
 
         public abstract void StartDocument();
 
         public abstract DocFieldConsumerPerField AddField(FieldInfo fi);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void FinishDocument();
     }
 }

--- a/src/Lucene.Net/Index/DocFieldConsumerPerField.cs
+++ b/src/Lucene.Net/Index/DocFieldConsumerPerField.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Lucene.Net.Index
 {
     /*
@@ -25,7 +23,6 @@ namespace Lucene.Net.Index
         /// Processes all occurrences of a single field </summary>
         public abstract void ProcessFields(IIndexableField[] fields, int count);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void Abort();
 
         internal abstract FieldInfo FieldInfo { get; }

--- a/src/Lucene.Net/Index/DocValuesFieldUpdates.cs
+++ b/src/Lucene.Net/Index/DocValuesFieldUpdates.cs
@@ -1,8 +1,6 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -104,7 +102,7 @@ namespace Lucene.Net.Index
 
             public override string ToString()
             {
-                return "numericDVUpdates=" + string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", numericDVUpdates) + 
+                return "numericDVUpdates=" + string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", numericDVUpdates) +
                     " binaryDVUpdates=" + string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", binaryDVUpdates);
             }
         }
@@ -147,7 +145,6 @@ namespace Lucene.Net.Index
         /// segment which received updates while it was being merged. The given updates
         /// should override whatever updates are in that instance.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Merge(DocValuesFieldUpdates other);
 
         /// <summary>

--- a/src/Lucene.Net/Index/DocValuesProcessor.cs
+++ b/src/Lucene.Net/Index/DocValuesProcessor.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Documents;
 using Lucene.Net.Documents.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
@@ -49,7 +48,6 @@ namespace Lucene.Net.Index
         {
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void FinishDocument()
         {
         }

--- a/src/Lucene.Net/Index/DocValuesWriter.cs
+++ b/src/Lucene.Net/Index/DocValuesWriter.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Lucene.Net.Index
 {
     /*
@@ -23,12 +21,10 @@ namespace Lucene.Net.Index
 
     internal abstract class DocValuesWriter
     {
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Abort();
 
         public abstract void Finish(int numDoc);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Flush(SegmentWriteState state, DocValuesConsumer consumer);
     }
 }

--- a/src/Lucene.Net/Index/FreqProxTermsWriter.cs
+++ b/src/Lucene.Net/Index/FreqProxTermsWriter.cs
@@ -29,9 +29,9 @@ namespace Lucene.Net.Index
 
     internal sealed class FreqProxTermsWriter : TermsHashConsumer
     {
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
-        { }
+        {
+        }
 
         // TODO: would be nice to factor out more of this, eg the
         // FreqProxFieldMergeState, and code to visit all Fields
@@ -124,7 +124,6 @@ namespace Lucene.Net.Index
             return new FreqProxTermsWriterPerField(termsHashPerField, this, fieldInfo);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void FinishDocument(TermsHash termsHash)
         {
         }

--- a/src/Lucene.Net/Index/IMergeScheduler.cs
+++ b/src/Lucene.Net/Index/IMergeScheduler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -23,7 +22,6 @@ namespace Lucene.Net.Index
     // LUCENENET specific
     public interface IMergeScheduler : IDisposable // LUCENENET specific: Not implementing ICloneable per Microsoft's recommendation
     {
-        [MethodImpl(MethodImplOptions.NoInlining)]
         void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound);
 
         object Clone();

--- a/src/Lucene.Net/Index/InvertedDocConsumer.cs
+++ b/src/Lucene.Net/Index/InvertedDocConsumer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -24,19 +23,16 @@ namespace Lucene.Net.Index
     {
         /// <summary>
         /// Abort (called after hitting AbortException) </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Abort();
 
         /// <summary>
         /// Flush a new segment </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void Flush(IDictionary<string, InvertedDocConsumerPerField> fieldsToFlush, SegmentWriteState state);
 
         internal abstract InvertedDocConsumerPerField AddField(DocInverterPerField docInverterPerField, FieldInfo fieldInfo);
 
         internal abstract void StartDocument();
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void FinishDocument();
     }
 }

--- a/src/Lucene.Net/Index/InvertedDocConsumerPerField.cs
+++ b/src/Lucene.Net/Index/InvertedDocConsumerPerField.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Lucene.Net.Index
 {
     /*
@@ -38,7 +36,6 @@ namespace Lucene.Net.Index
         internal abstract void Finish();
 
         // Called on hitting an aborting exception
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Abort();
     }
 }

--- a/src/Lucene.Net/Index/InvertedDocEndConsumer.cs
+++ b/src/Lucene.Net/Index/InvertedDocEndConsumer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -22,17 +21,14 @@ namespace Lucene.Net.Index
 
     internal abstract class InvertedDocEndConsumer
     {
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void Flush(IDictionary<string, InvertedDocEndConsumerPerField> fieldsToFlush, SegmentWriteState state);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void Abort();
 
         internal abstract InvertedDocEndConsumerPerField AddField(DocInverterPerField docInverterPerField, FieldInfo fieldInfo);
 
         internal abstract void StartDocument();
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void FinishDocument();
     }
 }

--- a/src/Lucene.Net/Index/InvertedDocEndConsumerPerField.cs
+++ b/src/Lucene.Net/Index/InvertedDocEndConsumerPerField.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Lucene.Net.Index
 {
     /*
@@ -23,7 +21,6 @@ namespace Lucene.Net.Index
     {
         internal abstract void Finish();
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void Abort();
     }
 }

--- a/src/Lucene.Net/Index/MergeScheduler.cs
+++ b/src/Lucene.Net/Index/MergeScheduler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -46,7 +45,6 @@ namespace Lucene.Net.Index
         /// <param name="trigger"> the <see cref="MergeTrigger"/> that caused this merge to happen </param>
         /// <param name="newMergesFound"> <c>true</c> iff any new merges were found by the caller; otherwise <c>false</c>
         ///  </param>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound);
 
         /// <summary>

--- a/src/Lucene.Net/Index/NoMergeScheduler.cs
+++ b/src/Lucene.Net/Index/NoMergeScheduler.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Lucene.Net.Index
 {
     /*
@@ -44,7 +42,6 @@ namespace Lucene.Net.Index
         {
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound)
         {
         }

--- a/src/Lucene.Net/Index/NormsConsumer.cs
+++ b/src/Lucene.Net/Index/NormsConsumer.cs
@@ -35,7 +35,6 @@ namespace Lucene.Net.Index
 
     internal sealed class NormsConsumer : InvertedDocEndConsumer
     {
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void Abort()
         {
         }
@@ -87,7 +86,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void FinishDocument()
         {
         }

--- a/src/Lucene.Net/Index/NormsConsumerPerField.cs
+++ b/src/Lucene.Net/Index/NormsConsumerPerField.cs
@@ -74,10 +74,8 @@ namespace Lucene.Net.Index
 
         internal bool IsEmpty => consumer is null;
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void Abort()
         {
-            //
         }
     }
 }

--- a/src/Lucene.Net/Index/NumericDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/NumericDocValuesWriter.cs
@@ -133,7 +133,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
         }

--- a/src/Lucene.Net/Index/SegmentMerger.cs
+++ b/src/Lucene.Net/Index/SegmentMerger.cs
@@ -438,7 +438,7 @@ namespace Lucene.Net.Index
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void MergeTerms(SegmentWriteState segmentWriteState)
+        internal void MergeTerms(SegmentWriteState segmentWriteState)
         {
             IList<Fields> fields = new JCG.List<Fields>();
             IList<ReaderSlice> slices = new JCG.List<ReaderSlice>();

--- a/src/Lucene.Net/Index/SortedDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedDocValuesWriter.cs
@@ -130,7 +130,6 @@ namespace Lucene.Net.Index
                                       GetOrdsEnumberable(maxDoc, ordMap));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
         }

--- a/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
@@ -187,7 +187,6 @@ namespace Lucene.Net.Index
                 GetOrdsEnumerable(ordMap, maxCountPerDoc));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
         }

--- a/src/Lucene.Net/Index/StoredFieldsConsumer.cs
+++ b/src/Lucene.Net/Index/StoredFieldsConsumer.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Lucene.Net.Index
 {
     /*
@@ -23,15 +21,12 @@ namespace Lucene.Net.Index
     {
         public abstract void AddField(int docID, IIndexableField field, FieldInfo fieldInfo);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Flush(SegmentWriteState state);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Abort();
 
         public abstract void StartDocument();
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void FinishDocument();
     }
 }

--- a/src/Lucene.Net/Index/TermVectorsConsumer.cs
+++ b/src/Lucene.Net/Index/TermVectorsConsumer.cs
@@ -101,7 +101,7 @@ namespace Lucene.Net.Index
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void InitTermVectorsWriter()
+        internal void InitTermVectorsWriter()
         {
             if (writer is null)
             {

--- a/src/Lucene.Net/Index/TermsHashConsumer.cs
+++ b/src/Lucene.Net/Index/TermsHashConsumer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -22,15 +21,12 @@ namespace Lucene.Net.Index
 
     internal abstract class TermsHashConsumer
     {
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Flush(IDictionary<string, TermsHashConsumerPerField> fieldsToFlush, SegmentWriteState state);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Abort();
 
         internal abstract void StartDocument();
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal abstract void FinishDocument(TermsHash termsHash);
 
         public abstract TermsHashConsumerPerField AddField(TermsHashPerField termsHashPerField, FieldInfo fieldInfo);

--- a/src/Lucene.Net/Store/IndexOutput.cs
+++ b/src/Lucene.Net/Store/IndexOutput.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Store
 {
@@ -33,7 +32,6 @@ namespace Lucene.Net.Store
     {
         /// <summary>
         /// Forces any buffered output to be written. </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public abstract void Flush();
 
         /// <summary>
@@ -71,7 +69,7 @@ namespace Lucene.Net.Store
         /// <summary>
         /// Gets or Sets the file length. By default, this property's setter does
         /// nothing (it's optional for a <see cref="Directory"/> to implement
-        /// it).  But, certain <see cref="Directory"/> implementations (for 
+        /// it).  But, certain <see cref="Directory"/> implementations (for
         /// example <see cref="FSDirectory"/>) can use this to inform the
         /// underlying IO system to pre-allocate the file to the
         /// specified size.  If the length is longer than the

--- a/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractBlockPackedWriter.cs
@@ -148,7 +148,6 @@ namespace Lucene.Net.Util.Packed
         /// Return the number of values which have been added. </summary>
         public virtual long Ord => m_ord;
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         protected abstract void Flush();
 
         protected void WriteValues(int bitsRequired)

--- a/src/Lucene.Net/Util/TimSorter.cs
+++ b/src/Lucene.Net/Util/TimSorter.cs
@@ -219,7 +219,6 @@ namespace Lucene.Net.Util
             --stackSize;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal virtual void Merge(int lo, int mid, int hi)
         {
             if (Compare(mid - 1, mid) <= 0)


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Remove unnecessary use of `[MethodImpl(MethodImplOptions.NoInlining)]`

Partial #931

## Description

I need to finish reviewing the methods mentioned in calls to `StackTraceHelper.DoesStackTraceContainMethod(string methodName)` (the overload without the class name parameter) to make sure there aren't any false positives there, but I've at least validated that those existing usages of NoInlining _seem_ like they might plausibly match their use in the tests. 

This PR removes NoInlining from interface and abstract methods, where it has no effect because the attribute is not inherited. It also removes it from methods with empty bodies, because an empty body doesn't call anything, and thus those checks in the tests would never be true anyways. Finally, it removes it in a few other places that were not asserted in tests.

As a TODO, I left the SystemConsole attributes there, even though those are suspect. We had discussed possibly being able to remove that class anyways, but I'll defer that for now.