### PR TITLE
Lucene.Net.Util.Events.TestPubSubEvent::CanAddSubscriptionWhileEventIsFiringNonGeneric(): Added [Ignore] attribute

### DIFF
--- a/src/Lucene.Net.Tests/Support/Util/Events/TestPubSubEvent.cs
+++ b/src/Lucene.Net.Tests/Support/Util/Events/TestPubSubEvent.cs
@@ -436,7 +436,7 @@ namespace Lucene.Net.Util.Events
         }
 
         [Test]
-        [Ignore("This test has been flakey since it was brought over from Prism")]
+        [Ignore("This test has been flakey since it was brought over from Prism (see https://github.com/apache/lucenenet/issues/998#issuecomment-2438994483)")]
         public void CanAddSubscriptionWhileEventIsFiring()
         {
             var PubSubEvent = new TestablePubSubEvent<string>();
@@ -459,6 +459,7 @@ namespace Lucene.Net.Util.Events
         }
 
         [Test]
+        [Ignore("This test has been flakey since it was brought over from Prism (see https://github.com/apache/lucenenet/issues/998#issuecomment-2438994483)")]
         public void CanAddSubscriptionWhileEventIsFiringNonGeneric()
         {
             var pubSubEvent = new TestablePubSubEvent();


### PR DESCRIPTION

<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Lucene.Net.Util.Events.TestPubSubEvent::CanAddSubscriptionWhileEventIsFiringNonGeneric(): Added [Ignore] attribute.

See #998

## Description

`Lucene.Net.Util.Events.TestPubSubEvent::CanAddSubscriptionWhileEventIsFiringNonGeneric()`: Added `[Ignore]` attribute, as this only applies prior to .NET Standard 2.1 and was an inherited problem from Prism.Core. This problem will eventually go away when every target below `netstandard2.1` is dropped and it doesn't seem like a priority to fix it unless a user reports a problem related to using weak events as a workaround to the fact that `ConditionalWeakTable<TKey, TValue>` didn't have an enumerator in older target frameworks.
