### PR TITLE
Lucene.Net.Replicator.LocalReplicator.ReplicationSession: Removed unnecessary array allocation

### DIFF
--- a/src/Lucene.Net.Replicator/LocalReplicator.cs
+++ b/src/Lucene.Net.Replicator/LocalReplicator.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Replicator
 {
@@ -132,14 +133,13 @@ namespace Lucene.Net.Replicator
         private volatile bool disposed = false;
 
         private readonly AtomicInt32 sessionToken = new AtomicInt32(0);
-        private readonly IDictionary<string, ReplicationSession> sessions = new Dictionary<string, ReplicationSession>();
+        private readonly JCG.Dictionary<string, ReplicationSession> sessions = new JCG.Dictionary<string, ReplicationSession>();
 
         /// <exception cref="InvalidOperationException"></exception>
         private void CheckExpiredSessions()
         {
-            // .NET NOTE: .ToArray() so we don't modify a collection we are enumerating...
-            //            I am wondering if it would be overall more practical to switch to a concurrent dictionary...
-            foreach (ReplicationSession token in sessions.Values.Where(token => token.IsExpired(ExpirationThreshold)).ToArray())
+            // LUCENENET NOTE: JCG.Dictionary<TKey, TValue> required for deleting while iterating forward prior to .NET Core
+            foreach (ReplicationSession token in sessions.Values.Where(token => token.IsExpired(ExpirationThreshold)))
             {
                 ReleaseSession(token.Session.Id);
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Lucene.Net.Replicator.LocalReplicator.ReplicationSession: Removed unnecessary array allocation

Fixes #1070

## Description

This changes `ReplicationSession.sessions` to use `J2N.Collections.Dictionary<TKey, TValue>` which allows deleting while iterating forward prior to .NET Core. This removes a `.ToArray()` allocation just for the sake of using an enumerator to clean up replication sessions.
