### PR TITLE
Add unit tests for Collections, #1116

### DIFF
--- a/src/Lucene.Net.Tests/Support/TestCollections.cs
+++ b/src/Lucene.Net.Tests/Support/TestCollections.cs
@@ -1,0 +1,274 @@
+// Some tests adapted from Apache Harmony:
+// https://github.com/apache/harmony/blob/02970cb7227a335edd2c8457ebdde0195a735733/classlib/modules/luni/src/test/api/common/org/apache/harmony/luni/tests/java/util/CollectionsTest.java
+
+using Lucene.Net.Attributes;
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Lucene.Net.Support
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    [TestFixture]
+    public class TestCollections : LuceneTestCase
+    {
+        private List<object> ll = null!; // LUCENENET specific: was LinkedList in Harmony tests, !: will be initialized in SetUp
+
+        // LUCENENET - omitting unused fields
+
+        private static object[] objArray = LoadObjArray(); // LUCENENET - use static loader method instead of static ctor
+
+        private static object[] LoadObjArray()
+        {
+            object[] objArray = new object[1000];
+            for (int i = 0; i < objArray.Length; i++)
+            {
+                objArray[i] = i;
+            }
+
+            return objArray;
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestEmptyList()
+        {
+            IList<object> list = Collections.EmptyList<object>();
+
+            Assert.AreEqual(0, list.Count);
+            Assert.IsTrue(list.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => list.Add(new object()));
+
+            IList<object> list2 = Collections.EmptyList<object>();
+
+            Assert.AreSame(list, list2); // ensure it does not allocate
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestEmptyMap()
+        {
+            IDictionary<object, object> map = Collections.EmptyMap<object, object>();
+
+            Assert.AreEqual(0, map.Count);
+            Assert.IsTrue(map.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => map.Add(new object(), new object()));
+
+            IDictionary<object, object> map2 = Collections.EmptyMap<object, object>();
+
+            Assert.AreSame(map, map2); // ensure it does not allocate
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestEmptySet()
+        {
+            ISet<object> set = Collections.EmptySet<object>();
+
+            Assert.AreEqual(0, set.Count);
+            Assert.IsTrue(set.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => set.Add(new object()));
+
+            ISet<object> set2 = Collections.EmptySet<object>();
+
+            Assert.AreSame(set, set2); // ensure it does not allocate
+        }
+
+        /// <summary>
+        /// Adapted from Harmony test_reverseLjava_util_List()
+        /// </summary>
+        [Test]
+        public void TestReverse()
+        {
+            // Test for method void java.util.Collections.reverse(java.util.List)
+            try
+            {
+                Collections.Reverse<object>(null!);
+                fail("Expected NullPointerException for null list parameter");
+            }
+            catch (Exception e) when (e.IsNullPointerException())
+            {
+                //Expected
+            }
+
+            Collections.Reverse(ll);
+            using var i = ll.GetEnumerator();
+            int count = objArray.Length - 1;
+            while (i.MoveNext())
+            {
+                assertEquals("Failed to reverse collection", objArray[count], i.Current);
+                --count;
+            }
+
+            var myList = new List<object?>
+            {
+                null,
+                20,
+            };
+            Collections.Reverse(myList);
+            assertEquals($"Did not reverse correctly--first element is: {myList[0]}", 20, myList[0]);
+            assertNull($"Did not reverse correctly--second element is: {myList[1]}", myList[1]);
+        }
+
+        /// <summary>
+        /// Adapted from Harmony test_reverseOrder()
+        /// </summary>
+        [Test]
+        public void TestReverseOrder() {
+            // Test for method IComparer<T>
+            // Collections.ReverseOrder()
+            // assumes no duplicates in ll
+            IComparer<object> comp = Collections.ReverseOrder<object>();
+            var list2 = new List<object>(ll); // LUCENENET - was LinkedList in Harmony
+            list2.Sort(comp);
+            int llSize = ll.Count;
+            for (int counter = 0; counter < llSize; counter++)
+            {
+                assertEquals("New comparator does not reverse sorting order", list2[llSize - counter - 1], ll[counter]);
+            }
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestReverseOrder_WithComparer()
+        {
+            IComparer<string> comp = Collections.ReverseOrder<string>(StringComparer.OrdinalIgnoreCase);
+            var list = new List<string> { "B", "c", "a", "D" };
+            list.Sort(comp);
+            Assert.AreEqual(4, list.Count);
+            Assert.AreEqual("D", list[0]);
+            Assert.AreEqual("c", list[1]);
+            Assert.AreEqual("B", list[2]);
+            Assert.AreEqual("a", list[3]);
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestSingletonMap()
+        {
+            IDictionary<string, string> map = Collections.SingletonMap("key", "value");
+
+            Assert.AreEqual(1, map.Count);
+            Assert.IsTrue(map.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => map.Add("key2", "value2"));
+            Assert.Throws<NotSupportedException>(() => map["key"] = "value2");
+
+            Assert.AreEqual("value", map["key"]);
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestToString_Collection_Null()
+        {
+            Assert.AreEqual("null", Collections.ToString<object>(null!));
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestToString_Collection_Empty()
+        {
+            Assert.AreEqual("[]", Collections.ToString(new List<object>()));
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestToString_Collection()
+        {
+            var list = new List<object?>();
+            list.Add(list);
+            list.Add(1);
+            list.Add('a');
+            list.Add(2.1);
+            list.Add("xyz");
+            list.Add(new List<int> { 1, 2, 3 });
+            list.Add(null);
+
+            Assert.AreEqual("[(this Collection), 1, a, 2.1, xyz, [1, 2, 3], null]", Collections.ToString(list));
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestToString_Dictionary()
+        {
+            var dict = new Dictionary<object, object?>()
+            {
+                { "key1", "value1" },
+                { "key2", 2 },
+                { "key3", 'a' },
+                { "key4", 3.1 },
+                { "key5", new List<int> { 1, 2, 3 } },
+                { "key6", null }
+            };
+
+            Assert.AreEqual("{key1=value1, key2=2, key3=a, key4=3.1, key5=[1, 2, 3], key6=null}", Collections.ToString(dict));
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestToString_Object_Null()
+        {
+            Assert.AreEqual("null", Collections.ToString(null));
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestToString_Object()
+        {
+            Assert.AreEqual("1", Collections.ToString(1));
+            Assert.AreEqual("a", Collections.ToString('a'));
+            Assert.AreEqual("2.1", Collections.ToString(2.1));
+            Assert.AreEqual("xyz", Collections.ToString("xyz"));
+            Assert.AreEqual("[1, 2, 3]", Collections.ToString(new List<int> { 1, 2, 3 }));
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestAsReadOnly_List()
+        {
+            var list = new List<object> { 1, 2, 3 };
+            IList<object> readOnlyList = Collections.AsReadOnly(list);
+
+            Assert.AreEqual(3, readOnlyList.Count);
+            Assert.IsTrue(readOnlyList.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => readOnlyList.Add(4));
+            Assert.Throws<NotSupportedException>(() => readOnlyList[0] = 5);
+        }
+
+        [Test, LuceneNetSpecific]
+        public void TestAsReadOnly_Dictionary()
+        {
+            var dict = new Dictionary<object, object>
+            {
+                { "key1", "value1" },
+                { "key2", 2 },
+                { "key3", 'a' }
+            };
+            IDictionary<object, object> readOnlyDict = Collections.AsReadOnly(dict);
+
+            Assert.AreEqual(3, readOnlyDict.Count);
+            Assert.IsTrue(readOnlyDict.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => readOnlyDict.Add("key4", 4));
+            Assert.Throws<NotSupportedException>(() => readOnlyDict["key1"] = "value2");
+        }
+
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            ll = new List<object>();
+            // LUCENENET - omitting unused fields
+
+            for (int i = 0; i < objArray.Length; i++)
+            {
+                ll.Add(objArray[i]);
+            }
+        }
+    }
+}

--- a/src/Lucene.Net/Support/Collections.cs
+++ b/src/Lucene.Net/Support/Collections.cs
@@ -1,14 +1,13 @@
 ﻿using J2N;
 using J2N.Collections.Generic.Extensions;
 using J2N.Collections.ObjectModel;
-using J2N.Globalization;
 using Lucene.Net.Diagnostics;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using JCG = J2N.Collections.Generic;
+#nullable enable
 
 namespace Lucene.Net.Support
 {
@@ -72,10 +71,10 @@ namespace Lucene.Net.Support
 
         public static IComparer<T> ReverseOrder<T>()
         {
-            return (IComparer<T>)ReverseComparer<T>.REVERSE_ORDER;
+            return ReverseComparer<T>.REVERSE_ORDER;
         }
 
-        public static IComparer<T> ReverseOrder<T>(IComparer<T> cmp)
+        public static IComparer<T> ReverseOrder<T>(IComparer<T>? cmp)
         {
             if (cmp is null)
                 return ReverseOrder<T>();
@@ -87,16 +86,16 @@ namespace Lucene.Net.Support
         }
 
         public static IDictionary<TKey, TValue> SingletonMap<TKey, TValue>(TKey key, TValue value)
+            where TKey : notnull
         {
             return AsReadOnly(new Dictionary<TKey, TValue> { { key, value } });
         }
-
 
         /// <summary>
         /// This is the same implementation of ToString from Java's AbstractCollection
         /// (the default implementation for all sets and lists)
         /// </summary>
-        public static string ToString<T>(ICollection<T> collection)
+        public static string ToString<T>(ICollection<T>? collection)
         {
             if (collection is null)
                 return "null";
@@ -114,7 +113,7 @@ namespace Lucene.Net.Support
             while (true)
             {
                 T e = it.Current;
-                sb.Append(object.ReferenceEquals(e, collection) ? "(this Collection)" : (isValueType ? e.ToString() : ToString(e)));
+                sb.Append(ReferenceEquals(e, collection) ? "(this Collection)" : (isValueType ? Convert.ToString(e, CultureInfo.InvariantCulture) : ToString(e)));
                 if (!it.MoveNext())
                 {
                     return sb.Append(']').ToString();
@@ -124,22 +123,10 @@ namespace Lucene.Net.Support
         }
 
         /// <summary>
-        /// This is the same implementation of ToString from Java's AbstractCollection
-        /// (the default implementation for all sets and lists), plus the ability
-        /// to specify culture for formatting of nested numbers and dates. Note that
-        /// this overload will change the culture of the current thread.
-        /// </summary>
-        public static string ToString<T>(ICollection<T> collection, CultureInfo culture)
-        {
-            using var context = new CultureContext(culture);
-            return ToString(collection);
-        }
-
-        /// <summary>
         /// This is the same implementation of ToString from Java's AbstractMap
         /// (the default implementation for all dictionaries)
         /// </summary>
-        public static string ToString<TKey, TValue>(IDictionary<TKey, TValue> dictionary)
+        public static string ToString<TKey, TValue>(IDictionary<TKey, TValue>? dictionary)
         {
             if (dictionary is null)
                 return "null";
@@ -160,9 +147,9 @@ namespace Lucene.Net.Support
                 KeyValuePair<TKey, TValue> e = i.Current;
                 TKey key = e.Key;
                 TValue value = e.Value;
-                sb.Append(object.ReferenceEquals(key, dictionary) ? "(this Dictionary)" : (keyIsValueType ? key.ToString() : ToString(key)));
+                sb.Append(ReferenceEquals(key, dictionary) ? "(this Dictionary)" : (keyIsValueType ? Convert.ToString(key, CultureInfo.InvariantCulture) : ToString(key)));
                 sb.Append('=');
-                sb.Append(object.ReferenceEquals(value, dictionary) ? "(this Dictionary)" : (valueIsValueType ? value.ToString() : ToString(value)));
+                sb.Append(ReferenceEquals(value, dictionary) ? "(this Dictionary)" : (valueIsValueType ? Convert.ToString(value, CultureInfo.InvariantCulture) : ToString(value)));
                 if (!i.MoveNext())
                 {
                     return sb.Append('}').ToString();
@@ -172,23 +159,16 @@ namespace Lucene.Net.Support
         }
 
         /// <summary>
-        /// This is the same implementation of ToString from Java's AbstractMap
-        /// (the default implementation for all dictionaries), plus the ability
-        /// to specify culture for formatting of nested numbers and dates. Note that
-        /// this overload will change the culture of the current thread.
-        /// </summary>
-        public static string ToString<TKey, TValue>(IDictionary<TKey, TValue> dictionary, CultureInfo culture)
-        {
-            using var context = new CultureContext(culture);
-            return ToString(dictionary);
-        }
-
-        /// <summary>
         /// This is a helper method that assists with recursively building
         /// a string of the current collection and all nested collections.
         /// </summary>
-        public static string ToString(object obj)
+        public static string? ToString(object? obj)
         {
+            if (obj is null)
+            {
+                return "null";
+            }
+
             Type t = obj.GetType();
             if (t.IsGenericType
                 && (t.ImplementsGenericInterface(typeof(ICollection<>)))
@@ -198,19 +178,7 @@ namespace Lucene.Net.Support
                 return ToString(genericType);
             }
 
-            return obj.ToString();
-        }
-
-        /// <summary>
-        /// This is a helper method that assists with recursively building
-        /// a string of the current collection and all nested collections, plus the ability
-        /// to specify culture for formatting of nested numbers and dates. Note that
-        /// this overload will change the culture of the current thread.
-        /// </summary>
-        public static string ToString(object obj, CultureInfo culture)
-        {
-            using var context = new CultureContext(culture);
-            return ToString(obj);
+            return Convert.ToString(obj, CultureInfo.InvariantCulture);
         }
 
         public static ReadOnlyList<T> AsReadOnly<T>(IList<T> list)
@@ -227,14 +195,14 @@ namespace Lucene.Net.Support
 
         #region ReverseComparer
 
-        private class ReverseComparer<T> : IComparer<T>
+        private class ReverseComparer<T> : IComparer<T?>
         {
             internal static readonly ReverseComparer<T> REVERSE_ORDER = new ReverseComparer<T>();
 
-            public int Compare(T x, T y)
+            public int Compare(T? x, T? y)
             {
                 // LUCENENET specific: Use J2N's Comparer<T> to mimic Java comparison behavior
-                return JCG.Comparer<T>.Default.Compare(y, x);
+                return JCG.Comparer<T?>.Default.Compare(y, x);
             }
         }
 
@@ -242,7 +210,7 @@ namespace Lucene.Net.Support
 
         #region ReverseComparer2
 
-        private class ReverseComparer2<T> : IComparer<T>
+        private class ReverseComparer2<T> : IComparer<T?>
 
         {
             /**
@@ -252,20 +220,21 @@ namespace Lucene.Net.Support
              *
              * @serial
              */
-            internal readonly IComparer<T> cmp;
+            internal readonly IComparer<T?> cmp;
 
             public ReverseComparer2(IComparer<T> cmp)
             {
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
                 if (Debugging.AssertsEnabled) Debugging.Assert(cmp != null);
-                this.cmp = cmp;
+                this.cmp = cmp!;
             }
 
-            public int Compare(T t1, T t2)
+            public int Compare(T? t1, T? t2)
             {
                 return cmp.Compare(t2, t1);
             }
 
-            public override bool Equals(object o)
+            public override bool Equals(object? o)
             {
                 return (o == this) ||
                     (o is ReverseComparer2<T> reverseComparer2 &&
@@ -275,11 +244,6 @@ namespace Lucene.Net.Support
             public override int GetHashCode()
             {
                 return cmp.GetHashCode() ^ int.MinValue;
-            }
-
-            public IComparer<T> Reversed()
-            {
-                return cmp;
             }
         }
 


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Add unit tests for Collections, including some Harmony tests.

Fixes #1116

## Description

This PR adds unit tests for the `Lucene.Net.Support.Collections` type. Some of the tests are from Harmony where applicable, and others are lucenenet-specific. 

Similar to the discussion at https://github.com/apache/lucenenet/pull/1121#discussion_r1927206723, this fixes some culture/locale inconsistencies with Java. It also removes some ToString methods that were Culture-aware overloads, but these overloads were unused (and this is an internal class, so that's not a breaking change).

As noted in the methods, `Collections.ToString` is based on the `toString` method from Java's `AbstractCollection`/`AbstractMap`. In Java, this method is not Locale-aware, so that the output is consistent across locales. As such, it does not format numbers using i.e. a decimal comma, nor does it use a Locale-aware list separator. It is neither good for serialization/deserialization, nor for display in a UI. It is simply a string representation to be used for debugging and diagnostic purposes and is intended to be closer to a code representation than user-facing. (Even then it's arguably poor in some ways, as strings are not enclosed in double quotes, but it is what it is.)

For example, this Java code (can be run with JBang if you'd like) sets the current Locale to `fr-FR`, which has a decimal comma, but it does not use that in the output. (Java does not have a list separator concept in its Locales, as far as I know, but if it did, that should use a semicolon for `fr-FR` if it were Locale-aware.) 

```java
///usr/bin/env jbang "$0" "$@" ; exit $?

import java.text.*;
import java.util.*;
import static java.lang.System.*;

public class hello {

    public static void main(String... args) {
        Locale.setDefault(new Locale("fr", "FR"));
        List<Object> list = new ArrayList<>();
        list.add(list);
        list.add(1);
        list.add('a');
        list.add(2.1);
        list.add("xyz");
        list.add(new ArrayList<>() { { add(1); add(2); add(3); } });
        list.add(null);
        System.out.println(list); // prints: [(this Collection), 1, a, 2.1, xyz, [1, 2, 3], null]
        // to demonstrate that the locale is applying when applicable...
        NumberFormat nf = NumberFormat.getInstance();
        System.out.println(nf.format(2.1)); // prints: 2,1
    }
}
```

Note the comma list separator and decimal point that indicates that the output is not Locale-aware. I set up the List-based test to exactly mimic this behavior, and assert the same output. This discovered that the test failed for cultures with a decimal comma, since it was just calling `.ToString()` on the value, which will use the current thread's culture. I changed this to use `Convert.ToString` with passing in the invariant culture to match Java's behavior. These ToString methods are only used in building exception messages or console app outputs so that fits the bill of diagnostic purposes that do not need to be locale-aware.

Additionally, it was discovered that the Object-based ToString method could fail if the argument was null, so this has been fixed along with making the file enabled for nullable type checking. This caused some inconsistencies in warnings between .NET Framework, .NET Standard, and .NET 8, so if it seems like the annotations are a little too much, this was likely because of getting warnings in one of the other targets. In particular, the private IComparer implementations were made aggressively nullable.