### PR TITLE
Add support unit tests for ConcurrentHashSet, #1117

### DIFF
--- a/src/Lucene.Net.Tests/Support/Support_CollectionTest.cs
+++ b/src/Lucene.Net.Tests/Support/Support_CollectionTest.cs
@@ -1,0 +1,115 @@
+// Adapted from Apache Harmony tests via J2N: https://github.com/NightOwl888/J2N/blob/main/tests/NUnit/J2N.Tests/Collections/Support_CollectionTest.cs
+using Lucene.Net.Util;
+using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
+
+namespace Lucene.Net
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public class Support_CollectionTest : LuceneTestCase
+    {
+        readonly ICollection<int> col; // must contain the Integers 0 to 99
+
+        // LUCENENET: removed unused string argument and overload
+        public Support_CollectionTest(/*String p1,*/ ICollection<int> c)
+            //: base(p1)
+        {
+            col = c;
+        }
+
+        public void RunTest()
+        {
+            new Support_UnmodifiableCollectionTest(col).RunTest();
+
+            // setup
+            ICollection<int> myCollection = new JCG.SortedSet<int>();
+            myCollection.Add(101);
+            myCollection.Add(102);
+            myCollection.Add(103);
+
+            // add
+            //assertTrue("CollectionTest - a) add did not work", col.Add(new Integer(
+            //        101)));
+            col.Add(101); // Does not return in .NET
+            assertTrue("CollectionTest - b) add did not work", col
+                    .Contains(101));
+
+            // remove
+            assertTrue("CollectionTest - a) remove did not work", col
+                    .Remove(101));
+            assertTrue("CollectionTest - b) remove did not work", !col
+                    .Contains(101));
+
+            if (col is ISet<int> set)
+            {
+                // addAll
+                //assertTrue("CollectionTest - a) addAll failed", set
+                //        .UnionWith(myCollection));
+                set.UnionWith(myCollection); // Does not return in .NET
+                assertTrue("CollectionTest - b) addAll failed", set
+                        .IsSupersetOf(myCollection));
+
+                // containsAll
+                assertTrue("CollectionTest - a) containsAll failed", set
+                        .IsSupersetOf(myCollection));
+                col.Remove(101);
+                assertTrue("CollectionTest - b) containsAll failed", !set
+                        .IsSupersetOf(myCollection));
+
+                // removeAll
+                //assertTrue("CollectionTest - a) removeAll failed", set
+                //        .ExceptWith(myCollection));
+                //assertTrue("CollectionTest - b) removeAll failed", !set
+                //        .ExceptWith(myCollection)); // should not change the colletion
+                //                                   // the 2nd time around
+
+                set.ExceptWith(myCollection); // Does not return in .NET
+                assertTrue("CollectionTest - c) removeAll failed", !set
+                        .Contains(102));
+                assertTrue("CollectionTest - d) removeAll failed", !set
+                        .Contains(103));
+
+                // retianAll
+                set.UnionWith(myCollection);
+                //assertTrue("CollectionTest - a) retainAll failed", set
+                //        .IntersectWith(myCollection));
+                //assertTrue("CollectionTest - b) retainAll failed", !set
+                //        .IntersectWith(myCollection)); // should not change the colletion
+                //                                   // the 2nd time around
+
+                set.IntersectWith(myCollection); // Does not return in .NET
+                assertTrue("CollectionTest - c) retainAll failed", set
+                        .IsSupersetOf(myCollection));
+                assertTrue("CollectionTest - d) retainAll failed", !set
+                        .Contains(0));
+                assertTrue("CollectionTest - e) retainAll failed", !set
+                        .Contains(50));
+
+            }
+
+            // clear
+            col.Clear();
+            assertTrue("CollectionTest - a) clear failed", col.Count == 0);
+            assertTrue("CollectionTest - b) clear failed", !col
+                    .Contains(101));
+
+        }
+
+    }
+}

--- a/src/Lucene.Net.Tests/Support/Support_SetTest.cs
+++ b/src/Lucene.Net.Tests/Support/Support_SetTest.cs
@@ -1,0 +1,48 @@
+// Adapted from Apache Harmony tests: https://github.com/apache/harmony/blob/trunk/classlib/support/src/test/java/tests/support/Support_SetTest.java
+using Lucene.Net.Util;
+using System.Collections.Generic;
+
+namespace Lucene.Net
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public class Support_SetTest : LuceneTestCase
+    {
+        ISet<int> set; // must contain the Integers 0 to 99
+
+        // LUCENENET: removed unused string argument and overload
+        public Support_SetTest(/*String p1,*/ ISet<int> s)
+            //: base(p1)
+        {
+            set = s;
+        }
+
+        public void RunTest() {
+            // add
+            assertTrue("Set Test - Adding a duplicate element changed the set",
+                !set.Add(50));
+            assertTrue("Set Test - Removing an element did not change the set", set
+                .Remove(50));
+            assertTrue(
+                "Set Test - Adding and removing a duplicate element failed to remove it",
+                !set.Contains(50));
+            set.Add(50);
+            new Support_CollectionTest(set).RunTest();
+        }
+    }
+}

--- a/src/Lucene.Net.Tests/Support/Support_UnmodifiableCollectionTest.cs
+++ b/src/Lucene.Net.Tests/Support/Support_UnmodifiableCollectionTest.cs
@@ -1,0 +1,112 @@
+// Adapted from Apache Harmony tests via J2N: https://github.com/NightOwl888/J2N/blob/main/tests/NUnit/J2N.Tests/Collections/Support_UnmodifiableCollectionTest.cs
+
+using Lucene.Net.Util;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Lucene.Net
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    public class Support_UnmodifiableCollectionTest : LuceneTestCase
+    {
+        readonly ICollection<int> col;
+
+        // must be a collection containing the Integers 0 to 99 (which will iterate
+        // in order)
+
+        // LUCENENET: removed unused string argument and overload
+        public Support_UnmodifiableCollectionTest(/*String p1,*/ ICollection<int> c)
+        //: base(p1)
+        {
+            col = c;
+        }
+
+        public void RunTest()
+        {
+
+            // contains
+            assertTrue("UnmodifiableCollectionTest - should contain 0", col
+                    .Contains(0));
+            assertTrue("UnmodifiableCollectionTest - should contain 50", col
+                    .Contains(50));
+            assertTrue("UnmodifiableCollectionTest - should not contain 100", !col
+                    .Contains(100));
+
+            // containsAll
+            HashSet<int> hs = new HashSet<int>();
+            hs.Add(0);
+            hs.Add(25);
+            hs.Add(99);
+            assertTrue(
+                    "UnmodifiableCollectionTest - should contain set of 0, 25, and 99",
+                    col.Intersect(hs).Count() == hs.Count); // Contains all
+            hs.Add(100);
+            assertTrue(
+                    "UnmodifiableCollectionTest - should not contain set of 0, 25, 99 and 100",
+                    col.Intersect(hs).Count() != hs.Count); // Doesn't contain all
+
+            // isEmpty
+            assertTrue("UnmodifiableCollectionTest - should not be empty", col.Count > 0);
+
+            // iterator
+            IEnumerator<int> it = col.GetEnumerator();
+            SortedSet<int> ss = new SortedSet<int>();
+            while (it.MoveNext())
+            {
+                ss.Add(it.Current);
+            }
+            it = ss.GetEnumerator();
+            for (int counter = 0; it.MoveNext(); counter++)
+            {
+                int nextValue = it.Current;
+                assertTrue(
+                        "UnmodifiableCollectionTest - Iterator returned wrong value.  Wanted: "
+                                + counter + " got: " + nextValue,
+                        nextValue == counter);
+            }
+
+            // size
+            assertTrue(
+                    "UnmodifiableCollectionTest - returned wrong size.  Wanted 100, got: "
+                            + col.Count, col.Count == 100);
+
+            // toArray
+            object[] objArray;
+            objArray = col.Cast<object>().ToArray();
+            it = ss.GetEnumerator(); // J2N: Bug in Harmony, this needs to be reset to run
+            for (int counter = 0; it.MoveNext(); counter++)
+            {
+                assertTrue(
+                        "UnmodifiableCollectionTest - toArray returned incorrect array",
+                        (int)objArray[counter] == it.Current);
+            }
+
+            // toArray (Object[])
+            var intArray = new int[100];
+            col.CopyTo(intArray, 0);
+            it = ss.GetEnumerator(); // J2N: Bug in Harmony, this needs to be reset to run
+            for (int counter = 0; it.MoveNext(); counter++)
+            {
+                assertTrue(
+                        "UnmodifiableCollectionTest - CopyTo(object[], int) filled array incorrectly",
+                        intArray[counter] == it.Current);
+            }
+        }
+    }
+}

--- a/src/Lucene.Net.Tests/Support/TestConcurrentHashSet.cs
+++ b/src/Lucene.Net.Tests/Support/TestConcurrentHashSet.cs
@@ -405,7 +405,7 @@ namespace Lucene.Net
             HashSet<object> smallSet = new HashSet<object>();
             for (int i = 0; i < 50; i++)
             {
-                smallSet.add(objArray[i]);
+                smallSet.Add(objArray[i]);
             }
 
             const int numberOfLoops = 200;
@@ -454,15 +454,14 @@ namespace Lucene.Net
             smallSet = new HashSet<object>();
             for (int i = 0; i < 100; i++)
             {
-                smallSet.add(objArray[i]);
+                smallSet.Add(objArray[i]);
             }
-            // LUCENENET TODO: could port this class and all of the classes it uses
-            // new Support_SetTest(new ConcurrentHashSet<object>(smallSet))
-            //     .RunTest();
+            new Support_SetTest(new ConcurrentHashSet<int>(smallSet.Cast<int>())) // LUCENENET: add cast to int
+                .RunTest();
 
             //Test self reference
             mySet = new ConcurrentHashSet<object?>(smallSet); // was: Collections.synchronizedSet(smallSet);
-            mySet.add(mySet); // LUCENENET specific - references are not the same when wrapping via constructor, so adding mySet instead of smallSet
+            mySet.Add(mySet); // LUCENENET specific - references are not the same when wrapping via constructor, so adding mySet instead of smallSet
             assertTrue("should contain self ref", Collections.ToString(mySet).IndexOf("(this", StringComparison.Ordinal) > -1);
         }
     }

--- a/src/Lucene.Net.Tests/Support/TestConcurrentHashSet.cs
+++ b/src/Lucene.Net.Tests/Support/TestConcurrentHashSet.cs
@@ -1,8 +1,18 @@
-﻿using Lucene.Net.Attributes;
+﻿// Some tests adapted from Apache Harmony:
+// https://github.com/apache/harmony/blob/02970cb7227a335edd2c8457ebdde0195a735733/classlib/modules/concurrent/src/test/java/ConcurrentHashMapTest.java
+// https://github.com/apache/harmony/blob/02970cb7227a335edd2c8457ebdde0195a735733/classlib/modules/luni/src/test/api/common/org/apache/harmony/luni/tests/java/util/CollectionsTest.java
+
+using J2N.Threading;
+using Lucene.Net.Attributes;
 using Lucene.Net.Support;
+using Lucene.Net.Support.Threading;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+#nullable enable
 
 namespace Lucene.Net
 {
@@ -23,8 +33,122 @@ namespace Lucene.Net
      * limitations under the License.
      */
 
-    public class TestConcurrentHashSet
+    /// <summary>
+    /// Tests for <see cref="ConcurrentHashSet{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// Some tests (those not marked with <see cref="LuceneNetSpecificAttribute"/>)
+    /// are adapted from Apache Harmony's ConcurrentHashMapTest class. This class
+    /// tests ConcurrentHashMap, which is a dictionary, but the key behavior is
+    /// similar to <see cref="ConcurrentHashSet{T}"/>.
+    /// </remarks>
+    public class TestConcurrentHashSet : JSR166TestCase
     {
+        /// <summary>
+        /// Used by <see cref="TestSynchronizedSet"/>
+        /// </summary>
+        // Ported from https://github.com/apache/harmony/blob/02970cb7227a335edd2c8457ebdde0195a735733/classlib/modules/luni/src/test/api/common/org/apache/harmony/luni/tests/java/util/CollectionsTest.java#L66-L76
+        private static readonly object[] objArray = LoadObjArray();
+
+        private static object[] LoadObjArray() // LUCENENET: avoid static constructors
+        {
+            object[] objArray = new object[1000];
+            for (int i = 0; i < objArray.Length; i++)
+            {
+                objArray[i] = i;
+            }
+            return objArray;
+        }
+
+        /// <summary>
+        /// Used by <see cref="TestSynchronizedSet"/>
+        /// </summary>
+        /// <remarks>
+        /// Implements ThreadJob instead of Runnable, as that's what we have access to here.
+        /// </remarks>
+        // Ported from https://github.com/apache/harmony/blob/02970cb7227a335edd2c8457ebdde0195a735733/classlib/modules/luni/src/test/api/common/org/apache/harmony/luni/tests/java/util/CollectionsTest.java#L88-L159
+        public class SynchCollectionChecker : ThreadJob
+        {
+            private ISet<object> col; // LUCENENET: was Collection, but we need to use ISet to access the containsAll method
+
+            // private int colSize; // LUCENENET: converted to local variable
+
+            private readonly int totalToRun;
+
+            private readonly bool offset;
+
+            private volatile int numberOfChecks /* = 0 */;
+
+            private bool result = true;
+
+            private readonly List<object> normalCountingList;
+
+            private readonly List<object> offsetCountingList;
+
+            public override void Run()
+            {
+                // ensure the list either contains the numbers from 0 to size-1 or
+                // the numbers from size to 2*size -1
+                while (numberOfChecks < totalToRun)
+                {
+                    UninterruptableMonitor.Enter(col);
+                    try
+                    {
+                        if (!(col.Count == 0
+                              || col.containsAll(normalCountingList)
+                              || col.containsAll(offsetCountingList)))
+                            result = false;
+                        col.clear();
+                    }
+                    finally
+                    {
+                        UninterruptableMonitor.Exit(col);
+                    }
+                    if (offset)
+                        col.addAll(offsetCountingList);
+                    else
+                        col.addAll(normalCountingList);
+                    Interlocked.Increment(ref numberOfChecks); // was: numberOfChecks++;
+                }
+            }
+
+            public SynchCollectionChecker(ISet<object> c, bool offset,
+                int totalChecks)
+            {
+                // The collection to test, whether to offset the filler values by
+                // size or not, and the min number of iterations to run
+                totalToRun = totalChecks;
+                col = c;
+                int colSize = c.size();
+                normalCountingList = new List<object>(colSize);
+                offsetCountingList = new List<object>(colSize);
+                for (int counter = 0; counter < colSize; counter++)
+                    normalCountingList.Add(counter);
+                for (int counter = 0; counter < colSize; counter++)
+                    offsetCountingList.Add(counter + colSize);
+                col.clear();
+                if (offset)
+                    col.addAll(offsetCountingList);
+                else
+                    col.addAll(normalCountingList);
+                this.offset = offset; // LUCENENET - this line was missing from the original code
+            }
+
+            public bool Offset
+                // answer true iff the list is filled with a counting sequence
+                // starting at the value size to 2*size - 1
+                // else the list with be filled starting at 0 to size - 1
+                => offset;
+
+            public bool Result
+                // answer true iff no corruption has been found in the collection
+                => result;
+
+            public int NumberOfChecks
+                // answer the number of checks that have been performed on the list
+                => numberOfChecks;
+        }
+
         [Test, LuceneNetSpecific]
         public void TestExceptWith()
         {
@@ -46,6 +170,279 @@ namespace Lucene.Net
             Assert.AreEqual(2, hashSet.Count);
             Assert.IsTrue(hashSet.Contains(0));
             Assert.IsTrue(hashSet.Contains(99));
+        }
+
+        /// <summary>
+        /// Create a set from Integers 1-5.
+        /// </summary>
+        /// <remarks>
+        /// In the Harmony tests, this returns a ConcurrentHashMap,
+        /// hence the name. Retaining the name, even though this is not a map,
+        /// for consistency with the original tests.
+        /// </remarks>
+        private static ConcurrentHashSet<object> Map5()
+        {
+            ConcurrentHashSet<object> map = new ConcurrentHashSet<object>();
+            assertTrue(map.IsEmpty);
+            map.Add(one);
+            map.Add(two);
+            map.Add(three);
+            map.Add(four);
+            map.Add(five);
+            assertFalse(map.IsEmpty);
+            assertEquals(5, map.Count);
+            return map;
+        }
+
+        /// <summary>
+        /// clear removes all items
+        /// </summary>
+        [Test]
+        public void TestClear()
+        {
+            ConcurrentHashSet<object> map = Map5();
+            map.Clear();
+            assertEquals(map.size(), 0);
+        }
+
+        /// <summary>
+        /// Sets with same contents are equal
+        /// </summary>
+        [Test]
+        [Ignore("ConcurrentHashSet does not currently implement structural Equals")]
+        public void TestEquals()
+        {
+            ConcurrentHashSet<object> map1 = Map5();
+            ConcurrentHashSet<object> map2 = Map5();
+            assertEquals(map1, map2);
+            assertEquals(map2, map1);
+            map1.Clear();
+            assertFalse(map1.Equals(map2));
+            assertFalse(map2.Equals(map1));
+        }
+
+        /// <summary>
+        /// contains returns true for contained value
+        /// </summary>
+        /// <remarks>
+        /// This was <c>testContainsKey</c> in the Harmony tests,
+        /// but we're using keys as values here.
+        /// </remarks>
+        [Test]
+        public void TestContains()
+        {
+            ConcurrentHashSet<object> map = Map5();
+            assertTrue(map.contains(one));
+            assertFalse(map.contains(zero));
+        }
+
+        /// <summary>
+        /// enumeration returns an enumeration containing the correct
+        /// elements
+        /// </summary>
+        [Test]
+        public void TestEnumeration()
+        {
+            ConcurrentHashSet<object> map = Map5();
+            using IEnumerator<object> e = map.GetEnumerator();
+            int count = 0;
+            while (e.MoveNext())
+            {
+                count++;
+                Assert.IsNotNull(e.Current); // LUCENENET specific - original test did not have an assert here
+            }
+
+            assertEquals(5, count);
+        }
+
+        // LUCENENET - omitted testGet because it is not applicable to a set
+
+        /// <summary>
+        /// IsEmpty is true of empty map and false for non-empty
+        /// </summary>
+        [Test]
+        public void TestIsEmpty()
+        {
+            ConcurrentHashSet<object> empty = new ConcurrentHashSet<object>();
+            ConcurrentHashSet<object> map = Map5();
+            assertTrue(empty.IsEmpty);
+            assertFalse(map.IsEmpty);
+        }
+
+        // LUCENENET - omitted testKeys, testKeySet, testKeySetToArray, testValuesToArray, testEntrySetToArray,
+        // testValues, testEntrySet
+
+        /// <summary>
+        /// UnionAll adds all elements from the given set
+        /// </summary>
+        /// <remarks>
+        /// This was adapted from testPutAll in the Harmony tests.
+        /// </remarks>
+        [Test]
+        public void TestUnionWith()
+        {
+            ConcurrentHashSet<object> empty = new ConcurrentHashSet<object>();
+            ConcurrentHashSet<object> map = Map5();
+            empty.UnionWith(map);
+            assertEquals(5, empty.size());
+            assertTrue(empty.Contains(one));
+            assertTrue(empty.Contains(two));
+            assertTrue(empty.Contains(three));
+            assertTrue(empty.Contains(four));
+            assertTrue(empty.Contains(five));
+        }
+
+        // LUCENENET - omitted testPutIfAbsent, testPutIfAbsent2, testReplace, testReplace2, testReplaceValue, testReplaceValue2
+
+        /// <summary>
+        /// remove removes the correct value from the set
+        /// </summary>
+        [Test]
+        public void TestRemove()
+        {
+            ConcurrentHashSet<object> map = Map5();
+            map.remove(five);
+            assertEquals(4, map.size());
+            assertFalse(map.Contains(five));
+        }
+
+        /// <summary>
+        /// remove(value) removes only if value present
+        /// </summary>
+        [Test]
+        public void TestRemove2()
+        {
+            ConcurrentHashSet<object> map = Map5();
+            map.remove(five);
+            assertEquals(4, map.size());
+            assertFalse(map.Contains(five));
+            map.remove(zero); // LUCENENET specific - modified, zero is not in the set
+            assertEquals(4, map.Count);
+            assertFalse(map.Contains(zero)); // LUCENENET specific - ensure zero was not added
+        }
+
+        /// <summary>
+        /// size returns the correct values
+        /// </summary>
+        [Test]
+        public void TestCount()
+        {
+            ConcurrentHashSet<object> map = Map5();
+            // ReSharper disable once CollectionNeverUpdated.Local - indeed, that's what we're testing here
+            ConcurrentHashSet<object> empty = new ConcurrentHashSet<object>();
+            assertEquals(0, empty.Count);
+            assertEquals(5, map.Count);
+        }
+
+        // LUCENENET - testToString omitted, could use Collections.ToString instead
+
+        /// <summary>
+        /// Cannot create with negative capacity
+        /// </summary>
+        [Test]
+        public void TestConstructor1() {
+            try
+            {
+                _ = new ConcurrentHashSet<object>(8, -1);
+                shouldThrow();
+            }
+            catch (ArgumentOutOfRangeException) // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException
+            {
+            }
+        }
+
+        /// <summary>
+        /// Cannot create with negative concurrency level
+        /// </summary>
+        [Test]
+        public void TestConstructor2()
+        {
+            try
+            {
+                _ = new ConcurrentHashSet<object>(-1, 100);
+                shouldThrow();
+            }
+            catch (ArgumentOutOfRangeException) // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException
+            {
+            }
+        }
+
+        // LUCENENET - testConstructor3 omitted, we don't have a single-int-argument constructor
+        // LUCENENET - omitted testGet_NullPointerException, testContainsKey_NullPointerException, testContainsValue_NullPointerException, etc.
+        // LUCENENET - omitted testPut_NullPointerException, etc. due to nullable reference type checking making them unnecessary
+        // LUCENENET - omitted testSerialization due to lack of serialization support
+        // LUCENENET - omitted testSetValueWriteThrough as that is not applicable to a set
+
+        // Ported from https://github.com/apache/harmony/blob/02970cb7227a335edd2c8457ebdde0195a735733/classlib/modules/luni/src/test/api/common/org/apache/harmony/luni/tests/java/util/CollectionsTest.java#L1474-L1532
+        /// <summary>
+        /// Apache Harmony test for java.util.Collections#synchronizedSet(java.util.Set), adapted for <see cref="ConcurrentHashSet{T}"/>.
+        /// </summary>
+        [Test]
+        public void TestSynchronizedSet()
+        {
+            HashSet<object> smallSet = new HashSet<object>();
+            for (int i = 0; i < 50; i++)
+            {
+                smallSet.add(objArray[i]);
+            }
+
+            const int numberOfLoops = 200;
+            ConcurrentHashSet<object> synchSet = new ConcurrentHashSet<object>(smallSet); // was: Collections.synchronizedSet(smallSet);
+            // Replacing the previous line with the line below should cause the test
+            // to fail--the set below isn't synchronized
+            // ISet<object> synchSet = smallSet;
+
+            SynchCollectionChecker normalSynchChecker = new SynchCollectionChecker(
+                synchSet, false, numberOfLoops);
+            SynchCollectionChecker offsetSynchChecker = new SynchCollectionChecker(
+                synchSet, true, numberOfLoops);
+            ThreadJob normalThread = normalSynchChecker;
+            ThreadJob offsetThread = offsetSynchChecker;
+            normalThread.Start();
+            offsetThread.Start();
+            while ((normalSynchChecker.NumberOfChecks < numberOfLoops)
+                   || (offsetSynchChecker.NumberOfChecks < numberOfLoops))
+            {
+                try
+                {
+                    Thread.Sleep(10);
+                }
+                catch (Exception e) when (e.IsInterruptedException())
+                {
+                    //Expected
+                }
+            }
+            assertTrue("Returned set corrupted by multiple thread access",
+                normalSynchChecker.Result
+                && offsetSynchChecker.Result);
+            try
+            {
+                normalThread.Join(5000);
+                offsetThread.Join(5000);
+            }
+            catch (Exception e) when (e.IsInterruptedException())
+            {
+                fail("join() interrupted");
+            }
+
+            ISet<object> mySet; // = new ConcurrentHashSet<object>(smallSet); // was: Collections.synchronizedSet(smallSet);
+            // LUCENENET: our type does not allow nulls
+            // mySet.add(null);
+            // assertTrue("Trying to use nulls in list failed", mySet.contains(null));
+
+            smallSet = new HashSet<object>();
+            for (int i = 0; i < 100; i++)
+            {
+                smallSet.add(objArray[i]);
+            }
+            // LUCENENET TODO: could port this class and all of the classes it uses
+            // new Support_SetTest(new ConcurrentHashSet<object>(smallSet))
+            //     .RunTest();
+
+            //Test self reference
+            mySet = new ConcurrentHashSet<object>(smallSet); // was: Collections.synchronizedSet(smallSet);
+            mySet.add(mySet); // LUCENENET specific - references are not the same when wrapping via constructor, so adding mySet instead of smallSet
+            assertTrue("should contain self ref", Collections.ToString(mySet).IndexOf("(this", StringComparison.Ordinal) > -1);
         }
     }
 }

--- a/src/Lucene.Net.Tests/Support/Threading/JSR166TestCase.cs
+++ b/src/Lucene.Net.Tests/Support/Threading/JSR166TestCase.cs
@@ -381,6 +381,24 @@ namespace Lucene.Net.Support.Threading
             fail("Unexpected exception");
         }
 
+        protected static readonly int zero = 0;
+        protected static readonly int one = 1;
+        protected static readonly int two = 2;
+        protected static readonly int three  = 3;
+        protected static readonly int four  = 4;
+        protected static readonly int five  = 5;
+        protected static readonly int six = 6;
+        protected static readonly int seven = 7;
+        protected static readonly int eight = 8;
+        protected static readonly int nine = 9;
+        protected static readonly int m1 = -1;
+        protected static readonly int m2 = -2;
+        protected static readonly int m3 = -3;
+        protected static readonly int m4 = -4;
+        protected static readonly int m5 = -5;
+        protected static readonly int m6 = -6;
+        protected static readonly int m10 = -10;
+
         internal void ShortRunnable()
         {
             try

--- a/src/Lucene.Net/Support/ConcurrentHashSet.cs
+++ b/src/Lucene.Net/Support/ConcurrentHashSet.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using JCG = J2N.Collections.Generic;
 #nullable enable
 
 namespace Lucene.Net.Support
@@ -44,7 +45,8 @@ namespace Lucene.Net.Support
     /// concurrently from multiple threads.
     /// </remarks>
     [DebuggerDisplay("Count = {Count}")]
-    internal class ConcurrentHashSet<T> : ISet<T>, IReadOnlyCollection<T>
+    // ReSharper disable once RedundantExtendsListEntry
+    internal class ConcurrentHashSet<T> : ISet<T>, IReadOnlyCollection<T>, ICollection<T>
     {
         private const int DefaultCapacity = 31;
         private const int MaxLockNumber = 1024;
@@ -291,7 +293,7 @@ namespace Lucene.Net.Support
 
             _growLockArray = growLockArray;
             _budget = buckets.Length / locks.Length;
-            _comparer = comparer ?? EqualityComparer<T>.Default;
+            _comparer = comparer ?? JCG.EqualityComparer<T>.Default;
         }
 
         /// <summary>

--- a/src/Lucene.Net/Support/ConcurrentHashSet.cs
+++ b/src/Lucene.Net/Support/ConcurrentHashSet.cs
@@ -32,6 +32,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using JCG = J2N.Collections.Generic;
+// ReSharper disable RedundantExtendsListEntry
 #nullable enable
 
 namespace Lucene.Net.Support
@@ -45,8 +46,10 @@ namespace Lucene.Net.Support
     /// concurrently from multiple threads.
     /// </remarks>
     [DebuggerDisplay("Count = {Count}")]
-    // ReSharper disable once RedundantExtendsListEntry
     internal class ConcurrentHashSet<T> : ISet<T>, IReadOnlyCollection<T>, ICollection<T>
+#if FEATURE_READONLYSET
+        , IReadOnlySet<T>
+#endif
     {
         private const int DefaultCapacity = 31;
         private const int MaxLockNumber = 1024;


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Add support unit tests for ConcurrentHashSet

Fixes #1117

## Description

This ports tests from Harmony for `Collections.synchronizedSet` and `ConcurrentHashMap` and adapts them to our `ConcurrentHashSet`.

This also adds nullable reference type checking to ConcurrentHashSet, which exposed some nullability issues. Given that our current use of this type is for values that should never be null (or would otherwise throw an NRE upon use as null is not checked-for), this adds a generic type constraint of `notnull` to ensure that it cannot be used with nullable reference types. Work would need to be done (under proper unit test coverage) to make this null-friendly if that is needed in the future.