### PR TITLE
Use J2N methods instead of StringBuilder.Remove, #664

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/De/GermanStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/De/GermanStemmer.cs
@@ -1,4 +1,6 @@
 // Lucene version compatibility level 4.8.1
+
+using J2N.Text;
 using System;
 using System.Globalization;
 using System.Text;
@@ -25,7 +27,7 @@ namespace Lucene.Net.Analysis.De
      */
 
     /// <summary>
-    /// A stemmer for German words. 
+    /// A stemmer for German words.
     /// <para>
     /// The algorithm is based on the report
     /// "A Fast and Simple Stemming Algorithm for German Words" by Jörg
@@ -60,8 +62,7 @@ namespace Lucene.Net.Analysis.De
                 return term;
             }
             // Reset the StringBuilder.
-            sb.Remove(0, sb.Length);
-            sb.Insert(0, term);
+            sb.Replace(0, sb.Length, term);
             // Stemming starts here...
             Substitute(sb);
             Strip(sb);
@@ -102,32 +103,32 @@ namespace Lucene.Net.Analysis.De
             {
                 if ((buffer.Length + substCount > 5) && buffer.ToString(buffer.Length - 2, buffer.Length - (buffer.Length - 2)).Equals("nd", StringComparison.Ordinal))
                 {
-                    buffer.Remove(buffer.Length - 2, buffer.Length - (buffer.Length - 2));
+                    buffer.Delete(buffer.Length - 2, buffer.Length - (buffer.Length - 2));
                 }
                 else if ((buffer.Length + substCount > 4) && buffer.ToString(buffer.Length - 2, buffer.Length - (buffer.Length - 2)).Equals("em", StringComparison.Ordinal))
                 {
-                    buffer.Remove(buffer.Length - 2, buffer.Length - (buffer.Length - 2));
+                    buffer.Delete(buffer.Length - 2, buffer.Length - (buffer.Length - 2));
                 }
                 else if ((buffer.Length + substCount > 4) && buffer.ToString(buffer.Length - 2, buffer.Length - (buffer.Length - 2)).Equals("er", StringComparison.Ordinal))
                 {
-                    buffer.Remove(buffer.Length - 2, buffer.Length - (buffer.Length - 2));
+                    buffer.Delete(buffer.Length - 2, buffer.Length - (buffer.Length - 2));
                 }
                 else if (buffer[buffer.Length - 1] == 'e')
                 {
-                    buffer.Remove(buffer.Length - 1, 1);
+                    buffer.Delete(buffer.Length - 1, 1);
                 }
                 else if (buffer[buffer.Length - 1] == 's')
                 {
-                    buffer.Remove(buffer.Length - 1, 1);
+                    buffer.Delete(buffer.Length - 1, 1);
                 }
                 else if (buffer[buffer.Length - 1] == 'n')
                 {
-                    buffer.Remove(buffer.Length - 1, 1);
+                    buffer.Delete(buffer.Length - 1, 1);
                 }
                 // "t" occurs only as suffix of verbs.
                 else if (buffer[buffer.Length - 1] == 't')
                 {
-                    buffer.Remove(buffer.Length - 1, 1);
+                    buffer.Delete(buffer.Length - 1, 1);
                 }
                 else
                 {
@@ -145,7 +146,7 @@ namespace Lucene.Net.Analysis.De
             // Additional step for female plurals of professions and inhabitants.
             if (buffer.Length > 5 && buffer.ToString(buffer.Length - 5, buffer.Length - (buffer.Length - 5)).Equals("erin*", StringComparison.Ordinal))
             {
-                buffer.Remove(buffer.Length - 1, 1);
+                buffer.Delete(buffer.Length - 1, 1);
                 Strip(buffer);
             }
             // Additional step for irregular plural nouns like "Matrizen -> Matrix".
@@ -167,7 +168,7 @@ namespace Lucene.Net.Analysis.De
                 {
                     if (buffer.ToString(c, 4).Equals("gege", StringComparison.Ordinal))
                     {
-                        buffer.Remove(c, (c + 2) - c);
+                        buffer.Delete(c, (c + 2) - c);
                         return;
                     }
                 }
@@ -176,7 +177,7 @@ namespace Lucene.Net.Analysis.De
 
         /// <summary>
         /// Do some substitutions for the term to reduce overstemming:
-        /// 
+        ///
         /// <list type="bullet">
         /// <item><description>Substitute Umlauts with their corresponding vowel: äöü -> aou,
         ///   "ß" is substituted by "ss"</description></item>
@@ -223,37 +224,37 @@ namespace Lucene.Net.Analysis.De
                     if ((c < buffer.Length - 2) && buffer[c] == 's' && buffer[c + 1] == 'c' && buffer[c + 2] == 'h')
                     {
                         buffer[c] = '$';
-                        buffer.Remove(c + 1, (c + 3) - (c + 1));
+                        buffer.Delete(c + 1, (c + 3) - (c + 1));
                         substCount = +2;
                     }
                     else if (buffer[c] == 'c' && buffer[c + 1] == 'h')
                     {
                         buffer[c] = '§';
-                        buffer.Remove(c + 1, 1);
+                        buffer.Delete(c + 1, 1);
                         substCount++;
                     }
                     else if (buffer[c] == 'e' && buffer[c + 1] == 'i')
                     {
                         buffer[c] = '%';
-                        buffer.Remove(c + 1, 1);
+                        buffer.Delete(c + 1, 1);
                         substCount++;
                     }
                     else if (buffer[c] == 'i' && buffer[c + 1] == 'e')
                     {
                         buffer[c] = '&';
-                        buffer.Remove(c + 1, 1);
+                        buffer.Delete(c + 1, 1);
                         substCount++;
                     }
                     else if (buffer[c] == 'i' && buffer[c + 1] == 'g')
                     {
                         buffer[c] = '#';
-                        buffer.Remove(c + 1, 1);
+                        buffer.Delete(c + 1, 1);
                         substCount++;
                     }
                     else if (buffer[c] == 's' && buffer[c + 1] == 't')
                     {
                         buffer[c] = '!';
-                        buffer.Remove(c + 1, 1);
+                        buffer.Delete(c + 1, 1);
                         substCount++;
                     }
                 }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Fr/FrenchStemmer.cs
@@ -1,4 +1,6 @@
 ﻿// Lucene version compatibility level 4.8.1
+
+using J2N.Text;
 using System;
 using System.Globalization;
 using System.Text;
@@ -23,14 +25,14 @@ namespace Lucene.Net.Analysis.Fr
      */
 
     /// <summary>
-    /// A stemmer for French words. 
+    /// A stemmer for French words.
     /// <para/>
     /// The algorithm is based on the work of
     /// Dr Martin Porter on his snowball project<para/>
     /// refer to http://snowball.sourceforge.net/french/stemmer.html
     /// (French stemming algorithm) for details
     /// </summary>
-    /// @deprecated Use <see cref="Tartarus.Snowball.Ext.FrenchStemmer"/> instead, 
+    /// @deprecated Use <see cref="Tartarus.Snowball.Ext.FrenchStemmer"/> instead,
     /// which has the same functionality. This filter will be removed in Lucene 4.0
     [Obsolete("Use FrenchStemmer instead, which has the same functionality.")]
     public class FrenchStemmer
@@ -102,8 +104,7 @@ namespace Lucene.Net.Analysis.Fr
             term = locale.TextInfo.ToLower(term);
 
             // Reset the StringBuilder.
-            sb.Remove(0, sb.Length);
-            sb.Insert(0, term);
+            sb.Replace(0, sb.Length, term);
 
             // reset the booleans
             modified = false;
@@ -155,8 +156,7 @@ namespace Lucene.Net.Analysis.Fr
             R1 = RetrieveR(sb);
             if (R1 != null)
             {
-                tb.Remove(0, tb.Length);
-                tb.Insert(0, R1);
+                tb.Replace(0, tb.Length, R1);
                 R2 = RetrieveR(tb);
             }
             else
@@ -291,7 +291,7 @@ namespace Lucene.Net.Analysis.Fr
                     char b = sb[sb.Length - 2];
                     if (b != 'a' && b != 'i' && b != 'o' && b != 'u' && b != 'è' && b != 's')
                     {
-                        sb.Remove(sb.Length - 1, sb.Length - (sb.Length - 1));
+                        sb.Delete(sb.Length - 1, sb.Length - (sb.Length - 1));
                         SetStrings();
                     }
                 }
@@ -317,7 +317,7 @@ namespace Lucene.Net.Analysis.Fr
             {
                 if (R0.EndsWith("enn", StringComparison.Ordinal) || R0.EndsWith("onn", StringComparison.Ordinal) || R0.EndsWith("ett", StringComparison.Ordinal) || R0.EndsWith("ell", StringComparison.Ordinal) || R0.EndsWith("eill", StringComparison.Ordinal))
                 {
-                    sb.Remove(sb.Length - 1, sb.Length - (sb.Length - 1));
+                    sb.Delete(sb.Length - 1, sb.Length - (sb.Length - 1));
                     SetStrings();
                 }
             }
@@ -387,7 +387,7 @@ namespace Lucene.Net.Analysis.Fr
                     {
                         if (from != null && from.EndsWith(prefix + search[i], StringComparison.Ordinal))
                         {
-                            sb.Remove(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length));
+                            sb.Delete(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length));
                             found = true;
                             SetStrings();
                             break;
@@ -420,7 +420,7 @@ namespace Lucene.Net.Analysis.Fr
                             bool test = IsVowel(sb[sb.Length - (search[i].Length + 1)]);
                             if (test == vowel)
                             {
-                                sb.Remove(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length));
+                                sb.Delete(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length));
                                 modified = true;
                                 found = true;
                                 SetStrings();
@@ -448,14 +448,14 @@ namespace Lucene.Net.Analysis.Fr
                 {
                     if (source.EndsWith(prefix + search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length - (sb.Length - (prefix.Length + search[i].Length)));
+                        sb.Delete(sb.Length - (prefix.Length + search[i].Length), sb.Length - (sb.Length - (prefix.Length + search[i].Length)));
                         modified = true;
                         SetStrings();
                         break;
                     }
                     else if (without && source.EndsWith(search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length));
+                        sb.Delete(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length));
                         modified = true;
                         SetStrings();
                         break;
@@ -483,21 +483,21 @@ namespace Lucene.Net.Analysis.Fr
                 {
                     if (source.EndsWith(prefix + search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length - (sb.Length - (prefix.Length + search[i].Length)));
+                        sb.Delete(sb.Length - (prefix.Length + search[i].Length), sb.Length - (sb.Length - (prefix.Length + search[i].Length)));
                         modified = true;
                         SetStrings();
                         break;
                     }
                     else if (from != null && from.EndsWith(prefix + search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - (prefix.Length + search[i].Length), sb.Length - (sb.Length - (prefix.Length + search[i].Length))).Insert(sb.Length - (prefix.Length + search[i].Length), replace);
+                        sb.Replace(sb.Length - (prefix.Length + search[i].Length), sb.Length - (sb.Length - (prefix.Length + search[i].Length)), replace);
                         modified = true;
                         SetStrings();
                         break;
                     }
                     else if (without && source.EndsWith(search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length));
+                        sb.Delete(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length));
                         modified = true;
                         SetStrings();
                         break;
@@ -521,7 +521,7 @@ namespace Lucene.Net.Analysis.Fr
                 {
                     if (source.EndsWith(search[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length)).Insert(sb.Length - search[i].Length, replace);
+                        sb.Replace(sb.Length - search[i].Length, sb.Length - (sb.Length - search[i].Length), replace);
                         modified = true;
                         found = true;
                         SetStrings();
@@ -545,7 +545,7 @@ namespace Lucene.Net.Analysis.Fr
                 {
                     if (source.EndsWith(suffix[i], StringComparison.Ordinal))
                     {
-                        sb.Remove(sb.Length - suffix[i].Length, sb.Length - (sb.Length - suffix[i].Length));
+                        sb.Delete(sb.Length - suffix[i].Length, sb.Length - (sb.Length - suffix[i].Length));
                         modified = true;
                         SetStrings();
                         break;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -1450,8 +1450,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
                 if (longestMatch >= 0)
                 {
-                    sb.Remove(i, longestMatch + 1 - i);
-                    sb.Insert(i, longestOutput);
+                    sb.Replace(i, longestMatch + 1 - i, longestOutput!.ToString()); // LUCENENET: [!]: longestOutput is set if longestMatch >= 0
                     i += (longestOutput.Length - 1);
                 }
             }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Nl/DutchStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Nl/DutchStemmer.cs
@@ -1,4 +1,6 @@
 // Lucene version compatibility level 4.8.1
+
+using J2N.Text;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -24,14 +26,14 @@ namespace Lucene.Net.Analysis.Nl
      */
 
     /// <summary>
-    /// A stemmer for Dutch words. 
+    /// A stemmer for Dutch words.
     /// <para>
     /// The algorithm is an implementation of
     /// the <a href="http://snowball.tartarus.org/algorithms/dutch/stemmer.html">dutch stemming</a>
     /// algorithm in Martin Porter's snowball project.
     /// </para> </summary>
-    /// @deprecated (3.1) Use <see cref="Tartarus.Snowball.Ext.DutchStemmer"/> instead, 
-    /// which has the same functionality. This filter will be removed in Lucene 5.0 
+    /// @deprecated (3.1) Use <see cref="Tartarus.Snowball.Ext.DutchStemmer"/> instead,
+    /// which has the same functionality. This filter will be removed in Lucene 5.0
     [Obsolete("(3.1) Use Tartarus.Snowball.Ext.DutchStemmer instead, which has the same functionality. This filter will be removed in Lucene 5.0")]
     public class DutchStemmer
     {
@@ -67,8 +69,7 @@ namespace Lucene.Net.Analysis.Nl
             }
 
             // Reset the StringBuilder.
-            sb.Remove(0, sb.Length);
-            sb.Insert(0, term);
+            sb.Replace(0, sb.Length, term);
             // Stemming starts here...
             Substitute(sb);
             StoreYandI(sb);
@@ -94,7 +95,7 @@ namespace Lucene.Net.Analysis.Nl
                 int index = s.Length - end.Length;
                 if (s.EndsWith(end, StringComparison.Ordinal) && index >= _R1 && IsValidEnEnding(sb, index - 1))
                 {
-                    sb.Remove(index, index + end.Length - index);
+                    sb.Delete(index, index + end.Length - index);
                     UnDouble(sb, index);
                     return true;
                 }
@@ -117,7 +118,8 @@ namespace Lucene.Net.Analysis.Nl
             if (s.EndsWith("heden", StringComparison.Ordinal))
             {
                 //sb.Remove(_R1, lengthR1 + _R1 - _R1).Insert(_R1, sb.Substring(_R1, lengthR1).replaceAll("heden", "heid"));
-                sb.Remove(_R1, lengthR1 + _R1 - _R1).Insert(_R1, sb.ToString(_R1, lengthR1).Replace("heden", "heid"));
+                // LUCENENET NOTE: Per #664, can't use Replace instead of Delete/Insert because argument references sb after Remove/Delete call
+                sb.Delete(_R1, lengthR1 + _R1 - _R1).Insert(_R1, sb.ToString(_R1, lengthR1).Replace("heden", "heid"));
                 return;
             }
 
@@ -128,12 +130,12 @@ namespace Lucene.Net.Analysis.Nl
 
             if (s.EndsWith("se", StringComparison.Ordinal) && (index = s.Length - 2) >= _R1 && IsValidSEnding(sb, index - 1))
             {
-                sb.Remove(index, index + 2 - index);
+                sb.Delete(index, index + 2 - index);
                 return;
             }
             if (s.EndsWith("s", StringComparison.Ordinal) && (index = s.Length - 1) >= _R1 && IsValidSEnding(sb, index - 1))
             {
-                sb.Remove(index, index + 1 - index);
+                sb.Delete(index, index + 1 - index);
             }
         }
 
@@ -153,7 +155,7 @@ namespace Lucene.Net.Analysis.Nl
             int index = s.Length - 1;
             if (index >= _R1 && s.EndsWith("e", StringComparison.Ordinal) && !IsVowel(sb[index - 1]))
             {
-                sb.Remove(index, index + 1 - index);
+                sb.Delete(index, index + 1 - index);
                 UnDouble(sb);
                 _removedE = true;
             }
@@ -173,7 +175,7 @@ namespace Lucene.Net.Analysis.Nl
             int index = s.Length - 4;
             if (s.EndsWith("heid", StringComparison.Ordinal) && index >= _R2 && sb[index - 1] != 'c')
             {
-                sb.Remove(index, index + 4 - index); //remove heid
+                sb.Delete(index, index + 4 - index); //remove heid
                 EnEnding(sb);
             }
         }
@@ -202,13 +204,13 @@ namespace Lucene.Net.Analysis.Nl
 
             if ((s.EndsWith("end", StringComparison.Ordinal) || s.EndsWith("ing", StringComparison.Ordinal)) && (index = s.Length - 3) >= _R2)
             {
-                sb.Remove(index, index + 3 - index);
+                sb.Delete(index, index + 3 - index);
                 if (sb[index - 2] == 'i' && sb[index - 1] == 'g')
                 {
                     if (sb[index - 3] != 'e' && index - 2 >= _R2) // LUCENENET: '&' was changed to '&&' following - https://github.com/apache/lucenenet/issues/673
                     {
                         index -= 2;
-                        sb.Remove(index, index + 2 - index);
+                        sb.Delete(index, index + 2 - index);
                     }
                 }
                 else
@@ -221,26 +223,26 @@ namespace Lucene.Net.Analysis.Nl
             {
                 if (sb[index - 1] != 'e')
                 {
-                    sb.Remove(index, index + 2 - index);
+                    sb.Delete(index, index + 2 - index);
                 }
                 return;
             }
             if (s.EndsWith("lijk", StringComparison.Ordinal) && (index = s.Length - 4) >= _R2)
             {
-                sb.Remove(index, index + 4 - index);
+                sb.Delete(index, index + 4 - index);
                 Step2(sb);
                 return;
             }
             if (s.EndsWith("baar", StringComparison.Ordinal) && (index = s.Length - 4) >= _R2)
             {
-                sb.Remove(index, index + 4 - index);
+                sb.Delete(index, index + 4 - index);
                 return;
             }
             if (s.EndsWith("bar", StringComparison.Ordinal) && (index = s.Length - 3) >= _R2)
             {
                 if (_removedE)
                 {
-                    sb.Remove(index, index + 3 - index);
+                    sb.Delete(index, index + 3 - index);
                 }
                 //return; // LUCENENET: Removed redundant jump statements. https://rules.sonarsource.com/csharp/RSPEC-3626
             }
@@ -264,7 +266,7 @@ namespace Lucene.Net.Analysis.Nl
             char d = end[3];
             if (v1 == v2 && d != 'I' && v1 != 'i' && IsVowel(v1) && !IsVowel(d) && !IsVowel(c))
             {
-                sb.Remove(sb.Length - 2, (sb.Length - 1) - (sb.Length - 2));
+                sb.Delete(sb.Length - 2, (sb.Length - 1) - (sb.Length - 2));
             }
         }
 
@@ -374,7 +376,7 @@ namespace Lucene.Net.Analysis.Nl
             string s = sb.ToString(0, endIndex);
             if (s.EndsWith("kk", StringComparison.Ordinal) || s.EndsWith("tt", StringComparison.Ordinal) || s.EndsWith("dd", StringComparison.Ordinal) || s.EndsWith("nn", StringComparison.Ordinal) || s.EndsWith("mm", StringComparison.Ordinal) || s.EndsWith("ff", StringComparison.Ordinal))
             {
-                sb.Remove(endIndex - 1, endIndex - (endIndex - 1));
+                sb.Delete(endIndex - 1, endIndex - (endIndex - 1));
             }
         }
 
@@ -436,8 +438,7 @@ namespace Lucene.Net.Analysis.Nl
         private void ReStoreYandI(StringBuilder sb)
         {
             string tmp = sb.ToString();
-            sb.Remove(0, sb.Length);
-            sb.Insert(0, tmp.Replace("I", "i").Replace("Y", "y"));
+            sb.Replace(0, sb.Length, tmp.Replace("I", "i").Replace("Y", "y"));
         }
 
         private bool IsVowel(char c)

--- a/src/Lucene.Net.Analysis.ICU/Analysis/Icu/ICUNormalizer2CharFilter.cs
+++ b/src/Lucene.Net.Analysis.ICU/Analysis/Icu/ICUNormalizer2CharFilter.cs
@@ -251,7 +251,7 @@ namespace Lucene.Net.Analysis.Icu
             resultBuffer.CopyTo(0, cbuf, begin, len);
             if (len > 0)
             {
-                resultBuffer.Remove(0, len);
+                resultBuffer.Delete(0, len);
             }
             return len;
         }

--- a/src/Lucene.Net.Analysis.Kuromoji/Dict/UserDictionary.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Dict/UserDictionary.cs
@@ -283,7 +283,7 @@ namespace Lucene.Net.Analysis.Ja.Dict
                     sb.Append(CSVUtil.QuoteEscape(allFeatures[field])).Append(',');
                 }
             }
-            return sb.Remove(sb.Length - 1, 1).ToString();
+            return sb.Delete(sb.Length - 1, 1).ToString();
         }
     }
 }

--- a/src/Lucene.Net.Analysis.Phonetic/Language/DaitchMokotoffSoundex.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/DaitchMokotoffSoundex.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
                     if (builder.Length > MAX_LENGTH)
                     {
                         //builder.delete(MAX_LENGTH, builder.Length);
-                        builder.Remove(MAX_LENGTH, builder.Length - MAX_LENGTH);
+                        builder.Delete(MAX_LENGTH, builder.Length - MAX_LENGTH);
                     }
                     cachedString = null;
                 }

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Nysiis.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Nysiis.cs
@@ -1,4 +1,6 @@
 ﻿// commons-codec version compatibility level: 1.9
+
+using J2N.Text;
 using Lucene.Net.Support;
 using System;
 using System.Text;
@@ -317,7 +319,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
                 if (lastChar == 'S')
                 {
                     //key.deleteCharAt(key.length() - 1);
-                    key.Remove(key.Length - 1, 1);
+                    key.Delete(key.Length - 1, 1);
                     lastChar = key[key.Length - 1];
                 }
 
@@ -328,7 +330,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
                     if (last2Char == 'A' && lastChar == 'Y')
                     {
                         //.key.deleteCharAt(key.length() - 2);
-                        key.Remove(key.Length - 2, 1);
+                        key.Delete(key.Length - 2, 1);
                     }
                 }
 
@@ -336,7 +338,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language
                 if (lastChar == 'A')
                 {
                     //key.deleteCharAt(key.length() - 1);
-                    key.Remove(key.Length - 1, 1);
+                    key.Delete(key.Length - 1, 1);
                 }
             }
 

--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/HHMMSegmenter.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/HHMMSegmenter.cs
@@ -1,4 +1,5 @@
 ﻿// lucene version compatibility level: 4.8.1
+
 using System.Collections.Generic;
 using System.Text;
 
@@ -60,9 +61,9 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
                     case CharType.HANZI:
                         j = i + 1;
                         //wordBuf.delete(0, wordBuf.length());
-                        wordBuf.Remove(0, wordBuf.Length);
-                        // It doesn't matter if a single Chinese character (Hanzi) can form a phrase or not, 
-                        // it will store that single Chinese character (Hanzi) in the SegGraph.  Otherwise, it will 
+                        wordBuf.Clear();
+                        // It doesn't matter if a single Chinese character (Hanzi) can form a phrase or not,
+                        // it will store that single Chinese character (Hanzi) in the SegGraph.  Otherwise, it will
                         // cause word division.
                         wordBuf.Append(sentence[i]);
                         charArray = new char[] { sentence[i] };
@@ -93,8 +94,8 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
                                 charArray = new char[wordBuf.Length];
                                 //wordBuf.GetChars(0, charArray.Length, charArray, 0);
                                 wordBuf.CopyTo(0, charArray, 0, charArray.Length);
-                                // idArray has been found (foundWordIndex!=-1) as a prefix before.  
-                                // Therefore, idArray after it has been lengthened can only appear after foundWordIndex.  
+                                // idArray has been found (foundWordIndex!=-1) as a prefix before.
+                                // Therefore, idArray after it has been lengthened can only appear after foundWordIndex.
                                 // So start searching after foundWordIndex.
                                 foundIndex = wordDict.GetPrefixMatch(charArray, foundIndex);
                                 j++;

--- a/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/Diff.cs
+++ b/src/Lucene.Net.Analysis.Stempel/Egothor.Stemmer/Diff.cs
@@ -1,4 +1,5 @@
-﻿using Lucene;
+﻿using J2N.Text;
+using Lucene;
 using Lucene.Net.Support;
 using System;
 using System.Text;
@@ -149,7 +150,7 @@ namespace Egothor.Stemmer
                             // String s = orig.toString();
                             // s = s.substring( 0, pos ) + s.substring( o + 1 );
                             // orig = new StringBuffer( s );
-                            dest.Remove(pos, (o + 1) - pos);
+                            dest.Delete(pos, (o + 1) - pos);
                             break;
                         case 'I':
                             dest.Insert(pos += 1, param);

--- a/src/Lucene.Net.Tests.Highlighter/VectorHighlight/AbstractTestCase.cs
+++ b/src/Lucene.Net.Tests.Highlighter/VectorHighlight/AbstractTestCase.cs
@@ -311,7 +311,7 @@ namespace Lucene.Net.Search.VectorHighlight
             {
                 startTerm = 0;
                 startOffset = nextStartOffset;
-                snippetBuffer.Remove(0, snippetBuffer.Length);
+                snippetBuffer.Clear();
                 while (true)
                 {
                     if (ch != -1)

--- a/src/Lucene.Net.Tests/Search/TestSearchWithThreads.cs
+++ b/src/Lucene.Net.Tests/Search/TestSearchWithThreads.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Search
                 }
                 body.SetStringValue(sb.ToString());
                 w.AddDocument(doc);
-                sb.Remove(0, sb.Length);
+                sb.Clear();
             }
             IndexReader r = w.GetReader();
             w.Dispose();

--- a/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
+++ b/src/Lucene.Net.Tests/Util/Fst/TestFSTs.cs
@@ -1,4 +1,5 @@
 ﻿using J2N.Collections.Generic.Extensions;
+using J2N.Text;
 using J2N.Threading.Atomic;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Index.Extensions;
@@ -1307,7 +1308,7 @@ namespace Lucene.Net.Util.Fst
                     {
                         b.Append(c);
                         Generate(@out, b, from, c == to ? to : from, depth - 1);
-                        b.Remove(b.Length - 1, 1);//remove last char
+                        b.Delete(b.Length - 1, 1);//remove last char
                     }
                 }
             }

--- a/src/Lucene.Net/Index/ParallelAtomicReader.cs
+++ b/src/Lucene.Net/Index/ParallelAtomicReader.cs
@@ -1,4 +1,5 @@
 ﻿using J2N.Runtime.CompilerServices;
+using J2N.Text;
 using Lucene.Net.Support;
 using Lucene.Net.Support.Threading;
 using System;
@@ -181,7 +182,7 @@ namespace Lucene.Net.Index
 
             if (removeLastCommaSpace)
             {
-                buffer.Remove(buffer.Length - 2, 2);
+                buffer.Delete(buffer.Length - 2, 2);
             }
 
             return buffer.Append(')').ToString();

--- a/src/Lucene.Net/Search/Payloads/PayloadNearQuery.cs
+++ b/src/Lucene.Net/Search/Payloads/PayloadNearQuery.cs
@@ -1,3 +1,4 @@
+using J2N.Text;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -96,7 +97,7 @@ namespace Lucene.Net.Search.Payloads
             }
 
             if (hasCommaSpace)
-                buffer.Remove(buffer.Length - 2, 2);
+                buffer.Delete(buffer.Length - 2, 2);
 
             buffer.Append("], ");
             buffer.Append(m_slop);


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Use J2N methods instead of StringBuilder.Remove

Fixes #664

## Description

See #664 for details. In one case, the Remove/Insert was not able to be replaced with Replace and that was noted with a comment. Also, use of the pattern `sb.Remove(0, sb.Length)` was replaced with `sb.Clear()` instead of `sb.Delete(0, sb.Length)`, as it is more semantically understandable, less prone to mistakes, and has a few less checks internally than `Delete` cascading to `Remove` so it should be a little more efficient.