### PR TITLE
Remove unnecessary use of NoInlining and add traceability for valid uses, #931

### DIFF
--- a/src/Lucene.Net.Misc/Util/Fst/ListOfOutputs.cs
+++ b/src/Lucene.Net.Misc/Util/Fst/ListOfOutputs.cs
@@ -2,8 +2,6 @@
 using Lucene.Net.Store;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Text;
 using JCG = J2N.Collections.Generic;
 
@@ -34,11 +32,11 @@ namespace Lucene.Net.Util.Fst
     /// output by calling <see cref="Builder{T}.Add(Int32sRef,T)"/> multiple
     /// times.  The builder will then combine the outputs using
     /// the <see cref="Outputs{T}.Merge(T,T)"/> method.
-    /// 
+    ///
     /// <para>The resulting FST may not be minimal when an input has
     /// more than one output, as this requires pushing all
     /// multi-output values to a final state.
-    /// 
+    ///
     /// </para>
     /// <para>NOTE: the only way to create multiple outputs is to
     /// add the same input to the FST multiple times in a row.  This is
@@ -48,11 +46,11 @@ namespace Lucene.Net.Util.Fst
     /// <see cref="UpToTwoPositiveInt64Outputs"/> instead since it stores
     /// the outputs more compactly (by stealing a bit from each
     /// long value).
-    /// 
+    ///
     /// </para>
     /// <para>NOTE: this cannot wrap itself (ie you cannot make an
     /// FST with List&lt;List&lt;Object&gt;&gt; outputs using this).
-    /// 
+    ///
     /// @lucene.experimental
     /// </para>
     /// </summary>
@@ -176,7 +174,6 @@ namespace Lucene.Net.Util.Fst
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override object Merge(object first, object second)
         {
             IList<T> outputList = new JCG.List<T>();

--- a/src/Lucene.Net.Misc/Util/Fst/UpToTwoPositiveIntOutputs.cs
+++ b/src/Lucene.Net.Misc/Util/Fst/UpToTwoPositiveIntOutputs.cs
@@ -295,7 +295,6 @@ namespace Lucene.Net.Util.Fst
             return output.ToString();
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override object Merge(object first, object second)
         {
             if (Debugging.AssertsEnabled)

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWPostingsFormat.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
                     // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                     // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                    if (StackTraceHelper.DoesStackTraceContainMethod("Merge"))
+                    if (StackTraceHelper.DoesStackTraceContainMethod(nameof(SegmentMerger.Merge)))
                     {
                         unicodeSortOrder = false;
                         if (LuceneTestCase.Verbose)

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsFormat.cs
@@ -54,6 +54,7 @@ namespace Lucene.Net.Codecs.Lucene3x
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
                 if (StackTraceHelper.DoesStackTraceContainMethod("Merge"))
                 {
+                    // LUCENENET TODO: This does not seem to be hit, unused?
                     unicodeSortOrder = false;
                     if (LuceneTestCase.Verbose)
                     {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene3x/PreFlexRWTermVectorsFormat.cs
@@ -54,11 +54,11 @@ namespace Lucene.Net.Codecs.Lucene3x
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
                 if (StackTraceHelper.DoesStackTraceContainMethod("Merge"))
                 {
-                        unicodeSortOrder = false;
-                        if (LuceneTestCase.Verbose)
-                        {
-                            Console.WriteLine("NOTE: PreFlexRW codec: forcing legacy UTF16 vector term sort order");
-                        }
+                    unicodeSortOrder = false;
+                    if (LuceneTestCase.Verbose)
+                    {
+                        Console.WriteLine("NOTE: PreFlexRW codec: forcing legacy UTF16 vector term sort order");
+                    }
                 }
 
                 return unicodeSortOrder;

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -237,7 +237,7 @@ namespace Lucene.Net.Store
             return @delegate is NRTCachingDirectory;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions,
         public override void Sync(ICollection<string> names)
         {
             UninterruptableMonitor.Enter(this);
@@ -519,7 +519,7 @@ namespace Lucene.Net.Store
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         public override void DeleteFile(string name)
         {
             UninterruptableMonitor.Enter(this);
@@ -576,7 +576,7 @@ namespace Lucene.Net.Store
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         private void DeleteFile(string name, bool forced)
         {
             UninterruptableMonitor.Enter(this);

--- a/src/Lucene.Net.Tests/Index/TestConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net.Tests/Index/TestConcurrentMergeScheduler.cs
@@ -66,9 +66,9 @@ namespace Lucene.Net.Index
                 {
                     // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                     // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                    bool isDoFlush = StackTraceHelper.DoesStackTraceContainMethod("Flush");
-                    bool isClose = StackTraceHelper.DoesStackTraceContainMethod("Close") ||
-                        StackTraceHelper.DoesStackTraceContainMethod("Dispose");
+                    bool isDoFlush = StackTraceHelper.DoesStackTraceContainMethod(nameof(DocumentsWriterPerThread.Flush));
+                    bool isClose = StackTraceHelper.DoesStackTraceContainMethod(nameof(IndexWriter.Close)) || // LUCENENET NOTE: Close is aggressively inlined, so likely won't hit this case, but would hit Dispose
+                        StackTraceHelper.DoesStackTraceContainMethod(nameof(IndexWriter.Dispose));
 
                     if (isDoFlush && !isClose && Random.NextBoolean())
                     {
@@ -334,7 +334,7 @@ namespace Lucene.Net.Index
                 this.failed = failed;
             }
 
-            protected override void DoMerge(MergePolicy.OneMerge merge)
+            protected internal override void DoMerge(MergePolicy.OneMerge merge)
             {
                 try
                 {
@@ -385,7 +385,7 @@ namespace Lucene.Net.Index
                 SetMaxMergesAndThreads(5, 5);
             }
 
-            protected override void DoMerge(MergePolicy.OneMerge merge)
+            protected internal override void DoMerge(MergePolicy.OneMerge merge)
             {
                 totMergedBytes += merge.TotalBytesSize;
                 base.DoMerge(merge);
@@ -432,7 +432,7 @@ namespace Lucene.Net.Index
             {
                 // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                if (StackTraceHelper.DoesStackTraceContainMethod("DoMerge"))
+                if (StackTraceHelper.DoesStackTraceContainMethod(nameof(ConcurrentMergeScheduler.DoMerge)))
                 {
                     throw new IOException("now failing during merge");
                 }

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterDelete.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterDelete.cs
@@ -975,8 +975,8 @@ namespace Lucene.Net.Index
                     // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                     // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
                     bool seen =
-                        StackTraceHelper.DoesStackTraceContainMethod("ApplyDeletesAndUpdates") ||
-                        StackTraceHelper.DoesStackTraceContainMethod("SlowFileExists");
+                        StackTraceHelper.DoesStackTraceContainMethod(nameof(BufferedUpdatesStream.ApplyDeletesAndUpdates)) ||
+                        StackTraceHelper.DoesStackTraceContainMethod(nameof(IndexWriter.SlowFileExists));
 
                     if (!seen)
                     {
@@ -994,7 +994,7 @@ namespace Lucene.Net.Index
                 {
                     // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                     // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                    if (StackTraceHelper.DoesStackTraceContainMethod("ApplyDeletesAndUpdates"))
+                    if (StackTraceHelper.DoesStackTraceContainMethod(nameof(BufferedUpdatesStream.ApplyDeletesAndUpdates)))
                     {
                         if (Verbose)
                         {

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterExceptions.cs
@@ -1,6 +1,8 @@
 ﻿using J2N.Threading;
 using J2N.Threading.Atomic;
 using Lucene.Net.Analysis;
+using Lucene.Net.Codecs;
+using Lucene.Net.Codecs.Lucene40;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Documents;
 using Lucene.Net.Index.Extensions;
@@ -699,7 +701,7 @@ namespace Lucene.Net.Index
                     // which will always be true if the first case is true. The name of the variable implies it checking for "Append"
                     // but that is not a method on FreqProxTermsWriterPerField.
                     bool sawAppend = StackTraceHelper.DoesStackTraceContainMethod(nameof(FreqProxTermsWriterPerField), nameof(FreqProxTermsWriterPerField.Flush));
-                    bool sawFlush = StackTraceHelper.DoesStackTraceContainMethod("Flush");
+                    bool sawFlush = StackTraceHelper.DoesStackTraceContainMethod(nameof(FreqProxTermsWriterPerField.Flush));
 
                     if (sawAppend && sawFlush && count++ >= 30)
                     {
@@ -1810,7 +1812,7 @@ namespace Lucene.Net.Index
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
                 if (doFail
                     && name.StartsWith("segments_", StringComparison.Ordinal)
-                    && StackTraceHelper.DoesStackTraceContainMethod("Read"))
+                    && StackTraceHelper.DoesStackTraceContainMethod(nameof(SegmentInfos.Read)))
                 {
                     throw UnsupportedOperationException.Create("expected UOE");
                 }
@@ -2349,9 +2351,9 @@ namespace Lucene.Net.Index
 
                 // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                bool sawSeal = StackTraceHelper.DoesStackTraceContainMethod("SealFlushedSegment");
-                bool sawWrite = StackTraceHelper.DoesStackTraceContainMethod("WriteLiveDocs")
-                        || StackTraceHelper.DoesStackTraceContainMethod("WriteFieldUpdates");
+                bool sawSeal = StackTraceHelper.DoesStackTraceContainMethod(nameof(DocumentsWriterPerThread.SealFlushedSegment));
+                bool sawWrite = StackTraceHelper.DoesStackTraceContainMethod(nameof(Lucene40LiveDocsFormat.WriteLiveDocs))
+                        || StackTraceHelper.DoesStackTraceContainMethod(nameof(ReadersAndUpdates.WriteFieldUpdates));
 
                 // Don't throw exc if we are "flushing", else
                 // the segment is aborted and docs are lost:
@@ -2527,7 +2529,7 @@ namespace Lucene.Net.Index
             {
                 // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                bool maybeFail = StackTraceHelper.DoesStackTraceContainMethod("RollbackInternal");
+                bool maybeFail = StackTraceHelper.DoesStackTraceContainMethod(nameof(IndexWriter.RollbackInternal));
 
                 if (maybeFail && Random.Next(10) == 0)
                 {

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterReader.cs
@@ -1379,7 +1379,7 @@ namespace Lucene.Net.Index
             {
                 // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                if (shouldFail && StackTraceHelper.DoesStackTraceContainMethod("GetReadOnlyClone"))
+                if (shouldFail && StackTraceHelper.DoesStackTraceContainMethod(nameof(ReadersAndUpdates.GetReadOnlyClone)))
                 {
                     if (Verbose)
                     {

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterWithThreads.cs
@@ -433,11 +433,11 @@ namespace Lucene.Net.Index
                 {
                     // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                     // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                    bool sawAbortOrFlushDoc = StackTraceHelper.DoesStackTraceContainMethod("Abort")
-                        || StackTraceHelper.DoesStackTraceContainMethod("FinishDocument");
-                    bool sawClose = StackTraceHelper.DoesStackTraceContainMethod("Close")
-                        || StackTraceHelper.DoesStackTraceContainMethod("Dispose");
-                    bool sawMerge = StackTraceHelper.DoesStackTraceContainMethod("Merge");
+                    bool sawAbortOrFlushDoc = StackTraceHelper.DoesStackTraceContainMethod(nameof(DocumentsWriterPerThread.Abort))
+                        || StackTraceHelper.DoesStackTraceContainMethod(nameof(DocFieldProcessor.FinishDocument));
+                    bool sawClose = StackTraceHelper.DoesStackTraceContainMethod(nameof(IndexWriter.Close))
+                        || StackTraceHelper.DoesStackTraceContainMethod(nameof(IndexWriter.Dispose));
+                    bool sawMerge = StackTraceHelper.DoesStackTraceContainMethod(nameof(IndexWriter.Merge));
 
                     if (sawAbortOrFlushDoc && !sawClose && !sawMerge)
                     {

--- a/src/Lucene.Net.Tests/TestMergeSchedulerExternal.cs
+++ b/src/Lucene.Net.Tests/TestMergeSchedulerExternal.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net
                 outerInstance.excCalled = true;
             }
 
-            protected override void DoMerge(MergePolicy.OneMerge merge)
+            protected internal override void DoMerge(MergePolicy.OneMerge merge)
             {
                 outerInstance.mergeCalled = true;
                 base.DoMerge(merge);
@@ -97,7 +97,7 @@ namespace Lucene.Net
             {
                 // LUCENENET specific: for these to work in release mode, we have added [MethodImpl(MethodImplOptions.NoInlining)]
                 // to each possible target of the StackTraceHelper. If these change, so must the attribute on the target methods.
-                if (StackTraceHelper.DoesStackTraceContainMethod("DoMerge"))
+                if (StackTraceHelper.DoesStackTraceContainMethod(nameof(ConcurrentMergeScheduler.DoMerge)))
                 {
                     throw new IOException("now failing during merge");
                 }

--- a/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsWriter.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingStoredFieldsWriter.cs
@@ -166,7 +166,6 @@ namespace Lucene.Net.Codecs.Compressing
             ++numBufferedDocs;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void FinishDocument()
         {
             endOffsets[numBufferedDocs - 1] = bufferedDocs.Length;
@@ -240,7 +239,6 @@ namespace Lucene.Net.Codecs.Compressing
             return bufferedDocs.Length >= chunkSize || numBufferedDocs >= MAX_DOCUMENTS_PER_CHUNK; // chunks of at least chunkSize bytes
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void Flush()
         {
             indexWriter.WriteIndex(numBufferedDocs, fieldsStream.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
@@ -363,7 +361,6 @@ namespace Lucene.Net.Codecs.Compressing
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             IOUtils.DisposeWhileHandlingException(this);
@@ -389,7 +386,6 @@ namespace Lucene.Net.Codecs.Compressing
             if (Debugging.AssertsEnabled) Debugging.Assert(bufferedDocs.Length == 0);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override int Merge(MergeState mergeState)
         {
             int docCount = 0;

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
@@ -318,7 +318,6 @@ namespace Lucene.Net.Codecs.Compressing
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             IOUtils.DisposeWhileHandlingException(this);
@@ -331,7 +330,6 @@ namespace Lucene.Net.Codecs.Compressing
             curDoc = AddDocData(numVectorFields);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void FinishDocument()
         {
             // append the payload bytes of the doc after its terms
@@ -390,7 +388,6 @@ namespace Lucene.Net.Codecs.Compressing
             return termSuffixes.Length >= chunkSize || pendingDocs.Count >= MAX_DOCUMENTS_PER_CHUNK;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void Flush()
         {
             int chunkDocs = pendingDocs.Count;
@@ -879,7 +876,6 @@ namespace Lucene.Net.Codecs.Compressing
             curField.totalPositions += numProx;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override int Merge(MergeState mergeState)
         {
             int docCount = 0;

--- a/src/Lucene.Net/Codecs/FieldsConsumer.cs
+++ b/src/Lucene.Net/Codecs/FieldsConsumer.cs
@@ -1,7 +1,5 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs
 {
@@ -77,11 +75,10 @@ namespace Lucene.Net.Codecs
         /// <summary>
         /// Called during merging to merge all <see cref="Fields"/> from
         /// sub-readers.  this must recurse to merge all postings
-        /// (terms, docs, positions, etc.).  A 
+        /// (terms, docs, positions, etc.).  A
         /// <see cref="PostingsFormat"/> can override this default
         /// implementation to do its own merging.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public virtual void Merge(MergeState mergeState, Fields fields)
         {
             foreach (string field in fields)

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40LiveDocsFormat.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40LiveDocsFormat.cs
@@ -100,7 +100,7 @@ namespace Lucene.Net.Codecs.Lucene40
             return liveDocs;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions, TestIndexWriterOnDiskFull
         public override void WriteLiveDocs(IMutableBits bits, Directory dir, SegmentCommitInfo info, int newDelCount, IOContext context)
         {
             string filename = IndexFileNames.FileNameFromGeneration(info.Info.Name, DELETES_EXTENSION, info.NextDelGen);

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsWriter.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40StoredFieldsWriter.cs
@@ -147,7 +147,6 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             try
@@ -288,7 +287,6 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override int Merge(MergeState mergeState)
         {
             int docCount = 0;

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsWriter.cs
@@ -141,7 +141,6 @@ namespace Lucene.Net.Codecs.Lucene40
             tvf.WriteByte((byte)bits);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void FinishDocument()
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(fieldCount == numVectorFields);
@@ -327,7 +326,6 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             try
@@ -372,7 +370,6 @@ namespace Lucene.Net.Codecs.Lucene40
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override int Merge(MergeState mergeState)
         {
             // Used for bulk-reading raw bytes for term vectors

--- a/src/Lucene.Net/Codecs/PostingsConsumer.cs
+++ b/src/Lucene.Net/Codecs/PostingsConsumer.cs
@@ -1,7 +1,5 @@
 ﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs
 {
@@ -86,7 +84,6 @@ namespace Lucene.Net.Codecs
         /// Default merge impl: append documents, mapping around
         /// deletes.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public virtual TermStats Merge(MergeState mergeState, IndexOptions indexOptions, DocsEnum postings, FixedBitSet visitedDocs)
         {
             int df = 0;

--- a/src/Lucene.Net/Codecs/StoredFieldsWriter.cs
+++ b/src/Lucene.Net/Codecs/StoredFieldsWriter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs
 {
@@ -98,7 +97,6 @@ namespace Lucene.Net.Codecs
         /// Implementations can override this method for more sophisticated
         /// merging (bulk-byte copying, etc).
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public virtual int Merge(MergeState mergeState)
         {
             int docCount = 0;

--- a/src/Lucene.Net/Codecs/TermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/TermVectorsWriter.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs
 {
@@ -217,7 +216,6 @@ namespace Lucene.Net.Codecs
         /// Implementations can override this method for more sophisticated
         /// merging (bulk-byte copying, etc).
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public virtual int Merge(MergeState mergeState)
         {
             int docCount = 0;

--- a/src/Lucene.Net/Codecs/TermsConsumer.cs
+++ b/src/Lucene.Net/Codecs/TermsConsumer.cs
@@ -1,7 +1,6 @@
 ﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs
 {
@@ -96,7 +95,6 @@ namespace Lucene.Net.Codecs
 
         /// <summary>
         /// Default merge impl. </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public virtual void Merge(MergeState mergeState, IndexOptions indexOptions, TermsEnum termsEnum)
         {
             BytesRef term;

--- a/src/Lucene.Net/Index/BinaryDocValuesFieldUpdates.cs
+++ b/src/Lucene.Net/Index/BinaryDocValuesFieldUpdates.cs
@@ -1,6 +1,4 @@
 ﻿using Lucene.Net.Documents;
-using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -250,7 +248,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Merge(DocValuesFieldUpdates other)
         {
             BinaryDocValuesFieldUpdates otherUpdates = (BinaryDocValuesFieldUpdates)other;

--- a/src/Lucene.Net/Index/BinaryDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/BinaryDocValuesWriter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -122,7 +121,6 @@ namespace Lucene.Net.Index
         {
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush(SegmentWriteState state, DocValuesConsumer dvConsumer)
         {
             int maxDoc = state.SegmentInfo.DocCount;

--- a/src/Lucene.Net/Index/BufferedUpdatesStream.cs
+++ b/src/Lucene.Net/Index/BufferedUpdatesStream.cs
@@ -177,7 +177,7 @@ namespace Lucene.Net.Index
         /// actual deleted docIDs in the liveDocs <see cref="Util.IMutableBits"/> for
         /// each <see cref="SegmentReader"/>.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterDelete
         public virtual ApplyDeletesResult ApplyDeletesAndUpdates(IndexWriter.ReaderPool readerPool, IList<SegmentCommitInfo> infos)
         {
             UninterruptableMonitor.Enter(this);

--- a/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
@@ -539,7 +539,7 @@ namespace Lucene.Net.Index
         /// <summary>
         /// Does the actual merge, by calling <see cref="IndexWriter.Merge(MergePolicy.OneMerge)"/> </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        protected virtual void DoMerge(MergePolicy.OneMerge merge)
+        protected internal virtual void DoMerge(MergePolicy.OneMerge merge) // LUCENENET: made protected internal for test access
         {
             m_writer.Merge(merge);
         }

--- a/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
+++ b/src/Lucene.Net/Index/ConcurrentMergeScheduler.cs
@@ -4,7 +4,6 @@ using Lucene.Net.Support.Threading;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Security;
 using System.Text;
 using System.Threading;
 using JCG = J2N.Collections.Generic;
@@ -419,7 +418,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound)
         {
             UninterruptableMonitor.Enter(this);
@@ -538,7 +536,7 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Does the actual merge, by calling <see cref="IndexWriter.Merge(MergePolicy.OneMerge)"/> </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestConcurrentMergeScheduler
         protected internal virtual void DoMerge(MergePolicy.OneMerge merge) // LUCENENET: made protected internal for test access
         {
             m_writer.Merge(merge);

--- a/src/Lucene.Net/Index/DocFieldProcessor.cs
+++ b/src/Lucene.Net/Index/DocFieldProcessor.cs
@@ -71,7 +71,7 @@ namespace Lucene.Net.Index
             this.storedConsumer = storedConsumer;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterWithThreads
         public override void Flush(SegmentWriteState state)
         {
             IDictionary<string, DocFieldConsumerPerField> childFields = new Dictionary<string, DocFieldConsumerPerField>();
@@ -94,7 +94,6 @@ namespace Lucene.Net.Index
             infosWriter.Write(state.Directory, state.SegmentInfo.Name, "", state.FieldInfos, IOContext.DEFAULT);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             Exception th = null;
@@ -286,7 +285,7 @@ namespace Lucene.Net.Index
 
         private static readonly IComparer<DocFieldProcessorPerField> fieldsComp = Comparer<DocFieldProcessorPerField>.Create((o1, o2) => o1.fieldInfo.Name.CompareToOrdinal(o2.fieldInfo.Name));
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterWithThreads
         internal override void FinishDocument()
         {
             try

--- a/src/Lucene.Net/Index/DocInverter.cs
+++ b/src/Lucene.Net/Index/DocInverter.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -39,7 +38,6 @@ namespace Lucene.Net.Index
             this.endConsumer = endConsumer;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void Flush(IDictionary<string, DocFieldConsumerPerField> fieldsToFlush, SegmentWriteState state)
         {
             IDictionary<string, InvertedDocConsumerPerField> childFieldsToFlush = new Dictionary<string, InvertedDocConsumerPerField>();
@@ -62,7 +60,6 @@ namespace Lucene.Net.Index
             endConsumer.StartDocument();
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void FinishDocument()
         {
             // TODO: allow endConsumer.finishDocument to also return
@@ -71,7 +68,6 @@ namespace Lucene.Net.Index
             consumer.FinishDocument();
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void Abort()
         {
             try

--- a/src/Lucene.Net/Index/DocInverterPerField.cs
+++ b/src/Lucene.Net/Index/DocInverterPerField.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Analysis.TokenAttributes;
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -49,7 +48,6 @@ namespace Lucene.Net.Index
             this.endConsumer = parent.endConsumer.AddField(this, fieldInfo);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void Abort()
         {
             try

--- a/src/Lucene.Net/Index/DocValuesProcessor.cs
+++ b/src/Lucene.Net/Index/DocValuesProcessor.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Documents;
 using Lucene.Net.Documents.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -85,7 +84,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush(SegmentWriteState state)
         {
             if (writers.Count > 0)
@@ -214,7 +212,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             foreach (DocValuesWriter writer in writers.Values)

--- a/src/Lucene.Net/Index/DocumentsWriter.cs
+++ b/src/Lucene.Net/Index/DocumentsWriter.cs
@@ -1,11 +1,9 @@
 ﻿using J2N.Threading.Atomic;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support.Threading;
-using Lucene.Net.Util;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using JCG = J2N.Collections.Generic;
 
@@ -45,7 +43,7 @@ namespace Lucene.Net.Index
     /// Each added document is passed to the <see cref="DocConsumer"/>,
     /// which in turn processes the document and interacts with
     /// other consumers in the indexing chain.  Certain
-    /// consumers, like <see cref="StoredFieldsConsumer"/> and 
+    /// consumers, like <see cref="StoredFieldsConsumer"/> and
     /// <see cref="TermVectorsConsumer"/>, digest a document and
     /// immediately write bytes to the "doc store" files (ie,
     /// they do not consume RAM per document, except while they
@@ -259,7 +257,6 @@ namespace Lucene.Net.Index
         ///  currently buffered docs.  this resets our state,
         ///  discarding any docs added since last flush.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal void Abort(IndexWriter writer)
         {
             UninterruptableMonitor.Enter(this);

--- a/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -156,7 +155,7 @@ namespace Lucene.Net.Index
         /// currently buffered docs.  this resets our state,
         /// discarding any docs added since last flush.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterWithThreads
         internal virtual void Abort(ISet<string> createdFiles)
         {
             //System.out.println(Thread.currentThread().getName() + ": now abort seg=" + segmentInfo.name);
@@ -419,7 +418,6 @@ namespace Lucene.Net.Index
             return docCount;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void FinishDocument(Term delTerm)
         {
             /*
@@ -501,7 +499,7 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Flush all pending docs to a new segment </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestConcurrentMergeScheduler
         internal virtual FlushedSegment Flush()
         {
             if (Debugging.AssertsEnabled)
@@ -601,7 +599,7 @@ namespace Lucene.Net.Index
         /// Seals the <see cref="Index.SegmentInfo"/> for the new flushed segment and persists
         /// the deleted documents <see cref="IMutableBits"/>.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         internal virtual void SealFlushedSegment(FlushedSegment flushedSegment)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(flushedSegment != null);

--- a/src/Lucene.Net/Index/FreqProxTermsWriter.cs
+++ b/src/Lucene.Net/Index/FreqProxTermsWriter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Diagnostics;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
@@ -38,7 +37,6 @@ namespace Lucene.Net.Index
         // under the same FieldInfo together, up into TermsHash*.
         // Other writers would presumably share alot of this...
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush(IDictionary<string, TermsHashConsumerPerField> fieldsToFlush, SegmentWriteState state)
         {
             // Gather all FieldData's that have postings, across all

--- a/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
+++ b/src/Lucene.Net/Index/FreqProxTermsWriterPerField.cs
@@ -394,7 +394,7 @@ namespace Lucene.Net.Index
         /// instances) found in this field and serialize them
         /// into a single RAM segment.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         internal void Flush(string fieldName, FieldsConsumer consumer, SegmentWriteState state)
         {
             if (!fieldInfo.IsIndexed)

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -1186,7 +1186,7 @@ namespace Lucene.Net.Index
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Close(bool waitForMerges)
+        internal void Close(bool waitForMerges) // LUCENENET: made internal for test purposes
         {
             // Ensure that only one thread actually gets to do the
             // closing, and make sure no commit is also in progress:
@@ -2754,7 +2754,7 @@ namespace Lucene.Net.Index
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void RollbackInternal()
+        internal void RollbackInternal() // LUCENENET: made internal for test access
         {
             bool success = false;
 
@@ -6476,7 +6476,7 @@ namespace Lucene.Net.Index
         /// there's some unexpected error.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static bool SlowFileExists(Directory dir, string fileName)
+        internal static bool SlowFileExists(Directory dir, string fileName) // LUCENENET: made internal for test access
         {
             try
             {

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -1091,7 +1091,7 @@ namespace Lucene.Net.Index
         /// <see cref="IndexWriter"/> for details.</para>
         /// </summary>
         /// <exception cref="IOException"> if there is a low-level IO error </exception>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestConcurrentMergeScheduler and TestIndexWriterWithThreads
         public void Dispose()
         {
             Dispose(disposing: true, waitForMerges: true);
@@ -1124,7 +1124,7 @@ namespace Lucene.Net.Index
         /// running merges to abort, wait until those merges have
         /// finished (which should be at most a few seconds), and
         /// then return. </param>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestConcurrentMergeScheduler and TestIndexWriterWithThreads
         [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "This is a SonarCloud issue")]
         [SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "This is Lucene's alternate path to Dispose() and we must suppress the finalizer here.")]
         [SuppressMessage("Usage", "S2953:Methods named \"Dispose\" should implement \"IDisposable.Dispose\"", Justification = "This is Lucene's alternate path to Dispose() and we must suppress the finalizer here.")]
@@ -1176,7 +1176,7 @@ namespace Lucene.Net.Index
         /// <c>false</c> to release only unmanaged resources. </param>
         // LUCENENET specific - Added this overload to allow subclasses to dispose resoruces
         // in one place without also having to override Dispose(bool).
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestConcurrentMergeScheduler and TestIndexWriterWithThreads
         protected virtual void Dispose(bool disposing, bool waitForMerges)
         {
             if (disposing)
@@ -1185,7 +1185,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // LUCENENET NOTE: this will interfere with stack trace inspection in tests, but that case should be covered by Dispose above which is NoInlining
         internal void Close(bool waitForMerges) // LUCENENET: made internal for test purposes
         {
             // Ensure that only one thread actually gets to do the
@@ -2753,7 +2753,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         internal void RollbackInternal() // LUCENENET: made internal for test access
         {
             bool success = false;
@@ -4220,7 +4220,6 @@ namespace Lucene.Net.Index
         /// <param name="triggerMerge"> if <c>true</c>, we may merge segments (if
         /// deletes or docs were flushed) if necessary </param>
         /// <param name="applyAllDeletes"> whether pending deletes should also </param>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public void Flush(bool triggerMerge, bool applyAllDeletes)
         {
             // NOTE: this method cannot be sync'd because
@@ -4955,7 +4954,7 @@ namespace Lucene.Net.Index
         /// <para/>
         /// @lucene.experimental
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterWithThreads
         public virtual void Merge(MergePolicy.OneMerge merge)
         {
             bool success = false;
@@ -6475,7 +6474,7 @@ namespace Lucene.Net.Index
         /// (unlike <see cref="File.Exists(string)"/>) throws <see cref="IOException"/> if
         /// there's some unexpected error.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterDelete
         internal static bool SlowFileExists(Directory dir, string fileName) // LUCENENET: made internal for test access
         {
             try

--- a/src/Lucene.Net/Index/MergePolicy.cs
+++ b/src/Lucene.Net/Index/MergePolicy.cs
@@ -6,13 +6,11 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
 #if FEATURE_SERIALIZABLE_EXCEPTIONS
 using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 using System.Text;
-using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
@@ -267,7 +265,6 @@ namespace Lucene.Net.Index
             /// before the merge is committed then the merge will
             /// not be committed.
             /// </summary>
-            [MethodImpl(MethodImplOptions.NoInlining)]
             internal virtual void Abort()
             {
                 UninterruptableMonitor.Enter(this);

--- a/src/Lucene.Net/Index/NormsConsumer.cs
+++ b/src/Lucene.Net/Index/NormsConsumer.cs
@@ -1,6 +1,5 @@
 using Lucene.Net.Diagnostics;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -39,7 +38,6 @@ namespace Lucene.Net.Index
         {
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void Flush(IDictionary<string, InvertedDocEndConsumerPerField> fieldsToFlush, SegmentWriteState state)
         {
             bool success = false;

--- a/src/Lucene.Net/Index/NormsConsumerPerField.cs
+++ b/src/Lucene.Net/Index/NormsConsumerPerField.cs
@@ -1,6 +1,5 @@
 using J2N.Text;
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -58,7 +57,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal void Flush(SegmentWriteState state, DocValuesConsumer normsWriter)
         {
             int docCount = state.SegmentInfo.DocCount;

--- a/src/Lucene.Net/Index/NumericDocValuesFieldUpdates.cs
+++ b/src/Lucene.Net/Index/NumericDocValuesFieldUpdates.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Documents;
 using Lucene.Net.Search;
 using Lucene.Net.Util;
 using Lucene.Net.Util.Packed;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -206,7 +205,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Merge(DocValuesFieldUpdates other)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(other is NumericDocValuesFieldUpdates);

--- a/src/Lucene.Net/Index/NumericDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/NumericDocValuesWriter.cs
@@ -1,7 +1,6 @@
 ﻿using Lucene.Net.Util.Packed;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -93,7 +92,6 @@ namespace Lucene.Net.Index
         {
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush(SegmentWriteState state, DocValuesConsumer dvConsumer)
         {
             int maxDoc = state.SegmentInfo.DocCount;

--- a/src/Lucene.Net/Index/PersistentSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net/Index/PersistentSnapshotDeletionPolicy.cs
@@ -214,7 +214,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestPersistentSnapshotDeletionPolicy
         internal void Persist()
         {
             UninterruptableMonitor.Enter(this);

--- a/src/Lucene.Net/Index/ReadersAndUpdates.cs
+++ b/src/Lucene.Net/Index/ReadersAndUpdates.cs
@@ -326,7 +326,7 @@ namespace Lucene.Net.Index
         /// Returns a ref to a clone. NOTE: you should <see cref="DecRef()"/> the reader when you're
         /// done (ie do not call <see cref="IndexReader.Dispose()"/>).
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterReader
         public virtual SegmentReader GetReadOnlyClone(IOContext context)
         {
             UninterruptableMonitor.Enter(this);
@@ -452,7 +452,6 @@ namespace Lucene.Net.Index
         // _X_N updates files) to the directory; returns true if it wrote any file
         // and false if there were no new deletes or updates to write:
         // TODO (DVU_RENAME) to writeDeletesAndUpdates
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public virtual bool WriteLiveDocs(Directory dir)
         {
             UninterruptableMonitor.Enter(this);
@@ -522,7 +521,7 @@ namespace Lucene.Net.Index
         }
 
         // Writes field updates (new _X_N updates files) to the directory
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         public virtual void WriteFieldUpdates(Directory dir, DocValuesFieldUpdates.Container dvUpdates)
         {
             UninterruptableMonitor.Enter(this);

--- a/src/Lucene.Net/Index/SegmentInfos.cs
+++ b/src/Lucene.Net/Index/SegmentInfos.cs
@@ -498,7 +498,7 @@ namespace Lucene.Net.Index
         /// <param name="segmentFileName"> segment file to load </param>
         /// <exception cref="CorruptIndexException"> if the index is corrupt </exception>
         /// <exception cref="IOException"> if there is a low-level IO error </exception>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         public void Read(Directory directory, string segmentFileName)
         {
             var success = false;
@@ -617,7 +617,7 @@ namespace Lucene.Net.Index
         /// Find the latest commit (<c>segments_N file</c>) and
         /// load all <see cref="SegmentCommitInfo"/>s.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         public void Read(Directory directory)
         {
             generation = lastGeneration = -1;
@@ -1269,7 +1269,7 @@ namespace Lucene.Net.Index
         /// method if changes have been made to this <see cref="SegmentInfos"/> instance
         /// </para>
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         internal void PrepareCommit(Directory dir)
         {
             if (pendingSegnOutput != null)
@@ -1311,7 +1311,7 @@ namespace Lucene.Net.Index
             return files;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         internal void FinishCommit(Directory dir)
         {
             if (pendingSegnOutput is null)

--- a/src/Lucene.Net/Index/SegmentMerger.cs
+++ b/src/Lucene.Net/Index/SegmentMerger.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Index
         /// <returns> The number of documents that were merged </returns>
         /// <exception cref="CorruptIndexException"> if the index is corrupt </exception>
         /// <exception cref="IOException"> if there is a low-level IO error </exception>
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in PreFlexRWPostingsFormat
         internal MergeState Merge()
         {
             if (!ShouldMerge)
@@ -437,7 +437,7 @@ namespace Lucene.Net.Index
             return docBase;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterOnDiskFull
         internal void MergeTerms(SegmentWriteState segmentWriteState)
         {
             IList<Fields> fields = new JCG.List<Fields>();

--- a/src/Lucene.Net/Index/SerialMergeScheduler.cs
+++ b/src/Lucene.Net/Index/SerialMergeScheduler.cs
@@ -1,5 +1,4 @@
 ﻿using Lucene.Net.Support.Threading;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -37,7 +36,6 @@ namespace Lucene.Net.Index
         /// "synchronized" so that even if the application is using
         /// multiple threads, only one merge may run at a time.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound) // LUCENENET NOTE: This was internal in the original, but the base class is public so there isn't much choice here
         {
             UninterruptableMonitor.Enter(this);

--- a/src/Lucene.Net/Index/SortedDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedDocValuesWriter.cs
@@ -4,7 +4,6 @@ using Lucene.Net.Util;
 using Lucene.Net.Util.Packed;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -109,7 +108,6 @@ namespace Lucene.Net.Index
             bytesUsed = newBytesUsed;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush(SegmentWriteState state, DocValuesConsumer dvConsumer)
         {
             int maxDoc = state.SegmentInfo.DocCount;

--- a/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -160,7 +159,6 @@ namespace Lucene.Net.Index
             bytesUsed = newBytesUsed;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush(SegmentWriteState state, DocValuesConsumer dvConsumer)
         {
             int maxDoc = state.SegmentInfo.DocCount;

--- a/src/Lucene.Net/Index/StoredFieldsProcessor.cs
+++ b/src/Lucene.Net/Index/StoredFieldsProcessor.cs
@@ -1,8 +1,6 @@
 ﻿using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using Lucene.Net.Support.Threading;
-using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -64,7 +62,6 @@ namespace Lucene.Net.Index
             Reset();
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush(SegmentWriteState state)
         {
             int numDocs = state.SegmentInfo.DocCount;
@@ -115,7 +112,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             Reset();
@@ -142,7 +138,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void FinishDocument()
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(docWriter.TestPoint("StoredFieldsWriter.finishDocument start"));

--- a/src/Lucene.Net/Index/TermVectorsConsumer.cs
+++ b/src/Lucene.Net/Index/TermVectorsConsumer.cs
@@ -55,7 +55,6 @@ namespace Lucene.Net.Index
         }
 
         // LUCENENE specific - original was internal, but FreqProxTermsWriter requires public (little point, since both are internal classes)
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush(IDictionary<string, TermsHashConsumerPerField> fieldsToFlush, SegmentWriteState state)
         {
             if (writer != null)
@@ -100,7 +99,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         internal void InitTermVectorsWriter()
         {
             if (writer is null)
@@ -111,7 +110,7 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterExceptions
         internal override void FinishDocument(TermsHash termsHash)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(docWriter.TestPoint("TermVectorsTermsWriter.finishDocument start"));
@@ -142,7 +141,6 @@ namespace Lucene.Net.Index
             if (Debugging.AssertsEnabled) Debugging.Assert(docWriter.TestPoint("TermVectorsTermsWriter.finishDocument end"));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             hasVectors = false;
@@ -168,7 +166,6 @@ namespace Lucene.Net.Index
             return new TermVectorsConsumerPerField(termsHashPerField, this, fieldInfo);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal void AddFieldToFlush(TermVectorsConsumerPerField fieldToFlush)
         {
             if (numVectorFields == perFields.Length)

--- a/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
+++ b/src/Lucene.Net/Index/TermVectorsConsumerPerField.cs
@@ -158,7 +158,6 @@ namespace Lucene.Net.Index
             termsWriter.AddFieldToFlush(this);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal void FinishDocument()
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(docState.TestPoint("TermVectorsTermsWriterPerField.finish start"));

--- a/src/Lucene.Net/Index/TermsHash.cs
+++ b/src/Lucene.Net/Index/TermsHash.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -30,7 +29,7 @@ namespace Lucene.Net.Index
     /// is passed each token produced by the analyzer on each
     /// field.  It stores these tokens in a hash table, and
     /// allocates separate byte streams per token.  Consumers of
-    /// this class, eg <see cref="FreqProxTermsWriter"/> and 
+    /// this class, eg <see cref="FreqProxTermsWriter"/> and
     /// <see cref="TermVectorsConsumer"/>, write their own byte streams
     /// under each term.
     /// </summary>
@@ -80,7 +79,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             Reset();
@@ -105,7 +103,6 @@ namespace Lucene.Net.Index
             bytePool.Reset(false, false);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void Flush(IDictionary<string, InvertedDocConsumerPerField> fieldsToFlush, SegmentWriteState state)
         {
             IDictionary<string, TermsHashConsumerPerField> childFields = new Dictionary<string, TermsHashConsumerPerField>();
@@ -143,7 +140,6 @@ namespace Lucene.Net.Index
             return new TermsHashPerField(docInverterPerField, this, nextTermsHash, fieldInfo);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void FinishDocument()
         {
             consumer.FinishDocument(this);

--- a/src/Lucene.Net/Index/TermsHashPerField.cs
+++ b/src/Lucene.Net/Index/TermsHashPerField.cs
@@ -2,7 +2,6 @@
 using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -100,7 +99,6 @@ namespace Lucene.Net.Index
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort()
         {
             Reset();

--- a/src/Lucene.Net/Index/TwoStoredFieldsConsumers.cs
+++ b/src/Lucene.Net/Index/TwoStoredFieldsConsumers.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Index
 {
@@ -39,14 +38,12 @@ namespace Lucene.Net.Index
             second.AddField(docID, field, fieldInfo);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush(SegmentWriteState state) // LUCENENET NOTE: original was internal, but other implementations require public
         {
             first.Flush(state);
             second.Flush(state);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Abort() // LUCENENET NOTE: original was internal, but other implementations require public
         {
             try
@@ -74,7 +71,6 @@ namespace Lucene.Net.Index
             second.StartDocument();
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal override void FinishDocument()
         {
             first.FinishDocument();

--- a/src/Lucene.Net/Search/TopDocs.cs
+++ b/src/Lucene.Net/Search/TopDocs.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Lucene.Net.Search
@@ -299,7 +298,6 @@ namespace Lucene.Net.Search
         /// @lucene.experimental
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="shardHits"/> is <c>null</c>.</exception>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static TopDocs Merge(Sort? sort, int topN, TopDocs[] shardHits)
         {
             return Merge(sort, 0, topN, shardHits);
@@ -311,7 +309,6 @@ namespace Lucene.Net.Search
         /// at most <see cref="Util.PriorityQueue{T}.Count"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="shardHits"/> is <c>null</c>.</exception>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static TopDocs Merge(Sort? sort, int start, int size, TopDocs[] shardHits)
         {
             // LUCENENET specific - added guard clause.

--- a/src/Lucene.Net/Store/BufferedChecksum.cs
+++ b/src/Lucene.Net/Store/BufferedChecksum.cs
@@ -1,5 +1,4 @@
 ﻿using Lucene.Net.Support;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Store
 {
@@ -111,7 +110,6 @@ namespace Lucene.Net.Store
             @in.Reset();
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void Flush()
         {
             if (upto > 0)

--- a/src/Lucene.Net/Store/BufferedIndexOutput.cs
+++ b/src/Lucene.Net/Store/BufferedIndexOutput.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Support;
 using System;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Lucene.Net.Store
@@ -132,7 +131,6 @@ namespace Lucene.Net.Store
         }
 
         /// <inheritdoc/>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush()
         {
             if (buffer is null) return; // LUCENENET: Lazy-load the buffer, so we don't force all subclasses to allocate it

--- a/src/Lucene.Net/Store/CompoundFileWriter.cs
+++ b/src/Lucene.Net/Store/CompoundFileWriter.cs
@@ -367,7 +367,6 @@ namespace Lucene.Net.Store
                 this.isSeparate = isSeparate;
             }
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             public override void Flush()
             {
                 @delegate.Flush();

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;// Used only for WRITE_LOCK_NAME in deprecated create=true case:
-using System.Runtime.CompilerServices;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -561,7 +560,6 @@ namespace Lucene.Net.Store
             }
 
             /// <inheritdoc/>
-            [MethodImpl(MethodImplOptions.NoInlining)]
             public override void Flush()
             {
                 // LUCENENET specific: Guard to ensure we aren't disposed.

--- a/src/Lucene.Net/Store/RAMOutputStream.cs
+++ b/src/Lucene.Net/Store/RAMOutputStream.cs
@@ -1,7 +1,6 @@
 ﻿using Lucene.Net.Support;
 using System;
 using Lucene.Net.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Store
 {
@@ -206,7 +205,6 @@ namespace Lucene.Net.Store
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush()
         {
             SetFileLength();

--- a/src/Lucene.Net/Store/RateLimitedIndexOutput.cs
+++ b/src/Lucene.Net/Store/RateLimitedIndexOutput.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Lucene.Net.Store
@@ -83,7 +82,6 @@ namespace Lucene.Net.Store
             @delegate.Seek(pos);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush()
         {
             try

--- a/src/Lucene.Net/Support/ExceptionHandling/StackTraceHelper.cs
+++ b/src/Lucene.Net/Support/ExceptionHandling/StackTraceHelper.cs
@@ -33,6 +33,11 @@ namespace Lucene.Net.Util
         /// <para/>
         /// IMPORTANT: To make the tests pass in release mode, the method(s) named here
         /// must be decorated with <c>[MethodImpl(MethodImplOptions.NoInlining)]</c>.
+        /// However, do not add this attribute unless you determine it is necessary, as it can
+        /// harm performance. Always add two-way traceability to the method(s) in question
+        /// by using the <c>nameof</c> operator to reference the method name in the test,
+        /// and add a comment at the point of use of the <see cref="MethodImplAttribute"/>
+        /// of which test(s) require it.
         /// </summary>
         public static bool DoesStackTraceContainMethod(string methodName)
         {

--- a/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
+++ b/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -76,7 +75,6 @@ namespace Lucene.Net.Support.IO
             return Run(() => textWriter.Equals(obj));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Flush()
         {
             Run(() => textWriter.Flush());

--- a/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
+++ b/src/Lucene.Net/Support/Index/TaskMergeScheduler.cs
@@ -4,7 +4,6 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,12 +31,12 @@ namespace Lucene.Net.Index
     /// <summary>
     /// A <see cref="MergeScheduler"/> that runs each merge using
     /// <see cref="Task"/>s on the default <see cref="TaskScheduler"/>.
-    /// 
+    ///
     /// <para>If more than <see cref="MaxMergeCount"/> merges are
     /// requested then this class will forcefully throttle the
     /// incoming threads by pausing until one more more merges
     /// complete.</para>
-    ///  
+    ///
     /// LUCENENET specific
     /// </summary>
     [Obsolete("Use ConcurrentMergeScheduler instead. This class will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -172,7 +171,7 @@ namespace Lucene.Net.Index
         }
 
         /// <summary>
-        /// Wait for any running merge threads to finish. 
+        /// Wait for any running merge threads to finish.
         /// This call is not interruptible as used by <see cref="MergeScheduler.Dispose()"/>.
         /// </summary>
         public virtual void Sync()
@@ -214,7 +213,6 @@ namespace Lucene.Net.Index
         /// </summary>
         private int MergeThreadCount => _mergeThreads.Count(x => x.IsAlive && x.CurrentMerge != null);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override void Merge(IndexWriter writer, MergeTrigger trigger, bool newMergesFound)
         {
             using (_lock.Write())
@@ -322,7 +320,6 @@ namespace Lucene.Net.Index
 
         /// <summary>
         /// Does the actual merge, by calling <see cref="IndexWriter.Merge(MergePolicy.OneMerge)"/> </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         protected virtual void DoMerge(MergePolicy.OneMerge merge)
         {
             _writer.Merge(merge);
@@ -478,7 +475,7 @@ namespace Lucene.Net.Index
             }
 
             /// <summary>
-            /// Return the current merge, or <c>null</c> if this 
+            /// Return the current merge, or <c>null</c> if this
             /// <see cref="MergeThread"/> is done.
             /// </summary>
             public virtual MergePolicy.OneMerge CurrentMerge
@@ -569,9 +566,9 @@ namespace Lucene.Net.Index
                     while (true && !cancellationToken.IsCancellationRequested)
                     {
                         RunningMerge = merge;
-                        // LUCENENET NOTE: We MUST call DoMerge(merge) instead of 
+                        // LUCENENET NOTE: We MUST call DoMerge(merge) instead of
                         // _writer.Merge(merge) because the tests specifically look
-                        // for the method name DoMerge in the stack trace. 
+                        // for the method name DoMerge in the stack trace.
                         _doMerge(merge);
 
                         // Subsequent times through the loop we do any new

--- a/src/Lucene.Net/Util/Fst/NoOutputs.cs
+++ b/src/Lucene.Net/Util/Fst/NoOutputs.cs
@@ -93,7 +93,6 @@ namespace Lucene.Net.Util.Fst
             return NO_OUTPUT;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public override object Merge(object first, object second)
         {
             if (Debugging.AssertsEnabled)

--- a/src/Lucene.Net/Util/Fst/Outputs.cs
+++ b/src/Lucene.Net/Util/Fst/Outputs.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util.Fst
@@ -30,7 +29,7 @@ namespace Lucene.Net.Util.Fst
     /// <para>Note that any operation that returns NO_OUTPUT must
     /// return the same singleton object from
     /// <see cref="NoOutput"/>.</para>
-    /// 
+    ///
     /// <para>LUCENENET IMPORTANT: If <typeparamref name="T"/> is a collection type,
     /// it must implement <see cref="System.Collections.IStructuralEquatable"/>
     /// in order to properly compare its nested values.</para>
@@ -62,7 +61,7 @@ namespace Lucene.Net.Util.Fst
 
         /// <summary>
         /// Encode an final node output value into a
-        /// <see cref="DataOutput"/>.  By default this just calls 
+        /// <see cref="DataOutput"/>.  By default this just calls
         /// <see cref="Write(T, DataOutput)"/>.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -99,7 +98,6 @@ namespace Lucene.Net.Util.Fst
 
         // TODO: maybe make valid(T output) public...?  for asserts
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public virtual T Merge(T first, T second)
         {
             throw UnsupportedOperationException.Create();

--- a/src/Lucene.Net/Util/Packed/BlockPackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/BlockPackedWriter.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util.Packed
 {
@@ -68,7 +67,6 @@ namespace Lucene.Net.Util.Packed
         {
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         protected override void Flush()
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(m_off > 0);

--- a/src/Lucene.Net/Util/Packed/MonotonicBlockPackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/MonotonicBlockPackedWriter.cs
@@ -49,7 +49,7 @@ namespace Lucene.Net.Util.Packed
     ///     <a href="https://developers.google.com/protocol-buffers/docs/encoding#types">zigzag-encoded</a>
     ///     packed (<see cref="PackedInt32s"/>) deltas from the expected value (computed from
     ///     the function) using exaclty BitsPerValue bits per value</description></item>
-    /// </list> 
+    /// </list>
     /// <para/>
     /// @lucene.internal
     /// </summary>
@@ -71,7 +71,6 @@ namespace Lucene.Net.Util.Packed
             base.Add(l);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         protected override void Flush()
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(m_off > 0);

--- a/src/Lucene.Net/Util/Packed/PackedDataOutput.cs
+++ b/src/Lucene.Net/Util/Packed/PackedDataOutput.cs
@@ -1,6 +1,5 @@
 ﻿using Lucene.Net.Diagnostics;
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util.Packed
 {
@@ -72,7 +71,6 @@ namespace Lucene.Net.Util.Packed
         /// <summary>
         /// Flush pending bits to the underlying <see cref="DataOutput"/>.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public void Flush()
         {
             if (remainingBits < 8)

--- a/src/Lucene.Net/Util/Packed/PackedWriter.cs
+++ b/src/Lucene.Net/Util/Packed/PackedWriter.cs
@@ -1,7 +1,5 @@
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
-using System.IO;
-using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util.Packed
 {
@@ -86,7 +84,6 @@ namespace Lucene.Net.Util.Packed
             finished = true;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void Flush()
         {
             encoder.Encode(nextValues, 0, nextBlocks, 0, iterations);


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Remove unnecessary use of NoInlining and add traceability for valid uses

Fixes #931

## Description

This removes over 100 uses of NoInlining that did not trace back to actual usage in tests that inspect the stack trace, which unnecessarily harm performance. To determine this, debugging and code review was used to find which methods were actually being expected in the stack trace. Once the expected method was determined, the string literal of the method name was replaced with the `nameof` operator for go-to-definition traceability back to the method (or multiple overloads, in some cases) in question. Likewise, a comment was added on the use of NoInlining on the method to explain which test(s) needed this attribute. This way we have two-way traceability to help prevent accidental removal in the future. This could be improved with a custom dev analyzer and suppression in the near future.

One case remains, in PreFlexRWTermVectorsFormat, where I could not hit a breakpoint in tests that use this type, so I am not sure that it is actually needed. This was left as-is with a LUCENENET TODO comment. I presume it is likely expecting `SegmentMerger.Merge` like the similar PreFlexRWPostingsFormat, but I couldn't determine this for sure.

This PR is currently in draft status to ensure all tests pass. I'll publish it once I get extra validation that the removals are correct through multiple test runs.