### PR TITLE
Reduce Powershell build output noise

### DIFF
--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -205,7 +205,7 @@ steps:
 
             $testResultDirectory = "$testResultsArtifactDirectory/$testOSName/$framework/$testPlatform/$testName"
             if (!(Test-Path "$testResultDirectory")) {
-                New-Item "$testResultDirectory" -ItemType Directory -Force
+                New-Item "$testResultDirectory" -ItemType Directory -Force | Out-Null
             }
 
             if ($isNightly -ne 'true' -and $isWeekly -ne 'true') {
@@ -247,7 +247,7 @@ steps:
                 Start-Sleep -Milliseconds 500
 
                 # Execute the jobs in parallel
-                Start-Job -Name "$testName,$framework,$testPlatform" -ScriptBlock $scriptBlock -ArgumentList $testExpression
+                Start-Job -Name "$testName,$framework,$testPlatform" -ScriptBlock $scriptBlock -ArgumentList $testExpression | Out-Null
             }
         }
     }

--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -223,7 +223,7 @@ task Publish -depends Compile -description "This task uses dotnet publish to pac
             }
 
             # Execute the jobs in parallel
-            Start-Job -Name "$framework" -ScriptBlock $scriptBlock -ArgumentList @($expression)
+            Start-Job -Name "$framework" -ScriptBlock $scriptBlock -ArgumentList @($expression) | Out-Null
         }
 
         # Wait for it all to complete

--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -343,7 +343,7 @@ task Test -depends CheckSDK, UpdateLocalSDKVersion, Restore -description "This t
             }
 
             # Execute the jobs in parallel
-            Start-Job -Name "$testName,$framework" -ScriptBlock $scriptBlock -ArgumentList $testExpression,$testResultDirectory
+            Start-Job -Name "$testName,$framework" -ScriptBlock $scriptBlock -ArgumentList $testExpression,$testResultDirectory | Out-Null
 
             #Invoke-Expression $testExpression
             ## fail the build on negative exit codes (NUnit errors - if positive it is a test count or, if 1, it could be a dotnet error)
@@ -749,14 +749,14 @@ function Delete-Added-File([string]$path) {
 
 function Ensure-Directory-Exists([string] $path) {
     if (!(Test-Path $path)) {
-        New-Item $path -ItemType Directory
+        New-Item $path -ItemType Directory | Out-Null
     }
 }
 
 function New-TemporaryDirectory {
     $parent = [System.IO.Path]::GetTempPath()
     [string] $name = [System.Guid]::NewGuid()
-    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+    New-Item -ItemType Directory -Path (Join-Path $parent $name) | Out-Null
 }
 
 function Normalize-FileSystemSlashes([string]$path) {


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Reduce Powershell build output noise

## Description

The Start-Job (and to a lesser degree, New-Item for new directories) cmdlets produce a lot of useless noise to the logs when running tests, when we're already logging the test command being executed.

Example (before, paths anonymized):
```
Frameworks To Test for /.../lucene.net/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj: net9.0;net8.0;net6.0

  Next Project in Queue: Lucene.Net.Tests.ICU, Framework: net9.0
d----          3/7/2025  10:06 AM                  Lucene.Net.Tests.ICU
dotnet test /.../lucene.net/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj --configuration Release --framework net9.0 --no-build --no-restore --blame  --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --results-directory /.../lucene.net/_artifacts/TestResults/net9.0/Lucene.Net.Tests.ICU --logger:"console;verbosity=normal" --logger:"trx;LogFileName=TestResults.trx" -- NUnit.DisplayName=FullName

HasMoreData   : True
StatusMessage :
Location      : localhost
Command       :
                                param([string]$testExpression, [string]$testResultDirectory)
                                $testExpression = "$testExpression >
                '$testResultDirectory/dotnet-test.log' 2>
                '$testResultDirectory/dotnet-test-error.log'"
                                Invoke-Expression $testExpression

JobStateInfo  : Running
Finished      : System.Threading.ManualResetEvent
InstanceId    : f2a7bd20-808a-4859-8d47-f35ddaefd211
Id            : 749
Name          : Lucene.Net.Tests.ICU,net9.0
ChildJobs     : {Job750}
PSBeginTime   : 3/7/2025 10:06:08 AM
PSEndTime     :
PSJobTypeName : BackgroundJob
Output        : {}
Error         : {}
Progress      : {}
Verbose       : {}
Debug         : {}
Warning       : {}
Information   : {}
State         : Running
```

After piping the output of Start-Job and New-Item to Out-Null:
```
Frameworks To Test for /.../lucene.net/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj: net9.0;net8.0;net6.0

  Next Project in Queue: Lucene.Net.Tests.ICU, Framework: net9.0
dotnet test /.../lucene.net/src/dotnet/Lucene.Net.Tests.ICU/Lucene.Net.Tests.ICU.csproj --configuration Release --framework net9.0 --no-build --no-restore --blame  --blame-hang --blame-hang-dump-type mini --blame-hang-timeout 15minutes --results-directory /.../lucene.net/_artifacts/TestResults/net9.0/Lucene.Net.Tests.ICU --logger:"console;verbosity=normal" --logger:"trx;LogFileName=TestResults.trx" -- NUnit.DisplayName=FullName

  Next Project in Queue: Lucene.Net.Tests.ICU, Framework: net8.0
...
```

This should help reduce build log noise, while still retaining the important information including which project and framework is being tested, and the `dotnet test` command being executed. This might even speed up our ADO builds a little.