### PR TITLE
Fix random failing tests when near a DST boundary, #1133

### DIFF
--- a/src/Lucene.Net.TestFramework/Index/AlcoholicMergePolicy.cs
+++ b/src/Lucene.Net.TestFramework/Index/AlcoholicMergePolicy.cs
@@ -42,9 +42,10 @@ namespace Lucene.Net.Index
         public AlcoholicMergePolicy(TimeZoneInfo timeZone, Random random)
         {
             // LUCENENET NOTE: All we care about here is that we have a random distribution of "Hour", picking any valid
-            // date at random achives this. We have no actual need to create a Calendar object in .NET.
-            var randomTime = new DateTime(TestUtil.NextInt64(random, DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks));
-            this.calendar = TimeZoneInfo.ConvertTime(randomTime, TimeZoneInfo.Local, timeZone);
+            // date at random achieves this. We have no actual need to create a Calendar object in .NET.
+            var randomTicks = TestUtil.NextInt64(random, DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks);
+            var randomTime = new DateTime(randomTicks);
+            this.calendar = TimeZoneInfo.ConvertTime(randomTime, TimeZoneInfo.Utc, timeZone);
             this.random = random;
             m_maxMergeSize = TestUtil.NextInt32(random, 1024 * 1024, int.MaxValue);
         }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fixes random failing tests when local time zone participates in Daylight Saving Time

Fixes #1133

## Description

The random seed in #1133 results in many failing tests due to the lucenenet-specific code in AlcoholicMergePolicy converting between the local time zone and the random time zone in a way that could result in an invalid date/time being created when near a DST boundary. This fixes this particular issue by always converting from UTC (which does not have DST) to the random time zone. I believe this should be reliable even if the destination/random time zone participates in DST.