### PR TITLE
Fix random failing test with MMapDirectory capacity out of range, #1090

### DIFF
--- a/src/Lucene.Net/Store/MMapDirectory.cs
+++ b/src/Lucene.Net/Store/MMapDirectory.cs
@@ -314,7 +314,7 @@ namespace Lucene.Net.Store
                 input.memoryMappedFile = MemoryMappedFile.CreateFromFile(
                     fileStream: fc,
                     mapName: null,
-                    capacity: length,
+                    capacity: 0, // use the full length of the file
                     access: MemoryMappedFileAccess.Read,
 #if FEATURE_MEMORYMAPPEDFILESECURITY
                     memoryMappedFileSecurity: null,

--- a/src/Lucene.Net/Store/MMapDirectory.cs
+++ b/src/Lucene.Net/Store/MMapDirectory.cs
@@ -330,15 +330,15 @@ namespace Lucene.Net.Store
 
                 // LUCENENET: We get an UnauthorizedAccessException if we create a 0 byte file at the end of the range.
                 // See: https://stackoverflow.com/a/5501331
-                // We can fix this by moving back 1 byte on the offset if the bufSize is 0.
-                int adjust = 0;
-                if (bufSize == 0 && bufNr == (nrBuffers - 1) && (offset + bufferStart) > 0)
+                // We can fix this by using an empty ByteBuffer if the buffer size is 0.
+                if (bufSize == 0 && bufNr == (nrBuffers - 1))
                 {
-                    adjust = 1;
+                    buffers[bufNr] = ByteBuffer.Allocate(0).AsReadOnlyBuffer();
+                    break;
                 }
 
                 buffers[bufNr] = input.memoryMappedFile.CreateViewByteBuffer(
-                    offset: (offset + bufferStart) - adjust,
+                    offset: offset + bufferStart,
                     size: bufSize,
                     access: MemoryMappedFileAccess.Read);
                 bufferStart += bufSize;


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fixes a random failing test when the MMapDirectory's MemoryMappedFile capacity is out of range, plus some other related logic.

Fixes #1090

## Description

See discussion on #1090. The solution I came up with is to pass 0 for the capacity, per the docs on that method: "Specify 0 to set the capacity to the size of the file on disk." This should avoid the problem where the provided capacity was smaller than the file size, likely due to a concurrency bug.

This also fixes an "adjust" variable hack to allocate an empty buffer instead of subtracting 1 from the offset.