### PR TITLE
Remove unused private members, #669

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
@@ -31056,36 +31056,37 @@ namespace Lucene.Net.Analysis.CharFilters
                 zzReader.Dispose();
         }
 
-        /// <summary>
-        /// Resets the scanner to read from a new input stream.
-        /// Does not close the old reader.
-        /// <para/>
-        /// All internal variables are reset, the old input stream
-        /// <b>cannot</b> be reused (internal buffer is discarded and lost).
-        /// Lexical state is set to <see cref="YYINITIAL"/>.
-        /// <para/>
-        /// Internal scan buffer is resized down to its initial length, if it has grown.
-        /// </summary>
-        /// <param name="reader">the new input stream</param>
-        private void YyReset(BufferedCharFilter reader)
-        {
-            zzReader = reader;
-            //zzAtBOL = true; // LUCENENET: Never read
-            zzAtEOF = false;
-            zzEOFDone = false;
-            zzEndRead = zzStartRead = 0;
-            zzCurrentPos = zzMarkedPos = 0;
-            //yyline = yychar = yycolumn = 0; // LUCENENET: Never read
-            zzLexicalState = YYINITIAL;
-            if (zzBuffer.Length > ZZ_BUFFERSIZE)
-                zzBuffer = new char[ZZ_BUFFERSIZE];
-        }
+        // LUCENENET: commented-out unused method
+        // /// <summary>
+        // /// Resets the scanner to read from a new input stream.
+        // /// Does not close the old reader.
+        // /// <para/>
+        // /// All internal variables are reset, the old input stream
+        // /// <b>cannot</b> be reused (internal buffer is discarded and lost).
+        // /// Lexical state is set to <see cref="YYINITIAL"/>.
+        // /// <para/>
+        // /// Internal scan buffer is resized down to its initial length, if it has grown.
+        // /// </summary>
+        // /// <param name="reader">the new input stream</param>
+        // private void YyReset(BufferedCharFilter reader)
+        // {
+        //     zzReader = reader;
+        //     //zzAtBOL = true; // LUCENENET: Never read
+        //     zzAtEOF = false;
+        //     zzEOFDone = false;
+        //     zzEndRead = zzStartRead = 0;
+        //     zzCurrentPos = zzMarkedPos = 0;
+        //     //yyline = yychar = yycolumn = 0; // LUCENENET: Never read
+        //     zzLexicalState = YYINITIAL;
+        //     if (zzBuffer.Length > ZZ_BUFFERSIZE)
+        //         zzBuffer = new char[ZZ_BUFFERSIZE];
+        // }
 
-
-        /// <summary>
-        /// Returns the current lexical state.
-        /// </summary>
-        private int YyState => zzLexicalState;
+        // LUCENENET: commented out unused property
+        // /// <summary>
+        // /// Returns the current lexical state.
+        // /// </summary>
+        // private int YyState => zzLexicalState;
 
         /// <summary>
         /// Enters a new lexical state
@@ -31103,16 +31104,17 @@ namespace Lucene.Net.Analysis.CharFilters
         ///// <returns>Returns the text matched by the current regular expression.</returns>
         //private string YyText => new string(zzBuffer, zzStartRead, zzMarkedPos - zzStartRead);
 
-        /// <summary>
-        /// Returns the character at position <tt>pos</tt> from the
-        /// matched text. It is equivalent to YyText[pos], but faster
-        /// </summary>
-        /// <param name="pos">the position of the character to fetch. A value from 0 to YyLength()-1.</param>
-        /// <returns>the character at position pos</returns>
-        private char YyCharAt(int pos)
-        {
-            return zzBuffer[zzStartRead + pos];
-        }
+        // LUCENENET: commented out unused method
+        // /// <summary>
+        // /// Returns the character at position <tt>pos</tt> from the
+        // /// matched text. It is equivalent to YyText[pos], but faster
+        // /// </summary>
+        // /// <param name="pos">the position of the character to fetch. A value from 0 to YyLength()-1.</param>
+        // /// <returns>the character at position pos</returns>
+        // private char YyCharAt(int pos)
+        // {
+        //     return zzBuffer[zzStartRead + pos];
+        // }
 
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
@@ -1003,8 +1003,8 @@ namespace Lucene.Net.Analysis.El
         /// <param name="len"> The length of the char[] array. </param>
         /// <param name="suffix"> A <see cref="string"/> object to check if the word given ends with these characters. </param>
         /// <returns> True if the word ends with the suffix given , false otherwise. </returns>
-        private static bool EndsWith(ReadOnlySpan<char> s, int len, string suffix) // LUCENENET: CA1822: Mark members as static
-            => s.Slice(0, len).EndsWith(suffix.AsSpan()); // LUCENENET specific - optimized for ReadOnlySpan<char>
+        private static bool EndsWith(char[] s, int len, string suffix) // LUCENENET: CA1822: Mark members as static
+            => s.AsSpan(0, len).EndsWith(suffix.AsSpan()); // LUCENENET specific - optimized for ReadOnlySpan<char>
 
         /// <summary>
         /// Checks if the word contained in the leading portion of <see cref="T:char[]"/> array ,

--- a/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
@@ -1,6 +1,7 @@
 // Lucene version compatibility level 4.8.1
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Util;
+using System;
 
 namespace Lucene.Net.Analysis.El
 {
@@ -81,101 +82,101 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule0(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 9 && (StemmerUtil.EndsWith(s, len, "καθεστωτοσ") ||
-                StemmerUtil.EndsWith(s, len, "καθεστωτων")))
+            if (len > 9 && (EndsWith(s, len, "καθεστωτοσ") ||
+                EndsWith(s, len, "καθεστωτων")))
             {
                 return len - 4;
             }
 
-            if (len > 8 && (StemmerUtil.EndsWith(s, len, "γεγονοτοσ") ||
-                StemmerUtil.EndsWith(s, len, "γεγονοτων")))
+            if (len > 8 && (EndsWith(s, len, "γεγονοτοσ") ||
+                EndsWith(s, len, "γεγονοτων")))
             {
                 return len - 4;
             }
 
-            if (len > 8 && StemmerUtil.EndsWith(s, len, "καθεστωτα"))
+            if (len > 8 && EndsWith(s, len, "καθεστωτα"))
             {
                 return len - 3;
             }
 
-            if (len > 7 && (StemmerUtil.EndsWith(s, len, "τατογιου") ||
-                StemmerUtil.EndsWith(s, len, "τατογιων")))
+            if (len > 7 && (EndsWith(s, len, "τατογιου") ||
+                EndsWith(s, len, "τατογιων")))
             {
                 return len - 4;
             }
 
-            if (len > 7 && StemmerUtil.EndsWith(s, len, "γεγονοτα"))
+            if (len > 7 && EndsWith(s, len, "γεγονοτα"))
             {
                 return len - 3;
             }
 
-            if (len > 7 && StemmerUtil.EndsWith(s, len, "καθεστωσ"))
+            if (len > 7 && EndsWith(s, len, "καθεστωσ"))
             {
                 return len - 2;
             }
 
-            if (len > 6 && (StemmerUtil.EndsWith(s, len, "σκαγιου")) ||
-                StemmerUtil.EndsWith(s, len, "σκαγιων") ||
-                StemmerUtil.EndsWith(s, len, "ολογιου") ||
-                StemmerUtil.EndsWith(s, len, "ολογιων") ||
-                StemmerUtil.EndsWith(s, len, "κρεατοσ") ||
-                StemmerUtil.EndsWith(s, len, "κρεατων") ||
-                StemmerUtil.EndsWith(s, len, "περατοσ") ||
-                StemmerUtil.EndsWith(s, len, "περατων") ||
-                StemmerUtil.EndsWith(s, len, "τερατοσ") ||
-                StemmerUtil.EndsWith(s, len, "τερατων"))
+            if (len > 6 && (EndsWith(s, len, "σκαγιου")) ||
+                EndsWith(s, len, "σκαγιων") ||
+                EndsWith(s, len, "ολογιου") ||
+                EndsWith(s, len, "ολογιων") ||
+                EndsWith(s, len, "κρεατοσ") ||
+                EndsWith(s, len, "κρεατων") ||
+                EndsWith(s, len, "περατοσ") ||
+                EndsWith(s, len, "περατων") ||
+                EndsWith(s, len, "τερατοσ") ||
+                EndsWith(s, len, "τερατων"))
             {
                 return len - 4;
             }
 
-            if (len > 6 && StemmerUtil.EndsWith(s, len, "τατογια"))
+            if (len > 6 && EndsWith(s, len, "τατογια"))
             {
                 return len - 3;
             }
 
-            if (len > 6 && StemmerUtil.EndsWith(s, len, "γεγονοσ"))
+            if (len > 6 && EndsWith(s, len, "γεγονοσ"))
             {
                 return len - 2;
             }
 
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "φαγιου") ||
-                StemmerUtil.EndsWith(s, len, "φαγιων") ||
-                StemmerUtil.EndsWith(s, len, "σογιου") ||
-                StemmerUtil.EndsWith(s, len, "σογιων")))
+            if (len > 5 && (EndsWith(s, len, "φαγιου") ||
+                EndsWith(s, len, "φαγιων") ||
+                EndsWith(s, len, "σογιου") ||
+                EndsWith(s, len, "σογιων")))
             {
                 return len - 4;
             }
 
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "σκαγια") ||
-                StemmerUtil.EndsWith(s, len, "ολογια") ||
-                StemmerUtil.EndsWith(s, len, "κρεατα") ||
-                StemmerUtil.EndsWith(s, len, "περατα") ||
-                StemmerUtil.EndsWith(s, len, "τερατα")))
+            if (len > 5 && (EndsWith(s, len, "σκαγια") ||
+                EndsWith(s, len, "ολογια") ||
+                EndsWith(s, len, "κρεατα") ||
+                EndsWith(s, len, "περατα") ||
+                EndsWith(s, len, "τερατα")))
             {
                 return len - 3;
             }
 
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "φαγια") ||
-                StemmerUtil.EndsWith(s, len, "σογια") ||
-                StemmerUtil.EndsWith(s, len, "φωτοσ") ||
-                StemmerUtil.EndsWith(s, len, "φωτων")))
+            if (len > 4 && (EndsWith(s, len, "φαγια") ||
+                EndsWith(s, len, "σογια") ||
+                EndsWith(s, len, "φωτοσ") ||
+                EndsWith(s, len, "φωτων")))
             {
                 return len - 3;
             }
 
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "κρεασ") ||
-                StemmerUtil.EndsWith(s, len, "περασ") ||
-                StemmerUtil.EndsWith(s, len, "τερασ")))
+            if (len > 4 && (EndsWith(s, len, "κρεασ") ||
+                EndsWith(s, len, "περασ") ||
+                EndsWith(s, len, "τερασ")))
             {
                 return len - 2;
             }
 
-            if (len > 3 && StemmerUtil.EndsWith(s, len, "φωτα"))
+            if (len > 3 && EndsWith(s, len, "φωτα"))
             {
                 return len - 2;
             }
 
-            if (len > 2 && StemmerUtil.EndsWith(s, len, "φωσ"))
+            if (len > 2 && EndsWith(s, len, "φωσ"))
             {
                 return len - 1;
             }
@@ -185,20 +186,20 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule1(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "αδεσ") ||
-                StemmerUtil.EndsWith(s, len, "αδων")))
+            if (len > 4 && (EndsWith(s, len, "αδεσ") ||
+                EndsWith(s, len, "αδων")))
             {
                 len -= 4;
-                if (!(StemmerUtil.EndsWith(s, len, "οκ") ||
-                    StemmerUtil.EndsWith(s, len, "μαμ") ||
-                    StemmerUtil.EndsWith(s, len, "μαν") ||
-                    StemmerUtil.EndsWith(s, len, "μπαμπ") ||
-                    StemmerUtil.EndsWith(s, len, "πατερ") ||
-                    StemmerUtil.EndsWith(s, len, "γιαγι") ||
-                    StemmerUtil.EndsWith(s, len, "νταντ") ||
-                    StemmerUtil.EndsWith(s, len, "κυρ") ||
-                    StemmerUtil.EndsWith(s, len, "θει") ||
-                    StemmerUtil.EndsWith(s, len, "πεθερ")))
+                if (!(EndsWith(s, len, "οκ") ||
+                    EndsWith(s, len, "μαμ") ||
+                    EndsWith(s, len, "μαν") ||
+                    EndsWith(s, len, "μπαμπ") ||
+                    EndsWith(s, len, "πατερ") ||
+                    EndsWith(s, len, "γιαγι") ||
+                    EndsWith(s, len, "νταντ") ||
+                    EndsWith(s, len, "κυρ") ||
+                    EndsWith(s, len, "θει") ||
+                    EndsWith(s, len, "πεθερ")))
                 {
                     len += 2; // add back -αδ
                 }
@@ -208,18 +209,18 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule2(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "εδεσ") ||
-                StemmerUtil.EndsWith(s, len, "εδων")))
+            if (len > 4 && (EndsWith(s, len, "εδεσ") ||
+                EndsWith(s, len, "εδων")))
             {
                 len -= 4;
-                if (StemmerUtil.EndsWith(s, len, "οπ") ||
-                    StemmerUtil.EndsWith(s, len, "ιπ") ||
-                    StemmerUtil.EndsWith(s, len, "εμπ") ||
-                    StemmerUtil.EndsWith(s, len, "υπ") ||
-                    StemmerUtil.EndsWith(s, len, "γηπ") ||
-                    StemmerUtil.EndsWith(s, len, "δαπ") ||
-                    StemmerUtil.EndsWith(s, len, "κρασπ") ||
-                    StemmerUtil.EndsWith(s, len, "μιλ"))
+                if (EndsWith(s, len, "οπ") ||
+                    EndsWith(s, len, "ιπ") ||
+                    EndsWith(s, len, "εμπ") ||
+                    EndsWith(s, len, "υπ") ||
+                    EndsWith(s, len, "γηπ") ||
+                    EndsWith(s, len, "δαπ") ||
+                    EndsWith(s, len, "κρασπ") ||
+                    EndsWith(s, len, "μιλ"))
                 {
                     len += 2; // add back -εδ
                 }
@@ -229,25 +230,25 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule3(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "ουδεσ") ||
-                StemmerUtil.EndsWith(s, len, "ουδων")))
+            if (len > 5 && (EndsWith(s, len, "ουδεσ") ||
+                EndsWith(s, len, "ουδων")))
             {
                 len -= 5;
-                if (StemmerUtil.EndsWith(s, len, "αρκ") ||
-                    StemmerUtil.EndsWith(s, len, "καλιακ") ||
-                    StemmerUtil.EndsWith(s, len, "πεταλ") ||
-                    StemmerUtil.EndsWith(s, len, "λιχ") ||
-                    StemmerUtil.EndsWith(s, len, "πλεξ") ||
-                    StemmerUtil.EndsWith(s, len, "σκ") ||
-                    StemmerUtil.EndsWith(s, len, "σ") ||
-                    StemmerUtil.EndsWith(s, len, "φλ") ||
-                    StemmerUtil.EndsWith(s, len, "φρ") ||
-                    StemmerUtil.EndsWith(s, len, "βελ") ||
-                    StemmerUtil.EndsWith(s, len, "λουλ") ||
-                    StemmerUtil.EndsWith(s, len, "χν") ||
-                    StemmerUtil.EndsWith(s, len, "σπ") ||
-                    StemmerUtil.EndsWith(s, len, "τραγ") ||
-                    StemmerUtil.EndsWith(s, len, "φε"))
+                if (EndsWith(s, len, "αρκ") ||
+                    EndsWith(s, len, "καλιακ") ||
+                    EndsWith(s, len, "πεταλ") ||
+                    EndsWith(s, len, "λιχ") ||
+                    EndsWith(s, len, "πλεξ") ||
+                    EndsWith(s, len, "σκ") ||
+                    EndsWith(s, len, "σ") ||
+                    EndsWith(s, len, "φλ") ||
+                    EndsWith(s, len, "φρ") ||
+                    EndsWith(s, len, "βελ") ||
+                    EndsWith(s, len, "λουλ") ||
+                    EndsWith(s, len, "χν") ||
+                    EndsWith(s, len, "σπ") ||
+                    EndsWith(s, len, "τραγ") ||
+                    EndsWith(s, len, "φε"))
                 {
                     len += 3; // add back -ουδ
                 }
@@ -261,8 +262,8 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule4(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 3 && (StemmerUtil.EndsWith(s, len, "εωσ") ||
-                StemmerUtil.EndsWith(s, len, "εων")))
+            if (len > 3 && (EndsWith(s, len, "εωσ") ||
+                EndsWith(s, len, "εων")))
             {
                 len -= 3;
                 if (exc4.Contains(s, 0, len))
@@ -275,7 +276,7 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule5(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 2 && StemmerUtil.EndsWith(s, len, "ια"))
+            if (len > 2 && EndsWith(s, len, "ια"))
             {
                 len -= 2;
                 if (EndsWithVowel(s, len))
@@ -283,8 +284,8 @@ namespace Lucene.Net.Analysis.El
                     len++; // add back -ι
                 }
             }
-            else if (len > 3 && (StemmerUtil.EndsWith(s, len, "ιου") ||
-                StemmerUtil.EndsWith(s, len, "ιων")))
+            else if (len > 3 && (EndsWith(s, len, "ιου") ||
+                EndsWith(s, len, "ιων")))
             {
                 len -= 3;
                 if (EndsWithVowel(s, len))
@@ -308,14 +309,14 @@ namespace Lucene.Net.Analysis.El
         private static int Rule6(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
-            if (len > 3 && (StemmerUtil.EndsWith(s, len, "ικα") ||
-                StemmerUtil.EndsWith(s, len, "ικο")))
+            if (len > 3 && (EndsWith(s, len, "ικα") ||
+                EndsWith(s, len, "ικο")))
             {
                 len -= 3;
                 removed = true;
             }
-            else if (len > 4 && (StemmerUtil.EndsWith(s, len, "ικου") ||
-                StemmerUtil.EndsWith(s, len, "ικων")))
+            else if (len > 4 && (EndsWith(s, len, "ικου") ||
+                EndsWith(s, len, "ικων")))
             {
                 len -= 4;
                 removed = true;
@@ -340,27 +341,27 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule7(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len == 5 && StemmerUtil.EndsWith(s, len, "αγαμε"))
+            if (len == 5 && EndsWith(s, len, "αγαμε"))
             {
                 return len - 1;
             }
 
-            if (len > 7 && StemmerUtil.EndsWith(s, len, "ηθηκαμε"))
+            if (len > 7 && EndsWith(s, len, "ηθηκαμε"))
             {
                 len -= 7;
             }
-            else if (len > 6 && StemmerUtil.EndsWith(s, len, "ουσαμε"))
+            else if (len > 6 && EndsWith(s, len, "ουσαμε"))
             {
                 len -= 6;
             }
-            else if (len > 5 && (StemmerUtil.EndsWith(s, len, "αγαμε") ||
-                StemmerUtil.EndsWith(s, len, "ησαμε") ||
-                StemmerUtil.EndsWith(s, len, "ηκαμε")))
+            else if (len > 5 && (EndsWith(s, len, "αγαμε") ||
+                EndsWith(s, len, "ησαμε") ||
+                EndsWith(s, len, "ηκαμε")))
             {
                 len -= 5;
             }
 
-            if (len > 3 && StemmerUtil.EndsWith(s, len, "αμε"))
+            if (len > 3 && EndsWith(s, len, "αμε"))
             {
                 len -= 3;
                 if (exc7.Contains(s, 0, len))
@@ -400,29 +401,29 @@ namespace Lucene.Net.Analysis.El
         {
             bool removed = false;
 
-            if (len > 8 && StemmerUtil.EndsWith(s, len, "ιουντανε"))
+            if (len > 8 && EndsWith(s, len, "ιουντανε"))
             {
                 len -= 8;
                 removed = true;
             }
-            else if (len > 7 && StemmerUtil.EndsWith(s, len, "ιοντανε") ||
-                StemmerUtil.EndsWith(s, len, "ουντανε") ||
-                StemmerUtil.EndsWith(s, len, "ηθηκανε"))
+            else if (len > 7 && EndsWith(s, len, "ιοντανε") ||
+                EndsWith(s, len, "ουντανε") ||
+                EndsWith(s, len, "ηθηκανε"))
             {
                 len -= 7;
                 removed = true;
             }
-            else if (len > 6 && StemmerUtil.EndsWith(s, len, "ιοτανε") ||
-                StemmerUtil.EndsWith(s, len, "οντανε") ||
-                StemmerUtil.EndsWith(s, len, "ουσανε"))
+            else if (len > 6 && EndsWith(s, len, "ιοτανε") ||
+                EndsWith(s, len, "οντανε") ||
+                EndsWith(s, len, "ουσανε"))
             {
                 len -= 6;
                 removed = true;
             }
-            else if (len > 5 && StemmerUtil.EndsWith(s, len, "αγανε") ||
-                StemmerUtil.EndsWith(s, len, "ησανε") ||
-                StemmerUtil.EndsWith(s, len, "οτανε") ||
-                StemmerUtil.EndsWith(s, len, "ηκανε"))
+            else if (len > 5 && EndsWith(s, len, "αγανε") ||
+                EndsWith(s, len, "ησανε") ||
+                EndsWith(s, len, "οτανε") ||
+                EndsWith(s, len, "ηκανε"))
             {
                 len -= 5;
                 removed = true;
@@ -438,7 +439,7 @@ namespace Lucene.Net.Analysis.El
                 s[len - 1] = 'ν';
             }
 
-            if (len > 3 && StemmerUtil.EndsWith(s, len, "ανε"))
+            if (len > 3 && EndsWith(s, len, "ανε"))
             {
                 len -= 3;
                 if (EndsWithVowelNoY(s, len) || exc8b.Contains(s, 0, len))
@@ -460,47 +461,47 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule9(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 5 && StemmerUtil.EndsWith(s, len, "ησετε"))
+            if (len > 5 && EndsWith(s, len, "ησετε"))
             {
                 len -= 5;
             }
 
-            if (len > 3 && StemmerUtil.EndsWith(s, len, "ετε"))
+            if (len > 3 && EndsWith(s, len, "ετε"))
             {
                 len -= 3;
                 if (exc9.Contains(s, 0, len) ||
                     EndsWithVowelNoY(s, len) ||
-                    StemmerUtil.EndsWith(s, len, "οδ") ||
-                    StemmerUtil.EndsWith(s, len, "αιρ") ||
-                    StemmerUtil.EndsWith(s, len, "φορ") ||
-                    StemmerUtil.EndsWith(s, len, "ταθ") ||
-                    StemmerUtil.EndsWith(s, len, "διαθ") ||
-                    StemmerUtil.EndsWith(s, len, "σχ") ||
-                    StemmerUtil.EndsWith(s, len, "ενδ") ||
-                    StemmerUtil.EndsWith(s, len, "ευρ") ||
-                    StemmerUtil.EndsWith(s, len, "τιθ") ||
-                    StemmerUtil.EndsWith(s, len, "υπερθ") ||
-                    StemmerUtil.EndsWith(s, len, "ραθ") ||
-                    StemmerUtil.EndsWith(s, len, "ενθ") ||
-                    StemmerUtil.EndsWith(s, len, "ροθ") ||
-                    StemmerUtil.EndsWith(s, len, "σθ") ||
-                    StemmerUtil.EndsWith(s, len, "πυρ") ||
-                    StemmerUtil.EndsWith(s, len, "αιν") ||
-                    StemmerUtil.EndsWith(s, len, "συνδ") ||
-                    StemmerUtil.EndsWith(s, len, "συν") ||
-                    StemmerUtil.EndsWith(s, len, "συνθ") ||
-                    StemmerUtil.EndsWith(s, len, "χωρ") ||
-                    StemmerUtil.EndsWith(s, len, "πον") ||
-                    StemmerUtil.EndsWith(s, len, "βρ") ||
-                    StemmerUtil.EndsWith(s, len, "καθ") ||
-                    StemmerUtil.EndsWith(s, len, "ευθ") ||
-                    StemmerUtil.EndsWith(s, len, "εκθ") ||
-                    StemmerUtil.EndsWith(s, len, "νετ") ||
-                    StemmerUtil.EndsWith(s, len, "ρον") ||
-                    StemmerUtil.EndsWith(s, len, "αρκ") ||
-                    StemmerUtil.EndsWith(s, len, "βαρ") ||
-                    StemmerUtil.EndsWith(s, len, "βολ") ||
-                    StemmerUtil.EndsWith(s, len, "ωφελ"))
+                    EndsWith(s, len, "οδ") ||
+                    EndsWith(s, len, "αιρ") ||
+                    EndsWith(s, len, "φορ") ||
+                    EndsWith(s, len, "ταθ") ||
+                    EndsWith(s, len, "διαθ") ||
+                    EndsWith(s, len, "σχ") ||
+                    EndsWith(s, len, "ενδ") ||
+                    EndsWith(s, len, "ευρ") ||
+                    EndsWith(s, len, "τιθ") ||
+                    EndsWith(s, len, "υπερθ") ||
+                    EndsWith(s, len, "ραθ") ||
+                    EndsWith(s, len, "ενθ") ||
+                    EndsWith(s, len, "ροθ") ||
+                    EndsWith(s, len, "σθ") ||
+                    EndsWith(s, len, "πυρ") ||
+                    EndsWith(s, len, "αιν") ||
+                    EndsWith(s, len, "συνδ") ||
+                    EndsWith(s, len, "συν") ||
+                    EndsWith(s, len, "συνθ") ||
+                    EndsWith(s, len, "χωρ") ||
+                    EndsWith(s, len, "πον") ||
+                    EndsWith(s, len, "βρ") ||
+                    EndsWith(s, len, "καθ") ||
+                    EndsWith(s, len, "ευθ") ||
+                    EndsWith(s, len, "εκθ") ||
+                    EndsWith(s, len, "νετ") ||
+                    EndsWith(s, len, "ρον") ||
+                    EndsWith(s, len, "αρκ") ||
+                    EndsWith(s, len, "βαρ") ||
+                    EndsWith(s, len, "βολ") ||
+                    EndsWith(s, len, "ωφελ"))
                 {
                     len += 2; // add back -ετ
                 }
@@ -511,15 +512,15 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule10(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "οντασ") || StemmerUtil.EndsWith(s, len, "ωντασ")))
+            if (len > 5 && (EndsWith(s, len, "οντασ") || EndsWith(s, len, "ωντασ")))
             {
                 len -= 5;
-                if (len == 3 && StemmerUtil.EndsWith(s, len, "αρχ"))
+                if (len == 3 && EndsWith(s, len, "αρχ"))
                 {
                     len += 3; // add back *ντ
                     s[len - 3] = 'ο';
                 }
-                if (StemmerUtil.EndsWith(s, len, "κρε"))
+                if (EndsWith(s, len, "κρε"))
                 {
                     len += 3; // add back *ντ
                     s[len - 3] = 'ω';
@@ -531,18 +532,18 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule11(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 6 && StemmerUtil.EndsWith(s, len, "ομαστε"))
+            if (len > 6 && EndsWith(s, len, "ομαστε"))
             {
                 len -= 6;
-                if (len == 2 && StemmerUtil.EndsWith(s, len, "ον"))
+                if (len == 2 && EndsWith(s, len, "ον"))
                 {
                     len += 5; // add back -ομαστ
                 }
             }
-            else if (len > 7 && StemmerUtil.EndsWith(s, len, "ιομαστε"))
+            else if (len > 7 && EndsWith(s, len, "ιομαστε"))
             {
                 len -= 7;
-                if (len == 2 && StemmerUtil.EndsWith(s, len, "ον"))
+                if (len == 2 && EndsWith(s, len, "ον"))
                 {
                     len += 5;
                     s[len - 5] = 'ο';
@@ -565,7 +566,7 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule12(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 5 && StemmerUtil.EndsWith(s, len, "ιεστε"))
+            if (len > 5 && EndsWith(s, len, "ιεστε"))
             {
                 len -= 5;
                 if (exc12a.Contains(s, 0, len))
@@ -574,7 +575,7 @@ namespace Lucene.Net.Analysis.El
                 }
             }
 
-            if (len > 4 && StemmerUtil.EndsWith(s, len, "εστε"))
+            if (len > 4 && EndsWith(s, len, "εστε"))
             {
                 len -= 4;
                 if (exc12b.Contains(s, 0, len))
@@ -594,35 +595,35 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule13(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 6 && StemmerUtil.EndsWith(s, len, "ηθηκεσ"))
+            if (len > 6 && EndsWith(s, len, "ηθηκεσ"))
             {
                 len -= 6;
             }
-            else if (len > 5 && (StemmerUtil.EndsWith(s, len, "ηθηκα") || StemmerUtil.EndsWith(s, len, "ηθηκε")))
+            else if (len > 5 && (EndsWith(s, len, "ηθηκα") || EndsWith(s, len, "ηθηκε")))
             {
                 len -= 5;
             }
 
             bool removed = false;
 
-            if (len > 4 && StemmerUtil.EndsWith(s, len, "ηκεσ"))
+            if (len > 4 && EndsWith(s, len, "ηκεσ"))
             {
                 len -= 4;
                 removed = true;
             }
-            else if (len > 3 && (StemmerUtil.EndsWith(s, len, "ηκα") || StemmerUtil.EndsWith(s, len, "ηκε")))
+            else if (len > 3 && (EndsWith(s, len, "ηκα") || EndsWith(s, len, "ηκε")))
             {
                 len -= 3;
                 removed = true;
             }
 
             if (removed && (exc13.Contains(s, 0, len) ||
-                StemmerUtil.EndsWith(s, len, "σκωλ") ||
-                StemmerUtil.EndsWith(s, len, "σκουλ") ||
-                StemmerUtil.EndsWith(s, len, "ναρθ") ||
-                StemmerUtil.EndsWith(s, len, "σφ") ||
-                StemmerUtil.EndsWith(s, len, "οθ") ||
-                StemmerUtil.EndsWith(s, len, "πιθ")))
+                EndsWith(s, len, "σκωλ") ||
+                EndsWith(s, len, "σκουλ") ||
+                EndsWith(s, len, "ναρθ") ||
+                EndsWith(s, len, "σφ") ||
+                EndsWith(s, len, "οθ") ||
+                EndsWith(s, len, "πιθ")))
             {
                 len += 2; // add back the -ηκ
             }
@@ -642,13 +643,13 @@ namespace Lucene.Net.Analysis.El
         {
             bool removed = false;
 
-            if (len > 5 && StemmerUtil.EndsWith(s, len, "ουσεσ"))
+            if (len > 5 && EndsWith(s, len, "ουσεσ"))
             {
                 len -= 5;
                 removed = true;
             }
-            else if (len > 4 && (StemmerUtil.EndsWith(s, len, "ουσα") ||
-                StemmerUtil.EndsWith(s, len, "ουσε")))
+            else if (len > 4 && (EndsWith(s, len, "ουσα") ||
+                EndsWith(s, len, "ουσε")))
             {
                 len -= 4;
                 removed = true;
@@ -656,18 +657,18 @@ namespace Lucene.Net.Analysis.El
 
             if (removed && (exc14.Contains(s, 0, len) ||
                 EndsWithVowel(s, len) ||
-                StemmerUtil.EndsWith(s, len, "ποδαρ") ||
-                StemmerUtil.EndsWith(s, len, "βλεπ") ||
-                StemmerUtil.EndsWith(s, len, "πανταχ") ||
-                StemmerUtil.EndsWith(s, len, "φρυδ") ||
-                StemmerUtil.EndsWith(s, len, "μαντιλ") ||
-                StemmerUtil.EndsWith(s, len, "μαλλ") ||
-                StemmerUtil.EndsWith(s, len, "κυματ") ||
-                StemmerUtil.EndsWith(s, len, "λαχ") ||
-                StemmerUtil.EndsWith(s, len, "ληγ") ||
-                StemmerUtil.EndsWith(s, len, "φαγ") ||
-                StemmerUtil.EndsWith(s, len, "ομ") ||
-                StemmerUtil.EndsWith(s, len, "πρωτ")))
+                EndsWith(s, len, "ποδαρ") ||
+                EndsWith(s, len, "βλεπ") ||
+                EndsWith(s, len, "πανταχ") ||
+                EndsWith(s, len, "φρυδ") ||
+                EndsWith(s, len, "μαντιλ") ||
+                EndsWith(s, len, "μαλλ") ||
+                EndsWith(s, len, "κυματ") ||
+                EndsWith(s, len, "λαχ") ||
+                EndsWith(s, len, "ληγ") ||
+                EndsWith(s, len, "φαγ") ||
+                EndsWith(s, len, "ομ") ||
+                EndsWith(s, len, "πρωτ")))
             {
                 len += 3; // add back -ουσ
             }
@@ -695,12 +696,12 @@ namespace Lucene.Net.Analysis.El
         private static int Rule15(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
-            if (len > 4 && StemmerUtil.EndsWith(s, len, "αγεσ"))
+            if (len > 4 && EndsWith(s, len, "αγεσ"))
             {
                 len -= 4;
                 removed = true;
             }
-            else if (len > 3 && (StemmerUtil.EndsWith(s, len, "αγα") || StemmerUtil.EndsWith(s, len, "αγε")))
+            else if (len > 3 && (EndsWith(s, len, "αγα") || EndsWith(s, len, "αγε")))
             {
                 len -= 3;
                 removed = true;
@@ -709,18 +710,18 @@ namespace Lucene.Net.Analysis.El
             if (removed)
             {
                 bool cond1 = exc15a.Contains(s, 0, len) ||
-                    StemmerUtil.EndsWith(s, len, "οφ") ||
-                    StemmerUtil.EndsWith(s, len, "πελ") ||
-                    StemmerUtil.EndsWith(s, len, "χορτ") ||
-                    StemmerUtil.EndsWith(s, len, "λλ") ||
-                    StemmerUtil.EndsWith(s, len, "σφ") ||
-                    StemmerUtil.EndsWith(s, len, "ρπ") ||
-                    StemmerUtil.EndsWith(s, len, "φρ") ||
-                    StemmerUtil.EndsWith(s, len, "πρ") ||
-                    StemmerUtil.EndsWith(s, len, "λοχ") ||
-                    StemmerUtil.EndsWith(s, len, "σμην");
+                    EndsWith(s, len, "οφ") ||
+                    EndsWith(s, len, "πελ") ||
+                    EndsWith(s, len, "χορτ") ||
+                    EndsWith(s, len, "λλ") ||
+                    EndsWith(s, len, "σφ") ||
+                    EndsWith(s, len, "ρπ") ||
+                    EndsWith(s, len, "φρ") ||
+                    EndsWith(s, len, "πρ") ||
+                    EndsWith(s, len, "λοχ") ||
+                    EndsWith(s, len, "σμην");
 
-                bool cond2 = exc15b.Contains(s, 0, len) || StemmerUtil.EndsWith(s, len, "κολλ");
+                bool cond2 = exc15b.Contains(s, 0, len) || EndsWith(s, len, "κολλ");
 
                 if (cond1 && !cond2)
                 {
@@ -740,12 +741,12 @@ namespace Lucene.Net.Analysis.El
         private static int Rule16(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
-            if (len > 4 && StemmerUtil.EndsWith(s, len, "ησου"))
+            if (len > 4 && EndsWith(s, len, "ησου"))
             {
                 len -= 4;
                 removed = true;
             }
-            else if (len > 3 && (StemmerUtil.EndsWith(s, len, "ησε") || StemmerUtil.EndsWith(s, len, "ησα")))
+            else if (len > 3 && (EndsWith(s, len, "ησε") || EndsWith(s, len, "ησα")))
             {
                 len -= 3;
                 removed = true;
@@ -767,7 +768,7 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule17(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 4 && StemmerUtil.EndsWith(s, len, "ηστε"))
+            if (len > 4 && EndsWith(s, len, "ηστε"))
             {
                 len -= 4;
                 if (exc17.Contains(s, 0, len))
@@ -789,12 +790,12 @@ namespace Lucene.Net.Analysis.El
         {
             bool removed = false;
 
-            if (len > 6 && (StemmerUtil.EndsWith(s, len, "ησουνε") || StemmerUtil.EndsWith(s, len, "ηθουνε")))
+            if (len > 6 && (EndsWith(s, len, "ησουνε") || EndsWith(s, len, "ηθουνε")))
             {
                 len -= 6;
                 removed = true;
             }
-            else if (len > 4 && StemmerUtil.EndsWith(s, len, "ουνε"))
+            else if (len > 4 && EndsWith(s, len, "ουνε"))
             {
                 len -= 4;
                 removed = true;
@@ -820,12 +821,12 @@ namespace Lucene.Net.Analysis.El
         {
             bool removed = false;
 
-            if (len > 6 && (StemmerUtil.EndsWith(s, len, "ησουμε") || StemmerUtil.EndsWith(s, len, "ηθουμε")))
+            if (len > 6 && (EndsWith(s, len, "ησουμε") || EndsWith(s, len, "ηθουμε")))
             {
                 len -= 6;
                 removed = true;
             }
-            else if (len > 4 && StemmerUtil.EndsWith(s, len, "ουμε"))
+            else if (len > 4 && EndsWith(s, len, "ουμε"))
             {
                 len -= 4;
                 removed = true;
@@ -843,11 +844,11 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule20(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "ματων") || StemmerUtil.EndsWith(s, len, "ματοσ")))
+            if (len > 5 && (EndsWith(s, len, "ματων") || EndsWith(s, len, "ματοσ")))
             {
                 len -= 3;
             }
-            else if (len > 4 && StemmerUtil.EndsWith(s, len, "ματα"))
+            else if (len > 4 && EndsWith(s, len, "ματα"))
             {
                 len -= 2;
             }
@@ -856,111 +857,111 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule21(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 9 && StemmerUtil.EndsWith(s, len, "ιοντουσαν"))
+            if (len > 9 && EndsWith(s, len, "ιοντουσαν"))
             {
                 return len - 9;
             }
 
-            if (len > 8 && (StemmerUtil.EndsWith(s, len, "ιομασταν") ||
-                StemmerUtil.EndsWith(s, len, "ιοσασταν") ||
-                StemmerUtil.EndsWith(s, len, "ιουμαστε") ||
-                StemmerUtil.EndsWith(s, len, "οντουσαν")))
+            if (len > 8 && (EndsWith(s, len, "ιομασταν") ||
+                EndsWith(s, len, "ιοσασταν") ||
+                EndsWith(s, len, "ιουμαστε") ||
+                EndsWith(s, len, "οντουσαν")))
             {
                 return len - 8;
             }
 
-            if (len > 7 && (StemmerUtil.EndsWith(s, len, "ιεμαστε") ||
-                StemmerUtil.EndsWith(s, len, "ιεσαστε") ||
-                StemmerUtil.EndsWith(s, len, "ιομουνα") ||
-                StemmerUtil.EndsWith(s, len, "ιοσαστε") ||
-                StemmerUtil.EndsWith(s, len, "ιοσουνα") ||
-                StemmerUtil.EndsWith(s, len, "ιουνται") ||
-                StemmerUtil.EndsWith(s, len, "ιουνταν") ||
-                StemmerUtil.EndsWith(s, len, "ηθηκατε") ||
-                StemmerUtil.EndsWith(s, len, "ομασταν") ||
-                StemmerUtil.EndsWith(s, len, "οσασταν") ||
-                StemmerUtil.EndsWith(s, len, "ουμαστε")))
+            if (len > 7 && (EndsWith(s, len, "ιεμαστε") ||
+                EndsWith(s, len, "ιεσαστε") ||
+                EndsWith(s, len, "ιομουνα") ||
+                EndsWith(s, len, "ιοσαστε") ||
+                EndsWith(s, len, "ιοσουνα") ||
+                EndsWith(s, len, "ιουνται") ||
+                EndsWith(s, len, "ιουνταν") ||
+                EndsWith(s, len, "ηθηκατε") ||
+                EndsWith(s, len, "ομασταν") ||
+                EndsWith(s, len, "οσασταν") ||
+                EndsWith(s, len, "ουμαστε")))
             {
                 return len - 7;
             }
 
-            if (len > 6 && (StemmerUtil.EndsWith(s, len, "ιομουν") ||
-                StemmerUtil.EndsWith(s, len, "ιονταν") ||
-                StemmerUtil.EndsWith(s, len, "ιοσουν") ||
-                StemmerUtil.EndsWith(s, len, "ηθειτε") ||
-                StemmerUtil.EndsWith(s, len, "ηθηκαν") ||
-                StemmerUtil.EndsWith(s, len, "ομουνα") ||
-                StemmerUtil.EndsWith(s, len, "οσαστε") ||
-                StemmerUtil.EndsWith(s, len, "οσουνα") ||
-                StemmerUtil.EndsWith(s, len, "ουνται") ||
-                StemmerUtil.EndsWith(s, len, "ουνταν") ||
-                StemmerUtil.EndsWith(s, len, "ουσατε")))
+            if (len > 6 && (EndsWith(s, len, "ιομουν") ||
+                EndsWith(s, len, "ιονταν") ||
+                EndsWith(s, len, "ιοσουν") ||
+                EndsWith(s, len, "ηθειτε") ||
+                EndsWith(s, len, "ηθηκαν") ||
+                EndsWith(s, len, "ομουνα") ||
+                EndsWith(s, len, "οσαστε") ||
+                EndsWith(s, len, "οσουνα") ||
+                EndsWith(s, len, "ουνται") ||
+                EndsWith(s, len, "ουνταν") ||
+                EndsWith(s, len, "ουσατε")))
             {
                 return len - 6;
             }
 
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "αγατε") ||
-                StemmerUtil.EndsWith(s, len, "ιεμαι") ||
-                StemmerUtil.EndsWith(s, len, "ιεται") ||
-                StemmerUtil.EndsWith(s, len, "ιεσαι") ||
-                StemmerUtil.EndsWith(s, len, "ιοταν") ||
-                StemmerUtil.EndsWith(s, len, "ιουμα") ||
-                StemmerUtil.EndsWith(s, len, "ηθεισ") ||
-                StemmerUtil.EndsWith(s, len, "ηθουν") ||
-                StemmerUtil.EndsWith(s, len, "ηκατε") ||
-                StemmerUtil.EndsWith(s, len, "ησατε") ||
-                StemmerUtil.EndsWith(s, len, "ησουν") ||
-                StemmerUtil.EndsWith(s, len, "ομουν") ||
-                StemmerUtil.EndsWith(s, len, "ονται") ||
-                StemmerUtil.EndsWith(s, len, "ονταν") ||
-                StemmerUtil.EndsWith(s, len, "οσουν") ||
-                StemmerUtil.EndsWith(s, len, "ουμαι") ||
-                StemmerUtil.EndsWith(s, len, "ουσαν")))
+            if (len > 5 && (EndsWith(s, len, "αγατε") ||
+                EndsWith(s, len, "ιεμαι") ||
+                EndsWith(s, len, "ιεται") ||
+                EndsWith(s, len, "ιεσαι") ||
+                EndsWith(s, len, "ιοταν") ||
+                EndsWith(s, len, "ιουμα") ||
+                EndsWith(s, len, "ηθεισ") ||
+                EndsWith(s, len, "ηθουν") ||
+                EndsWith(s, len, "ηκατε") ||
+                EndsWith(s, len, "ησατε") ||
+                EndsWith(s, len, "ησουν") ||
+                EndsWith(s, len, "ομουν") ||
+                EndsWith(s, len, "ονται") ||
+                EndsWith(s, len, "ονταν") ||
+                EndsWith(s, len, "οσουν") ||
+                EndsWith(s, len, "ουμαι") ||
+                EndsWith(s, len, "ουσαν")))
             {
                 return len - 5;
             }
 
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "αγαν") ||
-                StemmerUtil.EndsWith(s, len, "αμαι") ||
-                StemmerUtil.EndsWith(s, len, "ασαι") ||
-                StemmerUtil.EndsWith(s, len, "αται") ||
-                StemmerUtil.EndsWith(s, len, "ειτε") ||
-                StemmerUtil.EndsWith(s, len, "εσαι") ||
-                StemmerUtil.EndsWith(s, len, "εται") ||
-                StemmerUtil.EndsWith(s, len, "ηδεσ") ||
-                StemmerUtil.EndsWith(s, len, "ηδων") ||
-                StemmerUtil.EndsWith(s, len, "ηθει") ||
-                StemmerUtil.EndsWith(s, len, "ηκαν") ||
-                StemmerUtil.EndsWith(s, len, "ησαν") ||
-                StemmerUtil.EndsWith(s, len, "ησει") ||
-                StemmerUtil.EndsWith(s, len, "ησεσ") ||
-                StemmerUtil.EndsWith(s, len, "ομαι") ||
-                StemmerUtil.EndsWith(s, len, "οταν")))
+            if (len > 4 && (EndsWith(s, len, "αγαν") ||
+                EndsWith(s, len, "αμαι") ||
+                EndsWith(s, len, "ασαι") ||
+                EndsWith(s, len, "αται") ||
+                EndsWith(s, len, "ειτε") ||
+                EndsWith(s, len, "εσαι") ||
+                EndsWith(s, len, "εται") ||
+                EndsWith(s, len, "ηδεσ") ||
+                EndsWith(s, len, "ηδων") ||
+                EndsWith(s, len, "ηθει") ||
+                EndsWith(s, len, "ηκαν") ||
+                EndsWith(s, len, "ησαν") ||
+                EndsWith(s, len, "ησει") ||
+                EndsWith(s, len, "ησεσ") ||
+                EndsWith(s, len, "ομαι") ||
+                EndsWith(s, len, "οταν")))
             {
                 return len - 4;
             }
 
-            if (len > 3 && (StemmerUtil.EndsWith(s, len, "αει") ||
-                StemmerUtil.EndsWith(s, len, "εισ") ||
-                StemmerUtil.EndsWith(s, len, "ηθω") ||
-                StemmerUtil.EndsWith(s, len, "ησω") ||
-                StemmerUtil.EndsWith(s, len, "ουν") ||
-                StemmerUtil.EndsWith(s, len, "ουσ")))
+            if (len > 3 && (EndsWith(s, len, "αει") ||
+                EndsWith(s, len, "εισ") ||
+                EndsWith(s, len, "ηθω") ||
+                EndsWith(s, len, "ησω") ||
+                EndsWith(s, len, "ουν") ||
+                EndsWith(s, len, "ουσ")))
             {
                 return len - 3;
             }
 
-            if (len > 2 && (StemmerUtil.EndsWith(s, len, "αν") ||
-                StemmerUtil.EndsWith(s, len, "ασ") ||
-                StemmerUtil.EndsWith(s, len, "αω") ||
-                StemmerUtil.EndsWith(s, len, "ει") ||
-                StemmerUtil.EndsWith(s, len, "εσ") ||
-                StemmerUtil.EndsWith(s, len, "ησ") ||
-                StemmerUtil.EndsWith(s, len, "οι") ||
-                StemmerUtil.EndsWith(s, len, "οσ") ||
-                StemmerUtil.EndsWith(s, len, "ου") ||
-                StemmerUtil.EndsWith(s, len, "υσ") ||
-                StemmerUtil.EndsWith(s, len, "ων")))
+            if (len > 2 && (EndsWith(s, len, "αν") ||
+                EndsWith(s, len, "ασ") ||
+                EndsWith(s, len, "αω") ||
+                EndsWith(s, len, "ει") ||
+                EndsWith(s, len, "εσ") ||
+                EndsWith(s, len, "ησ") ||
+                EndsWith(s, len, "οι") ||
+                EndsWith(s, len, "οσ") ||
+                EndsWith(s, len, "ου") ||
+                EndsWith(s, len, "υσ") ||
+                EndsWith(s, len, "ων")))
             {
                 return len - 2;
             }
@@ -975,18 +976,18 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule22(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (StemmerUtil.EndsWith(s, len, "εστερ") ||
-                StemmerUtil.EndsWith(s, len, "εστατ"))
+            if (EndsWith(s, len, "εστερ") ||
+                EndsWith(s, len, "εστατ"))
             {
                 return len - 5;
             }
 
-            if (StemmerUtil.EndsWith(s, len, "οτερ") ||
-                StemmerUtil.EndsWith(s, len, "οτατ") ||
-                StemmerUtil.EndsWith(s, len, "υτερ") ||
-                StemmerUtil.EndsWith(s, len, "υτατ") ||
-                StemmerUtil.EndsWith(s, len, "ωτερ") ||
-                StemmerUtil.EndsWith(s, len, "ωτατ"))
+            if (EndsWith(s, len, "οτερ") ||
+                EndsWith(s, len, "οτατ") ||
+                EndsWith(s, len, "υτερ") ||
+                EndsWith(s, len, "υτατ") ||
+                EndsWith(s, len, "ωτερ") ||
+                EndsWith(s, len, "ωτατ"))
             {
                 return len - 4;
             }
@@ -994,32 +995,16 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        // LUCENENET: commented out unused private method
-        // /// <summary>
-        // /// Checks if the word contained in the leading portion of char[] array ,
-        // /// ends with the suffix given as parameter.
-        // /// </summary>
-        // /// <param name="s"> A char[] array that represents a word. </param>
-        // /// <param name="len"> The length of the char[] array. </param>
-        // /// <param name="suffix"> A <see cref="string"/> object to check if the word given ends with these characters. </param>
-        // /// <returns> True if the word ends with the suffix given , false otherwise. </returns>
-        // private static bool EndsWith(char[] s, int len, string suffix) // LUCENENET: CA1822: Mark members as static
-        // {
-        //     int suffixLen = suffix.Length;
-        //     if (suffixLen > len)
-        //     {
-        //         return false;
-        //     }
-        //     for (int i = suffixLen - 1; i >= 0; i--)
-        //     {
-        //         if (s[len - (suffixLen - i)] != suffix[i])
-        //         {
-        //             return false;
-        //         }
-        //     }
-        //
-        //     return true;
-        // }
+        /// <summary>
+        /// Checks if the word contained in the leading portion of char[] array ,
+        /// ends with the suffix given as parameter.
+        /// </summary>
+        /// <param name="s"> A char[] array that represents a word. </param>
+        /// <param name="len"> The length of the char[] array. </param>
+        /// <param name="suffix"> A <see cref="string"/> object to check if the word given ends with these characters. </param>
+        /// <returns> True if the word ends with the suffix given , false otherwise. </returns>
+        private static bool EndsWith(ReadOnlySpan<char> s, int len, string suffix) // LUCENENET: CA1822: Mark members as static
+            => s.Slice(0, len).EndsWith(suffix.AsSpan()); // LUCENENET specific - optimized for ReadOnlySpan<char>
 
         /// <summary>
         /// Checks if the word contained in the leading portion of <see cref="T:char[]"/> array ,

--- a/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Analysis.El
     /// Greek Language.</c> Georgios Ntais
     /// <para>
     /// NOTE: Input is expected to be casefolded for Greek (including folding of final
-    /// sigma to sigma), and with diacritics removed. This can be achieved with 
+    /// sigma to sigma), and with diacritics removed. This can be achieved with
     /// either <see cref="GreekLowerCaseFilter"/> or ICUFoldingFilter.
     /// @lucene.experimental
     /// </para>
@@ -81,13 +81,13 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule0(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 9 && (StemmerUtil.EndsWith(s, len, "καθεστωτοσ") || 
+            if (len > 9 && (StemmerUtil.EndsWith(s, len, "καθεστωτοσ") ||
                 StemmerUtil.EndsWith(s, len, "καθεστωτων")))
             {
                 return len - 4;
             }
 
-            if (len > 8 && (StemmerUtil.EndsWith(s, len, "γεγονοτοσ") || 
+            if (len > 8 && (StemmerUtil.EndsWith(s, len, "γεγονοτοσ") ||
                 StemmerUtil.EndsWith(s, len, "γεγονοτων")))
             {
                 return len - 4;
@@ -98,7 +98,7 @@ namespace Lucene.Net.Analysis.El
                 return len - 3;
             }
 
-            if (len > 7 && (StemmerUtil.EndsWith(s, len, "τατογιου") || 
+            if (len > 7 && (StemmerUtil.EndsWith(s, len, "τατογιου") ||
                 StemmerUtil.EndsWith(s, len, "τατογιων")))
             {
                 return len - 4;
@@ -114,15 +114,15 @@ namespace Lucene.Net.Analysis.El
                 return len - 2;
             }
 
-            if (len > 6 && (StemmerUtil.EndsWith(s, len, "σκαγιου")) || 
-                StemmerUtil.EndsWith(s, len, "σκαγιων") || 
-                StemmerUtil.EndsWith(s, len, "ολογιου") || 
-                StemmerUtil.EndsWith(s, len, "ολογιων") || 
-                StemmerUtil.EndsWith(s, len, "κρεατοσ") || 
-                StemmerUtil.EndsWith(s, len, "κρεατων") || 
-                StemmerUtil.EndsWith(s, len, "περατοσ") || 
-                StemmerUtil.EndsWith(s, len, "περατων") || 
-                StemmerUtil.EndsWith(s, len, "τερατοσ") || 
+            if (len > 6 && (StemmerUtil.EndsWith(s, len, "σκαγιου")) ||
+                StemmerUtil.EndsWith(s, len, "σκαγιων") ||
+                StemmerUtil.EndsWith(s, len, "ολογιου") ||
+                StemmerUtil.EndsWith(s, len, "ολογιων") ||
+                StemmerUtil.EndsWith(s, len, "κρεατοσ") ||
+                StemmerUtil.EndsWith(s, len, "κρεατων") ||
+                StemmerUtil.EndsWith(s, len, "περατοσ") ||
+                StemmerUtil.EndsWith(s, len, "περατων") ||
+                StemmerUtil.EndsWith(s, len, "τερατοσ") ||
                 StemmerUtil.EndsWith(s, len, "τερατων"))
             {
                 return len - 4;
@@ -138,33 +138,33 @@ namespace Lucene.Net.Analysis.El
                 return len - 2;
             }
 
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "φαγιου") || 
-                StemmerUtil.EndsWith(s, len, "φαγιων") || 
-                StemmerUtil.EndsWith(s, len, "σογιου") || 
+            if (len > 5 && (StemmerUtil.EndsWith(s, len, "φαγιου") ||
+                StemmerUtil.EndsWith(s, len, "φαγιων") ||
+                StemmerUtil.EndsWith(s, len, "σογιου") ||
                 StemmerUtil.EndsWith(s, len, "σογιων")))
             {
                 return len - 4;
             }
 
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "σκαγια") || 
-                StemmerUtil.EndsWith(s, len, "ολογια") || 
-                StemmerUtil.EndsWith(s, len, "κρεατα") || 
-                StemmerUtil.EndsWith(s, len, "περατα") || 
+            if (len > 5 && (StemmerUtil.EndsWith(s, len, "σκαγια") ||
+                StemmerUtil.EndsWith(s, len, "ολογια") ||
+                StemmerUtil.EndsWith(s, len, "κρεατα") ||
+                StemmerUtil.EndsWith(s, len, "περατα") ||
                 StemmerUtil.EndsWith(s, len, "τερατα")))
             {
                 return len - 3;
             }
 
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "φαγια") || 
-                StemmerUtil.EndsWith(s, len, "σογια") || 
-                StemmerUtil.EndsWith(s, len, "φωτοσ") || 
+            if (len > 4 && (StemmerUtil.EndsWith(s, len, "φαγια") ||
+                StemmerUtil.EndsWith(s, len, "σογια") ||
+                StemmerUtil.EndsWith(s, len, "φωτοσ") ||
                 StemmerUtil.EndsWith(s, len, "φωτων")))
             {
                 return len - 3;
             }
 
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "κρεασ") || 
-                StemmerUtil.EndsWith(s, len, "περασ") || 
+            if (len > 4 && (StemmerUtil.EndsWith(s, len, "κρεασ") ||
+                StemmerUtil.EndsWith(s, len, "περασ") ||
                 StemmerUtil.EndsWith(s, len, "τερασ")))
             {
                 return len - 2;
@@ -185,19 +185,19 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule1(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "αδεσ") || 
+            if (len > 4 && (StemmerUtil.EndsWith(s, len, "αδεσ") ||
                 StemmerUtil.EndsWith(s, len, "αδων")))
             {
                 len -= 4;
-                if (!(StemmerUtil.EndsWith(s, len, "οκ") || 
-                    StemmerUtil.EndsWith(s, len, "μαμ") || 
-                    StemmerUtil.EndsWith(s, len, "μαν") || 
-                    StemmerUtil.EndsWith(s, len, "μπαμπ") || 
-                    StemmerUtil.EndsWith(s, len, "πατερ") || 
-                    StemmerUtil.EndsWith(s, len, "γιαγι") || 
-                    StemmerUtil.EndsWith(s, len, "νταντ") || 
-                    StemmerUtil.EndsWith(s, len, "κυρ") || 
-                    StemmerUtil.EndsWith(s, len, "θει") || 
+                if (!(StemmerUtil.EndsWith(s, len, "οκ") ||
+                    StemmerUtil.EndsWith(s, len, "μαμ") ||
+                    StemmerUtil.EndsWith(s, len, "μαν") ||
+                    StemmerUtil.EndsWith(s, len, "μπαμπ") ||
+                    StemmerUtil.EndsWith(s, len, "πατερ") ||
+                    StemmerUtil.EndsWith(s, len, "γιαγι") ||
+                    StemmerUtil.EndsWith(s, len, "νταντ") ||
+                    StemmerUtil.EndsWith(s, len, "κυρ") ||
+                    StemmerUtil.EndsWith(s, len, "θει") ||
                     StemmerUtil.EndsWith(s, len, "πεθερ")))
                 {
                     len += 2; // add back -αδ
@@ -208,17 +208,17 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule2(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "εδεσ") || 
+            if (len > 4 && (StemmerUtil.EndsWith(s, len, "εδεσ") ||
                 StemmerUtil.EndsWith(s, len, "εδων")))
             {
                 len -= 4;
                 if (StemmerUtil.EndsWith(s, len, "οπ") ||
-                    StemmerUtil.EndsWith(s, len, "ιπ") || 
-                    StemmerUtil.EndsWith(s, len, "εμπ") || 
-                    StemmerUtil.EndsWith(s, len, "υπ") || 
-                    StemmerUtil.EndsWith(s, len, "γηπ") || 
-                    StemmerUtil.EndsWith(s, len, "δαπ") || 
-                    StemmerUtil.EndsWith(s, len, "κρασπ") || 
+                    StemmerUtil.EndsWith(s, len, "ιπ") ||
+                    StemmerUtil.EndsWith(s, len, "εμπ") ||
+                    StemmerUtil.EndsWith(s, len, "υπ") ||
+                    StemmerUtil.EndsWith(s, len, "γηπ") ||
+                    StemmerUtil.EndsWith(s, len, "δαπ") ||
+                    StemmerUtil.EndsWith(s, len, "κρασπ") ||
                     StemmerUtil.EndsWith(s, len, "μιλ"))
                 {
                     len += 2; // add back -εδ
@@ -229,24 +229,24 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule3(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "ουδεσ") || 
+            if (len > 5 && (StemmerUtil.EndsWith(s, len, "ουδεσ") ||
                 StemmerUtil.EndsWith(s, len, "ουδων")))
             {
                 len -= 5;
-                if (StemmerUtil.EndsWith(s, len, "αρκ") || 
-                    StemmerUtil.EndsWith(s, len, "καλιακ") || 
-                    StemmerUtil.EndsWith(s, len, "πεταλ") || 
-                    StemmerUtil.EndsWith(s, len, "λιχ") || 
-                    StemmerUtil.EndsWith(s, len, "πλεξ") || 
-                    StemmerUtil.EndsWith(s, len, "σκ") || 
-                    StemmerUtil.EndsWith(s, len, "σ") || 
-                    StemmerUtil.EndsWith(s, len, "φλ") || 
-                    StemmerUtil.EndsWith(s, len, "φρ") || 
-                    StemmerUtil.EndsWith(s, len, "βελ") || 
-                    StemmerUtil.EndsWith(s, len, "λουλ") || 
-                    StemmerUtil.EndsWith(s, len, "χν") || 
-                    StemmerUtil.EndsWith(s, len, "σπ") || 
-                    StemmerUtil.EndsWith(s, len, "τραγ") || 
+                if (StemmerUtil.EndsWith(s, len, "αρκ") ||
+                    StemmerUtil.EndsWith(s, len, "καλιακ") ||
+                    StemmerUtil.EndsWith(s, len, "πεταλ") ||
+                    StemmerUtil.EndsWith(s, len, "λιχ") ||
+                    StemmerUtil.EndsWith(s, len, "πλεξ") ||
+                    StemmerUtil.EndsWith(s, len, "σκ") ||
+                    StemmerUtil.EndsWith(s, len, "σ") ||
+                    StemmerUtil.EndsWith(s, len, "φλ") ||
+                    StemmerUtil.EndsWith(s, len, "φρ") ||
+                    StemmerUtil.EndsWith(s, len, "βελ") ||
+                    StemmerUtil.EndsWith(s, len, "λουλ") ||
+                    StemmerUtil.EndsWith(s, len, "χν") ||
+                    StemmerUtil.EndsWith(s, len, "σπ") ||
+                    StemmerUtil.EndsWith(s, len, "τραγ") ||
                     StemmerUtil.EndsWith(s, len, "φε"))
                 {
                     len += 3; // add back -ουδ
@@ -261,7 +261,7 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule4(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (len > 3 && (StemmerUtil.EndsWith(s, len, "εωσ") || 
+            if (len > 3 && (StemmerUtil.EndsWith(s, len, "εωσ") ||
                 StemmerUtil.EndsWith(s, len, "εων")))
             {
                 len -= 3;
@@ -283,7 +283,7 @@ namespace Lucene.Net.Analysis.El
                     len++; // add back -ι
                 }
             }
-            else if (len > 3 && (StemmerUtil.EndsWith(s, len, "ιου") || 
+            else if (len > 3 && (StemmerUtil.EndsWith(s, len, "ιου") ||
                 StemmerUtil.EndsWith(s, len, "ιων")))
             {
                 len -= 3;
@@ -308,13 +308,13 @@ namespace Lucene.Net.Analysis.El
         private static int Rule6(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
             bool removed = false;
-            if (len > 3 && (StemmerUtil.EndsWith(s, len, "ικα") || 
+            if (len > 3 && (StemmerUtil.EndsWith(s, len, "ικα") ||
                 StemmerUtil.EndsWith(s, len, "ικο")))
             {
                 len -= 3;
                 removed = true;
             }
-            else if (len > 4 && (StemmerUtil.EndsWith(s, len, "ικου") || 
+            else if (len > 4 && (StemmerUtil.EndsWith(s, len, "ικου") ||
                 StemmerUtil.EndsWith(s, len, "ικων")))
             {
                 len -= 4;
@@ -353,8 +353,8 @@ namespace Lucene.Net.Analysis.El
             {
                 len -= 6;
             }
-            else if (len > 5 && (StemmerUtil.EndsWith(s, len, "αγαμε") || 
-                StemmerUtil.EndsWith(s, len, "ησαμε") || 
+            else if (len > 5 && (StemmerUtil.EndsWith(s, len, "αγαμε") ||
+                StemmerUtil.EndsWith(s, len, "ησαμε") ||
                 StemmerUtil.EndsWith(s, len, "ηκαμε")))
             {
                 len -= 5;
@@ -405,23 +405,23 @@ namespace Lucene.Net.Analysis.El
                 len -= 8;
                 removed = true;
             }
-            else if (len > 7 && StemmerUtil.EndsWith(s, len, "ιοντανε") || 
-                StemmerUtil.EndsWith(s, len, "ουντανε") || 
+            else if (len > 7 && StemmerUtil.EndsWith(s, len, "ιοντανε") ||
+                StemmerUtil.EndsWith(s, len, "ουντανε") ||
                 StemmerUtil.EndsWith(s, len, "ηθηκανε"))
             {
                 len -= 7;
                 removed = true;
             }
-            else if (len > 6 && StemmerUtil.EndsWith(s, len, "ιοτανε") || 
-                StemmerUtil.EndsWith(s, len, "οντανε") || 
+            else if (len > 6 && StemmerUtil.EndsWith(s, len, "ιοτανε") ||
+                StemmerUtil.EndsWith(s, len, "οντανε") ||
                 StemmerUtil.EndsWith(s, len, "ουσανε"))
             {
                 len -= 6;
                 removed = true;
             }
-            else if (len > 5 && StemmerUtil.EndsWith(s, len, "αγανε") || 
-                StemmerUtil.EndsWith(s, len, "ησανε") || 
-                StemmerUtil.EndsWith(s, len, "οτανε") || 
+            else if (len > 5 && StemmerUtil.EndsWith(s, len, "αγανε") ||
+                StemmerUtil.EndsWith(s, len, "ησανε") ||
+                StemmerUtil.EndsWith(s, len, "οτανε") ||
                 StemmerUtil.EndsWith(s, len, "ηκανε"))
             {
                 len -= 5;
@@ -468,38 +468,38 @@ namespace Lucene.Net.Analysis.El
             if (len > 3 && StemmerUtil.EndsWith(s, len, "ετε"))
             {
                 len -= 3;
-                if (exc9.Contains(s, 0, len) || 
-                    EndsWithVowelNoY(s, len) || 
-                    StemmerUtil.EndsWith(s, len, "οδ") || 
-                    StemmerUtil.EndsWith(s, len, "αιρ") || 
-                    StemmerUtil.EndsWith(s, len, "φορ") || 
-                    StemmerUtil.EndsWith(s, len, "ταθ") || 
-                    StemmerUtil.EndsWith(s, len, "διαθ") || 
-                    StemmerUtil.EndsWith(s, len, "σχ") || 
-                    StemmerUtil.EndsWith(s, len, "ενδ") || 
-                    StemmerUtil.EndsWith(s, len, "ευρ") || 
-                    StemmerUtil.EndsWith(s, len, "τιθ") || 
-                    StemmerUtil.EndsWith(s, len, "υπερθ") || 
-                    StemmerUtil.EndsWith(s, len, "ραθ") || 
-                    StemmerUtil.EndsWith(s, len, "ενθ") || 
-                    StemmerUtil.EndsWith(s, len, "ροθ") || 
-                    StemmerUtil.EndsWith(s, len, "σθ") || 
-                    StemmerUtil.EndsWith(s, len, "πυρ") || 
-                    StemmerUtil.EndsWith(s, len, "αιν") || 
-                    StemmerUtil.EndsWith(s, len, "συνδ") || 
-                    StemmerUtil.EndsWith(s, len, "συν") || 
-                    StemmerUtil.EndsWith(s, len, "συνθ") || 
-                    StemmerUtil.EndsWith(s, len, "χωρ") || 
-                    StemmerUtil.EndsWith(s, len, "πον") || 
-                    StemmerUtil.EndsWith(s, len, "βρ") || 
-                    StemmerUtil.EndsWith(s, len, "καθ") || 
-                    StemmerUtil.EndsWith(s, len, "ευθ") || 
-                    StemmerUtil.EndsWith(s, len, "εκθ") || 
-                    StemmerUtil.EndsWith(s, len, "νετ") || 
-                    StemmerUtil.EndsWith(s, len, "ρον") || 
-                    StemmerUtil.EndsWith(s, len, "αρκ") || 
-                    StemmerUtil.EndsWith(s, len, "βαρ") || 
-                    StemmerUtil.EndsWith(s, len, "βολ") || 
+                if (exc9.Contains(s, 0, len) ||
+                    EndsWithVowelNoY(s, len) ||
+                    StemmerUtil.EndsWith(s, len, "οδ") ||
+                    StemmerUtil.EndsWith(s, len, "αιρ") ||
+                    StemmerUtil.EndsWith(s, len, "φορ") ||
+                    StemmerUtil.EndsWith(s, len, "ταθ") ||
+                    StemmerUtil.EndsWith(s, len, "διαθ") ||
+                    StemmerUtil.EndsWith(s, len, "σχ") ||
+                    StemmerUtil.EndsWith(s, len, "ενδ") ||
+                    StemmerUtil.EndsWith(s, len, "ευρ") ||
+                    StemmerUtil.EndsWith(s, len, "τιθ") ||
+                    StemmerUtil.EndsWith(s, len, "υπερθ") ||
+                    StemmerUtil.EndsWith(s, len, "ραθ") ||
+                    StemmerUtil.EndsWith(s, len, "ενθ") ||
+                    StemmerUtil.EndsWith(s, len, "ροθ") ||
+                    StemmerUtil.EndsWith(s, len, "σθ") ||
+                    StemmerUtil.EndsWith(s, len, "πυρ") ||
+                    StemmerUtil.EndsWith(s, len, "αιν") ||
+                    StemmerUtil.EndsWith(s, len, "συνδ") ||
+                    StemmerUtil.EndsWith(s, len, "συν") ||
+                    StemmerUtil.EndsWith(s, len, "συνθ") ||
+                    StemmerUtil.EndsWith(s, len, "χωρ") ||
+                    StemmerUtil.EndsWith(s, len, "πον") ||
+                    StemmerUtil.EndsWith(s, len, "βρ") ||
+                    StemmerUtil.EndsWith(s, len, "καθ") ||
+                    StemmerUtil.EndsWith(s, len, "ευθ") ||
+                    StemmerUtil.EndsWith(s, len, "εκθ") ||
+                    StemmerUtil.EndsWith(s, len, "νετ") ||
+                    StemmerUtil.EndsWith(s, len, "ρον") ||
+                    StemmerUtil.EndsWith(s, len, "αρκ") ||
+                    StemmerUtil.EndsWith(s, len, "βαρ") ||
+                    StemmerUtil.EndsWith(s, len, "βολ") ||
                     StemmerUtil.EndsWith(s, len, "ωφελ"))
                 {
                     len += 2; // add back -ετ
@@ -556,10 +556,10 @@ namespace Lucene.Net.Analysis.El
         }
 
 #pragma warning disable 612, 618
-        private static readonly CharArraySet exc12a = new CharArraySet(LuceneVersion.LUCENE_CURRENT, 
+        private static readonly CharArraySet exc12a = new CharArraySet(LuceneVersion.LUCENE_CURRENT,
             new string[] { "π", "απ", "συμπ", "ασυμπ", "ακαταπ", "αμεταμφ" }, false);
 
-        private static readonly CharArraySet exc12b = new CharArraySet(LuceneVersion.LUCENE_CURRENT, 
+        private static readonly CharArraySet exc12b = new CharArraySet(LuceneVersion.LUCENE_CURRENT,
             new string[] { "αλ", "αρ", "εκτελ", "ζ", "μ", "ξ", "παρακαλ", "αρ", "προ", "νισ" }, false);
 #pragma warning restore 612, 618
 
@@ -616,12 +616,12 @@ namespace Lucene.Net.Analysis.El
                 removed = true;
             }
 
-            if (removed && (exc13.Contains(s, 0, len) || 
-                StemmerUtil.EndsWith(s, len, "σκωλ") || 
-                StemmerUtil.EndsWith(s, len, "σκουλ") || 
-                StemmerUtil.EndsWith(s, len, "ναρθ") || 
-                StemmerUtil.EndsWith(s, len, "σφ") || 
-                StemmerUtil.EndsWith(s, len, "οθ") || 
+            if (removed && (exc13.Contains(s, 0, len) ||
+                StemmerUtil.EndsWith(s, len, "σκωλ") ||
+                StemmerUtil.EndsWith(s, len, "σκουλ") ||
+                StemmerUtil.EndsWith(s, len, "ναρθ") ||
+                StemmerUtil.EndsWith(s, len, "σφ") ||
+                StemmerUtil.EndsWith(s, len, "οθ") ||
                 StemmerUtil.EndsWith(s, len, "πιθ")))
             {
                 len += 2; // add back the -ηκ
@@ -647,26 +647,26 @@ namespace Lucene.Net.Analysis.El
                 len -= 5;
                 removed = true;
             }
-            else if (len > 4 && (StemmerUtil.EndsWith(s, len, "ουσα") || 
+            else if (len > 4 && (StemmerUtil.EndsWith(s, len, "ουσα") ||
                 StemmerUtil.EndsWith(s, len, "ουσε")))
             {
                 len -= 4;
                 removed = true;
             }
 
-            if (removed && (exc14.Contains(s, 0, len) || 
-                EndsWithVowel(s, len) || 
-                StemmerUtil.EndsWith(s, len, "ποδαρ") || 
-                StemmerUtil.EndsWith(s, len, "βλεπ") || 
-                StemmerUtil.EndsWith(s, len, "πανταχ") || 
-                StemmerUtil.EndsWith(s, len, "φρυδ") || 
-                StemmerUtil.EndsWith(s, len, "μαντιλ") || 
-                StemmerUtil.EndsWith(s, len, "μαλλ") || 
-                StemmerUtil.EndsWith(s, len, "κυματ") || 
-                StemmerUtil.EndsWith(s, len, "λαχ") || 
-                StemmerUtil.EndsWith(s, len, "ληγ") || 
-                StemmerUtil.EndsWith(s, len, "φαγ") || 
-                StemmerUtil.EndsWith(s, len, "ομ") || 
+            if (removed && (exc14.Contains(s, 0, len) ||
+                EndsWithVowel(s, len) ||
+                StemmerUtil.EndsWith(s, len, "ποδαρ") ||
+                StemmerUtil.EndsWith(s, len, "βλεπ") ||
+                StemmerUtil.EndsWith(s, len, "πανταχ") ||
+                StemmerUtil.EndsWith(s, len, "φρυδ") ||
+                StemmerUtil.EndsWith(s, len, "μαντιλ") ||
+                StemmerUtil.EndsWith(s, len, "μαλλ") ||
+                StemmerUtil.EndsWith(s, len, "κυματ") ||
+                StemmerUtil.EndsWith(s, len, "λαχ") ||
+                StemmerUtil.EndsWith(s, len, "ληγ") ||
+                StemmerUtil.EndsWith(s, len, "φαγ") ||
+                StemmerUtil.EndsWith(s, len, "ομ") ||
                 StemmerUtil.EndsWith(s, len, "πρωτ")))
             {
                 len += 3; // add back -ουσ
@@ -708,16 +708,16 @@ namespace Lucene.Net.Analysis.El
 
             if (removed)
             {
-                bool cond1 = exc15a.Contains(s, 0, len) || 
-                    StemmerUtil.EndsWith(s, len, "οφ") || 
-                    StemmerUtil.EndsWith(s, len, "πελ") || 
-                    StemmerUtil.EndsWith(s, len, "χορτ") || 
-                    StemmerUtil.EndsWith(s, len, "λλ") || 
-                    StemmerUtil.EndsWith(s, len, "σφ") || 
-                    StemmerUtil.EndsWith(s, len, "ρπ") || 
-                    StemmerUtil.EndsWith(s, len, "φρ") || 
-                    StemmerUtil.EndsWith(s, len, "πρ") || 
-                    StemmerUtil.EndsWith(s, len, "λοχ") || 
+                bool cond1 = exc15a.Contains(s, 0, len) ||
+                    StemmerUtil.EndsWith(s, len, "οφ") ||
+                    StemmerUtil.EndsWith(s, len, "πελ") ||
+                    StemmerUtil.EndsWith(s, len, "χορτ") ||
+                    StemmerUtil.EndsWith(s, len, "λλ") ||
+                    StemmerUtil.EndsWith(s, len, "σφ") ||
+                    StemmerUtil.EndsWith(s, len, "ρπ") ||
+                    StemmerUtil.EndsWith(s, len, "φρ") ||
+                    StemmerUtil.EndsWith(s, len, "πρ") ||
+                    StemmerUtil.EndsWith(s, len, "λοχ") ||
                     StemmerUtil.EndsWith(s, len, "σμην");
 
                 bool cond2 = exc15b.Contains(s, 0, len) || StemmerUtil.EndsWith(s, len, "κολλ");
@@ -861,105 +861,105 @@ namespace Lucene.Net.Analysis.El
                 return len - 9;
             }
 
-            if (len > 8 && (StemmerUtil.EndsWith(s, len, "ιομασταν") || 
-                StemmerUtil.EndsWith(s, len, "ιοσασταν") || 
-                StemmerUtil.EndsWith(s, len, "ιουμαστε") || 
+            if (len > 8 && (StemmerUtil.EndsWith(s, len, "ιομασταν") ||
+                StemmerUtil.EndsWith(s, len, "ιοσασταν") ||
+                StemmerUtil.EndsWith(s, len, "ιουμαστε") ||
                 StemmerUtil.EndsWith(s, len, "οντουσαν")))
             {
                 return len - 8;
             }
 
-            if (len > 7 && (StemmerUtil.EndsWith(s, len, "ιεμαστε") || 
-                StemmerUtil.EndsWith(s, len, "ιεσαστε") || 
-                StemmerUtil.EndsWith(s, len, "ιομουνα") || 
-                StemmerUtil.EndsWith(s, len, "ιοσαστε") || 
-                StemmerUtil.EndsWith(s, len, "ιοσουνα") || 
-                StemmerUtil.EndsWith(s, len, "ιουνται") || 
-                StemmerUtil.EndsWith(s, len, "ιουνταν") || 
-                StemmerUtil.EndsWith(s, len, "ηθηκατε") || 
-                StemmerUtil.EndsWith(s, len, "ομασταν") || 
-                StemmerUtil.EndsWith(s, len, "οσασταν") || 
+            if (len > 7 && (StemmerUtil.EndsWith(s, len, "ιεμαστε") ||
+                StemmerUtil.EndsWith(s, len, "ιεσαστε") ||
+                StemmerUtil.EndsWith(s, len, "ιομουνα") ||
+                StemmerUtil.EndsWith(s, len, "ιοσαστε") ||
+                StemmerUtil.EndsWith(s, len, "ιοσουνα") ||
+                StemmerUtil.EndsWith(s, len, "ιουνται") ||
+                StemmerUtil.EndsWith(s, len, "ιουνταν") ||
+                StemmerUtil.EndsWith(s, len, "ηθηκατε") ||
+                StemmerUtil.EndsWith(s, len, "ομασταν") ||
+                StemmerUtil.EndsWith(s, len, "οσασταν") ||
                 StemmerUtil.EndsWith(s, len, "ουμαστε")))
             {
                 return len - 7;
             }
 
-            if (len > 6 && (StemmerUtil.EndsWith(s, len, "ιομουν") || 
-                StemmerUtil.EndsWith(s, len, "ιονταν") || 
-                StemmerUtil.EndsWith(s, len, "ιοσουν") || 
-                StemmerUtil.EndsWith(s, len, "ηθειτε") || 
-                StemmerUtil.EndsWith(s, len, "ηθηκαν") || 
-                StemmerUtil.EndsWith(s, len, "ομουνα") || 
-                StemmerUtil.EndsWith(s, len, "οσαστε") || 
-                StemmerUtil.EndsWith(s, len, "οσουνα") || 
-                StemmerUtil.EndsWith(s, len, "ουνται") || 
-                StemmerUtil.EndsWith(s, len, "ουνταν") || 
+            if (len > 6 && (StemmerUtil.EndsWith(s, len, "ιομουν") ||
+                StemmerUtil.EndsWith(s, len, "ιονταν") ||
+                StemmerUtil.EndsWith(s, len, "ιοσουν") ||
+                StemmerUtil.EndsWith(s, len, "ηθειτε") ||
+                StemmerUtil.EndsWith(s, len, "ηθηκαν") ||
+                StemmerUtil.EndsWith(s, len, "ομουνα") ||
+                StemmerUtil.EndsWith(s, len, "οσαστε") ||
+                StemmerUtil.EndsWith(s, len, "οσουνα") ||
+                StemmerUtil.EndsWith(s, len, "ουνται") ||
+                StemmerUtil.EndsWith(s, len, "ουνταν") ||
                 StemmerUtil.EndsWith(s, len, "ουσατε")))
             {
                 return len - 6;
             }
 
-            if (len > 5 && (StemmerUtil.EndsWith(s, len, "αγατε") || 
-                StemmerUtil.EndsWith(s, len, "ιεμαι") || 
-                StemmerUtil.EndsWith(s, len, "ιεται") || 
-                StemmerUtil.EndsWith(s, len, "ιεσαι") || 
-                StemmerUtil.EndsWith(s, len, "ιοταν") || 
-                StemmerUtil.EndsWith(s, len, "ιουμα") || 
-                StemmerUtil.EndsWith(s, len, "ηθεισ") || 
-                StemmerUtil.EndsWith(s, len, "ηθουν") || 
-                StemmerUtil.EndsWith(s, len, "ηκατε") || 
-                StemmerUtil.EndsWith(s, len, "ησατε") || 
-                StemmerUtil.EndsWith(s, len, "ησουν") || 
+            if (len > 5 && (StemmerUtil.EndsWith(s, len, "αγατε") ||
+                StemmerUtil.EndsWith(s, len, "ιεμαι") ||
+                StemmerUtil.EndsWith(s, len, "ιεται") ||
+                StemmerUtil.EndsWith(s, len, "ιεσαι") ||
+                StemmerUtil.EndsWith(s, len, "ιοταν") ||
+                StemmerUtil.EndsWith(s, len, "ιουμα") ||
+                StemmerUtil.EndsWith(s, len, "ηθεισ") ||
+                StemmerUtil.EndsWith(s, len, "ηθουν") ||
+                StemmerUtil.EndsWith(s, len, "ηκατε") ||
+                StemmerUtil.EndsWith(s, len, "ησατε") ||
+                StemmerUtil.EndsWith(s, len, "ησουν") ||
                 StemmerUtil.EndsWith(s, len, "ομουν") ||
-                StemmerUtil.EndsWith(s, len, "ονται") || 
-                StemmerUtil.EndsWith(s, len, "ονταν") || 
-                StemmerUtil.EndsWith(s, len, "οσουν") || 
-                StemmerUtil.EndsWith(s, len, "ουμαι") || 
+                StemmerUtil.EndsWith(s, len, "ονται") ||
+                StemmerUtil.EndsWith(s, len, "ονταν") ||
+                StemmerUtil.EndsWith(s, len, "οσουν") ||
+                StemmerUtil.EndsWith(s, len, "ουμαι") ||
                 StemmerUtil.EndsWith(s, len, "ουσαν")))
             {
                 return len - 5;
             }
 
-            if (len > 4 && (StemmerUtil.EndsWith(s, len, "αγαν") || 
-                StemmerUtil.EndsWith(s, len, "αμαι") || 
-                StemmerUtil.EndsWith(s, len, "ασαι") || 
-                StemmerUtil.EndsWith(s, len, "αται") || 
-                StemmerUtil.EndsWith(s, len, "ειτε") || 
-                StemmerUtil.EndsWith(s, len, "εσαι") || 
-                StemmerUtil.EndsWith(s, len, "εται") || 
-                StemmerUtil.EndsWith(s, len, "ηδεσ") || 
-                StemmerUtil.EndsWith(s, len, "ηδων") || 
-                StemmerUtil.EndsWith(s, len, "ηθει") || 
-                StemmerUtil.EndsWith(s, len, "ηκαν") || 
-                StemmerUtil.EndsWith(s, len, "ησαν") || 
-                StemmerUtil.EndsWith(s, len, "ησει") || 
-                StemmerUtil.EndsWith(s, len, "ησεσ") || 
-                StemmerUtil.EndsWith(s, len, "ομαι") || 
+            if (len > 4 && (StemmerUtil.EndsWith(s, len, "αγαν") ||
+                StemmerUtil.EndsWith(s, len, "αμαι") ||
+                StemmerUtil.EndsWith(s, len, "ασαι") ||
+                StemmerUtil.EndsWith(s, len, "αται") ||
+                StemmerUtil.EndsWith(s, len, "ειτε") ||
+                StemmerUtil.EndsWith(s, len, "εσαι") ||
+                StemmerUtil.EndsWith(s, len, "εται") ||
+                StemmerUtil.EndsWith(s, len, "ηδεσ") ||
+                StemmerUtil.EndsWith(s, len, "ηδων") ||
+                StemmerUtil.EndsWith(s, len, "ηθει") ||
+                StemmerUtil.EndsWith(s, len, "ηκαν") ||
+                StemmerUtil.EndsWith(s, len, "ησαν") ||
+                StemmerUtil.EndsWith(s, len, "ησει") ||
+                StemmerUtil.EndsWith(s, len, "ησεσ") ||
+                StemmerUtil.EndsWith(s, len, "ομαι") ||
                 StemmerUtil.EndsWith(s, len, "οταν")))
             {
                 return len - 4;
             }
 
-            if (len > 3 && (StemmerUtil.EndsWith(s, len, "αει") || 
-                StemmerUtil.EndsWith(s, len, "εισ") || 
-                StemmerUtil.EndsWith(s, len, "ηθω") || 
-                StemmerUtil.EndsWith(s, len, "ησω") || 
-                StemmerUtil.EndsWith(s, len, "ουν") || 
+            if (len > 3 && (StemmerUtil.EndsWith(s, len, "αει") ||
+                StemmerUtil.EndsWith(s, len, "εισ") ||
+                StemmerUtil.EndsWith(s, len, "ηθω") ||
+                StemmerUtil.EndsWith(s, len, "ησω") ||
+                StemmerUtil.EndsWith(s, len, "ουν") ||
                 StemmerUtil.EndsWith(s, len, "ουσ")))
             {
                 return len - 3;
             }
 
-            if (len > 2 && (StemmerUtil.EndsWith(s, len, "αν") || 
-                StemmerUtil.EndsWith(s, len, "ασ") || 
-                StemmerUtil.EndsWith(s, len, "αω") || 
-                StemmerUtil.EndsWith(s, len, "ει") || 
-                StemmerUtil.EndsWith(s, len, "εσ") || 
-                StemmerUtil.EndsWith(s, len, "ησ") || 
-                StemmerUtil.EndsWith(s, len, "οι") || 
-                StemmerUtil.EndsWith(s, len, "οσ") || 
-                StemmerUtil.EndsWith(s, len, "ου") || 
-                StemmerUtil.EndsWith(s, len, "υσ") || 
+            if (len > 2 && (StemmerUtil.EndsWith(s, len, "αν") ||
+                StemmerUtil.EndsWith(s, len, "ασ") ||
+                StemmerUtil.EndsWith(s, len, "αω") ||
+                StemmerUtil.EndsWith(s, len, "ει") ||
+                StemmerUtil.EndsWith(s, len, "εσ") ||
+                StemmerUtil.EndsWith(s, len, "ησ") ||
+                StemmerUtil.EndsWith(s, len, "οι") ||
+                StemmerUtil.EndsWith(s, len, "οσ") ||
+                StemmerUtil.EndsWith(s, len, "ου") ||
+                StemmerUtil.EndsWith(s, len, "υσ") ||
                 StemmerUtil.EndsWith(s, len, "ων")))
             {
                 return len - 2;
@@ -975,17 +975,17 @@ namespace Lucene.Net.Analysis.El
 
         private static int Rule22(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
-            if (StemmerUtil.EndsWith(s, len, "εστερ") || 
+            if (StemmerUtil.EndsWith(s, len, "εστερ") ||
                 StemmerUtil.EndsWith(s, len, "εστατ"))
             {
                 return len - 5;
             }
 
-            if (StemmerUtil.EndsWith(s, len, "οτερ") || 
-                StemmerUtil.EndsWith(s, len, "οτατ") || 
-                StemmerUtil.EndsWith(s, len, "υτερ") || 
-                StemmerUtil.EndsWith(s, len, "υτατ") || 
-                StemmerUtil.EndsWith(s, len, "ωτερ") || 
+            if (StemmerUtil.EndsWith(s, len, "οτερ") ||
+                StemmerUtil.EndsWith(s, len, "οτατ") ||
+                StemmerUtil.EndsWith(s, len, "υτερ") ||
+                StemmerUtil.EndsWith(s, len, "υτατ") ||
+                StemmerUtil.EndsWith(s, len, "ωτερ") ||
                 StemmerUtil.EndsWith(s, len, "ωτατ"))
             {
                 return len - 4;
@@ -994,39 +994,40 @@ namespace Lucene.Net.Analysis.El
             return len;
         }
 
-        /// <summary>
-        /// Checks if the word contained in the leading portion of char[] array , 
-        /// ends with the suffix given as parameter.
-        /// </summary>
-        /// <param name="s"> A char[] array that represents a word. </param>
-        /// <param name="len"> The length of the char[] array. </param>
-        /// <param name="suffix"> A <see cref="string"/> object to check if the word given ends with these characters. </param>
-        /// <returns> True if the word ends with the suffix given , false otherwise. </returns>
-        private static bool EndsWith(char[] s, int len, string suffix) // LUCENENET: CA1822: Mark members as static
-        {
-            int suffixLen = suffix.Length;
-            if (suffixLen > len)
-            {
-                return false;
-            }
-            for (int i = suffixLen - 1; i >= 0; i--)
-            {
-                if (s[len - (suffixLen - i)] != suffix[i])
-                {
-                    return false;
-                }
-            }
+        // LUCENENET: commented out unused private method
+        // /// <summary>
+        // /// Checks if the word contained in the leading portion of char[] array ,
+        // /// ends with the suffix given as parameter.
+        // /// </summary>
+        // /// <param name="s"> A char[] array that represents a word. </param>
+        // /// <param name="len"> The length of the char[] array. </param>
+        // /// <param name="suffix"> A <see cref="string"/> object to check if the word given ends with these characters. </param>
+        // /// <returns> True if the word ends with the suffix given , false otherwise. </returns>
+        // private static bool EndsWith(char[] s, int len, string suffix) // LUCENENET: CA1822: Mark members as static
+        // {
+        //     int suffixLen = suffix.Length;
+        //     if (suffixLen > len)
+        //     {
+        //         return false;
+        //     }
+        //     for (int i = suffixLen - 1; i >= 0; i--)
+        //     {
+        //         if (s[len - (suffixLen - i)] != suffix[i])
+        //         {
+        //             return false;
+        //         }
+        //     }
+        //
+        //     return true;
+        // }
 
-            return true;
-        }
-
         /// <summary>
-        /// Checks if the word contained in the leading portion of <see cref="T:char[]"/> array , 
+        /// Checks if the word contained in the leading portion of <see cref="T:char[]"/> array ,
         /// ends with a Greek vowel.
         /// </summary>
         /// <param name="s"> A <see cref="T:char[]"/> array that represents a word. </param>
         /// <param name="len"> The length of the <see cref="T:char[]"/> array. </param>
-        /// <returns> True if the word contained in the leading portion of <see cref="T:char[]"/> array , 
+        /// <returns> True if the word contained in the leading portion of <see cref="T:char[]"/> array ,
         /// ends with a vowel , false otherwise. </returns>
         private static bool EndsWithVowel(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {
@@ -1050,12 +1051,12 @@ namespace Lucene.Net.Analysis.El
         }
 
         /// <summary>
-        /// Checks if the word contained in the leading portion of <see cref="T:char[]"/> array , 
+        /// Checks if the word contained in the leading portion of <see cref="T:char[]"/> array ,
         /// ends with a Greek vowel.
         /// </summary>
         /// <param name="s"> A <see cref="T:char[]"/> array that represents a word. </param>
         /// <param name="len"> The length of the <see cref="T:char[]"/> array. </param>
-        /// <returns> True if the word contained in the leading portion of <see cref="T:char[]"/> array , 
+        /// <returns> True if the word contained in the leading portion of <see cref="T:char[]"/> array ,
         /// ends with a vowel , false otherwise. </returns>
         private static bool EndsWithVowelNoY(char[] s, int len) // LUCENENET: CA1822: Mark members as static
         {

--- a/src/Lucene.Net.Analysis.Common/Analysis/En/KStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/En/KStemmer.cs
@@ -359,7 +359,8 @@ namespace Lucene.Net.Analysis.En
         // private void initializeStemHash() { if (maxCacheSize > 0) cache = new
         // CharArrayDictionary<String>(maxCacheSize,false); }
 
-        private char FinalChar => word[k];
+        // LUCENENET: commented out unused private property
+        // private char FinalChar => word[k];
 
         private char PenultChar => word[k - 1];
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/HunspellStemFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/HunspellStemFilterFactory.cs
@@ -32,12 +32,12 @@ namespace Lucene.Net.Analysis.Hunspell
     /// <code>
     /// &lt;filter class=&quot;solr.HunspellStemFilterFactory&quot;
     ///         dictionary=&quot;en_GB.dic,my_custom.dic&quot;
-    ///         affix=&quot;en_GB.aff&quot; 
+    ///         affix=&quot;en_GB.aff&quot;
     ///         ignoreCase=&quot;false&quot;
     ///         longestOnly=&quot;false&quot; /&gt;</code>
     /// Both parameters dictionary and affix are mandatory.
     /// Dictionaries for many languages are available through the OpenOffice project.
-    /// 
+    ///
     /// See <a href="http://wiki.apache.org/solr/Hunspell">http://wiki.apache.org/solr/Hunspell</a>
     /// @lucene.experimental
     /// </summary>
@@ -45,7 +45,7 @@ namespace Lucene.Net.Analysis.Hunspell
     {
         private const string PARAM_DICTIONARY = "dictionary";
         private const string PARAM_AFFIX = "affix";
-        private const string PARAM_RECURSION_CAP = "recursionCap";
+        // private const string PARAM_RECURSION_CAP = "recursionCap"; // LUCENENET: commented out unused private constant
         private const string PARAM_IGNORE_CASE = "ignoreCase";
         private const string PARAM_LONGEST_ONLY = "longestOnly";
 
@@ -57,7 +57,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
         /// <summary>
         /// Creates a new <see cref="HunspellStemFilterFactory"/> </summary>
-        public HunspellStemFilterFactory(IDictionary<string, string> args) 
+        public HunspellStemFilterFactory(IDictionary<string, string> args)
             : base(args)
         {
             dictionaryFiles = Require(args, PARAM_DICTIONARY);
@@ -67,7 +67,7 @@ namespace Lucene.Net.Analysis.Hunspell
             // this isnt necessary: we properly load all dictionaries.
             // but recognize and ignore for back compat
             GetBoolean(args, "strictAffixParsing", true);
-            // this isn't necessary: multi-stage stripping is fixed and 
+            // this isn't necessary: multi-stage stripping is fixed and
             // flags like COMPLEXPREFIXES in the data itself control this.
             // but recognize and ignore for back compat
             GetInt32(args, "recursionCap", 0);

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/ArmenianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/ArmenianStemmer.cs
@@ -248,12 +248,13 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p2;
         private int I_pV;
 
-        private void copy_from(ArmenianStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_pV = other.I_pV;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(ArmenianStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_pV = other.I_pV;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/BasqueStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/BasqueStemmer.cs
@@ -478,13 +478,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p1;
         private int I_pV;
 
-        private void copy_from(BasqueStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            I_pV = other.I_pV;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(BasqueStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     I_pV = other.I_pV;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/CatalanStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/CatalanStemmer.cs
@@ -617,12 +617,13 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p2;
         private int I_p1;
 
-        private void copy_from(CatalanStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(CatalanStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/DanishStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/DanishStemmer.cs
@@ -100,13 +100,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p1;
         private StringBuilder S_ch = new StringBuilder();
 
-        private void copy_from(DanishStemmer other)
-        {
-            I_x = other.I_x;
-            I_p1 = other.I_p1;
-            S_ch = other.S_ch;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(DanishStemmer other)
+        // {
+        //     I_x = other.I_x;
+        //     I_p1 = other.I_p1;
+        //     S_ch = other.S_ch;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/DutchStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/DutchStemmer.cs
@@ -100,13 +100,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p1;
         private bool B_e_found;
 
-        private void copy_from(DutchStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            B_e_found = other.B_e_found;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(DutchStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     B_e_found = other.B_e_found;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_prelude()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/EnglishStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/EnglishStemmer.cs
@@ -195,13 +195,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p2;
         private int I_p1;
 
-        private void copy_from(EnglishStemmer other)
-        {
-            B_Y_found = other.B_Y_found;
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(EnglishStemmer other)
+        // {
+        //     B_Y_found = other.B_Y_found;
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_prelude()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/FinnishStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/FinnishStemmer.cs
@@ -173,14 +173,15 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p2;
         private int I_p1;
 
-        private void copy_from(FinnishStemmer other)
-        {
-            B_ending_removed = other.B_ending_removed;
-            S_x = other.S_x;
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(FinnishStemmer other)
+        // {
+        //     B_ending_removed = other.B_ending_removed;
+        //     S_x = other.S_x;
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/FrenchStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/FrenchStemmer.cs
@@ -219,13 +219,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p1;
         private int I_pV;
 
-        private void copy_from(FrenchStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            I_pV = other.I_pV;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(FrenchStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     I_pV = other.I_pV;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_prelude()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/German2Stemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/German2Stemmer.cs
@@ -101,13 +101,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p2;
         private int I_p1;
 
-        private void copy_from(German2Stemmer other)
-        {
-            I_x = other.I_x;
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(German2Stemmer other)
+        // {
+        //     I_x = other.I_x;
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_prelude()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/GermanStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/GermanStemmer.cs
@@ -92,13 +92,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p2;
         private int I_p1;
 
-        private void copy_from(GermanStemmer other)
-        {
-            I_x = other.I_x;
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(GermanStemmer other)
+        // {
+        //     I_x = other.I_x;
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_prelude()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/HungarianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/HungarianStemmer.cs
@@ -262,11 +262,12 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
 
         private int I_p1;
 
-        private void copy_from(HungarianStemmer other)
-        {
-            I_p1 = other.I_p1;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(HungarianStemmer other)
+        // {
+        //     I_p1 = other.I_p1;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/IrishStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/IrishStemmer.cs
@@ -135,13 +135,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p1;
         private int I_pV;
 
-        private void copy_from(IrishStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            I_pV = other.I_pV;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(IrishStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     I_pV = other.I_pV;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/ItalianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/ItalianStemmer.cs
@@ -271,13 +271,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p1;
         private int I_pV;
 
-        private void copy_from(ItalianStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            I_pV = other.I_pV;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(ItalianStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     I_pV = other.I_pV;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_prelude()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/KpStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/KpStemmer.cs
@@ -160,17 +160,18 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_x;
         private StringBuilder S_ch = new StringBuilder();
 
-        private void copy_from(KpStemmer other)
-        {
-            B_GE_removed = other.B_GE_removed;
-            B_stemmed = other.B_stemmed;
-            B_Y_found = other.B_Y_found;
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            I_x = other.I_x;
-            S_ch = other.S_ch;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(KpStemmer other)
+        // {
+        //     B_GE_removed = other.B_GE_removed;
+        //     B_stemmed = other.B_stemmed;
+        //     B_Y_found = other.B_Y_found;
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     I_x = other.I_x;
+        //     S_ch = other.S_ch;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_R1()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/LovinsStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/LovinsStemmer.cs
@@ -399,10 +399,11 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
                     new Among ( "yz", -1, 34 )
                 };
 
-        private void copy_from(LovinsStemmer other)
-        {
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(LovinsStemmer other)
+        // {
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_A()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/NorwegianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/NorwegianStemmer.cs
@@ -98,12 +98,13 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_x;
         private int I_p1;
 
-        private void copy_from(NorwegianStemmer other)
-        {
-            I_x = other.I_x;
-            I_p1 = other.I_p1;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(NorwegianStemmer other)
+        // {
+        //     I_x = other.I_x;
+        //     I_p1 = other.I_p1;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/PorterStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/PorterStemmer.cs
@@ -134,13 +134,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p2;
         private int I_p1;
 
-        private void copy_from(PorterStemmer other)
-        {
-            B_Y_found = other.B_Y_found;
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(PorterStemmer other)
+        // {
+        //     B_Y_found = other.B_Y_found;
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     base.CopyFrom(other);
+        // }
 
         [ExceptionToNetNumericConvention]
         private bool r_shortv()

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/PortugueseStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/PortugueseStemmer.cs
@@ -265,13 +265,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p1;
         private int I_pV;
 
-        private void copy_from(PortugueseStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            I_pV = other.I_pV;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(PortugueseStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     I_pV = other.I_pV;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_prelude()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/RomanianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/RomanianStemmer.cs
@@ -291,14 +291,15 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p1;
         private int I_pV;
 
-        private void copy_from(RomanianStemmer other)
-        {
-            B_standard_suffix_removed = other.B_standard_suffix_removed;
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            I_pV = other.I_pV;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(RomanianStemmer other)
+        // {
+        //     B_standard_suffix_removed = other.B_standard_suffix_removed;
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     I_pV = other.I_pV;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_prelude()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/RussianStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/RussianStemmer.cs
@@ -202,12 +202,13 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p2;
         private int I_pV;
 
-        private void copy_from(RussianStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_pV = other.I_pV;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(RussianStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_pV = other.I_pV;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/SpanishStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/SpanishStemmer.cs
@@ -278,13 +278,14 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_p1;
         private int I_pV;
 
-        private void copy_from(SpanishStemmer other)
-        {
-            I_p2 = other.I_p2;
-            I_p1 = other.I_p1;
-            I_pV = other.I_pV;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(SpanishStemmer other)
+        // {
+        //     I_p2 = other.I_p2;
+        //     I_p1 = other.I_p1;
+        //     I_pV = other.I_pV;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/SwedishStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/SwedishStemmer.cs
@@ -105,12 +105,13 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private int I_x;
         private int I_p1;
 
-        private void copy_from(SwedishStemmer other)
-        {
-            I_x = other.I_x;
-            I_p1 = other.I_p1;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(SwedishStemmer other)
+        // {
+        //     I_x = other.I_x;
+        //     I_p1 = other.I_p1;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_mark_regions()
         {

--- a/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/TurkishStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Tartarus/Snowball/Ext/TurkishStemmer.cs
@@ -251,12 +251,13 @@ namespace Lucene.Net.Tartarus.Snowball.Ext
         private bool B_continue_stemming_noun_suffixes;
         private int I_strlen;
 
-        private void copy_from(TurkishStemmer other)
-        {
-            B_continue_stemming_noun_suffixes = other.B_continue_stemming_noun_suffixes;
-            I_strlen = other.I_strlen;
-            base.CopyFrom(other);
-        }
+        // LUCENENET: commented out unused private method
+        // private void copy_from(TurkishStemmer other)
+        // {
+        //     B_continue_stemming_noun_suffixes = other.B_continue_stemming_noun_suffixes;
+        //     I_strlen = other.I_strlen;
+        //     base.CopyFrom(other);
+        // }
 
         private bool r_check_vowel_harmony()
         {

--- a/src/Lucene.Net.Analysis.Kuromoji/Support/Util/EncodingProviderInitializer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Support/Util/EncodingProviderInitializer.cs
@@ -15,6 +15,7 @@ namespace Lucene.Net.Util
     {
         private static int initialized;
 
+#if FEATURE_ENCODINGPROVIDERS
         private static bool IsNetFramework =>
 #if NETSTANDARD2_0
             RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
@@ -22,6 +23,7 @@ namespace Lucene.Net.Util
             true;
 #else
             false;
+#endif
 #endif
 
         [Conditional("FEATURE_ENCODINGPROVIDERS")]

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
@@ -157,19 +157,19 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             return rules;
         }
 
-#pragma warning disable IDE0051 // Remove unused private members
-        private static bool Contains(ICharSequence chars, char input)
-#pragma warning restore IDE0051 // Remove unused private members
-        {
-            for (int i = 0; i < chars.Length; i++)
-            {
-                if (chars[i] == input)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
+        // LUCENENET: commented out unused private method
+        // private static bool Contains(ICharSequence chars, char input)
+        // {
+        //     for (int i = 0; i < chars.Length; i++)
+        //     {
+        //         if (chars[i] == input)
+        //         {
+        //             return true;
+        //         }
+        //     }
+        //     return false;
+        // }
+
         private static bool Contains(string chars, char input)
         {
             for (int i = 0; i < chars.Length; i++)
@@ -181,19 +181,19 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             }
             return false;
         }
-#pragma warning disable IDE0051 // Remove unused private members
-        private static bool Contains(StringBuilder chars, char input)
-#pragma warning restore IDE0051 // Remove unused private members
-        {
-            for (int i = 0; i < chars.Length; i++)
-            {
-                if (chars[i] == input)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
+
+        // LUCENENET: commented out unused private method
+        // private static bool Contains(StringBuilder chars, char input)
+        // {
+        //     for (int i = 0; i < chars.Length; i++)
+        //     {
+        //         if (chars[i] == input)
+        //         {
+        //             return true;
+        //         }
+        //     }
+        //     return false;
+        // }
 
         private static string CreateResourceName(NameType nameType, RuleType rt, string lang)
         {

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
@@ -157,43 +157,19 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             return rules;
         }
 
-        // LUCENENET: commented out unused private method
-        // private static bool Contains(ICharSequence chars, char input)
-        // {
-        //     for (int i = 0; i < chars.Length; i++)
-        //     {
-        //         if (chars[i] == input)
-        //         {
-        //             return true;
-        //         }
-        //     }
-        //     return false;
-        // }
-
-        private static bool Contains(string chars, char input)
+        private static bool Contains(ReadOnlySpan<char> chars, char input)
         {
-            for (int i = 0; i < chars.Length; i++)
+            // LUCENENET TODO: change this implementation to use MemoryExtensions.Contains with a polyfill for net462.
+            foreach (var c in chars)
             {
-                if (chars[i] == input)
+                if (c == input)
                 {
                     return true;
                 }
             }
+
             return false;
         }
-
-        // LUCENENET: commented out unused private method
-        // private static bool Contains(StringBuilder chars, char input)
-        // {
-        //     for (int i = 0; i < chars.Length; i++)
-        //     {
-        //         if (chars[i] == input)
-        //         {
-        //             return true;
-        //         }
-        //     }
-        //     return false;
-        // }
 
         private static string CreateResourceName(NameType nameType, RuleType rt, string lang)
         {
@@ -660,13 +636,13 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                             // exact match
                             return new RPatternHelper(isMatchSB: (input) =>
                             {
-                                return input.Length == 1 && Contains(bContent, input[0]) == shouldMatch;
+                                return input.Length == 1 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
                             }, isMatchStr: (input) =>
                             {
-                                return input.Length == 1 && Contains(bContent, input[0]) == shouldMatch;
+                                return input.Length == 1 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
                             }, isMatchCS: (input) =>
                             {
-                                return input.Length == 1 && Contains(bContent, input[0]) == shouldMatch;
+                                return input.Length == 1 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
                             });
                         }
                         else if (startsWith)
@@ -674,13 +650,13 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                             // first char
                             return new RPatternHelper(isMatchSB: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent, input[0]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
                             }, isMatchStr: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent, input[0]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
                             }, isMatchCS: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent, input[0]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
                             });
                         }
                         else if (endsWith)
@@ -688,13 +664,13 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                             // last char
                             return new RPatternHelper(isMatchSB: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent.AsSpan(), input[input.Length - 1]) == shouldMatch;
                             }, isMatchStr: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent.AsSpan(), input[input.Length - 1]) == shouldMatch;
                             }, isMatchCS: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent.AsSpan(), input[input.Length - 1]) == shouldMatch;
                             });
                         }
                     }

--- a/src/Lucene.Net.Analysis.SmartCn/Support/Util/EncodingProviderInitializer.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Support/Util/EncodingProviderInitializer.cs
@@ -15,6 +15,7 @@ namespace Lucene.Net.Util
     {
         private static int initialized;
 
+#if FEATURE_ENCODINGPROVIDERS
         private static bool IsNetFramework =>
 #if NETSTANDARD2_0
             RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
@@ -22,6 +23,7 @@ namespace Lucene.Net.Util
             true;
 #else
             false;
+#endif
 #endif
 
         [Conditional("FEATURE_ENCODINGPROVIDERS")]

--- a/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
@@ -2414,9 +2414,11 @@ namespace Lucene.Net.Codecs.Memory
             [SuppressMessage("Microsoft.Performance", "CA1819", Justification = "Lucene's design requires some writable array properties")]
             public int[][] Positions => positions;
 
-            public int PosJump => posJump;
+            // LUCENENET: commented out unused property in private class
+            // public int PosJump => posJump;
 
-            public IBits LiveDocs => liveDocs;
+            // LUCENENET: commented out unused property in private class
+            // public IBits LiveDocs => liveDocs;
 
             public DocsAndPositionsEnum Reset(int[] docIDs, int[] freqs, int[][] positions, byte[][][] payloads)
             {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
@@ -530,17 +530,18 @@ namespace Lucene.Net.Codecs.SimpleText
             public override long GetCost() => cost;
         }
 
-        internal class TermData
-        {
-            public long DocsStart { get; set; }
-            public int DocFreq { get; set; }
-
-            public TermData(long docsStart, int docFreq)
-            {
-                DocsStart = docsStart;
-                DocFreq = docFreq;
-            }
-        }
+        // LUCENENET: commented out unused internal class
+        // internal class TermData
+        // {
+        //     public long DocsStart { get; set; }
+        //     public int DocFreq { get; set; }
+        //
+        //     public TermData(long docsStart, int docFreq)
+        //     {
+        //         DocsStart = docsStart;
+        //         DocFreq = docFreq;
+        //     }
+        // }
 
         private class SimpleTextTerms : Terms
         {

--- a/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.MemoryIndexReader.cs
@@ -513,11 +513,12 @@ namespace Lucene.Net.Index.Memory
                 }
             }
 
-            internal IndexSearcher Searcher
-            {
-                get => this.searcher; // LUCENENET specific: added getter per MSDN guidelines
-                set => this.searcher = value;
-            }
+            // LUCENENET: commented out unused internal property
+            // internal IndexSearcher Searcher
+            // {
+            //     get => this.searcher; // LUCENENET specific: added getter per MSDN guidelines
+            //     set => this.searcher = value;
+            // }
 
             [SuppressMessage("Style", "IDE0025:Use expression body for properties", Justification = "Multiple lines")]
             public override int NumDocs

--- a/src/Lucene.Net.Queries/Function/BoostedQuery.cs
+++ b/src/Lucene.Net.Queries/Function/BoostedQuery.cs
@@ -176,19 +176,20 @@ namespace Lucene.Net.Queries.Function
                 return new JCG.List<ChildScorer> { new ChildScorer(scorer, "CUSTOM") };
             }
 
-            public Explanation Explain(int doc)
-            {
-                var subQueryExpl = weight.qWeight.Explain(readerContext, doc);
-                if (!subQueryExpl.IsMatch)
-                {
-                    return subQueryExpl;
-                }
-                float sc = subQueryExpl.Value * vals.SingleVal(doc);
-                Explanation res = new ComplexExplanation(true, sc, outerInstance.ToString() + ", product of:");
-                res.AddDetail(subQueryExpl);
-                res.AddDetail(vals.Explain(doc));
-                return res;
-            }
+            // LUCENENET: commented out unused method in private class
+            // public Explanation Explain(int doc)
+            // {
+            //     var subQueryExpl = weight.qWeight.Explain(readerContext, doc);
+            //     if (!subQueryExpl.IsMatch)
+            //     {
+            //         return subQueryExpl;
+            //     }
+            //     float sc = subQueryExpl.Value * vals.SingleVal(doc);
+            //     Explanation res = new ComplexExplanation(true, sc, outerInstance.ToString() + ", product of:");
+            //     res.AddDetail(subQueryExpl);
+            //     res.AddDetail(vals.Explain(doc));
+            //     return res;
+            // }
 
             public override long GetCost()
             {

--- a/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserTokenManager.cs
@@ -40,10 +40,12 @@ namespace Lucene.Net.QueryParsers.Classic
             }
         }
 
-        private int JjStartNfa_2(int pos, long active0)
-        {
-            return JjMoveNfa_2(JjStopStringLiteralDfa_2(pos, active0), pos + 1);
-        }
+        // LUCENENET: commented out unused private method
+        // private int JjStartNfa_2(int pos, long active0)
+        // {
+        //     return JjMoveNfa_2(JjStopStringLiteralDfa_2(pos, active0), pos + 1);
+        // }
+
         private int JjStopAtPos(int pos, int kind)
         {
             jjmatchedKind = kind;

--- a/src/Lucene.Net.QueryParser/Surround/Parser/QueryParserTokenManager.cs
+++ b/src/Lucene.Net.QueryParser/Surround/Parser/QueryParserTokenManager.cs
@@ -40,10 +40,13 @@ namespace Lucene.Net.QueryParsers.Surround.Parser
                     return -1;
             }
         }
-        private int JjStartNfa_1(int pos, long active0)
-        {
-            return JjMoveNfa_1(JjStopStringLiteralDfa_1(pos, active0), pos + 1);
-        }
+
+        // LUCENENET: commented out unused private method
+        // private int JjStartNfa_1(int pos, long active0)
+        // {
+        //     return JjMoveNfa_1(JjStopStringLiteralDfa_1(pos, active0), pos + 1);
+        // }
+
         private int JjStopAtPos(int pos, int kind)
         {
             jjmatchedKind = kind;

--- a/src/Lucene.Net/Index/Term.cs
+++ b/src/Lucene.Net/Index/Term.cs
@@ -37,7 +37,9 @@ namespace Lucene.Net.Index
     /// </summary>
     public sealed class Term : IComparable<Term>, IEquatable<Term> // LUCENENET specific - class implements IEquatable<T>
     {
+#if FEATURE_UTF8_TOUTF16
         private const int CharStackBufferSize = 64;
+#endif
 
         /// <summary>
         /// Constructs a <see cref="Term"/> with the given field and bytes.

--- a/src/Lucene.Net/Support/Collections.cs
+++ b/src/Lucene.Net/Support/Collections.cs
@@ -276,11 +276,6 @@ namespace Lucene.Net.Support
             {
                 return cmp.GetHashCode() ^ int.MinValue;
             }
-
-            public IComparer<T> Reversed()
-            {
-                return cmp;
-            }
         }
 
         #endregion ReverseComparer2


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Remove unused private members

Fixes #669

## Description

Removes many unused members found by SonarQube, except for those that have justifications.