### PR TITLE
Optimize StemmerUtil for `ReadOnlySpan<char>`/`Span<char>`, #1140

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
@@ -62,7 +62,7 @@ namespace Lucene.Net.Analysis.Util
             }
 
             // LUCENENET: use more efficient implementation in MemoryExtensions
-            return s.StartsWith(prefix);
+            return s.StartsWith(prefix, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Lucene.Net.Analysis.Util
             }
 
             // LUCENENET: use more efficient implementation in MemoryExtensions
-            return s.Slice(0, len).EndsWith(suffix);
+            return s.Slice(0, len).EndsWith(suffix, StringComparison.Ordinal);
         }
 
         // LUCENENET NOTE: char[] overload of EndsWith removed because the ReadOnlySpan<char> overload can be used instead

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
@@ -173,7 +173,6 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="s"> Input Buffer </param>
         /// <param name="pos"> Position of character to delete </param>
-        /// <param name="len"> length of input buffer </param>
         /// <returns> length of input buffer after deletion </returns>
         /// <remarks>
         /// LUCENENET NOTE: This method has been converted to use <see cref="Span{T}"/>.
@@ -211,7 +210,6 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="s"> Input Buffer </param>
         /// <param name="pos"> Position of character to delete </param>
-        /// <param name="len"> Length of input buffer </param>
         /// <param name="nChars"> number of characters to delete </param>
         /// <returns> length of input buffer after deletion </returns>
         /// <remarks>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
@@ -1,8 +1,6 @@
 // Lucene version compatibility level 4.8.1
 using Lucene.Net.Diagnostics;
-using Lucene.Net.Support;
 using System;
-using System.Diagnostics;
 
 namespace Lucene.Net.Analysis.Util
 {
@@ -37,21 +35,34 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="len"> length of input buffer </param>
         /// <param name="prefix"> Prefix string to test </param>
         /// <returns> <c>true</c> if <paramref name="s"/> starts with <paramref name="prefix"/> </returns>
-        public static bool StartsWith(char[] s, int len, string prefix)
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// </remarks>
+        public static bool StartsWith(ReadOnlySpan<char> s, int len, string prefix)
+        {
+            return StartsWith(s, len, prefix.AsSpan());
+        }
+
+        /// <summary>
+        /// Returns true if the character array starts with the prefix.
+        /// </summary>
+        /// <param name="s"> Input Buffer </param>
+        /// <param name="len"> length of input buffer </param>
+        /// <param name="prefix"> Prefix string to test </param>
+        /// <returns> <c>true</c> if <paramref name="s"/> starts with <paramref name="prefix"/> </returns>
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// </remarks>
+        public static bool StartsWith(ReadOnlySpan<char> s, int len, ReadOnlySpan<char> prefix)
         {
             int prefixLen = prefix.Length;
             if (prefixLen > len)
             {
                 return false;
             }
-            for (int i = 0; i < prefixLen; i++)
-            {
-                if (s[i] != prefix[i])
-                {
-                    return false;
-                }
-            }
-            return true;
+
+            // LUCENENET: use more efficient implementation in MemoryExtensions
+            return s.StartsWith(prefix);
         }
 
         /// <summary>
@@ -61,22 +72,12 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="len"> length of input buffer </param>
         /// <param name="suffix"> Suffix string to test </param>
         /// <returns> <c>true</c> if <paramref name="s"/> ends with <paramref name="suffix"/> </returns>
-        public static bool EndsWith(char[] s, int len, string suffix)
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// </remarks>
+        public static bool EndsWith(ReadOnlySpan<char> s, int len, string suffix)
         {
-            int suffixLen = suffix.Length;
-            if (suffixLen > len)
-            {
-                return false;
-            }
-            for (int i = suffixLen - 1; i >= 0; i--)
-            {
-                if (s[len - (suffixLen - i)] != suffix[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return EndsWith(s, len, suffix.AsSpan());
         }
 
         /// <summary>
@@ -86,23 +87,22 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="len"> length of input buffer </param>
         /// <param name="suffix"> Suffix string to test </param>
         /// <returns> <c>true</c> if <paramref name="s"/> ends with <paramref name="suffix"/> </returns>
-        public static bool EndsWith(char[] s, int len, char[] suffix)
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// </remarks>
+        public static bool EndsWith(ReadOnlySpan<char> s, int len, ReadOnlySpan<char> suffix)
         {
             int suffixLen = suffix.Length;
             if (suffixLen > len)
             {
                 return false;
             }
-            for (int i = suffixLen - 1; i >= 0; i--)
-            {
-                if (s[len - (suffixLen - i)] != suffix[i])
-                {
-                    return false;
-                }
-            }
 
-            return true;
+            // LUCENENET: use more efficient implementation in MemoryExtensions
+            return s.Slice(0, len).EndsWith(suffix);
         }
+
+        // LUCENENET NOTE: char[] overload of EndsWith removed because the ReadOnlySpan<char> overload can be used instead
 
         /// <summary>
         /// Delete a character in-place
@@ -111,12 +111,16 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="pos"> Position of character to delete </param>
         /// <param name="len"> length of input buffer </param>
         /// <returns> length of input buffer after deletion </returns>
-        public static int Delete(char[] s, int pos, int len)
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="Span{T}"/>.
+        /// </remarks>
+        public static int Delete(Span<char> s, int pos, int len)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(pos < len);
             if (pos < len - 1) // don't arraycopy if asked to delete last character
             {
-                Arrays.Copy(s, pos + 1, s, pos, len - pos - 1);
+                // Arrays.Copy(s, pos + 1, s, pos, len - pos - 1);
+                s.Slice(pos + 1, len - pos - 1).CopyTo(s.Slice(pos, len - pos - 1));
             }
             return len - 1;
         }
@@ -129,12 +133,16 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="len"> Length of input buffer </param>
         /// <param name="nChars"> number of characters to delete </param>
         /// <returns> length of input buffer after deletion </returns>
-        public static int DeleteN(char[] s, int pos, int len, int nChars)
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="Span{T}"/>.
+        /// </remarks>
+        public static int DeleteN(Span<char> s, int pos, int len, int nChars)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(pos + nChars <= len);
             if (pos + nChars < len) // don't arraycopy if asked to delete the last characters
             {
-                Arrays.Copy(s, pos + nChars, s, pos, len - pos - nChars);
+                // Arrays.Copy(s, pos + nChars, s, pos, len - pos - nChars);
+                s.Slice(pos + nChars, len - pos - nChars).CopyTo(s.Slice(pos, len - pos - nChars));
             }
             return len - nChars;
         }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
@@ -32,15 +32,14 @@ namespace Lucene.Net.Analysis.Util
         /// Returns true if the character array starts with the prefix.
         /// </summary>
         /// <param name="s"> Input Buffer </param>
-        /// <param name="len"> length of input buffer </param>
         /// <param name="prefix"> Prefix string to test </param>
         /// <returns> <c>true</c> if <paramref name="s"/> starts with <paramref name="prefix"/> </returns>
         /// <remarks>
         /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
         /// </remarks>
-        public static bool StartsWith(ReadOnlySpan<char> s, int len, string prefix)
+        public static bool StartsWith(ReadOnlySpan<char> s, string prefix)
         {
-            return StartsWith(s, len, prefix.AsSpan());
+            return StartsWith(s, prefix.AsSpan());
         }
 
         /// <summary>
@@ -52,11 +51,27 @@ namespace Lucene.Net.Analysis.Util
         /// <returns> <c>true</c> if <paramref name="s"/> starts with <paramref name="prefix"/> </returns>
         /// <remarks>
         /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// Callers should prefer the overload without the <paramref name="len"/> parameter and use a slice instead,
+        /// but this overload is provided for compatibility with existing code.
         /// </remarks>
-        public static bool StartsWith(ReadOnlySpan<char> s, int len, ReadOnlySpan<char> prefix)
+        internal static bool StartsWith(ReadOnlySpan<char> s, int len, string prefix)
+        {
+            return StartsWith(s.Slice(0, len), prefix.AsSpan());
+        }
+
+        /// <summary>
+        /// Returns true if the character array starts with the prefix.
+        /// </summary>
+        /// <param name="s"> Input Buffer </param>
+        /// <param name="prefix"> Prefix string to test </param>
+        /// <returns> <c>true</c> if <paramref name="s"/> starts with <paramref name="prefix"/> </returns>
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// </remarks>
+        public static bool StartsWith(ReadOnlySpan<char> s, ReadOnlySpan<char> prefix)
         {
             int prefixLen = prefix.Length;
-            if (prefixLen > len)
+            if (prefixLen > s.Length)
             {
                 return false;
             }
@@ -66,18 +81,34 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Returns true if the character array ends with the suffix.
+        /// Returns true if the character array starts with the prefix.
         /// </summary>
         /// <param name="s"> Input Buffer </param>
         /// <param name="len"> length of input buffer </param>
+        /// <param name="prefix"> Prefix string to test </param>
+        /// <returns> <c>true</c> if <paramref name="s"/> starts with <paramref name="prefix"/> </returns>
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// Callers should prefer the overload without the <paramref name="len"/> parameter and use a slice instead,
+        /// but this overload is provided for compatibility with existing code.
+        /// </remarks>
+        internal static bool StartsWith(ReadOnlySpan<char> s, int len, ReadOnlySpan<char> prefix)
+        {
+            return StartsWith(s.Slice(0, len), prefix);
+        }
+
+        /// <summary>
+        /// Returns true if the character array ends with the suffix.
+        /// </summary>
+        /// <param name="s"> Input Buffer </param>
         /// <param name="suffix"> Suffix string to test </param>
         /// <returns> <c>true</c> if <paramref name="s"/> ends with <paramref name="suffix"/> </returns>
         /// <remarks>
         /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
         /// </remarks>
-        public static bool EndsWith(ReadOnlySpan<char> s, int len, string suffix)
+        public static bool EndsWith(ReadOnlySpan<char> s, string suffix)
         {
-            return EndsWith(s, len, suffix.AsSpan());
+            return EndsWith(s, suffix.AsSpan());
         }
 
         /// <summary>
@@ -89,17 +120,50 @@ namespace Lucene.Net.Analysis.Util
         /// <returns> <c>true</c> if <paramref name="s"/> ends with <paramref name="suffix"/> </returns>
         /// <remarks>
         /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// Callers should prefer the overload without the <paramref name="len"/> parameter and use a slice instead,
+        /// but this overload is provided for compatibility with existing code.
         /// </remarks>
-        public static bool EndsWith(ReadOnlySpan<char> s, int len, ReadOnlySpan<char> suffix)
+        internal static bool EndsWith(ReadOnlySpan<char> s, int len, string suffix)
+        {
+            return EndsWith(s.Slice(0, len), suffix.AsSpan());
+        }
+
+        /// <summary>
+        /// Returns true if the character array ends with the suffix.
+        /// </summary>
+        /// <param name="s"> Input Buffer </param>
+        /// <param name="suffix"> Suffix string to test </param>
+        /// <returns> <c>true</c> if <paramref name="s"/> ends with <paramref name="suffix"/> </returns>
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// </remarks>
+        public static bool EndsWith(ReadOnlySpan<char> s, ReadOnlySpan<char> suffix)
         {
             int suffixLen = suffix.Length;
-            if (suffixLen > len)
+            if (suffixLen > s.Length)
             {
                 return false;
             }
 
             // LUCENENET: use more efficient implementation in MemoryExtensions
-            return s.Slice(0, len).EndsWith(suffix, StringComparison.Ordinal);
+            return s.EndsWith(suffix, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Returns true if the character array ends with the suffix.
+        /// </summary>
+        /// <param name="s"> Input Buffer </param>
+        /// <param name="len"> length of input buffer </param>
+        /// <param name="suffix"> Suffix string to test </param>
+        /// <returns> <c>true</c> if <paramref name="s"/> ends with <paramref name="suffix"/> </returns>
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
+        /// Callers should prefer the overload without the <paramref name="len"/> parameter and use a slice instead,
+        /// but this overload is provided for compatibility with existing code.
+        /// </remarks>
+        internal static bool EndsWith(ReadOnlySpan<char> s, int len, ReadOnlySpan<char> suffix)
+        {
+            return EndsWith(s.Slice(0, len), suffix);
         }
 
         // LUCENENET NOTE: char[] overload of EndsWith removed because the ReadOnlySpan<char> overload can be used instead
@@ -114,15 +178,32 @@ namespace Lucene.Net.Analysis.Util
         /// <remarks>
         /// LUCENENET NOTE: This method has been converted to use <see cref="Span{T}"/>.
         /// </remarks>
-        public static int Delete(Span<char> s, int pos, int len)
+        public static int Delete(Span<char> s, int pos)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(pos < len);
-            if (pos < len - 1) // don't arraycopy if asked to delete last character
+            if (Debugging.AssertsEnabled) Debugging.Assert(pos < s.Length);
+            if (pos < s.Length - 1) // don't arraycopy if asked to delete last character
             {
                 // Arrays.Copy(s, pos + 1, s, pos, len - pos - 1);
-                s.Slice(pos + 1, len - pos - 1).CopyTo(s.Slice(pos, len - pos - 1));
+                s.Slice(pos + 1, s.Length - pos - 1).CopyTo(s.Slice(pos, s.Length - pos - 1));
             }
-            return len - 1;
+            return s.Length - 1;
+        }
+
+        /// <summary>
+        /// Delete a character in-place
+        /// </summary>
+        /// <param name="s"> Input Buffer </param>
+        /// <param name="pos"> Position of character to delete </param>
+        /// <param name="len"> length of input buffer </param>
+        /// <returns> length of input buffer after deletion </returns>
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="Span{T}"/>.
+        /// Callers should prefer the overload without the <paramref name="len"/> parameter and use a slice instead,
+        /// but this overload is provided for compatibility with existing code.
+        /// </remarks>
+        internal static int Delete(Span<char> s, int pos, int len)
+        {
+            return Delete(s.Slice(0, len), pos);
         }
 
         /// <summary>
@@ -136,15 +217,31 @@ namespace Lucene.Net.Analysis.Util
         /// <remarks>
         /// LUCENENET NOTE: This method has been converted to use <see cref="Span{T}"/>.
         /// </remarks>
-        public static int DeleteN(Span<char> s, int pos, int len, int nChars)
+        public static int DeleteN(Span<char> s, int pos, int nChars)
         {
-            if (Debugging.AssertsEnabled) Debugging.Assert(pos + nChars <= len);
-            if (pos + nChars < len) // don't arraycopy if asked to delete the last characters
+            if (Debugging.AssertsEnabled) Debugging.Assert(pos + nChars <= s.Length);
+            if (pos + nChars < s.Length) // don't arraycopy if asked to delete the last characters
             {
                 // Arrays.Copy(s, pos + nChars, s, pos, len - pos - nChars);
-                s.Slice(pos + nChars, len - pos - nChars).CopyTo(s.Slice(pos, len - pos - nChars));
+                s.Slice(pos + nChars, s.Length - pos - nChars).CopyTo(s.Slice(pos, s.Length - pos - nChars));
             }
-            return len - nChars;
+            return s.Length - nChars;
+        }
+
+        /// <summary>
+        /// Delete n characters in-place
+        /// </summary>
+        /// <param name="s"> Input Buffer </param>
+        /// <param name="pos"> Position of character to delete </param>
+        /// <param name="len"> Length of input buffer </param>
+        /// <param name="nChars"> number of characters to delete </param>
+        /// <returns> length of input buffer after deletion </returns>
+        /// <remarks>
+        /// LUCENENET NOTE: This method has been converted to use <see cref="Span{T}"/>.
+        /// </remarks>
+        internal static int DeleteN(Span<char> s, int pos, int len, int nChars)
+        {
+            return DeleteN(s.Slice(0, len), pos, nChars);
         }
     }
 }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
@@ -1,5 +1,6 @@
 // Lucene version compatibility level 4.8.1
 using Lucene.Net.Diagnostics;
+using Lucene.Net.Support;
 using System;
 
 namespace Lucene.Net.Analysis.Util
@@ -182,8 +183,7 @@ namespace Lucene.Net.Analysis.Util
             if (Debugging.AssertsEnabled) Debugging.Assert(pos < s.Length);
             if (pos < s.Length - 1) // don't arraycopy if asked to delete last character
             {
-                // Arrays.Copy(s, pos + 1, s, pos, len - pos - 1);
-                s.Slice(pos + 1, s.Length - pos - 1).CopyTo(s.Slice(pos, s.Length - pos - 1));
+                Arrays.Copy(s, pos + 1, s, pos, s.Length - pos - 1);
             }
             return s.Length - 1;
         }
@@ -220,8 +220,7 @@ namespace Lucene.Net.Analysis.Util
             if (Debugging.AssertsEnabled) Debugging.Assert(pos + nChars <= s.Length);
             if (pos + nChars < s.Length) // don't arraycopy if asked to delete the last characters
             {
-                // Arrays.Copy(s, pos + nChars, s, pos, len - pos - nChars);
-                s.Slice(pos + nChars, s.Length - pos - nChars).CopyTo(s.Slice(pos, s.Length - pos - nChars));
+                Arrays.Copy(s, pos + nChars, s, pos, s.Length - pos - nChars);
             }
             return s.Length - nChars;
         }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestStemmerUtil.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestStemmerUtil.cs
@@ -37,7 +37,11 @@ namespace Lucene.Net.Analysis.Util
         [TestCase("foobar", 2, "foo", false)]
         public void TestStartsWith(string input, int len, string prefix, bool expected)
         {
+            // test len overload
             Assert.AreEqual(expected, StemmerUtil.StartsWith(input.AsSpan(), len, prefix));
+
+            // test no len overload
+            Assert.AreEqual(expected, StemmerUtil.StartsWith(input.AsSpan(0, len), prefix));
         }
 
         [Test]
@@ -48,7 +52,11 @@ namespace Lucene.Net.Analysis.Util
         [TestCase("foobar", 3, "foo", true)]
         public void TestEndsWith(string input, int len, string prefix, bool expected)
         {
+            // test len overload
             Assert.AreEqual(expected, StemmerUtil.EndsWith(input.AsSpan(), len, prefix));
+
+            // test no len overload
+            Assert.AreEqual(expected, StemmerUtil.EndsWith(input.AsSpan(0, len), prefix));
         }
 
         [Test]
@@ -58,8 +66,14 @@ namespace Lucene.Net.Analysis.Util
         [TestCase("foobar", 5, 6, "fooba", 5)]
         public void TestDelete(string input, int pos, int len, string expected, int expectedLen)
         {
+            // test len overload
             char[] buffer = input.ToCharArray();
             Assert.AreEqual(expectedLen, StemmerUtil.Delete(buffer, pos, len));
+            Assert.AreEqual(expected, new string(buffer, 0, expectedLen));
+
+            // test no len overload
+            buffer = input.ToCharArray();
+            Assert.AreEqual(expectedLen, StemmerUtil.Delete(buffer.AsSpan(0, len), pos));
             Assert.AreEqual(expected, new string(buffer, 0, expectedLen));
         }
 
@@ -70,8 +84,14 @@ namespace Lucene.Net.Analysis.Util
         [TestCase("foobar", 4, 6, 2, "foob", 4)]
         public void TestDeleteN(string input, int pos, int len, int nChars, string expected, int expectedLen)
         {
+            // test len overload
             char[] buffer = input.ToCharArray();
             Assert.AreEqual(expectedLen, StemmerUtil.DeleteN(buffer, pos, len, nChars));
+            Assert.AreEqual(expected, new string(buffer, 0, expectedLen));
+
+            // test no len overload
+            buffer = input.ToCharArray();
+            Assert.AreEqual(expectedLen, StemmerUtil.DeleteN(buffer.AsSpan(0, len), pos, nChars));
             Assert.AreEqual(expected, new string(buffer, 0, expectedLen));
         }
     }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestStemmerUtil.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestStemmerUtil.cs
@@ -1,0 +1,78 @@
+using Lucene.Net.Attributes;
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System;
+using Assert = Lucene.Net.TestFramework.Assert;
+
+namespace Lucene.Net.Analysis.Util
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Tests for <see cref="StemmerUtil"/>
+    /// </summary>
+    [TestFixture]
+    [LuceneNetSpecific]
+    public class TestStemmerUtil : LuceneTestCase
+    {
+        [Test]
+        [TestCase("foobar", 6, "foo", true)]
+        [TestCase("foobar", 3, "foo", true)]
+        [TestCase("foobar", 6, "bar", false)]
+        [TestCase("foobar", 2, "foo", false)]
+        public void TestStartsWith(string input, int len, string prefix, bool expected)
+        {
+            Assert.AreEqual(expected, StemmerUtil.StartsWith(input.AsSpan(), len, prefix));
+        }
+
+        [Test]
+        [TestCase("foobar", 6, "bar", true)]
+        [TestCase("foobar", 3, "bar", false)]
+        [TestCase("foobar", 6, "foo", false)]
+        [TestCase("foobar", 2, "bar", false)]
+        [TestCase("foobar", 3, "foo", true)]
+        public void TestEndsWith(string input, int len, string prefix, bool expected)
+        {
+            Assert.AreEqual(expected, StemmerUtil.EndsWith(input.AsSpan(), len, prefix));
+        }
+
+        [Test]
+        [TestCase("foobar", 3, 6, "fooar", 5)]
+        [TestCase("foobar", 0, 6, "oobar", 5)]
+        [TestCase("foobar", 0, 3, "oo", 2)]
+        [TestCase("foobar", 5, 6, "fooba", 5)]
+        public void TestDelete(string input, int pos, int len, string expected, int expectedLen)
+        {
+            char[] buffer = input.ToCharArray();
+            Assert.AreEqual(expectedLen, StemmerUtil.Delete(buffer, pos, len));
+            Assert.AreEqual(expected, new string(buffer, 0, expectedLen));
+        }
+
+        [Test]
+        [TestCase("foobar", 3, 6, 2, "foor", 4)]
+        [TestCase("foobar", 0, 6, 2, "obar", 4)]
+        [TestCase("foobar", 0, 3, 2, "o", 1)]
+        [TestCase("foobar", 4, 6, 2, "foob", 4)]
+        public void TestDeleteN(string input, int pos, int len, int nChars, string expected, int expectedLen)
+        {
+            char[] buffer = input.ToCharArray();
+            Assert.AreEqual(expectedLen, StemmerUtil.DeleteN(buffer, pos, len, nChars));
+            Assert.AreEqual(expected, new string(buffer, 0, expectedLen));
+        }
+    }
+}


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Optimize StemmerUtil for `ReadOnlySpan<char>`/`Span<char>`

Fixes #1140

## Description

This PR optimizes StemmerUtil's EndsWith and StartsWith for `ReadOnlySpan<char>`, and Delete and DeleteN for `Span<char>`. Additionally, this type was missing unit tests (including in latest Lucene AFAICT), so this adds some lucenenet-specific unit tests for this type.

Note that the `len` parameters are not quite what you might expect on a naïve reading of the XML doc comments. It is not always equal to the input buffer length (otherwise we could just use `s.Length` and drop the parameter). Instead, it's Lucene's equivalent of what we would call a Slice in .NET. Any characters after `len` chars in the input buffer are treated as if they aren't there. While we could update every callsite of these methods to pass in a slice of the input buffer (via `.AsSpan(0, len)`) and drop the parameter, there are over 200 uses of these methods that would have to be updated (and kept in sync in future ports), and the additional overhead of creating an extra slice should be negligible as it's a stack-allocated ref struct. So I figured it would be best to keep the method signatures as close to the original as possible, without removing the `len` parameter.