### PR TITLE
Make Lucene.Net.Store.Lock reusable, #1073

### DIFF
--- a/src/Lucene.Net.TestFramework/Store/MockLockFactoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockLockFactoryWrapper.cs
@@ -81,13 +81,10 @@ namespace Lucene.Net.Store
                 }
             }
 
-            protected override void Dispose(bool disposing)
+            public override void Close()
             {
-                if (disposing)
-                {
-                    delegateLock.Dispose();
-                    outerInstance.dir.openLocks.Remove(name);
-                }
+                delegateLock.Close();
+                outerInstance.dir.openLocks.Remove(name);
             }
 
             public override bool IsLocked()

--- a/src/Lucene.Net.Tests/Store/TestLock.cs
+++ b/src/Lucene.Net.Tests/Store/TestLock.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Store
                 return false;
             }
 
-            protected override void Dispose(bool disposing)
+            public override void Close()
             {
                 // do nothing
             }

--- a/src/Lucene.Net.Tests/Store/TestLockFactory.cs
+++ b/src/Lucene.Net.Tests/Store/TestLockFactory.cs
@@ -463,7 +463,7 @@ namespace Lucene.Net.Store
                     return true;
                 }
 
-                protected override void Dispose(bool disposing)
+                public override void Close()
                 {
                     // do nothing
                 }

--- a/src/Lucene.Net/Store/NativeFSLockFactory.cs
+++ b/src/Lucene.Net/Store/NativeFSLockFactory.cs
@@ -339,60 +339,57 @@ namespace Lucene.Net.Store
             }
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Close()
         {
-            if (disposing)
+            UninterruptableMonitor.Enter(this);
+            try
             {
-                UninterruptableMonitor.Enter(this);
+                // whether or not we have created a file, we need to remove
+                // the lock instance from the dictionary that tracks them.
                 try
                 {
-                    // whether or not we have created a file, we need to remove
-                    // the lock instance from the dictionary that tracks them.
+                    UninterruptableMonitor.Enter(NativeFSLockFactory._locks);
                     try
                     {
-                        UninterruptableMonitor.Enter(NativeFSLockFactory._locks);
-                        try
-                        {
-                            NativeFSLockFactory._locks.Remove(path);
-                        }
-                        finally
-                        {
-                            UninterruptableMonitor.Exit(NativeFSLockFactory._locks);
-                        }
+                        NativeFSLockFactory._locks.Remove(path);
                     }
                     finally
                     {
-                        if (channel != null)
-                        {
-                            IOUtils.DisposeWhileHandlingException(channel);
-                            channel = null;
-
-                            bool tmpBool;
-                            if (File.Exists(path))
-                            {
-                                File.Delete(path);
-                                tmpBool = true;
-                            }
-                            else if (System.IO.Directory.Exists(path))
-                            {
-                                System.IO.Directory.Delete(path);
-                                tmpBool = true;
-                            }
-                            else
-                            {
-                                tmpBool = false;
-                            }
-                            if (!tmpBool)
-                            {
-                                throw new LockReleaseFailedException("failed to delete " + path);
-                            }
-                        }
+                        UninterruptableMonitor.Exit(NativeFSLockFactory._locks);
                     }
                 }
                 finally
                 {
-                    UninterruptableMonitor.Exit(this);
+                    if (channel != null)
+                    {
+                        IOUtils.DisposeWhileHandlingException(channel);
+                        channel = null;
+
+                        bool tmpBool;
+                        if (File.Exists(path))
+                        {
+                            File.Delete(path);
+                            tmpBool = true;
+                        }
+                        else if (System.IO.Directory.Exists(path))
+                        {
+                            System.IO.Directory.Delete(path);
+                            tmpBool = true;
+                        }
+                        else
+                        {
+                            tmpBool = false;
+                        }
+                        if (!tmpBool)
+                        {
+                            throw new LockReleaseFailedException("failed to delete " + path);
+                        }
+                    }
                 }
+            }
+            finally
+            {
+                UninterruptableMonitor.Exit(this);
             }
         }
 
@@ -424,7 +421,7 @@ namespace Lucene.Net.Store
                     bool obtained = Obtain();
                     if (obtained)
                     {
-                        Dispose();
+                        Close();
                     }
                     return !obtained;
                 }
@@ -541,46 +538,43 @@ namespace Lucene.Net.Store
             }
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Close()
         {
-            if (disposing)
+            UninterruptableMonitor.Enter(this);
+            try
             {
-                UninterruptableMonitor.Enter(this);
+                // whether or not we have created a file, we need to remove
+                // the lock instance from the dictionary that tracks them.
                 try
                 {
-                    // whether or not we have created a file, we need to remove
-                    // the lock instance from the dictionary that tracks them.
+                    UninterruptableMonitor.Enter(NativeFSLockFactory._locks);
                     try
                     {
-                        UninterruptableMonitor.Enter(NativeFSLockFactory._locks);
-                        try
-                        {
-                            NativeFSLockFactory._locks.Remove(path);
-                        }
-                        finally
-                        {
-                            UninterruptableMonitor.Exit(NativeFSLockFactory._locks);
-                        }
+                        NativeFSLockFactory._locks.Remove(path);
                     }
                     finally
                     {
-                        if (channel != null)
-                        {
-                            try
-                            {
-                                IOUtils.DisposeWhileHandlingException(channel);
-                            }
-                            finally
-                            {
-                                channel = null;
-                            }
-                        }
+                        UninterruptableMonitor.Exit(NativeFSLockFactory._locks);
                     }
                 }
                 finally
                 {
-                    UninterruptableMonitor.Exit(this);
+                    if (channel != null)
+                    {
+                        try
+                        {
+                            IOUtils.DisposeWhileHandlingException(channel);
+                        }
+                        finally
+                        {
+                            channel = null;
+                        }
+                    }
                 }
+            }
+            finally
+            {
+                UninterruptableMonitor.Exit(this);
             }
         }
 
@@ -729,55 +723,52 @@ namespace Lucene.Net.Store
             }
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Close()
         {
-            if (disposing)
+            UninterruptableMonitor.Enter(this);
+            try
             {
-                UninterruptableMonitor.Enter(this);
+                // whether or not we have created a file, we need to remove
+                // the lock instance from the dictionary that tracks them.
                 try
                 {
-                    // whether or not we have created a file, we need to remove
-                    // the lock instance from the dictionary that tracks them.
+                    UninterruptableMonitor.Enter(NativeFSLockFactory._locks);
                     try
                     {
-                        UninterruptableMonitor.Enter(NativeFSLockFactory._locks);
-                        try
-                        {
-                            NativeFSLockFactory._locks.Remove(path);
-                        }
-                        finally
-                        {
-                            UninterruptableMonitor.Exit(NativeFSLockFactory._locks);
-                        }
+                        NativeFSLockFactory._locks.Remove(path);
                     }
                     finally
                     {
-                        if (channel != null)
-                        {
-                            try
-                            {
-                                IOUtils.DisposeWhileHandlingException(channel);
-                            }
-                            finally
-                            {
-                                channel = null;
-                            }
-                            // try to delete the file if we created it, but it's not an error if we can't.
-                            try
-                            {
-                                File.Delete(path);
-                            }
-                            catch
-                            {
-                                // ignored
-                            }
-                        }
+                        UninterruptableMonitor.Exit(NativeFSLockFactory._locks);
                     }
                 }
                 finally
                 {
-                    UninterruptableMonitor.Exit(this);
+                    if (channel != null)
+                    {
+                        try
+                        {
+                            IOUtils.DisposeWhileHandlingException(channel);
+                        }
+                        finally
+                        {
+                            channel = null;
+                        }
+                        // try to delete the file if we created it, but it's not an error if we can't.
+                        try
+                        {
+                            File.Delete(path);
+                        }
+                        catch
+                        {
+                            // ignored
+                        }
+                    }
                 }
+            }
+            finally
+            {
+                UninterruptableMonitor.Exit(this);
             }
         }
 

--- a/src/Lucene.Net/Store/NoLockFactory.cs
+++ b/src/Lucene.Net/Store/NoLockFactory.cs
@@ -19,7 +19,7 @@ namespace Lucene.Net.Store
 
     /// <summary>
     /// Use this <see cref="LockFactory"/> to disable locking entirely.
-    /// Only one instance of this lock is created.  You should call 
+    /// Only one instance of this lock is created.  You should call
     /// <see cref="GetNoLockFactory()"/> to get the instance.
     /// </summary>
     /// <seealso cref="LockFactory"/>
@@ -55,7 +55,7 @@ namespace Lucene.Net.Store
             return true;
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Close()
         {
         }
 

--- a/src/Lucene.Net/Store/SimpleFSLockFactory.cs
+++ b/src/Lucene.Net/Store/SimpleFSLockFactory.cs
@@ -157,19 +157,16 @@ namespace Lucene.Net.Store
             }
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Close()
         {
-            if (disposing)
+            if (File.Exists(lockFile.FullName))
             {
+                File.Delete(lockFile.FullName);
+
+                // If lockFile still exists, delete failed
                 if (File.Exists(lockFile.FullName))
                 {
-                    File.Delete(lockFile.FullName);
-
-                    // If lockFile still exists, delete failed
-                    if (File.Exists(lockFile.FullName))
-                    {
-                        throw new LockReleaseFailedException("failed to delete " + lockFile);
-                    }
+                    throw new LockReleaseFailedException("failed to delete " + lockFile);
                 }
             }
         }

--- a/src/Lucene.Net/Store/SingleInstanceLockFactory.cs
+++ b/src/Lucene.Net/Store/SingleInstanceLockFactory.cs
@@ -83,19 +83,16 @@ namespace Lucene.Net.Store
             }
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Close()
         {
-            if (disposing)
+            UninterruptableMonitor.Enter(locks);
+            try
             {
-                UninterruptableMonitor.Enter(locks);
-                try
-                {
-                    locks.Remove(lockName);
-                }
-                finally
-                {
-                    UninterruptableMonitor.Exit(locks);
-                }
+                locks.Remove(lockName);
+            }
+            finally
+            {
+                UninterruptableMonitor.Exit(locks);
             }
         }
 

--- a/src/Lucene.Net/Store/VerifyingLockFactory.cs
+++ b/src/Lucene.Net/Store/VerifyingLockFactory.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Store
      */
 
     /// <summary>
-    /// A <see cref="LockFactory"/> that wraps another 
+    /// A <see cref="LockFactory"/> that wraps another
     /// <see cref="LockFactory"/> and verifies that each lock obtain/release
     /// is "correct" (never results in two processes holding the
     /// lock at the same time).  It does this by contacting an
@@ -96,23 +96,20 @@ namespace Lucene.Net.Store
                 }
             }
 
-            protected override void Dispose(bool disposing)
+            public override void Close()
             {
-                if (disposing)
+                UninterruptableMonitor.Enter(this);
+                try
                 {
-                    UninterruptableMonitor.Enter(this);
-                    try
+                    if (IsLocked())
                     {
-                        if (IsLocked())
-                        {
-                            Verify((byte)0);
-                            @lock.Dispose();
-                        }
+                        Verify((byte)0);
+                        @lock.Close();
                     }
-                    finally
-                    {
-                        UninterruptableMonitor.Exit(this);
-                    }
+                }
+                finally
+                {
+                    UninterruptableMonitor.Exit(this);
                 }
             }
         }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Make Lucene.Net.Store.Lock reusable via ICloseable

Fixes #1073

## Description

See rationale in #1073. It is theoretically possible to reuse a Lock instance in Lucene 4.8.1 by calling `obtain()` after a call to `close()`, and some Lucene.NET code does this implicitly (such as in `FallbackNativeFSLock.IsLocked()`, which attempts to obtain and then release the lock). Therefore, the IDisposable pattern doesn't really always work, as you're not supposed to reuse an object after disposing of it.

This PR adds the ICloseable interface to Lock, and makes its Close method the primary extension point for Lock subclasses to implement their release logic, better matching Lucene. Dispose has been changed into a virtual method to allow for custom Lock subclasses to dispose of resources in a non-reusable way if needed.

This will be changing in a future version of Lucene.NET post-5.3.0, where the locks are no longer reusable, so at that time we will remove the ICloseable interface and just use IDisposable.

Because of the change to the Lock base class, this is a breaking change for any custom Lock implementations.