### PR TITLE
ThaiTokenizer + ICUTokenizer: Fixed ICU4N BreakIterator issues to address concurrency problems (Fixes #1035, #1135, and #1159)

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -33,8 +33,7 @@
         https://github.com/apache/lucene-solr/tree/31d7ec7bbfdcd2c4cc61d9d35e962165410b65fe/lucene/analysis/icu/src/data/utr30
         Just make sure they are adjusted to the right version of ICU/Lucene.
     <ICU4NPackageVersion>[60.1,60.2)</ICU4NPackageVersion> -->
-    <!--<ICU4NPackageVersion>[60.1.0-alpha.437,60.1.0-alpha.446)</ICU4NPackageVersion>-->
-    <ICU4NPackageVersion>60.1.0-alpha.438.g06cf803beb</ICU4NPackageVersion>
+    <ICU4NPackageVersion>[60.1.0-alpha.438,60.1.0-alpha.446)</ICU4NPackageVersion>
     <IKVMPackageVersion>8.7.5</IKVMPackageVersion>
     <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -33,7 +33,7 @@
         https://github.com/apache/lucene-solr/tree/31d7ec7bbfdcd2c4cc61d9d35e962165410b65fe/lucene/analysis/icu/src/data/utr30
         Just make sure they are adjusted to the right version of ICU/Lucene.
     <ICU4NPackageVersion>[60.1,60.2)</ICU4NPackageVersion> -->
-    <ICU4NPackageVersion>[60.1.0-alpha.436,60.1.0-alpha.446)</ICU4NPackageVersion>
+    <ICU4NPackageVersion>[60.1.0-alpha.437,60.1.0-alpha.446)</ICU4NPackageVersion>
     <IKVMPackageVersion>8.7.5</IKVMPackageVersion>
     <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -33,7 +33,8 @@
         https://github.com/apache/lucene-solr/tree/31d7ec7bbfdcd2c4cc61d9d35e962165410b65fe/lucene/analysis/icu/src/data/utr30
         Just make sure they are adjusted to the right version of ICU/Lucene.
     <ICU4NPackageVersion>[60.1,60.2)</ICU4NPackageVersion> -->
-    <ICU4NPackageVersion>[60.1.0-alpha.437,60.1.0-alpha.446)</ICU4NPackageVersion>
+    <!--<ICU4NPackageVersion>[60.1.0-alpha.437,60.1.0-alpha.446)</ICU4NPackageVersion>-->
+    <ICU4NPackageVersion>60.1.0-alpha.438.g06cf803beb</ICU4NPackageVersion>
     <IKVMPackageVersion>8.7.5</IKVMPackageVersion>
     <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->

--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -27,7 +27,7 @@ properties {
     [string]$testResultsDirectory = "$artifactsDirectory/TestResults"
     [string]$publishDirectory = "$artifactsDirectory/Publish"
     [string]$solutionFile = "$baseDirectory/Lucene.Net.sln"
-    [string]$minimumSdkVersion = "9.0.100"
+    [string]$minimumSdkVersion = "9.0.200" # We need at least 9.0.200 for ICU4N satellite assemblies with 3-character language codes to get copied to the output.
     [string]$globalJsonFile = "$baseDirectory/global.json"
     [string]$versionPropsFile = "$baseDirectory/version.props"
     [string]$luceneReadmeFile = "$baseDirectory/src/Lucene.Net/readme-nuget.md"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ variables:
 - name: BuildCounter
   value: $[counter(variables['VersionSuffix'],coalesce(variables['BuildCounterSeed'], 1250))]
 - name: DotNetSDKVersion
-  value: '9.0.100'
+  value: '9.0.300'
 - name: DocumentationArtifactName
   value: 'docs'
 - name: DocumentationArtifactZipFileName

--- a/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiTokenizer.cs
@@ -164,6 +164,7 @@ namespace Lucene.Net.Analysis.Th
         {
             this.text.CopyChars(text.Text, text.Start, text.Length);
             wordBreaker.SetText(text);
+            transitions.Clear();
         }
 
         public int Current

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -382,6 +382,14 @@ namespace Lucene.Net.Analysis
                     Assert.AreEqual((int)finalPosInc, posIncrAtt.PositionIncrement, "finalPosInc");
                 }
             }
+            catch (Exception)
+            {
+                // LUCENENET: Since we are using a finally block to call Close(), we need to ensure the state is cleared first so we don't
+                // obscure the real error message an invalid token stream state exception.
+                ts.ClearAttributes();
+                ts.End();
+                throw; // LUCENENET: CA2200: Rethrow to preserve stack details (https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200-rethrow-to-preserve-stack-details)
+            }
             finally
             {
                 ts.Close();

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -1100,82 +1100,75 @@ namespace Lucene.Net.Analysis
 
             ts = a.GetTokenStream("dummy", useCharFilter ? new MockCharFilter(reader, remainder) : reader);
 
-            try
+            if (typeAtt != null && posIncAtt != null && posLengthAtt != null && offsetAtt != null)
             {
-                if (typeAtt != null && posIncAtt != null && posLengthAtt != null && offsetAtt != null)
-                {
-                    // offset + pos + posLength + type
-                    AssertTokenStreamContents(ts,
-                        tokens.ToArray(),
-                        ToIntArray(startOffsets),
-                        ToIntArray(endOffsets),
-                        types.ToArray(),
-                        ToIntArray(positions),
-                        ToIntArray(positionLengths),
-                        text.Length,
-                        offsetsAreCorrect);
-                }
-                else if (typeAtt != null && posIncAtt != null && offsetAtt != null)
-                {
-                    // offset + pos + type
-                    AssertTokenStreamContents(ts,
-                        tokens.ToArray(),
-                        ToIntArray(startOffsets),
-                        ToIntArray(endOffsets),
-                        types.ToArray(),
-                        ToIntArray(positions),
-                        null,
-                        text.Length,
-                        offsetsAreCorrect);
-                }
-                else if (posIncAtt != null && posLengthAtt != null && offsetAtt != null)
-                {
-                    // offset + pos + posLength
-                    AssertTokenStreamContents(ts,
-                        tokens.ToArray(),
-                        ToIntArray(startOffsets),
-                        ToIntArray(endOffsets),
-                        null,
-                        ToIntArray(positions),
-                        ToIntArray(positionLengths),
-                        text.Length,
-                        offsetsAreCorrect);
-                }
-                else if (posIncAtt != null && offsetAtt != null)
-                {
-                    // offset + pos
-                    AssertTokenStreamContents(ts,
-                        tokens.ToArray(),
-                        ToIntArray(startOffsets),
-                        ToIntArray(endOffsets),
-                        null,
-                        ToIntArray(positions),
-                        null,
-                        text.Length,
-                        offsetsAreCorrect);
-                }
-                else if (offsetAtt != null)
-                {
-                    // offset
-                    AssertTokenStreamContents(ts,
-                        tokens.ToArray(),
-                        ToIntArray(startOffsets),
-                        ToIntArray(endOffsets),
-                        null,
-                        null,
-                        null,
-                        text.Length,
-                        offsetsAreCorrect);
-                }
-                else
-                {
-                    // terms only
-                    AssertTokenStreamContents(ts, tokens.ToArray());
-                }
+                // offset + pos + posLength + type
+                AssertTokenStreamContents(ts,
+                    tokens.ToArray(),
+                    ToIntArray(startOffsets),
+                    ToIntArray(endOffsets),
+                    types.ToArray(),
+                    ToIntArray(positions),
+                    ToIntArray(positionLengths),
+                    text.Length,
+                    offsetsAreCorrect);
             }
-            finally
+            else if (typeAtt != null && posIncAtt != null && offsetAtt != null)
             {
-                ts.Close();
+                // offset + pos + type
+                AssertTokenStreamContents(ts,
+                    tokens.ToArray(),
+                    ToIntArray(startOffsets),
+                    ToIntArray(endOffsets),
+                    types.ToArray(),
+                    ToIntArray(positions),
+                    null,
+                    text.Length,
+                    offsetsAreCorrect);
+            }
+            else if (posIncAtt != null && posLengthAtt != null && offsetAtt != null)
+            {
+                // offset + pos + posLength
+                AssertTokenStreamContents(ts,
+                    tokens.ToArray(),
+                    ToIntArray(startOffsets),
+                    ToIntArray(endOffsets),
+                    null,
+                    ToIntArray(positions),
+                    ToIntArray(positionLengths),
+                    text.Length,
+                    offsetsAreCorrect);
+            }
+            else if (posIncAtt != null && offsetAtt != null)
+            {
+                // offset + pos
+                AssertTokenStreamContents(ts,
+                    tokens.ToArray(),
+                    ToIntArray(startOffsets),
+                    ToIntArray(endOffsets),
+                    null,
+                    ToIntArray(positions),
+                    null,
+                    text.Length,
+                    offsetsAreCorrect);
+            }
+            else if (offsetAtt != null)
+            {
+                // offset
+                AssertTokenStreamContents(ts,
+                    tokens.ToArray(),
+                    ToIntArray(startOffsets),
+                    ToIntArray(endOffsets),
+                    null,
+                    null,
+                    null,
+                    text.Length,
+                    offsetsAreCorrect);
+            }
+            else
+            {
+                // terms only
+                AssertTokenStreamContents(ts, tokens.ToArray());
             }
 
             if (field != null)

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Th/TestThaiAnalyzer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Th/TestThaiAnalyzer.cs
@@ -366,7 +366,6 @@ namespace Lucene.Net.Analysis.Th
         /// <summary>
         /// blast some random strings through the analyzer </summary>
         [Test]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/269")] // LUCENENET TODO: this test occasionally fails
         public virtual void TestRandomStrings()
         {
             CheckRandomData(Random, new ThaiAnalyzer(TEST_VERSION_CURRENT), 1000 * RandomMultiplier);
@@ -376,7 +375,6 @@ namespace Lucene.Net.Analysis.Th
         /// blast some random large strings through the analyzer </summary>
         ///
         [Test]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/269")] // LUCENENET TODO: this test occasionally fails
         public virtual void TestRandomHugeStrings()
         {
             Random random = Random;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Fixes #1044, Fixes #1135, Fixes #1159

## Description

This bumps ICU4N to 60.1.0-alpha.438 which contains patches to address:

- ICU4J 60 had a concurrency bug when cloning dictionary-based break engine instances where the state was shared between threads after cloning. This bug was transferred from upstream in ICU4N (fixed in https://github.com/NightOwl888/ICU4N/pull/96). See #1044.
- ICU4N had another shared memory problem in the CJK dictionary engine, which was addressed in https://github.com/NightOwl888/ICU4N/pull/109 by reverting the System.Memory optimizations, for now.
- ICU4N.Text (Normalizer + Normalizer2): Addressed access to unsafe pointers that was addressed in https://github.com/NightOwl888/ICU4N/pull/101
- The Normalizer2 in ICU4N had several allocation bugs that were addressed in https://github.com/NightOwl888/ICU4N/pull/104

This also fixes:

- #1135 
- Bumped .NET 9 SDK to 9.0.200 minimum to address issue with satellite assemblies for 3-character language codes not being copied to build/publish output (for ICU4N.Resources)
- #1159 - Log exceptions that occur when calling `Close()` in `BaseTokenStreamTestCase` when there is already an exception being thrown by the test
- `ThaiWordBreaker`: Clear the state of the `transitions` queue when `SetText()` is called. This was causing random `CheckRandomData()` test failures when there was a failure in the middle of a set of transitions.
