### PR TITLE
Fix .asf.yaml syntax error for Apache Infrastructure

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,6 +25,6 @@ github:
     # Enable projects for project management boards
     projects: false
 
-    # Disallow forced pushes
+  # Disallow forced pushes
   protected_branches:
-    master
+    master: {}


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

This is a chore PR to fix an error that Apache Infra is reporting:

```
An error occurred while processing the github feature in .asf.yaml:

when expecting a mapping
found arbitrary text
  in "lucenenet.git/.asf.yaml::github", line 24, column 1:
        # Disallow forced pushes
    ^ (line: 24)
```

My (and Claude Code's) theory is that the comment is not indented properly, which is causing the error.

Upon reviewing the docs, it appears like our syntax for [branch protection](https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#branch-protection) was missing the "minimal dictionary" so I added that as well. 