### PR TITLE
More BytesRef/UnicodeUtil UTF-8-to-string fixes, #1024

### DIFF
--- a/src/Lucene.Net.Tests/Util/TestBytesRef.cs
+++ b/src/Lucene.Net.Tests/Util/TestBytesRef.cs
@@ -3,6 +3,8 @@ using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Assert = Lucene.Net.TestFramework.Assert;
@@ -609,6 +611,65 @@ namespace Lucene.Net.Util
 
             string decoded = System.Text.Encoding.UTF8.GetString(br.AsSpan());
             Assert.AreEqual("\uFFFD", decoded);
+        }
+
+        #endregion
+
+        #region DebuggerDisplay
+
+        private static string GetDebuggerDisplay(BytesRef br)
+        {
+            var prop = typeof(BytesRef).GetProperty("DebuggerDisplay", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(prop, "BytesRef.DebuggerDisplay private property not found");
+            return (string)prop.GetValue(br);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public static void Test_DebuggerDisplayAttribute_ReferencesExistingMember()
+        {
+            // Guards against typos/renames in the [DebuggerDisplay] expression.
+            var attr = typeof(BytesRef).GetCustomAttribute<DebuggerDisplayAttribute>();
+            Assert.IsNotNull(attr);
+            Assert.AreEqual("{DebuggerDisplay,nq}", attr.Value);
+
+            var prop = typeof(BytesRef).GetProperty("DebuggerDisplay", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(prop);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public static void Test_DebuggerDisplay_ValidUtf8_ShowsStringThenBytes()
+        {
+            var br = new BytesRef("abc");
+            Assert.AreEqual("abc [61 62 63]", GetDebuggerDisplay(br));
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public static void Test_DebuggerDisplay_InvalidUtf8_ShowsInvalidLabel()
+        {
+            // 0xC3 starts a 2-byte UTF-8 sequence but the continuation byte is missing.
+            var br = new BytesRef(new byte[] { 0xC3 });
+            Assert.AreEqual("Invalid UTF-8 [c3]", GetDebuggerDisplay(br));
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public static void Test_DebuggerDisplay_EmbeddedFFFD_IsNotMistakenForInvalid()
+        {
+            // U+FFFD encoded as legitimate UTF-8 (EF BF BD) must round-trip, not be reported as invalid.
+            var br = new BytesRef("\uFFFD");
+            Assert.AreEqual("\uFFFD [ef bf bd]", GetDebuggerDisplay(br));
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public static void Test_DebuggerDisplay_RespectsOffsetAndLength()
+        {
+            var bytes = new[] { (byte)'a', (byte)'b', (byte)'c', (byte)'d' };
+            var br = new BytesRef(bytes, 1, 2); // "bc"
+            Assert.AreEqual("bc [62 63]", GetDebuggerDisplay(br));
         }
 
         #endregion

--- a/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
@@ -3,6 +3,7 @@ using J2N.Text;
 using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System;
+using System.Text;
 using Assert = Lucene.Net.TestFramework.Assert;
 
 namespace Lucene.Net.Util
@@ -339,7 +340,7 @@ namespace Lucene.Net.Util
 
             if (shouldThrow)
             {
-                Assert.Throws<FormatException>(() => UnicodeUtil.UTF8toUTF16(invalidUtf8, scratch));
+                Assert.Throws<DecoderFallbackException>(() => UnicodeUtil.UTF8toUTF16(invalidUtf8, scratch));
             }
             else
             {

--- a/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
@@ -379,6 +379,25 @@ namespace Lucene.Net.Util
 
         [Test]
         [LuceneNetSpecific]
+        [TestCase(new byte[] { 0x63, 0x61, 0xc3 }, "ca\ufffd")] // ca�, start of 2-byte sequence
+        [TestCase(new byte[] { 0x63, 0x61, 0xe3 }, "ca\ufffd")] // ca�, start of 3-byte sequence
+        [TestCase(new byte[] { 0x63, 0x61, 0xf3 }, "ca\ufffd")] // ca�, start of 4-byte sequence
+        [TestCase(new byte[] { 0x63, 0x61, 0xc3, 0xb1, 0x6f, 0x6e }, "cañon")]
+        public void TestUTF8toUTF16WithFallback_ByteArrayOverload(byte[] utf8, string expected)
+        {
+            // Regression: the 4-arg byte[] overload must delegate to the fallback implementation,
+            // not the throwing one. Exercise it via a non-zero offset to confirm the arguments flow through.
+            var scratch = new CharsRef();
+            var padded = new byte[utf8.Length + 2];
+            Array.Copy(utf8, 0, padded, 2, utf8.Length);
+
+            UnicodeUtil.UTF8toUTF16WithFallback(padded, 2, utf8.Length, scratch);
+
+            Assert.AreEqual(expected, scratch.ToString());
+        }
+
+        [Test]
+        [LuceneNetSpecific]
         [Repeat(100)]
         public void TestTryUTF16toUTF8()
         {

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Util
     [Serializable]
 #endif
     // LUCENENET specific: Not implementing ICloneable per Microsoft's recommendation
-    [DebuggerDisplay("{ToString()} {Utf8ToString()}")]
+    [DebuggerDisplay("{ToString()} {Utf8ToStringWithFallback()}")]
     public sealed class BytesRef : IComparable<BytesRef>, IComparable, IEquatable<BytesRef> // LUCENENET specific - implemented IComparable for FieldComparator, IEquatable<BytesRef>
     {
         /// <summary>

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -45,7 +45,7 @@ namespace Lucene.Net.Util
     [Serializable]
 #endif
     // LUCENENET specific: Not implementing ICloneable per Microsoft's recommendation
-    [DebuggerDisplay("{ToString()} {Utf8ToStringWithFallback()}")]
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public sealed class BytesRef : IComparable<BytesRef>, IComparable, IEquatable<BytesRef> // LUCENENET specific - implemented IComparable for FieldComparator, IEquatable<BytesRef>
     {
         /// <summary>
@@ -316,6 +316,11 @@ namespace Lucene.Net.Util
             return false;
         }
         #nullable restore
+
+        // LUCENENET specific: "Invalid UTF-8" disambiguates a decode failure from a legitimate U+FFFD in the data.
+        [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Referenced by DebuggerDisplay attribute")]
+        private string DebuggerDisplay
+            => $"{(TryUtf8ToString(out var s) ? s : "Invalid UTF-8")} {ToString()}";
 
         /// <summary>
         /// Returns hex encoded bytes, eg [0x6c 0x75 0x63 0x65 0x6e 0x65] </summary>

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -975,7 +975,7 @@ namespace Lucene.Net.Util
         /// it doesn't provide enough space to hold the worst case of each byte becoming a UTF-16 codepoint.
         /// <para/>
         /// NOTE: Full characters are read, even if this reads past the length passed (and
-        /// can result in an <see cref="FormatException"/> if invalid UTF-8 is passed).
+        /// can result in a <see cref="DecoderFallbackException"/> if invalid UTF-8 is passed).
         /// Explicit checks for valid UTF-8 are not performed.
         /// </summary>
         /// <seealso cref="UTF8toUTF16(ReadOnlySpan{byte}, CharsRef)"/>
@@ -990,7 +990,7 @@ namespace Lucene.Net.Util
         /// it doesn't provide enough space to hold the worst case of each byte becoming a UTF-16 codepoint.
         /// <para/>
         /// NOTE: Full characters are read, even if this reads past the length passed (and
-        /// can result in an <see cref="FormatException"/> if invalid UTF-8 is passed).
+        /// can result in a <see cref="DecoderFallbackException"/> if invalid UTF-8 is passed).
         /// Explicit checks for valid UTF-8 are not performed.
         /// </summary>
         /// <remarks>
@@ -1015,7 +1015,7 @@ namespace Lucene.Net.Util
                 {
                     if (utf8.Length <= i)
                     {
-                        throw new FormatException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}");
+                        throw new DecoderFallbackException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}");
                     }
                     @out[out_offset++] = (char)(((b & 0x1f) << 6) + (utf8[i++] & 0x3f));
                 }
@@ -1023,7 +1023,7 @@ namespace Lucene.Net.Util
                 {
                     if (utf8.Length <= i + 1)
                     {
-                        throw new FormatException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}");
+                        throw new DecoderFallbackException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}");
                     }
                     @out[out_offset++] = (char)(((b & 0xf) << 12) + ((utf8[i] & 0x3f) << 6) + (utf8[i + 1] & 0x3f));
                     i += 2;
@@ -1032,7 +1032,7 @@ namespace Lucene.Net.Util
                 {
                     if (utf8.Length <= i + 2)
                     {
-                        throw new FormatException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}");
+                        throw new DecoderFallbackException($"Invalid UTF-8 starting at [{b:x2}] at offset {i - 1}");
                     }
                     if (Debugging.AssertsEnabled) Debugging.Assert(b < 0xf8, "b = 0x{0:x}", b);
                     int ch = ((b & 0x7) << 18) + ((utf8[i] & 0x3f) << 12) + ((utf8[i + 1] & 0x3f) << 6) + (utf8[i + 2] & 0x3f);

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -1065,7 +1065,7 @@ namespace Lucene.Net.Util
         // TODO: broken if chars.offset != 0
         public static void UTF8toUTF16WithFallback(byte[] utf8, int offset, int length, CharsRef chars)
         {
-            UTF8toUTF16(utf8.AsSpan(offset, length), chars);
+            UTF8toUTF16WithFallback(utf8.AsSpan(offset, length), chars);
         }
 
         /// <summary>


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making.

Some fixes to BytesRef / UnicodeUtil UTF-8 handling.

Related #1024

## Description

- `UnicodeUtil.UTF8toUTF16` now throws `DecoderFallbackException` instead of `FormatException` on invalid UTF-8, aligning with the BCL's canonical decoding exception.
- `UnicodeUtil.UTF8toUTF16WithFallback(byte[], int, int, CharsRef)` was silently delegating to the *throwing* `UTF8toUTF16` overload; it now correctly delegates to the fallback implementation, so invalid sequences are replaced with U+FFFD as documented.
- `BytesRef`'s `[DebuggerDisplay]` now shows the decoded UTF-8 string first, followed by the raw bytes. When the bytes are not valid UTF-8, the string portion is replaced with the literal label `"Invalid UTF-8"` (via `TryUtf8ToString`) so developers can unambiguously distinguish a decode failure from a legitimate U+FFFD in the data — per review feedback from @NightOwl888.
