### PR TITLE
Fix integer overflow in IndexInputStream.Read(), #1158

### DIFF
--- a/src/Lucene.Net.Replicator/IndexInputInputStream.cs
+++ b/src/Lucene.Net.Replicator/IndexInputInputStream.cs
@@ -65,8 +65,8 @@ namespace Lucene.Net.Replicator
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            int remaining = (int)(input.Length - input.Position); // LUCENENET specific: Renamed from getFilePointer() to match FileStream
-            int readCount = Math.Min(remaining, count);
+            long remaining = input.Length - input.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
+            int readCount = (int)Math.Min(remaining, count);
             input.ReadBytes(buffer, offset, readCount);
             return readCount;
         }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix integer overflow in IndexInputStream.Read()

Fixes #1158

## Description

When input.Length - input.Position exceeds int.MaxValue, casting to int causes overflow resulting in negative values. This fix uses long for the remaining calculation before safely casting to int via Math.Min.

Thanks to @ChaoMaWisetech for providing the proposed solution.
