### PR TITLE
Added Lucene.Net.CodeAnalysis.Dev package reference

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -40,6 +40,7 @@
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
     <J2NPackageVersion>[2.1.0, 3.0.0)</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
+    <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.6</LuceneNetCodeAnalysisDevPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.3.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
     <MicrosoftAspNetCoreTestHostPackageVersion>8.0.19</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftCodeAnalysisAnalyzersPackageVersion>2.9.8</MicrosoftCodeAnalysisAnalyzersPackageVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,6 +24,12 @@
 
   <PropertyGroup Label="Warnings to be Disabled in Solution">
     <NoWarn Label="Legacy serialization support APIs are obsolete">$(NoWarn);SYSLIB0051</NoWarn>
+
+    <!-- These are noisy, but may be helpful during Lucene upgrades or optimization -->
+    <NoWarn Label="Floating point types should not be compared for exact equality">$(NoWarn);LuceneDev1000</NoWarn>
+    <NoWarn Label="Floating point type arithmetic needs to be checked on x86 in .NET Framework and may require extra casting">$(NoWarn);LuceneDev1002</NoWarn>
+    <NoWarn Label="Java array parameters can sometimes be replaced with .NET out or ref parameters">$(NoWarn);LuceneDev1003</NoWarn>
+    <NoWarn Label="Return array may be able to be replaced with out values">$(NoWarn);LuceneDev1004</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Label="Solution-level Publish to Project-specific Directory">
@@ -220,6 +226,10 @@
 
   <ItemGroup Condition=" '$(BUILD_REPOSITORY_PROVIDER)' == 'GitHub' " Label="SourceLink Packages (main repo)">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageReferenceVersion)" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Lucene.Net.CodeAnalysis.Dev" Version="$(LuceneNetCodeAnalysisDevPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <Import Project=".build/release.targets" Condition="Exists('.build/release.targets')" />

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
@@ -155,7 +155,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                                     {
                                         case StreamTokenizer.TokenType_Number:
                                             {
-                                                argValue = stok.NumberValue.ToString(CultureInfo.InvariantCulture);
+                                                argValue = J2N.Numerics.Double.ToString(stok.NumberValue, CultureInfo.InvariantCulture);
                                                 // Drop the ".0" from numbers, for integer arguments
                                                 argValue = TRAILING_DOT_ZERO_PATTERN.Replace(argValue, "", 1);
                                                 // Intentional fallthrough
@@ -440,7 +440,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                                 {
                                     case StreamTokenizer.TokenType_Number:
                                         {
-                                            argValue = stok.NumberValue.ToString(CultureInfo.InvariantCulture);
+                                            argValue = J2N.Numerics.Double.ToString(stok.NumberValue, CultureInfo.InvariantCulture);
                                             // Drop the ".0" from numbers, for integer arguments
                                             argValue = TRAILING_DOT_ZERO_PATTERN.Replace(argValue, "", 1);
                                             // Intentional fall-through

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/Algorithm.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/Algorithm.cs
@@ -116,7 +116,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
                                     {
                                         case StreamTokenizer.TokenType_Number:
                                             {
-                                                @params.Append(stok.NumberValue.ToString(CultureInfo.InvariantCulture));
+                                                @params.Append(J2N.Numerics.Double.ToString(stok.NumberValue, CultureInfo.InvariantCulture));
                                                 break;
                                             }
                                         case StreamTokenizer.TokenType_Word:

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/Config.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/Config.cs
@@ -269,7 +269,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
             // done if not by round
             if (!props.TryGetValue(name, out string sval))
             {
-                sval = dflt.ToString(CultureInfo.InvariantCulture);
+                sval = J2N.Numerics.Double.ToString(dflt, CultureInfo.InvariantCulture);
             }
             if (sval.IndexOf(':') < 0)
             {

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/BoostQueryNode.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/BoostQueryNode.cs
@@ -83,7 +83,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
             if (f == (long)f)
                 return "" + (long)f;
             else
-                return "" + f.ToString("0.0#######"); // LUCENENET TODO: Culture
+                return "" + J2N.Numerics.Single.ToString(f, "0.0#######"); // LUCENENET TODO: Culture
         }
 
         public override string ToString()

--- a/src/Lucene.Net/Index/CheckIndex.cs
+++ b/src/Lucene.Net/Index/CheckIndex.cs
@@ -717,7 +717,7 @@ namespace Lucene.Net.Index
 #pragma warning restore 612, 618
                     {
                         // don't print size in bytes if its a 3.0 segment with shared docstores
-                        Msg(infoStream, "    size (MB)=" + segInfoStat.SizeMB.ToString(nf));
+                        Msg(infoStream, "    size (MB)=" + J2N.Numerics.Double.ToString(segInfoStat.SizeMB, nf));
                     }
                     IDictionary<string, string> diagnostics = info.Info.Diagnostics;
                     segInfoStat.Diagnostics = diagnostics;
@@ -2269,7 +2269,7 @@ namespace Lucene.Net.Index
                     }
                 }
                 float vectorAvg = status.DocCount == 0 ? 0 : status.TotVectors / (float)status.DocCount;
-                Msg(infoStream, "OK [" + status.TotVectors + " total vector count; avg " + vectorAvg.ToString(CultureInfo.InvariantCulture.NumberFormat) + " term/freq vector fields per doc]");
+                Msg(infoStream, "OK [" + status.TotVectors + " total vector count; avg " + J2N.Numerics.Single.ToString(vectorAvg, NumberFormatInfo.InvariantInfo) + " term/freq vector fields per doc]");
             }
             catch (Exception e) when (e.IsThrowable())
             {

--- a/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
+++ b/src/Lucene.Net/Index/DocumentsWriterPerThread.cs
@@ -571,7 +571,7 @@ namespace Lucene.Net.Index
                 if (infoStream.IsEnabled("DWPT"))
                 {
                     double newSegmentSize = segmentInfoPerCommit.GetSizeInBytes() / 1024.0 / 1024.0;
-                    infoStream.Message("DWPT", "flushed: segment=" + segmentInfo.Name + " ramUsed=" + startMBUsed.ToString(nf) + " MB" + " newFlushedSize(includes docstores)=" + newSegmentSize.ToString(nf) + " MB" + " docs/MB=" + (flushState.SegmentInfo.DocCount / newSegmentSize).ToString(nf));
+                    infoStream.Message("DWPT", "flushed: segment=" + segmentInfo.Name + " ramUsed=" + J2N.Numerics.Double.ToString(startMBUsed, nf) + " MB" + " newFlushedSize(includes docstores)=" + J2N.Numerics.Double.ToString(newSegmentSize, nf) + " MB" + " docs/MB=" + J2N.Numerics.Double.ToString((flushState.SegmentInfo.DocCount / newSegmentSize), nf));
                 }
 
                 if (Debugging.AssertsEnabled) Debugging.Assert(segmentInfo != null);

--- a/src/Lucene.Net/Index/LogMergePolicy.cs
+++ b/src/Lucene.Net/Index/LogMergePolicy.cs
@@ -660,7 +660,7 @@ namespace Lucene.Net.Index
                 }
                 if (IsVerbose)
                 {
-                    Message("  level " + levelBottom.ToString("0.0") + " to " + maxLevel.ToString("0.0") + ": " + (1 + upto - start) + " segments");
+                    Message("  level " + J2N.Numerics.Single.ToString(levelBottom) + " to " + J2N.Numerics.Single.ToString(maxLevel) + ": " + (1 + upto - start) + " segments");
                 }
 
                 // Finally, record all merges that are viable at this level:

--- a/src/Lucene.Net/Index/TieredMergePolicy.cs
+++ b/src/Lucene.Net/Index/TieredMergePolicy.cs
@@ -152,7 +152,7 @@ namespace Lucene.Net.Index
             {
                 if (value < 0.0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(MaxMergedSegmentMB), "maxMergedSegmentMB must be >=0 (got " + value.ToString("0.0") + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentOutOfRangeException(nameof(MaxMergedSegmentMB), "maxMergedSegmentMB must be >=0 (got " + J2N.Numerics.Double.ToString(value) + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
                 }
                 value *= 1024 * 1024;
                 maxMergedSegmentBytes = (value > long.MaxValue) ? long.MaxValue : (long)value;
@@ -175,7 +175,7 @@ namespace Lucene.Net.Index
             {
                 if (value < 0.0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(ReclaimDeletesWeight), "reclaimDeletesWeight must be >= 0.0 (got " + value.ToString("0.0") + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentOutOfRangeException(nameof(ReclaimDeletesWeight), "reclaimDeletesWeight must be >= 0.0 (got " + J2N.Numerics.Double.ToString(value) + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
                 }
                 reclaimDeletesWeight = value;
             }
@@ -195,7 +195,7 @@ namespace Lucene.Net.Index
             {
                 if (value <= 0.0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(FloorSegmentMB), "floorSegmentMB must be >= 0.0 (got " + value.ToString("0.0") + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentOutOfRangeException(nameof(FloorSegmentMB), "floorSegmentMB must be >= 0.0 (got " + J2N.Numerics.Double.ToString(value) + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
                 }
                 value *= 1024 * 1024;
                 floorSegmentBytes = (value > long.MaxValue) ? long.MaxValue : (long)value;
@@ -214,7 +214,7 @@ namespace Lucene.Net.Index
             {
                 if (value < 0.0 || value > 100.0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(ForceMergeDeletesPctAllowed), "forceMergeDeletesPctAllowed must be between 0.0 and 100.0 inclusive (got " + value.ToString("0.0") + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentOutOfRangeException(nameof(ForceMergeDeletesPctAllowed), "forceMergeDeletesPctAllowed must be between 0.0 and 100.0 inclusive (got " + J2N.Numerics.Double.ToString(value) + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
                 }
                 forceMergeDeletesPctAllowed = value;
             }
@@ -237,7 +237,7 @@ namespace Lucene.Net.Index
             {
                 if (value < 2.0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(SegmentsPerTier), "segmentsPerTier must be >= 2.0 (got " + value.ToString("0.0") + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
+                    throw new ArgumentOutOfRangeException(nameof(SegmentsPerTier), "segmentsPerTier must be >= 2.0 (got " + J2N.Numerics.Double.ToString(value) + ")"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
                 }
                 segsPerTier = value;
             }

--- a/src/Lucene.Net/Search/ControlledRealTimeReopenThread.cs
+++ b/src/Lucene.Net/Search/ControlledRealTimeReopenThread.cs
@@ -83,7 +83,7 @@ namespace Lucene.Net.Search
         {
             if (targetMaxStaleSec < targetMinStaleSec)
             {
-                throw new ArgumentException("targetMaxScaleSec (= " + targetMaxStaleSec.ToString("0.0") + ") < targetMinStaleSec (=" + targetMinStaleSec.ToString("0.0") + ")");
+                throw new ArgumentException("targetMaxScaleSec (= " + J2N.Numerics.Double.ToString(targetMaxStaleSec) + ") < targetMinStaleSec (=" + J2N.Numerics.Double.ToString(targetMinStaleSec) + ")");
             }
 
             this.writer = writer;

--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -1127,7 +1127,7 @@ namespace Lucene.Net.Search
 
             public override string ToString()
             {
-                return Value.ToString();
+                return J2N.Numerics.Single.ToString(Value);
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This adds a reference to the new [Lucene.Net.CodeAnalysis.Dev](https://github.com/apache/lucenenet-codeanalysis-dev) package, where we can build code analysis rules that are specific to this project to do advanced code cleanup and validation tasks.

These warnings were disabled because they are too noisy for general use:

```xml
  <PropertyGroup Label="Warnings to be Disabled in Solution">
    <!-- These are noisy, but may be helpful during Lucene upgrades or optimization -->
    <NoWarn Label="Floating point types should not be compared for exact equality">$(NoWarn);LuceneDev1000</NoWarn>
    <NoWarn Label="Floating point type arithmetic needs to be checked on x86 in .NET Framework and may require extra casting">$(NoWarn);LuceneDev1002</NoWarn>
    <NoWarn Label="Java array parameters can sometimes be replaced with .NET out or ref parameters">$(NoWarn);LuceneDev1003</NoWarn>
    <NoWarn Label="Return array may be able to be replaced with out values">$(NoWarn);LuceneDev1004</NoWarn>
  </PropertyGroup>
```

This also fixes `LuceneDev1001` warnings.
