### PR TITLE
Removed FEATURE_UTF8_TOUTF16

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -47,7 +47,6 @@
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ASPNETCORE_TESTHOST</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_UTF8_TOUTF16</DefineConstants>
 
   </PropertyGroup>
 

--- a/src/Lucene.Net/Index/Term.cs
+++ b/src/Lucene.Net/Index/Term.cs
@@ -1,10 +1,8 @@
 using J2N.Text;
-using Lucene.Net.Support;
 using Lucene.Net.Support.Buffers;
-using Lucene.Net.Support.Text;
+using Lucene.Net.Util;
 using System;
 using System.Buffers;
-using System.Text;
 
 namespace Lucene.Net.Index
 {
@@ -25,8 +23,6 @@ namespace Lucene.Net.Index
      * limitations under the License.
      */
 
-    using BytesRef = Lucene.Net.Util.BytesRef;
-
     /// <summary>
     /// A <see cref="Term"/> represents a word from text.  This is the unit of search.  It is
     /// composed of two elements, the text of the word, as a string, and the name of
@@ -37,9 +33,7 @@ namespace Lucene.Net.Index
     /// </summary>
     public sealed class Term : IComparable<Term>, IEquatable<Term> // LUCENENET specific - class implements IEquatable<T>
     {
-#if FEATURE_UTF8_TOUTF16
         private const int CharStackBufferSize = 64;
-#endif
 
         /// <summary>
         /// Constructs a <see cref="Term"/> with the given field and bytes.
@@ -100,9 +94,11 @@ namespace Lucene.Net.Index
         {
             if (termText is null)
                 throw new ArgumentNullException(nameof(termText)); // LUCENENET: Added guard clause
-#if FEATURE_UTF8_TOUTF16
+
+            // the term might not be text, but usually is. so we make a best effort
+
             // View the relevant portion of the byte array
-            ReadOnlySpan<byte> utf8Span = new ReadOnlySpan<byte>(termText.Bytes, termText.Offset, termText.Length);
+            ReadOnlySpan<byte> utf8Span = termText.AsSpan();
 
             // Allocate a buffer for the maximum possible UTF-16 output
             int maxChars = utf8Span.Length; // Worst case: 1 byte -> 1 char (ASCII)
@@ -136,18 +132,6 @@ namespace Lucene.Net.Index
 
             // Fallback to the default string representation if decoding fails
             return termText.ToString();
-#else
-            // the term might not be text, but usually is. so we make a best effort
-            Encoding decoder = StandardCharsets.UTF_8.WithDecoderExceptionFallback();
-            try
-            {
-                return decoder.GetString(termText.Bytes, termText.Offset, termText.Length);
-            }
-            catch (DecoderFallbackException)
-            {
-                return termText.ToString();
-            }
-#endif
         }
 #nullable restore
 


### PR DESCRIPTION

<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Removed FEATURE_UTF8_TOUTF16

## Description

Removed the FEATURE_UTF8_TOUTF16 compilation symbol, since the `Microsoft.Bcl.Memory` package was added in #1192 and now supports the `Utf8` class on all target frameworks.
