### PR TITLE
Replace LinkedDictionary with OrderedDictionary

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -290,7 +290,8 @@ namespace Lucene.Net.Analysis.Hunspell
             patterns.Add(null);
 
             // zero strip -> 0 ord
-            IDictionary<string, int> seenStrips = new JCG.LinkedDictionary<string, int>
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            IDictionary<string, int> seenStrips = new JCG.OrderedDictionary<string, int>
             {
                 [""] = 0
             };

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PerFieldAnalyzerWrapper.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PerFieldAnalyzerWrapper.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
         ///         <description>Use when sorted keys are required. <c>null</c> keys are supported.</description>
         ///     </item>
         ///     <item>
-        ///         <term><see cref="JCG.LinkedDictionary{TKey, TValue}"/></term>
+        ///         <term><see cref="JCG.OrderedDictionary{TKey, TValue}"/></term>
         ///         <description>Use when insertion order must be preserved (<see cref="Dictionary{TKey, TValue}"/> preserves insertion
         ///             order only until items are removed). <c>null</c> keys are supported.</description>
         ///     </item>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/AnalysisSPILoader.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/AnalysisSPILoader.cs
@@ -63,7 +63,8 @@ namespace Lucene.Net.Analysis.Util
             UninterruptableMonitor.Enter(this);
             try
             {
-                IDictionary<string, Type> services = new JCG.LinkedDictionary<string, Type>(this.services);
+                // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+                IDictionary<string, Type> services = new JCG.OrderedDictionary<string, Type>(this.services);
                 SPIClassIterator<S> loader = SPIClassIterator<S>.Get();
 
                 foreach (var service in loader)

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/RepSumByNameRoundTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/RepSumByNameRoundTask.cs
@@ -55,7 +55,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         protected virtual Report ReportSumByNameRound(IList<TaskStats> taskStats)
         {
             // aggregate by task name and round
-            JCG.LinkedDictionary<string, TaskStats> p2 = new JCG.LinkedDictionary<string, TaskStats>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            JCG.OrderedDictionary<string, TaskStats> p2 = new JCG.OrderedDictionary<string, TaskStats>();
             int reported = 0;
             foreach (TaskStats stat1 in taskStats)
             {

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/RepSumByNameTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/RepSumByNameTask.cs
@@ -56,7 +56,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         {
             // aggregate by task name
             int reported = 0;
-            JCG.LinkedDictionary<string, TaskStats> p2 = new JCG.LinkedDictionary<string, TaskStats>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            JCG.OrderedDictionary<string, TaskStats> p2 = new JCG.OrderedDictionary<string, TaskStats>();
             foreach (TaskStats stat1 in taskStats)
             {
                 if (stat1.Elapsed >= 0)

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/RepSumByPrefRoundTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/RepSumByPrefRoundTask.cs
@@ -51,7 +51,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         {
             // aggregate by task name and by round
             int reported = 0;
-            JCG.LinkedDictionary<string, TaskStats> p2 = new JCG.LinkedDictionary<string, TaskStats>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            JCG.OrderedDictionary<string, TaskStats> p2 = new JCG.OrderedDictionary<string, TaskStats>();
             foreach (TaskStats stat1 in taskStats)
             {
                 if (stat1.Elapsed >= 0 && stat1.Task.GetName().StartsWith(m_prefix, StringComparison.Ordinal))

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/RepSumByPrefTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/RepSumByPrefTask.cs
@@ -53,7 +53,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         {
             // aggregate by task name
             int reported = 0;
-            JCG.LinkedDictionary<string, TaskStats> p2 = new JCG.LinkedDictionary<string, TaskStats>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            JCG.OrderedDictionary<string, TaskStats> p2 = new JCG.OrderedDictionary<string, TaskStats>();
             foreach (TaskStats stat1 in taskStats)
             {
                 if (stat1.Elapsed >= 0 && stat1.Task.GetName().StartsWith(m_prefix, StringComparison.Ordinal))

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/ReportTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/ReportTask.cs
@@ -130,7 +130,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
             return sb.ToString();
         }
 
-        protected virtual Report GenPartialReport(int reported, JCG.LinkedDictionary<string, TaskStats> partOfTasks, int totalSize)
+        // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+        protected virtual Report GenPartialReport(int reported, JCG.OrderedDictionary<string, TaskStats> partOfTasks, int totalSize)
         {
             string longetOp = LongestOp(partOfTasks.Values);
             bool first = true;

--- a/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
@@ -89,7 +89,8 @@ namespace Lucene.Net.Expressions.JS
 
         private readonly string sourceText;
 
-        private readonly IDictionary<string, int> externalsMap = new JCG.LinkedDictionary<string, int>();
+        // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+        private readonly IDictionary<string, int> externalsMap = new JCG.OrderedDictionary<string, int>();
 
         private TypeBuilder dynamicType;
 

--- a/src/Lucene.Net.Facet/DrillDownQuery.cs
+++ b/src/Lucene.Net.Facet/DrillDownQuery.cs
@@ -76,7 +76,8 @@ namespace Lucene.Net.Facet
 
         private readonly FacetsConfig config;
         private readonly BooleanQuery query;
-        private readonly IDictionary<string, int> drillDownDims = new JCG.LinkedDictionary<string, int>();
+        // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+        private readonly IDictionary<string, int> drillDownDims = new JCG.OrderedDictionary<string, int>();
 
         /// <summary>
         /// Used by <see cref="Clone"/>

--- a/src/Lucene.Net.Grouping/Function/FunctionDistinctValuesCollector.cs
+++ b/src/Lucene.Net.Grouping/Function/FunctionDistinctValuesCollector.cs
@@ -46,7 +46,8 @@ namespace Lucene.Net.Search.Grouping.Function
             this.vsContext = vsContext;
             this.groupSource = groupSource;
             this.countSource = countSource;
-            groupMap = new JCG.LinkedDictionary<MutableValue, GroupCount>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            groupMap = new JCG.OrderedDictionary<MutableValue, GroupCount>();
             foreach (SearchGroup<MutableValue> group in groups)
             {
                 groupMap[group.GroupValue] = new GroupCount(group.GroupValue);

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Config/StandardQueryConfigHandler.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Config/StandardQueryConfigHandler.cs
@@ -50,7 +50,8 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Config
             Set(ConfigurationKeys.PHRASE_SLOP, 0); //default value 2.4
             Set(ConfigurationKeys.LOWERCASE_EXPANDED_TERMS, true); //default value 2.4
             Set(ConfigurationKeys.ENABLE_POSITION_INCREMENTS, false); //default value 2.4
-            Set(ConfigurationKeys.FIELD_BOOST_MAP, new JCG.LinkedDictionary<string, float>());
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            Set(ConfigurationKeys.FIELD_BOOST_MAP, new JCG.OrderedDictionary<string, float>());
             Set(ConfigurationKeys.FUZZY_CONFIG, new FuzzyConfig());
             Set(ConfigurationKeys.LOCALE, null);
             Set(ConfigurationKeys.MULTI_TERM_REWRITE_METHOD, MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE_DEFAULT);

--- a/src/Lucene.Net.Tests.Grouping/DistinctValuesCollectorTest.cs
+++ b/src/Lucene.Net.Tests.Grouping/DistinctValuesCollectorTest.cs
@@ -537,7 +537,8 @@ namespace Lucene.Net.Search.Grouping
                 if (!searchTermToGroupCounts.TryGetValue(content, out var groupToCounts))
                 {
                     // Groups sort always DOCID asc...
-                    searchTermToGroupCounts.Add(content, groupToCounts = new JCG.LinkedDictionary<string, ISet<string>>());
+                    // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+                    searchTermToGroupCounts.Add(content, groupToCounts = new JCG.OrderedDictionary<string, ISet<string>>());
                     contentStrings.Add(content);
                 }
 

--- a/src/Lucene.Net.Tests.QueryParser/Simple/TestSimpleQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Simple/TestSimpleQueryParser.cs
@@ -541,7 +541,8 @@ namespace Lucene.Net.QueryParsers.Simple
         [Test]
         public virtual void TestWeightedTerm()
         {
-            IDictionary<string, float> weights = new JCG.LinkedDictionary<string, float>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            IDictionary<string, float> weights = new JCG.OrderedDictionary<string, float>();
             weights["field0"] = 5f;
             weights["field1"] = 10f;
 
@@ -562,7 +563,8 @@ namespace Lucene.Net.QueryParsers.Simple
         [Test]
         public virtual void TestWeightedOR()
         {
-            IDictionary<string, float> weights = new JCG.LinkedDictionary<string, float>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            IDictionary<string, float> weights = new JCG.OrderedDictionary<string, float>();
             weights["field0"] = 5f;
             weights["field1"] = 10f;
 

--- a/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
+++ b/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
@@ -231,8 +231,10 @@ namespace Lucene.Net.Spatial.Prefix
             bool biasContains = (operation == SpatialOperation.Contains);
 
             //Main index loop:
-            IDictionary<String, IShape> indexedShapes = new JCG.LinkedDictionary<String, IShape>();
-            IDictionary<String, IShape> indexedShapesGS = new JCG.LinkedDictionary<String, IShape>();//grid snapped
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            IDictionary<String, IShape> indexedShapes = new JCG.OrderedDictionary<String, IShape>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            IDictionary<String, IShape> indexedShapesGS = new JCG.OrderedDictionary<String, IShape>(); //grid snapped
             int numIndexedShapes = randomIntBetween(1, 6);
 #pragma warning disable 219
             bool indexedAtLeastOneShapePair = false;

--- a/src/Lucene.Net/Index/BufferedUpdates.cs
+++ b/src/Lucene.Net/Index/BufferedUpdates.cs
@@ -130,7 +130,8 @@ namespace Lucene.Net.Index
         // one that came in wins), and helps us detect faster if the same Term is
         // used to update the same field multiple times (so we later traverse it
         // only once).
-        internal readonly SCG.IDictionary<string, LinkedDictionary<Term, NumericDocValuesUpdate>> numericUpdates = new Dictionary<string, LinkedDictionary<Term, NumericDocValuesUpdate>>();
+        // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+        internal readonly SCG.IDictionary<string, OrderedDictionary<Term, NumericDocValuesUpdate>> numericUpdates = new Dictionary<string, OrderedDictionary<Term, NumericDocValuesUpdate>>();
 
         // Map<dvField,Map<updateTerm,BinaryUpdate>>
         // For each field we keep an ordered list of BinaryUpdates, key'd by the
@@ -139,7 +140,8 @@ namespace Lucene.Net.Index
         // one that came in wins), and helps us detect faster if the same Term is
         // used to update the same field multiple times (so we later traverse it
         // only once).
-        internal readonly SCG.IDictionary<string, LinkedDictionary<Term, BinaryDocValuesUpdate>> binaryUpdates = new Dictionary<string, LinkedDictionary<Term, BinaryDocValuesUpdate>>();
+        // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+        internal readonly SCG.IDictionary<string, OrderedDictionary<Term, BinaryDocValuesUpdate>> binaryUpdates = new Dictionary<string, OrderedDictionary<Term, BinaryDocValuesUpdate>>();
 
         /// <summary>
         /// NOTE: This was MAX_INT in Lucene
@@ -245,9 +247,10 @@ namespace Lucene.Net.Index
 
         internal virtual void AddNumericUpdate(NumericDocValuesUpdate update, int docIDUpto) // LUCENENET specific - Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
         {
-            if (!numericUpdates.TryGetValue(update.field, out LinkedDictionary<Term, NumericDocValuesUpdate> fieldUpdates))
+            if (!numericUpdates.TryGetValue(update.field, out OrderedDictionary<Term, NumericDocValuesUpdate> fieldUpdates))
             {
-                fieldUpdates = new LinkedDictionary<Term, NumericDocValuesUpdate>();
+                // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+                fieldUpdates = new OrderedDictionary<Term, NumericDocValuesUpdate>();
                 numericUpdates[update.field] = fieldUpdates;
                 bytesUsed.AddAndGet(BYTES_PER_NUMERIC_FIELD_ENTRY);
             }
@@ -278,9 +281,10 @@ namespace Lucene.Net.Index
 
         internal virtual void AddBinaryUpdate(BinaryDocValuesUpdate update, int docIDUpto) // LUCENENET specific - Made internal rather than public, since this class is intended to be internal but couldn't be because it is exposed through a public API
         {
-            if (!binaryUpdates.TryGetValue(update.field, out LinkedDictionary<Term, BinaryDocValuesUpdate> fieldUpdates))
+            if (!binaryUpdates.TryGetValue(update.field, out OrderedDictionary<Term, BinaryDocValuesUpdate> fieldUpdates))
             {
-                fieldUpdates = new LinkedDictionary<Term, BinaryDocValuesUpdate>();
+                // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+                fieldUpdates = new OrderedDictionary<Term, BinaryDocValuesUpdate>();
                 binaryUpdates[update.field] = fieldUpdates;
                 bytesUsed.AddAndGet(BYTES_PER_BINARY_FIELD_ENTRY);
             }

--- a/src/Lucene.Net/Search/SloppyPhraseScorer.cs
+++ b/src/Lucene.Net/Search/SloppyPhraseScorer.cs
@@ -452,7 +452,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Detect repetition groups. Done once - for first doc. </summary>
-        private IList<IList<PhrasePositions>> GatherRptGroups(JCG.LinkedDictionary<Term, int> rptTerms)
+        private IList<IList<PhrasePositions>> GatherRptGroups(JCG.OrderedDictionary<Term, int> rptTerms)
         {
             PhrasePositions[] rpp = RepeatingPPs(rptTerms);
             IList<IList<PhrasePositions>> res = new JCG.List<IList<PhrasePositions>>();
@@ -534,9 +534,10 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Find repeating terms and assign them ordinal values </summary>
-        private JCG.LinkedDictionary<Term, int> RepeatingTerms()
+        private JCG.OrderedDictionary<Term, int> RepeatingTerms()
         {
-            JCG.LinkedDictionary<Term, int> tord = new JCG.LinkedDictionary<Term, int>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            JCG.OrderedDictionary<Term, int> tord = new JCG.OrderedDictionary<Term, int>();
             Dictionary<Term, int> tcnt = new Dictionary<Term, int>();
             for (PhrasePositions pp = min, prev = null; prev != max; pp = (prev = pp).next) // iterate cyclic list: done once handled max
             {
@@ -618,7 +619,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Map each term to the single group that contains it </summary>
-        private static IDictionary<Term, int> TermGroups(JCG.LinkedDictionary<Term, int> tord, IList<FixedBitSet> bb) // LUCENENET: CA1822: Mark members as static
+        private static IDictionary<Term, int> TermGroups(JCG.OrderedDictionary<Term, int> tord, IList<FixedBitSet> bb) // LUCENENET: CA1822: Mark members as static
         {
             Dictionary<Term, int> tg = new Dictionary<Term, int>();
             Term[] t = tord.Keys.ToArray(/*new Term[0]*/);

--- a/src/Lucene.Net/Util/AttributeSource.cs
+++ b/src/Lucene.Net/Util/AttributeSource.cs
@@ -245,8 +245,10 @@ namespace Lucene.Net.Util
         /// </summary>
         public AttributeSource(AttributeFactory factory)
         {
-            this.attributes = new JCG.LinkedDictionary<Type, Util.Attribute>();
-            this.attributeImpls = new JCG.LinkedDictionary<Type, Util.Attribute>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            this.attributes = new JCG.OrderedDictionary<Type, Util.Attribute>();
+            // LUCENENET specific: OrderedDictioary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
+            this.attributeImpls = new JCG.OrderedDictionary<Type, Util.Attribute>();
             this.currentState = new State[1];
             this.factory = factory;
         }


### PR DESCRIPTION


<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->


Fixes [#1199](https://github.com/apache/lucenenet/issues/1199)

## Description

Replaced all usages of JCG.LinkedDictionary with JCG.OrderedDictionary across the codebase for consistency and to better match the semantics of LinkedHashMap in the JDK. Updated comments to clarify the change as Lucene.NET specific.