### PR TITLE
Upgrade dev analyzers to 1.0.0-alpha.18; make WindowsFsyncSupport internal, #1100

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -40,7 +40,7 @@
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
     <J2NPackageVersion>[2.2.0-alpha-0021, 3.0.0)</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
-    <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.6</LuceneNetCodeAnalysisDevPackageVersion>
+    <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.18</LuceneNetCodeAnalysisDevPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.3.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
     <MicrosoftAspNetCoreTestHostPackageVersion>8.0.19</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftBclMemoryPackageVersion>10.0.0-rc.1.25451.107</MicrosoftBclMemoryPackageVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -30,6 +30,8 @@
     <NoWarn Label="Floating point type arithmetic needs to be checked on x86 in .NET Framework and may require extra casting">$(NoWarn);LuceneDev1002</NoWarn>
     <NoWarn Label="Java array parameters can sometimes be replaced with .NET out or ref parameters">$(NoWarn);LuceneDev1003</NoWarn>
     <NoWarn Label="Return array may be able to be replaced with out values">$(NoWarn);LuceneDev1004</NoWarn>
+    <NoWarn Label="Floating point values embedded in strings should be formatted with J2N.Numerics Single or Double ToString methods">$(NoWarn);LuceneDev1006</NoWarn>
+
   </PropertyGroup>
 
   <PropertyGroup Label="Solution-level Publish to Project-specific Directory">

--- a/TestTargetFramework.props
+++ b/TestTargetFramework.props
@@ -91,6 +91,9 @@
 
     <!-- SonarCloud issues -->
     <NoWarn Label="Add at least one assertion to this test case">$(NoWarn);S2699</NoWarn>
+
+    <!-- Lucene.NET Dev Analyzers -->
+    <NoWarn Label="Types in the Lucene.Net.Support namespace should not be public">$(NoWarn);LuceneDev1005</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
+++ b/src/Lucene.Net/Support/IO/WindowsFsyncSupport.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Support.IO
      * limitations under the License.
      */
 
-    public static class WindowsFsyncSupport
+    internal static class WindowsFsyncSupport
     {
         public static void Fsync(string path, bool isDir)
         {


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fixes #1100

## Description

Upgrades dev analyzers which adds the LuceneDev1005 analyzer for public types in the Lucene.Net.Support namespace. Fixes the only violation: WindowsFsyncSupport.

Note that upgrading this analyzer reference adds a lot of build warnings due to the new LuceneDev1006 analyzer.