### PR TITLE
Fix query parser failure with Unicode minus sign, #846

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -38,7 +38,7 @@
     <IKVMPackageVersion>8.7.5</IKVMPackageVersion>
     <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
-    <J2NPackageVersion>[2.2.0-alpha-0021, 3.0.0)</J2NPackageVersion>
+    <J2NPackageVersion>[2.2.0-alpha-0026, 3.0.0)</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
     <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.6</LuceneNetCodeAnalysisDevPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.3.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix query parser failure with Unicode minus sign in exponential notation.

Fixes #846

## Description

Some cultures such as sv-FI use a Unicode minus sign instead of a hyphen as the negative sign. When this is in the exponential notation (i.e. `1.0E-20`), this can cause the numeric query parser to fail, and it was causing some flaky test failures. This bug was fixed in J2N 2.2.0-alpha-0026 (see https://github.com/NightOwl888/J2N/issues/128). This PR upgrades J2N to this version, and adds a unit test confirming the fix. (If you're interested in validating, you can downgrade J2N in this branch to 2.2.0-alpha-0021 and see that the test fails.)

This is the last remaining failure on #846, so that issue will be closed when this PR is merged.