### PR TITLE
Use the J2N.MathExtensions.Log2() hardware optimized method for queries

### DIFF
--- a/src/Lucene.Net/Search/Similarities/SimilarityBase.cs
+++ b/src/Lucene.Net/Search/Similarities/SimilarityBase.cs
@@ -1,5 +1,6 @@
 using Lucene.Net.Diagnostics;
 using System;
+using System.Runtime.CompilerServices;
 using AtomicReaderContext = Lucene.Net.Index.AtomicReaderContext;
 using BytesRef = Lucene.Net.Util.BytesRef;
 using FieldInvertState = Lucene.Net.Index.FieldInvertState;
@@ -43,9 +44,7 @@ namespace Lucene.Net.Search.Similarities
     /// </summary>
     public abstract class SimilarityBase : Similarity
     {
-        /// <summary>
-        /// For <see cref="Log2(double)"/>. Precomputed for efficiency reasons. </summary>
-        private static readonly double LOG_2 = Math.Log(2);
+        // LUCENENET specific - pre-computed LOG_2 value not needed because we are using J2N.MathExtensions.Log2() instead, which may be hardware optimized
 
         /// <summary>
         /// True if overlap tokens (tokens with a position of increment of zero) are
@@ -272,10 +271,11 @@ namespace Lucene.Net.Search.Similarities
 
         /// <summary>
         /// Returns the base two logarithm of <c>x</c>. </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Log2(double x)
         {
             // Put this to a 'util' class if we need more of these.
-            return Math.Log(x) / LOG_2;
+            return J2N.MathExtensions.Log2(x); // LUCENENET: Use hardware-optimized Log2() method, when available
         }
 
         // --------------------------------- Classes ---------------------------------


### PR DESCRIPTION

<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

`Lucene.Net.Search.Similarities.SimilarityBase::Log2():` Use the `J2N.MathExtensions.Log2()` method, which may be hardware optimized.

I didn't run any benchmarks, but this should be a no-brainer. The software fallback is similar to what it was in Lucene, but calculated to more digits of precision.