### PR TITLE
Fix #1175: Change IndexInputStream to throw NotSupportedException for…

### DIFF
--- a/src/Lucene.Net.Replicator/IndexInputInputStream.cs
+++ b/src/Lucene.Net.Replicator/IndexInputInputStream.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Replicator
 
         public override void Flush()
         {
-            throw IllegalStateException.Create("Cannot flush a readonly stream."); // LUCENENET TODO: Change to NotSupportedException ?
+            throw new NotSupportedException("Cannot flush a readonly stream.");
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -60,7 +60,7 @@ namespace Lucene.Net.Replicator
 
         public override void SetLength(long value)
         {
-            throw IllegalStateException.Create("Cannot change length of a readonly stream."); // LUCENENET TODO: Change to NotSupportedException ?
+            throw new NotSupportedException("Cannot change length of a readonly stream.");
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -74,7 +74,7 @@ namespace Lucene.Net.Replicator
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            throw new InvalidCastException("Cannot write to a readonly stream."); // LUCENENET TODO: Change to NotSupportedException ?
+            throw new NotSupportedException("Cannot write to a readonly stream.");
         }
 
         public override bool CanRead => true;

--- a/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexInputStreamTest.cs
@@ -65,6 +65,51 @@ namespace Lucene.Net.Tests.Replicator
         }
 
         /// <summary>
+        /// Test for GitHub issue #1175: IndexInputStream should throw NotSupportedException for writable members
+        /// https://github.com/apache/lucenenet/issues/1175
+        /// </summary>
+        [Test]
+        [LuceneNetSpecific]
+        public void TestGitHubIssue1175_Flush_ThrowsNotSupportedException()
+        {
+            byte[] buffer = new byte[1.KiloBytes()];
+            Random.NextBytes(buffer);
+            using IndexInputStream stream = new IndexInputStream(new MockIndexInput(buffer));
+
+            Assert.Throws<NotSupportedException>(() => stream.Flush());
+        }
+
+        /// <summary>
+        /// Test for GitHub issue #1175: IndexInputStream should throw NotSupportedException for writable members
+        /// https://github.com/apache/lucenenet/issues/1175
+        /// </summary>
+        [Test]
+        [LuceneNetSpecific]
+        public void TestGitHubIssue1175_SetLength_ThrowsNotSupportedException()
+        {
+            byte[] buffer = new byte[1.KiloBytes()];
+            Random.NextBytes(buffer);
+            using IndexInputStream stream = new IndexInputStream(new MockIndexInput(buffer));
+
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(100));
+        }
+
+        /// <summary>
+        /// Test for GitHub issue #1175: IndexInputStream should throw NotSupportedException for writable members
+        /// https://github.com/apache/lucenenet/issues/1175
+        /// </summary>
+        [Test]
+        [LuceneNetSpecific]
+        public void TestGitHubIssue1175_Write_ThrowsNotSupportedException()
+        {
+            byte[] buffer = new byte[1.KiloBytes()];
+            Random.NextBytes(buffer);
+            using IndexInputStream stream = new IndexInputStream(new MockIndexInput(buffer));
+
+            Assert.Throws<NotSupportedException>(() => stream.Write(new byte[10], 0, 10));
+        }
+
+        /// <summary>
         /// Test for GitHub issue #1158: Integer overflow in IndexInputStream.Read()
         /// https://github.com/apache/lucenenet/issues/1158
         /// </summary>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Fixes #1175

## Description

Change IndexInputStream to throw NotSupportedException for writable members

Changed Flush(), SetLength(), and Write() methods to throw NotSupportedException instead of IllegalStateException/InvalidCastException to be consistent with .NET conventions for read-only streams.

Added unit tests to verify the correct exception types are thrown.
