### PR TITLE
Bugfix: Lucene.Net.Replicator.SessionToken ToString() overload doesn't output values correctly

### DIFF
--- a/src/Lucene.Net.Replicator/ReplicationClient.cs
+++ b/src/Lucene.Net.Replicator/ReplicationClient.cs
@@ -179,7 +179,6 @@ namespace Lucene.Net.Replicator
                     return;
 
                 IDictionary<string, IList<RevisionFile>> requiredFiles = RequiredFiles(session.SourceFiles);
-                WriteToInfoStream(string.Format("DoUpdate(): handlerVersion={0} session={1}", version, session));
 
                 foreach (KeyValuePair<string, IList<RevisionFile>> pair in requiredFiles)
                 {

--- a/src/Lucene.Net.Replicator/SessionToken.cs
+++ b/src/Lucene.Net.Replicator/SessionToken.cs
@@ -1,4 +1,5 @@
 using J2N.IO;
+using Lucene.Net.Support;
 using System.Collections.Generic;
 using System;
 using System.IO;
@@ -149,30 +150,7 @@ namespace Lucene.Net.Replicator
 
         public override string ToString()
         {
-            System.Text.StringBuilder sb = new System.Text.StringBuilder();
-            sb.Append("id=").Append(Id).Append(" version=").Append(Version).Append(" files={");
-            
-            bool firstSource = true;
-            foreach (KeyValuePair<string, IList<RevisionFile>> pair in SourceFiles)
-            {
-                if (!firstSource)
-                    sb.Append(", ");
-                firstSource = false;
-                
-                sb.Append(pair.Key).Append("=[");
-                bool firstFile = true;
-                foreach (RevisionFile file in pair.Value)
-                {
-                    if (!firstFile)
-                        sb.Append(", ");
-                    firstFile = false;
-                    sb.Append(file.ToString());
-                }
-                sb.Append("]");
-            }
-            sb.Append("}");
-            
-            return sb.ToString();
+            return string.Format("id={0} version={1} files={2}", Id, Version, Collections.ToString(SourceFiles));
         }
     }
 }

--- a/src/Lucene.Net.Replicator/SessionToken.cs
+++ b/src/Lucene.Net.Replicator/SessionToken.cs
@@ -149,7 +149,30 @@ namespace Lucene.Net.Replicator
 
         public override string ToString()
         {
-            return string.Format("id={0} version={1} files={2}", Id, Version, SourceFiles);
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            sb.Append("id=").Append(Id).Append(" version=").Append(Version).Append(" files={");
+            
+            bool firstSource = true;
+            foreach (KeyValuePair<string, IList<RevisionFile>> pair in SourceFiles)
+            {
+                if (!firstSource)
+                    sb.Append(", ");
+                firstSource = false;
+                
+                sb.Append(pair.Key).Append("=[");
+                bool firstFile = true;
+                foreach (RevisionFile file in pair.Value)
+                {
+                    if (!firstFile)
+                        sb.Append(", ");
+                    firstFile = false;
+                    sb.Append(file.ToString());
+                }
+                sb.Append("]");
+            }
+            sb.Append("}");
+            
+            return sb.ToString();
         }
     }
 }

--- a/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using JCG = J2N.Collections.Generic;
 using Directory = Lucene.Net.Store.Directory;
 
 namespace Lucene.Net.Replicator
@@ -61,6 +62,61 @@ namespace Lucene.Net.Replicator
             assertEquals(files1, files2, aggressive: false);
 
             IOUtils.Dispose(writer, directory);
+        }
+
+        [Test]
+        public void TestToString()
+        {
+            // Create a mock SessionToken with known data
+            Dictionary<string, IList<RevisionFile>> sourceFiles = new Dictionary<string, IList<RevisionFile>>();
+            IList<RevisionFile> files1 = new JCG.List<RevisionFile>
+            {
+                new RevisionFile("file1.txt", 100),
+                new RevisionFile("file2.txt", 200)
+            };
+            IList<RevisionFile> files2 = new JCG.List<RevisionFile>
+            {
+                new RevisionFile("file3.txt", 300)
+            };
+            sourceFiles.Add("source1", files1);
+            sourceFiles.Add("source2", files2);
+
+            MockRevision revision = new MockRevision("v1.0", sourceFiles);
+            SessionToken session = new SessionToken("session123", revision);
+
+            string result = session.ToString();
+
+            // Verify the output contains all expected components
+            Assert.IsTrue(result.Contains("id=session123"), "Should contain session id");
+            Assert.IsTrue(result.Contains("version=v1.0"), "Should contain version");
+            Assert.IsTrue(result.Contains("source1"), "Should contain source1");
+            Assert.IsTrue(result.Contains("source2"), "Should contain source2");
+            Assert.IsTrue(result.Contains("fileName=file1.txt length=100"), "Should contain file1 details");
+            Assert.IsTrue(result.Contains("fileName=file2.txt length=200"), "Should contain file2 details");
+            Assert.IsTrue(result.Contains("fileName=file3.txt length=300"), "Should contain file3 details");
+            
+            // Verify it's not using the generic dictionary ToString()
+            Assert.IsFalse(result.Contains("System.Collections.Generic.Dictionary"), "Should not contain generic Dictionary type");
+        }
+
+        // Mock implementation for testing
+        private class MockRevision : IRevision
+        {
+            private readonly string version;
+            private readonly IDictionary<string, IList<RevisionFile>> sourceFiles;
+
+            public MockRevision(string version, IDictionary<string, IList<RevisionFile>> sourceFiles)
+            {
+                this.version = version;
+                this.sourceFiles = sourceFiles;
+            }
+
+            public string Version => version;
+            public IDictionary<string, IList<RevisionFile>> SourceFiles => sourceFiles;
+            public int CompareTo(string other) => version.CompareTo(other);
+            public int CompareTo(IRevision other) => version.CompareTo(other?.Version);
+            public Stream Open(string source, string fileName) => null;
+            public void Release() { }
         }
 
     }

--- a/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
@@ -65,7 +65,7 @@ namespace Lucene.Net.Replicator
             IOUtils.Dispose(writer, directory);
         }
 
-        [Test]
+        [Test, LuceneNetSpecific]
         public void TestToString()
         {
             // Create a mock SessionToken with known data

--- a/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Util;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -115,7 +116,7 @@ namespace Lucene.Net.Replicator
             public IDictionary<string, IList<RevisionFile>> SourceFiles => sourceFiles;
             public int CompareTo(string other) => version.CompareTo(other);
             public int CompareTo(IRevision other) => version.CompareTo(other?.Version);
-            public Stream Open(string source, string fileName) => null;
+            public Stream Open(string source, string fileName) => throw new NotImplementedException();
             public void Release() { }
         }
 

--- a/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
@@ -96,7 +96,7 @@ namespace Lucene.Net.Replicator
             Assert.IsTrue(result.Contains("fileName=file1.txt length=100"), "Should contain file1 details");
             Assert.IsTrue(result.Contains("fileName=file2.txt length=200"), "Should contain file2 details");
             Assert.IsTrue(result.Contains("fileName=file3.txt length=300"), "Should contain file3 details");
-            
+
             // Verify it's not using the generic dictionary ToString()
             Assert.IsFalse(result.Contains("System.Collections.Generic.Dictionary"), "Should not contain generic Dictionary type");
         }

--- a/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
@@ -1,4 +1,5 @@
 using J2N.IO;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Util;


### PR DESCRIPTION
Fixes #1226 

`SessionToken.ToString()` was not writing out the key/values and instead was just the ToString() output of Dictionary which is the type name. This PR replaces it with the standard `Collections.ToString()` helper used throughout the codebase.

**Changes:**
- Updates `SessionToken.ToString()` to use `Collections.ToString(SourceFiles)`
- Added `using Lucene.Net.Support` import for Collections helper
- Output format unchanged: `id={id} version={ver} files={source1=[file1, file2], source2=[file3]}`
- Removes duplicate call to WriteToInfoStream

This aligns with the standard pattern used in 20+ other files in the codebase and handles nested collections recursively.
