### PR TITLE
pre-commit: upgrade codespell; fix spelling; exclude directories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,12 +32,12 @@ repos:
         name: run check hooks apply
         description: check that all the hooks apply to the repository
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         name: run codespell
         description: check spelling with codespell
-        exclude: ^.*Lucene\.Net\.Tests.*$
+        exclude: ^src/Lucene\.Net\.Analysis\.Common/Analysis/../.*\.rslp$|^.*Lucene\.Net\.Tests.*$
         args: [--ignore-words=.github/linters/codespell.txt]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/src/Lucene.Net/Search/SearcherLifetimeManager.cs
+++ b/src/Lucene.Net/Search/SearcherLifetimeManager.cs
@@ -265,7 +265,7 @@ namespace Lucene.Net.Search
         /// entries are passed to the <see cref="IPruner"/> in sorted (newest to
         /// oldest <see cref="IndexSearcher"/>) order.
         ///
-        /// <para/><b>NOTE</b>: you must peridiocally call this, ideally
+        /// <para/><b>NOTE</b>: you must periodically call this, ideally
         /// from the same background thread that opens new
         /// searchers.
         /// </summary>


### PR DESCRIPTION
After running `pre-commit autoupdate` the codespell hook was updated to the latest version

The new version of codespell found more spelling mistakes.

Which lead me to exclude some "language" files from the English spelling checking

One typo was fixed

https://pre-commit.com/#pre-commit-autoupdate
