### PR TITLE
Add fix-byte-order-marker pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,3 +72,6 @@ repos:
       - id: forbid-submodules
         name: run forbid-submodules
         description: forbids any submodules in the repository
+      - id: fix-byte-order-marker
+        name: run fix-byte-order-marker
+        description: fixes files with UTF-8 byte order markers


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Adds the fix-byte-order-marker standard pre-commit hook to remove UTF-8 BOMs.

## Description

This will make it easier on contributors that use pre-commit to find and automatically fix accidental UTF-8 BOMs.