### PR TITLE
Fix Stream.ReadExactly CA2022 warning; optimize for stackalloc/arraypool

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,17 +38,17 @@
     <PublishDir Condition="'$(AlternatePublishRootDirectory)' != ''">$(AlternatePublishRootDirectory)/$(TargetFramework)/$(MSBuildProjectName)/</PublishDir>
   </PropertyGroup>
 
-  <!-- Features in .NET 9.x+ only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
-
-    <DefineConstants>$(DefineConstants);FEATURE_STREAM_READEXACTLY</DefineConstants>
-
-  </PropertyGroup>
-
   <!-- Features in .NET 8.x+ only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ASPNETCORE_TESTHOST</DefineConstants>
+
+  </PropertyGroup>
+
+  <!-- Features in .NET 7.x+ only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
+
+    <DefineConstants>$(DefineConstants);FEATURE_STREAM_READEXACTLY</DefineConstants>
 
   </PropertyGroup>
 

--- a/src/Lucene.Net.Tests/Support/IO/TestStreamExtensions.cs
+++ b/src/Lucene.Net.Tests/Support/IO/TestStreamExtensions.cs
@@ -78,6 +78,70 @@ namespace Lucene.Net.Support.IO
             Assert.IsTrue(Encoding.UTF8.GetString(buffer).Equals(fileString));
         }
 
+#if !FEATURE_STREAM_READEXACTLY
+        [Test]
+        public void TestReadExactly_ZeroLength()
+        {
+            using var ms = new MemoryStream();
+            Span<byte> buffer = Array.Empty<byte>();
+            ms.ReadExactly(buffer); // should succeed
+        }
+
+        [Test]
+        public void TestReadExactly_Success_FromStart()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            using var ms = new MemoryStream(bytes);
+
+            Span<byte> buffer = stackalloc byte[2];
+            ms.ReadExactly(buffer);
+
+            Assert.AreEqual((byte)1, buffer[0]);
+            Assert.AreEqual((byte)2, buffer[1]);
+        }
+
+        [Test]
+        public void TestReadExactly_Success_FromMiddle()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            using var ms = new MemoryStream(bytes);
+            ms.Seek(2, SeekOrigin.Begin);
+
+            Span<byte> buffer = stackalloc byte[2];
+            ms.ReadExactly(buffer);
+
+            Assert.AreEqual((byte)3, buffer[0]);
+            Assert.AreEqual((byte)4, buffer[1]);
+        }
+
+        [Test]
+        public void TestReadExactly_Success_IntoMiddle()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            using var ms = new MemoryStream(bytes);
+
+            Span<byte> buffer = stackalloc byte[4];
+            ms.ReadExactly(buffer.Slice(2));
+
+            Assert.AreEqual((byte)1, buffer[2]);
+            Assert.AreEqual((byte)2, buffer[3]);
+        }
+
+        [Test]
+        public void TestReadExactly_EndOfStream()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+
+            Assert.Throws<EndOfStreamException>(() =>
+            {
+                using var ms = new MemoryStream(bytes);
+
+                Span<byte> buffer = stackalloc byte[5];
+                ms.ReadExactly(buffer);
+            });
+        }
+#endif
+
         [Test]
         public void TestWrite_Span()
         {
@@ -237,7 +301,7 @@ namespace Lucene.Net.Support.IO
         /// Helper method to calculate expected UTF stream length for validation
         /// Matches DataOutput.writeUTF() spec (Java)
         /// </summary>
-        private long CalculateExpectedUTFStreamLength(string value)
+        private static long CalculateExpectedUTFStreamLength(string value)
         {
             long utfCount = 0;
             foreach (char ch in value)

--- a/src/Lucene.Net.Tests/Support/IO/TestStreamExtensions.cs
+++ b/src/Lucene.Net.Tests/Support/IO/TestStreamExtensions.cs
@@ -205,17 +205,23 @@ namespace Lucene.Net.Support.IO
         }
 
         [Test]
-        public void TestReadExactlyAsync_EndOfStream()
+        public async Task TestReadExactlyAsync_EndOfStream()
         {
             var bytes = new byte[] { 1, 2, 3, 4 };
 
-            Assert.ThrowsAsync<EndOfStreamException>(async () =>
+            try
             {
                 using var ms = new MemoryStream(bytes);
 
                 var buffer = new byte[5];
                 await ms.ReadExactlyAsync(buffer, 0, 5);
-            });
+
+                Assert.Fail("Should have thrown an exception");
+            }
+            catch (EndOfStreamException)
+            {
+                Assert.Pass("Expected EndOfStreamException thrown");
+            }
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Support/IO/TestStreamExtensions.cs
+++ b/src/Lucene.Net.Tests/Support/IO/TestStreamExtensions.cs
@@ -140,6 +140,98 @@ namespace Lucene.Net.Support.IO
                 ms.ReadExactly(buffer);
             });
         }
+
+        [Test]
+        public void TestReadExactly_PartialReads()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            var partialStream = new MaxBytesPerReadStream(bytes, maxBytesPerRead: 1);
+
+            Span<byte> buffer = stackalloc byte[4];
+            partialStream.ReadExactly(buffer);
+
+            Assert.AreEqual((byte)1, buffer[0]);
+            Assert.AreEqual((byte)2, buffer[1]);
+            Assert.AreEqual((byte)3, buffer[2]);
+            Assert.AreEqual((byte)4, buffer[3]);
+        }
+
+        [Test]
+        public async Task TestReadExactlyAsync_ZeroLength()
+        {
+            using var ms = new MemoryStream();
+            var buffer = Array.Empty<byte>();
+            await ms.ReadExactlyAsync(buffer, 0, 0); // should succeed
+        }
+
+        [Test]
+        public async Task TestReadExactlyAsync_Success_FromStart()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            using var ms = new MemoryStream(bytes);
+
+            var buffer = new byte[2];
+            await ms.ReadExactlyAsync(buffer, 0, 2);
+
+            Assert.AreEqual((byte)1, buffer[0]);
+            Assert.AreEqual((byte)2, buffer[1]);
+        }
+
+        [Test]
+        public async Task TestReadExactlyAsync_Success_FromMiddle()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            using var ms = new MemoryStream(bytes);
+            ms.Seek(2, SeekOrigin.Begin);
+
+            var buffer = new byte[2];
+            await ms.ReadExactlyAsync(buffer, 0, 2);
+
+            Assert.AreEqual((byte)3, buffer[0]);
+            Assert.AreEqual((byte)4, buffer[1]);
+        }
+
+        [Test]
+        public async Task TestReadExactlyAsync_Success_IntoMiddle()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            using var ms = new MemoryStream(bytes);
+
+            var buffer = new byte[4];
+            await ms.ReadExactlyAsync(buffer, 2, 2);
+
+            Assert.AreEqual((byte)1, buffer[2]);
+            Assert.AreEqual((byte)2, buffer[3]);
+        }
+
+        [Test]
+        public void TestReadExactlyAsync_EndOfStream()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+
+            Assert.ThrowsAsync<EndOfStreamException>(async () =>
+            {
+                using var ms = new MemoryStream(bytes);
+
+                var buffer = new byte[5];
+                await ms.ReadExactlyAsync(buffer, 0, 5);
+            });
+        }
+
+        [Test]
+        public async Task TestReadExactlyAsync_PartialReads()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            var partialStream = new MaxBytesPerReadStream(bytes, maxBytesPerRead: 1);
+
+            var buffer = new byte[4];
+            await partialStream.ReadExactlyAsync(buffer, 0, 4);
+
+            Assert.AreEqual((byte)1, buffer[0]);
+            Assert.AreEqual((byte)2, buffer[1]);
+            Assert.AreEqual((byte)3, buffer[2]);
+            Assert.AreEqual((byte)4, buffer[3]);
+        }
 #endif
 
         [Test]
@@ -324,10 +416,71 @@ namespace Lucene.Net.Support.IO
             stream.Position = 0;
         }
 
+        // Partial-read async tests: verify that async read methods handle
+        // streams that return fewer bytes than requested per call.
+
+        [Test]
+        public async Task TestReadInt32BigEndianAsync_PartialReads()
+        {
+            await stream.WriteInt32BigEndianAsync(768347202);
+            var partialStream = new MaxBytesPerReadStream(((MemoryStream)stream).ToArray(), maxBytesPerRead: 1);
+
+            int result = await partialStream.ReadInt32BigEndianAsync();
+            Assert.AreEqual(768347202, result, "Incorrect int read with partial reads (async)");
+        }
+
+        [Test]
+        public async Task TestReadInt64BigEndianAsync_PartialReads()
+        {
+            await stream.WriteInt64BigEndianAsync(9875645283333L);
+            var partialStream = new MaxBytesPerReadStream(((MemoryStream)stream).ToArray(), maxBytesPerRead: 1);
+
+            long result = await partialStream.ReadInt64BigEndianAsync();
+            Assert.AreEqual(9875645283333L, result, "Incorrect long read with partial reads (async)");
+        }
+
+        [Test]
+        public async Task TestReadUTFAsync_PartialReads()
+        {
+            await stream.WriteUTFAsync(unihw);
+            var partialStream = new MaxBytesPerReadStream(((MemoryStream)stream).ToArray(), maxBytesPerRead: 1);
+
+            string result = await partialStream.ReadUTFAsync();
+            Assert.AreEqual(unihw, result, "Incorrect string read with partial reads (async)");
+        }
+
         public override void SetUp()
         {
             base.SetUp();
             stream = new MemoryStream();
+        }
+    }
+
+    /// <summary>
+    /// A stream wrapper that returns at most <c>maxBytesPerRead</c> bytes per
+    /// <see cref="ReadAsync(byte[], int, int, System.Threading.CancellationToken)"/> call,
+    /// simulating partial reads (e.g. network streams).
+    /// </summary>
+    internal sealed class MaxBytesPerReadStream : MemoryStream
+    {
+        private readonly int maxBytesPerRead;
+
+        public MaxBytesPerReadStream(byte[] data, int maxBytesPerRead)
+            : base(data, writable: false)
+        {
+            this.maxBytesPerRead = maxBytesPerRead;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int clamped = Math.Min(count, maxBytesPerRead);
+            return base.Read(buffer, offset, clamped);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken)
+        {
+            int clamped = Math.Min(count, maxBytesPerRead);
+            return base.ReadAsync(buffer, offset, clamped, cancellationToken);
         }
     }
 }

--- a/src/Lucene.Net/Support/IO/StreamExtensions.cs
+++ b/src/Lucene.Net/Support/IO/StreamExtensions.cs
@@ -173,12 +173,56 @@ namespace Lucene.Net.Support.IO
             if (stream is null)
                 throw new ArgumentNullException(nameof(stream));
 
-            while (buffer.Length > 0)
+            byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
             {
-                int numRead = stream.Read(buffer);
+                while (buffer.Length > 0)
+                {
+                    int numRead = stream.Read(sharedBuffer, 0, buffer.Length);
+
+                    if (numRead == 0)
+                    {
+                        throw new EndOfStreamException(SR.IO_EOF_ReadBeyondEOF);
+                    }
+
+                    new ReadOnlySpan<byte>(sharedBuffer, 0, numRead).CopyTo(buffer);
+                    buffer = buffer.Slice(numRead);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(sharedBuffer);
+            }
+        }
+
+        /// <summary>
+        /// Reads bytes asynchronously from the stream into <paramref name="buffer"/> until it is completely filled.
+        /// </summary>
+        /// <param name="stream">The stream to read from.</param>
+        /// <param name="buffer">The buffer to read into.</param>
+        /// <param name="offset">The byte offset in <paramref name="buffer"/> at which to begin writing data read from the stream.</param>
+        /// <param name="count">The count of bytes to read.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+        /// <exception cref="EndOfStreamException">The end of the stream is reached before filling the buffer.</exception>
+        /// <remarks>
+        /// This method is a polyfill for platforms (prior to .NET 7) that do not have the ReadExactlyAsync method.
+        /// </remarks>
+        public static async Task ReadExactlyAsync(this Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+        {
+            if (stream is null)
+                throw new ArgumentNullException(nameof(stream));
+
+            while (count > 0)
+            {
+                int numRead = await stream.ReadAsync(buffer, offset, count, cancellationToken);
+
                 if (numRead == 0)
-                    throw new EndOfStreamException();
-                buffer = buffer.Slice(numRead);
+                {
+                    throw new EndOfStreamException(SR.IO_EOF_ReadBeyondEOF);
+                }
+
+                count -= numRead;
+                offset += numRead;
             }
         }
 #endif
@@ -386,12 +430,7 @@ namespace Lucene.Net.Support.IO
             byte[] buff = ArrayPool<byte>.Shared.Rent(4);
             try
             {
-                int read = await input.ReadAsync(buff, 0, 4, cancellationToken).ConfigureAwait(false);
-
-                if (read < 4)
-                {
-                    throw new EndOfStreamException();
-                }
+                await input.ReadExactlyAsync(buff, 0, 4, cancellationToken).ConfigureAwait(false);
 
                 return (buff[0] << 24) | (buff[1] << 16) | (buff[2] << 8) | buff[3];
             }
@@ -409,12 +448,7 @@ namespace Lucene.Net.Support.IO
             byte[] buff = ArrayPool<byte>.Shared.Rent(8);
             try
             {
-                int read = await input.ReadAsync(buff, 0, 8, cancellationToken).ConfigureAwait(false);
-
-                if (read < 8)
-                {
-                    throw new EndOfStreamException();
-                }
+                await input.ReadExactlyAsync(buff, 0, 8, cancellationToken).ConfigureAwait(false);
 
                 return ((long)buff[0] << 56) |
                        ((long)buff[1] << 48) |
@@ -439,24 +473,14 @@ namespace Lucene.Net.Support.IO
             byte[] lenBuff = ArrayPool<byte>.Shared.Rent(2);
             try
             {
-                int readLen = await input.ReadAsync(lenBuff, 0, 2, cancellationToken).ConfigureAwait(false);
-
-                if (readLen < 2)
-                {
-                    throw new EndOfStreamException("Unexpected end of stream while reading UTF length.");
-                }
+                await input.ReadExactlyAsync(lenBuff, 0, 2, cancellationToken).ConfigureAwait(false);
 
                 int length = (lenBuff[0] << 8) | lenBuff[1];
 
                 byte[] buffer = ArrayPool<byte>.Shared.Rent(length);
                 try
                 {
-                    int read = await input.ReadAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
-
-                    if (read < length)
-                    {
-                        throw new EndOfStreamException("Unexpected end of stream while reading UTF string.");
-                    }
+                    await input.ReadExactlyAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
 
                     return Encoding.UTF8.GetString(buffer, 0, length);
                 }
@@ -523,7 +547,7 @@ namespace Lucene.Net.Support.IO
         private static class SR
         {
             public const string IO_StreamTooLong = "Stream was too long.";
+            public const string IO_EOF_ReadBeyondEOF = "Unable to read beyond the end of the stream.";
         }
-
     }
 }

--- a/src/Lucene.Net/Support/IO/StreamExtensions.cs
+++ b/src/Lucene.Net/Support/IO/StreamExtensions.cs
@@ -1,11 +1,14 @@
-using Lucene.Net.Support.Threading;
 using System;
 using System.Buffers;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
+#if !FEATURE_RANDOMACCESS_READ
+using Lucene.Net.Support.Threading;
+using System.Runtime.CompilerServices;
+#endif
 
 namespace Lucene.Net.Support.IO
 {
@@ -154,6 +157,32 @@ namespace Lucene.Net.Support.IO
             }
         }
 
+#if !FEATURE_STREAM_READEXACTLY
+        /// <summary>
+        /// Reads bytes from the stream into <paramref name="buffer"/> until it is completely filled.
+        /// </summary>
+        /// <param name="stream">The stream to read from.</param>
+        /// <param name="buffer">The buffer to read into.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+        /// <exception cref="EndOfStreamException">The end of the stream is reached before filling the buffer.</exception>
+        /// <remarks>
+        /// This method is a polyfill for platforms (prior to .NET 7) that do not have the ReadExactly method.
+        /// </remarks>
+        public static void ReadExactly(this Stream stream, Span<byte> buffer)
+        {
+            if (stream is null)
+                throw new ArgumentNullException(nameof(stream));
+
+            while (buffer.Length > 0)
+            {
+                int numRead = stream.Read(buffer);
+                if (numRead == 0)
+                    throw new EndOfStreamException();
+                buffer = buffer.Slice(numRead);
+            }
+        }
+#endif
+
         /// <summary>
         /// Writes a sequence of bytes to the current stream and advances the current
         /// position within this stream by the number of bytes written.
@@ -186,14 +215,23 @@ namespace Lucene.Net.Support.IO
             if (chars is null)
                 throw new ArgumentNullException(nameof(chars));
 
-            byte[] newBytes = new byte[chars.Length * 2];
-            for (int index = 0; index < chars.Length; index++)
+            int byteCount = chars.Length * 2;
+            byte[] newBytes = ArrayPool<byte>.Shared.Rent(byteCount);
+            try
             {
-                int newIndex = index == 0 ? index : index * 2;
-                newBytes[newIndex] = (byte)chars[index];
-                newBytes[newIndex + 1] = (byte)(chars[index] >> 8);
+                for (int index = 0; index < chars.Length; index++)
+                {
+                    int newIndex = index == 0 ? index : index * 2;
+                    newBytes[newIndex] = (byte)chars[index];
+                    newBytes[newIndex + 1] = (byte)(chars[index] >> 8);
+                }
+
+                stream.Write(newBytes, 0, byteCount);
             }
-            stream.Write(newBytes, 0, newBytes.Length);
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(newBytes);
+            }
         }
 
         public static char[] ReadChars(this Stream stream, int count)
@@ -203,11 +241,11 @@ namespace Lucene.Net.Support.IO
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            byte[] buff = new byte[2];
+            Span<byte> buff = stackalloc byte[2];
             char[] newChars = new char[count];
             for (int i = 0; i < count; i++)
             {
-                stream.Read(buff, 0, 2);
+                stream.ReadExactly(buff);
                 newChars[i] = (char)((buff[0] & 0xff) | ((buff[1] & 0xff) << 8));
             }
             return newChars;
@@ -218,12 +256,12 @@ namespace Lucene.Net.Support.IO
             if (stream is null)
                 throw new ArgumentNullException(nameof(stream));
 
-            byte[] buff = new byte[4];
+            Span<byte> buff = stackalloc byte[4];
             buff[0] = (byte)(value);
             buff[1] = (byte)(value >> 8);
             buff[2] = (byte)(value >> 16);
             buff[3] = (byte)(value >> 24);
-            stream.Write(buff, 0, buff.Length);
+            stream.Write(buff);
         }
 
         public static int ReadInt32(this Stream stream)
@@ -231,8 +269,8 @@ namespace Lucene.Net.Support.IO
             if (stream is null)
                 throw new ArgumentNullException(nameof(stream));
 
-            byte[] buff = new byte[4];
-            stream.Read(buff, 0, buff.Length);
+            Span<byte> buff = stackalloc byte[4];
+            stream.ReadExactly(buff);
             return (buff[0] & 0xff) | ((buff[1] & 0xff) << 8) |
                 ((buff[2] & 0xff) << 16) | ((buff[3] & 0xff) << 24);
         }
@@ -242,7 +280,7 @@ namespace Lucene.Net.Support.IO
             if (stream is null)
                 throw new ArgumentNullException(nameof(stream));
 
-            byte[] buff = new byte[8];
+            Span<byte> buff = stackalloc byte[8];
             buff[0] = (byte)value;
             buff[1] = (byte)(value >> 8);
             buff[2] = (byte)(value >> 16);
@@ -251,7 +289,7 @@ namespace Lucene.Net.Support.IO
             buff[5] = (byte)(value >> 40);
             buff[6] = (byte)(value >> 48);
             buff[7] = (byte)(value >> 56);
-            stream.Write(buff, 0, buff.Length);
+            stream.Write(buff);
         }
 
         public static long ReadInt64(this Stream stream)
@@ -259,8 +297,8 @@ namespace Lucene.Net.Support.IO
             if (stream is null)
                 throw new ArgumentNullException(nameof(stream));
 
-            byte[] buff = new byte[8];
-            stream.Read(buff, 0, buff.Length);
+            Span<byte> buff = stackalloc byte[8];
+            stream.ReadExactly(buff);
             uint lo = (uint)(buff[0] | buff[1] << 8 |
                              buff[2] << 16 | buff[3] << 24);
             uint hi = (uint)(buff[4] | buff[5] << 8 |
@@ -268,19 +306,26 @@ namespace Lucene.Net.Support.IO
             return (long)((ulong)hi) << 32 | lo;
         }
 
-        //async versions of the above methods
+        // async versions of the above methods
         public static async Task WriteInt32BigEndianAsync(this Stream output, int value, CancellationToken cancellationToken = default)
         {
             if (output is null)
                 throw new ArgumentNullException(nameof(output));
 
-            byte[] buff = new byte[4];
-            buff[0] = (byte)(value >> 24);
-            buff[1] = (byte)(value >> 16);
-            buff[2] = (byte)(value >> 8);
-            buff[3] = (byte)value;
+            byte[] buff = ArrayPool<byte>.Shared.Rent(4);
+            try
+            {
+                buff[0] = (byte)(value >> 24);
+                buff[1] = (byte)(value >> 16);
+                buff[2] = (byte)(value >> 8);
+                buff[3] = (byte)value;
 
-            await output.WriteAsync(buff, 0, buff.Length, cancellationToken).ConfigureAwait(false);
+                await output.WriteAsync(buff, 0, 4, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buff);
+            }
         }
 
         public static async Task WriteInt64BigEndianAsync(this Stream output, long value, CancellationToken cancellationToken = default)
@@ -288,17 +333,24 @@ namespace Lucene.Net.Support.IO
             if (output is null)
                 throw new ArgumentNullException(nameof(output));
 
-            byte[] buff = new byte[8];
-            buff[0] = (byte)(value >> 56);
-            buff[1] = (byte)(value >> 48);
-            buff[2] = (byte)(value >> 40);
-            buff[3] = (byte)(value >> 32);
-            buff[4] = (byte)(value >> 24);
-            buff[5] = (byte)(value >> 16);
-            buff[6] = (byte)(value >> 8);
-            buff[7] = (byte)value;
+            byte[] buff = ArrayPool<byte>.Shared.Rent(8);
+            try
+            {
+                buff[0] = (byte)(value >> 56);
+                buff[1] = (byte)(value >> 48);
+                buff[2] = (byte)(value >> 40);
+                buff[3] = (byte)(value >> 32);
+                buff[4] = (byte)(value >> 24);
+                buff[5] = (byte)(value >> 16);
+                buff[6] = (byte)(value >> 8);
+                buff[7] = (byte)value;
 
-            await output.WriteAsync(buff, 0, buff.Length, cancellationToken).ConfigureAwait(false);
+                await output.WriteAsync(buff, 0, 8, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buff);
+            }
         }
 
         public static async Task WriteUTFAsync(this Stream output, string value, CancellationToken cancellationToken = default)
@@ -317,7 +369,7 @@ namespace Lucene.Net.Support.IO
             {
                 int offset = 0;
                 offset = WriteInt16BigEndianToBuffer((int)utfCount, buffer, offset);
-                offset = WriteUTFBytesToBuffer(value, (int)utfCount, buffer, offset);
+                offset = WriteUTFBytesToBuffer(value, buffer, offset);
 
                 await output.WriteAsync(buffer, 0, offset, cancellationToken).ConfigureAwait(false);
             }
@@ -331,11 +383,22 @@ namespace Lucene.Net.Support.IO
             if (input is null)
                 throw new ArgumentNullException(nameof(input));
 
-            byte[] buff = new byte[4];
-            int read = await input.ReadAsync(buff, 0, buff.Length, cancellationToken).ConfigureAwait(false);
-            if (read < buff.Length) throw new EndOfStreamException();
+            byte[] buff = ArrayPool<byte>.Shared.Rent(4);
+            try
+            {
+                int read = await input.ReadAsync(buff, 0, 4, cancellationToken).ConfigureAwait(false);
 
-            return (buff[0] << 24) | (buff[1] << 16) | (buff[2] << 8) | buff[3];
+                if (read < 4)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                return (buff[0] << 24) | (buff[1] << 16) | (buff[2] << 8) | buff[3];
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buff);
+            }
         }
 
         public static async Task<long> ReadInt64BigEndianAsync(this Stream input, CancellationToken cancellationToken = default)
@@ -343,18 +406,29 @@ namespace Lucene.Net.Support.IO
             if (input is null)
                 throw new ArgumentNullException(nameof(input));
 
-            byte[] buff = new byte[8];
-            int read = await input.ReadAsync(buff, 0, buff.Length, cancellationToken).ConfigureAwait(false);
-            if (read < buff.Length) throw new EndOfStreamException();
+            byte[] buff = ArrayPool<byte>.Shared.Rent(8);
+            try
+            {
+                int read = await input.ReadAsync(buff, 0, 8, cancellationToken).ConfigureAwait(false);
 
-            return ((long)buff[0] << 56) |
-                   ((long)buff[1] << 48) |
-                   ((long)buff[2] << 40) |
-                   ((long)buff[3] << 32) |
-                   ((long)buff[4] << 24) |
-                   ((long)buff[5] << 16) |
-                   ((long)buff[6] << 8) |
-                   buff[7];
+                if (read < 8)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                return ((long)buff[0] << 56) |
+                       ((long)buff[1] << 48) |
+                       ((long)buff[2] << 40) |
+                       ((long)buff[3] << 32) |
+                       ((long)buff[4] << 24) |
+                       ((long)buff[5] << 16) |
+                       ((long)buff[6] << 8) |
+                       buff[7];
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buff);
+            }
         }
 
         public static async Task<string> ReadUTFAsync(this Stream input, CancellationToken cancellationToken = default)
@@ -366,8 +440,11 @@ namespace Lucene.Net.Support.IO
             try
             {
                 int readLen = await input.ReadAsync(lenBuff, 0, 2, cancellationToken).ConfigureAwait(false);
+
                 if (readLen < 2)
+                {
                     throw new EndOfStreamException("Unexpected end of stream while reading UTF length.");
+                }
 
                 int length = (lenBuff[0] << 8) | lenBuff[1];
 
@@ -375,8 +452,11 @@ namespace Lucene.Net.Support.IO
                 try
                 {
                     int read = await input.ReadAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
+
                     if (read < length)
+                    {
                         throw new EndOfStreamException("Unexpected end of stream while reading UTF string.");
+                    }
 
                     return Encoding.UTF8.GetString(buffer, 0, length);
                 }
@@ -410,14 +490,14 @@ namespace Lucene.Net.Support.IO
             return utfCount;
         }
 
-        private static int WriteInt16BigEndianToBuffer(int value, byte[] buffer, int offset)
+        private static int WriteInt16BigEndianToBuffer(int value, Span<byte> buffer, int offset)
         {
             buffer[offset++] = (byte)(value >> 8);
             buffer[offset++] = (byte)value;
             return offset;
         }
 
-        private static int WriteUTFBytesToBuffer(string value, long count, byte[] buffer, int offset)
+        private static int WriteUTFBytesToBuffer(string value, Span<byte> buffer, int offset)
         {
             foreach (char ch in value)
             {

--- a/src/Lucene.Net/Support/IO/StreamExtensions.cs
+++ b/src/Lucene.Net/Support/IO/StreamExtensions.cs
@@ -211,10 +211,18 @@ namespace Lucene.Net.Support.IO
         {
             if (stream is null)
                 throw new ArgumentNullException(nameof(stream));
+            if (buffer is null)
+                throw new ArgumentNullException(nameof(buffer));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count));
+            if (buffer.Length - offset < count)
+                throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
 
             while (count > 0)
             {
-                int numRead = await stream.ReadAsync(buffer, offset, count, cancellationToken);
+                int numRead = await stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
 
                 if (numRead == 0)
                 {


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix the CA2022 code analysis warning, and add some related optimizations.

## Description

This fixes the CA2022 code analysis warning that started appearing in main Lucene.Net non-test code after the .NET 10 upgrade, saying that you should make sure to respect the return value of `Stream.Read` or you can use `Stream.ReadExactly`. Note that we started seeing this a while back when we added .NET 9 to the unit test projects (see #1052), but it did not flag this StreamExtensions code since the main library was still compiled with .NET 8 at the time.

For older platforms that don't support `Stream.ReadExactly`, this adds a polyfill, only for the `Span<T>` version, including unit tests. This is an improved version of the one that was originally proposed in (and then removed from) PR #1052, and simplified since it uses spans instead of arrays. While one valid approach could be to simply check the result of the Read call to address the warning, this at least lets us delegate to the BCL version for modern versions of .NET.

Also this corrects the feature flag for `Stream.ReadExactly` to correctly note that it was introduced in .NET 7, not .NET 9. The method is available for our .NET 8 target; it just wasn't a CA warning as of the .NET 8 SDK.

Finally, while I was in here I noticed several opportunities to reduce allocations. The small arrays of length 2-8 that were allocated on the heap previously are now stack-allocated for the synchronous methods. The asynchronous methods that weren't already using ArrayPool were updated to use that, since spans can't cross an await boundary. (A couple of the Write methods could be updated to use stack-allocated arrays instead of rented pool ones with C# 13, but that would require a further polyfill of WriteAsync, which could be done in a separate PR.) The synchronous methods are really only used by `Lucene.Net.Facet.Taxonomy.WriterCache.CharBlockArray`, and the asynchronous ones are used in `Lucene.Net.Replicator.SessionToken`.