### PR TITLE
Add 4 more pre-commit hooks; fix JSON file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,12 +54,24 @@ repos:
         description: trims trailing whitespace
         files: \.(bat|config|json|md|props|ps1|rdf|targets|tmpl|xml|ya?ml)$
         args: [--markdown-linebreak-ext=md]
+      - id: check-ast
+        name: run check-ast
+        description: check Python files for syntax errors
+      - id: check-builtin-literals
+        name: run check-builtin-literals
+        description: check Python files for proper use of built-in literals
       - id: check-case-conflict
         name: run check-case-conflict
         description: check for case conflicts in file names
+      - id: check-executables-have-shebangs
+        name: run check-executables-have-shebangs
+        description: check that executable scripts have shebang lines
       - id: check-illegal-windows-names
         name: run check-illegal-windows-names
         description: check for Windows-illegal file names
+      - id: check-json
+        name: run check-json
+        description: check JSON files for syntax errors
       - id: check-merge-conflict
         name: run check-merge-conflict
         description: check for merge conflict markers

--- a/websites/apidocs/docfx.json
+++ b/websites/apidocs/docfx.json
@@ -582,7 +582,7 @@
       "_appFaviconPath": "logo/favicon.ico",
       "_enableSearch": true,
       "_appLogoPath": "logo/lucene-net-color.png",
-      "_appFooter": "Copyright &copy; 2024 The Apache Software Foundation, Licensed under the <a href='http://www.apache.org/licenses/LICENSE-2.0' target='_blank'>Apache License, Version 2.0</a><br/> <small>Apache Lucene.Net, Lucene.Net, Apache, the Apache feather logo, and the Apache Lucene.Net project logo are trademarks of The Apache Software Foundation. <br/>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</small>",
+      "_appFooter": "Copyright &copy; 2024 The Apache Software Foundation, Licensed under the <a href='http://www.apache.org/licenses/LICENSE-2.0' target='_blank'>Apache License, Version 2.0</a><br/> <small>Apache Lucene.Net, Lucene.Net, Apache, the Apache feather logo, and the Apache Lucene.Net project logo are trademarks of The Apache Software Foundation. <br/>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</small>"
     },
     "overwrite": [
       {


### PR DESCRIPTION
The `check-json` hook found a JSON file with an unneeded trailing comma on one line

4 hooks from the official pre-commit org:

https://github.com/pre-commit/pre-commit-hooks

<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.
