### PR TITLE
Backport fixes for AnalyzingInfixSuggester

### DIFF
--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// <summary>
         /// Used for ongoing NRT additions/updates. </summary>
         // LUCENENET specific - changed from private to protected internal for LUCENE-7564 test support.
-        protected internal IndexWriter writer;
+        protected internal IndexWriter m_writer;
 
         /// <summary>
         /// <see cref="IndexSearcher"/> used for lookups. </summary>
@@ -307,19 +307,18 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     m_searcherMgr = null;
                 }
 
-                if (writer != null)
+                if (m_writer != null)
                 {
-                    writer.Dispose();
-                    writer = null;
+                    m_writer.Dispose();
+                    m_writer = null;
                 }
 
-                AtomicReader r = null;
                 bool success = false;
                 try
                 {
                     // First pass: build a temporary normal Lucene index,
                     // just indexing the suggestions as they iterate:
-                    writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.CREATE));
+                    m_writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.CREATE));
                     //long t0 = System.nanoTime();
 
                     // TODO: use threads?
@@ -345,7 +344,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     {
                         Commit();
                     }
-                    m_searcherMgr = new SearcherManager(writer, true, null);
+                    m_searcherMgr = new SearcherManager(m_writer, true, null);
                     success = true;
                 }
                 finally
@@ -354,19 +353,17 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     {
                         if (closeIndexWriterOnBuild)  // LUCENENET specific - Support for LUCENE-7564.
                         {
-                            writer.Dispose();
-                            writer = null;
+                            m_writer.Dispose();
+                            m_writer = null;
                         }
-                        IOUtils.Dispose(r);
                     }
                     else
                     {
-                        if (writer != null)
+                        if (m_writer != null)
                         {
-                            writer.Rollback();
-                            writer = null;
+                            m_writer.Rollback();
+                            m_writer = null;
                         }
-                        IOUtils.DisposeWhileHandlingException(r);
                     }
                 }
             }
@@ -379,17 +376,17 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         // LUCENENET specific - Support for LUCENE-5889, LUCENE-7564.
         public void Commit()
         {
-            if (writer is null)
+            if (m_writer is null)
             {
                 if (m_searcherMgr is null || closeIndexWriterOnBuild == false)
                 {
-                    throw IllegalStateException.Create("Cannot commit on an closed writer. Add documents first");
+                    throw IllegalStateException.Create("Cannot commit on a closed writer. Add documents first");
                 }
                 // else no-op: writer was committed and closed after the index was built, so commit is unnecessary
             }
             else
             {
-                writer.Commit();
+                m_writer.Commit();
             }
         }
 
@@ -432,28 +429,28 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         // LUCENENET specific - Support for LUCENE-5889, LUCENE-7564.
         private void EnsureOpen()
         {
-            if (writer != null)
+            if (m_writer != null)
                 return;
 
             UninterruptableMonitor.Enter(syncLock);
             try
             {
-                if (writer is null)
+                if (m_writer is null)
                 {
                     if (DirectoryReader.IndexExists(dir))
                     {
                         // Already built; open it:
-                        writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.APPEND));
+                        m_writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.APPEND));
                     }
                     else
                     {
-                        writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.CREATE));
+                        m_writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.CREATE));
                     }
                     UninterruptableMonitor.Enter(searcherMgrLock);
                     try
                     {
                         SearcherManager oldSearcherMgr = m_searcherMgr;
-                        m_searcherMgr = new SearcherManager(writer, true, null);
+                        m_searcherMgr = new SearcherManager(m_writer, true, null);
                         if (oldSearcherMgr != null)
                         {
                             oldSearcherMgr.Dispose();
@@ -481,7 +478,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         public virtual void Add(BytesRef text, IEnumerable<BytesRef> contexts, long weight, BytesRef payload)
         {
             EnsureOpen();    // LUCENENET specific - Support for LUCENE-5889.
-            writer.AddDocument(BuildDocument(text, contexts, weight, payload));
+            m_writer.AddDocument(BuildDocument(text, contexts, weight, payload));
         }
 
         /// <summary>
@@ -496,7 +493,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         public virtual void Update(BytesRef text, IEnumerable<BytesRef> contexts, long weight, BytesRef payload)
         {
             EnsureOpen();    // LUCENENET specific - Support for LUCENE-5889.
-            writer.UpdateDocument(new Term(EXACT_TEXT_FIELD_NAME, text.Utf8ToString()), BuildDocument(text, contexts, weight, payload));
+            m_writer.UpdateDocument(new Term(EXACT_TEXT_FIELD_NAME, text.Utf8ToString()), BuildDocument(text, contexts, weight, payload));
         }
 
         private Document BuildDocument(BytesRef text, IEnumerable<BytesRef> contexts, long weight, BytesRef payload)
@@ -539,7 +536,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             {
                 throw IllegalStateException.Create("suggester was not built");
             }
-            if (writer != null) // LUCENENET specific - Support for LUCENE-7564.
+            if (m_writer != null) // LUCENENET specific - Support for LUCENE-7564.
             {
                 m_searcherMgr.MaybeRefreshBlocking();
             }
@@ -975,10 +972,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     m_searcherMgr.Dispose();
                     m_searcherMgr = null;
                 }
-                if (writer != null)
+                if (m_writer != null)
                 {
-                    writer.Dispose();
-                    writer = null;
+                    m_writer.Dispose();
+                    m_writer = null;
                 }
                 if (dir != null) // LUCENENET specific - Support for LUCENE-7564. Close dir even when writer is null.
                 {

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -92,12 +92,14 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         private readonly Directory dir;
         internal readonly int minPrefixChars;
         private readonly bool commitOnBuild;
+        private readonly bool closeIndexWriterOnBuild; // LUCENENET specific - Support for LUCENE-7564.
         // LUCENENET specific - index writer config factory for extending classes
         private readonly IAnalyzingInfixSuggesterIndexWriterConfigFactory indexWriterConfigFactory;
 
         /// <summary>
         /// Used for ongoing NRT additions/updates. </summary>
-        private IndexWriter writer;
+        // LUCENENET specific - changed from private to protected internal for LUCENE-7564 test support.
+        protected internal IndexWriter writer;
 
         /// <summary>
         /// <see cref="IndexSearcher"/> used for lookups. </summary>
@@ -108,6 +110,12 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         ///  PrefixQuery is used (4).
         /// </summary>
         public const int DEFAULT_MIN_PREFIX_CHARS = 4;
+
+        /// <summary>
+        /// Default option to close the <see cref="IndexWriter"/> once the index has been built.
+        /// </summary>
+        // LUCENENET specific - Support for LUCENE-7564.
+        protected const bool DEFAULT_CLOSE_INDEXWRITER_ON_BUILD = true;
 
         /// <summary>
         /// How we sort the postings and search results. </summary>
@@ -138,8 +146,9 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         ///     Prefixes shorter than this are indexed as character
         ///     ngrams (increasing index size but making lookups
         ///     faster). </param>
-        // LUCENENET specific - LUCENE-5889, a 4.11.0 feature. calls new constructor with extra param.
-        // LUCENENET UPGRADE TODO: Remove method at version 4.11.0. Was retained for perfect 4.8 compatibility
+        // LUCENENET specific - backported from LUCENE-5889 (4.11.0), LUCENE-7564 (6.4.0), LUCENE-7670 (6.4.1).
+        // Calls new constructor with default values for commitOnBuild and closeIndexWriterOnBuild.
+        // Retained for backwards compatibility.
         public AnalyzingInfixSuggester(LuceneVersion matchVersion, Directory dir, Analyzer indexAnalyzer,
             Analyzer queryAnalyzer, int minPrefixChars)
             : this(matchVersion, dir, indexAnalyzer, queryAnalyzer, minPrefixChars, commitOnBuild: false)
@@ -165,7 +174,33 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         // LUCENENET specific - LUCENE-5889, a 4.11.0 feature. (Code moved from other constructor to here.)
         public AnalyzingInfixSuggester(LuceneVersion matchVersion, Directory dir, Analyzer indexAnalyzer,
             Analyzer queryAnalyzer, int minPrefixChars, bool commitOnBuild)
-            : this(new AnalyzingInfixSuggesterIndexWriterConfigFactory(SORT), matchVersion, dir, indexAnalyzer, queryAnalyzer, minPrefixChars, commitOnBuild)
+            : this(matchVersion, dir, indexAnalyzer, queryAnalyzer, minPrefixChars, commitOnBuild, DEFAULT_CLOSE_INDEXWRITER_ON_BUILD)
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance, loading from a previously built
+        /// <see cref="AnalyzingInfixSuggester"/> directory, if it exists.  This directory must be
+        /// private to the infix suggester (i.e., not an external
+        /// Lucene index).  Note that <see cref="Dispose()"/>
+        /// will also dispose the provided directory.
+        /// </summary>
+        ///  <param name="minPrefixChars"> Minimum number of leading characters
+        ///     before <see cref="PrefixQuery"/> is used (default 4).
+        ///     Prefixes shorter than this are indexed as character
+        ///     ngrams (increasing index size but making lookups
+        ///     faster). </param>
+        ///  <param name="commitOnBuild"> Call commit after the index has finished building. This
+        ///  would persist the suggester index to disk and future instances of this suggester can
+        ///  use this pre-built dictionary. </param>
+        ///  <param name="closeIndexWriterOnBuild"> If <c>true</c>, the <see cref="IndexWriter"/> will be closed
+        ///  after the index has finished building. </param>
+        // LUCENENET specific - closeIndexWriterOnBuild backported from LUCENE-7564.
+        // Note: Java's equivalent constructor also has allTermsRequired and highlight parameters, which
+        // are not present here because those are method-level parameters in this version of Lucene.NET.
+        public AnalyzingInfixSuggester(LuceneVersion matchVersion, Directory dir, Analyzer indexAnalyzer,
+            Analyzer queryAnalyzer, int minPrefixChars, bool commitOnBuild, bool closeIndexWriterOnBuild)
+            : this(new AnalyzingInfixSuggesterIndexWriterConfigFactory(SORT), matchVersion, dir, indexAnalyzer, queryAnalyzer, minPrefixChars, commitOnBuild, closeIndexWriterOnBuild)
         {
         }
 
@@ -186,14 +221,41 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         ///  use this pre-built dictionary. </param>
         /// <param name="indexWriterConfigFactory"> Factory for creating the <see cref="IndexWriterConfig"/>. </param>
         // LUCENENET specific - added indexWriterConfigFactory parameter to allow for customizing the index writer config.
+        // Retained for backwards compatibility.
         public AnalyzingInfixSuggester(IAnalyzingInfixSuggesterIndexWriterConfigFactory indexWriterConfigFactory, LuceneVersion matchVersion,
             Directory dir, Analyzer indexAnalyzer, Analyzer queryAnalyzer, int minPrefixChars, bool commitOnBuild)
+            : this(indexWriterConfigFactory, matchVersion, dir, indexAnalyzer, queryAnalyzer, minPrefixChars, commitOnBuild, DEFAULT_CLOSE_INDEXWRITER_ON_BUILD)
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance, loading from a previously built
+        /// <see cref="AnalyzingInfixSuggester"/> directory, if it exists.  This directory must be
+        /// private to the infix suggester (i.e., not an external
+        /// Lucene index).  Note that <see cref="Dispose()"/>
+        /// will also dispose the provided directory.
+        /// </summary>
+        ///  <param name="minPrefixChars"> Minimum number of leading characters
+        ///     before <see cref="PrefixQuery"/> is used (default 4).
+        ///     Prefixes shorter than this are indexed as character
+        ///     ngrams (increasing index size but making lookups
+        ///     faster). </param>
+        ///  <param name="commitOnBuild"> Call commit after the index has finished building. This
+        ///  would persist the suggester index to disk and future instances of this suggester can
+        ///  use this pre-built dictionary. </param>
+        ///  <param name="closeIndexWriterOnBuild"> If <c>true</c>, the <see cref="IndexWriter"/> will be closed
+        ///  after the index has finished building. </param>
+        /// <param name="indexWriterConfigFactory"> Factory for creating the <see cref="IndexWriterConfig"/>. </param>
+        // LUCENENET specific - added indexWriterConfigFactory and closeIndexWriterOnBuild parameters.
+        public AnalyzingInfixSuggester(IAnalyzingInfixSuggesterIndexWriterConfigFactory indexWriterConfigFactory, LuceneVersion matchVersion,
+            Directory dir, Analyzer indexAnalyzer, Analyzer queryAnalyzer, int minPrefixChars, bool commitOnBuild, bool closeIndexWriterOnBuild)
         {
             if (minPrefixChars < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(minPrefixChars), "minPrefixChars must be >= 0; got: " + minPrefixChars);// LUCENENET specific - changed from IllegalArgumentException to ArgumentOutOfRangeException (.NET convention)
             }
 
+            // LUCENENET specific - moved IndexWriterConfig to AnalyzingInfixSuggesterIndexWriterConfigFactory
             if (indexWriterConfigFactory is null) throw new ArgumentNullException(nameof(indexWriterConfigFactory));
 
             this.m_queryAnalyzer = queryAnalyzer;
@@ -202,14 +264,19 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             this.dir = dir;
             this.minPrefixChars = minPrefixChars;
             this.commitOnBuild = commitOnBuild;
+            this.closeIndexWriterOnBuild = closeIndexWriterOnBuild;
             this.indexWriterConfigFactory = indexWriterConfigFactory;
 
             if (DirectoryReader.IndexExists(dir))
             {
                 // Already built; open it:
-                var config = indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.APPEND);
-                writer = new IndexWriter(dir, config);
-                m_searcherMgr = new SearcherManager(writer, true, null);
+
+                // LUCENENET specific - backported fix from Lucene 6.4.1 to fix #1242. previously was:
+                // var config = indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.APPEND);
+                // writer = new IndexWriter(dir, config);
+                // m_searcherMgr = new SearcherManager(writer, true, null);
+
+                m_searcherMgr = new SearcherManager(dir, null);
             }
         }
 
@@ -268,7 +335,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 }
 
                 //System.out.println("initial indexing time: " + ((System.nanoTime()-t0)/1000000) + " msec");
-                if (commitOnBuild)                      //LUCENENET specific -Support for LUCENE - 5889.
+                if (commitOnBuild || closeIndexWriterOnBuild) // LUCENENET specific - Support for LUCENE-5889, LUCENE-7564.
                 {
                     Commit();
                 }
@@ -279,24 +346,40 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             {
                 if (success)
                 {
+                    if (closeIndexWriterOnBuild)  // LUCENENET specific - Support for LUCENE-7564.
+                    {
+                        writer.Dispose();
+                        writer = null;
+                    }
                     IOUtils.Dispose(r);
                 }
                 else
                 {
-                    IOUtils.DisposeWhileHandlingException(writer, r);
-                    writer = null;
+                    if (writer != null)
+                    {
+                        writer.Rollback();
+                        writer = null;
+                    }
+                    IOUtils.DisposeWhileHandlingException(r);
                 }
             }
         }
 
-        // LUCENENET specific -Support for LUCENE-5889.
+        // LUCENENET specific - Support for LUCENE-5889, LUCENE-7564.
         public void Commit()
         {
             if (writer is null)
             {
-                throw IllegalStateException.Create("Cannot commit on an closed writer. Add documents first");
+                if (m_searcherMgr is null || closeIndexWriterOnBuild == false)
+                {
+                    throw IllegalStateException.Create("Cannot commit on an closed writer. Add documents first");
+                }
+                // else no-op: writer was committed and closed after the index was built, so commit is unnecessary
             }
-            writer.Commit();
+            else
+            {
+                writer.Commit();
+            }
         }
 
         private Analyzer GetGramAnalyzer()
@@ -335,7 +418,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
         }
 
-        //LUCENENET specific -Support for LUCENE - 5889.
+        // LUCENENET specific - Support for LUCENE-5889, LUCENE-7564.
         private void EnsureOpen()
         {
             if (writer != null)
@@ -346,13 +429,21 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             {
                 if (writer is null)
                 {
-                    if (m_searcherMgr != null)
+                    if (DirectoryReader.IndexExists(dir))
                     {
-                        m_searcherMgr.Dispose();
-                        m_searcherMgr = null;
+                        // Already built; open it:
+                        writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.APPEND));
                     }
-                    writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.CREATE));
+                    else
+                    {
+                        writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.CREATE));
+                    }
+                    SearcherManager oldSearcherMgr = m_searcherMgr;
                     m_searcherMgr = new SearcherManager(writer, true, null);
+                    if (oldSearcherMgr != null)
+                    {
+                        oldSearcherMgr.Dispose();
+                    }
                 }
             }
             finally
@@ -370,14 +461,14 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// </summary>
         public virtual void Add(BytesRef text, IEnumerable<BytesRef> contexts, long weight, BytesRef payload)
         {
-            EnsureOpen();    //LUCENENET specific -Support for LUCENE - 5889.
+            EnsureOpen();    // LUCENENET specific - Support for LUCENE-5889.
             writer.AddDocument(BuildDocument(text, contexts, weight, payload));
         }
 
         /// <summary>
         /// Updates a previous suggestion, matching the exact same
         /// text as before.  Use this to change the weight or
-        /// payload of an already added suggstion.  If you know
+        /// payload of an already added suggestion.  If you know
         /// this text is not already present you can use <see cref="Add"/>
         /// instead.  After adding or updating a batch of
         /// new suggestions, you must call <see cref="Refresh()"/> in the
@@ -385,6 +476,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// </summary>
         public virtual void Update(BytesRef text, IEnumerable<BytesRef> contexts, long weight, BytesRef payload)
         {
+            EnsureOpen();    // LUCENENET specific - Support for LUCENE-5889.
             writer.UpdateDocument(new Term(EXACT_TEXT_FIELD_NAME, text.Utf8ToString()), BuildDocument(text, contexts, weight, payload));
         }
 
@@ -424,11 +516,16 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// </summary>
         public virtual void Refresh()
         {
-            if (m_searcherMgr is null) // LUCENENET specific -Support for LUCENE-5889.
+            if (m_searcherMgr is null) // LUCENENET specific - Support for LUCENE-5889.
             {
                 throw IllegalStateException.Create("suggester was not built");
             }
-            m_searcherMgr.MaybeRefreshBlocking();
+            if (writer != null) // LUCENENET specific - Support for LUCENE-7564.
+            {
+                m_searcherMgr.MaybeRefreshBlocking();
+            }
+            // else no-op: writer was committed and closed after the index was built
+            //             and before searcherMgr was constructed, so refresh is unnecessary
         }
 
         /// <summary>
@@ -851,8 +948,11 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 if (writer != null)
                 {
                     writer.Dispose();
-                    dir.Dispose();
                     writer = null;
+                }
+                if (dir != null) // LUCENENET specific - Support for LUCENE-7564. Close dir even when writer is null.
+                {
+                    dir.Dispose();
                 }
             }
         }

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -65,6 +65,9 @@ namespace Lucene.Net.Search.Suggest.Analyzing
     public class AnalyzingInfixSuggester : Lookup, IDisposable
     {
         private readonly object syncLock = new object();            //uses syncLock as substitute for Java's synchronized (method) keyword
+        // LUCENENET specific - Support for LUCENE-7564.
+        // Forces single-threaded access to the SearcherManager when performing an acquire() or reassigning.
+        private readonly object searcherMgrLock = new object();
 
         /// <summary>
         /// Field name used for the indexed text. </summary>
@@ -295,73 +298,81 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
         public override void Build(IInputEnumerator enumerator)
         {
-            if (m_searcherMgr != null)
-            {
-                m_searcherMgr.Dispose();
-                m_searcherMgr = null;
-            }
-
-            if (writer != null)
-            {
-                writer.Dispose();
-                writer = null;
-            }
-
-            AtomicReader r = null;
-            bool success = false;
+            UninterruptableMonitor.Enter(searcherMgrLock);
             try
             {
-                // First pass: build a temporary normal Lucene index,
-                // just indexing the suggestions as they iterate:
-                writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.CREATE));
-                //long t0 = System.nanoTime();
-
-                // TODO: use threads?
-                BytesRef text;
-                while (enumerator.MoveNext())
+                if (m_searcherMgr != null)
                 {
-                    text = enumerator.Current;
-                    BytesRef payload;
-                    if (enumerator.HasPayloads)
+                    m_searcherMgr.Dispose();
+                    m_searcherMgr = null;
+                }
+
+                if (writer != null)
+                {
+                    writer.Dispose();
+                    writer = null;
+                }
+
+                AtomicReader r = null;
+                bool success = false;
+                try
+                {
+                    // First pass: build a temporary normal Lucene index,
+                    // just indexing the suggestions as they iterate:
+                    writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.CREATE));
+                    //long t0 = System.nanoTime();
+
+                    // TODO: use threads?
+                    BytesRef text;
+                    while (enumerator.MoveNext())
                     {
-                        payload = enumerator.Payload;
+                        text = enumerator.Current;
+                        BytesRef payload;
+                        if (enumerator.HasPayloads)
+                        {
+                            payload = enumerator.Payload;
+                        }
+                        else
+                        {
+                            payload = null;
+                        }
+
+                        Add(text, enumerator.Contexts, enumerator.Weight, payload);
+                    }
+
+                    //System.out.println("initial indexing time: " + ((System.nanoTime()-t0)/1000000) + " msec");
+                    if (commitOnBuild || closeIndexWriterOnBuild) // LUCENENET specific - Support for LUCENE-5889, LUCENE-7564.
+                    {
+                        Commit();
+                    }
+                    m_searcherMgr = new SearcherManager(writer, true, null);
+                    success = true;
+                }
+                finally
+                {
+                    if (success)
+                    {
+                        if (closeIndexWriterOnBuild)  // LUCENENET specific - Support for LUCENE-7564.
+                        {
+                            writer.Dispose();
+                            writer = null;
+                        }
+                        IOUtils.Dispose(r);
                     }
                     else
                     {
-                        payload = null;
+                        if (writer != null)
+                        {
+                            writer.Rollback();
+                            writer = null;
+                        }
+                        IOUtils.DisposeWhileHandlingException(r);
                     }
-
-                    Add(text, enumerator.Contexts, enumerator.Weight, payload);
                 }
-
-                //System.out.println("initial indexing time: " + ((System.nanoTime()-t0)/1000000) + " msec");
-                if (commitOnBuild || closeIndexWriterOnBuild) // LUCENENET specific - Support for LUCENE-5889, LUCENE-7564.
-                {
-                    Commit();
-                }
-                m_searcherMgr = new SearcherManager(writer, true, null);
-                success = true;
             }
             finally
             {
-                if (success)
-                {
-                    if (closeIndexWriterOnBuild)  // LUCENENET specific - Support for LUCENE-7564.
-                    {
-                        writer.Dispose();
-                        writer = null;
-                    }
-                    IOUtils.Dispose(r);
-                }
-                else
-                {
-                    if (writer != null)
-                    {
-                        writer.Rollback();
-                        writer = null;
-                    }
-                    IOUtils.DisposeWhileHandlingException(r);
-                }
+                UninterruptableMonitor.Exit(searcherMgrLock);
             }
         }
 
@@ -438,11 +449,19 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     {
                         writer = new IndexWriter(dir, indexWriterConfigFactory.Get(matchVersion, GetGramAnalyzer(), OpenMode.CREATE));
                     }
-                    SearcherManager oldSearcherMgr = m_searcherMgr;
-                    m_searcherMgr = new SearcherManager(writer, true, null);
-                    if (oldSearcherMgr != null)
+                    UninterruptableMonitor.Enter(searcherMgrLock);
+                    try
                     {
-                        oldSearcherMgr.Dispose();
+                        SearcherManager oldSearcherMgr = m_searcherMgr;
+                        m_searcherMgr = new SearcherManager(writer, true, null);
+                        if (oldSearcherMgr != null)
+                        {
+                            oldSearcherMgr.Dispose();
+                        }
+                    }
+                    finally
+                    {
+                        UninterruptableMonitor.Exit(searcherMgrLock);
                     }
                 }
             }
@@ -704,8 +723,19 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             // We sorted postings by weight during indexing, so we
             // only retrieve the first num hits now:
             ICollector c2 = new EarlyTerminatingSortingCollector(c, SORT, num);
-            IndexSearcher searcher = m_searcherMgr.Acquire();
             IList<LookupResult> results = null;
+            SearcherManager mgr; // LUCENENET specific - Support for LUCENE-7564: acquire & release on same SearcherManager, via local reference
+            IndexSearcher searcher;
+            UninterruptableMonitor.Enter(searcherMgrLock);
+            try
+            {
+                mgr = m_searcherMgr;
+                searcher = mgr.Acquire();
+            }
+            finally
+            {
+                UninterruptableMonitor.Exit(searcherMgrLock);
+            }
             try
             {
                 //System.out.println("got searcher=" + searcher);
@@ -719,7 +749,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
             finally
             {
-                m_searcherMgr.Release(searcher);
+                mgr.Release(searcher);
             }
 
             //System.out.println(((J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond) - t0) + " msec for infix suggest"); // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
@@ -964,7 +994,18 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             {
                 if (m_searcherMgr != null)
                 {
-                    IndexSearcher searcher = m_searcherMgr.Acquire();
+                    SearcherManager mgr; // LUCENENET specific - Support for LUCENE-7564: acquire & release on same SearcherManager, via local reference
+                    IndexSearcher searcher;
+                    UninterruptableMonitor.Enter(searcherMgrLock);
+                    try
+                    {
+                        mgr = m_searcherMgr;
+                        searcher = mgr.Acquire();
+                    }
+                    finally
+                    {
+                        UninterruptableMonitor.Exit(searcherMgrLock);
+                    }
                     try
                     {
                         foreach (AtomicReaderContext context in searcher.IndexReader.Leaves)
@@ -978,7 +1019,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     }
                     finally
                     {
-                        m_searcherMgr.Release(searcher);
+                        mgr.Release(searcher);
                     }
                 }
                 return mem;
@@ -997,14 +1038,25 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 {
                     return 0;
                 }
-                IndexSearcher searcher = m_searcherMgr.Acquire();
+                SearcherManager mgr; // LUCENENET specific - Support for LUCENE-7564: acquire & release on same SearcherManager, via local reference
+                IndexSearcher searcher;
+                UninterruptableMonitor.Enter(searcherMgrLock);
+                try
+                {
+                    mgr = m_searcherMgr;
+                    searcher = mgr.Acquire();
+                }
+                finally
+                {
+                    UninterruptableMonitor.Exit(searcherMgrLock);
+                }
                 try
                 {
                     return searcher.IndexReader.NumDocs;
                 }
                 finally
                 {
-                    m_searcherMgr.Release(searcher);
+                    mgr.Release(searcher);
                 }
             }
         }

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/BlendedInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/BlendedInfixSuggester.cs
@@ -105,8 +105,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// <param name="blenderType"> Type of blending strategy, see BlenderType for more precisions </param>
         /// <param name="numFactor">   Factor to multiply the number of searched elements before ponderate </param>
         /// <exception cref="IOException"> If there are problems opening the underlying Lucene index. </exception>
-        // LUCENENET specific - LUCENE-5889, a 4.11.0 feature. calls new constructor with extra param.
-        // LUCENENET UPGRADE TODO: Remove method at version 4.11.0. Was retained for perfect 4.8 compatibility
+        // LUCENENET specific - retained for backwards compatibility. Calls new constructor with default
+        // commitOnBuild value. Java does not have this overload without commitOnBuild post-LUCENE-5889.
         public BlendedInfixSuggester(LuceneVersion matchVersion, Directory dir, Analyzer indexAnalyzer, Analyzer queryAnalyzer, int minPrefixChars,
                                      BlenderType blenderType, int numFactor)
             : this(matchVersion, dir, indexAnalyzer, queryAnalyzer, minPrefixChars, blenderType, numFactor, commitOnBuild: false)

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
@@ -4,6 +4,7 @@ using J2N.Threading;
 using J2N.Threading.Atomic;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Core;
+using Lucene.Net.Index;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Support.Threading;
@@ -52,7 +53,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             };
 
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
-            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false);
             suggester.Build(new InputArrayEnumerator(keys));
 
             IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), 10, true, true);
@@ -95,14 +96,14 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             DirectoryInfo tempDir = CreateTempDir("AnalyzingInfixSuggesterTest");
 
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
-            AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, 3);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+            AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, 3, false);
             try
             {
                 suggester.Build(new InputArrayEnumerator(keys));
                 assertEquals(2, suggester.Count);
                 suggester.Dispose();
 
-                suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, 3);                            //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, 3, false);
                 IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), 10, true, true);
                 assertEquals(2, results.size());
                 assertEquals("a penny saved is a penny <b>ear</b>ned", results[0].Key);
@@ -145,7 +146,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         internal class TestHighlightAnalyzingInfixSuggester : AnalyzingInfixSuggester
         {
             public TestHighlightAnalyzingInfixSuggester(AnalyzingInfixSuggesterTest outerInstance, Analyzer a)
-                : base(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3)                                                               //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                : base(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false)
             {
             }
 
@@ -254,7 +255,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
             int minPrefixLength = Random.nextInt(10);
-            AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, minPrefixLength);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+            AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, minPrefixLength, false);
             try
             {
                 suggester.Build(new InputArrayEnumerator(keys));
@@ -330,7 +331,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
                     // Make sure things still work after close and reopen:
                     suggester.Dispose();
-                    suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, minPrefixLength);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                    suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, minPrefixLength, false);
                 }
             }
             finally
@@ -348,7 +349,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             };
 
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
-            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false);
             suggester.Build(new InputArrayEnumerator(keys));
             IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("penn", Random).ToString(), 10, true, true);
             assertEquals(1, results.size());
@@ -359,7 +360,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         {
             private readonly AnalyzingInfixSuggesterTest outerInstance;
             public TestHighlightChangeCaseAnalyzingInfixSuggester(AnalyzingInfixSuggesterTest outerInstance, Analyzer a)
-                : base(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3)                                                               //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                : base(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false)
             {
                 this.outerInstance = outerInstance;
             }
@@ -381,7 +382,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, true);
             IList<Lookup.LookupResult> results;
-            using (AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3))                  //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+            using (AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false))
             {
                 suggester.Build(new InputArrayEnumerator(keys));
                 results = suggester.DoLookup(TestUtil.StringToCharSequence("penn", Random).ToString(), 10, true, true);
@@ -445,7 +446,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         public void TestEmptyAtStart()
         {
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
-            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3);                       //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false);
             suggester.Build(new InputArrayEnumerator(new Input[0]));
             suggester.Add(new BytesRef("a penny saved is a penny earned"), null, 10, new BytesRef("foobaz"));
             suggester.Add(new BytesRef("lend me your ear"), null, 8, new BytesRef("foobar"));
@@ -483,7 +484,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         public void TestBothExactAndPrefix()
         {
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
-            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false);
             suggester.Build(new InputArrayEnumerator(new Input[0]));
             suggester.Add(new BytesRef("the pen is pretty"), null, 10, new BytesRef("foobaz"));
             suggester.Refresh();
@@ -595,7 +596,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                 Console.WriteLine("  minPrefixChars=" + minPrefixChars);
             }
 
-            AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, minPrefixChars);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+            AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, minPrefixChars, false);
             try
             {
 
@@ -692,7 +693,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                         }
                         lookupThread.Finish();
                         suggester.Dispose();
-                        suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, minPrefixChars);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                        suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, minPrefixChars, false);
                         lookupThread = new LookupThread(this, suggester);
                         lookupThread.Start();
 
@@ -896,7 +897,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             };
 
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
-            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false);
             suggester.Build(new InputArrayEnumerator(keys));
 
             IList<Lookup.LookupResult> results = suggester.DoLookup(TestUtil.StringToCharSequence("ear", Random).ToString(), 10, true, true);
@@ -1034,6 +1035,145 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             return result;
         }
 
+        // LUCENENET specific - helper subclass for LUCENE-7564 tests.
+        // Exposes writer and searcherMgr for assertions.
+        internal class MyAnalyzingInfixSuggester : AnalyzingInfixSuggester
+        {
+            public MyAnalyzingInfixSuggester(Store.Directory dir, Analyzer indexAnalyzer, Analyzer queryAnalyzer,
+                int minPrefixChars, bool commitOnBuild, bool closeIndexWriterOnBuild)
+                : base(TEST_VERSION_CURRENT, dir, indexAnalyzer, queryAnalyzer, minPrefixChars, commitOnBuild, closeIndexWriterOnBuild)
+            {
+            }
+
+            public IndexWriter GetIndexWriter()
+            {
+                return writer;
+            }
+
+            public SearcherManager GetSearcherManager()
+            {
+                return m_searcherMgr;
+            }
+        }
+
+        // LUCENENET specific - backported from LUCENE-7564, with additions from LUCENE-7670.
+        [Test]
+        public void TestCloseIndexWriterOnBuild()
+        {
+            Input[] sharedInputs = new Input[]
+            {
+                new Input("lend me your ear", 8, new BytesRef("foobar")),
+                new Input("a penny saved is a penny earned", 10, new BytesRef("foobaz")),
+            };
+
+            // After Build(), when closeIndexWriterOnBuild = true:
+            // * The IndexWriter should be null
+            // * The SearcherManager should be non-null
+            // * SearcherManager's IndexWriter reference should be closed
+            //   (as evidenced by MaybeRefreshBlocking() throwing AlreadyClosedException)
+            Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
+            DirectoryInfo tempDir = CreateTempDir("analyzingInfixContext");
+            MyAnalyzingInfixSuggester suggester = new MyAnalyzingInfixSuggester(NewFSDirectory(tempDir), a, a, 3, false, true);
+            suggester.Build(new InputArrayEnumerator(sharedInputs));
+            assertNull(suggester.GetIndexWriter());
+            assertNotNull(suggester.GetSearcherManager());
+            Assert.Throws<ObjectDisposedException>(() => suggester.GetSearcherManager().MaybeRefreshBlocking());
+
+            suggester.Dispose();
+
+            // LUCENENET specific - backported from LUCENE-7670.
+            // After instantiating from an already-built suggester dir:
+            // * The IndexWriter should be null
+            // * The SearcherManager should be non-null
+            MyAnalyzingInfixSuggester suggester2 = new MyAnalyzingInfixSuggester(NewFSDirectory(tempDir), a, a, 3, false, true);
+            assertNull(suggester2.GetIndexWriter());
+            assertNotNull(suggester2.GetSearcherManager());
+
+            suggester2.Dispose();
+        }
+
+        // LUCENENET specific - backported from LUCENE-7564.
+        [Test]
+        public void TestCommitAfterBuild()
+        {
+            PerformOperationWithAllOptionCombinations(suggester =>
+            {
+                suggester.Build(new InputArrayEnumerator(SharedInputs));
+                suggester.Commit();
+            });
+        }
+
+        // LUCENENET specific - backported from LUCENE-7564.
+        [Test]
+        public void TestRefreshAfterBuild()
+        {
+            PerformOperationWithAllOptionCombinations(suggester =>
+            {
+                suggester.Build(new InputArrayEnumerator(SharedInputs));
+                suggester.Refresh();
+            });
+        }
+
+        // LUCENENET specific - backported from LUCENE-7564.
+        [Test]
+        public void TestDisallowCommitBeforeBuild()
+        {
+            PerformOperationWithAllOptionCombinations(suggester =>
+                Assert.Throws<InvalidOperationException>(() => suggester.Commit()));
+        }
+
+        // LUCENENET specific - backported from LUCENE-7564.
+        [Test]
+        public void TestDisallowRefreshBeforeBuild()
+        {
+            PerformOperationWithAllOptionCombinations(suggester =>
+                Assert.Throws<InvalidOperationException>(() => suggester.Refresh()));
+        }
+
+        private static readonly Input[] SharedInputs = new Input[]
+        {
+            new Input("lend me your ear", 8, new BytesRef("foobar")),
+            new Input("a penny saved is a penny earned", 10, new BytesRef("foobaz")),
+        };
+
+        /// <summary>
+        /// Perform the given operation on suggesters constructed with all combinations of options
+        /// commitOnBuild and closeIndexWriterOnBuild, including defaults.
+        /// </summary>
+        // LUCENENET specific - backported from LUCENE-7564.
+        private static void PerformOperationWithAllOptionCombinations(Action<AnalyzingInfixSuggester> operation)
+        {
+            Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
+
+            AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a);
+            operation(suggester);
+            suggester.Dispose();
+
+            suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false);
+            operation(suggester);
+            suggester.Dispose();
+
+            suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, true);
+            operation(suggester);
+            suggester.Dispose();
+
+            suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, true, true);
+            operation(suggester);
+            suggester.Dispose();
+
+            suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, true, false);
+            operation(suggester);
+            suggester.Dispose();
+
+            suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false, true);
+            operation(suggester);
+            suggester.Dispose();
+
+            suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3, false, false);
+            operation(suggester);
+            suggester.Dispose();
+        }
+
         // LUCENE-5528
         [Test]
         public void TestBasicContext()
@@ -1053,13 +1193,13 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                     Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
                     if (iter == 0)
                     {
-                        suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, 3);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                        suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, 3, false);
                         suggester.Build(new InputArrayEnumerator(keys));
                     }
                     else
                     {
                         // Test again, after close/reopen:
-                        suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, 3);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                        suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a, 3, false);
                     }
 
                     // No context provided, all results returned

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
@@ -1047,7 +1047,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
 
             public IndexWriter GetIndexWriter()
             {
-                return writer;
+                return m_writer;
             }
 
             public SearcherManager GetSearcherManager()
@@ -1070,7 +1070,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             // * The IndexWriter should be null
             // * The SearcherManager should be non-null
             // * SearcherManager's IndexWriter reference should be closed
-            //   (as evidenced by MaybeRefreshBlocking() throwing AlreadyClosedException)
+            //   (as evidenced by MaybeRefreshBlocking() throwing AlreadyClosedException/ObjectDisposedException)
             Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
             DirectoryInfo tempDir = CreateTempDir("analyzingInfixContext");
             MyAnalyzingInfixSuggester suggester = new MyAnalyzingInfixSuggester(NewFSDirectory(tempDir), a, a, 3, false, true);

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/BlendedInfixSuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/BlendedInfixSuggesterTest.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             BlendedInfixSuggester suggester = new BlendedInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a,
                                                                         AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS,
                                                                         BlendedInfixSuggester.BlenderType.POSITION_LINEAR,
-                                                                        BlendedInfixSuggester.DEFAULT_NUM_FACTOR);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                                                                        BlendedInfixSuggester.DEFAULT_NUM_FACTOR, false);
             suggester.Build(new InputArrayEnumerator(keys));
 
             // we query for star wars and check that the weight
@@ -99,7 +99,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             // BlenderType.RECIPROCAL is using 1/(1+p) * w where w is weight and p the position of the word
             suggester = new BlendedInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a,
                                                   AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS,
-                                                  BlendedInfixSuggester.BlenderType.POSITION_RECIPROCAL, 1);    //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                                                  BlendedInfixSuggester.BlenderType.POSITION_RECIPROCAL, 1, false);
             suggester.Build(new InputArrayEnumerator(keys));
 
             assertEquals(w, GetInResults(suggester, "top", pl, 1));
@@ -133,7 +133,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             // if factor is small, we don't get the expected element
             BlendedInfixSuggester suggester = new BlendedInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a,
                                                                         AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS,
-                                                                        BlendedInfixSuggester.BlenderType.POSITION_RECIPROCAL, 1);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                                                                        BlendedInfixSuggester.BlenderType.POSITION_RECIPROCAL, 1, false);
 
             suggester.Build(new InputArrayEnumerator(keys));
 
@@ -153,7 +153,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             // if we increase the factor we have it
             suggester = new BlendedInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a,
                                                   AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS,
-                                                  BlendedInfixSuggester.BlenderType.POSITION_RECIPROCAL, 2);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                                                  BlendedInfixSuggester.BlenderType.POSITION_RECIPROCAL, 2, false);
             suggester.Build(new InputArrayEnumerator(keys));
 
             // we have it
@@ -185,7 +185,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             BlendedInfixSuggester suggester = new BlendedInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a,
                                                                         AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS,
                                                                         BlendedInfixSuggester.BlenderType.POSITION_LINEAR,
-                                                                        BlendedInfixSuggester.DEFAULT_NUM_FACTOR);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                                                                        BlendedInfixSuggester.DEFAULT_NUM_FACTOR, false);
             suggester.Build(new InputArrayEnumerator(keys));
 
             GetInResults(suggester, "of ", payload, 1);
@@ -216,7 +216,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             BlendedInfixSuggester suggester = new BlendedInfixSuggester(TEST_VERSION_CURRENT, NewFSDirectory(tempDir), a, a,
                                                                         AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS,
                                                                         BlendedInfixSuggester.BlenderType.POSITION_RECIPROCAL,
-                                                                        BlendedInfixSuggester.DEFAULT_NUM_FACTOR);     //LUCENENET UPGRADE TODO: add extra false param at version 4.11.0
+                                                                        BlendedInfixSuggester.DEFAULT_NUM_FACTOR, false);
             suggester.Build(new InputArrayEnumerator(keys));
 
 


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Backport fixes for AnalyzingInfixSuggester.

Fixes #1242

## Description

This backports the Lucene fixes for LUCENE-7564 and LUCENE-7670. It also fixes a missed line of code when LUCENE-5889 was originally backported.