### PR TITLE
BREAKING: More cancellation support in APIs that call IndexSearcher, #922

### DIFF
--- a/src/Lucene.Net.Classification/ClassificationResult.cs
+++ b/src/Lucene.Net.Classification/ClassificationResult.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Lucene.Net.Classification
 {
     /*
@@ -18,7 +20,7 @@ namespace Lucene.Net.Classification
      */
 
     /// <summary>
-    /// The result of a call to <see cref="IClassifier{T}.AssignClass(string)"/> holding an assigned class of type <typeparam name="T"/> and a score.
+    /// The result of a call to <see cref="IClassifier{T}.AssignClass(string, CancellationToken)"/> holding an assigned class of type <typeparam name="T"/> and a score.
     /// @lucene.experimental
     /// </summary>
     public class ClassificationResult<T>

--- a/src/Lucene.Net.Classification/IClassifier.cs
+++ b/src/Lucene.Net.Classification/IClassifier.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Analysis;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
+using System.Threading;
 
 namespace Lucene.Net.Classification
 {
@@ -33,8 +34,9 @@ namespace Lucene.Net.Classification
         /// Assign a class (with score) to the given text string
         /// </summary>
         /// <param name="text">a string containing text to be classified</param>
+        /// <param name="cancellationToken">a cancellation token to cancel the classification operation. LUCENENET specific.</param>
         /// <returns>a <see cref="ClassificationResult{T}"/> holding assigned class of type <typeparamref name="T"/> and score</returns>
-        ClassificationResult<T> AssignClass(string text);
+        ClassificationResult<T> AssignClass(string text, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Train the classifier using the underlying Lucene index
@@ -43,7 +45,12 @@ namespace Lucene.Net.Classification
         /// <param name="atomicReader">the reader to use to access the Lucene index</param>
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        void Train(AtomicReader atomicReader, string textFieldName, string classFieldName, Analyzer analyzer);
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        void Train(AtomicReader atomicReader,
+            string textFieldName,
+            string classFieldName,
+            Analyzer analyzer,
+            CancellationToken cancellationToken = default);
 
         /// <summary>Train the classifier using the underlying Lucene index</summary>
         /// <param name="analyzer">the analyzer used to tokenize / filter the unseen text</param>
@@ -51,7 +58,13 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        void Train(AtomicReader atomicReader, string textFieldName, string classFieldName, Analyzer analyzer, Query query);
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        void Train(AtomicReader atomicReader,
+            string textFieldName,
+            string classFieldName,
+            Analyzer analyzer,
+            Query query,
+            CancellationToken cancellationToken = default);
 
         /// <summary>Train the classifier using the underlying Lucene index</summary>
         /// <param name="analyzer">the analyzer used to tokenize / filter the unseen text</param>
@@ -59,7 +72,12 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldNames">the names of the fields to be used to compare documents</param>
-        void Train(AtomicReader atomicReader, string[] textFieldNames, string classFieldName, Analyzer analyzer,
-                   Query query);
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        void Train(AtomicReader atomicReader,
+            string[] textFieldNames,
+            string classFieldName,
+            Analyzer analyzer,
+            Query query,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Lucene.Net.Classification/IClassifier.cs
+++ b/src/Lucene.Net.Classification/IClassifier.cs
@@ -45,7 +45,8 @@ namespace Lucene.Net.Classification
         /// <param name="atomicReader">the reader to use to access the Lucene index</param>
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.
+        /// Note that not all implementations are actually cancelable.</param>
         void Train(AtomicReader atomicReader,
             string textFieldName,
             string classFieldName,
@@ -58,7 +59,8 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.
+        /// Note that not all implementations are actually cancelable.</param>
         void Train(AtomicReader atomicReader,
             string textFieldName,
             string classFieldName,
@@ -72,7 +74,8 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldNames">the names of the fields to be used to compare documents</param>
-        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.
+        /// Note that not all implementations are actually cancelable.</param>
         void Train(AtomicReader atomicReader,
             string[] textFieldNames,
             string classFieldName,

--- a/src/Lucene.Net.Classification/KNearestNeighborClassifier.cs
+++ b/src/Lucene.Net.Classification/KNearestNeighborClassifier.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Search;
 using Lucene.Net.Util;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 
 namespace Lucene.Net.Classification
 {
@@ -34,7 +35,6 @@ namespace Lucene.Net.Classification
     /// </summary>
     public class KNearestNeighborClassifier : IClassifier<BytesRef>
     {
-
         private MoreLikeThis mlt;
         private string[] textFieldNames;
         private string classFieldName;
@@ -67,8 +67,9 @@ namespace Lucene.Net.Classification
         /// Assign a class (with score) to the given text string
         /// </summary>
         /// <param name="text">a string containing text to be classified</param>
+        /// <param name="cancellationToken">a cancellation token to cancel the search. LUCENENET specific.</param>
         /// <returns>a <see cref="ClassificationResult{BytesRef}"/> holding assigned class of type <see cref="BytesRef"/> and score</returns>
-        public virtual ClassificationResult<BytesRef> AssignClass(string text)
+        public virtual ClassificationResult<BytesRef> AssignClass(string text, CancellationToken cancellationToken = default)
         {
             if (mlt is null)
             {
@@ -86,7 +87,7 @@ namespace Lucene.Net.Classification
             {
                 mltQuery.Add(query, Occur.MUST);
             }
-            TopDocs topDocs = indexSearcher.Search(mltQuery, k);
+            TopDocs topDocs = indexSearcher.Search(mltQuery, k, cancellationToken);
             return SelectClassFromNeighbors(topDocs);
         }
 
@@ -129,9 +130,14 @@ namespace Lucene.Net.Classification
         /// <param name="atomicReader">the reader to use to access the Lucene index</param>
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        public virtual void Train(AtomicReader atomicReader, string textFieldName, string classFieldName, Analyzer analyzer)
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        public virtual void Train(AtomicReader atomicReader,
+            string textFieldName,
+            string classFieldName,
+            Analyzer analyzer,
+            CancellationToken cancellationToken = default)
         {
-            Train(atomicReader, textFieldName, classFieldName, analyzer, null);
+            Train(atomicReader, textFieldName, classFieldName, analyzer, null, cancellationToken);
         }
 
         /// <summary>Train the classifier using the underlying Lucene index</summary>
@@ -140,9 +146,15 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        public virtual void Train(AtomicReader atomicReader, string textFieldName, string classFieldName, Analyzer analyzer, Query query)
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        public virtual void Train(AtomicReader atomicReader,
+            string textFieldName,
+            string classFieldName,
+            Analyzer analyzer,
+            Query query,
+            CancellationToken cancellationToken = default)
         {
-            Train(atomicReader, new string[] { textFieldName }, classFieldName, analyzer, query);
+            Train(atomicReader, new[] { textFieldName }, classFieldName, analyzer, query, cancellationToken);
         }
 
         /// <summary>Train the classifier using the underlying Lucene index</summary>
@@ -151,7 +163,13 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldNames">the names of the fields to be used to compare documents</param>
-        public virtual void Train(AtomicReader atomicReader, string[] textFieldNames, string classFieldName, Analyzer analyzer, Query query)
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        public virtual void Train(AtomicReader atomicReader,
+            string[] textFieldNames,
+            string classFieldName,
+            Analyzer analyzer,
+            Query query,
+            CancellationToken cancellationToken = default)
         {
             this.textFieldNames = textFieldNames;
             this.classFieldName = classFieldName;

--- a/src/Lucene.Net.Classification/KNearestNeighborClassifier.cs
+++ b/src/Lucene.Net.Classification/KNearestNeighborClassifier.cs
@@ -130,7 +130,8 @@ namespace Lucene.Net.Classification
         /// <param name="atomicReader">the reader to use to access the Lucene index</param>
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.
+        /// Note that at this time, this implementation is not actually cancelable.</param>
         public virtual void Train(AtomicReader atomicReader,
             string textFieldName,
             string classFieldName,
@@ -146,7 +147,8 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.
+        /// Note that at this time, this implementation is not actually cancelable.</param>
         public virtual void Train(AtomicReader atomicReader,
             string textFieldName,
             string classFieldName,
@@ -163,7 +165,8 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldNames">the names of the fields to be used to compare documents</param>
-        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.
+        /// Note that at this time, this implementation is not actually cancelable.</param>
         public virtual void Train(AtomicReader atomicReader,
             string[] textFieldNames,
             string classFieldName,

--- a/src/Lucene.Net.Classification/KNearestNeighborClassifier.cs
+++ b/src/Lucene.Net.Classification/KNearestNeighborClassifier.cs
@@ -171,6 +171,8 @@ namespace Lucene.Net.Classification
             Query query,
             CancellationToken cancellationToken = default)
         {
+            // LUCENENET: cancellationToken is present for IClassifier interface compliance;
+            // can be utilized here if a suitable cancellation point is added in the future.
             this.textFieldNames = textFieldNames;
             this.classFieldName = classFieldName;
             mlt = new MoreLikeThis(atomicReader);

--- a/src/Lucene.Net.Classification/SimpleNaiveBayesClassifier.cs
+++ b/src/Lucene.Net.Classification/SimpleNaiveBayesClassifier.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 
 namespace Lucene.Net.Classification
 {
@@ -44,7 +45,7 @@ namespace Lucene.Net.Classification
 
         /// <summary>
         /// Creates a new NaiveBayes classifier.
-        /// Note that you must call <see cref="Train(AtomicReader, string, string, Analyzer)"/> before you can
+        /// Note that you must call <see cref="Train(AtomicReader, string, string, Analyzer, CancellationToken)"/> before you can
         /// classify any documents.
         /// </summary>
         public SimpleNaiveBayesClassifier()
@@ -58,9 +59,14 @@ namespace Lucene.Net.Classification
         /// <param name="atomicReader">the reader to use to access the Lucene index</param>
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        public virtual void Train(AtomicReader atomicReader, string textFieldName, string classFieldName, Analyzer analyzer)
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        public virtual void Train(AtomicReader atomicReader,
+            string textFieldName,
+            string classFieldName,
+            Analyzer analyzer,
+            CancellationToken cancellationToken = default)
         {
-            Train(atomicReader, textFieldName, classFieldName, analyzer, null);
+            Train(atomicReader, textFieldName, classFieldName, analyzer, null, cancellationToken);
         }
 
         /// <summary>Train the classifier using the underlying Lucene index</summary>
@@ -69,9 +75,15 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldName">the name of the field used to compare documents</param>
-        public virtual void Train(AtomicReader atomicReader, string textFieldName, string classFieldName, Analyzer analyzer, Query query)
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        public virtual void Train(AtomicReader atomicReader,
+            string textFieldName,
+            string classFieldName,
+            Analyzer analyzer,
+            Query query,
+            CancellationToken cancellationToken = default)
         {
-            Train(atomicReader, new string[] { textFieldName }, classFieldName, analyzer, query);
+            Train(atomicReader, new[] { textFieldName }, classFieldName, analyzer, query, cancellationToken);
         }
 
         /// <summary>Train the classifier using the underlying Lucene index</summary>
@@ -80,7 +92,13 @@ namespace Lucene.Net.Classification
         /// <param name="classFieldName">the name of the field containing the class assigned to documents</param>
         /// <param name="query">the query to filter which documents use for training</param>
         /// <param name="textFieldNames">the names of the fields to be used to compare documents</param>
-        public virtual void Train(AtomicReader atomicReader, string[] textFieldNames, string classFieldName, Analyzer analyzer, Query query)
+        /// <param name="cancellationToken">a cancellation token to cancel the training operation. LUCENENET specific.</param>
+        public virtual void Train(AtomicReader atomicReader,
+            string[] textFieldNames,
+            string classFieldName,
+            Analyzer analyzer,
+            Query query,
+            CancellationToken cancellationToken = default)
         {
             this.atomicReader = atomicReader;
             indexSearcher = new IndexSearcher(this.atomicReader);
@@ -88,10 +106,10 @@ namespace Lucene.Net.Classification
             this.classFieldName = classFieldName;
             this.analyzer = analyzer;
             this.query = query;
-            docsWithClassSize = CountDocsWithClass();
+            docsWithClassSize = CountDocsWithClass(cancellationToken);
         }
 
-        private int CountDocsWithClass()
+        private int CountDocsWithClass(CancellationToken cancellationToken)
         {
             int docCount = MultiFields.GetTerms(atomicReader, classFieldName).DocCount;
             if (docCount == -1)
@@ -105,7 +123,7 @@ namespace Lucene.Net.Classification
                 {
                     q.Add(query, Occur.MUST);
                 }
-                indexSearcher.Search(q, totalHitCountCollector);
+                indexSearcher.Search(q, totalHitCountCollector, cancellationToken);
                 docCount = totalHitCountCollector.TotalHits;
             }
             return docCount;
@@ -141,8 +159,9 @@ namespace Lucene.Net.Classification
         /// Assign a class (with score) to the given text string
         /// </summary>
         /// <param name="inputDocument">a string containing text to be classified</param>
+        /// <param name="cancellationToken">a cancellation token to cancel the search. LUCENENET specific.</param>
         /// <returns>a <see cref="ClassificationResult{BytesRef}"/> holding assigned class of type <see cref="BytesRef"/> and score</returns>
-        public virtual ClassificationResult<BytesRef> AssignClass(string inputDocument)
+        public virtual ClassificationResult<BytesRef> AssignClass(string inputDocument, CancellationToken cancellationToken = default)
         {
             if (atomicReader is null)
             {
@@ -158,7 +177,7 @@ namespace Lucene.Net.Classification
             while (termsEnum.MoveNext())
             {
                 next = termsEnum.Term;
-                double clVal = CalculateLogPrior(next) + CalculateLogLikelihood(tokenizedDoc, next);
+                double clVal = CalculateLogPrior(next) + CalculateLogLikelihood(tokenizedDoc, next, cancellationToken);
                 if (clVal > max)
                 {
                     max = clVal;
@@ -170,14 +189,14 @@ namespace Lucene.Net.Classification
         }
 
 
-        private double CalculateLogLikelihood(string[] tokenizedDoc, BytesRef c)
+        private double CalculateLogLikelihood(string[] tokenizedDoc, BytesRef c, CancellationToken cancellationToken)
         {
             // for each word
             double result = 0d;
             foreach (string word in tokenizedDoc)
             {
                 // search with text:word AND class:c
-                int hits = GetWordFreqForClass(word, c);
+                int hits = GetWordFreqForClass(word, c, cancellationToken);
 
                 // num : count the no of times the word appears in documents of class c (+1)
                 double num = hits + 1; // +1 is added because of add 1 smoothing
@@ -207,7 +226,7 @@ namespace Lucene.Net.Classification
             return avgNumberOfUniqueTerms * docsWithC; // avg # of unique terms in text fields per doc * # docs with c
         }
 
-        private int GetWordFreqForClass(string word, BytesRef c)
+        private int GetWordFreqForClass(string word, BytesRef c, CancellationToken cancellationToken)
         {
             BooleanQuery booleanQuery = new BooleanQuery();
             BooleanQuery subQuery = new BooleanQuery();
@@ -222,7 +241,7 @@ namespace Lucene.Net.Classification
                 booleanQuery.Add(query, Occur.MUST);
             }
             TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
-            indexSearcher.Search(booleanQuery, totalHitCountCollector);
+            indexSearcher.Search(booleanQuery, totalHitCountCollector, cancellationToken);
             return totalHitCountCollector.TotalHits;
         }
 

--- a/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
+++ b/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
@@ -93,9 +93,9 @@ namespace Lucene.Net.Classification.Utils
         {
 #pragma warning disable 612, 618
             // create IWs for train / test / cv IDXs
-            IndexWriter testWriter = new IndexWriter(testIndex, new IndexWriterConfig(LuceneVersion.LUCENE_CURRENT, analyzer));
-            IndexWriter cvWriter = new IndexWriter(crossValidationIndex, new IndexWriterConfig(LuceneVersion.LUCENE_CURRENT, analyzer));
-            IndexWriter trainingWriter = new IndexWriter(trainingIndex, new IndexWriterConfig(LuceneVersion.LUCENE_CURRENT, analyzer));
+            using IndexWriter testWriter = new IndexWriter(testIndex, new IndexWriterConfig(LuceneVersion.LUCENE_CURRENT, analyzer));
+            using IndexWriter cvWriter = new IndexWriter(crossValidationIndex, new IndexWriterConfig(LuceneVersion.LUCENE_CURRENT, analyzer));
+            using IndexWriter trainingWriter = new IndexWriter(trainingIndex, new IndexWriterConfig(LuceneVersion.LUCENE_CURRENT, analyzer));
 #pragma warning restore 612, 618
 
             try
@@ -176,10 +176,11 @@ namespace Lucene.Net.Classification.Utils
                 testWriter.Commit();
                 cvWriter.Commit();
                 trainingWriter.Commit();
-                // close IWs
-                testWriter.Dispose();
-                cvWriter.Dispose();
-                trainingWriter.Dispose();
+
+                // close IWs - LUCENENET specific removal: disposed via `using` declaration
+                // testWriter.Dispose();
+                // cvWriter.Dispose();
+                // trainingWriter.Dispose();
             }
         }
     }

--- a/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
+++ b/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Util;
 using System;
 using System.Globalization;
 using System.IO;
+using System.Threading;
 using Directory = Lucene.Net.Store.Directory;
 
 namespace Lucene.Net.Classification.Utils
@@ -57,7 +58,38 @@ namespace Lucene.Net.Classification.Utils
         /// <param name="analyzer"><see cref="Analyzer"/> used to create the new docs</param>
         /// <param name="fieldNames">names of fields that need to be put in the new indexes or <c>null</c> if all should be used</param>
         /// <exception cref="IOException">if any writing operation fails on any of the indexes</exception>
-        public virtual void Split(AtomicReader originalIndex, Directory trainingIndex, Directory testIndex, Directory crossValidationIndex, Analyzer analyzer, params string[] fieldNames)
+        public virtual void Split(AtomicReader originalIndex,
+            Directory trainingIndex,
+            Directory testIndex,
+            Directory crossValidationIndex,
+            Analyzer analyzer,
+            params string[] fieldNames)
+        {
+            Split(originalIndex, trainingIndex, testIndex, crossValidationIndex, analyzer, CancellationToken.None, fieldNames);
+        }
+
+        /// <summary>
+        /// Split a given index into 3 indexes for training, test and cross validation tasks respectively
+        /// </summary>
+        /// <param name="originalIndex">an <see cref="AtomicReader"/> on the source index</param>
+        /// <param name="trainingIndex">a <see cref="Directory"/> used to write the training index</param>
+        /// <param name="testIndex">a <see cref="Directory"/> used to write the test index</param>
+        /// <param name="crossValidationIndex">a <see cref="Directory"/> used to write the cross validation index</param>
+        /// <param name="analyzer"><see cref="Analyzer"/> used to create the new docs</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the search.</param>
+        /// <param name="fieldNames">names of fields that need to be put in the new indexes or <c>null</c> if all should be used</param>
+        /// <exception cref="IOException">if any writing operation fails on any of the indexes</exception>
+        /// <exception cref="OperationCanceledException">if the <paramref name="cancellationToken"/> requested cancellation</exception>
+        /// <remarks>
+        /// LUCENENET specific overload to add cancellation support.
+        /// </remarks>
+        public virtual void Split(AtomicReader originalIndex,
+            Directory trainingIndex,
+            Directory testIndex,
+            Directory crossValidationIndex,
+            Analyzer analyzer,
+            CancellationToken cancellationToken,
+            params string[] fieldNames)
         {
 #pragma warning disable 612, 618
             // create IWs for train / test / cv IDXs
@@ -71,7 +103,7 @@ namespace Lucene.Net.Classification.Utils
                 int size = originalIndex.MaxDoc;
 
                 IndexSearcher indexSearcher = new IndexSearcher(originalIndex);
-                TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), int.MaxValue);
+                TopDocs topDocs = indexSearcher.Search(new MatchAllDocsQuery(), int.MaxValue, cancellationToken);
 
                 // set the type to be indexed, stored, with term vectors
                 FieldType ft = new FieldType(TextField.TYPE_STORED);
@@ -134,10 +166,13 @@ namespace Lucene.Net.Classification.Utils
             }
             catch (Exception e) when (e.IsException())
             {
-                throw new IOException("Exceptio in DatasetSplitter", e);
+                throw new IOException("Exception in DatasetSplitter", e);
             }
             finally
             {
+                // LUCENENET Specific - if we've gotten this far and cancellation was requested, don't commit
+                cancellationToken.ThrowIfCancellationRequested();
+
                 testWriter.Commit();
                 cvWriter.Commit();
                 trainingWriter.Commit();

--- a/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
+++ b/src/Lucene.Net.Classification/Utils/DatasetSplitter.cs
@@ -76,7 +76,7 @@ namespace Lucene.Net.Classification.Utils
         /// <param name="testIndex">a <see cref="Directory"/> used to write the test index</param>
         /// <param name="crossValidationIndex">a <see cref="Directory"/> used to write the cross validation index</param>
         /// <param name="analyzer"><see cref="Analyzer"/> used to create the new docs</param>
-        /// <param name="cancellationToken">A cancellation token to cancel the search.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the split operation.</param>
         /// <param name="fieldNames">names of fields that need to be put in the new indexes or <c>null</c> if all should be used</param>
         /// <exception cref="IOException">if any writing operation fails on any of the indexes</exception>
         /// <exception cref="OperationCanceledException">if the <paramref name="cancellationToken"/> requested cancellation</exception>
@@ -164,20 +164,22 @@ namespace Lucene.Net.Classification.Utils
                     b++;
                 }
             }
+            catch (OperationCanceledException) { throw; } // LUCENENET: Don't wrap cancellation in IOException
             catch (Exception e) when (e.IsException())
             {
                 throw new IOException("Exception in DatasetSplitter", e);
             }
             finally
             {
-                // LUCENENET Specific - if we've gotten this far and cancellation was requested, don't commit
-                cancellationToken.ThrowIfCancellationRequested();
+                // LUCENENET Specific - if cancellation was requested, don't commit.
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    testWriter.Commit();
+                    cvWriter.Commit();
+                    trainingWriter.Commit();
+                }
 
-                testWriter.Commit();
-                cvWriter.Commit();
-                trainingWriter.Commit();
-
-                // close IWs - LUCENENET specific removal: disposed via `using` declaration
+                // close IWs - LUCENENET specific: disposed via `using` declaration
                 // testWriter.Dispose();
                 // cvWriter.Dispose();
                 // trainingWriter.Dispose();

--- a/src/Lucene.Net.Facet/DrillSideways.cs
+++ b/src/Lucene.Net.Facet/DrillSideways.cs
@@ -6,7 +6,7 @@ using Lucene.Net.Facet.Taxonomy;
 using Lucene.Net.Search;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Threading;
 
 namespace Lucene.Net.Facet
 {
@@ -147,7 +147,9 @@ namespace Lucene.Net.Facet
         /// Search, collecting hits with a <see cref="ICollector"/>, and
         /// computing drill down and sideways counts.
         /// </summary>
-        public virtual DrillSidewaysResult Search(DrillDownQuery query, ICollector hitCollector)
+        public virtual DrillSidewaysResult Search(DrillDownQuery query,
+            ICollector hitCollector,
+            CancellationToken cancellationToken = default)
         {
 
             IDictionary<string, int> drillDownDims = query.Dims;
@@ -158,7 +160,7 @@ namespace Lucene.Net.Facet
             {
                 // There are no drill-down dims, so there is no
                 // drill-sideways to compute:
-                m_searcher.Search(query, MultiCollector.Wrap(hitCollector, drillDownCollector));
+                m_searcher.Search(query, MultiCollector.Wrap(hitCollector, drillDownCollector), cancellationToken);
                 return new DrillSidewaysResult(BuildFacetsResult(drillDownCollector, null, null), null);
             }
 
@@ -193,7 +195,7 @@ namespace Lucene.Net.Facet
                 drillDownQueries[i - startClause] = clauses[i].Query;
             }
             DrillSidewaysQuery dsq = new DrillSidewaysQuery(baseQuery, drillDownCollector, drillSidewaysCollectors, drillDownQueries, ScoreSubDocsAtOnce);
-            m_searcher.Search(dsq, hitCollector);
+            m_searcher.Search(dsq, hitCollector, cancellationToken);
 
             return new DrillSidewaysResult(BuildFacetsResult(drillDownCollector, drillSidewaysCollectors, drillDownDims.Keys.ToArray()), null);
         }
@@ -202,7 +204,14 @@ namespace Lucene.Net.Facet
         /// Search, sorting by <see cref="Sort"/>, and computing
         /// drill down and sideways counts.
         /// </summary>
-        public virtual DrillSidewaysResult Search(DrillDownQuery query, Filter filter, FieldDoc after, int topN, Sort sort, bool doDocScores, bool doMaxScore)
+        public virtual DrillSidewaysResult Search(DrillDownQuery query,
+            Filter filter,
+            FieldDoc after,
+            int topN,
+            Sort sort,
+            bool doDocScores,
+            bool doMaxScore,
+            CancellationToken cancellationToken = default)
         {
             if (filter != null)
             {
@@ -213,11 +222,11 @@ namespace Lucene.Net.Facet
                 int limit = m_searcher.IndexReader.MaxDoc;
                 if (limit == 0)
                 {
-                    limit = 1; // the collector does not alow numHits = 0
+                    limit = 1; // the collector does not allow numHits = 0
                 }
                 topN = Math.Min(topN, limit);
                 TopFieldCollector hitCollector = TopFieldCollector.Create(sort, topN, after, true, doDocScores, doMaxScore, true);
-                DrillSidewaysResult r = Search(query, hitCollector);
+                DrillSidewaysResult r = Search(query, hitCollector, cancellationToken);
                 return new DrillSidewaysResult(r.Facets, hitCollector.GetTopDocs());
             }
             else
@@ -230,25 +239,28 @@ namespace Lucene.Net.Facet
         /// Search, sorting by score, and computing
         /// drill down and sideways counts.
         /// </summary>
-        public virtual DrillSidewaysResult Search(DrillDownQuery query, int topN)
+        public virtual DrillSidewaysResult Search(DrillDownQuery query, int topN, CancellationToken cancellationToken = default)
         {
-            return Search(null, query, topN);
+            return Search(null, query, topN, cancellationToken);
         }
 
         /// <summary>
         /// Search, sorting by score, and computing
         /// drill down and sideways counts.
         /// </summary>
-        public virtual DrillSidewaysResult Search(ScoreDoc after, DrillDownQuery query, int topN)
+        public virtual DrillSidewaysResult Search(ScoreDoc after,
+            DrillDownQuery query,
+            int topN,
+            CancellationToken cancellationToken = default)
         {
             int limit = m_searcher.IndexReader.MaxDoc;
             if (limit == 0)
             {
-                limit = 1; // the collector does not alow numHits = 0
+                limit = 1; // the collector does not allow numHits = 0
             }
             topN = Math.Min(topN, limit);
             TopScoreDocCollector hitCollector = TopScoreDocCollector.Create(topN, after, true);
-            DrillSidewaysResult r = Search(query, hitCollector);
+            DrillSidewaysResult r = Search(query, hitCollector, cancellationToken);
             return new DrillSidewaysResult(r.Facets, hitCollector.GetTopDocs());
         }
 

--- a/src/Lucene.Net.Facet/FacetsCollector.cs
+++ b/src/Lucene.Net.Facet/FacetsCollector.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet
@@ -31,7 +32,7 @@ namespace Lucene.Net.Facet
     /// Collects hits for subsequent faceting.  Once you've run
     /// a search and collect hits into this, instantiate one of
     /// the <see cref="ICollector"/> subclasses to do the facet
-    /// counting.  Use the Search utility methods (such as <see cref="Search(IndexSearcher, Query, int, ICollector)"/>) to
+    /// counting.  Use the Search utility methods (such as <see cref="Search(IndexSearcher, Query, int, ICollector, CancellationToken)"/>) to
     /// perform an "ordinary" search but also collect into a
     /// <see cref="Facets"/>.
     /// </summary>
@@ -218,93 +219,154 @@ namespace Lucene.Net.Facet
         /// Utility method, to search and also collect all hits
         /// into the provided <see cref="ICollector"/>.
         /// </summary>
-        public static TopDocs Search(IndexSearcher searcher, Query q, int n, ICollector fc)
+        public static TopDocs Search(IndexSearcher searcher,
+            Query q,
+            int n,
+            ICollector fc,
+            CancellationToken cancellationToken = default)
         {
-            return DoSearch(searcher, null, q, null, n, null, false, false, fc);
+            return DoSearch(searcher, null, q, null, n, null, false, false, fc, cancellationToken);
         }
 
         /// <summary>
         /// Utility method, to search and also collect all hits
         /// into the provided <see cref="ICollector"/>.
         /// </summary>
-        public static TopDocs Search(IndexSearcher searcher, Query q, Filter filter, int n, ICollector fc)
+        public static TopDocs Search(IndexSearcher searcher,
+            Query q,
+            Filter filter,
+            int n,
+            ICollector fc,
+            CancellationToken cancellationToken = default)
         {
-            return DoSearch(searcher, null, q, filter, n, null, false, false, fc);
+            return DoSearch(searcher, null, q, filter, n, null, false, false, fc, cancellationToken);
         }
 
         /// <summary>
         /// Utility method, to search and also collect all hits
         /// into the provided <see cref="ICollector"/>.
         /// </summary>
-        public static TopFieldDocs Search(IndexSearcher searcher, Query q, Filter filter, int n, Sort sort, ICollector fc)
+        public static TopFieldDocs Search(IndexSearcher searcher,
+            Query q,
+            Filter filter,
+            int n,
+            Sort sort,
+            ICollector fc,
+            CancellationToken cancellationToken = default)
         {
             if (sort is null)
             {
                 throw new ArgumentNullException(nameof(sort), "sort must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
             }
-            return (TopFieldDocs)DoSearch(searcher, null, q, filter, n, sort, false, false, fc);
+
+            return (TopFieldDocs)DoSearch(searcher, null, q, filter, n, sort, false, false, fc, cancellationToken);
         }
 
         /// <summary>
         /// Utility method, to search and also collect all hits
         /// into the provided <see cref="ICollector"/>.
         /// </summary>
-        public static TopFieldDocs Search(IndexSearcher searcher, Query q, Filter filter, int n, Sort sort, bool doDocScores, bool doMaxScore, ICollector fc)
+        public static TopFieldDocs Search(IndexSearcher searcher,
+            Query q,
+            Filter filter,
+            int n,
+            Sort sort,
+            bool doDocScores,
+            bool doMaxScore,
+            ICollector fc,
+            CancellationToken cancellationToken = default)
         {
             if (sort is null)
             {
                 throw new ArgumentNullException(nameof(sort), "sort must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
             }
-            return (TopFieldDocs)DoSearch(searcher, null, q, filter, n, sort, doDocScores, doMaxScore, fc);
+
+            return (TopFieldDocs)DoSearch(searcher, null, q, filter, n, sort, doDocScores, doMaxScore, fc, cancellationToken);
         }
 
         /// <summary>
         /// Utility method, to search and also collect all hits
         /// into the provided <see cref="ICollector"/>.
         /// </summary>
-        public virtual TopDocs SearchAfter(IndexSearcher searcher, ScoreDoc after, Query q, int n, ICollector fc)
+        public virtual TopDocs SearchAfter(IndexSearcher searcher,
+            ScoreDoc after,
+            Query q,
+            int n,
+            ICollector fc,
+            CancellationToken cancellationToken = default)
         {
-            return DoSearch(searcher, after, q, null, n, null, false, false, fc);
+            return DoSearch(searcher, after, q, null, n, null, false, false, fc, cancellationToken);
         }
 
         /// <summary>
         /// Utility method, to search and also collect all hits
         /// into the provided <see cref="ICollector"/>.
         /// </summary>
-        public static TopDocs SearchAfter(IndexSearcher searcher, ScoreDoc after, Query q, Filter filter, int n, ICollector fc)
+        public static TopDocs SearchAfter(IndexSearcher searcher,
+            ScoreDoc after,
+            Query q,
+            Filter filter,
+            int n,
+            ICollector fc,
+            CancellationToken cancellationToken = default)
         {
-            return DoSearch(searcher, after, q, filter, n, null, false, false, fc);
+            return DoSearch(searcher, after, q, filter, n, null, false, false, fc, cancellationToken);
         }
 
         /// <summary>
         /// Utility method, to search and also collect all hits
         /// into the provided <see cref="ICollector"/>.
         /// </summary>
-        public static TopDocs SearchAfter(IndexSearcher searcher, ScoreDoc after, Query q, Filter filter, int n, Sort sort, ICollector fc)
+        public static TopDocs SearchAfter(IndexSearcher searcher,
+            ScoreDoc after,
+            Query q,
+            Filter filter,
+            int n,
+            Sort sort,
+            ICollector fc,
+            CancellationToken cancellationToken = default)
         {
             if (sort is null)
             {
                 throw new ArgumentNullException(nameof(sort), "sort must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
             }
-            return DoSearch(searcher, after, q, filter, n, sort, false, false, fc);
+
+            return DoSearch(searcher, after, q, filter, n, sort, false, false, fc, cancellationToken);
         }
 
         /// <summary>
         /// Utility method, to search and also collect all hits
         /// into the provided <see cref="ICollector"/>.
         /// </summary>
-        public static TopDocs SearchAfter(IndexSearcher searcher, ScoreDoc after, Query q, Filter filter, int n, Sort sort, bool doDocScores, bool doMaxScore, ICollector fc)
+        public static TopDocs SearchAfter(IndexSearcher searcher,
+            ScoreDoc after,
+            Query q,
+            Filter filter,
+            int n,
+            Sort sort,
+            bool doDocScores,
+            bool doMaxScore,
+            ICollector fc,
+            CancellationToken cancellationToken = default)
         {
             if (sort is null)
             {
                 throw new ArgumentNullException(nameof(sort), "sort must not be null"); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
             }
-            return DoSearch(searcher, after, q, filter, n, sort, doDocScores, doMaxScore, fc);
+            return DoSearch(searcher, after, q, filter, n, sort, doDocScores, doMaxScore, fc, cancellationToken);
         }
 
-        private static TopDocs DoSearch(IndexSearcher searcher, ScoreDoc after, Query q, Filter filter, int n, Sort sort, bool doDocScores, bool doMaxScore, ICollector fc)
+        private static TopDocs DoSearch(IndexSearcher searcher,
+            ScoreDoc after,
+            Query q,
+            Filter filter,
+            int n,
+            Sort sort,
+            bool doDocScores,
+            bool doMaxScore,
+            ICollector fc,
+            CancellationToken cancellationToken)
         {
-
             if (filter != null)
             {
                 q = new FilteredQuery(q, filter);
@@ -333,7 +395,7 @@ namespace Lucene.Net.Facet
                 }
                 const bool fillFields = true;
                 var hitsCollector = TopFieldCollector.Create(sort, n, (FieldDoc)after, fillFields, doDocScores, doMaxScore, false);
-                searcher.Search(q, MultiCollector.Wrap(hitsCollector, fc));
+                searcher.Search(q, MultiCollector.Wrap(hitsCollector, fc), cancellationToken);
                 return hitsCollector.GetTopDocs();
             }
             else
@@ -343,7 +405,7 @@ namespace Lucene.Net.Facet
                 // need access to the protected IS.search methods
                 // taking Weight... could use reflection...
                 var hitsCollector = TopScoreDocCollector.Create(n, after, false);
-                searcher.Search(q, MultiCollector.Wrap(hitsCollector, fc));
+                searcher.Search(q, MultiCollector.Wrap(hitsCollector, fc), cancellationToken);
                 return hitsCollector.GetTopDocs();
             }
         }

--- a/src/Lucene.Net.Grouping/GroupingSearch.cs
+++ b/src/Lucene.Net.Grouping/GroupingSearch.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Util.Mutable;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 // ReSharper disable VirtualMemberNeverOverridden.Global - justification: this is a public API
@@ -298,12 +299,17 @@ namespace Lucene.Net.Search.Grouping
             this.groupEndDocs = groupEndDocs;
         }
 
-        /// <inheritdoc cref="GroupingSearch{T,TSelf}.Search(IndexSearcher,Filter,Query,int,int)"/>
-        public override TopGroups<object?> Search(IndexSearcher searcher, Filter filter, Query query, int groupOffset, int groupLimit)
+        /// <inheritdoc cref="GroupingSearch{T,TSelf}.Search(IndexSearcher,Filter,Query,int,int,CancellationToken)"/>
+        public override TopGroups<object?> Search(IndexSearcher searcher,
+            Filter filter,
+            Query query,
+            int groupOffset,
+            int groupLimit,
+            CancellationToken cancellationToken = default)
         {
             int topN = groupOffset + groupLimit;
             BlockGroupingCollector c = new BlockGroupingCollector(GroupSort, topN, IncludeScores, groupEndDocs);
-            searcher.Search(query, filter, c);
+            searcher.Search(query, filter, c, cancellationToken);
             int topNInsideGroup = GroupDocsOffset + GroupDocsLimit;
             return c.GetTopGroups<object?>(SortWithinGroup, groupOffset, GroupDocsOffset, topNInsideGroup, FillSortFields);
         }
@@ -382,8 +388,13 @@ namespace Lucene.Net.Search.Grouping
 
         #endregion
 
-        /// <inheritdoc cref="GroupingSearch{T,TSelf}.Search(IndexSearcher,Filter,Query,int,int)"/>
-        public override TopGroups<T> Search(IndexSearcher searcher, Filter filter, Query query, int groupOffset, int groupLimit)
+        /// <inheritdoc cref="GroupingSearch{T,TSelf}.Search(IndexSearcher,Filter,Query,int,int,CancellationToken)"/>
+        public override TopGroups<T> Search(IndexSearcher searcher,
+            Filter filter,
+            Query query,
+            int groupOffset,
+            int groupLimit,
+            CancellationToken cancellationToken = default)
         {
             int topN = groupOffset + groupLimit;
 
@@ -420,11 +431,11 @@ namespace Lucene.Net.Search.Grouping
                 cachedCollector = MaxCacheRAMMB != null
                     ? CachingCollector.Create(firstRound, CacheScores, MaxCacheRAMMB.Value)
                     : CachingCollector.Create(firstRound, CacheScores, MaxDocsToCache!.Value);
-                searcher.Search(query, filter, cachedCollector);
+                searcher.Search(query, filter, cachedCollector, cancellationToken);
             }
             else
             {
-                searcher.Search(query, filter, firstRound);
+                searcher.Search(query, filter, firstRound, cancellationToken);
             }
 
             MatchingGroups = AllGroups
@@ -453,7 +464,7 @@ namespace Lucene.Net.Search.Grouping
             }
             else
             {
-                searcher.Search(query, filter, secondPassCollector);
+                searcher.Search(query, filter, secondPassCollector, cancellationToken);
             }
 
             return AllGroups
@@ -603,10 +614,16 @@ namespace Lucene.Net.Search.Grouping
         /// <param name="query">The query to execute with the grouping</param>
         /// <param name="groupOffset">The group offset</param>
         /// <param name="groupLimit">The number of groups to return from the specified group offset</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the search. LUCENENET specific.</param>
+        /// <exception cref="OperationCanceledException">if the <paramref name="cancellationToken"/> requests cancellation</exception>
         /// <returns>the grouped result as a <see cref="TopGroups"/> instance</returns>
-        public TopGroups<T> Search(IndexSearcher searcher, Query query, int groupOffset, int groupLimit)
+        public TopGroups<T> Search(IndexSearcher searcher,
+            Query query,
+            int groupOffset,
+            int groupLimit,
+            CancellationToken cancellationToken = default)
         {
-            return Search(searcher, null, query, groupOffset, groupLimit);
+            return Search(searcher, null, query, groupOffset, groupLimit, cancellationToken);
         }
 
         /// <summary>
@@ -617,8 +634,15 @@ namespace Lucene.Net.Search.Grouping
         /// <param name="query">The query to execute with the grouping</param>
         /// <param name="groupOffset">The group offset</param>
         /// <param name="groupLimit">The number of groups to return from the specified group offset</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the search. LUCENENET specific.</param>
+        /// <exception cref="OperationCanceledException">if the <paramref name="cancellationToken"/> requests cancellation</exception>
         /// <returns>the grouped result as a <see cref="TopGroups"/> instance</returns>
-        public abstract TopGroups<T> Search(IndexSearcher searcher, Filter filter, Query query, int groupOffset, int groupLimit);
+        public abstract TopGroups<T> Search(IndexSearcher searcher,
+            Filter filter,
+            Query query,
+            int groupOffset,
+            int groupLimit,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Specifies how groups are sorted.

--- a/src/Lucene.Net.Grouping/GroupingSearch.cs
+++ b/src/Lucene.Net.Grouping/GroupingSearch.cs
@@ -714,13 +714,13 @@ namespace Lucene.Net.Search.Grouping
 
         #region Explicit interface implementations
 
-        /// <inheritdoc cref="IGroupingSearch.Search(IndexSearcher, Query, int, int)"/>
-        ITopGroups IGroupingSearch.Search(IndexSearcher searcher, Query query, int groupOffset, int groupLimit)
-            => Search(searcher, query, groupOffset, groupLimit);
+        /// <inheritdoc cref="IGroupingSearch.Search(IndexSearcher, Query, int, int, CancellationToken)"/>
+        ITopGroups IGroupingSearch.Search(IndexSearcher searcher, Query query, int groupOffset, int groupLimit, CancellationToken cancellationToken)
+            => Search(searcher, query, groupOffset, groupLimit, cancellationToken);
 
-        /// <inheritdoc cref="IGroupingSearch.Search(IndexSearcher, Filter, Query, int, int)"/>
-        ITopGroups IGroupingSearch.Search(IndexSearcher searcher, Filter filter, Query query, int groupOffset, int groupLimit)
-            => Search(searcher, filter, query, groupOffset, groupLimit);
+        /// <inheritdoc cref="IGroupingSearch.Search(IndexSearcher, Filter, Query, int, int, CancellationToken)"/>
+        ITopGroups IGroupingSearch.Search(IndexSearcher searcher, Filter filter, Query query, int groupOffset, int groupLimit, CancellationToken cancellationToken)
+            => Search(searcher, filter, query, groupOffset, groupLimit, cancellationToken);
 
         #endregion
     }
@@ -740,8 +740,9 @@ namespace Lucene.Net.Search.Grouping
         /// <param name="query">The query to execute with the grouping</param>
         /// <param name="groupOffset">The group offset</param>
         /// <param name="groupLimit">The number of groups to return from the specified group offset</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the search.</param>
         /// <returns>the grouped result as an <see cref="ITopGroups"/> instance</returns>
-        ITopGroups Search(IndexSearcher searcher, Query query, int groupOffset, int groupLimit);
+        ITopGroups Search(IndexSearcher searcher, Query query, int groupOffset, int groupLimit, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes a grouped search. Both the first pass and second pass are executed on the specified searcher.
@@ -751,7 +752,8 @@ namespace Lucene.Net.Search.Grouping
         /// <param name="query">The query to execute with the grouping</param>
         /// <param name="groupOffset">The group offset</param>
         /// <param name="groupLimit">The number of groups to return from the specified group offset</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the search.</param>
         /// <returns>the grouped result as an <see cref="ITopGroups"/> instance</returns>
-        ITopGroups Search(IndexSearcher searcher, Filter filter, Query query, int groupOffset, int groupLimit);
+        ITopGroups Search(IndexSearcher searcher, Filter filter, Query query, int groupOffset, int groupLimit, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Lucene.Net.Join/JoinUtil.cs
+++ b/src/Lucene.Net.Join/JoinUtil.cs
@@ -1,6 +1,7 @@
 // Lucene version compatibility level 4.8.1
 using System;
 using System.IO;
+using System.Threading;
 
 namespace Lucene.Net.Search.Join
 {
@@ -56,24 +57,31 @@ namespace Lucene.Net.Search.Join
         /// <param name="fromQuery">                 The query to match documents on the from side </param>
         /// <param name="fromSearcher">              The searcher that executed the specified <paramref name="fromQuery"/> </param>
         /// <param name="scoreMode">                 Instructs how scores from the <paramref name="fromQuery"/> are mapped to the returned query </param>
+        /// <param name="cancellationToken">         A cancellation token used to cancel the search. LUCENENET specific. </param>
         /// <returns>A <see cref="Query"/> instance that can be used to join documents based on the terms in the from and to field</returns>
         /// <exception cref="IOException"> If I/O related errors occur </exception>
-        public static Query CreateJoinQuery(string fromField, bool multipleValuesPerDocument, string toField, Query fromQuery, IndexSearcher fromSearcher, ScoreMode scoreMode)
+        public static Query CreateJoinQuery(string fromField,
+            bool multipleValuesPerDocument,
+            string toField,
+            Query fromQuery,
+            IndexSearcher fromSearcher,
+            ScoreMode scoreMode,
+            CancellationToken cancellationToken = default)
         {
             switch (scoreMode)
             {
                 case ScoreMode.None:
                     TermsCollector termsCollector = TermsCollector.Create(fromField, multipleValuesPerDocument);
-                    fromSearcher.Search(fromQuery, termsCollector);
+                    fromSearcher.Search(fromQuery, termsCollector, cancellationToken);
                     return new TermsQuery(toField, fromQuery, termsCollector.CollectorTerms);
                 case ScoreMode.Total:
                 case ScoreMode.Max:
                 case ScoreMode.Avg:
                     TermsWithScoreCollector termsWithScoreCollector = TermsWithScoreCollector.Create(fromField, multipleValuesPerDocument, scoreMode);
-                    fromSearcher.Search(fromQuery, termsWithScoreCollector);
+                    fromSearcher.Search(fromQuery, termsWithScoreCollector, cancellationToken);
                     return new TermsIncludingScoreQuery(toField, multipleValuesPerDocument, termsWithScoreCollector.CollectedTerms, termsWithScoreCollector.ScoresPerTerm, fromQuery);
                 default:
-                    throw new ArgumentException(string.Format("Score mode {0} isn't supported.", scoreMode));
+                    throw new ArgumentException($"Score mode {scoreMode} isn't supported.");
             }
         }
     }

--- a/src/Lucene.Net.Memory/MemoryIndex.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading;
 
 namespace Lucene.Net.Index.Memory
 {
@@ -569,11 +570,12 @@ namespace Lucene.Net.Index.Memory
         /// matching this index against the given Lucene query expression.
         /// </summary>
         /// <param name="query"> an arbitrary Lucene query to run against this index </param>
+        /// <param name="cancellationToken"> A cancellation token used to cancel the search. LUCENENET specific. </param>
         /// <returns> the relevance score of the matchmaking; A number in the range
         ///         [0.0 .. 1.0], with 0.0 indicating no match. The higher the number
         ///         the better the match.
         ///  </returns>
-        public virtual float Search(Query query)
+        public virtual float Search(Query query, CancellationToken cancellationToken = default)
         {
             if (query is null)
             {
@@ -584,7 +586,7 @@ namespace Lucene.Net.Index.Memory
             try
             {
                 float[] scores = new float[1]; // inits to 0.0f (no match)
-                searcher.Search(query, new CollectorAnonymousClass(scores));
+                searcher.Search(query, new CollectorAnonymousClass(scores), cancellationToken);
                 float score = scores[0];
                 return score;
             } // can never happen (RAMDirectory)

--- a/src/Lucene.Net.Suggest/Spell/SpellChecker.cs
+++ b/src/Lucene.Net.Suggest/Spell/SpellChecker.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Directory = Lucene.Net.Store.Directory;
 using JCG = J2N.Collections.Generic;
 
@@ -51,7 +52,7 @@ namespace Lucene.Net.Search.Spell
     {
         /// <summary>
         /// The default minimum score to use, if not specified by setting <see cref="Accuracy"/>
-        /// or overriding with <see cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float)"/> .
+        /// or overriding with <see cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float, CancellationToken)"/> .
         /// </summary>
         public const float DEFAULT_ACCURACY = 0.5f;
 
@@ -190,7 +191,7 @@ namespace Lucene.Net.Search.Spell
 
         /// <summary>
         /// Gets or sets the accuracy (minimum score) to be used, unless overridden in
-        /// <see cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float)"/>,
+        /// <see cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float, CancellationToken)"/>,
         /// to decide whether a suggestion is included or not.
         /// Sets the accuracy 0 &lt; minScore &lt; 1; default <see cref="DEFAULT_ACCURACY"/>
         /// </summary>
@@ -221,7 +222,7 @@ namespace Lucene.Net.Search.Spell
         /// <returns>string[] the sorted list of the suggest words with these 2 criteria:
         /// first criteria: the edit distance, second criteria (only if restricted mode): the popularity
         /// of the suggest words in the field of the user index</returns>
-        /// <seealso cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float)"/>
+        /// <seealso cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float, CancellationToken)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual string[] SuggestSimilar(string word, int numSug)
         {
@@ -249,7 +250,7 @@ namespace Lucene.Net.Search.Spell
         /// <returns>string[] the sorted list of the suggest words with these 2 criteria:
         /// first criteria: the edit distance, second criteria (only if restricted mode): the popularity
         /// of the suggest words in the field of the user index</returns>
-        /// <seealso cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float)"/>
+        /// <seealso cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float, CancellationToken)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual string[] SuggestSimilar(string word, int numSug, float accuracy)
         {
@@ -257,7 +258,7 @@ namespace Lucene.Net.Search.Spell
         }
 
         /// <summary>
-        /// Calls <see cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float)"/>
+        /// Calls <see cref="SuggestSimilar(string, int, IndexReader, string, SuggestMode, float, CancellationToken)"/>
         ///       SuggestSimilar(word, numSug, ir, suggestMode, field, this.accuracy)
         ///
         /// </summary>
@@ -288,13 +289,21 @@ namespace Lucene.Net.Search.Spell
         /// <param name="suggestMode">
         /// (NOTE: if indexReader==null and/or field==null, then this is overridden with SuggestMode.SUGGEST_ALWAYS) </param>
         /// <param name="accuracy"> The minimum score a suggestion must have in order to qualify for inclusion in the results </param>
+        /// <param name="cancellationToken"> A cancellation token to cancel the search. LUCENENET specific. </param>
         /// <exception cref="IOException"> if the underlying index throws an <see cref="IOException"/> </exception>
         /// <exception cref="ObjectDisposedException"> if the <see cref="SpellChecker"/> is already disposed </exception>
+        /// <exception cref="OperationCanceledException"> if the <paramref name="cancellationToken"/> requested cancellation </exception>
         /// <returns> string[] the sorted list of the suggest words with these 2 criteria:
         /// first criteria: the edit distance, second criteria (only if restricted mode): the popularity
         /// of the suggest words in the field of the user index
         ///  </returns>
-        public virtual string[] SuggestSimilar(string word, int numSug, IndexReader ir, string field, SuggestMode suggestMode, float accuracy)
+        public virtual string[] SuggestSimilar(string word,
+            int numSug,
+            IndexReader ir,
+            string field,
+            SuggestMode suggestMode,
+            float accuracy,
+            CancellationToken cancellationToken = default)
         {
             // obtainSearcher calls ensureOpen
             IndexSearcher indexSearcher = ObtainSearcher();
@@ -355,7 +364,7 @@ namespace Lucene.Net.Search.Spell
                 int maxHits = 10 * numSug;
 
                 //    System.out.println("Q: " + query);
-                ScoreDoc[] hits = indexSearcher.Search(query, null, maxHits).ScoreDocs;
+                ScoreDoc[] hits = indexSearcher.Search(query, null, maxHits, cancellationToken).ScoreDocs;
                 //    System.out.println("HITS: " + hits.length());
                 SuggestWordQueue sugQueue = new SuggestWordQueue(numSug, comparer);
 

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingInfixSuggester.cs
@@ -13,6 +13,7 @@ using System.Text;
 using JCG = J2N.Collections.Generic;
 using Directory = Lucene.Net.Store.Directory;
 using Lucene.Net.Support.Threading;
+using System.Threading;
 
 namespace Lucene.Net.Search.Suggest.Analyzing
 {
@@ -365,7 +366,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// instead if you want to replace a previous suggestion.
         /// After adding or updating a batch of new suggestions,
         /// you must call <see cref="Refresh()"/> in the end in order to
-        /// see the suggestions in <see cref="DoLookup(string, IEnumerable{BytesRef}, int, bool, bool)"/>
+        /// see the suggestions in <see cref="DoLookup(string, IEnumerable{BytesRef}, int, bool, bool, CancellationToken)"/>
         /// </summary>
         public virtual void Add(BytesRef text, IEnumerable<BytesRef> contexts, long weight, BytesRef payload)
         {
@@ -380,7 +381,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// this text is not already present you can use <see cref="Add"/>
         /// instead.  After adding or updating a batch of
         /// new suggestions, you must call <see cref="Refresh()"/> in the
-        /// end in order to see the suggestions in <see cref="DoLookup(string, IEnumerable{BytesRef}, int, bool, bool)"/>
+        /// end in order to see the suggestions in <see cref="DoLookup(string, IEnumerable{BytesRef}, int, bool, bool, CancellationToken)"/>
         /// </summary>
         public virtual void Update(BytesRef text, IEnumerable<BytesRef> contexts, long weight, BytesRef payload)
         {
@@ -443,17 +444,25 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             return ft;
         }
 
-        public override IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, bool onlyMorePopular, int num)
+        public override IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default)
         {
-            return DoLookup(key, contexts, num, true, true);
+            return DoLookup(key, contexts, num, true, true, cancellationToken);
         }
 
         /// <summary>
         /// Lookup, without any context.
         /// </summary>
-        public virtual IList<LookupResult> DoLookup(string key, int num, bool allTermsRequired, bool doHighlight)
+        public virtual IList<LookupResult> DoLookup(string key,
+            int num,
+            bool allTermsRequired,
+            bool doHighlight,
+            CancellationToken cancellationToken = default)
         {
-            return DoLookup(key, null, num, allTermsRequired, doHighlight);
+            return DoLookup(key, null, num, allTermsRequired, doHighlight, cancellationToken);
         }
 
         /// <summary>
@@ -477,9 +486,13 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         ///  must match (<paramref name="allTermsRequired"/>) and whether the hits
         ///  should be highlighted (<paramref name="doHighlight"/>).
         /// </summary>
-        public virtual IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, int num, bool allTermsRequired, bool doHighlight)
+        public virtual IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            int num,
+            bool allTermsRequired,
+            bool doHighlight,
+            CancellationToken cancellationToken = default)
         {
-
             if (m_searcherMgr is null)
             {
                 throw IllegalStateException.Create("suggester was not built");
@@ -599,7 +612,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             try
             {
                 //System.out.println("got searcher=" + searcher);
-                searcher.Search(finalQuery, c2);
+                searcher.Search(finalQuery, c2, cancellationToken);
 
                 TopFieldDocs hits = (TopFieldDocs)c.GetTopDocs();
 

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
@@ -9,6 +9,7 @@ using Lucene.Net.Util.Automaton;
 using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Int64 = J2N.Numerics.Int64;
 using JCG = J2N.Collections.Generic;
 
@@ -712,7 +713,11 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             }
         }
 
-        public override IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, bool onlyMorePopular, int num)
+        public override IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default)
         {
             if (Debugging.AssertsEnabled) Debugging.Assert(num > 0);
 
@@ -751,7 +756,6 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             var utf8Key = new BytesRef(key);
             try
             {
-
                 Automaton lookupAutomaton = ToLookupAutomaton(key);
 
                 var spare = new CharsRef();

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/BlendedInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/BlendedInfixSuggester.cs
@@ -4,11 +4,11 @@ using Lucene.Net.Index;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using JCG = J2N.Collections.Generic;
 using Directory = Lucene.Net.Store.Directory;
 using Lucene.Net.Diagnostics;
+using System.Threading;
 
 namespace Lucene.Net.Search.Suggest.Analyzing
 {
@@ -132,16 +132,25 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             this.numFactor = numFactor;
         }
 
-        public override IList<Lookup.LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, bool onlyMorePopular, int num)
+        public override IList<Lookup.LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default)
         {
             // here we multiply the number of searched element by the defined factor
-            return base.DoLookup(key, contexts, onlyMorePopular, num * numFactor);
+            return base.DoLookup(key, contexts, onlyMorePopular, num * numFactor, cancellationToken);
         }
 
-        public override IList<Lookup.LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, int num, bool allTermsRequired, bool doHighlight)
+        public override IList<Lookup.LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            int num,
+            bool allTermsRequired,
+            bool doHighlight,
+            CancellationToken cancellationToken = default)
         {
             // here we multiply the number of searched element by the defined factor
-            return base.DoLookup(key, contexts, num * numFactor, allTermsRequired, doHighlight);
+            return base.DoLookup(key, contexts, num * numFactor, allTermsRequired, doHighlight, cancellationToken);
         }
 
         protected override FieldType GetTextFieldType()

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/FreeTextSuggester.cs
@@ -12,8 +12,8 @@ using Lucene.Net.Util;
 using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using Directory = Lucene.Net.Store.Directory;
 using JCG = J2N.Collections.Generic;
 using Int64 = J2N.Numerics.Int64;
@@ -44,7 +44,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
     /// <summary>
     /// Builds an ngram model from the text sent to <see cref="Build(IInputEnumerator, double)"/>
     /// and predicts based on the last grams-1 tokens in
-    /// the request sent to <see cref="DoLookup(string, IEnumerable{BytesRef}, bool, int)"/>.  This tries to
+    /// the request sent to <see cref="DoLookup(string, IEnumerable{BytesRef}, bool, int, CancellationToken)"/>.  This tries to
     /// handle the "long tail" of suggestions for when the
     /// incoming query is a never before seen query string.
     ///
@@ -64,7 +64,7 @@ namespace Lucene.Net.Search.Suggest.Analyzing
     /// "Large language models in machine translation"</a> for details.
     ///
     /// </para>
-    /// <para> From <see cref="DoLookup(string, IEnumerable{BytesRef}, bool, int)"/>, the key of each result is the
+    /// <para> From <see cref="DoLookup(string, IEnumerable{BytesRef}, bool, int, CancellationToken)"/>, the key of each result is the
     /// ngram token; the value is <see cref="long.MaxValue"/> * score (fixed
     /// point, cast to long).  Divide by <see cref="long.MaxValue"/> to get
     /// the score back, which ranges from 0.0 to 1.0.
@@ -433,23 +433,30 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             return true;
         }
 
-        public override IList<LookupResult> DoLookup(string key, bool onlyMorePopular, int num) // ignored
+        public override IList<LookupResult> DoLookup(string key,
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default) // ignored
         {
-            return DoLookup(key, null, onlyMorePopular, num);
+            return DoLookup(key, null, onlyMorePopular, num, cancellationToken);
         }
 
         /// <summary>
         /// Lookup, without any context. </summary>
-        public virtual IList<LookupResult> DoLookup(string key, int num)
+        public virtual IList<LookupResult> DoLookup(string key, int num, CancellationToken cancellationToken = default)
         {
-            return DoLookup(key, null, true, num);
+            return DoLookup(key, null, true, num, cancellationToken);
         }
 
-        public override IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, /* ignored */ bool onlyMorePopular, int num)
+        public override IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts, /* ignored */
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                return DoLookup(key, contexts, num);
+                return DoLookup(key, contexts, num, cancellationToken);
             }
             catch (Exception ioe) when (ioe.IsIOException())
             {
@@ -477,7 +484,10 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         /// <summary>
         /// Retrieve suggestions.
         /// </summary>
-        public virtual IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, int num)
+        public virtual IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            int num,
+            CancellationToken cancellationToken = default)
         {
             // LUCENENET: Added guard clause for null
             if (key is null)

--- a/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletionLookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/FSTCompletionLookup.cs
@@ -1,5 +1,4 @@
 using Lucene.Net.Store;
-using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
 using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
@@ -7,6 +6,7 @@ using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Suggest.Fst
@@ -257,7 +257,11 @@ namespace Lucene.Net.Search.Suggest.Fst
             return (int)value;
         }
 
-        public override IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, bool higherWeightsFirst, int num)
+        public override IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            bool higherWeightsFirst,
+            int num,
+            CancellationToken cancellationToken = default)
         {
             // LUCENENET: Added guard clause for null
             if (key is null)

--- a/src/Lucene.Net.Suggest/Suggest/Fst/WFSTCompletionLookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Fst/WFSTCompletionLookup.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Util;
 using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 using Int64 = J2N.Numerics.Int64;
 
@@ -139,7 +140,11 @@ namespace Lucene.Net.Search.Suggest.Fst
             return true;
         }
 
-        public override IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, bool onlyMorePopular, int num)
+        public override IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default)
         {
             // LUCENENET: Added guard clause for null
             if (key is null)

--- a/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellLookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Jaspell/JaspellLookup.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Store;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Suggest.Jaspell
@@ -113,7 +114,11 @@ namespace Lucene.Net.Search.Suggest.Jaspell
             return trie.Get(key);
         }
 
-        public override IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, bool onlyMorePopular, int num)
+        public override IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default)
         {
             if (contexts != null)
             {
@@ -167,7 +172,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
         private const sbyte HI_KID = 0x04;
         private const sbyte HAS_VALUE = 0x08;
 
-        private void ReadRecursively(DataInput @in, JaspellTernarySearchTrie.TSTNode node)
+        private static void ReadRecursively(DataInput @in, JaspellTernarySearchTrie.TSTNode node)
         {
             node.splitchar = @in.ReadString()[0];
             sbyte mask = (sbyte)@in.ReadByte();
@@ -195,7 +200,7 @@ namespace Lucene.Net.Search.Suggest.Jaspell
             }
         }
 
-        private void WriteRecursively(DataOutput @out, JaspellTernarySearchTrie.TSTNode node)
+        private static void WriteRecursively(DataOutput @out, JaspellTernarySearchTrie.TSTNode node)
         {
             if (node is null)
             {

--- a/src/Lucene.Net.Suggest/Suggest/Lookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Lookup.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 
 namespace Lucene.Net.Search.Suggest
 {
@@ -302,10 +303,14 @@ namespace Lucene.Net.Search.Suggest
         /// a prefix, misspelling, or even infix. </param>
         /// <param name="onlyMorePopular"> return only more popular results </param>
         /// <param name="num"> maximum number of results to return </param>
+        /// <param name="cancellationToken"> token to monitor for cancellation requests. LUCENENET specific. Note that not all implementations support cancellation. </param>
         /// <returns> a list of possible completions, with their relative weight (e.g. popularity) </returns>
-        public virtual IList<LookupResult> DoLookup(string key, bool onlyMorePopular, int num)
+        public virtual IList<LookupResult> DoLookup(string key,
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default)
         {
-            return DoLookup(key, null, onlyMorePopular, num);
+            return DoLookup(key, null, onlyMorePopular, num, cancellationToken);
         }
 
         /// <summary>
@@ -315,8 +320,13 @@ namespace Lucene.Net.Search.Suggest
         /// <param name="contexts"> contexts to filter the lookup by, or null if all contexts are allowed; if the suggestion contains any of the contexts, it's a match </param>
         /// <param name="onlyMorePopular"> return only more popular results </param>
         /// <param name="num"> maximum number of results to return </param>
+        /// <param name="cancellationToken"> token to monitor for cancellation requests. LUCENENET specific. Note that not all implementations support cancellation. </param>
         /// <returns> a list of possible completions, with their relative weight (e.g. popularity) </returns>
-        public abstract IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, bool onlyMorePopular, int num);
+        public abstract IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Persist the constructed lookup data to a directory. Optional operation. </summary>

--- a/src/Lucene.Net.Suggest/Suggest/Tst/TSTLookup.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Tst/TSTLookup.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Suggest.Tst
@@ -48,7 +49,7 @@ namespace Lucene.Net.Search.Suggest.Tst
 
         public override void Build(IInputEnumerator enumerator)
         {
-            // LUCENENT: Added guard clause for null
+            // LUCENENET: Added guard clause for null
             if (enumerator is null)
                 throw new ArgumentNullException(nameof(enumerator));
 
@@ -137,7 +138,11 @@ namespace Lucene.Net.Search.Suggest.Tst
             return true;
         }
 
-        public override IList<LookupResult> DoLookup(string key, IEnumerable<BytesRef> contexts, bool onlyMorePopular, int num)
+        public override IList<LookupResult> DoLookup(string key,
+            IEnumerable<BytesRef> contexts,
+            bool onlyMorePopular,
+            int num,
+            CancellationToken cancellationToken = default)
         {
             if (contexts != null)
             {
@@ -181,7 +186,7 @@ namespace Lucene.Net.Search.Suggest.Tst
         private const sbyte HAS_VALUE = 0x10;
 
         // pre-order traversal
-        private void ReadRecursively(DataInput @in, TernaryTreeNode node)
+        private static void ReadRecursively(DataInput @in, TernaryTreeNode node)
         {
             node.splitchar = @in.ReadString()[0];
             sbyte mask = (sbyte)@in.ReadByte();
@@ -211,7 +216,7 @@ namespace Lucene.Net.Search.Suggest.Tst
         }
 
         // pre-order traversal
-        private void WriteRecursively(DataOutput @out, TernaryTreeNode node)
+        private static void WriteRecursively(DataOutput @out, TernaryTreeNode node)
         {
             // write out the current node
             @out.WriteString(new string(new char[] { node.splitchar }, 0, 1));

--- a/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
@@ -1,5 +1,6 @@
 // Lucene version compatibility level 4.8.1 + LUCENE-6001
 using J2N.Collections.Generic.Extensions;
+using Lucene.Net.Attributes;
 using J2N.Text;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Search;
@@ -10,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Assert = Lucene.Net.TestFramework.Assert;
 using JCG = J2N.Collections.Generic;
 
@@ -1329,6 +1331,76 @@ namespace Lucene.Net.Facet
 
             writer.Dispose();
             IOUtils.Dispose(searcher.IndexReader, taxoReader, taxoWriter, dir, taxoDir);
+        }
+
+        // LUCENENET specific - tests for the CancellationToken support
+        // added to DrillSideways and FacetsCollector. See #922.
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestCancellation_DrillSideways_PreCanceledToken_ThrowsOperationCanceledException()
+        {
+            using Directory dir = NewDirectory();
+            using Directory taxoDir = NewDirectory();
+            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, OpenMode.CREATE);
+            FacetsConfig config = new FacetsConfig();
+
+            RandomIndexWriter writer = new RandomIndexWriter(Random, dir);
+            Document doc = new Document();
+            doc.Add(new FacetField("Author", "Bob"));
+            writer.AddDocument(config.Build(taxoWriter, doc));
+            doc = new Document();
+            doc.Add(new FacetField("Author", "Lisa"));
+            writer.AddDocument(config.Build(taxoWriter, doc));
+
+            IndexSearcher searcher = NewSearcher(writer.GetReader());
+            var taxoReader = new DirectoryTaxonomyReader(taxoWriter);
+            DrillSideways ds = new DrillSideways(searcher, config, taxoReader);
+
+            DrillDownQuery ddq = new DrillDownQuery(config);
+            ddq.Add("Author", "Lisa");
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(
+                () => ds.Search(null, ddq, 10, cts.Token));
+
+            Assert.Throws<OperationCanceledException>(
+                () => ds.Search(ddq, 10, cts.Token));
+
+            Assert.Throws<OperationCanceledException>(
+                () => ds.Search(ddq, new TotalHitCountCollector(), cts.Token));
+
+            writer.Dispose();
+            IOUtils.Dispose(searcher.IndexReader, taxoReader, taxoWriter);
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestCancellation_FacetsCollector_PreCanceledToken_ThrowsOperationCanceledException()
+        {
+            using Directory dir = NewDirectory();
+            using Directory taxoDir = NewDirectory();
+            var taxoWriter = new DirectoryTaxonomyWriter(taxoDir, OpenMode.CREATE);
+            FacetsConfig config = new FacetsConfig();
+
+            RandomIndexWriter writer = new RandomIndexWriter(Random, dir);
+            Document doc = new Document();
+            doc.Add(new FacetField("Author", "Bob"));
+            writer.AddDocument(config.Build(taxoWriter, doc));
+
+            IndexSearcher searcher = NewSearcher(writer.GetReader());
+            FacetsCollector fc = new FacetsCollector();
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(
+                () => FacetsCollector.Search(searcher, new MatchAllDocsQuery(), 10, fc, cts.Token));
+
+            writer.Dispose();
+            IOUtils.Dispose(searcher.IndexReader, taxoWriter);
         }
     }
 }

--- a/src/Lucene.Net.Tests.Grouping/GroupingSearchTest.cs
+++ b/src/Lucene.Net.Tests.Grouping/GroupingSearchTest.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Analysis;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Index.Extensions;
@@ -11,6 +12,7 @@ using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Linq;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Grouping
@@ -331,6 +333,47 @@ namespace Lucene.Net.Search.Grouping
             assertEquals(1, gs.GetAllMatchingGroups().Count);
             indexSearcher.IndexReader.Dispose();
             dir.Dispose();
+        }
+
+        // LUCENENET specific - tests for the CancellationToken support
+        // added to GroupingSearch. See #922.
+
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestCancellation_PreCanceledToken_ThrowsOperationCanceledException()
+        {
+            using Directory dir = NewDirectory();
+            RandomIndexWriter w = new RandomIndexWriter(
+                Random,
+                dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT,
+                    new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy()));
+
+            Document doc = new Document();
+            doc.Add(new StringField("group", "foo", Field.Store.NO));
+            doc.Add(new TextField("content", "random text", Field.Store.NO));
+            w.AddDocument(doc);
+
+            doc = new Document();
+            doc.Add(new StringField("group", "bar", Field.Store.NO));
+            doc.Add(new TextField("content", "random words", Field.Store.NO));
+            w.AddDocument(doc);
+
+            IndexSearcher indexSearcher = NewSearcher(w.GetReader());
+            w.Dispose();
+
+            var gs = GroupingSearch.ByField("group");
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(
+                () => gs.Search(indexSearcher, new MatchAllDocsQuery(), 0, 10, cts.Token));
+
+            Assert.Throws<OperationCanceledException>(
+                () => gs.Search(indexSearcher, null, new MatchAllDocsQuery(), 0, 10, cts.Token));
+
+            indexSearcher.IndexReader.Dispose();
         }
     }
 }

--- a/src/Lucene.Net.Tests.Join/TestJoinUtil.cs
+++ b/src/Lucene.Net.Tests.Join/TestJoinUtil.cs
@@ -1,5 +1,6 @@
 // Lucene version compatibility level 4.8.1
 using Lucene.Net.Analysis;
+using Lucene.Net.Attributes;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
@@ -11,6 +12,7 @@ using RandomizedTesting.Generators;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Join
@@ -1073,6 +1075,48 @@ namespace Lucene.Net.Search.Join
                 }
                 throw new ArgumentException("Unsupported ScoreMode: " + mode);
             }
+        }
+
+        // LUCENENET specific - tests for the CancellationToken support
+        // added to JoinUtil.CreateJoinQuery. See #922.
+
+        [Test]
+        [LuceneNetSpecific]
+        public void TestCancellation_PreCanceledToken_ThrowsOperationCanceledException()
+        {
+            string idField = "id";
+            string toField = "productId";
+
+            using Directory dir = NewDirectory();
+            RandomIndexWriter w = new RandomIndexWriter(Random, dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
+                    .SetMergePolicy(NewLogMergePolicy()));
+
+            Document doc = new Document();
+            doc.Add(new TextField("name", "name1", Field.Store.NO));
+            doc.Add(new TextField(idField, "1", Field.Store.NO));
+            w.AddDocument(doc);
+
+            doc = new Document();
+            doc.Add(new TextField(idField, "2", Field.Store.NO));
+            doc.Add(new TextField(toField, "1", Field.Store.NO));
+            w.AddDocument(doc);
+
+            IndexSearcher indexSearcher = new IndexSearcher(w.GetReader());
+            w.Dispose();
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(
+                () => JoinUtil.CreateJoinQuery(idField, false, toField,
+                    new TermQuery(new Term("name", "name1")), indexSearcher, ScoreMode.None, cts.Token));
+
+            Assert.Throws<OperationCanceledException>(
+                () => JoinUtil.CreateJoinQuery(idField, false, toField,
+                    new TermQuery(new Term("name", "name1")), indexSearcher, ScoreMode.Total, cts.Token));
+
+            indexSearcher.IndexReader.Dispose();
         }
     }
 }

--- a/src/Lucene.Net.Tests.Memory/Index/Memory/MemoryIndexTest.cs
+++ b/src/Lucene.Net.Tests.Memory/Index/Memory/MemoryIndexTest.cs
@@ -20,6 +20,7 @@
 */
 
 using Lucene.Net.Analysis;
+using Lucene.Net.Attributes;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Codecs.Lucene41;
 using Lucene.Net.Documents;
@@ -35,6 +36,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index.Memory
@@ -457,6 +459,34 @@ namespace Lucene.Net.Index.Memory
             assertEquals(0, mindex.Search(query), 0.00001f);
             query.Slop = (10);
             assertTrue("posGap" + mockAnalyzer.GetPositionIncrementGap("field"), mindex.Search(query) > 0.0001);
+        }
+
+        // LUCENENET specific - tests for the CancellationToken support
+        // added to MemoryIndex.Search. See #922.
+
+        [Test]
+        [LuceneNetSpecific]
+        public void TestCancellation_PreCanceledToken_ThrowsOperationCanceledException()
+        {
+            MemoryIndex mindex = new MemoryIndex(Random.nextBoolean(), Random.nextInt(50) * 1024 * 1024);
+            mindex.AddField("field", "the quick brown fox", new MockAnalyzer(Random));
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(
+                () => mindex.Search(new TermQuery(new Term("field", "fox")), cts.Token));
+        }
+
+        [Test]
+        [LuceneNetSpecific]
+        public void TestCancellation_DefaultToken_SearchCompletesNormally()
+        {
+            MemoryIndex mindex = new MemoryIndex(Random.nextBoolean(), Random.nextInt(50) * 1024 * 1024);
+            mindex.AddField("field", "the quick brown fox", new MockAnalyzer(Random));
+
+            float score = mindex.Search(new TermQuery(new Term("field", "fox")), CancellationToken.None);
+            assertTrue("Expected a match", score > 0.0f);
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Suggest/Spell/TestSpellChecker.cs
+++ b/src/Lucene.Net.Tests.Suggest/Spell/TestSpellChecker.cs
@@ -1,6 +1,7 @@
 using J2N.Threading;
 using J2N.Threading.Atomic;
 using Lucene.Net.Analysis;
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
@@ -627,6 +628,27 @@ namespace Lucene.Net.Search.Spell
                     terminated = true;
                 }
             }
+        }
+
+        // LUCENENET specific - tests for the CancellationToken support
+        // added to SpellChecker.SuggestSimilar. See #922.
+
+        [Test]
+        [LuceneNetSpecific]
+        public void TestCancellation_PreCanceledToken_ThrowsOperationCanceledException()
+        {
+            using IndexReader r = DirectoryReader.Open(userindex);
+            spellChecker.ClearIndex();
+            Addwords(r, spellChecker, "field1");
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Use SUGGEST_ALWAYS to ensure we reach the internal IndexSearcher.Search call
+            // (other modes may short-circuit before searching if the word is found in the reader).
+            Assert.Throws<OperationCanceledException>(
+                () => spellChecker.SuggestSimilar("eighty", 2, r, "field1",
+                    SuggestMode.SUGGEST_ALWAYS, 0.5f, cts.Token));
         }
 
         internal class SpellCheckerMock : SpellChecker

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingInfixSuggesterTest.cs
@@ -1,4 +1,5 @@
 using J2N.Text;
+using Lucene.Net.Attributes;
 using J2N.Threading;
 using J2N.Threading.Atomic;
 using Lucene.Net.Analysis;
@@ -1158,6 +1159,31 @@ namespace Lucene.Net.Search.Suggest.Analyzing
                         suggester.Dispose();
                 }
             }
+        }
+
+        // LUCENENET specific - tests for the CancellationToken support
+        // added to AnalyzingInfixSuggester.DoLookup. See #922.
+
+        [Test]
+        [LuceneNetSpecific]
+        public void TestCancellation_PreCanceledToken_ThrowsOperationCanceledException()
+        {
+            Input[] keys = new Input[] {
+                new Input("lend me your ear", 8, new BytesRef("foobar")),
+                new Input("a penny saved is a penny earned", 10, new BytesRef("foobaz")),
+            };
+
+            Analyzer a = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
+            using AnalyzingInfixSuggester suggester = new AnalyzingInfixSuggester(TEST_VERSION_CURRENT, NewDirectory(), a, a, 3);
+            suggester.Build(new InputArrayEnumerator(keys));
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(
+                () => suggester.DoLookup(
+                    TestUtil.StringToCharSequence("ear", Random).ToString(),
+                    10, true, true, cts.Token));
         }
     }
 }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Adds remaining API support for cancellation tokens with index searching.

Fixes #922

## Description

This PR adds the remaining cancellation token support to classes that internally call IndexSearcher's Search or SearchAfter methods. In some cases this bubbles up to the interface contract, even though not all implementations might currently support cancellation. It was determined that it was not worth it to call i.e. `ThrowIfCancellationRequested` in those cases, to avoid hot path performance issues. However, it can always be added later or improved after this PR is merged. The most important thing for the next beta release is that the breaking API changes are out of the way; cancellation can now be improved in these types in the future without breaking the API.

AI: This PR was mostly written by hand, then extensively reviewed by Claude Code (Opus 4.6 and 4.7) locally, and I used Claude Code (Opus 4.6) to add some unit tests.
