### PR TITLE
Fix concurrent-write race in SafeTextWriterWrapper, #1246

### DIFF
--- a/src/Lucene.Net.Tests/Support/IO/TestSafeTextWriterWrapper.cs
+++ b/src/Lucene.Net.Tests/Support/IO/TestSafeTextWriterWrapper.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Lucene.Net.Support.IO
 {
@@ -59,6 +60,34 @@ namespace Lucene.Net.Support.IO
             Assert.DoesNotThrow(() => safe.WriteLine('a'));
             Assert.DoesNotThrow(() => safe.WriteLine("Testing"));
             Assert.DoesNotThrow(() => safe.WriteLine("Testing"));
+        }
+
+        /// <summary>
+        /// LUCENENET specific. When <see cref="SafeTextWriterWrapper"/> wraps a
+        /// non-thread-safe <see cref="TextWriter"/> (such as <see cref="StringWriter"/>),
+        /// concurrent writes from multiple threads must not throw. This reproduces
+        /// https://github.com/apache/lucenenet/issues/1246 where the <see cref="FieldCache"/>
+        /// info stream was written concurrently from <see cref="Search.IndexSearcher"/>'s
+        /// executor threads, causing <see cref="ArgumentException"/> ("Destination is too
+        /// short") from <see cref="System.Text.StringBuilder"/>.
+        /// </summary>
+        [Test]
+        public void TestConcurrentWrites()
+        {
+            using var wrapped = new StringWriter();
+            using var safe = new SafeTextWriterWrapper(wrapped);
+
+            const int threadCount = 8;
+            const int iterationsPerThread = 2000;
+            const string line = "WARNING: new FieldCache insanity created. Details: some long-ish message for buffer growth.";
+
+            Parallel.For(0, threadCount, _ =>
+            {
+                for (int i = 0; i < iterationsPerThread; i++)
+                {
+                    safe.WriteLine(line);
+                }
+            });
         }
     }
 }

--- a/src/Lucene.Net.Tests/Support/IO/TestSafeTextWriterWrapper.cs
+++ b/src/Lucene.Net.Tests/Support/IO/TestSafeTextWriterWrapper.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Attributes;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
@@ -23,6 +24,8 @@ namespace Lucene.Net.Support.IO
      * limitations under the License.
      */
 
+    [TestFixture]
+    [LuceneNetSpecific]
     public class TestSafeTextWriterWrapper : LuceneTestCase
     {
         [Test]

--- a/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
+++ b/src/Lucene.Net/Support/IO/SafeTextWriterWrapper.cs
@@ -44,7 +44,16 @@ namespace Lucene.Net.Support.IO
 
         public SafeTextWriterWrapper(TextWriter textWriter)
         {
-            this.textWriter = textWriter ?? throw new ArgumentNullException(nameof(textWriter));
+            if (textWriter is null)
+                throw new ArgumentNullException(nameof(textWriter));
+
+            // LUCENENET specific: Wrap in a synchronized TextWriter so that concurrent
+            // writes from multiple threads (e.g., IndexSearcher executor threads writing
+            // to FieldCache.InfoStream) do not corrupt non-thread-safe writers such as
+            // StringWriter. This matches the thread-safety of Java's PrintStream, which
+            // synchronizes at the println boundary. See
+            // https://github.com/apache/lucenenet/issues/1246.
+            this.textWriter = TextWriter.Synchronized(textWriter);
         }
 
         public override Encoding Encoding => Run(() => textWriter.Encoding);


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix concurrent-write race in SafeTextWriterWrapper

Fixes #1246

## Description

- Fixes the flaky `TestFieldCacheRangeFilterInts` failure reported in #1246 where concurrent writes from `IndexSearcher` executor threads to `FieldCache.DEFAULT.InfoStream` (a `StringWriter`) corrupted its internal `StringBuilder`, surfacing as `ArgumentException: Destination is too short`.
- Root cause: `SafeTextWriterWrapper` wrapped the caller's `TextWriter` but did not synchronize access. Non-thread-safe writers (e.g. `StringWriter`) broke when Lucene's multi-threaded search code (via `FieldCacheImpl.PrintNewInsanity`) wrote to them concurrently.
- Fix: wrap the inner writer in `TextWriter.Synchronized` in the `SafeTextWriterWrapper` constructor. This matches Java `PrintStream`'s thread-safety (synchronized at the `println` boundary) and covers all current users — `FieldCacheImpl`, `SegmentInfos`, `CheckIndex`, and `TextWriterInfoStream` (used by `IndexWriter.infoStream`).

## Notes

- All four sites are diagnostic/debug streams, typically null in production hot paths. When enabled, one extra uncontended lock per write is negligible compared with the existing I/O cost.
- The issue's reported failing seed reproduced the bug, but the race itself is seed-independent. The added test (`TestConcurrentWrites`) reliably reproduces the exact `ArgumentException` stack trace from the issue report without any seed.
- This was fixed via TDD by adding the test, observing failure, applying the fix, and confirming that the test passes.

AI: Generated with Claude Code Opus 4.7