### PR TITLE
SWEEP: Upgraded to the navigable APIs on `SortedSet<T>` and `SortedDictionary<TKey, TValue>`

### DIFF
--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextTermVectorsReader.cs
@@ -362,12 +362,7 @@ namespace Lucene.Net.Codecs.SimpleText
 
             public override SeekStatus SeekCeil(BytesRef text)
             {
-                var newTerms = new JCG.SortedDictionary<BytesRef, SimpleTVPostings>(_terms.Comparer);
-                foreach (var p in _terms)
-                    if (p.Key.CompareTo(text) >= 0)
-                        newTerms.Add(p.Key, p.Value);
-
-                _iterator = newTerms.GetEnumerator();
+                _iterator = _terms.GetViewAfter(text).GetEnumerator();
 
                 // LUCENENET specific: Since in .NET we don't have a HasNext() method, we need
                 // to call MoveNext(). Since we need

--- a/src/Lucene.Net.Grouping/AbstractFirstPassGroupingCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractFirstPassGroupingCollector.cs
@@ -258,7 +258,7 @@ namespace Lucene.Net.Search.Grouping
                 if (Debugging.AssertsEnabled) Debugging.Assert(m_orderedGroups.Count == topNGroups);
 
                 // LUCENENET: We know this call cannot fail because we just added a group, so we can safely ignore the return value.
-                m_orderedGroups.TryGetLast(out CollectedSearchGroup<TGroupValue> lastGroup);
+                _ = m_orderedGroups.TryGetLast(out CollectedSearchGroup<TGroupValue> lastGroup);
                 int lastComparerSlot = lastGroup.ComparerSlot;
                 foreach (FieldComparer fc in comparers)
                 {

--- a/src/Lucene.Net.Grouping/AbstractFirstPassGroupingCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractFirstPassGroupingCollector.cs
@@ -1,11 +1,9 @@
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Index;
 using Lucene.Net.Support;
-using Lucene.Net.Support.Threading;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Grouping
@@ -241,18 +239,7 @@ namespace Lucene.Net.Search.Grouping
 
                 // We already tested that the document is competitive, so replace
                 // the bottom group with this new group.
-                //CollectedSearchGroup<TGroupValue> bottomGroup = orderedGroups.PollLast();
-                CollectedSearchGroup<TGroupValue> bottomGroup;
-                UninterruptableMonitor.Enter(m_orderedGroups);
-                try
-                {
-                    bottomGroup = m_orderedGroups.Last();
-                    m_orderedGroups.Remove(bottomGroup);
-                }
-                finally
-                {
-                    UninterruptableMonitor.Exit(m_orderedGroups);
-                }
+                m_orderedGroups.RemoveLast(out CollectedSearchGroup<TGroupValue> bottomGroup);
                 if (Debugging.AssertsEnabled) Debugging.Assert(m_orderedGroups.Count == topNGroups - 1);
 
                 groupMap.Remove(bottomGroup.GroupValue);
@@ -270,7 +257,9 @@ namespace Lucene.Net.Search.Grouping
                 m_orderedGroups.Add(bottomGroup);
                 if (Debugging.AssertsEnabled) Debugging.Assert(m_orderedGroups.Count == topNGroups);
 
-                int lastComparerSlot = m_orderedGroups.Last().ComparerSlot;
+                // LUCENENET: We know this call cannot fail because we just added a group, so we can safely ignore the return value.
+                m_orderedGroups.TryGetLast(out CollectedSearchGroup<TGroupValue> lastGroup);
+                int lastComparerSlot = lastGroup.ComparerSlot;
                 foreach (FieldComparer fc in comparers)
                 {
                     fc.SetBottom(lastComparerSlot);
@@ -315,16 +304,8 @@ namespace Lucene.Net.Search.Grouping
             CollectedSearchGroup<TGroupValue> prevLast;
             if (m_orderedGroups != null)
             {
-                UninterruptableMonitor.Enter(m_orderedGroups);
-                try
-                {
-                    prevLast = m_orderedGroups.Last();
-                    m_orderedGroups.Remove(group);
-                }
-                finally
-                {
-                    UninterruptableMonitor.Exit(m_orderedGroups);
-                }
+                m_orderedGroups.TryGetLast(out prevLast);
+                m_orderedGroups.Remove(group);
                 if (Debugging.AssertsEnabled) Debugging.Assert(m_orderedGroups.Count == topNGroups - 1);
             }
             else
@@ -344,7 +325,11 @@ namespace Lucene.Net.Search.Grouping
             {
                 m_orderedGroups.Add(group);
                 if (Debugging.AssertsEnabled) Debugging.Assert(m_orderedGroups.Count == topNGroups);
-                var newLast = m_orderedGroups.Last();
+                if (!m_orderedGroups.TryGetLast(out CollectedSearchGroup<TGroupValue> newLast))
+                {
+                    // LUCENENET: Added because Java would throw NoSuchElementException if orderedGroups is empty.
+                    throw new InvalidOperationException("orderedGroups must not be empty");
+                }
                 // If we changed the value of the last group, or changed which group was last, then update bottom:
                 if (group == newLast || prevLast != newLast)
                 {
@@ -390,7 +375,10 @@ namespace Lucene.Net.Search.Grouping
 
             foreach (FieldComparer fc in comparers)
             {
-                fc.SetBottom(m_orderedGroups.Last().ComparerSlot);
+                if (!m_orderedGroups.TryGetLast(out CollectedSearchGroup<TGroupValue> lastGroup))
+                    // LUCENENET: Added because Java would throw NoSuchElementException if orderedGroups is empty.
+                    throw new InvalidOperationException("orderedGroups must not be empty");
+                fc.SetBottom(lastGroup.ComparerSlot);
             }
         }
 

--- a/src/Lucene.Net.Grouping/AbstractGroupFacetCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractGroupFacetCollector.cs
@@ -192,7 +192,7 @@ namespace Lucene.Net.Search.Grouping
                 {
                     // LUCENENET: We can safely ignore the return value of TryGetLast() here, because we
                     // know that the collection is not empty (we just added an entry to it).
-                    facetEntries.TryGetLast(out FacetEntry last);
+                    _ = facetEntries.TryGetLast(out FacetEntry last);
                     currentMin = last.Count;
                 }
             }

--- a/src/Lucene.Net.Grouping/AbstractGroupFacetCollector.cs
+++ b/src/Lucene.Net.Grouping/AbstractGroupFacetCollector.cs
@@ -184,16 +184,16 @@ namespace Lucene.Net.Search.Grouping
                     {
                         return;
                     }
-                    var max = facetEntries.Max;
-                    if (max != null)
-                        facetEntries.Remove(max);
+                    facetEntries.RemoveLast(out _);
                 }
                 facetEntries.Add(facetEntry);
 
                 if (facetEntries.Count == maxSize)
                 {
-                    var max = facetEntries.Max;
-                    currentMin = max != null ? max.Count : 0;
+                    // LUCENENET: We can safely ignore the return value of TryGetLast() here, because we
+                    // know that the collection is not empty (we just added an entry to it).
+                    facetEntries.TryGetLast(out FacetEntry last);
+                    currentMin = last.Count;
                 }
             }
 

--- a/src/Lucene.Net.Grouping/SearchGroup.cs
+++ b/src/Lucene.Net.Grouping/SearchGroup.cs
@@ -392,8 +392,7 @@ namespace Lucene.Net.Search.Grouping
                 // Prune un-competitive groups:
                 while (queue.Count > topN)
                 {
-                    MergedGroup<T> group = queue.Max;
-                    queue.Remove(group);
+                    queue.RemoveLast(out MergedGroup<T> group);
                     //System.out.println("PRUNE: " + group);
                     group.IsInQueue = false;
                 }
@@ -401,7 +400,6 @@ namespace Lucene.Net.Search.Grouping
 
             public virtual ICollection<SearchGroup<T>> Merge(IList<ICollection<SearchGroup<T>>> shards, int offset, int topN)
             {
-
                 int maxQueueSize = offset + topN;
 
                 //System.out.println("merge");
@@ -423,8 +421,7 @@ namespace Lucene.Net.Search.Grouping
 
                 while (queue.Count != 0)
                 {
-                    MergedGroup<T> group = queue.Min;
-                    queue.Remove(group);
+                    queue.RemoveFirst(out MergedGroup<T> group);
                     group.IsProcessed = true;
                     //System.out.println("  pop: shards=" + group.shards + " group=" + (group.groupValue is null ? "null" : (((BytesRef) group.groupValue).utf8ToString())) + " sortValues=" + Arrays.toString(group.topValues));
                     if (count++ >= offset)

--- a/src/Lucene.Net.Highlighter/PostingsHighlight/PostingsHighlighter.cs
+++ b/src/Lucene.Net.Highlighter/PostingsHighlight/PostingsHighlighter.cs
@@ -436,8 +436,8 @@ namespace Lucene.Net.Search.PostingsHighlight
                 Term floor = new Term(field, "");
                 Term ceiling = new Term(field, UnicodeUtil.BIG_TERM);
 
-                // LUCENENET: Call custom GetViewBetween overload to mimic Java's exclusive upper bound behavior.
-                var fieldTerms = queryTerms.GetViewBetween(floor, lowerValueInclusive: true, ceiling, upperValueInclusive: false);
+                // LUCENENET: Call J2N's GetView overload to mimic Java's exclusive upper bound behavior.
+                var fieldTerms = queryTerms.GetView(floor, fromInclusive: true, ceiling, toInclusive: false);
 
                 // TODO: should we have some reasonable defaults for term pruning? (e.g. stopwords)
 

--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/BlendedInfixSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/BlendedInfixSuggester.cs
@@ -240,10 +240,12 @@ namespace Lucene.Net.Search.Suggest.Analyzing
         {
             if (results.Count >= num)
             {
-                var first = results.Min; // "get" our first object so we don't cross threads
+                if (!results.TryGetFirst(out Lookup.LookupResult first)) // "get" our first object so we don't cross threads
+                    // LUCENENET: Java would throw NoSuchElementException here, so we are also throwing in this case.
+                    throw new InvalidOperationException("Expected at least one result in the set, but there were none.");
                 if (first.Value < result.Value)
                     // Code similar to the java TreeMap class
-                    results.Remove(first);
+                    results.Remove(first); // LUCENENET: Calling RemoveFirst() would be redundant here, since we already have the value.
                 else
                     return;
             }

--- a/src/Lucene.Net.TestFramework/Analysis/MockCharFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockCharFilter.cs
@@ -103,9 +103,9 @@ namespace Lucene.Net.Analysis
         {
             int ret;
             // LUCENENET NOTE: TryGetPredecessor is equivalent to TreeMap.lowerEntry() in Java
-            if (corrections.TryGetPredecessor(currentOff + 1, out KeyValuePair<int, int> lastEntry))
+            if (corrections.TryGetPredecessor(currentOff + 1, out _, out int lastEntryValue))
             {
-                ret = currentOff + lastEntry.Value;
+                ret = currentOff + lastEntryValue;
             }
             else
             {

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40DocValuesWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40DocValuesWriter.cs
@@ -389,7 +389,10 @@ namespace Lucene.Net.Codecs.Lucene40
                 {
                     brefDummy = new BytesRef();
                 }
-                //int ord = dictionary.HeadSet(brefDummy).Size();
+                // LUCENENET: This LINQ call will actually be less overhead than the
+                // equivalent check using dictionary.GetViewBefore(brefDummy, false).Count
+                // due to all of the range checks during the tree walk to determine the count.
+                // In this case, LINQ doesn't allocate anything so will always be faster.
                 int ord = dictionary.Count(@ref => @ref.CompareTo(brefDummy) < 0);
                 w.Add(ord);
             }

--- a/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
@@ -8,7 +8,6 @@ using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.RAMOnly
@@ -391,8 +390,7 @@ namespace Lucene.Net.Codecs.RAMOnly
                     }
                     else
                     {
-                        //It = RamField.TermToDocs.tailMap(Current).Keys.GetEnumerator();
-                        it = ramField.termToDocs.Where(kvpair => string.CompareOrdinal(kvpair.Key, current) >= 0).Select(pair => pair.Key).GetEnumerator();
+                        it = ramField.termToDocs.GetViewAfter(current).Keys.GetEnumerator();
                     }
                 }
             }
@@ -407,7 +405,12 @@ namespace Lucene.Net.Codecs.RAMOnly
                 }
                 else
                 {
-                    if (current.CompareToOrdinal(ramField.termToDocs.Last().Key) > 0)
+                    if (!ramField.termToDocs.TryGetLast(out string lastKey, out _))
+                        // LUCENENET: Java would throw a NoSuchElementException here, so we throw InvalidOperationException
+                        // to indicate that the dictionary is empty when it shouldn't be.
+                        throw new InvalidOperationException("The termToDocs dictionary is empty, but it should have at least one term.");
+
+                    if (current.CompareToOrdinal(lastKey) > 0)
                     {
                         return SeekStatus.END;
                     }

--- a/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
+++ b/src/Lucene.Net/Codecs/Compressing/CompressingTermVectorsWriter.cs
@@ -472,7 +472,14 @@ namespace Lucene.Net.Codecs.Compressing
 
             int numDistinctFields = fieldNums.Count;
             if (Debugging.AssertsEnabled) Debugging.Assert(numDistinctFields > 0);
-            int bitsRequired = PackedInt32s.BitsRequired(fieldNums.Max);
+            // LUCENENET specific - Java would throw a NoSuchElementException, but in .NET we throw an
+            // InvalidOperationException instead, since the collection is empty and .NET doesn't throw
+            // in this case. In practice, this exception should never happen.
+            if (!fieldNums.TryGetLast(out int last))
+            {
+                throw new InvalidOperationException("fieldNums must not be empty");
+            }
+            int bitsRequired = PackedInt32s.BitsRequired(last);
             int token = (Math.Min(numDistinctFields - 1, 0x07) << 5) | bitsRequired;
             vectorsStream.WriteByte((byte)token);
             if (numDistinctFields - 1 >= 0x07)

--- a/src/Lucene.Net/Util/Fst/Util.cs
+++ b/src/Lucene.Net/Util/Fst/Util.cs
@@ -393,7 +393,9 @@ namespace Lucene.Net.Util.Fst
 
                 if (queue.Count == maxQueueDepth)
                 {
-                    FSTPath<T> bottom = queue.Max;
+                    if (!queue.TryGetLast(out FSTPath<T> bottom))
+                        // LUCENENET: Java would throw NoSuchElementException in this case, so we are throwing also.
+                        throw new InvalidOperationException("Expected the queue to contain an element, but it was empty.");
                     int comp = comparer.Compare(cost, bottom.Cost);
                     if (comp > 0)
                     {
@@ -436,7 +438,7 @@ namespace Lucene.Net.Util.Fst
 
                 if (queue.Count == maxQueueDepth + 1)
                 {
-                    queue.Remove(queue.Max);
+                    queue.RemoveLast(out _);
                 }
             }
 
@@ -505,12 +507,7 @@ namespace Lucene.Net.Util.Fst
 
                     // Remove top path since we are now going to
                     // pursue it:
-                    path = queue.Min;
-                    if (path != null)
-                    {
-                        queue.Remove(path);
-                    }
-                    else
+                    if (!queue.RemoveFirst(out path) || path is null)
                     {
                         // There were less than topN paths available:
                         //System.out.println("  break no more paths");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Upgraded to the navigable APIs on `SortedSet<T>` and `SortedDictionary<TKey, TValue>`

## Description

This upgrades several classes to use the navigable APIs of `SortedSet<T>` and `SortedDictionary<TKey, TValue>`. These APIs are available in the JDK but are missing in the BCL. J2N added support in https://github.com/NightOwl888/J2N/pull/178.

Several lines of LINQ code were removed and replaced with calls that don't produce so many allocations. Some behavior that throws exceptions in the JDK was also patched to throw under the same conditions in .NET, but replaces the `NoSuchElementException` in Java with `InvalidOperationException`.