### PR TITLE
Improve performance and correctness of NumericUtils methods, #1280

### DIFF
--- a/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
+++ b/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
@@ -179,7 +179,7 @@ namespace Lucene.Net.Util
             // Build a valid encoding, then corrupt one of the data bytes to have the high bit set.
             BytesRef encoded = new BytesRef(NumericUtils.BUF_SIZE_INT64);
 
-            // Int64 path: encode 12345L at shift=0 -> 10 bytes (1 shift byte + 9 data bytes).
+            // Int64 path: encode 12345L at shift=0 -> 11 bytes (1 shift byte + 10 data bytes).
             NumericUtils.Int64ToPrefixCodedBytes(12345L, 0, encoded);
             // Sanity: the round-trip works as-is.
             Assert.AreEqual(12345L, NumericUtils.PrefixCodedToInt64(encoded));

--- a/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
+++ b/src/Lucene.Net.Tests/Util/TestNumericUtils.cs
@@ -1,5 +1,6 @@
 #if FEATURE_UTIL_TESTS
 using J2N.Text;
+using Lucene.Net.Attributes;
 using Lucene.Net.Support;
 using NUnit.Framework;
 using RandomizedTesting.Generators;
@@ -165,6 +166,74 @@ namespace Lucene.Net.Util
                     int mask = (1 << j) - 1;
                     Assert.AreEqual(vals[i] & mask, vals[i] - prefixVal, "difference between prefix val and original value for " + vals[i] + " with shift=" + j);
                 }
+            }
+        }
+
+        // LUCENENET-specific: verifies PrefixCodedToInt64/Int32 reject bytes with the high bit
+        // set, matching upstream Java's `if (b < 0)` guard on signed bytes. In .NET byte is
+        // unsigned, so the equivalent C# check is `b > 127`. Asserting this behavior protects
+        // against future "optimization" that drops the check thinking it's dead code.
+        [Test, LuceneNetSpecific]
+        public virtual void TestPrefixCodedDecodeRejectsHighBitBytes()
+        {
+            // Build a valid encoding, then corrupt one of the data bytes to have the high bit set.
+            BytesRef encoded = new BytesRef(NumericUtils.BUF_SIZE_INT64);
+
+            // Int64 path: encode 12345L at shift=0 -> 10 bytes (1 shift byte + 9 data bytes).
+            NumericUtils.Int64ToPrefixCodedBytes(12345L, 0, encoded);
+            // Sanity: the round-trip works as-is.
+            Assert.AreEqual(12345L, NumericUtils.PrefixCodedToInt64(encoded));
+            // Corrupt the second-to-last data byte with the high bit set (0x80 = -128 as signed byte).
+            // Skip index 0 (the shift byte) and pick an index with a real data byte.
+            int corruptIndex = encoded.Offset + encoded.Length - 2;
+            byte original = encoded.Bytes[corruptIndex];
+            encoded.Bytes[corruptIndex] = 0x80;
+            try
+            {
+                NumericUtils.PrefixCodedToInt64(encoded);
+                Assert.Fail("PrefixCodedToInt64 should reject a data byte with the high bit set (matches Java's signed `b < 0` guard)");
+            }
+            catch (Exception e) when (e.IsNumberFormatException())
+            {
+                // expected
+            }
+            encoded.Bytes[corruptIndex] = original; // restore
+
+            // Int32 path: encode 12345 at shift=0 -> 6 bytes (1 shift byte + 5 data bytes).
+            NumericUtils.Int32ToPrefixCodedBytes(12345, 0, encoded);
+            Assert.AreEqual(12345, NumericUtils.PrefixCodedToInt32(encoded));
+            corruptIndex = encoded.Offset + encoded.Length - 2;
+            original = encoded.Bytes[corruptIndex];
+            encoded.Bytes[corruptIndex] = 0xFF; // any value > 127
+            try
+            {
+                NumericUtils.PrefixCodedToInt32(encoded);
+                Assert.Fail("PrefixCodedToInt32 should reject a data byte with the high bit set (matches Java's signed `b < 0` guard)");
+            }
+            catch (Exception e) when (e.IsNumberFormatException())
+            {
+                // expected
+            }
+            encoded.Bytes[corruptIndex] = original;
+
+            // Boundary: byte == 127 (0x7F) is valid (high bit clear), should NOT throw.
+            NumericUtils.Int64ToPrefixCodedBytes(12345L, 0, encoded);
+            corruptIndex = encoded.Offset + encoded.Length - 2;
+            encoded.Bytes[corruptIndex] = 0x7F;
+            // We don't assert the decoded value here — just that it doesn't throw.
+            // (0x7F is a valid 7-bit-data byte; it just produces a different encoded value.)
+            NumericUtils.PrefixCodedToInt64(encoded);
+
+            // Boundary: byte == 128 (0x80) is the smallest invalid value; verify it throws.
+            encoded.Bytes[corruptIndex] = 0x80;
+            try
+            {
+                NumericUtils.PrefixCodedToInt64(encoded);
+                Assert.Fail("byte == 0x80 (smallest with high bit set) should throw");
+            }
+            catch (Exception e) when (e.IsNumberFormatException())
+            {
+                // expected
             }
         }
 

--- a/src/Lucene.Net/Util/NumericUtils.cs
+++ b/src/Lucene.Net/Util/NumericUtils.cs
@@ -155,19 +155,22 @@ namespace Lucene.Net.Util
             int nChars = (((63 - shift) * 37) >> 8) + 1; // i/7 is the same as (i*37)>>8 for i in 0..63
             bytes.Offset = 0;
             bytes.Length = nChars + 1; // one extra for the byte that contains the shift info
-            if (bytes.Bytes.Length < bytes.Length)
+            byte[] buf = bytes.Bytes; // LUCENENET: local reference to array to avoid repeated property access
+            if (buf.Length < bytes.Length)
             {
-                bytes.Bytes = new byte[NumericUtils.BUF_SIZE_INT64]; // use the max
+                // LUCENENET: update `buf` reference too
+                bytes.Bytes = buf = new byte[NumericUtils.BUF_SIZE_INT64]; // use the max
             }
-            bytes.Bytes[0] = (byte)(SHIFT_START_INT64 + shift);
-            ulong sortableBits = BitConverter.ToUInt64(BitConverter.GetBytes(val), 0) ^ 0x8000000000000000L; // LUCENENET TODO: Performance - Benchmark this
-            sortableBits = sortableBits >> shift;
-            while (nChars > 0)
+
+            long sortableBits = val ^ long.MinValue; // LUCENENET: was long sortableBits = val ^ 0x8000000000000000L; in Java
+            sortableBits >>>= shift;
+            buf[0] = (byte)(SHIFT_START_INT64 + shift);
+            // LUCENENET: shift directly from sortableBits each iteration (independent shifts) instead
+            // of the carried `sortableBits >>>= 7` so the CPU can ILP the byte computations.
+            for (int k = 0; k < nChars; k++)
             {
-                // Store 7 bits per byte for compatibility
-                // with UTF-8 encoding of terms
-                bytes.Bytes[nChars--] = (byte)(sortableBits & 0x7f);
-                sortableBits = sortableBits >> 7;
+                // Store 7 bits per byte for compatibility with UTF-8 encoding of terms
+                buf[nChars - k] = (byte)((sortableBits >>> (7 * k)) & 0x7f);
             }
         }
 
@@ -190,19 +193,21 @@ namespace Lucene.Net.Util
             int nChars = (((31 - shift) * 37) >> 8) + 1; // i/7 is the same as (i*37)>>8 for i in 0..63
             bytes.Offset = 0;
             bytes.Length = nChars + 1; // one extra for the byte that contains the shift info
-            if (bytes.Bytes.Length < bytes.Length)
+            byte[] buf = bytes.Bytes; // LUCENENET: local reference to array to avoid repeated property access
+            if (buf.Length < bytes.Length)
             {
-                bytes.Bytes = new byte[NumericUtils.BUF_SIZE_INT64]; // use the max
+                // LUCENENET: update `buf` reference too
+                bytes.Bytes = buf = new byte[NumericUtils.BUF_SIZE_INT64]; // use the max
             }
-            bytes.Bytes[0] = (byte)(SHIFT_START_INT32 + shift);
-            int sortableBits = val ^ unchecked((int)0x80000000);
+
+            int sortableBits = val ^ int.MinValue; // LUCENENET: was int sortableBits = val ^ 0x80000000; in Java
             sortableBits >>>= shift;
-            while (nChars > 0)
+            buf[0] = (byte)(SHIFT_START_INT32 + shift);
+            // LUCENENET: see Int64ToPrefixCodedBytes for the independent-shift rationale.
+            for (int k = 0; k < nChars; k++)
             {
-                // Store 7 bits per byte for compatibility
-                // with UTF-8 encoding of terms
-                bytes.Bytes[nChars--] = (byte)(sortableBits & 0x7f);
-                sortableBits >>>= 7;
+                // Store 7 bits per byte for compatibility with UTF-8 encoding of terms
+                buf[nChars - k] = (byte)((sortableBits >>> (7 * k)) & 0x7f);
             }
         }
 
@@ -254,16 +259,24 @@ namespace Lucene.Net.Util
         /// <seealso cref="Int64ToPrefixCodedBytes(long, int, BytesRef)"/>
         public static long PrefixCodedToInt64(BytesRef val)
         {
+            // LUCENENET specific: hoist BytesRef fields to locals so the JIT doesn't
+            // reload them through the property accessors on every iteration.
+            byte[] bytes = val.Bytes;
+            int offset = val.Offset;
+            int length = val.Length;
+
             long sortableBits = 0L;
-            for (int i = val.Offset + 1, limit = val.Offset + val.Length; i < limit; i++)
+            for (int i = offset + 1, limit = offset + length; i < limit; i++)
             {
                 sortableBits <<= 7;
-                var b = val.Bytes[i];
-                if (b < 0)
+                var b = bytes[i];
+                // LUCENENET: upstream Java tests `b < 0` (signed byte). In C# byte is unsigned,
+                // so the equivalent high-bit-set check is `b > 127`.
+                if (b > 127)
                 {
-                    throw NumberFormatException.Create("Invalid prefixCoded numerical value representation (byte " + (b & 0xff).ToString("x") + " at position " + (i - val.Offset) + " is invalid)");
+                    throw NumberFormatException.Create("Invalid prefixCoded numerical value representation (byte " + b.ToString("x") + " at position " + (i - offset) + " is invalid)");
                 }
-                sortableBits |= (byte)b;
+                sortableBits |= b;
             }
             return (long)((ulong)(sortableBits << GetPrefixCodedInt64Shift(val)) ^ 0x8000000000000000L); // LUCENENET TODO: Is the casting here necessary?
         }
@@ -280,14 +293,27 @@ namespace Lucene.Net.Util
         /// <seealso cref="Int32ToPrefixCodedBytes(int, int, BytesRef)"/>
         public static int PrefixCodedToInt32(BytesRef val)
         {
+            // LUCENENET specific: hoist BytesRef fields to locals so the JIT doesn't
+            // reload them through the property accessors on every iteration.
+            byte[] bytes = val.Bytes;
+            int offset = val.Offset;
+            int length = val.Length;
+
             long sortableBits = 0;
-            for (int i = val.Offset, limit = val.Offset + val.Length; i < limit; i++)
+            // LUCENENET: start at offset+1 (skip the leading shift byte), matching Java's upstream
+            // prefixCodedToInt(). The previous code started at offset, doing one extra iteration
+            // per call. The extra byte's bits always get shifted past bit 31 and truncated by the
+            // final (int) cast for any valid (shift, nChars) combo, so the result is unchanged —
+            // but the iteration is wasted work.
+            for (int i = offset + 1, limit = offset + length; i < limit; i++)
             {
                 sortableBits <<= 7;
-                var b = val.Bytes[i];
-                if (b < 0)
+                var b = bytes[i];
+                // LUCENENET: upstream Java tests `b < 0` (signed byte). In C# byte is unsigned,
+                // so the equivalent high-bit-set check is `b > 127`.
+                if (b > 127)
                 {
-                    throw NumberFormatException.Create("Invalid prefixCoded numerical value representation (byte " + (b & 0xff).ToString("x") + " at position " + (i - val.Offset) + " is invalid)");
+                    throw NumberFormatException.Create("Invalid prefixCoded numerical value representation (byte " + b.ToString("x") + " at position " + (i - offset) + " is invalid)");
                 }
                 sortableBits |= b;
             }

--- a/src/Lucene.Net/Util/NumericUtils.cs
+++ b/src/Lucene.Net/Util/NumericUtils.cs
@@ -265,18 +265,22 @@ namespace Lucene.Net.Util
             int offset = val.Offset;
             int length = val.Length;
 
+            // LUCENENET specific: branchless invalid-byte detection. Upstream Java throws
+            // inside the loop on signed `b < 0`; we OR each byte into a sign accumulator and
+            // validate once after the loop, keeping the hot path branch-free. (Equivalent
+            // C# check is `b > 127` since `byte` is unsigned — see ThrowInvalidPrefixCodedByte.)
             long sortableBits = 0L;
+            int signAccum = 0;
             for (int i = offset + 1, limit = offset + length; i < limit; i++)
             {
                 sortableBits <<= 7;
-                var b = bytes[i];
-                // LUCENENET: upstream Java tests `b < 0` (signed byte). In C# byte is unsigned,
-                // so the equivalent high-bit-set check is `b > 127`.
-                if (b > 127)
-                {
-                    throw NumberFormatException.Create("Invalid prefixCoded numerical value representation (byte " + b.ToString("x") + " at position " + (i - offset) + " is invalid)");
-                }
+                byte b = bytes[i];
+                signAccum |= b;
                 sortableBits |= b;
+            }
+            if ((signAccum & 0x80) != 0)
+            {
+                ThrowInvalidPrefixCodedByte(bytes, offset, length);
             }
             return (long)((ulong)(sortableBits << GetPrefixCodedInt64Shift(val)) ^ 0x8000000000000000L); // LUCENENET TODO: Is the casting here necessary?
         }
@@ -300,11 +304,11 @@ namespace Lucene.Net.Util
             int length = val.Length;
 
             long sortableBits = 0;
-            // LUCENENET: start at offset+1 (skip the leading shift byte), matching Java's upstream
-            // prefixCodedToInt(). The previous code started at offset, doing one extra iteration
-            // per call. The extra byte's bits always get shifted past bit 31 and truncated by the
-            // final (int) cast for any valid (shift, nChars) combo, so the result is unchanged —
-            // but the iteration is wasted work.
+
+            // LUCENENET: unlike PrefixCodedToInt64, we use the in-loop branch (not the sign
+            // accumulator). The Int32 loop is 1-5 iterations; the per-iteration `if (b > 127)`
+            // is cheaper than the accumulator's extra OR + post-loop check at this size,
+            // confirmed via benchmarks.
             for (int i = offset + 1, limit = offset + length; i < limit; i++)
             {
                 sortableBits <<= 7;
@@ -608,6 +612,23 @@ namespace Lucene.Net.Util
         public static TermsEnum FilterPrefixCodedInt32s(TermsEnum termsEnum)
         {
             return new FilteredTermsEnumAnonymousClass2(termsEnum);
+        }
+
+        // LUCENENET specific: cold helper used by PrefixCodedToInt64 when the branchless
+        // sign accumulator detects an invalid byte. Kept out-of-line (NoInlining) so the hot
+        // decode loop stays free of the throw site.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidPrefixCodedByte(byte[] bytes, int offset, int length)
+        {
+            int limit = offset + length;
+            for (int i = offset + 1; i < limit; i++)
+            {
+                byte b = bytes[i];
+                if (b > 127)
+                {
+                    throw NumberFormatException.Create("Invalid prefixCoded numerical value representation (byte " + b.ToString("x") + " at position " + (i - offset) + " is invalid)");
+                }
+            }
         }
 
         private sealed class FilteredTermsEnumAnonymousClass2 : FilteredTermsEnum


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Improves performance of NumericUtils encode methods, and fixes some defensive check issues.

Fixes #1280

## Description

This PR optimizes the encode methods of prefix-coded integers in NumericUtils. This should have a positive impact on indexing numeric fields.

The decode methods now have more correct validation by fixing port bugs, and performance gains for the 64-bit versions, for these operations:
- Range queries on numeric fields
- Sorting/faceting numeric fields (during cache build)

The Java-port bugs were:

1. The 32-bit decode was doing an extra unnecessary iteration because it started at Offset instead of Offset + 1. This extra byte was shifted away at the end of the method, so only is a performance concern as of Lucene 4.8.1.
2. The `if (b < 0)` check was ported incorrectly. In Java, `byte` is signed, whereas it is unsigned in .NET. So not only was this always false, potentially resulting in corrupted results instead of an exception, but the JIT was likely optimizing it away. This case was not covered by tests, so this adds a LuceneNetSpecific test for this case.

So there is a slight performance hit in the 32-bit case to add in the check properly (which is potentially important for data integrity, depending on use case) due to its low number of iterations, but this is mitigated some by the other performance improvements in the method, and the 64-bit version is still faster than beta 17 across the board.

I attempted to do the same accumulator improvement to the 32-bit version of the decoder, but it actually made the perf even worse, so I only kept it for the 64-bit version.

## NumericUtils benchmarks

All times in µs.

### Encode

| Method | Java | beta17 | PR | PR vs beta17 |
|---|---:|---:|---:|---:|
| `Int64ToPrefixCodedBytes_Shift0`  | 110.9 | 575.1 | 324.1 | −44% |
| `Int64ToPrefixCodedBytes_Shift32` |  52.3 | 277.0 | 191.3 | −31% |
| `Int64ToPrefixCodedBytes_Shift63` |  10.5 | 177.6 |  82.0 | −54% |
| `Int32ToPrefixCodedBytes_Shift0`  |  52.8 | 275.9 | 187.9 | −32% |
| `Int32ToPrefixCodedBytes_Shift16` |  31.7 | 256.8 | 146.2 | −43% |
| `Int32ToPrefixCodedBytes_Shift31` |  10.5 | 111.4 |  81.0 | −27% |

### Decode

| Method | Java | beta17 | PR | PR vs beta17 |
|---|---:|---:|---:|---:|
| `PrefixCodedToInt64_Shift0`  | 148.6 | 202.3 | 194.0 |  -4% |
| `PrefixCodedToInt64_Shift32` | 107.5 | 150.0 | 134.0 |  −11% |
| `PrefixCodedToInt64_Shift63` |  75.3 |  87.9 |  83.0 | -6% |
| `PrefixCodedToInt32_Shift0`  | 111.2 | 135.1 | 146.9 |  +9% |
| `PrefixCodedToInt32_Shift16` |  92.2 | 112.1 | 122.4 | +9% |
| `PrefixCodedToInt32_Shift31` |  74.8 |  77.9 | 107.0 | +37% |

Note that the 32-bit shift 31 case results in just one iteration, making the new correctness check (which was dead-code eliminated by the JIT previously since it was incorrect) have an outsized performance hit. However, it's still faster than the other shift values.

### Alternatives

I explored going further with this with using Span and even MemoryMarshal/Unsafe, but the small gains were not worth the sacrifice to simplicity and having to do conditional compilation in the case of the latter, and sometimes even regressed perf. I also explored several other approaches (casting to sbyte instead of checking > 127, etc) and there was no meaningful difference.

### A note on perf vs Java

It was surprising that Java performed so much better across the board, even without these optimizations. I can't rule out HotSpot-vs-RyuJIT optimization differences on ARM64, or JMH vs BenchmarkDotNet differences. But, this PR is still worth doing for the defensive correctness, performance improvement for encode, reduced allocations, and performance improvements for decode that help mitigate the hit of the correct check.