### PR TITLE
Disable MyGet preview feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -21,8 +21,8 @@ under the License.
 
 <configuration>
   <packageSources>
-    <add key="ICU4N preview feed" value="https://www.myget.org/F/icu4n/api/v3/index.json" />
-    <add key="J2N preview feed" value="https://www.myget.org/F/j2n-preview/api/v3/index.json" />
+    <!-- <add key="ICU4N preview feed" value="https://www.myget.org/F/icu4n/api/v3/index.json" /> -->
+    <!-- <add key="J2N preview feed" value="https://www.myget.org/F/j2n-preview/api/v3/index.json" /> -->
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Disable MyGet preview feeds

## Description

We are not currently using the ICU4N or J2N preview feeds, and MyGet is currently having issues which is breaking our CI restore steps. Disabling them for now until we need them again.

As a nice bonus, it speeds up local restores/builds too.