### PR TITLE
Fix ArgumentOutOfRangeException in IrishLowerCaseFilter span slicing, #1150

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Ga/IrishLowerCaseFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Ga/IrishLowerCaseFilter.cs
@@ -65,9 +65,10 @@ namespace Lucene.Net.Analysis.Ga
                 }
 
                 // LUCENENET: Reduce allocations by using the stack and spans
-                var source = new ReadOnlySpan<char>(chArray, idx, chLen);
-                var destination = chArray.AsSpan(idx, chLen);
-                var spare = chLen * sizeof(char) <= Constants.MaxStackByteLimit ? stackalloc char[chLen] : new char[chLen];
+                int spanLen = chLen - idx;
+                var source = new ReadOnlySpan<char>(chArray, idx, spanLen);
+                var destination = chArray.AsSpan(idx, spanLen);
+                var spare = spanLen * sizeof(char) <= Constants.MaxStackByteLimit ? stackalloc char[spanLen] : new char[spanLen];
                 source.ToLower(spare, culture); // LUCENENET specific - use Irish culture when lowercasing
                 spare.CopyTo(destination);
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ga/TestIrishLowerCaseFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ga/TestIrishLowerCaseFilter.cs
@@ -93,23 +93,16 @@ namespace Lucene.Net.Analysis.Ga
         /// <summary>
         /// Regression test for issue #1150: ArgumentOutOfRangeException in IrishLowerCaseFilter.
         ///
-        /// The bug: when the n-/t-prothesis path runs, idx is set to 2 but the span length was
-        /// left as chLen (full term length) instead of chLen - idx. This creates a span that reads
-        /// chArray[idx .. idx+chLen], which exceeds the buffer when the buffer is sized just large
-        /// enough for chLen chars.
-        ///
-        /// We reproduce by using a custom TokenStream that writes directly into the internal
-        /// CharTermAttributeImpl.termBuffer field, bypassing the Oversize over-allocation that
+        /// We confirm this is fixed by using a custom TokenStream that writes directly into the
+        /// internal CharTermAttribute.termBuffer field, bypassing the Oversize over-allocation that
         /// all public paths go through, so the buffer is sized to exactly the post-prothesis
-        /// term length. The buggy code then asks for chArray[2..2+chLen] which is 2 chars past
-        /// the end.
+        /// term length. Any out-of-range access would throw an exception and fail the test.
         /// </summary>
         [Test, LuceneNetSpecific] // Issue #1150
-        public virtual void TestProthesis_SpanBoundaryThrows()
+        public virtual void TestProthesis_SpanBoundary()
         {
             // "nAthair" has length 7; after prothesis it becomes "n-athair" (length 8).
-            // We pre-size the buffer to exactly 8 so that chArray[2..2+8] = chArray[2..10]
-            // exceeds the buffer and throws ArgumentOutOfRangeException on the buggy code.
+            // We pre-size the buffer to exactly 8 so that we can detect out-of-range access.
             const string input = "nAthair";
             const string expected = "n-athair";
 
@@ -121,8 +114,8 @@ namespace Lucene.Net.Analysis.Ga
         /// <summary>
         /// A TokenStream that emits a single token with the backing buffer sized to exactly
         /// the post-prothesis term length (term.Length + 1), bypassing Oversize over-allocation.
-        /// This forces the tight-buffer condition that triggers the span length bug in
-        /// IrishLowerCaseFilter when idx=2 and spanLen is incorrectly computed as chLen.
+        /// This forces the tight-buffer condition that could detect span length bugs in
+        /// IrishLowerCaseFilter.
         /// </summary>
         private sealed class TightBufferTokenStream : TokenStream
         {
@@ -130,7 +123,7 @@ namespace Lucene.Net.Analysis.Ga
             private bool _done;
             private readonly CharTermAttribute _termAtt;
 
-            public TightBufferTokenStream(string term) : base()
+            public TightBufferTokenStream(string term)
             {
                 _term = term;
                 _termAtt = (CharTermAttribute)AddAttribute<ICharTermAttribute>();

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ga/TestIrishLowerCaseFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ga/TestIrishLowerCaseFilter.cs
@@ -1,5 +1,7 @@
 // Lucene version compatibility level 4.8.1
 using Lucene.Net.Analysis.Core;
+using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System.IO;
 
@@ -48,6 +50,74 @@ namespace Lucene.Net.Analysis.Ga
                 return new TokenStreamComponents(tokenizer, new IrishLowerCaseFilter(tokenizer));
             });
             CheckOneTerm(a, "", "");
+        }
+
+        /// <summary>
+        /// Regression test for issue #1150: ArgumentOutOfRangeException in IrishLowerCaseFilter.
+        ///
+        /// The bug: when the n-/t-prothesis path runs, idx is set to 2 but the span length was
+        /// left as chLen (full term length) instead of chLen - idx. This creates a span that reads
+        /// chArray[idx .. idx+chLen], which exceeds the buffer when the buffer is sized just large
+        /// enough for chLen chars.
+        ///
+        /// We reproduce by using a custom TokenStream that writes directly into the internal
+        /// CharTermAttributeImpl.termBuffer field, bypassing the Oversize over-allocation that
+        /// all public paths go through, so the buffer is sized to exactly the post-prothesis
+        /// term length. The buggy code then asks for chArray[2..2+chLen] which is 2 chars past
+        /// the end.
+        /// </summary>
+        [Test, LuceneNetSpecific] // Issue #1150
+        public virtual void TestProthesis_SpanBoundaryThrows()
+        {
+            // "nAthair" has length 7; after prothesis it becomes "n-athair" (length 8).
+            // We pre-size the buffer to exactly 8 so that chArray[2..2+8] = chArray[2..10]
+            // exceeds the buffer and throws ArgumentOutOfRangeException on the buggy code.
+            const string input = "nAthair";
+            const string expected = "n-athair";
+
+            var source = new TightBufferTokenStream(input);
+            var filter = new IrishLowerCaseFilter(source);
+            AssertTokenStreamContents(filter, new[] { expected });
+        }
+
+        /// <summary>
+        /// A TokenStream that emits a single token with the backing buffer sized to exactly
+        /// the post-prothesis term length (term.Length + 1), bypassing Oversize over-allocation.
+        /// This forces the tight-buffer condition that triggers the span length bug in
+        /// IrishLowerCaseFilter when idx=2 and spanLen is incorrectly computed as chLen.
+        /// </summary>
+        private sealed class TightBufferTokenStream : TokenStream
+        {
+            private readonly string _term;
+            private bool _done;
+            private readonly CharTermAttribute _termAtt;
+
+            public TightBufferTokenStream(string term) : base()
+            {
+                _term = term;
+                _termAtt = (CharTermAttribute)AddAttribute<ICharTermAttribute>();
+            }
+
+            public override bool IncrementToken()
+            {
+                if (_done) return false;
+                _done = true;
+                ClearAttributes();
+                // Set the backing buffer to exactly postProthesisLen chars — no Oversize slack.
+                // IrishLowerCaseFilter.IncrementToken calls ResizeBuffer(chLen+1) which is a no-op
+                // when the buffer is already that size, leaving the span with no room for idx=2.
+                int postProthesisLen = _term.Length + 1;
+                _termAtt.termBuffer = new char[postProthesisLen];
+                _term.CopyTo(0, _termAtt.termBuffer, 0, _term.Length);
+                _termAtt.Length = _term.Length;
+                return true;
+            }
+
+            public override void Reset()
+            {
+                base.Reset();
+                _done = false;
+            }
         }
     }
 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ga/TestIrishLowerCaseFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Ga/TestIrishLowerCaseFilter.cs
@@ -53,6 +53,44 @@ namespace Lucene.Net.Analysis.Ga
         }
 
         /// <summary>
+        /// Test that prothesis output is correct across all upper vowels and fadas,
+        /// and for both n- and t- prefixes.
+        /// </summary>
+        [Test, LuceneNetSpecific] // Issue #1150
+        public virtual void TestProthesisCorrectness()
+        {
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new KeywordTokenizer(reader);
+                return new TokenStreamComponents(tokenizer, new IrishLowerCaseFilter(tokenizer));
+            });
+
+            // Plain upper vowels
+            CheckOneTerm(a, "nAthair", "n-athair");
+            CheckOneTerm(a, "nEan", "n-ean");
+            CheckOneTerm(a, "nIasc", "n-iasc");
+            CheckOneTerm(a, "nOiche", "n-oiche");
+            CheckOneTerm(a, "nUll", "n-ull");
+            CheckOneTerm(a, "tAthair", "t-athair");
+            CheckOneTerm(a, "tEan", "t-ean");
+            CheckOneTerm(a, "tIasc", "t-iasc");
+            CheckOneTerm(a, "tOiche", "t-oiche");
+            CheckOneTerm(a, "tUll", "t-ull");
+
+            // Accented vowels (fadas)
+            CheckOneTerm(a, "nÁit", "n-áit");
+            CheckOneTerm(a, "nÉan", "n-éan");
+            CheckOneTerm(a, "nÍoc", "n-íoc");
+            CheckOneTerm(a, "nÓg", "n-óg");
+            CheckOneTerm(a, "nÚll", "n-úll");
+            CheckOneTerm(a, "tÁit", "t-áit");
+            CheckOneTerm(a, "tÉan", "t-éan");
+            CheckOneTerm(a, "tÍoc", "t-íoc");
+            CheckOneTerm(a, "tÓg", "t-óg");
+            CheckOneTerm(a, "tÚll", "t-úll");
+        }
+
+        /// <summary>
         /// Regression test for issue #1150: ArgumentOutOfRangeException in IrishLowerCaseFilter.
         ///
         /// The bug: when the n-/t-prothesis path runs, idx is set to 2 but the span length was


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Fixes #1150

## Description

IrishLowerCaseFilter was incorrectly calculating the span length for the lowercase operation. When the n-/t-prothesis path runs (inserting a hyphen after 'n' or 't'), idx becomes 2 and the span length should be (chLen - idx), not chLen. This caused out-of-bounds span creation.

The fix calculates spanLen = chLen - idx and uses this corrected length for both the source and destination spans, as well as the spare buffer allocation.

Added a regression test using a custom TightBufferTokenStream that writes directly into CharTermAttribute.termBuffer to bypass the Oversize over-allocation all public tokenizer paths use, producing a buffer sized to exactly the post-prothesis term length. This reliably triggers the ArgumentOutOfRangeException on the buggy code.

AI: co-authored with Claude Code Opus 4.7