### PR TITLE
SWEEP: Replace BCL Dictionary<TKey,TValue> with JCG.Dictionary<TKey,TValue> (#1273)

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/HTMLStripCharFilter.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using Integer = J2N.Numerics.Int32;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.CharFilters
 {
@@ -30679,7 +30680,7 @@ namespace Lucene.Net.Analysis.CharFilters
         /// user code:
         /// </summary>
         private static readonly IDictionary<string, string> upperCaseVariantsAccepted
-            = new Dictionary<string, string>()
+            = new JCG.Dictionary<string, string>()
             {
                 {"quot", "QUOT"},
                 {"copy", "COPY" },

--- a/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/NormalizeCharMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/CharFilter/NormalizeCharMap.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Analysis.CharFilters
     public class NormalizeCharMap
     {
         internal readonly FST<CharsRef> map;
-        internal readonly IDictionary<char?, FST.Arc<CharsRef>> cachedRootArcs = new Dictionary<char?, FST.Arc<CharsRef>>();
+        internal readonly IDictionary<char?, FST.Arc<CharsRef>> cachedRootArcs = new JCG.Dictionary<char?, FST.Arc<CharsRef>>();
 
         // Use the builder to create:
         private NormalizeCharMap(FST<CharsRef> map)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/PatternParser.cs
@@ -195,7 +195,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
 
         private static IDictionary<string, string> GetAttributes(XmlReader node) // LUCENENET: CA1822: Mark members as static
         {
-            var result = new Dictionary<string, string>();
+            var result = new JCG.Dictionary<string, string>();
             if (node.HasAttributes)
             {
                 for (int i = 0; i < node.AttributeCount; i++)

--- a/src/Lucene.Net.Analysis.Common/Analysis/Core/LowerCaseTokenizerFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Core/LowerCaseTokenizerFactory.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Core
 {
@@ -55,7 +56,7 @@ namespace Lucene.Net.Analysis.Core
 
         public virtual AbstractAnalysisFactory GetMultiTermComponent()
         {
-            return new LowerCaseFilterFactory(new Dictionary<string, string>(OriginalArgs));
+            return new LowerCaseFilterFactory(new JCG.Dictionary<string, string>(OriginalArgs));
         }
     }
 }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Dictionary.cs
@@ -725,7 +725,7 @@ namespace Lucene.Net.Analysis.Hunspell
         internal static readonly IDictionary<string, string> CHARSET_ALIASES = LoadCharsetAliases();
         private static IDictionary<string, string> LoadCharsetAliases() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            return Collections.AsReadOnly(new Dictionary<string, string>
+            return Collections.AsReadOnly(new JCG.Dictionary<string, string>
             {
                 ["microsoft-cp1251"] = "windows-1251",
                 ["TIS620-2533"] = "TIS-620"

--- a/src/Lucene.Net.Analysis.Common/Analysis/Pt/RSLPStemmerBase.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Pt/RSLPStemmerBase.cs
@@ -284,7 +284,7 @@ namespace Lucene.Net.Analysis.Pt
         {
             try
             {
-                IDictionary<string, Step> steps = new Dictionary<string, Step>();
+                IDictionary<string, Step> steps = new JCG.Dictionary<string, Step>();
 
                 using (TextReader r = IOUtils.GetDecodingReader(clazz, resource, Encoding.UTF8))
                 {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Query/QueryAutoStopWordAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Query/QueryAutoStopWordAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Analysis.Query
     public sealed class QueryAutoStopWordAnalyzer : AnalyzerWrapper
     {
         private readonly Analyzer @delegate;
-        private readonly IDictionary<string, ISet<string>> stopWordsPerField = new Dictionary<string, ISet<string>>();
+        private readonly IDictionary<string, ISet<string>> stopWordsPerField = new JCG.Dictionary<string, ISet<string>>();
         //The default maximum percentage (40%) of index documents which
         //can contain a term, after which the term is considered to be a stop word.
         public const float defaultMaxDocFreqPercent = 0.4f;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/FSTSynonymFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/FSTSynonymFilterFactory.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Analysis.Synonym
         private readonly string synonyms;
         private readonly string format;
         private readonly bool expand;
-        private readonly IDictionary<string, string> tokArgs = new Dictionary<string, string>();
+        private readonly IDictionary<string, string> tokArgs = new JCG.Dictionary<string, string>();
 
         private SynonymMap map;
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SlowSynonymFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SlowSynonymFilterFactory.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Analysis.Synonym
         private readonly bool ignoreCase;
         private readonly bool expand;
         private readonly string tf;
-        private readonly IDictionary<string, string> tokArgs = new Dictionary<string, string>();
+        private readonly IDictionary<string, string> tokArgs = new JCG.Dictionary<string, string>();
 
         // LUCENENET: Optimized by pre-comiling regex and lazy-loading
         private class Holder

--- a/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Synonym/SynonymFilterFactory.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Analysis.Util;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Synonym
 {
@@ -67,7 +68,7 @@ namespace Lucene.Net.Analysis.Synonym
 #pragma warning disable 612, 618
             if (m_luceneMatchVersion.OnOrAfter(Lucene.Net.Util.LuceneVersion.LUCENE_34))
             {
-                delegator = new FSTSynonymFilterFactory(new Dictionary<string, string>(OriginalArgs));
+                delegator = new FSTSynonymFilterFactory(new JCG.Dictionary<string, string>(OriginalArgs));
             }
 #pragma warning restore 612, 618
             else
@@ -79,7 +80,7 @@ namespace Lucene.Net.Analysis.Synonym
                     throw new ArgumentException("You must specify luceneMatchVersion >= 3.4 to use alternate synonyms formats");
                 }
 #pragma warning disable 612, 618
-                delegator = new SlowSynonymFilterFactory(new Dictionary<string, string>(OriginalArgs));
+                delegator = new SlowSynonymFilterFactory(new JCG.Dictionary<string, string>(OriginalArgs));
 #pragma warning restore 612, 618
             }
         }

--- a/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizerFactory.cs
+++ b/src/Lucene.Net.Analysis.ICU/Analysis/Icu/Segmentation/ICUTokenizerFactory.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Icu.Segmentation
 {
@@ -81,7 +82,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         public ICUTokenizerFactory(IDictionary<string, string> args)
             : base(args)
         {
-            tailored = new Dictionary<int, string>();
+            tailored = new JCG.Dictionary<int, string>();
             string rulefilesArg = Get(args, RULEFILES);
             if (rulefilesArg != null)
             {

--- a/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -46,7 +47,7 @@ namespace Lucene.Net.Analysis.Ja
         public GraphvizFormatter(ConnectionCosts costs)
         {
             this.costs = costs;
-            this.bestPathMap = new Dictionary<string, string>();
+            this.bestPathMap = new JCG.Dictionary<string, string>();
             sb.Append(FormatHeader());
             sb.Append("  init [style=invis]\n");
             sb.Append("  init -> 0.0 [label=\"" + BOS_LABEL + "\"]\n");

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Analysis.Ja
         private const int MAX_UNKNOWN_WORD_LENGTH = 1024;
         private const int MAX_BACKTRACE_GAP = 1024;
 
-        private readonly IDictionary<JapaneseTokenizerType, IDictionary> dictionaryMap = new Dictionary<JapaneseTokenizerType, IDictionary>();
+        private readonly IDictionary<JapaneseTokenizerType, IDictionary> dictionaryMap = new JCG.Dictionary<JapaneseTokenizerType, IDictionary>();
 
         private readonly TokenInfoFST fst;
         private readonly TokenInfoDictionary dictionary;

--- a/src/Lucene.Net.Analysis.Kuromoji/Util/ToStringUtil.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Util/ToStringUtil.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Ja.Util
 {
@@ -29,7 +30,7 @@ namespace Lucene.Net.Analysis.Ja.Util
     public static class ToStringUtil
     {
         // a translation map for parts of speech, only used for reflectWith
-        private static readonly IDictionary<string, string> posTranslations = new Dictionary<string, string>(StringComparer.Ordinal)
+        private static readonly IDictionary<string, string> posTranslations = new JCG.Dictionary<string, string>(StringComparer.Ordinal)
         {
             { "名詞", "noun"},
             { "名詞-一般", "noun-common" },
@@ -133,7 +134,7 @@ namespace Lucene.Net.Analysis.Ja.Util
         }
 
         // a translation map for inflection types, only used for reflectWith
-        private static readonly IDictionary<string, string> inflTypeTranslations = new Dictionary<string, string>(StringComparer.Ordinal)
+        private static readonly IDictionary<string, string> inflTypeTranslations = new JCG.Dictionary<string, string>(StringComparer.Ordinal)
         {
             { "*", "*" },
             { "形容詞・アウオ段", "adj-group-a-o-u" },
@@ -206,7 +207,7 @@ namespace Lucene.Net.Analysis.Ja.Util
         }
 
         // a translation map for inflection forms, only used for reflectWith
-        private static readonly IDictionary<string, string> inflFormTranslations = new Dictionary<string, string>(StringComparer.Ordinal)
+        private static readonly IDictionary<string, string> inflFormTranslations = new JCG.Dictionary<string, string>(StringComparer.Ordinal)
         {
             { "*", "*" },
             { "基本形", "base" },

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Lang.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Lang.cs
@@ -116,7 +116,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static IDictionary<NameType, Lang> LoadLangs() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            IDictionary<NameType, Lang> result = new Dictionary<NameType, Lang>();
+            IDictionary<NameType, Lang> result = new JCG.Dictionary<NameType, Lang>();
             foreach (NameType s in Enum.GetValues(typeof(NameType)))
             {
                 result[s] = LoadFromResource(LANGUAGE_RULES_RN, Languages.GetInstance(s));

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Languages.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Languages.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static IDictionary<NameType, Languages> LoadLanguages() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            IDictionary<NameType, Languages> result = new Dictionary<NameType, Languages>();
+            IDictionary<NameType, Languages> result = new JCG.Dictionary<NameType, Languages>();
             foreach (NameType s in Enum.GetValues(typeof(NameType)))
             {
                 result[s] = GetInstance(LangResourceName(s));

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
@@ -265,7 +265,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static IDictionary<NameType, ISet<string>> LoadNamePrefixes() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            return new Dictionary<NameType, ISet<string>>
+            return new JCG.Dictionary<NameType, ISet<string>>
             {
                 [NameType.ASHKENAZI] = new JCG.HashSet<string>() { "bar", "ben", "da", "de", "van", "von" }.AsReadOnly(),
                 [NameType.SEPHARDIC] = new JCG.HashSet<string>() { "al", "el", "da", "dal", "de", "del", "dela", "de la",

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
@@ -122,15 +122,15 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static IDictionary<NameType, IDictionary<RuleType, IDictionary<string, IDictionary<string, IList<Rule>>>>> LoadRules() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            var rules = new Dictionary<NameType, IDictionary<RuleType, IDictionary<string, IDictionary<string, IList<Rule>>>>>();
+            var rules = new JCG.Dictionary<NameType, IDictionary<RuleType, IDictionary<string, IDictionary<string, IList<Rule>>>>>();
             foreach (NameType s in Enum.GetValues(typeof(NameType)))
             {
                 IDictionary<RuleType, IDictionary<string, IDictionary<string, IList<Rule>>>> rts =
-                        new Dictionary<RuleType, IDictionary<string, IDictionary<string, IList<Rule>>>>();
+                        new JCG.Dictionary<RuleType, IDictionary<string, IDictionary<string, IList<Rule>>>>();
 
                 foreach (RuleType rt in Enum.GetValues(typeof(RuleType)))
                 {
-                    IDictionary<string, IDictionary<string, IList<Rule>>> rs = new Dictionary<string, IDictionary<string, IList<Rule>>>();
+                    IDictionary<string, IDictionary<string, IList<Rule>>> rs = new JCG.Dictionary<string, IDictionary<string, IList<Rule>>>();
 
                     Languages ls = Languages.GetInstance(s);
                     foreach (string l in ls.GetLanguages())

--- a/src/Lucene.Net.Analysis.Phonetic/Language/DaitchMokotoffSoundex.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/DaitchMokotoffSoundex.cs
@@ -235,10 +235,10 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         private const int MAX_LENGTH = 6;
 
         /// <summary>Transformation rules indexed by the first character of their pattern.</summary>
-        private static readonly IDictionary<char, IList<Rule>> RULES = new Dictionary<char, IList<Rule>>();
+        private static readonly IDictionary<char, IList<Rule>> RULES = new JCG.Dictionary<char, IList<Rule>>();
 
         /// <summary>Folding rules.</summary>
-        private static readonly IDictionary<char, char> FOLDINGS = new Dictionary<char, char>();
+        private static readonly IDictionary<char, char> FOLDINGS = new JCG.Dictionary<char, char>();
 
         private static readonly Regex WHITESPACE = new Regex(@"\s+", RegexOptions.Compiled);
 

--- a/src/Lucene.Net.Analysis.Phonetic/PhoneticFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/PhoneticFilterFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Phonetic
 {
@@ -77,7 +78,7 @@ namespace Lucene.Net.Analysis.Phonetic
         private const string PACKAGE_CONTAINING_ENCODERS = "Lucene.Net.Analysis.Phonetic.Language.";
 
         //Effectively constants; uppercase keys
-        private static readonly IDictionary<string, Type> registry = new Dictionary<string, Type> // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        private static readonly IDictionary<string, Type> registry = new JCG.Dictionary<string, Type> // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
             { "DoubleMetaphone".ToUpperInvariant(), typeof(DoubleMetaphone) },
             { "Metaphone".ToUpperInvariant(), typeof(Metaphone) },

--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/BiSegGraph.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/BiSegGraph.cs
@@ -33,7 +33,7 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
     /// </summary>
     internal class BiSegGraph
     {
-        private readonly IDictionary<int, IList<SegTokenPair>> tokenPairListTable = new Dictionary<int, IList<SegTokenPair>>(); // LUCENENET: marked readonly
+        private readonly IDictionary<int, IList<SegTokenPair>> tokenPairListTable = new JCG.Dictionary<int, IList<SegTokenPair>>(); // LUCENENET: marked readonly
 
         private IList<SegToken> segTokenList;
 

--- a/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegGraph.cs
+++ b/src/Lucene.Net.Analysis.SmartCn/Hhmm/SegGraph.cs
@@ -34,7 +34,7 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
         /// <summary>
         /// Map of start offsets to <see cref="T:IList{SegToken}"/> of tokens at that position
         /// </summary>
-        private readonly IDictionary<int, IList<SegToken>> tokenListTable = new Dictionary<int, IList<SegToken>>(); // LUCENENET: marked readonly
+        private readonly IDictionary<int, IList<SegToken>> tokenListTable = new JCG.Dictionary<int, IList<SegToken>>(); // LUCENENET: marked readonly
 
         private int maxStart = -1;
 

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/DemoHTMLParser.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/DemoHTMLParser.cs
@@ -37,7 +37,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         /// <summary>The actual parser to read HTML documents.</summary>
         public sealed class Parser
         {
-            private readonly IDictionary<string, string> metaTags = new Dictionary<string, string>();
+            private readonly IDictionary<string, string> metaTags = new JCG.Dictionary<string, string>();
             private readonly string title, body;
 
             // LUCENENET specific - expose field through property

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/DocMaker.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/DocMaker.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -89,8 +90,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
 
                 if (reuseFields)
                 {
-                    fields = new Dictionary<string, Field>();
-                    numericFields = new Dictionary<string, Field>();
+                    fields = new JCG.Dictionary<string, Field>();
+                    numericFields = new JCG.Dictionary<string, Field>();
 
                     // Initialize the map with the default fields.
                     fields[BODY_FIELD] = new Field(BODY_FIELD, "", bodyFt);

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/EnwikiContentSource.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -338,7 +339,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             }
         }
 
-        private static readonly IDictionary<string, int> ELEMENTS = new Dictionary<string, int> // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        private static readonly IDictionary<string, int> ELEMENTS = new JCG.Dictionary<string, int> // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
             { "page", PAGE },
             { "text", BODY },

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/LineDocSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/LineDocSource.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -323,7 +324,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
                     var p = docData.Props;
                     if (p is null)
                     {
-                        p = new Dictionary<string, string>();
+                        p = new JCG.Dictionary<string, string>();
                         docData.Props = p;
                     }
                     p[m_header[position]] = text;

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/SortableSingleDocSource.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/SortableSingleDocSource.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Benchmarks.ByTask.Utils;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -79,7 +80,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         public override DocData GetNextDocData(DocData docData)
         {
             docData = base.GetNextDocData(docData);
-            var props = new Dictionary<string, string>
+            var props = new JCG.Dictionary<string, string>
             {
                 // random int
                 ["sort_field"] = r.Next(sortRange).ToString(CultureInfo.InvariantCulture)

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/SpatialDocMaker.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/SpatialDocMaker.cs
@@ -8,6 +8,7 @@ using Spatial4n.Shapes;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -43,7 +44,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         public const string SPATIAL_FIELD = "spatial";
 
         //cache spatialStrategy by round number
-        private static readonly IDictionary<int, SpatialStrategy> spatialStrategyCache = new Dictionary<int, SpatialStrategy>(); // LUCENENET: marked readonly
+        private static readonly IDictionary<int, SpatialStrategy> spatialStrategyCache = new JCG.Dictionary<int, SpatialStrategy>(); // LUCENENET: marked readonly
 
         private SpatialStrategy strategy;
         private IShapeConverter shapeConverter;

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/SpatialFileQueryMaker.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/SpatialFileQueryMaker.cs
@@ -60,7 +60,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         protected override Query[] PrepareQueries()
         {
             int maxQueries = m_config.Get("query.file.maxQueries", 1000);
-            Config srcConfig = new Config(new Dictionary<string, string>());
+            Config srcConfig = new Config(new JCG.Dictionary<string, string>());
             srcConfig.Set("docs.file", m_config.Get("query.file", null));
             srcConfig.Set("line.parser", m_config.Get("query.file.line.parser", null));
             srcConfig.Set("content.source.forever", "false");

--- a/src/Lucene.Net.Benchmark/ByTask/Feeds/TrecDocParser.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Feeds/TrecDocParser.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -36,7 +37,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         /// <summary>trec parser type used for unknown extensions</summary>
         public const ParsePathType DEFAULT_PATH_TYPE = ParsePathType.GOV2;
 
-        internal static readonly IDictionary<ParsePathType, TrecDocParser> pathType2parser = new Dictionary<ParsePathType, TrecDocParser>() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        internal static readonly IDictionary<ParsePathType, TrecDocParser> pathType2parser = new JCG.Dictionary<ParsePathType, TrecDocParser>() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
             { ParsePathType.GOV2, new TrecGov2Parser() },
             { ParsePathType.FBIS, new TrecFBISParser() },
@@ -48,7 +49,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         internal static readonly IDictionary<string, ParsePathType?> pathName2Type = LoadPathName2Type();
         private static IDictionary<string, ParsePathType?> LoadPathName2Type() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            var result = new Dictionary<string, ParsePathType?>();
+            var result = new JCG.Dictionary<string, ParsePathType?>();
             foreach (ParsePathType ppt in Enum.GetValues(typeof(ParsePathType)))
             {
                 result[ppt.ToString().ToUpperInvariant()] = ppt;

--- a/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/PerfRunData.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Benchmarks.ByTask
 #pragma warning disable CA2213 // Disposable fields should be disposed
         private Store.Directory directory;
 #pragma warning restore CA2213 // Disposable fields should be disposed
-        private readonly IDictionary<string, AnalyzerFactory> analyzerFactories = new Dictionary<string, AnalyzerFactory>(); // LUCENENET: marked readonly
+        private readonly IDictionary<string, AnalyzerFactory> analyzerFactories = new JCG.Dictionary<string, AnalyzerFactory>(); // LUCENENET: marked readonly
         private Analyzer analyzer;
         private readonly DocMaker docMaker; // LUCENENET: marked readonly
         private readonly ContentSource contentSource; // LUCENENET: marked readonly
@@ -95,7 +95,7 @@ namespace Lucene.Net.Benchmarks.ByTask
         private readonly Config config;
         private long startTimeMillis;
 
-        private readonly IDictionary<string, object> perfObjects = new Dictionary<string, object>();
+        private readonly IDictionary<string, object> perfObjects = new JCG.Dictionary<string, object>();
 
         // constructor
         public PerfRunData(Config config) : this(
@@ -131,7 +131,7 @@ namespace Lucene.Net.Benchmarks.ByTask
                 typeof(RandomFacetSource).AssemblyQualifiedName))); // "org.apache.lucene.benchmark.byTask.feeds.RandomFacetSource")).asSubclass(FacetSource.class).newInstance();
             facetSource.SetConfig(config);
             // query makers
-            readTaskQueryMaker = new Dictionary<Type, IQueryMaker>();
+            readTaskQueryMaker = new JCG.Dictionary<Type, IQueryMaker>();
             qmkrClass = Type.GetType(config.Get("query.maker", typeof(SimpleQueryMaker).AssemblyQualifiedName));
 
             // index stuff

--- a/src/Lucene.Net.Benchmark/ByTask/Programmatic/Sample.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Programmatic/Sample.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Benchmarks.ByTask.Tasks;
 using Lucene.Net.Benchmarks.ByTask.Utils;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Programmatic
 {
@@ -89,7 +90,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Programmatic
         // Sample programmatic settings. Could also read from file.
         private static IDictionary<string, string> InitProps()
         {
-            return new Dictionary<string, string>
+            return new JCG.Dictionary<string, string>
             {
                 ["task.max.depth.log"] = "3",
                 ["max.buffered"] = "buf:10:10:100:100:10:10:100:100",

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/AnalyzerFactoryTask.cs
@@ -377,7 +377,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         /// <param name="clazz">Analysis factory class to instantiate.</param>
         private void CreateAnalysisPipelineComponent(StreamTokenizer stok, Type clazz)
         {
-            IDictionary<string, string> argMap = new Dictionary<string, string>();
+            IDictionary<string, string> argMap = new JCG.Dictionary<string, string>();
             bool parenthetical = false;
             try
             {

--- a/src/Lucene.Net.Benchmark/ByTask/Tasks/CommitIndexTask.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Tasks/CommitIndexTask.cs
@@ -1,5 +1,6 @@
 using Lucene.Net.Index;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
 {
@@ -37,7 +38,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         public override void SetParams(string @params)
         {
             base.SetParams(@params);
-            commitUserData = new Dictionary<string, string>
+            commitUserData = new JCG.Dictionary<string, string>
             {
                 [OpenReaderTask.USER_DATA] = @params
             };

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/Config.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/Config.cs
@@ -52,8 +52,8 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
 
         private int roundNumber = 0;
         private readonly IDictionary<string, string> props;
-        private readonly IDictionary<string, object> valByRound = new Dictionary<string, object>();
-        private readonly IDictionary<string, string> colForValByRound = new Dictionary<string, string>();
+        private readonly IDictionary<string, object> valByRound = new JCG.Dictionary<string, object>();
+        private readonly IDictionary<string, string> colForValByRound = new JCG.Dictionary<string, string>();
         private readonly string algorithmText;
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
                 writer.WriteLine(lines[i]);
             }
             // read props from string
-            this.props = new Dictionary<string, string>();
+            this.props = new JCG.Dictionary<string, string>();
             writer.Flush();
             ms.Position = 0;
             props.LoadProperties(ms);

--- a/src/Lucene.Net.Benchmark/ByTask/Utils/StreamUtils.cs
+++ b/src/Lucene.Net.Benchmark/ByTask/Utils/StreamUtils.cs
@@ -2,6 +2,7 @@ using ICSharpCode.SharpZipLib.BZip2;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Utils
 {
@@ -32,7 +33,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
 
         // LUCENENET specific - de-nested Type and renamed FileType
 
-        private static readonly IDictionary<string, FileType?> extensionToType = new Dictionary<string, FileType?>() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        private static readonly IDictionary<string, FileType?> extensionToType = new JCG.Dictionary<string, FileType?>() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
             // these in are lower case, we will lower case at the test as well
             { ".bz2", FileType.BZIP2 },

--- a/src/Lucene.Net.Benchmark/Quality/Trec/Trec1MQReader.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/Trec1MQReader.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
                     // qtext
                     string qtext = line.Substring(k + 1).Trim();
                     // we got a topic!
-                    IDictionary<string, string> fields = new Dictionary<string, string>
+                    IDictionary<string, string> fields = new JCG.Dictionary<string, string>
                     {
                         [name] = qtext
                     };

--- a/src/Lucene.Net.Benchmark/Quality/Trec/TrecJudge.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/TrecJudge.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
         /// <exception cref="IOException">If there is a low-level I/O error.</exception>
         public TrecJudge(TextReader reader)
         {
-            judgements = new Dictionary<string, QRelJudgement>();
+            judgements = new JCG.Dictionary<string, QRelJudgement>();
             QRelJudgement curr = null;
             string zero = "0";
             string line;
@@ -131,7 +131,7 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
         // inherit javadocs
         public virtual bool ValidateData(QualityQuery[] qq, TextWriter logger)
         {
-            IDictionary<string, QRelJudgement> missingQueries = new Dictionary<string, QRelJudgement>(judgements);
+            IDictionary<string, QRelJudgement> missingQueries = new JCG.Dictionary<string, QRelJudgement>(judgements);
             IList<string> missingJudgements = new JCG.List<string>();
             for (int i = 0; i < qq.Length; i++)
             {

--- a/src/Lucene.Net.Benchmark/Quality/Trec/TrecTopicsReader.cs
+++ b/src/Lucene.Net.Benchmark/Quality/Trec/TrecTopicsReader.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Benchmarks.Quality.Trec
             {
                 while (null != (sb = Read(reader, "<top>", null, false, false)))
                 {
-                    IDictionary<string, string> fields = new Dictionary<string, string>();
+                    IDictionary<string, string> fields = new JCG.Dictionary<string, string>();
                     // id
                     sb = Read(reader, "<num>", null, true, false);
                     int k = sb.IndexOf(":", StringComparison.Ordinal);

--- a/src/Lucene.Net.Benchmark/Support/Sax/Helpers/NamespaceSupport.cs
+++ b/src/Lucene.Net.Benchmark/Support/Sax/Helpers/NamespaceSupport.cs
@@ -811,8 +811,8 @@ namespace Sax.Helpers
                 {
                     uriTable = new Hashtable();
                 }
-                elementNameTable = new Dictionary<string, string[]>();
-                attributeNameTable = new Dictionary<string, string[]>();
+                elementNameTable = new JCG.Dictionary<string, string[]>();
+                attributeNameTable = new JCG.Dictionary<string, string[]>();
                 declSeen = true;
             }
 

--- a/src/Lucene.Net.Benchmark/Support/TagSoup/Parser.cs
+++ b/src/Lucene.Net.Benchmark/Support/TagSoup/Parser.cs
@@ -258,7 +258,7 @@ namespace TagSoup
         // the corresponding instance variables, but care must be taken
         // to keep them in sync.
 
-        private readonly IDictionary<string, bool> features = new Dictionary<string, bool> {
+        private readonly IDictionary<string, bool> features = new JCG.Dictionary<string, bool> {
             { NAMESPACES_FEATURE, DEFAULT_NAMESPACES },
             { NAMESPACE_PREFIXES_FEATURE, false },
             { EXTERNAL_GENERAL_ENTITIES_FEATURE, false },

--- a/src/Lucene.Net.Benchmark/Support/TagSoup/Schema.cs
+++ b/src/Lucene.Net.Benchmark/Support/TagSoup/Schema.cs
@@ -17,6 +17,7 @@
 using Lucene;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace TagSoup
 {
@@ -35,8 +36,8 @@ namespace TagSoup
         public const int F_CDATA = 2;
         public const int F_NOFORCE = 4;
 
-        private readonly IDictionary<string, int> theEntities = new Dictionary<string, int>(); // string -> Character
-        private readonly IDictionary<string, ElementType> theElementTypes = new Dictionary<string, ElementType>(); // string -> ElementType
+        private readonly IDictionary<string, int> theEntities = new JCG.Dictionary<string, int>(); // string -> Character
+        private readonly IDictionary<string, ElementType> theElementTypes = new JCG.Dictionary<string, ElementType>(); // string -> ElementType
 
         private string theURI = "";
         private string thePrefix = "";

--- a/src/Lucene.Net.Benchmark/Support/TagSoup/XMLWriter.cs
+++ b/src/Lucene.Net.Benchmark/Support/TagSoup/XMLWriter.cs
@@ -22,6 +22,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace TagSoup
 {
@@ -359,10 +360,10 @@ namespace TagSoup
         {
             SetOutput(writer);
             nsSupport = new NamespaceSupport();
-            prefixTable = new Dictionary<string, string>();
-            forcedDeclTable = new Dictionary<string, bool>();
-            doneDeclTable = new Dictionary<string, string>();
-            outputProperties = new Dictionary<string, string>();
+            prefixTable = new JCG.Dictionary<string, string>();
+            forcedDeclTable = new JCG.Dictionary<string, bool>();
+            doneDeclTable = new JCG.Dictionary<string, string>();
+            outputProperties = new JCG.Dictionary<string, string>();
         }
 
         /// <summary>

--- a/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
+++ b/src/Lucene.Net.Benchmark/Utils/ExtractWikipedia.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.Utils
 {
@@ -153,7 +154,7 @@ namespace Lucene.Net.Benchmarks.Utils
                 }
             }
 
-            IDictionary<string, string> properties = new Dictionary<string, string>
+            IDictionary<string, string> properties = new JCG.Dictionary<string, string>
             {
                 ["docs.file"] = wikipedia.FullName,
                 ["content.source.forever"] = "false",

--- a/src/Lucene.Net.Classification/KNearestNeighborClassifier.cs
+++ b/src/Lucene.Net.Classification/KNearestNeighborClassifier.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Util;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Classification
 {
@@ -94,7 +95,7 @@ namespace Lucene.Net.Classification
         private ClassificationResult<BytesRef> SelectClassFromNeighbors(TopDocs topDocs)
         {
             // TODO : improve the nearest neighbor selection
-            Dictionary<BytesRef, int> classCounts = new Dictionary<BytesRef, int>();
+            JCG.Dictionary<BytesRef, int> classCounts = new JCG.Dictionary<BytesRef, int>();
 
             foreach (ScoreDoc scoreDoc in topDocs.ScoreDocs)
             {

--- a/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/FixedGapTermsIndexReader.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Support;
 using Lucene.Net.Util;
 using Lucene.Net.Util.Packed;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.BlockTerms
 {
@@ -57,7 +58,7 @@ namespace Lucene.Net.Codecs.BlockTerms
         private readonly PagedBytes termBytes = new PagedBytes(PAGED_BYTES_BITS);
         private readonly PagedBytes.Reader termBytesReader;
 
-        private readonly IDictionary<FieldInfo, FieldIndexData> fields = new Dictionary<FieldInfo, FieldIndexData>();
+        private readonly IDictionary<FieldInfo, FieldIndexData> fields = new JCG.Dictionary<FieldInfo, FieldIndexData>();
 
         // start of the field info data
         private long dirOffset;

--- a/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexReader.cs
+++ b/src/Lucene.Net.Codecs/BlockTerms/VariableGapTermsIndexReader.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Util.Fst;
 using System;
 using System.Collections.Generic;
 using Int64 = J2N.Numerics.Int64;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.BlockTerms
 {
@@ -41,7 +42,7 @@ namespace Lucene.Net.Codecs.BlockTerms
         private readonly IndexInput input;
         private readonly /*volatile*/ bool indexLoaded;
 
-        private readonly IDictionary<FieldInfo, FieldIndexData> fields = new Dictionary<FieldInfo, FieldIndexData>();
+        private readonly IDictionary<FieldInfo, FieldIndexData> fields = new JCG.Dictionary<FieldInfo, FieldIndexData>();
 
         // start of the field info data
         private long dirOffset;

--- a/src/Lucene.Net.Codecs/Bloom/BloomFilteringPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Bloom/BloomFilteringPostingsFormat.cs
@@ -373,7 +373,7 @@ namespace Lucene.Net.Codecs.Bloom
             private readonly BloomFilteringPostingsFormat outerInstance;
 
             private readonly FieldsConsumer _delegateFieldsConsumer;
-            private readonly Dictionary<FieldInfo, FuzzySet> _bloomFilters = new Dictionary<FieldInfo, FuzzySet>();
+            private readonly JCG.Dictionary<FieldInfo, FuzzySet> _bloomFilters = new JCG.Dictionary<FieldInfo, FuzzySet>();
             private readonly SegmentWriteState _state;
 
             public BloomFilteredFieldsConsumer(BloomFilteringPostingsFormat outerInstance, FieldsConsumer fieldsConsumer,

--- a/src/Lucene.Net.Codecs/Memory/DirectDocValuesProducer.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectDocValuesProducer.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.Memory
 {
@@ -33,18 +34,18 @@ namespace Lucene.Net.Codecs.Memory
     internal class DirectDocValuesProducer : DocValuesProducer
     {
         // metadata maps (just file pointers and minimal stuff)
-        private readonly IDictionary<int, NumericEntry> numerics = new Dictionary<int, NumericEntry>();
-        private readonly IDictionary<int, BinaryEntry> binaries = new Dictionary<int, BinaryEntry>();
-        private readonly IDictionary<int, SortedEntry> sorteds = new Dictionary<int, SortedEntry>();
-        private readonly IDictionary<int, SortedSetEntry> sortedSets = new Dictionary<int, SortedSetEntry>();
+        private readonly IDictionary<int, NumericEntry> numerics = new JCG.Dictionary<int, NumericEntry>();
+        private readonly IDictionary<int, BinaryEntry> binaries = new JCG.Dictionary<int, BinaryEntry>();
+        private readonly IDictionary<int, SortedEntry> sorteds = new JCG.Dictionary<int, SortedEntry>();
+        private readonly IDictionary<int, SortedSetEntry> sortedSets = new JCG.Dictionary<int, SortedSetEntry>();
         private readonly IndexInput data;
 
         // ram instances we have already loaded
-        private readonly IDictionary<int, NumericDocValues> numericInstances = new Dictionary<int, NumericDocValues>();
-        private readonly IDictionary<int, BinaryDocValues> binaryInstances = new Dictionary<int, BinaryDocValues>();
-        private readonly IDictionary<int, SortedDocValues> sortedInstances = new Dictionary<int, SortedDocValues>();
-        private readonly IDictionary<int, SortedSetRawValues> sortedSetInstances = new Dictionary<int, SortedSetRawValues>();
-        private readonly IDictionary<int, IBits> docsWithFieldInstances = new Dictionary<int, IBits>();
+        private readonly IDictionary<int, NumericDocValues> numericInstances = new JCG.Dictionary<int, NumericDocValues>();
+        private readonly IDictionary<int, BinaryDocValues> binaryInstances = new JCG.Dictionary<int, BinaryDocValues>();
+        private readonly IDictionary<int, SortedDocValues> sortedInstances = new JCG.Dictionary<int, SortedDocValues>();
+        private readonly IDictionary<int, SortedSetRawValues> sortedSetInstances = new JCG.Dictionary<int, SortedSetRawValues>();
+        private readonly IDictionary<int, IBits> docsWithFieldInstances = new JCG.Dictionary<int, IBits>();
 
         private readonly int maxDoc;
         private readonly AtomicInt64 ramBytesUsed;

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesConsumer.cs
@@ -183,7 +183,7 @@ namespace Lucene.Net.Codecs.Memory
                     long[] decode = new long[uniqueValues.Count];
                     uniqueValues.CopyTo(decode, 0);
 
-                    var encode = new Dictionary<long?, int?>();
+                    var encode = new JCG.Dictionary<long?, int?>();
                     data.WriteVInt32(decode.Length);
                     for (int i = 0; i < decode.Length; i++)
                     {

--- a/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryDocValuesProducer.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Int64 = J2N.Numerics.Int64;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.Memory
 {
@@ -45,10 +46,10 @@ namespace Lucene.Net.Codecs.Memory
         private readonly IndexInput data;
 
         // ram instances we have already loaded
-        private readonly IDictionary<int, NumericDocValues> numericInstances = new Dictionary<int, NumericDocValues>();
-        private readonly IDictionary<int, BinaryDocValues> binaryInstances = new Dictionary<int, BinaryDocValues>();
-        private readonly IDictionary<int, FST<Int64>> fstInstances = new Dictionary<int, FST<Int64>>();
-        private readonly IDictionary<int, IBits> docsWithFieldInstances = new Dictionary<int, IBits>();
+        private readonly IDictionary<int, NumericDocValues> numericInstances = new JCG.Dictionary<int, NumericDocValues>();
+        private readonly IDictionary<int, BinaryDocValues> binaryInstances = new JCG.Dictionary<int, BinaryDocValues>();
+        private readonly IDictionary<int, FST<Int64>> fstInstances = new JCG.Dictionary<int, FST<Int64>>();
+        private readonly IDictionary<int, IBits> docsWithFieldInstances = new JCG.Dictionary<int, IBits>();
 
         private readonly int maxDoc;
         private readonly AtomicInt64 ramBytesUsed;
@@ -82,9 +83,9 @@ namespace Lucene.Net.Codecs.Memory
             try
             {
                 version = CodecUtil.CheckHeader(@in, metaCodec, VERSION_START, VERSION_CURRENT);
-                numerics = new Dictionary<int, NumericEntry>();
-                binaries = new Dictionary<int, BinaryEntry>();
-                fsts = new Dictionary<int, FSTEntry>();
+                numerics = new JCG.Dictionary<int, NumericEntry>();
+                binaries = new JCG.Dictionary<int, BinaryEntry>();
+                fsts = new JCG.Dictionary<int, FSTEntry>();
                 ReadFields(@in /*, state.FieldInfos // LUCENENET: Not referenced */);
                 if (version >= VERSION_CHECKSUM)
                 {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextDocValuesReader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.SimpleText
 {
@@ -58,7 +59,7 @@ namespace Lucene.Net.Codecs.SimpleText
         private readonly int maxDoc;
         private readonly IndexInput data;
         private readonly BytesRef scratch = new BytesRef();
-        private readonly IDictionary<string, OneField> fields = new Dictionary<string, OneField>();
+        private readonly IDictionary<string, OneField> fields = new JCG.Dictionary<string, OneField>();
 
         // LUCENENET NOTE: Changed from public to internal because the class had to be made public, but is not for public use.
         internal SimpleTextDocValuesReader(SegmentReadState state, string ext)

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldInfosReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldInfosReader.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.SimpleText
 {
@@ -119,7 +120,7 @@ namespace Lucene.Net.Codecs.SimpleText
                     SimpleTextUtil.ReadLine(input, scratch);
                     if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(scratch, SimpleTextFieldInfosWriter.NUM_ATTS));
                     int numAtts = Convert.ToInt32(ReadString(SimpleTextFieldInfosWriter.NUM_ATTS.Length, scratch), CultureInfo.InvariantCulture);
-                    IDictionary<string, string> atts = new Dictionary<string, string>();
+                    IDictionary<string, string> atts = new JCG.Dictionary<string, string>();
 
                     for (int j = 0; j < numAtts; j++)
                     {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextFieldsReader.cs
@@ -684,7 +684,7 @@ namespace Lucene.Net.Codecs.SimpleText
             return fields.Keys.GetEnumerator();
         }
 
-        private readonly IDictionary<string, SimpleTextTerms> termsCache = new Dictionary<string, SimpleTextTerms>();
+        private readonly IDictionary<string, SimpleTextTerms> termsCache = new JCG.Dictionary<string, SimpleTextTerms>();
 
         public override Terms GetTerms(string field)
         {

--- a/src/Lucene.Net.Codecs/SimpleText/SimpleTextSegmentInfoReader.cs
+++ b/src/Lucene.Net.Codecs/SimpleText/SimpleTextSegmentInfoReader.cs
@@ -67,7 +67,7 @@ namespace Lucene.Net.Codecs.SimpleText
                 SimpleTextUtil.ReadLine(input, scratch);
                 if (Debugging.AssertsEnabled) Debugging.Assert(StringHelper.StartsWith(scratch, SimpleTextSegmentInfoWriter.SI_NUM_DIAG));
                 int numDiag = Convert.ToInt32(ReadString(SimpleTextSegmentInfoWriter.SI_NUM_DIAG.Length, scratch), CultureInfo.InvariantCulture);
-                IDictionary<string, string> diagnostics = new Dictionary<string, string>();
+                IDictionary<string, string> diagnostics = new JCG.Dictionary<string, string>();
 
                 for (int i = 0; i < numDiag; i++)
                 {

--- a/src/Lucene.Net.Expressions/ExpressionComparator.cs
+++ b/src/Lucene.Net.Expressions/ExpressionComparator.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Expressions
             if (Debugging.AssertsEnabled) Debugging.Assert(readerContext != null);
             try
             {
-                var context = new Dictionary<string, object>();
+                var context = new JCG.Dictionary<string, object>();
                 if (Debugging.AssertsEnabled) Debugging.Assert(scorer != null);
                 context["scorer"] = scorer;
                 scores = source.GetValues(context, readerContext);

--- a/src/Lucene.Net.Expressions/ExpressionRescorer.cs
+++ b/src/Lucene.Net.Expressions/ExpressionRescorer.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Index;
 using Lucene.Net.Search;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Expressions
 {
@@ -99,7 +100,7 @@ namespace Lucene.Net.Expressions
             int subReader = ReaderUtil.SubIndex(docID, leaves);
             AtomicReaderContext readerContext = leaves[subReader];
             int docIDInSegment = docID - readerContext.DocBase;
-            var context = new Dictionary<string, object>();
+            var context = new JCG.Dictionary<string, object>();
             var fakeScorer = new FakeScorer { score = firstPassExplanation.Value, doc = docIDInSegment };
             context["scorer"] = fakeScorer;
             foreach (string variable in expression.Variables)

--- a/src/Lucene.Net.Expressions/ExpressionValueSource.cs
+++ b/src/Lucene.Net.Expressions/ExpressionValueSource.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Support;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Expressions
 {
@@ -81,7 +82,7 @@ namespace Lucene.Net.Expressions
             IDictionary<string, FunctionValues> valuesCache = (IDictionary<string, FunctionValues>)context["valuesCache"];
             if (valuesCache is null)
             {
-                valuesCache = new Dictionary<string, FunctionValues>();
+                valuesCache = new JCG.Dictionary<string, FunctionValues>();
                 context = new Hashtable(context)
                 {
                     ["valuesCache"] = valuesCache

--- a/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
+++ b/src/Lucene.Net.Expressions/JS/JavascriptCompiler.cs
@@ -851,7 +851,7 @@ namespace Lucene.Net.Expressions.JS
 
         private static IDictionary<string, MethodInfo> LoadDefaultFunctions() // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
-            IDictionary<string, MethodInfo> map = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> map = new JCG.Dictionary<string, MethodInfo>();
             try
             {
                 foreach (var property in GetDefaultSettings())
@@ -904,7 +904,7 @@ namespace Lucene.Net.Expressions.JS
 
         private static IDictionary<string, string> GetDefaultSettings()
         {
-            var settings = new Dictionary<string, string>();
+            var settings = new JCG.Dictionary<string, string>();
             var type = typeof(JavascriptCompiler);
             using var reader = new StreamReader(type.FindAndGetManifestResourceStream(type.Name + ".properties"), Encoding.UTF8);
             settings.LoadProperties(reader);

--- a/src/Lucene.Net.Expressions/SimpleBindings.cs
+++ b/src/Lucene.Net.Expressions/SimpleBindings.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Search;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Expressions
 {
@@ -47,7 +48,7 @@ namespace Lucene.Net.Expressions
     /// </summary>
     public sealed class SimpleBindings : Bindings, IEnumerable<KeyValuePair<string, object>> // LUCENENET specific - Added collection initializer to make populating easier
     {
-        internal readonly IDictionary<string, object> map = new Dictionary<string, object>();
+        internal readonly IDictionary<string, object> map = new JCG.Dictionary<string, object>();
 
         /// <summary>
         /// Creates a new empty <see cref="Bindings"/>

--- a/src/Lucene.Net.Facet/DrillSideways.cs
+++ b/src/Lucene.Net.Facet/DrillSideways.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Search;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet
 {
@@ -108,7 +109,7 @@ namespace Lucene.Net.Facet
         {
 
             Facets drillDownFacets;
-            var drillSidewaysFacets = new Dictionary<string, Facets>();
+            var drillSidewaysFacets = new JCG.Dictionary<string, Facets>();
 
             if (m_taxoReader != null)
             {

--- a/src/Lucene.Net.Facet/FacetsConfig.cs
+++ b/src/Lucene.Net.Facet/FacetsConfig.cs
@@ -304,13 +304,13 @@ namespace Lucene.Net.Facet
         public virtual Document Build(ITaxonomyWriter taxoWriter, Document doc)
         {
             // Find all FacetFields, collated by the actual field:
-            IDictionary<string, IList<FacetField>> byField = new Dictionary<string, IList<FacetField>>();
+            IDictionary<string, IList<FacetField>> byField = new JCG.Dictionary<string, IList<FacetField>>();
 
             // ... and also all SortedSetDocValuesFacetFields:
-            IDictionary<string, IList<SortedSetDocValuesFacetField>> dvByField = new Dictionary<string, IList<SortedSetDocValuesFacetField>>();
+            IDictionary<string, IList<SortedSetDocValuesFacetField>> dvByField = new JCG.Dictionary<string, IList<SortedSetDocValuesFacetField>>();
 
             // ... and also all AssociationFacetFields
-            IDictionary<string, IList<AssociationFacetField>> assocByField = new Dictionary<string, IList<AssociationFacetField>>();
+            IDictionary<string, IList<AssociationFacetField>> assocByField = new JCG.Dictionary<string, IList<AssociationFacetField>>();
 
             var seenDims = new JCG.HashSet<string>();
 

--- a/src/Lucene.Net.Facet/Range/LongRangeCounter.cs
+++ b/src/Lucene.Net.Facet/Range/LongRangeCounter.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Facet.Range
             // track the start vs end case separately because if a
             // given point is both, then it must be its own
             // elementary interval:
-            IDictionary<long, int> endsMap = new Dictionary<long, int>
+            IDictionary<long, int> endsMap = new JCG.Dictionary<long, int>
             {
                 [long.MinValue] = 1,
                 [long.MaxValue] = 2

--- a/src/Lucene.Net.Facet/SortedSet/DefaultSortedSetDocValuesReaderState.cs
+++ b/src/Lucene.Net.Facet/SortedSet/DefaultSortedSetDocValuesReaderState.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet.SortedSet
 {
@@ -37,7 +38,7 @@ namespace Lucene.Net.Facet.SortedSet
         /// <see cref="IndexReader"/> passed to the constructor. </summary>
         private readonly IndexReader origReader;
 
-        private readonly IDictionary<string, OrdRange> prefixToOrdRange = new Dictionary<string, OrdRange>();
+        private readonly IDictionary<string, OrdRange> prefixToOrdRange = new JCG.Dictionary<string, OrdRange>();
 
         /// <summary>
         /// Creates this, pulling doc values from the specified

--- a/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/Directory/DirectoryTaxonomyWriter.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet.Taxonomy.Directory
 {
@@ -772,8 +773,8 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         private IDictionary<string, string> CombinedCommitData(IDictionary<string, string> commitData)
         {
             IDictionary<string, string> m = commitData != null
-                ? new Dictionary<string, string>(commitData)
-                : new Dictionary<string, string>();
+                ? new JCG.Dictionary<string, string>(commitData)
+                : new JCG.Dictionary<string, string>();
             m[INDEX_EPOCH] = Convert.ToString(indexEpoch, 16);
             return m;
         }

--- a/src/Lucene.Net.Facet/Taxonomy/TaxonomyFacetSumValueSource.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/TaxonomyFacetSumValueSource.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet.Taxonomy
 {
@@ -110,7 +111,7 @@ namespace Lucene.Net.Facet.Taxonomy
         private void SumValues(IList<MatchingDocs> matchingDocs, bool keepScores, ValueSource valueSource)
         {
             FakeScorer scorer = new FakeScorer();
-            IDictionary context = new Dictionary<string, Scorer>();
+            IDictionary context = new JCG.Dictionary<string, Scorer>();
             if (keepScores)
             {
                 context["scorer"] = scorer;

--- a/src/Lucene.Net.Grouping/Function/FunctionAllGroupHeadsCollector.cs
+++ b/src/Lucene.Net.Grouping/Function/FunctionAllGroupHeadsCollector.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Queries.Function;
 using Lucene.Net.Util.Mutable;
 using System.Collections;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Grouping.Function
 {
@@ -50,7 +51,7 @@ namespace Lucene.Net.Search.Grouping.Function
         public FunctionAllGroupHeadsCollector(ValueSource groupBy, IDictionary /* Map<?, ?> */ vsContext, Sort sortWithinGroup)
             : base(sortWithinGroup.GetSort().Length)
         {
-            groups = new Dictionary<MutableValue, GroupHead>();
+            groups = new JCG.Dictionary<MutableValue, GroupHead>();
             this.sortWithinGroup = sortWithinGroup;
             this.groupBy = groupBy;
             this.vsContext = vsContext;

--- a/src/Lucene.Net.Highlighter/Highlight/QueryTermScorer.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/QueryTermScorer.cs
@@ -81,7 +81,7 @@ namespace Lucene.Net.Search.Highlight
 
         public QueryTermScorer(WeightedTerm[] weightedTerms)
         {
-            termsToFind = new Dictionary<string, WeightedTerm>();
+            termsToFind = new JCG.Dictionary<string, WeightedTerm>();
             for (int i = 0; i < weightedTerms.Length; i++)
             {
                 if (!termsToFind.TryGetValue(weightedTerms[i].Term, out WeightedTerm existingTerm)

--- a/src/Lucene.Net.Highlighter/Highlight/WeightedSpanTermExtractor.cs
+++ b/src/Lucene.Net.Highlighter/Highlight/WeightedSpanTermExtractor.cs
@@ -630,7 +630,7 @@ namespace Lucene.Net.Search.Highlight
         // so we need to implement IDictionary{TKey, TValue} instead.
         protected class PositionCheckingMap<K> : IDictionary<K, WeightedSpanTerm>
         {
-            private readonly IDictionary<K, WeightedSpanTerm> wrapped = new Dictionary<K, WeightedSpanTerm>();
+            private readonly IDictionary<K, WeightedSpanTerm> wrapped = new JCG.Dictionary<K, WeightedSpanTerm>();
 
             public WeightedSpanTerm this[K key]
             {

--- a/src/Lucene.Net.Highlighter/PostingsHighlight/PostingsHighlighter.cs
+++ b/src/Lucene.Net.Highlighter/PostingsHighlight/PostingsHighlighter.cs
@@ -318,7 +318,7 @@ namespace Lucene.Net.Search.PostingsHighlight
         /// <exception cref="ArgumentException">if <c>field</c> was indexed without <see cref="IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS"/></exception>
         public virtual IDictionary<string, string[]> HighlightFields(string[] fieldsIn, Query query, IndexSearcher searcher, int[] docidsIn, int[] maxPassagesIn)
         {
-            IDictionary<string, string[]> snippets = new Dictionary<string, string[]>();
+            IDictionary<string, string[]> snippets = new JCG.Dictionary<string, string[]>();
             foreach (var ent in HighlightFieldsAsObjects(fieldsIn, query, searcher, docidsIn, maxPassagesIn))
             {
                 object[] snippetObjects = ent.Value;
@@ -428,7 +428,7 @@ namespace Lucene.Net.Search.PostingsHighlight
             // pull stored data:
             IList<string[]> contents = LoadFieldValues(searcher, fields, docids, maxLength);
 
-            IDictionary<string, object[]> highlights = new Dictionary<string, object[]>();
+            IDictionary<string, object[]> highlights = new JCG.Dictionary<string, object[]>();
             for (int i = 0; i < fields.Length; i++)
             {
                 string field = fields[i];
@@ -514,7 +514,7 @@ namespace Lucene.Net.Search.PostingsHighlight
 
         private IDictionary<int, object> HighlightField(string field, string[] contents, BreakIterator bi, BytesRef[] terms, int[] docids, IList<AtomicReaderContext> leaves, int maxPassages, Query query)
         {
-            IDictionary<int, object> highlights = new Dictionary<int, object>();
+            IDictionary<int, object> highlights = new JCG.Dictionary<int, object>();
 
             PassageFormatter fieldFormatter = GetFormatter(field);
             if (fieldFormatter is null)

--- a/src/Lucene.Net.Highlighter/VectorHighlight/BaseFragmentsBuilder.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/BaseFragmentsBuilder.cs
@@ -251,7 +251,7 @@ namespace Lucene.Net.Search.VectorHighlight
 
         protected virtual IList<WeightedFragInfo> DiscreteMultiValueHighlighting(IList<WeightedFragInfo> fragInfos, Field[] fields)
         {
-            IDictionary<string, IList<WeightedFragInfo>> fieldNameToFragInfos = new Dictionary<string, IList<WeightedFragInfo>>();
+            IDictionary<string, IList<WeightedFragInfo>> fieldNameToFragInfos = new JCG.Dictionary<string, IList<WeightedFragInfo>>();
             foreach (Field field in fields)
             {
                 fieldNameToFragInfos[field.Name] = new JCG.List<WeightedFragInfo>();

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldQuery.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldQuery.cs
@@ -429,7 +429,7 @@ namespace Lucene.Net.Search.VectorHighlight
             internal float boost;  // valid if terminal == true
             internal int termOrPhraseNumber;   // valid if terminal == true
             internal readonly FieldQuery fieldQuery; // LUCENENET: marked readonly
-            internal readonly IDictionary<string, QueryPhraseMap> subMap = new Dictionary<string, QueryPhraseMap>(); // LUCENENET: marked readonly
+            internal readonly IDictionary<string, QueryPhraseMap> subMap = new JCG.Dictionary<string, QueryPhraseMap>(); // LUCENENET: marked readonly
 
             public QueryPhraseMap(FieldQuery fieldQuery)
             {

--- a/src/Lucene.Net.Join/ToParentBlockJoinCollector.cs
+++ b/src/Lucene.Net.Join/ToParentBlockJoinCollector.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Join
 {
@@ -80,7 +81,7 @@ namespace Lucene.Net.Search.Join
 
         // Maps each BlockJoinQuery instance to its "slot" in
         // joinScorers and in OneGroup's cached doc/scores/count:
-        private readonly IDictionary<Query, int> joinQueryID = new Dictionary<Query, int>();
+        private readonly IDictionary<Query, int> joinQueryID = new JCG.Dictionary<Query, int>();
         private readonly int numParentHits;
         private readonly FieldValueHitQueue<OneGroup> queue;
         private readonly FieldComparer[] comparers;

--- a/src/Lucene.Net.Memory/MemoryIndex.cs
+++ b/src/Lucene.Net.Memory/MemoryIndex.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index.Memory
 {
@@ -162,7 +163,7 @@ namespace Lucene.Net.Index.Memory
         /// <summary>
         /// info for each field: <see cref="IDictionary{String, Info}"/>
         /// </summary>
-        private readonly IDictionary<string, Info> fields = new Dictionary<string, Info>();
+        private readonly IDictionary<string, Info> fields = new JCG.Dictionary<string, Info>();
 
         /// <summary>
         /// fields sorted ascending by fieldName; lazily computed on demand </summary>
@@ -175,7 +176,7 @@ namespace Lucene.Net.Index.Memory
         //  private final IntBlockPool.SliceReader postingsReader;
         private readonly Int32BlockPool.SliceWriter postingsWriter;
 
-        private readonly Dictionary<string, FieldInfo> fieldInfos = new Dictionary<string, FieldInfo>(); // LUCENENET: marked readonly
+        private readonly JCG.Dictionary<string, FieldInfo> fieldInfos = new JCG.Dictionary<string, FieldInfo>(); // LUCENENET: marked readonly
 
         private readonly Counter bytesUsed; // LUCENENET: marked readonly
 

--- a/src/Lucene.Net.Misc/Document/LazyDocument.cs
+++ b/src/Lucene.Net.Misc/Document/LazyDocument.cs
@@ -41,7 +41,7 @@ namespace Lucene.Net.Documents
         // null until first field is loaded
         private Document doc;
 
-        private readonly IDictionary<int, IList<LazyField>> fields = new Dictionary<int, IList<LazyField>>(); // LUCENENET: marked readonly
+        private readonly IDictionary<int, IList<LazyField>> fields = new JCG.Dictionary<int, IList<LazyField>>(); // LUCENENET: marked readonly
         private readonly ISet<string> fieldNames = new JCG.HashSet<string>(); // LUCENENET: marked readonly
 
         public LazyDocument(IndexReader reader, int docID)

--- a/src/Lucene.Net.Queries/Mlt/MoreLikeThis.cs
+++ b/src/Lucene.Net.Queries/Mlt/MoreLikeThis.cs
@@ -498,7 +498,7 @@ namespace Lucene.Net.Queries.Mlt
         /// <exception cref="IOException"/>
         public PriorityQueue<ScoreTerm> RetrieveTerms(int docNum)
         {
-            IDictionary<string, Int32> termFreqMap = new Dictionary<string, Int32>();
+            IDictionary<string, Int32> termFreqMap = new JCG.Dictionary<string, Int32>();
             foreach (string fieldName in FieldNames)
             {
                 Fields vectors = ir.GetTermVectors(docNum);
@@ -665,7 +665,7 @@ namespace Lucene.Net.Queries.Mlt
         // LUCENENET: Factored out the object[] to avoid boxing
         public PriorityQueue<ScoreTerm> RetrieveTerms(TextReader r, string fieldName)
         {
-            IDictionary<string, Int32> words = new Dictionary<string, Int32>();
+            IDictionary<string, Int32> words = new JCG.Dictionary<string, Int32>();
             AddTermFrequencies(r, words, fieldName);
             return CreateQueue(words);
         }

--- a/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
+++ b/src/Lucene.Net.QueryParser/Classic/QueryParserBase.cs
@@ -16,6 +16,7 @@ using System.ComponentModel;
 using System.Runtime.Serialization;
 #endif
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Classic
 {
@@ -340,7 +341,7 @@ namespace Lucene.Net.QueryParsers.Classic
             if (fieldToDateResolution is null)
             {
                 // lazily initialize Dictionary
-                fieldToDateResolution = new Dictionary<string, DateResolution>();
+                fieldToDateResolution = new JCG.Dictionary<string, DateResolution>();
             }
 
             fieldToDateResolution[fieldName] = dateResolution;

--- a/src/Lucene.Net.QueryParser/Ext/Extensions.cs
+++ b/src/Lucene.Net.QueryParser/Ext/Extensions.cs
@@ -2,6 +2,7 @@ using Lucene.Net.QueryParsers.Classic;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Ext
 {
@@ -41,7 +42,7 @@ namespace Lucene.Net.QueryParsers.Ext
     /// <seealso cref="ParserExtension"/>
     public class Extensions
     {
-        private readonly IDictionary<string, ParserExtension> extensions = new Dictionary<string, ParserExtension>();
+        private readonly IDictionary<string, ParserExtension> extensions = new JCG.Dictionary<string, ParserExtension>();
         private readonly char extensionFieldDelimiter;
 
         /// <summary>

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Builders/QueryTreeBuilder.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Builders/QueryTreeBuilder.cs
@@ -3,6 +3,7 @@ using Lucene.Net.QueryParsers.Flexible.Core.Nodes;
 using Lucene.Net.QueryParsers.Flexible.Standard.Parser;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Flexible.Core.Builders
 {
@@ -74,7 +75,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Builders
 
             if (this.fieldNameBuilders is null)
             {
-                this.fieldNameBuilders = new Dictionary<string, IQueryBuilder<TQuery>>();
+                this.fieldNameBuilders = new JCG.Dictionary<string, IQueryBuilder<TQuery>>();
             }
 
             this.fieldNameBuilders[fieldName] = builder;
@@ -90,7 +91,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Builders
         {
             if (this.queryNodeBuilders is null)
             {
-                this.queryNodeBuilders = new Dictionary<Type, IQueryBuilder<TQuery>>();
+                this.queryNodeBuilders = new JCG.Dictionary<Type, IQueryBuilder<TQuery>>();
             }
 
             this.queryNodeBuilders[queryNodeClass] = builder;

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Config/AbstractQueryConfig.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Config/AbstractQueryConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Flexible.Core.Config
 {
@@ -31,7 +32,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Config
     /// </summary>
     public abstract class AbstractQueryConfig
     {
-        private readonly IDictionary<ConfigurationKey, object> configMap = new Dictionary<ConfigurationKey, object>();
+        private readonly IDictionary<ConfigurationKey, object> configMap = new JCG.Dictionary<ConfigurationKey, object>();
 
         private protected AbstractQueryConfig() // LUCENENET: Changed from internal to private protected
         {

--- a/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/QueryNodeImpl.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Core/Nodes/QueryNodeImpl.cs
@@ -39,7 +39,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
 
         private bool isLeaf = true;
 
-        private Dictionary<string, object> tags = new Dictionary<string, object>();
+        private JCG.Dictionary<string, object> tags = new JCG.Dictionary<string, object>();
 
         private JCG.List<IQueryNode> clauses = null;
 
@@ -124,7 +124,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
             clone.isLeaf = this.isLeaf;
 
             // Reset all tags
-            clone.tags = new Dictionary<string, object>();
+            clone.tags = new JCG.Dictionary<string, object>();
 
             // copy children
             if (this.clauses != null)
@@ -242,7 +242,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Core.Nodes
         /// <summary>
         /// Gets a map containing all tags attached to this query node.
         /// </summary>
-        public virtual IDictionary<string, object> TagMap => new Dictionary<string, object>(this.tags);
+        public virtual IDictionary<string, object> TagMap => new JCG.Dictionary<string, object>(this.tags);
 
         // LUCENENET NOTE: There was a bug in 4.8.1 here because parent.GetChildren() returns a copy of the
         // children, so removing items from it is pointless. We therefore diverge to the version 8.8.1 source of Lucene

--- a/src/Lucene.Net.QueryParser/Flexible/Messages/NLS.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Messages/NLS.cs
@@ -49,7 +49,7 @@
 //        /// into this class.
 //        /// </summary>
 //        private static IResourceManagerFactory resourceManagerFactory = new BundleResourceManagerFactory();
-//        private static readonly IDictionary<string, Type> bundles = new Dictionary<string, Type>(0); // LUCENENET: marked readonly
+//        private static readonly IDictionary<string, Type> bundles = new JCG.Dictionary<string, Type>(0); // LUCENENET: marked readonly
 
 //        protected NLS()
 //        {
@@ -170,7 +170,7 @@
 
 //            // build a map of field names to Field objects
 //            int len = fieldArray.Length;
-//            IDictionary<string, FieldInfo> fields = new Dictionary<string, FieldInfo>(len * 2);
+//            IDictionary<string, FieldInfo> fields = new JCG.Dictionary<string, FieldInfo>(len * 2);
 //            for (int i = 0; i < len; i++)
 //            {
 //                fields[fieldArray[i].Name] = fieldArray[i];

--- a/src/Lucene.Net.QueryParser/Xml/Builders/SpanQueryBuilderFactory.cs
+++ b/src/Lucene.Net.QueryParser/Xml/Builders/SpanQueryBuilderFactory.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Search;
 using Lucene.Net.Search.Spans;
 using System.Collections.Generic;
 using System.Xml;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Xml.Builders
 {
@@ -27,7 +28,7 @@ namespace Lucene.Net.QueryParsers.Xml.Builders
     /// </summary>
     public class SpanQueryBuilderFactory : ISpanQueryBuilder
     {
-        private readonly IDictionary<string, ISpanQueryBuilder> builders = new Dictionary<string, ISpanQueryBuilder>();
+        private readonly IDictionary<string, ISpanQueryBuilder> builders = new JCG.Dictionary<string, ISpanQueryBuilder>();
 
         public virtual Query GetQuery(XmlElement e)
         {

--- a/src/Lucene.Net.QueryParser/Xml/FilterBuilderFactory.cs
+++ b/src/Lucene.Net.QueryParser/Xml/FilterBuilderFactory.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Search;
 using System.Collections.Generic;
 using System.Xml;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Xml
 {
@@ -26,7 +27,7 @@ namespace Lucene.Net.QueryParsers.Xml
     /// </summary>
     public class FilterBuilderFactory : IFilterBuilder
     {
-        private readonly IDictionary<string, IFilterBuilder> builders = new Dictionary<string, IFilterBuilder>(); // LUCENENET: marked readonly
+        private readonly IDictionary<string, IFilterBuilder> builders = new JCG.Dictionary<string, IFilterBuilder>(); // LUCENENET: marked readonly
 
         public virtual Filter GetFilter(XmlElement n)
         {

--- a/src/Lucene.Net.QueryParser/Xml/QueryBuilderFactory.cs
+++ b/src/Lucene.Net.QueryParser/Xml/QueryBuilderFactory.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Search;
 using System.Collections.Generic;
 using System.Xml;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Xml
 {
@@ -26,7 +27,7 @@ namespace Lucene.Net.QueryParsers.Xml
     /// </summary>
     public class QueryBuilderFactory : IQueryBuilder
     {
-        private readonly IDictionary<string, IQueryBuilder> builders = new Dictionary<string, IQueryBuilder>(); // LUCENENET: marked readonly
+        private readonly IDictionary<string, IQueryBuilder> builders = new JCG.Dictionary<string, IQueryBuilder>(); // LUCENENET: marked readonly
 
         public virtual Query GetQuery(XmlElement n)
         {

--- a/src/Lucene.Net.QueryParser/Xml/QueryTemplateManager.cs
+++ b/src/Lucene.Net.QueryParser/Xml/QueryTemplateManager.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Xml;
 using System.Xml.Xsl;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Xml
 {
@@ -34,7 +35,7 @@ namespace Lucene.Net.QueryParsers.Xml
     /// </summary>
     public class QueryTemplateManager
     {
-        private readonly IDictionary<string, XslCompiledTransform> compiledTemplatesCache = new Dictionary<string, XslCompiledTransform>(); // LUCENENET: marked readonly
+        private readonly IDictionary<string, XslCompiledTransform> compiledTemplatesCache = new JCG.Dictionary<string, XslCompiledTransform>(); // LUCENENET: marked readonly
         private XslCompiledTransform defaultCompiledTemplates;
 
         public QueryTemplateManager()

--- a/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
+++ b/src/Lucene.Net.Replicator/IndexAndTaxonomyRevision.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Directory = Lucene.Net.Store.Directory;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Replicator
 {
@@ -61,7 +62,7 @@ namespace Lucene.Net.Replicator
         /// </summary>
         public static IDictionary<string, IList<RevisionFile>> RevisionFiles(IndexCommit indexCommit, IndexCommit taxonomyCommit)
         {
-            return new Dictionary<string, IList<RevisionFile>>{
+            return new JCG.Dictionary<string, IList<RevisionFile>>{
                     { INDEX_SOURCE,  IndexRevision.RevisionFiles(indexCommit).Values.First() },
                     { TAXONOMY_SOURCE,  IndexRevision.RevisionFiles(taxonomyCommit).Values.First() }
                 };

--- a/src/Lucene.Net.Replicator/IndexRevision.cs
+++ b/src/Lucene.Net.Replicator/IndexRevision.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Replicator
             }
             revisionFiles.Add(CreateRevisionFile(segmentsFile, dir)); // segments_N must be last
 
-            return Collections.AsReadOnly(new Dictionary<string, IList<RevisionFile>>
+            return Collections.AsReadOnly(new JCG.Dictionary<string, IList<RevisionFile>>
             {
                 { SOURCE, revisionFiles }
             });

--- a/src/Lucene.Net.Replicator/ReplicationClient.cs
+++ b/src/Lucene.Net.Replicator/ReplicationClient.cs
@@ -165,8 +165,8 @@ namespace Lucene.Net.Replicator
         private void DoUpdate()
         {
             SessionToken session = null;
-            Dictionary<string, Directory> sourceDirectory = new Dictionary<string, Directory>();
-            Dictionary<string, IList<string>> copiedFiles = new Dictionary<string, IList<string>>();
+            JCG.Dictionary<string, Directory> sourceDirectory = new JCG.Dictionary<string, Directory>();
+            JCG.Dictionary<string, IList<string>> copiedFiles = new JCG.Dictionary<string, IList<string>>();
             bool notify = false;
             try
             {
@@ -304,7 +304,7 @@ namespace Lucene.Net.Replicator
             if (handlerRevisionFiles is null)
                 return newRevisionFiles;
 
-            Dictionary<string, IList<RevisionFile>> requiredFiles = new Dictionary<string, IList<RevisionFile>>();
+            JCG.Dictionary<string, IList<RevisionFile>> requiredFiles = new JCG.Dictionary<string, IList<RevisionFile>>();
             foreach (var e in handlerRevisionFiles)
             {
                 // put the handler files in a Set, for faster contains() checks later

--- a/src/Lucene.Net.Replicator/SessionToken.cs
+++ b/src/Lucene.Net.Replicator/SessionToken.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Replicator
             Id = reader.ReadUTF();
             Version = reader.ReadUTF();
 
-            Dictionary<string, IList<RevisionFile>> sourceFiles = new Dictionary<string, IList<RevisionFile>>();
+            JCG.Dictionary<string, IList<RevisionFile>> sourceFiles = new JCG.Dictionary<string, IList<RevisionFile>>();
             int numSources = reader.ReadInt32();
             while (numSources > 0)
             {

--- a/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
+++ b/src/Lucene.Net.Sandbox/Queries/FuzzyLikeThisQuery.cs
@@ -297,7 +297,7 @@ namespace Lucene.Net.Sandbox.Queries
             //create BooleanQueries to hold the variants for each token/field pair and ensure it
             // has no coord factor
             //Step 1: sort the termqueries by term/field
-            IDictionary<Term, IList<ScoreTerm>> variantQueries = new Dictionary<Term, IList<ScoreTerm>>();
+            IDictionary<Term, IList<ScoreTerm>> variantQueries = new JCG.Dictionary<Term, IList<ScoreTerm>>();
             int size = q.Count;
             for (int i = 0; i < size; i++)
             {

--- a/src/Lucene.Net.Spatial/Query/SpatialArgsParser.cs
+++ b/src/Lucene.Net.Spatial/Query/SpatialArgsParser.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Spatial.Queries
 {
@@ -180,7 +181,7 @@ namespace Lucene.Net.Spatial.Queries
             if (body is null)
                 throw new ArgumentNullException(nameof(body));
 
-            var map = new Dictionary<string, string>();
+            var map = new JCG.Dictionary<string, string>();
             using StringTokenizer st = new StringTokenizer(body, " \n\t");
 
             while (st.MoveNext())

--- a/src/Lucene.Net.Spatial/Query/SpatialOperation.cs
+++ b/src/Lucene.Net.Spatial/Query/SpatialOperation.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.Spatial.Queries
     public abstract class SpatialOperation
     {
         // Private registry
-        private static readonly IDictionary<string, SpatialOperation> registry = new Dictionary<string, SpatialOperation>();
+        private static readonly IDictionary<string, SpatialOperation> registry = new JCG.Dictionary<string, SpatialOperation>();
         private static readonly IList<SpatialOperation> list = new JCG.List<SpatialOperation>();
 
         // Geometry Operations

--- a/src/Lucene.Net.Suggest/Suggest/DocumentValueSourceDictionary.cs
+++ b/src/Lucene.Net.Suggest/Suggest/DocumentValueSourceDictionary.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Queries.Function;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Search.Suggest
 {
@@ -129,7 +130,7 @@ namespace Lucene.Net.Search.Suggest
                     starts[i] = leaves[i].DocBase;
                 }
                 starts[leaves.Count] = outerInstance.m_reader.MaxDoc;
-                currentWeightValues = (leaves.Count > 0) ? outerInstance.weightsValueSource.GetValues(new Dictionary<string, object>(), leaves[currentLeafIndex]) : null;
+                currentWeightValues = (leaves.Count > 0) ? outerInstance.weightsValueSource.GetValues(new JCG.Dictionary<string, object>(), leaves[currentLeafIndex]) : null;
             }
 
             /// <summary>
@@ -148,7 +149,7 @@ namespace Lucene.Net.Search.Suggest
                     currentLeafIndex = subIndex;
                     try
                     {
-                        currentWeightValues = outerInstance.weightsValueSource.GetValues(new Dictionary<string, object>(), leaves[currentLeafIndex]);
+                        currentWeightValues = outerInstance.weightsValueSource.GetValues(new JCG.Dictionary<string, object>(), leaves[currentLeafIndex]);
                     }
                     catch (Exception e) when (e.IsIOException())
                     {

--- a/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/BaseTokenStreamTestCase.cs
@@ -181,8 +181,8 @@ namespace Lucene.Net.Analysis
                 // *********** End From Lucene 8.2.0 **************
 
                 // Maps position to the start/end offset:
-                IDictionary<int, int> posToStartOffset = new Dictionary<int, int>();
-                IDictionary<int, int> posToEndOffset = new Dictionary<int, int>();
+                IDictionary<int, int> posToStartOffset = new JCG.Dictionary<int, int>();
+                IDictionary<int, int> posToEndOffset = new JCG.Dictionary<int, int>();
 
                 ts.Reset();
                 int pos = -1;

--- a/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/CollationTestBase.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Text;
 using Assert = Lucene.Net.TestFramework.Assert;
 using Directory = Lucene.Net.Store.Directory;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis
 {
@@ -243,7 +244,7 @@ namespace Lucene.Net.Analysis
         {
             int numTestPoints = 100;
             int numThreads = TestUtil.NextInt32(Random, 3, 5);
-            Dictionary<string, BytesRef> map = new Dictionary<string, BytesRef>();
+            JCG.Dictionary<string, BytesRef> map = new JCG.Dictionary<string, BytesRef>();
 
             // create a map<String,SortKey> up front.
             // then with multiple threads, generate sort keys for all the keys in the map

--- a/src/Lucene.Net.TestFramework/Analysis/MockAnalyzer.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/MockAnalyzer.cs
@@ -5,6 +5,7 @@ using RandomizedTesting.Generators;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis
 {
@@ -57,7 +58,7 @@ namespace Lucene.Net.Analysis
         private int positionIncrementGap;
         private int? offsetGap;
         private readonly Random random;
-        private readonly IDictionary<string, int> previousMappings = new Dictionary<string, int>(); // LUCENENET: marked readonly
+        private readonly IDictionary<string, int> previousMappings = new JCG.Dictionary<string, int>(); // LUCENENET: marked readonly
         private bool enableChecks = true;
         private int maxTokenLength = MockTokenizer.DEFAULT_MAX_TOKEN_LENGTH;
 

--- a/src/Lucene.Net.TestFramework/Analysis/ValidatingTokenFilter.cs
+++ b/src/Lucene.Net.TestFramework/Analysis/ValidatingTokenFilter.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Analysis.TokenAttributes;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis
 {
@@ -40,9 +41,9 @@ namespace Lucene.Net.Analysis
         private int lastStartOffset;
 
         // Maps position to the start/end offset:
-        private readonly IDictionary<int, int> posToStartOffset = new Dictionary<int, int>();
+        private readonly IDictionary<int, int> posToStartOffset = new JCG.Dictionary<int, int>();
 
-        private readonly IDictionary<int, int> posToEndOffset = new Dictionary<int, int>();
+        private readonly IDictionary<int, int> posToEndOffset = new JCG.Dictionary<int, int>();
 
         private readonly IPositionIncrementAttribute posIncAtt;
         private readonly IPositionLengthAttribute posLenAtt;

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40DocValuesWriter.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene40/Lucene40DocValuesWriter.cs
@@ -417,7 +417,7 @@ namespace Lucene.Net.Codecs.Lucene40
             /* values */
             long startPosition = data.Position; // LUCENENET specific: Renamed from getFilePointer() to match FileStream
             long currentAddress = 0;
-            Dictionary<BytesRef, long> valueToAddress = new Dictionary<BytesRef, long>();
+            JCG.Dictionary<BytesRef, long> valueToAddress = new JCG.Dictionary<BytesRef, long>();
             foreach (BytesRef v in dictionary)
             {
                 currentAddress = data.Position - startPosition; // LUCENENET specific: Renamed from getFilePointer() to match FileStream

--- a/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/Lucene42/Lucene42DocValuesConsumer.cs
@@ -150,7 +150,7 @@ namespace Lucene.Net.Codecs.Lucene42
                     meta.WriteByte((byte)Lucene42DocValuesProducer.TABLE_COMPRESSED); // table-compressed
                     var decode = new long[uniqueValues.Count];
                     uniqueValues.CopyTo(decode, 0);
-                    var encode = new Dictionary<long, int>();
+                    var encode = new JCG.Dictionary<long, int>();
                     data.WriteVInt32(decode.Length);
                     for (int i = 0; i < decode.Length; i++)
                     {

--- a/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
+++ b/src/Lucene.Net.TestFramework/Codecs/RAMOnly/RAMOnlyPostingsFormat.cs
@@ -570,7 +570,7 @@ namespace Lucene.Net.Codecs.RAMOnly
         }
 
         // Holds all indexes created, keyed by the ID assigned in fieldsConsumer
-        private readonly IDictionary<int, RAMPostings> state = new Dictionary<int, RAMPostings>();
+        private readonly IDictionary<int, RAMPostings> state = new JCG.Dictionary<int, RAMPostings>();
 
         private readonly AtomicInt32 nextID = new AtomicInt32();
 

--- a/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseDocValuesFormatTestCase.cs
@@ -1178,7 +1178,7 @@ namespace Lucene.Net.Index
             using RandomIndexWriter w = new RandomIndexWriter(Random, dir, cfg);
             int numDocs = AtLeast(100);
             BytesRefHash hash = new BytesRefHash();
-            IDictionary<string, string> docToString = new Dictionary<string, string>();
+            IDictionary<string, string> docToString = new JCG.Dictionary<string, string>();
             int maxLength = TestUtil.NextInt32(Random, 1, 50);
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseStoredFieldsFormatTestCase.cs
@@ -87,7 +87,7 @@ namespace Lucene.Net.Index
                 fieldIDs.Add(i);
             }
 
-            IDictionary<string, Document> docs = new Dictionary<string, Document>();
+            IDictionary<string, Document> docs = new JCG.Dictionary<string, Document>();
 
             if (Verbose)
             {

--- a/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Index/BaseTermVectorsFormatTestCase.cs
@@ -311,8 +311,8 @@ namespace Lucene.Net.Index
                     }
                 }
 
-                positionToTerms = new Dictionary<int, ISet<int>>(len);
-                startOffsetToTerms = new Dictionary<int, ISet<int>>(len);
+                positionToTerms = new JCG.Dictionary<int, ISet<int>>(len);
+                startOffsetToTerms = new JCG.Dictionary<int, ISet<int>>(len);
                 for (int i = 0; i < len; ++i)
                 {
                     if (!positionToTerms.TryGetValue(positions[i], out ISet<int> positionTerms))
@@ -327,7 +327,7 @@ namespace Lucene.Net.Index
                     startOffsetTerms.Add(i);
                 }
 
-                freqs = new Dictionary<string, int>();
+                freqs = new JCG.Dictionary<string, int>();
                 foreach (string term in terms)
                 {
                     if (freqs.TryGetValue(term, out int freq))

--- a/src/Lucene.Net.TestFramework/Index/DocHelper.cs
+++ b/src/Lucene.Net.TestFramework/Index/DocHelper.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -147,16 +148,16 @@ namespace Lucene.Net.Index
             LargeLazyField
         };
 
-        public static IDictionary<string, IIndexableField> All { get; set; } = new Dictionary<string, IIndexableField>();
-        public static IDictionary<string, IIndexableField> Indexed { get; set; } = new Dictionary<string, IIndexableField>();
-        public static IDictionary<string, IIndexableField> Stored { get; set; } = new Dictionary<string, IIndexableField>();
-        public static IDictionary<string, IIndexableField> Unstored { get; set; } = new Dictionary<string, IIndexableField>();
-        public static IDictionary<string, IIndexableField> Unindexed { get; set; } = new Dictionary<string, IIndexableField>();
-        public static IDictionary<string, IIndexableField> Termvector { get; set; } = new Dictionary<string, IIndexableField>();
-        public static IDictionary<string, IIndexableField> Notermvector { get; set; } = new Dictionary<string, IIndexableField>();
-        public static IDictionary<string, IIndexableField> Lazy { get; set; } = new Dictionary<string, IIndexableField>();
-        public static IDictionary<string, IIndexableField> NoNorms { get; set; } = new Dictionary<string, IIndexableField>();
-        public static IDictionary<string, IIndexableField> NoTf { get; set; } = new Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> All { get; set; } = new JCG.Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> Indexed { get; set; } = new JCG.Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> Stored { get; set; } = new JCG.Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> Unstored { get; set; } = new JCG.Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> Unindexed { get; set; } = new JCG.Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> Termvector { get; set; } = new JCG.Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> Notermvector { get; set; } = new JCG.Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> Lazy { get; set; } = new JCG.Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> NoNorms { get; set; } = new JCG.Dictionary<string, IIndexableField>();
+        public static IDictionary<string, IIndexableField> NoTf { get; set; } = new JCG.Dictionary<string, IIndexableField>();
 
         private static void Add(IDictionary<string, IIndexableField> map, IIndexableField field)
         {
@@ -298,7 +299,7 @@ namespace Lucene.Net.Index
                 }
                 //if (f.isLazy()) add(lazy, f);
             }
-            NameValues = new Dictionary<string, object>
+            NameValues = new JCG.Dictionary<string, object>
             {
                 { TEXT_FIELD_1_KEY, FIELD_1_TEXT },
                 { TEXT_FIELD_2_KEY, FIELD_2_TEXT },

--- a/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Search/ShardSearchingTestBase.cs
@@ -226,7 +226,7 @@ namespace Lucene.Net.Search
         internal virtual IDictionary<Term, TermStatistics> GetNodeTermStats(ISet<Term> terms, int nodeID, long version)
         {
             NodeState node = m_nodes[nodeID];
-            IDictionary<Term, TermStatistics> stats = new Dictionary<Term, TermStatistics>();
+            IDictionary<Term, TermStatistics> stats = new JCG.Dictionary<Term, TermStatistics>();
             IndexSearcher s = node.Searchers.Acquire(version);
             if (s is null)
             {

--- a/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
@@ -10,6 +10,7 @@ using System;
 using System.IO;
 using System.Threading;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 using Test = NUnit.Framework.TestAttribute;
 
 namespace Lucene.Net.Store
@@ -376,7 +377,7 @@ namespace Lucene.Net.Store
         //[Test]
         //public virtual void TestMapOfStrings()
         //{
-        //    IDictionary<string, string> m = new Dictionary<string, string>()
+        //    IDictionary<string, string> m = new JCG.Dictionary<string, string>()
         //    {
         //        ["test1"] = "value1",
         //        ["test2"] = "value2"

--- a/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Store/BaseDirectoryTestCase.cs
@@ -10,7 +10,7 @@ using System;
 using System.IO;
 using System.Threading;
 using Assert = Lucene.Net.TestFramework.Assert;
-using JCG = J2N.Collections.Generic;
+//using JCG = J2N.Collections.Generic;
 using Test = NUnit.Framework.TestAttribute;
 
 namespace Lucene.Net.Store

--- a/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
+++ b/src/Lucene.Net.TestFramework/Store/MockDirectoryWrapper.cs
@@ -141,7 +141,7 @@ namespace Lucene.Net.Store
             {
                 if (openFiles is null)
                 {
-                    openFiles = new Dictionary<string, int>(StringComparer.Ordinal);
+                    openFiles = new JCG.Dictionary<string, int>(StringComparer.Ordinal);
                     openFilesDeleted = new JCG.HashSet<string>(StringComparer.Ordinal);
                 }
 
@@ -307,7 +307,7 @@ namespace Lucene.Net.Store
             try
             {
                 crashed = true;
-                openFiles = new Dictionary<string, int>(StringComparer.Ordinal);
+                openFiles = new JCG.Dictionary<string, int>(StringComparer.Ordinal);
                 openFilesForWrite = new JCG.HashSet<string>(StringComparer.Ordinal);
                 openFilesDeleted = new JCG.HashSet<string>(StringComparer.Ordinal);
                 using IEnumerator<string> it = unSyncedFiles.GetEnumerator();
@@ -934,7 +934,7 @@ namespace Lucene.Net.Store
                     MaybeYield();
                     if (openFiles is null)
                     {
-                        openFiles = new Dictionary<string, int>(StringComparer.Ordinal);
+                        openFiles = new JCG.Dictionary<string, int>(StringComparer.Ordinal);
                         openFilesDeleted = new JCG.HashSet<string>(StringComparer.Ordinal);
                     }
                     if (openFiles.Count > 0)

--- a/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
@@ -299,9 +299,9 @@ namespace Lucene.Net.Util.Automaton
         {
             int[] points = a.GetStartPoints();
             // subset construction
-            IDictionary<ISet<State>, ISet<State>> sets = new Dictionary<ISet<State>, ISet<State>>();
+            IDictionary<ISet<State>, ISet<State>> sets = new JCG.Dictionary<ISet<State>, ISet<State>>();
             Queue<ISet<State>> worklist = new Queue<ISet<State>>(); // LUCENENET specific - Queue is much more performant than LinkedList
-            IDictionary<ISet<State>, State> newstate = new Dictionary<ISet<State>, State>();
+            IDictionary<ISet<State>, State> newstate = new JCG.Dictionary<ISet<State>, State>();
             sets[initialset] = initialset;
             worklist.Enqueue(initialset);
             a.initial = new State();
@@ -438,7 +438,7 @@ namespace Lucene.Net.Util.Automaton
             // must use IdentityHashmap because two Transitions w/
             // different start nodes can be considered the same
             leadsToAccept = new JCG.Dictionary<Transition, bool>(IdentityEqualityComparer<Transition>.Default);
-            IDictionary<State, IList<ArrivingTransition>> allArriving = new Dictionary<State, IList<ArrivingTransition>>();
+            IDictionary<State, IList<ArrivingTransition>> allArriving = new JCG.Dictionary<State, IList<ArrivingTransition>>();
 
             Queue<State> q = new Queue<State>();
             ISet<State> seen = new JCG.HashSet<State>();

--- a/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
+++ b/src/Lucene.Net.TestFramework/Util/Fst/FSTTester.cs
@@ -502,7 +502,7 @@ namespace Lucene.Net.Util.Fst
                 Assert.IsFalse(fstEnum.MoveNext());
             }
 
-            IDictionary<Int32sRef, T> termsMap = new Dictionary<Int32sRef, T>();
+            IDictionary<Int32sRef, T> termsMap = new JCG.Dictionary<Int32sRef, T>();
             foreach (InputOutput<T> pair in pairs)
             {
                 termsMap[pair.Input] = pair.Output;

--- a/src/Lucene.Net.TestFramework/Util/TestRuleSetupAndRestoreClassEnv.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestRuleSetupAndRestoreClassEnv.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Util
         ///// <summary>
         ///// Restore these system property values.
         ///// </summary>
-        //private Dictionary<string, string> restoreProperties = new Dictionary<string, string>(); // LUCENENET: Never read
+        //private JCG.Dictionary<string, string> restoreProperties = new JCG.Dictionary<string, string>(); // LUCENENET: Never read
 
         private Codec savedCodec;
         private CultureInfo savedLocale;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/CharFilters/TestMappingCharFilter.cs
@@ -299,7 +299,7 @@ namespace Lucene.Net.Analysis.CharFilters
                 }
 
                 char endLetter = (char)TestUtil.NextInt32(random, 'b', 'z');
-                IDictionary<string, string> map = new Dictionary<string, string>();
+                IDictionary<string, string> map = new JCG.Dictionary<string, string>();
                 NormalizeCharMap.Builder builder = new NormalizeCharMap.Builder();
                 int numMappings = AtLeast(5);
                 if (Verbose)

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAllAnalyzersHaveFactories.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAllAnalyzersHaveFactories.cs
@@ -114,7 +114,7 @@ namespace Lucene.Net.Analysis.Core
             foreach (Type c in analysisClasses)
             {
 
-                IDictionary<string, string> args = new Dictionary<string, string>();
+                IDictionary<string, string> args = new JCG.Dictionary<string, string>();
                 args["luceneMatchVersion"] = TEST_VERSION_CURRENT.ToString();
 
                 if (c.IsSubclassOf(typeof(Tokenizer)))

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestFactories.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestFactories.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Core
 {
@@ -135,7 +136,7 @@ namespace Lucene.Net.Analysis.Core
         private static AbstractAnalysisFactory Initialize(Type factoryClazz) // LUCENENET: CA1822: Mark members as static
         {
             IDictionary<string, string> args =
-                new Dictionary<string, string> { ["luceneMatchVersion"] = TEST_VERSION_CURRENT_STRING };
+                new JCG.Dictionary<string, string> { ["luceneMatchVersion"] = TEST_VERSION_CURRENT_STRING };
 
             ConstructorInfo ctor;
             try
@@ -188,7 +189,7 @@ namespace Lucene.Net.Analysis.Core
         }
 
         // some silly classes just so we can use checkRandomData
-        private readonly TokenizerFactory assertingTokenizer = new TokenizerFactoryAnonymousClass(new Dictionary<string, string>());
+        private readonly TokenizerFactory assertingTokenizer = new TokenizerFactoryAnonymousClass(new JCG.Dictionary<string, string>());
 
         private sealed class TokenizerFactoryAnonymousClass : TokenizerFactory
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -80,10 +80,10 @@ namespace Lucene.Net.Analysis.Core
             }
         }
 
-        private static readonly IDictionary<ConstructorInfo, IPredicate<object[]>> brokenConstructors = new Dictionary<ConstructorInfo, IPredicate<object[]>>();
+        private static readonly IDictionary<ConstructorInfo, IPredicate<object[]>> brokenConstructors = new JCG.Dictionary<ConstructorInfo, IPredicate<object[]>>();
         // TODO: also fix these and remove (maybe):
         // Classes/options that don't produce consistent graph offsets:
-        private static readonly IDictionary<ConstructorInfo, IPredicate<object[]>> brokenOffsetsConstructors = new Dictionary<ConstructorInfo, IPredicate<object[]>>();
+        private static readonly IDictionary<ConstructorInfo, IPredicate<object[]>> brokenOffsetsConstructors = new JCG.Dictionary<ConstructorInfo, IPredicate<object[]>>();
 
         internal static readonly ISet<Type> allowedTokenizerArgs, allowedTokenFilterArgs, allowedCharFilterArgs;
 

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestPerFieldAnalyzerWrapper.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestPerFieldAnalyzerWrapper.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
         {
             string text = "Qwerty";
 
-            IDictionary<string, Analyzer> analyzerPerField = new Dictionary<string, Analyzer>();
+            IDictionary<string, Analyzer> analyzerPerField = new JCG.Dictionary<string, Analyzer>();
             analyzerPerField["special"] = new SimpleAnalyzer(TEST_VERSION_CURRENT);
 
             PerFieldAnalyzerWrapper analyzer = new PerFieldAnalyzerWrapper(new WhitespaceAnalyzer(TEST_VERSION_CURRENT), analyzerPerField);

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestStemmerOverrideFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestStemmerOverrideFilter.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestRandomRealisticWhiteSpace()
         {
-            IDictionary<string, string> map = new Dictionary<string, string>();
+            IDictionary<string, string> map = new JCG.Dictionary<string, string>();
             // LUCENENET: Ported the patch from https://github.com/apache/lucene/commit/bce10efeb40c11271cb398c37b859408818b8a00
             // so we don't have random failures.
             ISet<string> seen = new HashSet<string>();
@@ -174,7 +174,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
         [Test]
         public virtual void TestRandomRealisticKeyword()
         {
-            IDictionary<string, string> map = new Dictionary<string, string>();
+            IDictionary<string, string> map = new JCG.Dictionary<string, string>();
             int numTerms = AtLeast(50);
             for (int i = 0; i < numTerms; i++)
             {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMap.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMap.cs
@@ -256,7 +256,7 @@ namespace Lucene.Net.Analysis.Synonym
             SlowSynonymMap synMap;
 
             // prepare bi-gram tokenizer factory
-            IDictionary<string, string> args = new Dictionary<string, string>();
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>();
             args[AbstractAnalysisFactory.LUCENE_MATCH_VERSION_PARAM] = "4.4";
             args["minGramSize"] = "2";
             args["maxGramSize"] = "2";
@@ -279,7 +279,7 @@ namespace Lucene.Net.Analysis.Synonym
         [Test]
         public virtual void TestLoadRules()
         {
-            IDictionary<string, string> args = new Dictionary<string, string>();
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>();
             args["synonyms"] = "something.txt";
             SlowSynonymFilterFactory ff = new SlowSynonymFilterFactory(args);
             ff.Inform(new ResourceLoaderAnonymousClass());

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Synonym/TestSynonymMapFilter.cs
@@ -447,7 +447,7 @@ namespace Lucene.Net.Analysis.Synonym
             int numSyn = AtLeast(5);
             //final int numSyn = 2;
 
-            IDictionary<string, OneSyn> synMap = new Dictionary<string, OneSyn>();
+            IDictionary<string, OneSyn> synMap = new JCG.Dictionary<string, OneSyn>();
             IList<OneSyn> syns = new JCG.List<OneSyn>();
             bool dedup = Random.nextBoolean();
             if (Verbose)

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/BaseTokenStreamFactoryTestCase.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/BaseTokenStreamFactoryTestCase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using Lucene.Net.Util;
+using JCG = J2N.Collections.Generic;
 using Version = Lucene.Net.Util.LuceneVersion;
 
 namespace Lucene.Net.Analysis.Util
@@ -55,7 +56,7 @@ namespace Lucene.Net.Analysis.Util
                 throw new ArgumentException("invalid keysAndValues map");
             }
             string previous;
-            IDictionary<string, string> args = new Dictionary<string, string>();
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>();
             for (int i = 0; i < keysAndValues.Length; i += 2)
             {
                 if (args.TryGetValue(keysAndValues[i], out previous))

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestAnalysisSPILoader.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestAnalysisSPILoader.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Util
 {
@@ -34,7 +35,7 @@ namespace Lucene.Net.Analysis.Util
             return new HashMapAnonymousClass();
         }
 
-        private sealed class HashMapAnonymousClass : Dictionary<string, string>
+        private sealed class HashMapAnonymousClass : JCG.Dictionary<string, string>
         {
             public HashMapAnonymousClass()
             {
@@ -56,7 +57,7 @@ namespace Lucene.Net.Analysis.Util
         {
             try
             {
-                TokenizerFactory.ForName("sdfsdfsdfdsfsdfsdf", new Dictionary<string, string>());
+                TokenizerFactory.ForName("sdfsdfsdfdsfsdfsdf", new JCG.Dictionary<string, string>());
                 fail();
             }
             catch (Exception expected) when (expected.IsIllegalArgumentException())
@@ -66,7 +67,7 @@ namespace Lucene.Net.Analysis.Util
 
             try
             {
-                TokenizerFactory.ForName("!(**#$U*#$*", new Dictionary<string, string>());
+                TokenizerFactory.ForName("!(**#$U*#$*", new JCG.Dictionary<string, string>());
                 fail();
             }
             catch (Exception expected) when (expected.IsIllegalArgumentException())
@@ -130,7 +131,7 @@ namespace Lucene.Net.Analysis.Util
         {
             try
             {
-                TokenFilterFactory.ForName("sdfsdfsdfdsfsdfsdf", new Dictionary<string, string>());
+                TokenFilterFactory.ForName("sdfsdfsdfdsfsdfsdf", new JCG.Dictionary<string, string>());
                 fail();
             }
             catch (Exception expected) when (expected.IsIllegalArgumentException())
@@ -140,7 +141,7 @@ namespace Lucene.Net.Analysis.Util
 
             try
             {
-                TokenFilterFactory.ForName("!(**#$U*#$*", new Dictionary<string, string>());
+                TokenFilterFactory.ForName("!(**#$U*#$*", new JCG.Dictionary<string, string>());
                 fail();
             }
             catch (Exception expected) when (expected.IsIllegalArgumentException())
@@ -205,7 +206,7 @@ namespace Lucene.Net.Analysis.Util
         {
             try
             {
-                CharFilterFactory.ForName("sdfsdfsdfdsfsdfsdf", new Dictionary<string, string>());
+                CharFilterFactory.ForName("sdfsdfsdfdsfsdfsdf", new JCG.Dictionary<string, string>());
                 fail();
             }
             catch (Exception expected) when (expected.IsIllegalArgumentException())
@@ -215,7 +216,7 @@ namespace Lucene.Net.Analysis.Util
 
             try
             {
-                CharFilterFactory.ForName("!(**#$U*#$*", new Dictionary<string, string>());
+                CharFilterFactory.ForName("!(**#$U*#$*", new JCG.Dictionary<string, string>());
                 fail();
             }
             catch (Exception expected) when (expected.IsIllegalArgumentException())

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharArrayMap.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharArrayMap.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Analysis.Util
         public virtual void TestMethods()
         {
             CharArrayDictionary<int?> cm = new CharArrayDictionary<int?>(TEST_VERSION_CURRENT, 2, false);
-            Dictionary<string, int?> hm = new Dictionary<string, int?>();
+            JCG.Dictionary<string, int?> hm = new JCG.Dictionary<string, int?>();
             hm["foo"] = 1;
             hm["bar"] = 2;
             cm.PutAll(hm);

--- a/src/Lucene.Net.Tests.Analysis.Common/Collation/TestCollationKeyFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Collation/TestCollationKeyFilterFactory.cs
@@ -10,6 +10,7 @@ using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Collation
 {
@@ -123,7 +124,7 @@ namespace Lucene.Net.Collation
             // and use the custom parameter.
             string germanUmlaut = "Töne";
             string germanOE = "Toene";
-            IDictionary<string, string> args = new Dictionary<string, string>();
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>();
             args["custom"] = "rules.txt";
             args["strength"] = "primary";
 #pragma warning disable 612, 618

--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/Segmentation/TestICUTokenizerFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/Segmentation/TestICUTokenizerFactory.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Icu.Segmentation
 {
@@ -34,7 +35,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         public void TestMixedText()
         {
             TextReader reader = new StringReader("การที่ได้ต้องแสดงว่างานดี  This is a test ກວ່າດອກ");
-            ICUTokenizerFactory factory = new ICUTokenizerFactory(new Dictionary<string, string>());
+            ICUTokenizerFactory factory = new ICUTokenizerFactory(new JCG.Dictionary<string, string>());
             factory.Inform(new ClasspathResourceLoader(GetType()));
             TokenStream stream = factory.Create(reader);
             AssertTokenStreamContents(stream,
@@ -48,7 +49,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
             // “ U+201C LEFT DOUBLE QUOTATION MARK; ” U+201D RIGHT DOUBLE QUOTATION MARK
             TextReader reader = new StringReader
                 ("  Don't,break.at?/(punct)!  \u201Cnice\u201D\r\n\r\n85_At:all; `really\" +2=3$5,&813 !@#%$^)(*@#$   ");
-            IDictionary<string, string> args = new Dictionary<string, string>();
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>();
             args[ICUTokenizerFactory.RULEFILES] = "Latn:Latin-break-only-on-whitespace.rbbi";
             ICUTokenizerFactory factory = new ICUTokenizerFactory(args);
             factory.Inform(new ClasspathResourceLoader(this.GetType()));
@@ -63,7 +64,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         {
             TextReader reader = new StringReader
                 ("One-two punch.  Brang-, not brung-it.  This one--not that one--is the right one, -ish.");
-            IDictionary<string, string> args = new Dictionary<string, string>();
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>();
             args[ICUTokenizerFactory.RULEFILES] = "Latn:Latin-dont-break-on-hyphens.rbbi";
             ICUTokenizerFactory factory = new ICUTokenizerFactory(args);
             factory.Inform(new ClasspathResourceLoader(GetType()));
@@ -84,7 +85,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         {
             TextReader reader = new StringReader
                 ("Some English.  Немного русский.  ข้อความภาษาไทยเล็ก ๆ น้อย ๆ  More English.");
-            IDictionary<string, string> args = new Dictionary<string, string>();
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>();
             args[ICUTokenizerFactory.RULEFILES] = "Cyrl:KeywordTokenizer.rbbi,Thai:KeywordTokenizer.rbbi";
             ICUTokenizerFactory factory = new ICUTokenizerFactory(args);
             factory.Inform(new ClasspathResourceLoader(GetType()));
@@ -101,7 +102,7 @@ namespace Lucene.Net.Analysis.Icu.Segmentation
         {
             try
             {
-                new ICUTokenizerFactory(new Dictionary<string, string>() {
+                new ICUTokenizerFactory(new JCG.Dictionary<string, string>() {
                     {"bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUFoldingFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUFoldingFilterFactory.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Icu
 {
@@ -33,7 +34,7 @@ namespace Lucene.Net.Analysis.Icu
         public void Test()
         {
             TextReader reader = new StringReader("Résumé");
-            ICUFoldingFilterFactory factory = new ICUFoldingFilterFactory(new Dictionary<string, string>());
+            ICUFoldingFilterFactory factory = new ICUFoldingFilterFactory(new JCG.Dictionary<string, string>());
             TokenStream stream = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
             stream = factory.Create(stream);
             AssertTokenStreamContents(stream, new string[] { "resume" });
@@ -45,7 +46,7 @@ namespace Lucene.Net.Analysis.Icu
         {
             try
             {
-                new ICUFoldingFilterFactory(new Dictionary<string, string>() {
+                new ICUFoldingFilterFactory(new JCG.Dictionary<string, string>() {
                             {"bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUNormalizer2CharFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUNormalizer2CharFilterFactory.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Icu
 {
@@ -33,7 +34,7 @@ namespace Lucene.Net.Analysis.Icu
         public void TestDefaults()
         {
             TextReader reader = new StringReader("This is a Ｔｅｓｔ");
-            ICUNormalizer2CharFilterFactory factory = new ICUNormalizer2CharFilterFactory(new Dictionary<String, String>());
+            ICUNormalizer2CharFilterFactory factory = new ICUNormalizer2CharFilterFactory(new JCG.Dictionary<String, String>());
             reader = factory.Create(reader);
             TokenStream stream = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
             AssertTokenStreamContents(stream, new String[] { "this", "is", "a", "test" });
@@ -45,7 +46,7 @@ namespace Lucene.Net.Analysis.Icu
         {
             try
             {
-                new ICUNormalizer2CharFilterFactory(new Dictionary<String, String>() {
+                new ICUNormalizer2CharFilterFactory(new JCG.Dictionary<String, String>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUNormalizer2FilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUNormalizer2FilterFactory.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Icu
 {
@@ -33,7 +34,7 @@ namespace Lucene.Net.Analysis.Icu
         public void TestDefaults()
         {
             TextReader reader = new StringReader("This is a Ｔｅｓｔ");
-            ICUNormalizer2FilterFactory factory = new ICUNormalizer2FilterFactory(new Dictionary<String, String>());
+            ICUNormalizer2FilterFactory factory = new ICUNormalizer2FilterFactory(new JCG.Dictionary<String, String>());
             TokenStream stream = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
             stream = factory.Create(stream);
             AssertTokenStreamContents(stream, new String[] { "this", "is", "a", "test" });
@@ -45,7 +46,7 @@ namespace Lucene.Net.Analysis.Icu
         {
             try
             {
-                new ICUNormalizer2FilterFactory(new Dictionary<String, String>() {
+                new ICUNormalizer2FilterFactory(new JCG.Dictionary<String, String>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUTransformFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Analysis/Icu/TestICUTransformFilterFactory.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Icu
 {
@@ -33,7 +34,7 @@ namespace Lucene.Net.Analysis.Icu
         public void Test()
         {
             TextReader reader = new StringReader("簡化字");
-            IDictionary<string, string> args = new Dictionary<string, string>
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>
             {
                 { "id", "Traditional-Simplified" }
             };
@@ -49,7 +50,7 @@ namespace Lucene.Net.Analysis.Icu
         {
             // forward
             TextReader reader = new StringReader("Российская Федерация");
-            IDictionary<string, string> args = new Dictionary<string, string>
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>
             {
                 { "id", "Cyrillic-Latin" }
             };
@@ -64,7 +65,7 @@ namespace Lucene.Net.Analysis.Icu
         {
             // backward (invokes Latin-Cyrillic)
             TextReader reader = new StringReader("Rossijskaâ Federaciâ");
-            IDictionary<string, string> args = new Dictionary<string, string>
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>
             {
                 {"id", "Cyrillic-Latin" },
                 { "direction", "reverse"}
@@ -82,7 +83,7 @@ namespace Lucene.Net.Analysis.Icu
         {
             try
             {
-                new ICUTransformFilterFactory(new Dictionary<string, string> {
+                new ICUTransformFilterFactory(new JCG.Dictionary<string, string> {
                         {"id", "Null" },
                         { "bogusArg", "bogusValue"}
                 });

--- a/src/Lucene.Net.Tests.Analysis.ICU/Collation/TestICUCollationKeyFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.ICU/Collation/TestICUCollationKeyFilterFactory.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Collation
 {
@@ -243,7 +244,7 @@ namespace Lucene.Net.Collation
             //
             string germanUmlaut = "Töne";
             string germanOE = "Toene";
-            IDictionary<string, string> args = new Dictionary<string, string>();
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>();
             args["custom"] = "rules.txt";
             args["strength"] = "primary";
             ICUCollationKeyFilterFactory factory = new ICUCollationKeyFilterFactory(args);
@@ -312,7 +313,7 @@ namespace Lucene.Net.Collation
             {
                 throw new ArgumentException("invalid keysAndValues map");
             }
-            IDictionary<string, string> args = new Dictionary<string, string>();
+            IDictionary<string, string> args = new JCG.Dictionary<string, string>();
             for (int i = 0; i < keysAndValues.Length; i += 2)
             {
                 string prev = args.Put(keysAndValues[i], keysAndValues[i + 1]);

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseBaseFormFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseBaseFormFilterFactory.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -30,10 +31,10 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestBasics()
         {
-            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new Dictionary<String, String>());
+            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>());
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
             TokenStream ts = tokenizerFactory.Create(new StringReader("それはまだ実験段階にあります"));
-            JapaneseBaseFormFilterFactory factory = new JapaneseBaseFormFilterFactory(new Dictionary<String, String>());
+            JapaneseBaseFormFilterFactory factory = new JapaneseBaseFormFilterFactory(new JCG.Dictionary<String, String>());
             ts = factory.Create(ts);
             AssertTokenStreamContents(ts,
                 new String[] { "それ", "は", "まだ", "実験", "段階", "に", "ある", "ます" }
@@ -46,7 +47,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             try
             {
-                new JapaneseBaseFormFilterFactory(new Dictionary<String, String>() {
+                new JapaneseBaseFormFilterFactory(new JCG.Dictionary<String, String>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseIterationMarkCharFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseIterationMarkCharFilterFactory.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -32,7 +33,7 @@ namespace Lucene.Net.Analysis.Ja
         public void TestIterationMarksWithKeywordTokenizer()
         {
             String text = "時々馬鹿々々しいところゞゝゝミスヾ";
-            JapaneseIterationMarkCharFilterFactory filterFactory = new JapaneseIterationMarkCharFilterFactory(new Dictionary<String, String>());
+            JapaneseIterationMarkCharFilterFactory filterFactory = new JapaneseIterationMarkCharFilterFactory(new JCG.Dictionary<String, String>());
             TextReader filter = filterFactory.Create(new StringReader(text));
             TokenStream tokenStream = new MockTokenizer(filter, MockTokenizer.KEYWORD, false);
             AssertTokenStreamContents(tokenStream, new String[] { "時時馬鹿馬鹿しいところどころミスズ" });
@@ -41,10 +42,10 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestIterationMarksWithJapaneseTokenizer()
         {
-            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new Dictionary<String, String>());
+            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>());
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
 
-            JapaneseIterationMarkCharFilterFactory filterFactory = new JapaneseIterationMarkCharFilterFactory(new Dictionary<String, String>());
+            JapaneseIterationMarkCharFilterFactory filterFactory = new JapaneseIterationMarkCharFilterFactory(new JCG.Dictionary<String, String>());
             TextReader filter = filterFactory.Create(
                 new StringReader("時々馬鹿々々しいところゞゝゝミスヾ")
             );
@@ -55,10 +56,10 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestKanjiOnlyIterationMarksWithJapaneseTokenizer()
         {
-            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new Dictionary<String, String>());
+            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>());
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
 
-            IDictionary<String, String> filterArgs = new Dictionary<String, String>();
+            IDictionary<String, String> filterArgs = new JCG.Dictionary<String, String>();
             filterArgs["normalizeKanji"] = "true";
             filterArgs["normalizeKana"] = "false";
             JapaneseIterationMarkCharFilterFactory filterFactory = new JapaneseIterationMarkCharFilterFactory(filterArgs);
@@ -73,10 +74,10 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestKanaOnlyIterationMarksWithJapaneseTokenizer()
         {
-            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new Dictionary<String, String>());
+            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>());
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
 
-            IDictionary<String, String> filterArgs = new Dictionary<String, String>();
+            IDictionary<String, String> filterArgs = new JCG.Dictionary<String, String>();
             filterArgs["normalizeKanji"] = "false";
             filterArgs["normalizeKana"] = "true";
             JapaneseIterationMarkCharFilterFactory filterFactory = new JapaneseIterationMarkCharFilterFactory(filterArgs);
@@ -94,7 +95,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             try
             {
-                new JapaneseIterationMarkCharFilterFactory(new Dictionary<String, String>() {
+                new JapaneseIterationMarkCharFilterFactory(new JCG.Dictionary<String, String>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseKatakanaStemFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseKatakanaStemFilterFactory.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -30,12 +31,12 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestKatakanaStemming()
         {
-            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new Dictionary<String, String>());
+            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>());
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
             TokenStream tokenStream = tokenizerFactory.Create(
                 new StringReader("明後日パーティーに行く予定がある。図書館で資料をコピーしました。")
             );
-            JapaneseKatakanaStemFilterFactory filterFactory = new JapaneseKatakanaStemFilterFactory(new Dictionary<String, String>()); ;
+            JapaneseKatakanaStemFilterFactory filterFactory = new JapaneseKatakanaStemFilterFactory(new JCG.Dictionary<String, String>()); ;
             AssertTokenStreamContents(filterFactory.Create(tokenStream),
                 new String[]{ "明後日", "パーティ", "に", "行く", "予定", "が", "ある",   // パーティー should be stemmed
                       "図書館", "で", "資料", "を", "コピー", "し", "まし", "た"} // コピー should not be stemmed
@@ -48,7 +49,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             try
             {
-                new JapaneseKatakanaStemFilterFactory(new Dictionary<String, String>() {
+                new JapaneseKatakanaStemFilterFactory(new JCG.Dictionary<String, String>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapanesePartOfSpeechStopFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapanesePartOfSpeechStopFilterFactory.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -35,10 +36,10 @@ namespace Lucene.Net.Analysis.Ja
                 "#  verb-main:\n" +
                 "動詞-自立\n";
 
-            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new Dictionary<String, String>());
+            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>());
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
             TokenStream ts = tokenizerFactory.Create(new StringReader("私は制限スピードを超える。"));
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args["luceneMatchVersion"] = TEST_VERSION_CURRENT.ToString();
             args["tags"] = "stoptags.txt";
             JapanesePartOfSpeechStopFilterFactory factory = new JapanesePartOfSpeechStopFilterFactory(args);
@@ -55,7 +56,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             try
             {
-                new JapanesePartOfSpeechStopFilterFactory(new Dictionary<String, String>() {
+                new JapanesePartOfSpeechStopFilterFactory(new JCG.Dictionary<String, String>() {
                     { "luceneMatchVersion", TEST_VERSION_CURRENT.toString() },
                     { "bogusArg", "bogusValue" }
                 });

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseReadingFormFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseReadingFormFilterFactory.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -30,10 +31,10 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestReadings()
         {
-            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new Dictionary<String, String>());
+            JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>());
             tokenizerFactory.Inform(new StringMockResourceLoader(""));
             TokenStream tokenStream = tokenizerFactory.Create(new StringReader("先ほどベルリンから来ました。"));
-            JapaneseReadingFormFilterFactory filterFactory = new JapaneseReadingFormFilterFactory(new Dictionary<String, String>());
+            JapaneseReadingFormFilterFactory filterFactory = new JapaneseReadingFormFilterFactory(new JCG.Dictionary<String, String>());
             AssertTokenStreamContents(filterFactory.Create(tokenStream),
                 new String[] { "サキ", "ホド", "ベルリン", "カラ", "キ", "マシ", "タ" }
             );
@@ -45,7 +46,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             try
             {
-                new JapaneseReadingFormFilterFactory(new Dictionary<String, String>() {
+                new JapaneseReadingFormFilterFactory(new JCG.Dictionary<String, String>() {
                 { "bogusArg", "bogusValue" }
             });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseTokenizerFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseTokenizerFactory.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -31,7 +32,7 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestSimple()
         {
-            JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(new Dictionary<String, String>());
+            JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>());
             factory.Inform(new StringMockResourceLoader(""));
             TokenStream ts = factory.Create(new StringReader("これは本ではない"));
             AssertTokenStreamContents(ts,
@@ -47,7 +48,7 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestDefaults()
         {
-            JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(new Dictionary<String, String>());
+            JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>());
             factory.Inform(new StringMockResourceLoader(""));
             TokenStream ts = factory.Create(new StringReader("シニアソフトウェアエンジニア"));
             AssertTokenStreamContents(ts,
@@ -61,7 +62,7 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestMode()
         {
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args["mode"] = "normal";
             JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(args);
             factory.Inform(new StringMockResourceLoader(""));
@@ -83,7 +84,7 @@ namespace Lucene.Net.Analysis.Ja
                 "関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,テスト名詞\n" +
                 "# Custom reading for sumo wrestler\n" +
                 "朝青龍,朝青龍,アサショウリュウ,カスタム人名\n";
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args["userDictionary"] = "userdict.txt";
             JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(args);
             factory.Inform(new StringMockResourceLoader(userDict));
@@ -99,7 +100,7 @@ namespace Lucene.Net.Analysis.Ja
         [Test]
         public void TestPreservePunctuation()
         {
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args["discardPunctuation"] = "false";
             JapaneseTokenizerFactory factory = new JapaneseTokenizerFactory(args);
             factory.Inform(new StringMockResourceLoader(""));
@@ -120,7 +121,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             try
             {
-                new JapaneseTokenizerFactory(new Dictionary<String, String>() {
+                new JapaneseTokenizerFactory(new JCG.Dictionary<String, String>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/Util/TestToStringUtil.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/Util/TestToStringUtil.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Ja.Util
 {
@@ -45,7 +46,7 @@ namespace Lucene.Net.Analysis.Ja.Util
         [Test]
         public void TestHepburnTable()
         {
-            IDictionary<String, String> table = new Dictionary<String, String>() {
+            IDictionary<String, String> table = new JCG.Dictionary<String, String>() {
                 { "ア", "a" }, { "イ", "i" }, { "ウ", "u" }, { "エ", "e" }, { "オ", "o" },
                 { "カ", "ka" }, { "キ", "ki" }, { "ク", "ku" }, { "ケ", "ke" }, { "コ", "ko" },
                 { "サ", "sa" }, { "シ", "shi" }, { "ス", "su" }, { "セ", "se" }, { "ソ", "so" },

--- a/src/Lucene.Net.Tests.Analysis.Morfologik/Morfologik/TestMorfologikFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Morfologik/Morfologik/TestMorfologikFilterFactory.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Analysis.Morfologik
         public void TestDefaultDictionary()
         {
             StringReader reader = new StringReader("rowery bilety");
-            MorfologikFilterFactory factory = new MorfologikFilterFactory(new Dictionary<string, string>());
+            MorfologikFilterFactory factory = new MorfologikFilterFactory(new JCG.Dictionary<string, string>());
             factory.Inform(new ForbidResourcesLoader());
             TokenStream stream = new MockTokenizer(reader); //whitespaceMockTokenizer(reader);
             stream = factory.Create(stream);

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPChunkerFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPChunkerFilterFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.OpenNlp
 {
@@ -65,15 +66,15 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(NewAttributeFactory(), reader); //new OpenNLPTokenizer(reader, new Tools.NLPSentenceDetectorOp(sentenceModelFile), new Tools.NLPTokenizerOp(tokenizerModelFile));
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);  //new OpenNLPPOSFilter(opennlp, new Tools.NLPPOSTaggerOp(posTaggerModelFile));
 
-                var opennlpChunkerFilterFactory = new OpenNLPChunkerFilterFactory(new Dictionary<string, string> { { "chunkerModel", chunkerModelFile } });
+                var opennlpChunkerFilterFactory = new OpenNLPChunkerFilterFactory(new JCG.Dictionary<string, string> { { "chunkerModel", chunkerModelFile } });
                 opennlpChunkerFilterFactory.Inform(loader);
                 var opennlpChunkerFilter = opennlpChunkerFilterFactory.Create(opennlpPOSFilter);  //new OpenNLPChunkerFilter(filter1, new Tools.NLPChunkerOp(chunkerModelFile));
 
@@ -98,19 +99,19 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(NewAttributeFactory(), reader); //new OpenNLPTokenizer(reader, new Tools.NLPSentenceDetectorOp(sentenceModelFile), new Tools.NLPTokenizerOp(tokenizerModelFile));
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);  //new OpenNLPPOSFilter(opennlp, new Tools.NLPPOSTaggerOp(posTaggerModelFile));
 
-                var opennlpChunkerFilterFactory = new OpenNLPChunkerFilterFactory(new Dictionary<string, string> { { "chunkerModel", chunkerModelFile } });
+                var opennlpChunkerFilterFactory = new OpenNLPChunkerFilterFactory(new JCG.Dictionary<string, string> { { "chunkerModel", chunkerModelFile } });
                 opennlpChunkerFilterFactory.Inform(loader);
                 var opennlpChunkerFilter = opennlpChunkerFilterFactory.Create(opennlpPOSFilter);  //new OpenNLPChunkerFilter(filter1, new Tools.NLPChunkerOp(chunkerModelFile));
 
-                var typeAsPayloadFilterFactory = new TypeAsPayloadTokenFilterFactory(new Dictionary<string, string>());
+                var typeAsPayloadFilterFactory = new TypeAsPayloadTokenFilterFactory(new JCG.Dictionary<string, string>());
                 var typeAsPayloadFilter = typeAsPayloadFilterFactory.Create(opennlpChunkerFilter);
 
                 return new TokenStreamComponents(opennlp, typeAsPayloadFilter);

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPLemmatizerFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPLemmatizerFilterFactory.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Analysis.Util;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.OpenNlp
 {
@@ -76,15 +77,15 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(reader);
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);
 
-                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new Dictionary<string, string> { { "dictionary", lemmatizerDictFile } });
+                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new JCG.Dictionary<string, string> { { "dictionary", lemmatizerDictFile } });
                 opennlpLemmatizerFilterFactory.Inform(loader);
                 var opennlpLemmatizerFilter = opennlpLemmatizerFilterFactory.Create(opennlpPOSFilter);
 
@@ -106,15 +107,15 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(reader);
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);
 
-                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new Dictionary<string, string> { { "dictionary", lemmatizerDictFile } });
+                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new JCG.Dictionary<string, string> { { "dictionary", lemmatizerDictFile } });
                 opennlpLemmatizerFilterFactory.Inform(loader);
                 var opennlpLemmatizerFilter = opennlpLemmatizerFilterFactory.Create(opennlpPOSFilter);
 
@@ -136,15 +137,15 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(reader);
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);
 
-                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new Dictionary<string, string> { { "lemmatizerModel", lemmatizerModelFile } });
+                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new JCG.Dictionary<string, string> { { "lemmatizerModel", lemmatizerModelFile } });
                 opennlpLemmatizerFilterFactory.Inform(loader);
                 var opennlpLemmatizerFilter = opennlpLemmatizerFilterFactory.Create(opennlpPOSFilter);
 
@@ -166,15 +167,15 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(reader);
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);
 
-                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new Dictionary<string, string> { { "lemmatizerModel", lemmatizerModelFile } });
+                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new JCG.Dictionary<string, string> { { "lemmatizerModel", lemmatizerModelFile } });
                 opennlpLemmatizerFilterFactory.Inform(loader);
                 var opennlpLemmatizerFilter = opennlpLemmatizerFilterFactory.Create(opennlpPOSFilter);
 
@@ -197,15 +198,15 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(reader);
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);
 
-                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new Dictionary<string, string> { { "dictionary", lemmatizerDictFile }, { "lemmatizerModel", lemmatizerModelFile } });
+                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new JCG.Dictionary<string, string> { { "dictionary", lemmatizerDictFile }, { "lemmatizerModel", lemmatizerModelFile } });
                 opennlpLemmatizerFilterFactory.Inform(loader);
                 var opennlpLemmatizerFilter = opennlpLemmatizerFilterFactory.Create(opennlpPOSFilter);
 
@@ -227,15 +228,15 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(reader);
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);
 
-                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new Dictionary<string, string> { { "dictionary", lemmatizerDictFile }, { "lemmatizerModel", lemmatizerModelFile } });
+                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new JCG.Dictionary<string, string> { { "dictionary", lemmatizerDictFile }, { "lemmatizerModel", lemmatizerModelFile } });
                 opennlpLemmatizerFilterFactory.Inform(loader);
                 var opennlpLemmatizerFilter = opennlpLemmatizerFilterFactory.Create(opennlpPOSFilter);
 
@@ -258,22 +259,22 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(reader);
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);
 
-                var keywordRepeatFilterFactory = new KeywordRepeatFilterFactory(new Dictionary<string, string>());
+                var keywordRepeatFilterFactory = new KeywordRepeatFilterFactory(new JCG.Dictionary<string, string>());
                 var keywordRepeatFilter = keywordRepeatFilterFactory.Create(opennlpPOSFilter);
 
-                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new Dictionary<string, string> { { "dictionary", lemmatizerDictFile } });
+                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new JCG.Dictionary<string, string> { { "dictionary", lemmatizerDictFile } });
                 opennlpLemmatizerFilterFactory.Inform(loader);
                 var opennlpLemmatizerFilter = opennlpLemmatizerFilterFactory.Create(keywordRepeatFilter);
 
-                var removeDuplicatesTokenFilterFactory = new RemoveDuplicatesTokenFilterFactory(new Dictionary<string, string>());
+                var removeDuplicatesTokenFilterFactory = new RemoveDuplicatesTokenFilterFactory(new JCG.Dictionary<string, string>());
                 var removeDuplicatesTokenFilter = removeDuplicatesTokenFilterFactory.Create(opennlpLemmatizerFilter);
 
                 return new TokenStreamComponents(opennlp, removeDuplicatesTokenFilter);
@@ -297,22 +298,22 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(reader);
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);
 
-                var keywordRepeatFilterFactory = new KeywordRepeatFilterFactory(new Dictionary<string, string>());
+                var keywordRepeatFilterFactory = new KeywordRepeatFilterFactory(new JCG.Dictionary<string, string>());
                 var keywordRepeatFilter = keywordRepeatFilterFactory.Create(opennlpPOSFilter);
 
-                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new Dictionary<string, string> { { "lemmatizerModel", lemmatizerModelFile } });
+                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new JCG.Dictionary<string, string> { { "lemmatizerModel", lemmatizerModelFile } });
                 opennlpLemmatizerFilterFactory.Inform(loader);
                 var opennlpLemmatizerFilter = opennlpLemmatizerFilterFactory.Create(keywordRepeatFilter);
 
-                var removeDuplicatesTokenFilterFactory = new RemoveDuplicatesTokenFilterFactory(new Dictionary<string, string>());
+                var removeDuplicatesTokenFilterFactory = new RemoveDuplicatesTokenFilterFactory(new JCG.Dictionary<string, string>());
                 var removeDuplicatesTokenFilter = removeDuplicatesTokenFilterFactory.Create(opennlpLemmatizerFilter);
 
                 return new TokenStreamComponents(opennlp, removeDuplicatesTokenFilter);
@@ -335,22 +336,22 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var opennlpFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var opennlpFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 opennlpFactory.Inform(loader);
                 var opennlp = opennlpFactory.Create(reader);
 
-                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var opennlpPOSFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 opennlpPOSFilterFactory.Inform(loader);
                 var opennlpPOSFilter = opennlpPOSFilterFactory.Create(opennlp);
 
-                var keywordRepeatFilterFactory = new KeywordRepeatFilterFactory(new Dictionary<string, string>());
+                var keywordRepeatFilterFactory = new KeywordRepeatFilterFactory(new JCG.Dictionary<string, string>());
                 var keywordRepeatFilter = keywordRepeatFilterFactory.Create(opennlpPOSFilter);
 
-                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new Dictionary<string, string> { { "dictionary", lemmatizerDictFile }, { "lemmatizerModel", lemmatizerModelFile } });
+                var opennlpLemmatizerFilterFactory = new OpenNLPLemmatizerFilterFactory(new JCG.Dictionary<string, string> { { "dictionary", lemmatizerDictFile }, { "lemmatizerModel", lemmatizerModelFile } });
                 opennlpLemmatizerFilterFactory.Inform(loader);
                 var opennlpLemmatizerFilter = opennlpLemmatizerFilterFactory.Create(keywordRepeatFilter);
 
-                var removeDuplicatesTokenFilterFactory = new RemoveDuplicatesTokenFilterFactory(new Dictionary<string, string>());
+                var removeDuplicatesTokenFilterFactory = new RemoveDuplicatesTokenFilterFactory(new JCG.Dictionary<string, string>());
                 var removeDuplicatesTokenFilter = removeDuplicatesTokenFilterFactory.Create(opennlpLemmatizerFilter);
 
                 return new TokenStreamComponents(opennlp, removeDuplicatesTokenFilter);

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPPOSFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPPOSFilterFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.OpenNlp
 {
@@ -68,11 +69,11 @@ namespace Lucene.Net.Analysis.OpenNlp
             var loader = new ClasspathResourceLoader(GetType());
             Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldname, reader) =>
             {
-                var tokenizerFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var tokenizerFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 tokenizerFactory.Inform(loader);
                 var tokenizer = tokenizerFactory.Create(reader);
 
-                var filter1Factory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var filter1Factory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 filter1Factory.Inform(loader);
                 var filter1 = filter1Factory.Create(tokenizer);
 
@@ -91,11 +92,11 @@ namespace Lucene.Net.Analysis.OpenNlp
             var loader = new ClasspathResourceLoader(GetType());
             Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldname, reader) =>
             {
-                var tokenizerFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var tokenizerFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 tokenizerFactory.Inform(loader);
                 var tokenizer = tokenizerFactory.Create(reader);
 
-                var filter1Factory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var filter1Factory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 filter1Factory.Inform(loader);
                 var filter1 = filter1Factory.Create(tokenizer);
 
@@ -110,15 +111,15 @@ namespace Lucene.Net.Analysis.OpenNlp
 
             analyzer = Analyzer.NewAnonymous(createComponents: (fieldname, reader) =>
             {
-                var tokenizerFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var tokenizerFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 tokenizerFactory.Inform(loader);
                 var tokenizer = tokenizerFactory.Create(reader);
 
-                var filter1Factory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var filter1Factory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 filter1Factory.Inform(loader);
                 var filter1 = filter1Factory.Create(tokenizer);
 
-                var filter2Factory = new TypeAsPayloadTokenFilterFactory(new Dictionary<string, string>());
+                var filter2Factory = new TypeAsPayloadTokenFilterFactory(new JCG.Dictionary<string, string>());
                 var filter2 = filter2Factory.Create(filter1);
 
                 return new TokenStreamComponents(tokenizer, filter2);
@@ -139,11 +140,11 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 var loader = new ClasspathResourceLoader(GetType());
 
-                var tokenizerFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
+                var tokenizerFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", tokenizerModelFile }, { "sentenceModel", sentenceModelFile } });
                 tokenizerFactory.Inform(loader);
                 var tokenizer = tokenizerFactory.Create(reader);
 
-                var tokenFilterFactory = new OpenNLPPOSFilterFactory(new Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
+                var tokenFilterFactory = new OpenNLPPOSFilterFactory(new JCG.Dictionary<string, string> { { "posTaggerModel", posTaggerModelFile } });
                 tokenFilterFactory.Inform(loader);
                 var tokenFilter = tokenFilterFactory.Create(tokenizer);
 

--- a/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPTokenizerFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.OpenNLP/TestOpenNLPTokenizerFactory.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.OpenNlp
 {
@@ -43,7 +44,7 @@ namespace Lucene.Net.Analysis.OpenNlp
         {
             Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldname, reader) =>
             {
-                var tokenizerFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "sentenceModel", "en-test-sent.bin" }, { "tokenizerModel", "en-test-tokenizer.bin" } });
+                var tokenizerFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "sentenceModel", "en-test-sent.bin" }, { "tokenizerModel", "en-test-tokenizer.bin" } });
                 var tokenizer = tokenizerFactory.Create(reader);
                 return new TokenStreamComponents(tokenizer);
             });
@@ -61,7 +62,7 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldname, reader) =>
                 {
-                    var tokenizerFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "tokenizerModel", "en-test-tokenizer.bin" } });
+                    var tokenizerFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "tokenizerModel", "en-test-tokenizer.bin" } });
                     var tokenizer = tokenizerFactory.Create(reader);
                     return new TokenStreamComponents(tokenizer);
                 });
@@ -81,7 +82,7 @@ namespace Lucene.Net.Analysis.OpenNlp
         {
             //Analyzer analyzer2 = Analyzer.NewAnonymous(createComponents: (fieldname, reader) =>
             //{
-            //    var tokenizerFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "sentenceModel", "en-test-sent.bin" } });
+            //    var tokenizerFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "sentenceModel", "en-test-sent.bin" } });
             //    tokenizerFactory.Inform(new ClasspathResourceLoader(GetType()));
             //    var tokenizer = tokenizerFactory.Create(reader);
             //    return new TokenStreamComponents(tokenizer);
@@ -92,7 +93,7 @@ namespace Lucene.Net.Analysis.OpenNlp
             {
                 Analyzer analyzer = Analyzer.NewAnonymous(createComponents: (fieldname, reader) =>
                 {
-                    var tokenizerFactory = new OpenNLPTokenizerFactory(new Dictionary<string, string> { { "sentenceModel", "en-test-sent.bin" } });
+                    var tokenizerFactory = new OpenNLPTokenizerFactory(new JCG.Dictionary<string, string> { { "sentenceModel", "en-test-sent.bin" } });
                     var tokenizer = tokenizerFactory.Create(reader);
                     return new TokenStreamComponents(tokenizer);
                 });
@@ -111,7 +112,7 @@ namespace Lucene.Net.Analysis.OpenNlp
         [Test]
         public void TestClose()
         {
-            IDictionary<String, String> args = new Dictionary<String, String>()
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>()
             {
                 { "sentenceModel", "en-test-sent.bin" },
                 { "tokenizerModel", "en-test-tokenizer.bin" }

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/TestBeiderMorseFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/TestBeiderMorseFilterFactory.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Phonetic
 {
@@ -31,7 +32,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestBasics()
         {
-            BeiderMorseFilterFactory factory = new BeiderMorseFilterFactory(new Dictionary<String, String>());
+            BeiderMorseFilterFactory factory = new BeiderMorseFilterFactory(new JCG.Dictionary<String, String>());
             TokenStream ts = factory.Create(new MockTokenizer(new StringReader("Weinberg"), MockTokenizer.WHITESPACE, false));
             AssertTokenStreamContents(ts,
                 new String[] { "vDnbirk", "vanbirk", "vinbirk", "wDnbirk", "wanbirk", "winbirk" },
@@ -43,7 +44,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestLanguageSet()
         {
-            IDictionary<String, String> args = new Dictionary<string, string>();
+            IDictionary<String, String> args = new JCG.Dictionary<string, string>();
             args["languageSet"] = "polish";
             BeiderMorseFilterFactory factory = new BeiderMorseFilterFactory(args);
             TokenStream ts = factory.Create(new MockTokenizer(new StringReader("Weinberg"), MockTokenizer.WHITESPACE, false));
@@ -57,7 +58,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestOptions()
         {
-            IDictionary<String, String> args = new Dictionary<string, string>();
+            IDictionary<String, String> args = new JCG.Dictionary<string, string>();
             args["nameType"] = "ASHKENAZI";
             args["ruleType"] = "EXACT";
             BeiderMorseFilterFactory factory = new BeiderMorseFilterFactory(args);
@@ -75,7 +76,7 @@ namespace Lucene.Net.Analysis.Phonetic
         {
             try
             {
-                new BeiderMorseFilterFactory(new Dictionary<String, String>() {
+                new BeiderMorseFilterFactory(new JCG.Dictionary<String, String>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/TestDoubleMetaphoneFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/TestDoubleMetaphoneFilterFactory.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Phonetic
 {
@@ -27,7 +28,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestDefaults()
         {
-            DoubleMetaphoneFilterFactory factory = new DoubleMetaphoneFilterFactory(new Dictionary<String, String>());
+            DoubleMetaphoneFilterFactory factory = new DoubleMetaphoneFilterFactory(new JCG.Dictionary<String, String>());
             TokenStream inputStream = new MockTokenizer(new StringReader("international"), MockTokenizer.WHITESPACE, false);
 
             TokenStream filteredStream = factory.Create(inputStream);
@@ -38,7 +39,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestSettingSizeAndInject()
         {
-            IDictionary<string, string> parameters = new Dictionary<string, string>();
+            IDictionary<string, string> parameters = new JCG.Dictionary<string, string>();
             parameters["inject"] = "false";
             parameters["maxCodeLength"] = "8";
             DoubleMetaphoneFilterFactory factory = new DoubleMetaphoneFilterFactory(parameters);
@@ -56,7 +57,7 @@ namespace Lucene.Net.Analysis.Phonetic
         {
             try
             {
-                new DoubleMetaphoneFilterFactory(new Dictionary<String, String>() {
+                new DoubleMetaphoneFilterFactory(new JCG.Dictionary<String, String>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.Phonetic/TestPhoneticFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Phonetic/TestPhoneticFilterFactory.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Phonetic
 {
@@ -33,7 +34,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestFactoryDefaults()
         {
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args[PhoneticFilterFactory.ENCODER] = "Metaphone";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
@@ -44,7 +45,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestInjectFalse()
         {
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args[PhoneticFilterFactory.ENCODER] = "Metaphone";
             args[PhoneticFilterFactory.INJECT] = "false";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
@@ -55,7 +56,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestMaxCodeLength()
         {
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args[PhoneticFilterFactory.ENCODER] = "Metaphone";
             args[PhoneticFilterFactory.MAX_CODE_LENGTH] = "2";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
@@ -71,7 +72,7 @@ namespace Lucene.Net.Analysis.Phonetic
         {
             try
             {
-                new PhoneticFilterFactory(new Dictionary<String, String>());
+                new PhoneticFilterFactory(new JCG.Dictionary<String, String>());
                 fail();
             }
             catch (Exception expected) when (expected.IsIllegalArgumentException())
@@ -84,7 +85,7 @@ namespace Lucene.Net.Analysis.Phonetic
         {
             try
             {
-                IDictionary<String, String> args = new Dictionary<String, String>();
+                IDictionary<String, String> args = new JCG.Dictionary<String, String>();
                 args["encoder"] = "XXX";
                 PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
                 factory.Inform(new ClasspathResourceLoader(factory.GetType()));
@@ -101,7 +102,7 @@ namespace Lucene.Net.Analysis.Phonetic
         {
             try
             {
-                IDictionary<String, String> args = new Dictionary<String, String>();
+                IDictionary<String, String> args = new JCG.Dictionary<String, String>();
                 args["encoder"] = "org.apache.commons.codec.language.NonExistence";
                 PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
                 factory.Inform(new ClasspathResourceLoader(factory.GetType()));
@@ -119,7 +120,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestFactoryReflection()
         {
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args[PhoneticFilterFactory.ENCODER] = "Metaphone";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
@@ -134,7 +135,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestFactoryReflectionCaverphone2()
         {
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args[PhoneticFilterFactory.ENCODER] = "Caverphone2";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
@@ -145,7 +146,7 @@ namespace Lucene.Net.Analysis.Phonetic
         [Test]
         public void TestFactoryReflectionCaverphone()
         {
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args[PhoneticFilterFactory.ENCODER] = "Caverphone";
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);
             factory.Inform(new ClasspathResourceLoader(factory.GetType()));
@@ -200,7 +201,7 @@ namespace Lucene.Net.Analysis.Phonetic
         {
             try
             {
-                new PhoneticFilterFactory(new Dictionary<String, String>() {
+                new PhoneticFilterFactory(new JCG.Dictionary<String, String>() {
                     { "encoder", "Metaphone" },
                     { "bogusArg", "bogusValue" }
                 });
@@ -216,7 +217,7 @@ namespace Lucene.Net.Analysis.Phonetic
             String[] expected)
         {
             Tokenizer tokenizer = new MockTokenizer(new StringReader(input), MockTokenizer.WHITESPACE, false);
-            IDictionary<String, String> args = new Dictionary<String, String>();
+            IDictionary<String, String> args = new JCG.Dictionary<String, String>();
             args["encoder"] = algName;
             args["inject"] = inject;
             PhoneticFilterFactory factory = new PhoneticFilterFactory(args);

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/Hhmm/TestBuildDictionary.cs
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/Hhmm/TestBuildDictionary.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using Assert = Lucene.Net.TestFramework.Assert;
-using JCG = J2N.Collections.Generic;
+//using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
 {

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/Hhmm/TestBuildDictionary.cs
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/Hhmm/TestBuildDictionary.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
 {
@@ -99,7 +100,7 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
 
     //            string bigramInput = @"real/path/analysis-data/bigramdict.dct";
     //            string bigramOutput = @"real/path/analysis-data/custom-dictionary-input/bigramdict.dct";
-    //            var bigramReplacementFrequencies = new Dictionary<string, int>
+    //            var bigramReplacementFrequencies = new JCG.Dictionary<string, int>
     //            {
     //                ["锲而不舍@、"] = 10000,
     //                ["聆听@了"] = 15000,
@@ -111,7 +112,7 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
 
     //            string coreInput = @"real/path/analysis-data/analysis-data/coredict.dct";
     //            string coreOutput = @"real/path/analysis-data/analysis-data/custom-dictionary-input/coredict.dct";
-    //            var coreReplacementFrequencies = new Dictionary<string, int>
+    //            var coreReplacementFrequencies = new JCG.Dictionary<string, int>
     //            {
     //                ["魅力"] = 10000,
     //                ["聆听"] = 15000,

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/TestHMMChineseTokenizerFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/TestHMMChineseTokenizerFactory.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Cn.Smart
 {
@@ -43,7 +44,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
         public void TestSimple()
         {
             TextReader reader = new StringReader("我购买了道具和服装。");
-            TokenizerFactory factory = new HMMChineseTokenizerFactory(new Dictionary<string, string>());
+            TokenizerFactory factory = new HMMChineseTokenizerFactory(new JCG.Dictionary<string, string>());
             Tokenizer tokenizer = factory.Create(reader);
             tokenizer.SetReader(reader);
             // TODO: fix smart chinese to not emit punctuation tokens
@@ -60,7 +61,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
         {
             try
             {
-                new HMMChineseTokenizerFactory(new Dictionary<string, string>() {
+                new HMMChineseTokenizerFactory(new JCG.Dictionary<string, string>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/TestSmartChineseFactories.cs
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/TestSmartChineseFactories.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Cn.Smart
 {
@@ -37,7 +38,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
         {
             TextReader reader = new StringReader("我购买了道具和服装。");
             TokenStream stream = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
-            SmartChineseWordTokenFilterFactory factory = new SmartChineseWordTokenFilterFactory(new Dictionary<string, string>());
+            SmartChineseWordTokenFilterFactory factory = new SmartChineseWordTokenFilterFactory(new JCG.Dictionary<string, string>());
             stream = factory.Create(stream);
             // TODO: fix smart chinese to not emit punctuation tokens
             // at the moment: you have to clean up with WDF, or use the stoplist, etc
@@ -52,9 +53,9 @@ namespace Lucene.Net.Analysis.Cn.Smart
         public void TestTokenizer()
         {
             TextReader reader = new StringReader("我购买了道具和服装。我购买了道具和服装。");
-            SmartChineseSentenceTokenizerFactory tokenizerFactory = new SmartChineseSentenceTokenizerFactory(new Dictionary<string, string>());
+            SmartChineseSentenceTokenizerFactory tokenizerFactory = new SmartChineseSentenceTokenizerFactory(new JCG.Dictionary<string, string>());
             TokenStream stream = tokenizerFactory.Create(reader);
-            SmartChineseWordTokenFilterFactory factory = new SmartChineseWordTokenFilterFactory(new Dictionary<string, string>());
+            SmartChineseWordTokenFilterFactory factory = new SmartChineseWordTokenFilterFactory(new JCG.Dictionary<string, string>());
             stream = factory.Create(stream);
             // TODO: fix smart chinese to not emit punctuation tokens
             // at the moment: you have to clean up with WDF, or use the stoplist, etc
@@ -72,7 +73,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
         {
             try
             {
-                new SmartChineseSentenceTokenizerFactory(new Dictionary<string, string>() {
+                new SmartChineseSentenceTokenizerFactory(new JCG.Dictionary<string, string>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();
@@ -84,7 +85,7 @@ namespace Lucene.Net.Analysis.Cn.Smart
 
             try
             {
-                new SmartChineseWordTokenFilterFactory(new Dictionary<string, string>() {
+                new SmartChineseWordTokenFilterFactory(new JCG.Dictionary<string, string>() {
                     { "bogusArg", "bogusValue" }
                 });
                 fail();

--- a/src/Lucene.Net.Tests.Analysis.Stempel/Stempel/TestStempelPolishStemFilterFactory.cs
+++ b/src/Lucene.Net.Tests.Analysis.Stempel/Stempel/TestStempelPolishStemFilterFactory.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.Stempel
 {
@@ -31,7 +32,7 @@ namespace Lucene.Net.Analysis.Stempel
         public void TestBasics()
         {
             TextReader reader = new StringReader("studenta studenci");
-            StempelPolishStemFilterFactory factory = new StempelPolishStemFilterFactory(new Dictionary<string, string>());
+            StempelPolishStemFilterFactory factory = new StempelPolishStemFilterFactory(new JCG.Dictionary<string, string>());
             TokenStream stream = new MockTokenizer(reader, MockTokenizer.WHITESPACE, false);
             stream = factory.Create(stream);
             AssertTokenStreamContents(stream,
@@ -44,7 +45,7 @@ namespace Lucene.Net.Analysis.Stempel
         {
             try
             {
-                new StempelPolishStemFilterFactory(new Dictionary<string, string>() { { "bogusArg", "bogusValue" } });
+                new StempelPolishStemFilterFactory(new JCG.Dictionary<string, string>() { { "bogusArg", "bogusValue" } });
                 fail();
             }
             catch (Exception expected) when (expected.IsIllegalArgumentException())

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Feeds/DocMakerTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Feeds/DocMakerTest.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -53,7 +54,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
                 docData.Body = ("body");
                 docData.SetDate("date");
                 docData.Title = ("title");
-                Dictionary<string, string> props = new Dictionary<string, string>();
+                JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
                 props["key"] = "value";
                 docData.Props = props;
                 finish = true;
@@ -65,7 +66,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         private void doTestIndexProperties(bool setIndexProps,
             bool indexPropsVal, int numExpectedResults)
         {
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
 
             // Indexing configuration.
             props["analyzer"] = typeof(WhitespaceAnalyzer).AssemblyQualifiedName;
@@ -96,7 +97,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         private Document createTestNormsDocument(bool setNormsProp,
             bool normsPropVal, bool setBodyNormsProp, bool bodyNormsVal)
         {
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
 
             // Indexing configuration.
             props["analyzer"] = typeof(WhitespaceAnalyzer).AssemblyQualifiedName;
@@ -175,7 +176,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             ps.WriteLine("one title\t" + (J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond) + "\tsome content"); // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
             ps.Dispose();
 
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
             props["docs.file"] = f.FullName;
             props["content.source.forever"] = "false";
             Config config = new Config(props);

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Feeds/EnwikiContentSourceTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Feeds/EnwikiContentSourceTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -129,7 +130,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         private EnwikiContentSource createContentSource(String docs, bool forever)
         {
 
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
             props["print.props"] = "false";
             props["content.source.forever"] = forever.ToString();
             Config config = new Config(props);

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Feeds/LineDocSourceTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Feeds/LineDocSourceTest.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Feeds
 {
@@ -95,7 +96,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
         {
             Stream @out = new FileStream(file.FullName, FileMode.Create, FileAccess.Write);
             TextWriter writer = new StreamWriter(@out, StandardCharsets.UTF_8);
-            Dictionary<string, string> p = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> p = new JCG.Dictionary<string, string>();
             foreach (String f in extraFields)
             {
                 p[f] = f;
@@ -120,7 +121,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             PerfRunData runData = null;
             try
             {
-                Dictionary<string, string> props = new Dictionary<string, string>();
+                JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
 
                 // LineDocSource specific settings.
                 props["docs.file"] = file.FullName;

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Feeds/TrecContentSourceTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Feeds/TrecContentSourceTest.cs
@@ -371,7 +371,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Feeds
             using (var stream = GetDataFile("trecdocs.zip"))
                 TestUtil.Unzip(stream, dataDir);
             using TrecContentSource tcs = new TrecContentSource();
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
             props["print.props"] = "false";
             props["content.source.verbose"] = "false";
             props["content.source.excludeIteration"] = "true";

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/AddIndexesTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/AddIndexesTaskTest.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Store;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
 {
@@ -58,7 +59,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
 
         private PerfRunData createPerfRunData()
         {
-            IDictionary<string, string> props = new Dictionary<string, string>();
+            IDictionary<string, string> props = new JCG.Dictionary<string, string>();
             props["writer.version"] = TEST_VERSION_CURRENT.ToString();
             props["print.props"] = "false"; // don't print anything
             props["directory"] = "RAMDirectory";

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/CommitIndexTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/CommitIndexTaskTest.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Benchmarks.ByTask.Utils;
 using Lucene.Net.Index;
 using NUnit.Framework;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
 {
@@ -29,7 +30,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     {
         private PerfRunData createPerfRunData()
         {
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
             props["writer.version"] = TEST_VERSION_CURRENT.ToString();
             props["print.props"] = "false"; // don't print anything
             props["directory"] = "RAMDirectory";

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/CreateIndexTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/CreateIndexTaskTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
 {
@@ -34,7 +35,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
     {
         private PerfRunData createPerfRunData(String infoStreamValue)
         {
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
             // :Post-Release-Update-Version.LUCENE_XY:
 #pragma warning disable 612, 618
             props["writer.version"] = LuceneVersion.LUCENE_47.ToString();

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/PerfTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/PerfTaskTest.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Benchmarks.ByTask.Utils;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Globalization;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
 {
@@ -46,7 +47,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         private PerfRunData createPerfRunData(bool setLogStep, int logStepVal,
             bool setTaskLogStep, int taskLogStepVal)
         {
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
             if (setLogStep)
             {
                 props["log.step"] = logStepVal.ToString(CultureInfo.InvariantCulture);

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/SearchWithSortTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/SearchWithSortTaskTest.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Benchmarks.ByTask.Utils;
 using Lucene.Net.Search;
 using NUnit.Framework;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
 {
@@ -27,7 +28,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         [Test]
         public void TestSetParams_docField()
         {
-            SearchWithSortTask task = new SearchWithSortTask(new PerfRunData(new Config(new Dictionary<string, string>())));
+            SearchWithSortTask task = new SearchWithSortTask(new PerfRunData(new Config(new JCG.Dictionary<string, string>())));
             task.SetParams("doc");
             assertEquals(SortFieldType.DOC, task.Sort.GetSort()[0].Type);
         }

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/WriteEnwikiLineDocTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/WriteEnwikiLineDocTaskTest.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Tasks
 {
@@ -54,7 +55,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
         // LUCENENET specific: changed to use string fileName instead of allocating a FileInfo (#832)
         private PerfRunData createPerfRunData(string fileName, string docMakerName)
         {
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
             props["doc.maker"] = docMakerName;
             props["line.file.out"] = fileName;
             props["directory"] = "RAMDirectory"; // no accidental FS dir.

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/WriteLineDocTaskTest.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Tasks/WriteLineDocTaskTest.cs
@@ -143,7 +143,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Tasks
                                               bool allowEmptyDocs,
                                               String docMakerName)
         {
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
             props["doc.maker"] = docMakerName;
             props["line.file.out"] = file.FullName;
             props["directory"] = "RAMDirectory"; // no accidental FS dir.

--- a/src/Lucene.Net.Tests.Benchmark/ByTask/Utils/TestConfig.cs
+++ b/src/Lucene.Net.Tests.Benchmark/ByTask/Utils/TestConfig.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Benchmarks.ByTask.Utils
 {
@@ -26,7 +27,7 @@ namespace Lucene.Net.Benchmarks.ByTask.Utils
         [Test]
         public void TestAbsolutePathNamesWindows()
         {
-            Dictionary<string, string> props = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> props = new JCG.Dictionary<string, string>();
             props["work.dir1"] = "c:\\temp";
             props["work.dir2"] = "c:/temp";
             Config conf = new Config(props);

--- a/src/Lucene.Net.Tests.Expressions/JS/TestCustomFunctions.cs
+++ b/src/Lucene.Net.Tests.Expressions/JS/TestCustomFunctions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Expressions.JS
 {
@@ -62,7 +63,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestNoArgMethod()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = GetType().GetMethod(nameof(ZeroArgMethod));
             var expr = JavascriptCompiler.Compile("foo()", functions);
             Assert.AreEqual(5, expr.Evaluate(0, null), DELTA);
@@ -74,7 +75,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestOneArgMethod()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = GetType().GetMethod(nameof(OneArgMethod), new[] { typeof(double) });
             var expr = JavascriptCompiler.Compile("foo(3)", functions);
             Assert.AreEqual(6, expr.Evaluate(0, null), DELTA);
@@ -86,7 +87,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestThreeArgMethod()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = GetType().GetMethod(nameof(ThreeArgMethod), new[] { typeof(double), typeof(double), typeof(double) });
             var expr = JavascriptCompiler.Compile("foo(3, 4, 5)", functions);
             Assert.AreEqual(12, expr.Evaluate(0, null), DELTA);
@@ -96,7 +97,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestTwoMethods()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = GetType().GetMethod(nameof(ZeroArgMethod));
             functions["bar"] = GetType().GetMethod(nameof(OneArgMethod), new[] { typeof(double) });
             var expr = JavascriptCompiler.Compile("foo() + bar(3)", functions);
@@ -109,7 +110,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestWrongReturnType()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = GetType().GetMethod(nameof(BogusReturnType));
             try
             {
@@ -128,7 +129,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestWrongParameterType()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = GetType().GetMethod(nameof(BogusParameterType), new[] { typeof(string) });
             try
             {
@@ -147,7 +148,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestWrongNotStatic()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = GetType().GetMethod(nameof(NonStaticMethod));
             try
             {
@@ -166,7 +167,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestWrongNotPublic()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = GetType().GetMethod(nameof(NonPublicMethod), BindingFlags.NonPublic | BindingFlags.Static);
 
             try
@@ -189,7 +190,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestWrongNestedNotPublic()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = typeof(NestedNotPublic).GetMethod(nameof(NestedNotPublic.Method));
             try
             {
@@ -222,7 +223,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestThrowingException()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo"] = typeof(StaticThrowingException).GetMethod(nameof(StaticThrowingException.Method));
             const string source = "3 * foo() / 5";
             var expr = JavascriptCompiler.Compile(source, functions);
@@ -252,7 +253,7 @@ namespace Lucene.Net.Expressions.JS
         [Test]
         public virtual void TestNamespaces()
         {
-            IDictionary<string, MethodInfo> functions = new Dictionary<string, MethodInfo>();
+            IDictionary<string, MethodInfo> functions = new JCG.Dictionary<string, MethodInfo>();
             functions["foo.bar"] = GetType().GetMethod("ZeroArgMethod");
             const string source = "foo.bar()";
             var expr = JavascriptCompiler.Compile(source, functions);

--- a/src/Lucene.Net.Tests.Expressions/TestExpressionValueSource.cs
+++ b/src/Lucene.Net.Tests.Expressions/TestExpressionValueSource.cs
@@ -10,6 +10,7 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Expressions
 {
@@ -94,7 +95,7 @@ namespace Lucene.Net.Expressions
 
             Assert.AreEqual(1, reader.Leaves.Count);
             AtomicReaderContext leaf = reader.Leaves[0];
-            FunctionValues values = vs.GetValues(new Dictionary<string, object>(), leaf);
+            FunctionValues values = vs.GetValues(new JCG.Dictionary<string, object>(), leaf);
 
             Assert.AreEqual(10, values.DoubleVal(0), 0);
             Assert.AreEqual(10, values.SingleVal(0), 0);
@@ -134,7 +135,7 @@ namespace Lucene.Net.Expressions
 
             Assert.AreEqual(1, reader.Leaves.Count);
             AtomicReaderContext leaf = reader.Leaves[0];
-            FunctionValues values = vs.GetValues(new Dictionary<string, object>(), leaf);
+            FunctionValues values = vs.GetValues(new JCG.Dictionary<string, object>(), leaf);
 
             // everything
             ValueSourceScorer scorer = values.GetRangeScorer(leaf.Reader, "4", "40", true, true);

--- a/src/Lucene.Net.Tests.Facet/FacetTestCase.cs
+++ b/src/Lucene.Net.Tests.Facet/FacetTestCase.cs
@@ -214,7 +214,7 @@ namespace Lucene.Net.Facet
         {
             Assert.AreEqual(a.Count, b.Count);
             float lastValue = float.PositiveInfinity;
-            IDictionary<string, FacetResult> aByDim = new Dictionary<string, FacetResult>();
+            IDictionary<string, FacetResult> aByDim = new JCG.Dictionary<string, FacetResult>();
             for (int i = 0; i < a.Count; i++)
             {
                 Assert.IsTrue((float)a[i].Value <= lastValue);
@@ -222,7 +222,7 @@ namespace Lucene.Net.Facet
                 aByDim[a[i].Dim] = a[i];
             }
             lastValue = float.PositiveInfinity;
-            IDictionary<string, FacetResult> bByDim = new Dictionary<string, FacetResult>();
+            IDictionary<string, FacetResult> bByDim = new JCG.Dictionary<string, FacetResult>();
             for (int i = 0; i < b.Count; i++)
             {
                 bByDim[b[i].Dim] = b[i];

--- a/src/Lucene.Net.Tests.Facet/Range/TestRangeFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Range/TestRangeFacetCounts.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet.Range
 {
@@ -330,7 +331,7 @@ namespace Lucene.Net.Facet.Range
                     }
                 }
 
-                IDictionary<string, Facets> byDim = new Dictionary<string, Facets>();
+                IDictionary<string, Facets> byDim = new JCG.Dictionary<string, Facets>();
                 byDim["field"] = new Int64RangeFacetCounts("field", fieldFC,
                     new Int64Range("less than 10", 0L, true, 10L, false),
                     new Int64Range("less than or equal to 10", 0L, true, 10L, true),

--- a/src/Lucene.Net.Tests.Facet/SortedSet/TestSortedSetDocValuesFacets.cs
+++ b/src/Lucene.Net.Tests.Facet/SortedSet/TestSortedSetDocValuesFacets.cs
@@ -329,10 +329,10 @@ namespace Lucene.Net.Facet.SortedSet
                 Facets facets = new SortedSetDocValuesFacetCounts(state, fc);
 
                 // Slow, yet hopefully bug-free, faceting:
-                var expectedCounts = new JCG.List<Dictionary<string, int>>();
+                var expectedCounts = new JCG.List<JCG.Dictionary<string, int>>();
                 for (int i = 0; i < numDims; i++)
                 {
-                    expectedCounts.Add(new Dictionary<string, int>());
+                    expectedCounts.Add(new JCG.Dictionary<string, int>());
                 }
 
                 foreach (TestDoc doc in testDocs)

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/Directory/TestDirectoryTaxonomyWriter.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet.Taxonomy.Directory
 {
@@ -102,7 +103,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             var taxoWriter = new DirectoryTaxonomyWriter(dir, OpenMode.CREATE_OR_APPEND, NO_OP_CACHE);
             taxoWriter.AddCategory(new FacetLabel("a"));
             taxoWriter.AddCategory(new FacetLabel("b"));
-            IDictionary<string, string> userCommitData = new Dictionary<string, string>();
+            IDictionary<string, string> userCommitData = new JCG.Dictionary<string, string>();
             userCommitData["testing"] = "1 2 3";
             taxoWriter.SetCommitData(userCommitData);
             taxoWriter.Dispose();
@@ -118,7 +119,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
             // that the taxonomy index has been recreated.
             taxoWriter = new DirectoryTaxonomyWriter(dir, OpenMode.CREATE_OR_APPEND, NO_OP_CACHE);
             taxoWriter.AddCategory(new FacetLabel("c")); // add a category so that commit will happen
-            taxoWriter.SetCommitData(new Dictionary<string, string>()
+            taxoWriter.SetCommitData(new JCG.Dictionary<string, string>()
             {
                 {"just", "data"}
             });
@@ -192,7 +193,7 @@ namespace Lucene.Net.Facet.Taxonomy.Directory
         private void TouchTaxo(DirectoryTaxonomyWriter taxoWriter, FacetLabel cp)
         {
             taxoWriter.AddCategory(cp);
-            taxoWriter.SetCommitData(new Dictionary<string, string>()
+            taxoWriter.SetCommitData(new JCG.Dictionary<string, string>()
             {
                 {"just", "data"}
             });

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts.cs
@@ -788,10 +788,10 @@ namespace Lucene.Net.Facet.Taxonomy
                 Facets facets = GetTaxonomyFacetCounts(tr, config, fc);
 
                 // Slow, yet hopefully bug-free, faceting:
-                var expectedCounts = new JCG.List<Dictionary<string, int>>();
+                var expectedCounts = new JCG.List<JCG.Dictionary<string, int>>();
                 for (int i = 0; i < numDims; i++)
                 {
-                    expectedCounts.Add(new Dictionary<string, int>());
+                    expectedCounts.Add(new JCG.Dictionary<string, int>());
                 }
 
                 foreach (TestDoc doc in testDocs)

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetCounts2.cs
@@ -221,7 +221,7 @@ namespace Lucene.Net.Facet.Taxonomy
         // initialize expectedCounts w/ 0 for all categories
         private static IDictionary<string, int> newCounts()
         {
-            IDictionary<string, int> counts = new Dictionary<string, int>();
+            IDictionary<string, int> counts = new JCG.Dictionary<string, int>();
             counts[CP_A] = 0;
             counts[CP_B] = 0;
             counts[CP_C] = 0;

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/TestTaxonomyFacetSumValueSource.cs
@@ -527,10 +527,10 @@ namespace Lucene.Net.Facet.Taxonomy
                 Facets facets = new TaxonomyFacetSumValueSource(tr, config, fc, values);
 
                 // Slow, yet hopefully bug-free, faceting:
-                var expectedValues = new JCG.List<Dictionary<string, float>>(numDims);
+                var expectedValues = new JCG.List<JCG.Dictionary<string, float>>(numDims);
                 for (int i = 0; i < numDims; i++)
                 {
-                    expectedValues.Add(new Dictionary<string, float>());
+                    expectedValues.Add(new JCG.Dictionary<string, float>());
                 }
 
                 foreach (TestDoc doc in testDocs)

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCompactLabelToOrdinal.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCompactLabelToOrdinal.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet.Taxonomy.WriterCache
 {
@@ -262,7 +263,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
 
         private class LabelToOrdinalMap : LabelToOrdinal
         {
-            internal IDictionary<FacetLabel, int> map = new Dictionary<FacetLabel, int>();
+            internal IDictionary<FacetLabel, int> map = new JCG.Dictionary<FacetLabel, int>();
 
             internal LabelToOrdinalMap()
             {

--- a/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
+++ b/src/Lucene.Net.Tests.Facet/TestDrillSideways.cs
@@ -785,7 +785,7 @@ namespace Lucene.Net.Facet
                 DrillSidewaysResult actual = ds.Search(ddq, filter, null, numDocs, sort, true, true);
 
                 TopDocs hits = s.Search(baseQuery, numDocs);
-                IDictionary<string, float> scores = new Dictionary<string, float>();
+                IDictionary<string, float> scores = new JCG.Dictionary<string, float>();
                 foreach (ScoreDoc sd in hits.ScoreDocs)
                 {
                     scores[s.Doc(sd.Doc).Get("id")] = sd.Score;
@@ -871,7 +871,7 @@ namespace Lucene.Net.Facet
 
             protected override Facets BuildFacetsResult(FacetsCollector drillDowns, FacetsCollector[] drillSideways, string[] drillSidewaysDims)
             {
-                IDictionary<string, Facets> drillSidewaysFacets = new Dictionary<string, Facets>();
+                IDictionary<string, Facets> drillSidewaysFacets = new JCG.Dictionary<string, Facets>();
                 Facets drillDownFacets = outerInstance.GetTaxonomyFacetCounts(m_taxoReader, m_config, drillDowns);
                 if (drillSideways != null)
                 {
@@ -1103,7 +1103,7 @@ namespace Lucene.Net.Facet
             }
             //nextDocBreak:// Not referenced
 
-            IDictionary<string, int> idToDocID = new Dictionary<string, int>();
+            IDictionary<string, int> idToDocID = new JCG.Dictionary<string, int>();
             for (int i = 0; i < s.IndexReader.MaxDoc; i++)
             {
                 idToDocID[s.Doc(i).Get("id")] = i;
@@ -1169,7 +1169,7 @@ namespace Lucene.Net.Facet
                 }
 
                 int idx = 0;
-                IDictionary<string, int> actualValues = new Dictionary<string, int>();
+                IDictionary<string, int> actualValues = new JCG.Dictionary<string, int>();
 
                 if (fr != null)
                 {

--- a/src/Lucene.Net.Tests.Facet/TestMultipleIndexFields.cs
+++ b/src/Lucene.Net.Tests.Facet/TestMultipleIndexFields.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Facet
 {
@@ -125,7 +126,7 @@ namespace Lucene.Net.Facet
 
             FacetsCollector sfc = PerformSearch(tr, ir, searcher);
 
-            IDictionary<string, Facets> facetsMap = new Dictionary<string, Facets>();
+            IDictionary<string, Facets> facetsMap = new JCG.Dictionary<string, Facets>();
             facetsMap["Author"] = GetTaxonomyFacetCounts(tr, config, sfc, "$author");
             Facets facets = new MultiFacets(facetsMap, GetTaxonomyFacetCounts(tr, config, sfc));
 
@@ -166,7 +167,7 @@ namespace Lucene.Net.Facet
 
             FacetsCollector sfc = PerformSearch(tr, ir, searcher);
 
-            IDictionary<string, Facets> facetsMap = new Dictionary<string, Facets>();
+            IDictionary<string, Facets> facetsMap = new JCG.Dictionary<string, Facets>();
             Facets facets2 = GetTaxonomyFacetCounts(tr, config, sfc, "$music");
             facetsMap["Band"] = facets2;
             facetsMap["Composer"] = facets2;
@@ -223,7 +224,7 @@ namespace Lucene.Net.Facet
 
             FacetsCollector sfc = PerformSearch(tr, ir, searcher);
 
-            IDictionary<string, Facets> facetsMap = new Dictionary<string, Facets>();
+            IDictionary<string, Facets> facetsMap = new JCG.Dictionary<string, Facets>();
             facetsMap["Band"] = GetTaxonomyFacetCounts(tr, config, sfc, "$bands");
             facetsMap["Composer"] = GetTaxonomyFacetCounts(tr, config, sfc, "$composers");
             Facets facets = new MultiFacets(facetsMap, GetTaxonomyFacetCounts(tr, config, sfc));
@@ -266,7 +267,7 @@ namespace Lucene.Net.Facet
 
             FacetsCollector sfc = PerformSearch(tr, ir, searcher);
 
-            IDictionary<string, Facets> facetsMap = new Dictionary<string, Facets>();
+            IDictionary<string, Facets> facetsMap = new JCG.Dictionary<string, Facets>();
             Facets facets2 = GetTaxonomyFacetCounts(tr, config, sfc, "$music");
             facetsMap["Band"] = facets2;
             facetsMap["Composer"] = facets2;

--- a/src/Lucene.Net.Tests.Grouping/GroupFacetCollectorTest.cs
+++ b/src/Lucene.Net.Tests.Grouping/GroupFacetCollectorTest.cs
@@ -604,7 +604,7 @@ namespace Lucene.Net.Search.Grouping
             }));
 
             // LUCENENET NOTE: Need JCG.Dictionary here because of null keys
-            IDictionary<string, JCG.Dictionary<string, ISet<string>>> searchTermToFacetToGroups = new Dictionary<string, JCG.Dictionary<string, ISet<string>>>();
+            IDictionary<string, JCG.Dictionary<string, ISet<string>>> searchTermToFacetToGroups = new JCG.Dictionary<string, JCG.Dictionary<string, ISet<string>>>();
             int facetWithMostGroups = 0;
             for (int i = 0; i < numDocs; i++)
             {

--- a/src/Lucene.Net.Tests.Grouping/TestGrouping.cs
+++ b/src/Lucene.Net.Tests.Grouping/TestGrouping.cs
@@ -1003,7 +1003,7 @@ namespace Lucene.Net.Search.Grouping
                     // ReaderBlocks only increases maxDoc() vs reader, which
                     // means a monotonic shift in scores, so we can
                     // reliably remap them w/ Map:
-                    IDictionary<string, IDictionary<float, J2N.Numerics.Single>> scoreMap = new Dictionary<string, IDictionary<float, J2N.Numerics.Single>>();
+                    IDictionary<string, IDictionary<float, J2N.Numerics.Single>> scoreMap = new JCG.Dictionary<string, IDictionary<float, J2N.Numerics.Single>>();
 
                     // Tricky: must separately set .score2, because the doc
                     // block index was created with possible deletions!
@@ -1011,7 +1011,7 @@ namespace Lucene.Net.Search.Grouping
                     for (int contentID = 0; contentID < 3; contentID++)
                     {
                         //Console.WriteLine("  term=real" + contentID);
-                        IDictionary<float, J2N.Numerics.Single> termScoreMap = new Dictionary<float, J2N.Numerics.Single>();
+                        IDictionary<float, J2N.Numerics.Single> termScoreMap = new JCG.Dictionary<float, J2N.Numerics.Single>();
                         scoreMap["real" + contentID] = termScoreMap;
                         //Console.WriteLine("term=real" + contentID + " dfold=" + s.docFreq(new Term("content", "real"+contentID)) +
                         //" dfnew=" + sBlocks.docFreq(new Term("content", "real"+contentID)));

--- a/src/Lucene.Net.Tests.Join/TestJoinUtil.cs
+++ b/src/Lucene.Net.Tests.Join/TestJoinUtil.cs
@@ -674,7 +674,7 @@ namespace Lucene.Net.Search.Join
                     toField = "from";
                     queryVals = context.ToHitsToJoinScore;
                 }
-                IDictionary<BytesRef, JoinScore> joinValueToJoinScores = new Dictionary<BytesRef, JoinScore>();
+                IDictionary<BytesRef, JoinScore> joinValueToJoinScores = new JCG.Dictionary<BytesRef, JoinScore>();
                 if (multipleValuesPerDocument)
                 {
                     fromSearcher.Search(new TermQuery(new Term("value", uniqueRandomValue)),
@@ -686,7 +686,7 @@ namespace Lucene.Net.Search.Join
                         new CollectorAnonymousClass4(fromField, joinValueToJoinScores));
                 }
 
-                IDictionary<int, JoinScore> docToJoinScore = new Dictionary<int, JoinScore>();
+                IDictionary<int, JoinScore> docToJoinScore = new JCG.Dictionary<int, JoinScore>();
                 if (multipleValuesPerDocument)
                 {
                     if (scoreDocsInOrder)
@@ -1012,20 +1012,20 @@ namespace Lucene.Net.Search.Join
 
             internal string[] RandomUniqueValues { get; set; }
             internal bool[] RandomFrom { get; set; }
-            internal IDictionary<string, IList<RandomDoc>> FromDocuments { get; set; } = new Dictionary<string, IList<RandomDoc>>();
-            internal IDictionary<string, IList<RandomDoc>> ToDocuments { get; set; } = new Dictionary<string, IList<RandomDoc>>();
+            internal IDictionary<string, IList<RandomDoc>> FromDocuments { get; set; } = new JCG.Dictionary<string, IList<RandomDoc>>();
+            internal IDictionary<string, IList<RandomDoc>> ToDocuments { get; set; } = new JCG.Dictionary<string, IList<RandomDoc>>();
 
             internal IDictionary<string, IList<RandomDoc>> RandomValueFromDocs { get; set; } =
-                new Dictionary<string, IList<RandomDoc>>();
+                new JCG.Dictionary<string, IList<RandomDoc>>();
 
             internal IDictionary<string, IList<RandomDoc>> RandomValueToDocs { get; set; } =
-                new Dictionary<string, IList<RandomDoc>>();
+                new JCG.Dictionary<string, IList<RandomDoc>>();
 
             internal IDictionary<string, IDictionary<int, JoinScore>> FromHitsToJoinScore { get; set; } =
-                new Dictionary<string, IDictionary<int, JoinScore>>();
+                new JCG.Dictionary<string, IDictionary<int, JoinScore>>();
 
             internal IDictionary<string, IDictionary<int, JoinScore>> ToHitsToJoinScore { get; set; } =
-                new Dictionary<string, IDictionary<int, JoinScore>>();
+                new JCG.Dictionary<string, IDictionary<int, JoinScore>>();
         }
 
         private class RandomDoc

--- a/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
+++ b/src/Lucene.Net.Tests.Queries/Mlt/TestMoreLikeThis.cs
@@ -9,6 +9,7 @@ using Lucene.Net.Search;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using Directory = Lucene.Net.Store.Directory;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Tests.Queries.Mlt
 {
@@ -103,7 +104,7 @@ namespace Lucene.Net.Tests.Queries.Mlt
 
         private IDictionary<string, float> GetOriginalValues()
         {
-            IDictionary<string, float> originalValues = new Dictionary<string, float>();
+            IDictionary<string, float> originalValues = new JCG.Dictionary<string, float>();
             MoreLikeThis mlt = new MoreLikeThis(reader);
             mlt.Analyzer = new MockAnalyzer(Random, MockTokenizer.WHITESPACE, false);
             mlt.MinDocFreq = 1;

--- a/src/Lucene.Net.Tests.Queries/TermsFilterTest.cs
+++ b/src/Lucene.Net.Tests.Queries/TermsFilterTest.cs
@@ -338,7 +338,7 @@ namespace Lucene.Net.Tests.Queries
         // Source: https://stackoverflow.com/a/32027473
         private static void GenerateHashCollision(out string theString, out string stringWithCollision)
         {
-            var words = new Dictionary<int, string>();
+            var words = new JCG.Dictionary<int, string>();
 
             int i = 0;
             string teststring;

--- a/src/Lucene.Net.Tests.Queries/TestCustomScoreQuery.cs
+++ b/src/Lucene.Net.Tests.Queries/TestCustomScoreQuery.cs
@@ -7,6 +7,7 @@ using Lucene.Net.Queries.Function;
 using Lucene.Net.Search;
 using Lucene.Net.Tests.Queries.Function;
 using NUnit.Framework;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Tests.Queries
 {
@@ -390,7 +391,7 @@ namespace Lucene.Net.Tests.Queries
         /// <returns></returns>
         private IDictionary<int, float> TopDocsToMap(TopDocs td)
         {
-            var h = new Dictionary<int, float>();
+            var h = new JCG.Dictionary<int, float>();
             for (int i = 0; i < td.TotalHits; i++)
             {
                 h[td.ScoreDocs[i].Doc] = td.ScoreDocs[i].Score;

--- a/src/Lucene.Net.Tests.QueryParser/Analyzing/TestAnalyzingQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Analyzing/TestAnalyzingQueryParser.cs
@@ -8,6 +8,7 @@ using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Analyzing
 {
@@ -45,8 +46,8 @@ namespace Lucene.Net.QueryParsers.Analyzing
         private string[] fuzzyInput;
         private string[] fuzzyExpected;
 
-        private IDictionary<string, string> wildcardEscapeHits = new Dictionary<string, string>();
-        private IDictionary<string, string> wildcardEscapeMisses = new Dictionary<string, string>();
+        private IDictionary<string, string> wildcardEscapeHits = new JCG.Dictionary<string, string>();
+        private IDictionary<string, string> wildcardEscapeMisses = new JCG.Dictionary<string, string>();
 
         public override void SetUp()
         {

--- a/src/Lucene.Net.Tests.QueryParser/Classic/TestMultiFieldQueryParser.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Classic/TestMultiFieldQueryParser.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Classic
 {
@@ -130,7 +131,7 @@ namespace Lucene.Net.QueryParsers.Classic
         [Test]
         public virtual void TestBoostsSimple()
         {
-            IDictionary<string, float> boosts = new Dictionary<string, float>();
+            IDictionary<string, float> boosts = new JCG.Dictionary<string, float>();
             boosts["b"] = (float)5;
             boosts["t"] = (float)10;
             string[] fields = { "b", "t" };
@@ -396,7 +397,7 @@ namespace Lucene.Net.QueryParsers.Classic
 
             // Create a boost map that only contains boosts for some fields, not all
             // This tests that the TryGetValue fix prevents KeyNotFoundException
-            var boosts = new Dictionary<string, float>
+            var boosts = new JCG.Dictionary<string, float>
             {
                 { "title", 2.0f },
                 // Intentionally omitting "keyword" and "description" from boost map
@@ -424,7 +425,7 @@ namespace Lucene.Net.QueryParsers.Classic
             MockAnalyzer analyzer = new MockAnalyzer(Random);
 
             // Test 1: Verify boosts are applied to the query string representation
-            var boosts = new Dictionary<string, float>
+            var boosts = new JCG.Dictionary<string, float>
             {
                 { "title", 2.0f },
                 { "keyword", 1.0f }
@@ -439,7 +440,7 @@ namespace Lucene.Net.QueryParsers.Classic
             assertFalse("Keyword field should not have boost notation when boost is 1.0", queryString.Contains("keyword:ldqk^"));
 
             // Test 2: Different boost configuration
-            var boosts2 = new Dictionary<string, float>
+            var boosts2 = new JCG.Dictionary<string, float>
             {
                 { "title", 1.0f },
                 { "keyword", 2.0f }
@@ -474,7 +475,7 @@ namespace Lucene.Net.QueryParsers.Classic
                 IndexSearcher searcher = NewSearcher(ir);
 
                 // Test with equal boosts first (baseline)
-                var equalBoosts = new Dictionary<string, float>
+                var equalBoosts = new JCG.Dictionary<string, float>
                 {
                     { "title", 1.0f },
                     { "keyword", 1.0f }
@@ -492,7 +493,7 @@ namespace Lucene.Net.QueryParsers.Classic
                 }
 
                 // Search with title boosted 2.0
-                var titleBoosts = new Dictionary<string, float>
+                var titleBoosts = new JCG.Dictionary<string, float>
                 {
                     { "title", 2.0f },
                     { "keyword", 1.0f }
@@ -510,7 +511,7 @@ namespace Lucene.Net.QueryParsers.Classic
                 }
 
                 // Search with keyword boosted 2.0
-                var keywordBoosts = new Dictionary<string, float>
+                var keywordBoosts = new JCG.Dictionary<string, float>
                 {
                     { "title", 1.0f },
                     { "keyword", 2.0f }

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestMultiFieldQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestMultiFieldQPHelper.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Flexible.Standard
 {
@@ -143,7 +144,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
         [Test]
         public void TestBoostsSimple()
         {
-            IDictionary<String, float> boosts = new Dictionary<String, float>();
+            IDictionary<String, float> boosts = new JCG.Dictionary<String, float>();
             boosts["b"] = 5;
             boosts["t"] = 10;
             String[] fields = { "b", "t" };

--- a/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Flexible/Standard/TestQPHelper.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Flexible.Standard
 {
@@ -799,7 +800,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard
             String hourField = "hour";
             StandardQueryParser qp = new StandardQueryParser();
 
-            IDictionary<string, DateResolution> dateRes = new Dictionary<string, DateResolution>();
+            IDictionary<string, DateResolution> dateRes = new JCG.Dictionary<string, DateResolution>();
 
             // set a field specific date resolution
             dateRes[monthField] = DateResolution.MONTH;

--- a/src/Lucene.Net.Tests.QueryParser/Xml/TestQueryTemplateManager.cs
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/TestQueryTemplateManager.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.QueryParsers.Xml
 {
@@ -115,7 +116,7 @@ namespace Lucene.Net.QueryParsers.Xml
         //Helper method to construct Lucene query forms used in our test
         IDictionary<string, string> getPropsFromString(String nameValuePairs)
         {
-            IDictionary<string, string> result = new Dictionary<string, string>();
+            IDictionary<string, string> result = new JCG.Dictionary<string, string>();
             StringTokenizer st = new StringTokenizer(nameValuePairs, "\t=");
             while (st.MoveNext())
             {

--- a/src/Lucene.Net.Tests.Replicator/Http/HttpReplicatorTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/Http/HttpReplicatorTest.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Directory = Lucene.Net.Store.Directory;
+using JCG = J2N.Collections.Generic;
 
 #if FEATURE_ASPNETCORE_TESTHOST
 using Microsoft.AspNetCore.TestHost;
@@ -82,7 +83,7 @@ namespace Lucene.Net.Replicator.Http
 
         private void StartServer()
         {
-            ReplicationService service = new ReplicationService(new Dictionary<string, IReplicator> { { "s1", serverReplicator } });
+            ReplicationService service = new ReplicationService(new JCG.Dictionary<string, IReplicator> { { "s1", serverReplicator } });
             server = NewHttpServer(service, mockErrorConfig, useSynchronousIO, useStartupClass);
             port = ServerPort(server);
             host = ServerHost(server);

--- a/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexAndTaxonomyReplicationClientTest.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using Directory = Lucene.Net.Store.Directory;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Replicator
 {
@@ -177,7 +178,7 @@ namespace Lucene.Net.Replicator
         private IRevision CreateRevision(int id)
         {
             publishIndexWriter.AddDocument(NewDocument(publishTaxoWriter, id));
-            publishIndexWriter.SetCommitData(new Dictionary<string, string>{
+            publishIndexWriter.SetCommitData(new JCG.Dictionary<string, string>{
                 { VERSION_ID, id.ToString("X") }
             });
             publishIndexWriter.Commit();

--- a/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/IndexReplicationClientTest.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using Directory = Lucene.Net.Store.Directory;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Replicator
 {
@@ -140,7 +141,7 @@ namespace Lucene.Net.Replicator
         private IRevision CreateRevision(int id)
         {
             publishWriter.AddDocument(new Document());
-            publishWriter.SetCommitData(new Dictionary<string, string>{
+            publishWriter.SetCommitData(new JCG.Dictionary<string, string>{
                 { VERSION_ID, id.ToString("X") }
             });
             publishWriter.Commit();

--- a/src/Lucene.Net.Tests.Replicator/LocalReplicatorTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/LocalReplicatorTest.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Directory = Lucene.Net.Store.Directory;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Replicator
 {
@@ -57,7 +58,7 @@ namespace Lucene.Net.Replicator
         private IRevision CreateRevision(int id)
         {
             sourceWriter.AddDocument(new Document());
-            sourceWriter.SetCommitData(new Dictionary<string, string> {
+            sourceWriter.SetCommitData(new JCG.Dictionary<string, string> {
                 { VERSION_ID, id.ToString() }
             });
             sourceWriter.Commit();

--- a/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
@@ -70,7 +70,7 @@ namespace Lucene.Net.Replicator
         public void TestToString()
         {
             // Create a mock SessionToken with known data
-            Dictionary<string, IList<RevisionFile>> sourceFiles = new Dictionary<string, IList<RevisionFile>>();
+            JCG.Dictionary<string, IList<RevisionFile>> sourceFiles = new JCG.Dictionary<string, IList<RevisionFile>>();
             IList<RevisionFile> files1 = new JCG.List<RevisionFile>
             {
                 new RevisionFile("file1.txt", 100),

--- a/src/Lucene.Net.Tests.Spatial/Prefix/NtsPolygonTest.cs
+++ b/src/Lucene.Net.Tests.Spatial/Prefix/NtsPolygonTest.cs
@@ -9,6 +9,7 @@ using Spatial4n.Context.Nts;
 using Spatial4n.Shapes;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Spatial.Prefix
 {
@@ -37,7 +38,7 @@ namespace Lucene.Net.Spatial.Prefix
         {
             try
             {
-                IDictionary<string, string> args = new Dictionary<string, string>
+                IDictionary<string, string> args = new JCG.Dictionary<string, string>
                 {
                     ["SpatialContextFactory"] = typeof(NtsSpatialContextFactory).FullName
                 };

--- a/src/Lucene.Net.Tests.TestFramework/Configuration/Custom/MockConfigurationFactory.cs
+++ b/src/Lucene.Net.Tests.TestFramework/Configuration/Custom/MockConfigurationFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Configuration.Custom
 {
@@ -34,7 +35,7 @@ namespace Lucene.Net.Configuration.Custom
         public IConfiguration GetConfiguration()
         {
             return new MockConfiguration(wrapped.GetConfiguration(),
-                new Dictionary<string, string>
+                new JCG.Dictionary<string, string>
                 {
                     ["fruit"] = "banana",
                     ["vegetable"] = "lettuce",

--- a/src/Lucene.Net.Tests/Analysis/TestToken.cs
+++ b/src/Lucene.Net.Tests/Analysis/TestToken.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis
 {
@@ -275,7 +276,7 @@ namespace Lucene.Net.Analysis
         public virtual void TestAttributeReflection()
         {
             Token t = new Token("foobar", 6, 22, 8);
-            TestUtil.AssertAttributeReflection(t, new Dictionary<string, object>()
+            TestUtil.AssertAttributeReflection(t, new JCG.Dictionary<string, object>()
             {
                 { nameof(ICharTermAttribute) + "#term", "foobar" },
                 { nameof(ITermToBytesRefAttribute) + "#bytes", new BytesRef("foobar") },

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.TokenAttributes
 {
@@ -152,7 +153,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
         {
             CharTermAttribute t = new CharTermAttribute();
             t.Append("foobar");
-            TestUtil.AssertAttributeReflection(t, new Dictionary<string, object>()
+            TestUtil.AssertAttributeReflection(t, new JCG.Dictionary<string, object>()
             {
                     { nameof(ICharTermAttribute) + "#term", "foobar" },
                     { nameof(ITermToBytesRefAttribute) + "#bytes", new BytesRef("foobar") }

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestSimpleAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestSimpleAttributeImpl.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Support;
 using NUnit.Framework;
 using System.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Analysis.TokenAttributes
 {
@@ -38,7 +39,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
             TestUtil.AssertAttributeReflection(new TypeAttribute(), Collections.SingletonMap(nameof(ITypeAttribute) + "#type", (object)TypeAttribute.DEFAULT_TYPE));
             TestUtil.AssertAttributeReflection(new PayloadAttribute(), Collections.SingletonMap(nameof(IPayloadAttribute) + "#payload", (object)null));
             TestUtil.AssertAttributeReflection(new KeywordAttribute(), Collections.SingletonMap(nameof(IKeywordAttribute) + "#keyword", (object)false));
-            TestUtil.AssertAttributeReflection(new OffsetAttribute(), new Dictionary<string, object>()
+            TestUtil.AssertAttributeReflection(new OffsetAttribute(), new JCG.Dictionary<string, object>()
             {
                 {nameof(IOffsetAttribute) + "#startOffset", 0 },
                 {nameof(IOffsetAttribute) + "#endOffset", 0}

--- a/src/Lucene.Net.Tests/Codecs/Lucene3x/TestSurrogates.cs
+++ b/src/Lucene.Net.Tests/Codecs/Lucene3x/TestSurrogates.cs
@@ -182,7 +182,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         // from there
         private static void DoTestSeekExists(Random r, IList<Term> fieldTerms, IndexReader reader)
         {
-            IDictionary<string, TermsEnum> tes = new Dictionary<string, TermsEnum>();
+            IDictionary<string, TermsEnum> tes = new JCG.Dictionary<string, TermsEnum>();
 
             // Test random seek to existing term, then enum:
             if (Verbose)
@@ -256,7 +256,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         // LUCENENET specific - made static
         private static void DoTestSeekDoesNotExist(Random r, int numField, IList<Term> fieldTerms, Term[] fieldTermsArray, IndexReader reader)
         {
-            IDictionary<string, TermsEnum> tes = new Dictionary<string, TermsEnum>();
+            IDictionary<string, TermsEnum> tes = new JCG.Dictionary<string, TermsEnum>();
 
             if (Verbose)
             {

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility.cs
@@ -225,7 +225,7 @@ namespace Lucene.Net.Index
             JCG.List<string> names = new JCG.List<string>(oldNames.Length + oldSingleSegmentNames.Length);
             names.AddRange(oldNames);
             names.AddRange(oldSingleSegmentNames);
-            oldIndexDirs = new Dictionary<string, Directory>();
+            oldIndexDirs = new JCG.Dictionary<string, Directory>();
             foreach (string name in names)
             {
                 DirectoryInfo dir = CreateTempDir(name);

--- a/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
+++ b/src/Lucene.Net.Tests/Index/TestBackwardsCompatibility3x.cs
@@ -155,7 +155,7 @@ namespace Lucene.Net.Index
             JCG.List<string> names = new JCG.List<string>(oldNames.Length + oldSingleSegmentNames.Length);
             names.AddRange(oldNames);
             names.AddRange(oldSingleSegmentNames);
-            oldIndexDirs = new Dictionary<string, Directory>();
+            oldIndexDirs = new JCG.Dictionary<string, Directory>();
             foreach (string name in names)
             {
                 DirectoryInfo dir = CreateTempDir(name);

--- a/src/Lucene.Net.Tests/Index/TestDeletionPolicy.cs
+++ b/src/Lucene.Net.Tests/Index/TestDeletionPolicy.cs
@@ -253,7 +253,7 @@ namespace Lucene.Net.Index
             mp.NoCFSRatio = 1.0;
             IndexWriter writer = new IndexWriter(dir, conf);
             ExpirationTimeDeletionPolicy policy = (ExpirationTimeDeletionPolicy)writer.Config.IndexDeletionPolicy;
-            IDictionary<string, string> commitData = new Dictionary<string, string>();
+            IDictionary<string, string> commitData = new JCG.Dictionary<string, string>();
             commitData["commitTime"] = Convert.ToString(J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond); // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
             writer.SetCommitData(commitData);
             writer.Commit();
@@ -277,7 +277,7 @@ namespace Lucene.Net.Index
                 {
                     AddDoc(writer);
                 }
-                commitData = new Dictionary<string, string>();
+                commitData = new JCG.Dictionary<string, string>();
                 commitData["commitTime"] = Convert.ToString(J2N.Time.NanoTime() / J2N.Time.MillisecondsPerNanosecond); // LUCENENET: Use NanoTime() rather than CurrentTimeMilliseconds() for more accurate/reliable results
                 writer.SetCommitData(commitData);
                 writer.Commit();

--- a/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
+++ b/src/Lucene.Net.Tests/Index/TestDirectoryReaderReopen.cs
@@ -746,7 +746,7 @@ namespace Lucene.Net.Index
                 Document doc = new Document();
                 doc.Add(NewStringField("id", "" + i, Field.Store.NO));
                 writer.AddDocument(doc);
-                IDictionary<string, string> data = new Dictionary<string, string>();
+                IDictionary<string, string> data = new JCG.Dictionary<string, string>();
                 data["index"] = i + "";
                 writer.SetCommitData(data);
                 writer.Commit();
@@ -754,7 +754,7 @@ namespace Lucene.Net.Index
             for (int i = 0; i < 4; i++)
             {
                 writer.DeleteDocuments(new Term("id", "" + i));
-                IDictionary<string, string> data = new Dictionary<string, string>();
+                IDictionary<string, string> data = new JCG.Dictionary<string, string>();
                 data["index"] = (4 + i) + "";
                 writer.SetCommitData(data);
                 writer.Commit();

--- a/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriter.cs
@@ -2522,7 +2522,7 @@ namespace Lucene.Net.Index
             writer.Commit(); // first commit to complete IW create transaction.
 
             // this should store the commit data, even though no other changes were made
-            writer.SetCommitData(new Dictionary<string, string>() {
+            writer.SetCommitData(new JCG.Dictionary<string, string>() {
                 {"key", "value"}
             });
             writer.Commit();
@@ -2532,11 +2532,11 @@ namespace Lucene.Net.Index
             r.Dispose();
 
             // now check setCommitData and prepareCommit/commit sequence
-            writer.SetCommitData(new Dictionary<string, string>() {
+            writer.SetCommitData(new JCG.Dictionary<string, string>() {
                 {"key", "value1"}
             });
             writer.PrepareCommit();
-            writer.SetCommitData(new Dictionary<string, string>() {
+            writer.SetCommitData(new JCG.Dictionary<string, string>() {
                 {"key", "value2"}
             });
             writer.Commit(); // should commit the first commitData only, per protocol
@@ -2557,9 +2557,9 @@ namespace Lucene.Net.Index
         }
 
         // LUCENENET-specific: backport fix and test from Lucene 9.9.0 (lucene#12626, lucene#12637)
-        private Dictionary<string, string> GetLiveCommitData(IndexWriter writer)
+        private JCG.Dictionary<string, string> GetLiveCommitData(IndexWriter writer)
         {
-            Dictionary<string, string> data = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> data = new JCG.Dictionary<string, string>();
             // LUCENENET UPGRADE TODO: in a post-4.8 port, this should use LiveCommitData
             foreach (var ent in writer.CommitData)
             {
@@ -2574,7 +2574,7 @@ namespace Lucene.Net.Index
         {
             Directory dir = NewDirectory();
             IndexWriter writer = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, null));
-            writer.SetCommitData(new Dictionary<string, string>()
+            writer.SetCommitData(new JCG.Dictionary<string, string>()
             {
                 {"key", "value"}
             });
@@ -2596,7 +2596,7 @@ namespace Lucene.Net.Index
             Directory dir = NewDirectory();
             IndexWriter writer = new IndexWriter(dir, NewSnapshotIndexWriterConfig(TEST_VERSION_CURRENT, null));
             // LUCENENET UPGRADE TODO: in a post-4.8 port, this should use SetLiveCommitData
-            writer.SetCommitData(new Dictionary<string, string>
+            writer.SetCommitData(new JCG.Dictionary<string, string>
             {
                 { "key", "value" },
             });
@@ -2610,7 +2610,7 @@ namespace Lucene.Net.Index
             // Modify the commit data and commit on close so the most recent commit data is different
             writer = new IndexWriter(dir, NewSnapshotIndexWriterConfig(TEST_VERSION_CURRENT, null));
             // LUCENENET UPGRADE TODO: in a post-4.8 port, this should use SetLiveCommitData
-            writer.SetCommitData(new Dictionary<string, string>()
+            writer.SetCommitData(new JCG.Dictionary<string, string>()
             {
                 { "key", "value2" },
             });

--- a/src/Lucene.Net.Tests/Index/TestIndexWriterCommit.cs
+++ b/src/Lucene.Net.Tests/Index/TestIndexWriterCommit.cs
@@ -8,6 +8,7 @@ using RandomizedTesting.Generators;
 using System;
 using System.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -495,7 +496,7 @@ namespace Lucene.Net.Index
             w.AddDocument(doc);
 
             // commit to "first"
-            IDictionary<string, string> commitData = new Dictionary<string, string>();
+            IDictionary<string, string> commitData = new JCG.Dictionary<string, string>();
             commitData["tag"] = "first";
             w.SetCommitData(commitData);
             w.Commit();
@@ -735,7 +736,7 @@ namespace Lucene.Net.Index
             {
                 AddDoc(w);
             }
-            IDictionary<string, string> data = new Dictionary<string, string>();
+            IDictionary<string, string> data = new JCG.Dictionary<string, string>();
             data["label"] = "test1";
             w.SetCommitData(data);
             w.Dispose();

--- a/src/Lucene.Net.Tests/Index/TestMultiFields.cs
+++ b/src/Lucene.Net.Tests/Index/TestMultiFields.cs
@@ -51,7 +51,7 @@ namespace Lucene.Net.Index
                 // we can do this because we use NoMergePolicy (and dont merge to "nothing")
                 w.KeepFullyDeletedSegments = true;
 
-                IDictionary<BytesRef, IList<int>> docs = new Dictionary<BytesRef, IList<int>>();
+                IDictionary<BytesRef, IList<int>> docs = new JCG.Dictionary<BytesRef, IList<int>>();
                 ISet<int?> deleted = new JCG.HashSet<int?>();
                 IList<BytesRef> terms = new JCG.List<BytesRef>();
 

--- a/src/Lucene.Net.Tests/Index/TestPayloads.cs
+++ b/src/Lucene.Net.Tests/Index/TestPayloads.cs
@@ -385,7 +385,7 @@ namespace Lucene.Net.Index
         /// </summary>
         private class PayloadAnalyzer : Analyzer
         {
-            internal readonly IDictionary<string, PayloadData> fieldToData = new Dictionary<string, PayloadData>();
+            internal readonly IDictionary<string, PayloadData> fieldToData = new JCG.Dictionary<string, PayloadData>();
 
             public PayloadAnalyzer()
                 : base(PER_FIELD_REUSE_STRATEGY)

--- a/src/Lucene.Net.Tests/Index/TestPostingsOffsets.cs
+++ b/src/Lucene.Net.Tests/Index/TestPostingsOffsets.cs
@@ -247,7 +247,7 @@ namespace Lucene.Net.Index
         public virtual void TestRandom()
         {
             // token -> docID -> tokens
-            IDictionary<string, IDictionary<int, IList<Token>>> actualTokens = new Dictionary<string, IDictionary<int, IList<Token>>>();
+            IDictionary<string, IDictionary<int, IList<Token>>> actualTokens = new JCG.Dictionary<string, IDictionary<int, IList<Token>>>();
 
             Directory dir = NewDirectory();
             RandomIndexWriter w = new RandomIndexWriter(Random, dir, iwc);
@@ -308,7 +308,7 @@ namespace Lucene.Net.Index
                     Token token = MakeToken(text, posIncr, offset + offIncr, offset + offIncr + tokenOffset);
                     if (!actualTokens.TryGetValue(text, out IDictionary<int, IList<Token>> postingsByDoc))
                     {
-                        actualTokens[text] = postingsByDoc = new Dictionary<int, IList<Token>>();
+                        actualTokens[text] = postingsByDoc = new JCG.Dictionary<int, IList<Token>>();
                     }
                     if (!postingsByDoc.TryGetValue(docCount, out IList<Token> postings))
                     {

--- a/src/Lucene.Net.Tests/Index/TestStressIndexing2.cs
+++ b/src/Lucene.Net.Tests/Index/TestStressIndexing2.cs
@@ -165,7 +165,7 @@ namespace Lucene.Net.Index
 
         public virtual DocsAndWriter IndexRandomIWReader(int nThreads, int iterations, int range, Directory dir)
         {
-            IDictionary<string, Document> docs = new Dictionary<string, Document>();
+            IDictionary<string, Document> docs = new JCG.Dictionary<string, Document>();
             IndexWriter w = RandomIndexWriter.MockIndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
                 .SetOpenMode(OpenMode.CREATE)
                 .SetRAMBufferSizeMB(0.1)
@@ -228,7 +228,7 @@ namespace Lucene.Net.Index
 
         public virtual IDictionary<string, Document> IndexRandom(int nThreads, int iterations, int range, Directory dir, int maxThreadStates, bool doReaderPooling)
         {
-            IDictionary<string, Document> docs = new Dictionary<string, Document>();
+            IDictionary<string, Document> docs = new JCG.Dictionary<string, Document>();
             IndexWriter w = RandomIndexWriter.MockIndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
                 .SetOpenMode(OpenMode.CREATE)
                 .SetRAMBufferSizeMB(0.1)
@@ -812,7 +812,7 @@ namespace Lucene.Net.Index
             internal int @base;
             internal int range;
             internal int iterations;
-            internal IDictionary<string, Document> docs = new Dictionary<string, Document>();
+            internal IDictionary<string, Document> docs = new JCG.Dictionary<string, Document>();
             internal Random r;
 
             public virtual int NextInt(int lim)

--- a/src/Lucene.Net.Tests/Index/TestStressNRT.cs
+++ b/src/Lucene.Net.Tests/Index/TestStressNRT.cs
@@ -50,7 +50,7 @@ namespace Lucene.Net.Index
         private volatile DirectoryReader reader;
 
         private readonly ConcurrentDictionary<int, long> model = new ConcurrentDictionary<int, long>();
-        private IDictionary<int, long> committedModel = new Dictionary<int, long>();
+        private IDictionary<int, long> committedModel = new JCG.Dictionary<int, long>();
         private long snapshotCount;
         private long committedModelClock;
         private volatile int lastId;
@@ -211,7 +211,7 @@ namespace Lucene.Net.Index
                                 UninterruptableMonitor.Enter(outerInstance); // LUCENENET: using UninterruptableMonitor instead of lock/synchronized; see docs for type
                                 try
                                 {
-                                    newCommittedModel = new Dictionary<int, long>(outerInstance.model); // take a snapshot
+                                    newCommittedModel = new JCG.Dictionary<int, long>(outerInstance.model); // take a snapshot
                                     version = outerInstance.snapshotCount++;
                                     oldReader = outerInstance.reader;
                                     oldReader.IncRef(); // increment the reference since we will use this for reopening

--- a/src/Lucene.Net.Tests/Index/TestTermsEnum.cs
+++ b/src/Lucene.Net.Tests/Index/TestTermsEnum.cs
@@ -239,7 +239,7 @@ namespace Lucene.Net.Index
 
             ISet<string> terms = new JCG.HashSet<string>();
             ICollection<string> pendingTerms = new JCG.List<string>();
-            IDictionary<BytesRef, int> termToID = new Dictionary<BytesRef, int>();
+            IDictionary<BytesRef, int> termToID = new JCG.Dictionary<BytesRef, int>();
             int id = 0;
             while (terms.Count != numTerms)
             {

--- a/src/Lucene.Net.Tests/Index/TestTransactionRollback.cs
+++ b/src/Lucene.Net.Tests/Index/TestTransactionRollback.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Assert = Lucene.Net.TestFramework.Assert;
 using BitSet = Lucene.Net.Util.OpenBitSet;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -74,7 +75,7 @@ namespace Lucene.Net.Index
             IndexWriter w = new IndexWriter(dir, NewIndexWriterConfig(TEST_VERSION_CURRENT, new MockAnalyzer(Random))
                 .SetIndexDeletionPolicy(new RollbackDeletionPolicy(id))
                 .SetIndexCommit(last));
-            IDictionary<string, string> data = new Dictionary<string, string>();
+            IDictionary<string, string> data = new JCG.Dictionary<string, string>();
             data["index"] = "Rolled back to 1-" + id.ToString(CultureInfo.InvariantCulture);
             w.SetCommitData(data);
             w.Dispose();
@@ -153,7 +154,7 @@ namespace Lucene.Net.Index
 
                 if (currentRecordId % 10 == 0)
                 {
-                    IDictionary<string, string> data = new Dictionary<string, string>();
+                    IDictionary<string, string> data = new JCG.Dictionary<string, string>();
                     data["index"] = "records 1-" + currentRecordId.ToString(CultureInfo.InvariantCulture);
                     w.SetCommitData(data);
                     w.Commit();

--- a/src/Lucene.Net.Tests/Search/Spans/MultiSpansWrapper.cs
+++ b/src/Lucene.Net.Tests/Search/Spans/MultiSpansWrapper.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Search.Spans
 
         public static Spans Wrap(IndexReaderContext topLevelReaderContext, SpanQuery query)
         {
-            IDictionary<Term, TermContext> termContexts = new Dictionary<Term, TermContext>();
+            IDictionary<Term, TermContext> termContexts = new JCG.Dictionary<Term, TermContext>();
             JCG.SortedSet<Term> terms = new JCG.SortedSet<Term>();
             query.ExtractTerms(terms);
             foreach (Term term in terms)

--- a/src/Lucene.Net.Tests/Search/TestBooleanQueryVisitSubscorers.cs
+++ b/src/Lucene.Net.Tests/Search/TestBooleanQueryVisitSubscorers.cs
@@ -139,7 +139,7 @@ namespace Lucene.Net.Search
             private readonly TopDocsCollector<ScoreDoc> collector;
             private int docBase;
 
-            public IDictionary<int, int> DocCounts { get; } = new Dictionary<int, int>();
+            public IDictionary<int, int> DocCounts { get; } = new JCG.Dictionary<int, int>();
             private readonly ISet<Scorer> tqsSet = new JCG.HashSet<Scorer>();
 
             internal MyCollector()

--- a/src/Lucene.Net.Tests/Search/TestElevationComparator.cs
+++ b/src/Lucene.Net.Tests/Search/TestElevationComparator.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Search
     [TestFixture]
     public class TestElevationComparer : LuceneTestCase
     {
-        private readonly IDictionary<BytesRef, int> priority = new Dictionary<BytesRef, int>();
+        private readonly IDictionary<BytesRef, int> priority = new JCG.Dictionary<BytesRef, int>();
 
         [Test]
         public virtual void TestSorting()

--- a/src/Lucene.Net.Tests/Search/TestLiveFieldValues.cs
+++ b/src/Lucene.Net.Tests/Search/TestLiveFieldValues.cs
@@ -171,7 +171,7 @@ namespace Lucene.Net.Search
             {
                 try
                 {
-                    IDictionary<string, int?> values = new Dictionary<string, int?>();
+                    IDictionary<string, int?> values = new JCG.Dictionary<string, int?>();
                     IList<string> allIDs = new SynchronizedList<string>();
 
                     startingGun.Wait();

--- a/src/Lucene.Net.Tests/Search/TestSameScoresWithThreads.cs
+++ b/src/Lucene.Net.Tests/Search/TestSameScoresWithThreads.cs
@@ -79,7 +79,7 @@ namespace Lucene.Net.Search
             // Target ~10 terms to search:
             double chance = 10.0 / termCount;
             termsEnum = terms.GetEnumerator(termsEnum);
-            IDictionary<BytesRef, TopDocs> answers = new Dictionary<BytesRef, TopDocs>();
+            IDictionary<BytesRef, TopDocs> answers = new JCG.Dictionary<BytesRef, TopDocs>();
             while (termsEnum.MoveNext())
             {
                 if (Random.NextDouble() <= chance)

--- a/src/Lucene.Net.Tests/Search/TestSubScorerFreqs.cs
+++ b/src/Lucene.Net.Tests/Search/TestSubScorerFreqs.cs
@@ -76,9 +76,9 @@ namespace Lucene.Net.Search
             private readonly ICollector other;
             private int docBase;
 
-            public IDictionary<int, IDictionary<Query, float>> DocCounts { get; } = new Dictionary<int, IDictionary<Query, float>>();
+            public IDictionary<int, IDictionary<Query, float>> DocCounts { get; } = new JCG.Dictionary<int, IDictionary<Query, float>>();
 
-            private readonly IDictionary<Query, Scorer> subScorers = new Dictionary<Query, Scorer>();
+            private readonly IDictionary<Query, Scorer> subScorers = new JCG.Dictionary<Query, Scorer>();
             private readonly ISet<string> relationships;
 
             public CountingCollector(ICollector other)
@@ -113,7 +113,7 @@ namespace Lucene.Net.Search
 
             public virtual void Collect(int doc)
             {
-                IDictionary<Query, float> freqs = new Dictionary<Query, float>();
+                IDictionary<Query, float> freqs = new JCG.Dictionary<Query, float>();
                 foreach (KeyValuePair<Query, Scorer> ent in subScorers)
                 {
                     Scorer value = ent.Value;

--- a/src/Lucene.Net.Tests/Store/TestHugeRamFile.cs
+++ b/src/Lucene.Net.Tests/Store/TestHugeRamFile.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Store
 {
@@ -39,7 +40,7 @@ namespace Lucene.Net.Store
         private class DenseRAMFile : RAMFile
         {
             private long capacity = 0;
-            private readonly Dictionary<int, byte[]> singleBuffers = new Dictionary<int, byte[]>();
+            private readonly JCG.Dictionary<int, byte[]> singleBuffers = new JCG.Dictionary<int, byte[]>();
 
             protected override byte[] NewBuffer(int size)
             {

--- a/src/Lucene.Net.Tests/Store/TestLockFactory.cs
+++ b/src/Lucene.Net.Tests/Store/TestLockFactory.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Store
 {
@@ -427,7 +428,7 @@ namespace Lucene.Net.Store
         public class MockLockFactory : LockFactory
         {
             public bool LockPrefixSet;
-            public IDictionary<string, Lock> LocksCreated = /*CollectionsHelper.SynchronizedMap(*/new Dictionary<string, Lock>()/*)*/;
+            public IDictionary<string, Lock> LocksCreated = /*CollectionsHelper.SynchronizedMap(*/new JCG.Dictionary<string, Lock>()/*)*/;
             public int MakeLockCount = 0;
 
             public override string LockPrefix

--- a/src/Lucene.Net.Tests/Util/TestBytesRefHash.cs
+++ b/src/Lucene.Net.Tests/Util/TestBytesRefHash.cs
@@ -106,7 +106,7 @@ namespace Lucene.Net.Util
             int num = AtLeast(2);
             for (int j = 0; j < num; j++)
             {
-                IDictionary<string, int> strings = new Dictionary<string, int>();
+                IDictionary<string, int> strings = new JCG.Dictionary<string, int>();
                 int uniqueCount = 0;
                 for (int i = 0; i < 797; i++)
                 {

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xFields.cs
@@ -66,7 +66,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
         // LUCENENET specific: Use StringComparer.Ordinal to get the same ordering as Java
         internal readonly IDictionary<string, FieldInfo> fields = new JCG.SortedDictionary<string, FieldInfo>(StringComparer.Ordinal);
-        internal readonly IDictionary<string, Terms> preTerms = new Dictionary<string, Terms>();
+        internal readonly IDictionary<string, Terms> preTerms = new JCG.Dictionary<string, Terms>();
         //private readonly Directory dir; // LUCENENET: Never read
         //private readonly IOContext context; // LUCENENET: Never read
         //private Directory cfsReader; // LUCENENET NOTE: cfsReader not used

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xNormsProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xNormsProducer.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Codecs.Lucene3x
         /// Extension of separate norms file. </summary>
         internal const string SEPARATE_NORMS_EXTENSION = "s";
 
-        private readonly IDictionary<string, NormsDocValues> norms = new Dictionary<string, NormsDocValues>();
+        private readonly IDictionary<string, NormsDocValues> norms = new JCG.Dictionary<string, NormsDocValues>();
 
         // any .nrm or .sNN files we have open at any time.
         // TODO: just a list, and double-close() separate norms files?

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xSegmentInfoReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xSegmentInfoReader.cs
@@ -170,7 +170,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             long delGen = input.ReadInt64();
 
             int docStoreOffset = input.ReadInt32();
-            IDictionary<string, string> attributes = new Dictionary<string, string>();
+            IDictionary<string, string> attributes = new JCG.Dictionary<string, string>();
 
             // parse the docstore stuff and shove it into attributes
             string docStoreSegment;
@@ -203,7 +203,7 @@ namespace Lucene.Net.Codecs.Lucene3x
             }
             else
             {
-                normGen = new Dictionary<int, long>();
+                normGen = new JCG.Dictionary<int, long>();
                 for (int j = 0; j < numNormGen; j++)
                 {
                     normGen[j] = input.ReadInt64();

--- a/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene3x/Lucene3xTermVectorsReader.cs
@@ -8,6 +8,7 @@ using IBits = Lucene.Net.Util.IBits;
 using BytesRef = Lucene.Net.Util.BytesRef;
 using CompoundFileDirectory = Lucene.Net.Store.CompoundFileDirectory;
 using Directory = Lucene.Net.Store.Directory;
+using JCG = J2N.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs.Lucene3x
@@ -236,7 +237,7 @@ namespace Lucene.Net.Codecs.Lucene3x
 
             private readonly int[] fieldNumbers;
             private readonly long[] fieldFPs;
-            private readonly IDictionary<int, int> fieldNumberToIndex = new Dictionary<int, int>();
+            private readonly IDictionary<int, int> fieldNumberToIndex = new JCG.Dictionary<int, int>();
 
             public TVFields(Lucene3xTermVectorsReader outerInstance, int docID)
             {

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40DocValuesReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40DocValuesReader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.Lucene40
 {
@@ -58,10 +59,10 @@ namespace Lucene.Net.Codecs.Lucene40
         private const string segmentSuffix = "dv";
 
         // ram instances we have already loaded
-        private readonly IDictionary<int, NumericDocValues> numericInstances = new Dictionary<int, NumericDocValues>();
+        private readonly IDictionary<int, NumericDocValues> numericInstances = new JCG.Dictionary<int, NumericDocValues>();
 
-        private readonly IDictionary<int, BinaryDocValues> binaryInstances = new Dictionary<int, BinaryDocValues>();
-        private readonly IDictionary<int, SortedDocValues> sortedInstances = new Dictionary<int, SortedDocValues>();
+        private readonly IDictionary<int, BinaryDocValues> binaryInstances = new JCG.Dictionary<int, BinaryDocValues>();
+        private readonly IDictionary<int, SortedDocValues> sortedInstances = new JCG.Dictionary<int, SortedDocValues>();
 
         private readonly AtomicInt64 ramBytesUsed;
 

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40FieldInfosReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40FieldInfosReader.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Index;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.Lucene40
 {
@@ -200,7 +201,7 @@ namespace Lucene.Net.Codecs.Lucene40
         }
 
         // mapping of 4.0 types -> 4.2 types
-        internal static readonly IDictionary<LegacyDocValuesType, DocValuesType> mapping = new Dictionary<LegacyDocValuesType, DocValuesType>
+        internal static readonly IDictionary<LegacyDocValuesType, DocValuesType> mapping = new JCG.Dictionary<LegacyDocValuesType, DocValuesType>
         {
             { LegacyDocValuesType.NONE, DocValuesType.NONE },
             { LegacyDocValuesType.VAR_INTS, DocValuesType.NUMERIC },

--- a/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
+++ b/src/Lucene.Net/Codecs/Lucene40/Lucene40TermVectorsReader.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.Lucene40
 {
@@ -243,7 +244,7 @@ namespace Lucene.Net.Codecs.Lucene40
 
             private readonly int[] fieldNumbers;
             private readonly long[] fieldFPs;
-            private readonly IDictionary<int, int> fieldNumberToIndex = new Dictionary<int, int>();
+            private readonly IDictionary<int, int> fieldNumberToIndex = new JCG.Dictionary<int, int>();
 
             public TVFields(Lucene40TermVectorsReader outerInstance, int docID)
             {

--- a/src/Lucene.Net/Codecs/Lucene42/Lucene42DocValuesProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene42/Lucene42DocValuesProducer.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Int64 = J2N.Numerics.Int64;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.Lucene42
 {
@@ -70,10 +71,10 @@ namespace Lucene.Net.Codecs.Lucene42
         private readonly int version;
 
         // ram instances we have already loaded
-        private readonly IDictionary<int, NumericDocValues> numericInstances = new Dictionary<int, NumericDocValues>();
+        private readonly IDictionary<int, NumericDocValues> numericInstances = new JCG.Dictionary<int, NumericDocValues>();
 
-        private readonly IDictionary<int, BinaryDocValues> binaryInstances = new Dictionary<int, BinaryDocValues>();
-        private readonly IDictionary<int, FST<Int64>> fstInstances = new Dictionary<int, FST<Int64>>();
+        private readonly IDictionary<int, BinaryDocValues> binaryInstances = new JCG.Dictionary<int, BinaryDocValues>();
+        private readonly IDictionary<int, FST<Int64>> fstInstances = new JCG.Dictionary<int, FST<Int64>>();
 
         private readonly int maxDoc;
         private readonly AtomicInt64 ramBytesUsed;
@@ -105,9 +106,9 @@ namespace Lucene.Net.Codecs.Lucene42
             try
             {
                 version = CodecUtil.CheckHeader(@in, metaCodec, VERSION_START, VERSION_CURRENT);
-                numerics = new Dictionary<int, NumericEntry>();
-                binaries = new Dictionary<int, BinaryEntry>();
-                fsts = new Dictionary<int, FSTEntry>();
+                numerics = new JCG.Dictionary<int, NumericEntry>();
+                binaries = new JCG.Dictionary<int, BinaryEntry>();
+                fsts = new JCG.Dictionary<int, FSTEntry>();
                 ReadFields(@in /*, state.FieldInfos // LUCENENET: Never read */);
 
                 if (version >= VERSION_CHECKSUM)

--- a/src/Lucene.Net/Codecs/Lucene42/Lucene42NormsConsumer.cs
+++ b/src/Lucene.Net/Codecs/Lucene42/Lucene42NormsConsumer.cs
@@ -149,7 +149,7 @@ namespace Lucene.Net.Codecs.Lucene42
                     meta.WriteByte((byte)TABLE_COMPRESSED); // table-compressed
                     var decode = new long[uniqueValues.Count];
                     uniqueValues.CopyTo(decode);
-                    var encode = new Dictionary<long, int>();
+                    var encode = new JCG.Dictionary<long, int>();
                     data.WriteVInt32(decode.Length);
                     for (int i = 0; i < decode.Length; i++)
                     {

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesConsumer.cs
@@ -242,7 +242,7 @@ namespace Lucene.Net.Codecs.Lucene45
                     // LUCENENET NOTE: diming an array and then using .CopyTo() for better efficiency than LINQ .ToArray()
                     long[] decode = new long[uniqueValues.Count];
                     uniqueValues.CopyTo(decode, 0);
-                    Dictionary<long, int> encode = new Dictionary<long, int>();
+                    JCG.Dictionary<long, int> encode = new JCG.Dictionary<long, int>();
                     meta.WriteVInt32(decode.Length);
                     for (int i = 0; i < decode.Length; i++)
                     {

--- a/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesProducer.cs
+++ b/src/Lucene.Net/Codecs/Lucene45/Lucene45DocValuesProducer.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Codecs.Lucene45
 {
@@ -65,9 +66,9 @@ namespace Lucene.Net.Codecs.Lucene45
         private readonly int version;
 
         // memory-resident structures
-        private readonly IDictionary<int, MonotonicBlockPackedReader> addressInstances = new Dictionary<int, MonotonicBlockPackedReader>();
+        private readonly IDictionary<int, MonotonicBlockPackedReader> addressInstances = new JCG.Dictionary<int, MonotonicBlockPackedReader>();
 
-        private readonly IDictionary<int, MonotonicBlockPackedReader> ordIndexInstances = new Dictionary<int, MonotonicBlockPackedReader>();
+        private readonly IDictionary<int, MonotonicBlockPackedReader> ordIndexInstances = new JCG.Dictionary<int, MonotonicBlockPackedReader>();
 
         /// <summary>
         /// Expert: instantiates a new reader. </summary>
@@ -81,11 +82,11 @@ namespace Lucene.Net.Codecs.Lucene45
             try
             {
                 version = CodecUtil.CheckHeader(@in, metaCodec, Lucene45DocValuesFormat.VERSION_START, Lucene45DocValuesFormat.VERSION_CURRENT);
-                numerics = new Dictionary<int, NumericEntry>();
-                ords = new Dictionary<int, NumericEntry>();
-                ordIndexes = new Dictionary<int, NumericEntry>();
-                binaries = new Dictionary<int, BinaryEntry>();
-                sortedSets = new Dictionary<int, SortedSetEntry>();
+                numerics = new JCG.Dictionary<int, NumericEntry>();
+                ords = new JCG.Dictionary<int, NumericEntry>();
+                ordIndexes = new JCG.Dictionary<int, NumericEntry>();
+                binaries = new JCG.Dictionary<int, BinaryEntry>();
+                sortedSets = new JCG.Dictionary<int, SortedSetEntry>();
                 ReadFields(@in /*, state.FieldInfos // LUCENENET: Not read */);
 
                 if (version >= Lucene45DocValuesFormat.VERSION_CHECKSUM)

--- a/src/Lucene.Net/Codecs/PerField/PerFieldDocValuesFormat.cs
+++ b/src/Lucene.Net/Codecs/PerField/PerFieldDocValuesFormat.cs
@@ -111,8 +111,8 @@ namespace Lucene.Net.Codecs.PerField
         {
             private readonly PerFieldDocValuesFormat outerInstance;
 
-            internal readonly IDictionary<DocValuesFormat, ConsumerAndSuffix> formats = new Dictionary<DocValuesFormat, ConsumerAndSuffix>();
-            internal readonly IDictionary<string, int?> suffixes = new Dictionary<string, int?>();
+            internal readonly IDictionary<DocValuesFormat, ConsumerAndSuffix> formats = new JCG.Dictionary<DocValuesFormat, ConsumerAndSuffix>();
+            internal readonly IDictionary<string, int?> suffixes = new JCG.Dictionary<string, int?>();
 
             internal readonly SegmentWriteState segmentWriteState;
 
@@ -260,7 +260,7 @@ namespace Lucene.Net.Codecs.PerField
 
             // LUCENENET specific: Use StringComparer.Ordinal to get the same ordering as Java
             internal readonly IDictionary<string, DocValuesProducer> fields = new JCG.SortedDictionary<string, DocValuesProducer>(StringComparer.Ordinal);
-            internal readonly IDictionary<string, DocValuesProducer> formats = new Dictionary<string, DocValuesProducer>();
+            internal readonly IDictionary<string, DocValuesProducer> formats = new JCG.Dictionary<string, DocValuesProducer>();
 
             public FieldsReader(PerFieldDocValuesFormat outerInstance, SegmentReadState readState)
             {

--- a/src/Lucene.Net/Codecs/PerField/PerFieldPostingsFormat.cs
+++ b/src/Lucene.Net/Codecs/PerField/PerFieldPostingsFormat.cs
@@ -106,8 +106,8 @@ namespace Lucene.Net.Codecs.PerField
         {
             private readonly PerFieldPostingsFormat outerInstance;
 
-            internal readonly IDictionary<PostingsFormat, FieldsConsumerAndSuffix> formats = new Dictionary<PostingsFormat, FieldsConsumerAndSuffix>();
-            internal readonly IDictionary<string, int> suffixes = new Dictionary<string, int>();
+            internal readonly IDictionary<PostingsFormat, FieldsConsumerAndSuffix> formats = new JCG.Dictionary<PostingsFormat, FieldsConsumerAndSuffix>();
+            internal readonly IDictionary<string, int> suffixes = new JCG.Dictionary<string, int>();
 
             internal readonly SegmentWriteState segmentWriteState;
 
@@ -209,7 +209,7 @@ namespace Lucene.Net.Codecs.PerField
         {
             // LUCENENET specific: Use StringComparer.Ordinal to get the same ordering as Java
             internal readonly IDictionary<string, FieldsProducer> fields = new JCG.SortedDictionary<string, FieldsProducer>(StringComparer.Ordinal);
-            internal readonly IDictionary<string, FieldsProducer> formats = new Dictionary<string, FieldsProducer>();
+            internal readonly IDictionary<string, FieldsProducer> formats = new JCG.Dictionary<string, FieldsProducer>();
 
             public FieldsReader(SegmentReadState readState)
             {

--- a/src/Lucene.Net/Index/BufferedUpdates.cs
+++ b/src/Lucene.Net/Index/BufferedUpdates.cs
@@ -118,8 +118,8 @@ namespace Lucene.Net.Index
         internal readonly AtomicInt32 numTermDeletes = new AtomicInt32();
         internal readonly AtomicInt32 numNumericUpdates = new AtomicInt32();
         internal readonly AtomicInt32 numBinaryUpdates = new AtomicInt32();
-        internal readonly SCG.IDictionary<Term, int> terms = new Dictionary<Term, int>();
-        internal readonly SCG.IDictionary<Query, int> queries = new Dictionary<Query, int>();
+        internal readonly SCG.IDictionary<Term, int> terms = new JCG.Dictionary<Term, int>();
+        internal readonly SCG.IDictionary<Query, int> queries = new JCG.Dictionary<Query, int>();
         internal readonly SCG.IList<int> docIDs = new JCG.List<int>();
 
 
@@ -131,7 +131,7 @@ namespace Lucene.Net.Index
         // used to update the same field multiple times (so we later traverse it
         // only once).
         // LUCENENET specific: OrderedDictionary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
-        internal readonly SCG.IDictionary<string, OrderedDictionary<Term, NumericDocValuesUpdate>> numericUpdates = new Dictionary<string, OrderedDictionary<Term, NumericDocValuesUpdate>>();
+        internal readonly SCG.IDictionary<string, OrderedDictionary<Term, NumericDocValuesUpdate>> numericUpdates = new JCG.Dictionary<string, OrderedDictionary<Term, NumericDocValuesUpdate>>();
 
         // Map<dvField,Map<updateTerm,BinaryUpdate>>
         // For each field we keep an ordered list of BinaryUpdates, key'd by the
@@ -141,7 +141,7 @@ namespace Lucene.Net.Index
         // used to update the same field multiple times (so we later traverse it
         // only once).
         // LUCENENET specific: OrderedDictionary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
-        internal readonly SCG.IDictionary<string, OrderedDictionary<Term, BinaryDocValuesUpdate>> binaryUpdates = new Dictionary<string, OrderedDictionary<Term, BinaryDocValuesUpdate>>();
+        internal readonly SCG.IDictionary<string, OrderedDictionary<Term, BinaryDocValuesUpdate>> binaryUpdates = new JCG.Dictionary<string, OrderedDictionary<Term, BinaryDocValuesUpdate>>();
 
         /// <summary>
         /// NOTE: This was MAX_INT in Lucene

--- a/src/Lucene.Net/Index/CheckIndex.cs
+++ b/src/Lucene.Net/Index/CheckIndex.cs
@@ -1436,7 +1436,7 @@ namespace Lucene.Net.Index
                         if (Debugging.AssertsEnabled) Debugging.Assert(stats != null);
                         if (status.BlockTreeStats is null)
                         {
-                            status.BlockTreeStats = new Dictionary<string, BlockTreeTermsReader.Stats>();
+                            status.BlockTreeStats = new JCG.Dictionary<string, BlockTreeTermsReader.Stats>();
                         }
                         status.BlockTreeStats[field] = stats;
                     }

--- a/src/Lucene.Net/Index/CoalescedUpdates.cs
+++ b/src/Lucene.Net/Index/CoalescedUpdates.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Index
 
     internal class CoalescedUpdates
     {
-        internal readonly IDictionary<Query, int> queries = new Dictionary<Query, int>();
+        internal readonly IDictionary<Query, int> queries = new JCG.Dictionary<Query, int>();
         internal readonly IList<IEnumerable<Term>> iterables = new JCG.List<IEnumerable<Term>>();
         internal readonly IList<NumericDocValuesUpdate> numericDVUpdates = new JCG.List<NumericDocValuesUpdate>();
         internal readonly IList<BinaryDocValuesUpdate> binaryDVUpdates = new JCG.List<BinaryDocValuesUpdate>();

--- a/src/Lucene.Net/Index/DocFieldProcessor.cs
+++ b/src/Lucene.Net/Index/DocFieldProcessor.cs
@@ -74,7 +74,7 @@ namespace Lucene.Net.Index
         [MethodImpl(MethodImplOptions.NoInlining)] // Stack trace needed intact in TestIndexWriterWithThreads
         public override void Flush(SegmentWriteState state)
         {
-            IDictionary<string, DocFieldConsumerPerField> childFields = new Dictionary<string, DocFieldConsumerPerField>();
+            IDictionary<string, DocFieldConsumerPerField> childFields = new JCG.Dictionary<string, DocFieldConsumerPerField>();
             ICollection<DocFieldConsumerPerField> fields = Fields();
             foreach (DocFieldConsumerPerField f in fields)
             {

--- a/src/Lucene.Net/Index/DocInverter.cs
+++ b/src/Lucene.Net/Index/DocInverter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -40,8 +41,8 @@ namespace Lucene.Net.Index
 
         internal override void Flush(IDictionary<string, DocFieldConsumerPerField> fieldsToFlush, SegmentWriteState state)
         {
-            IDictionary<string, InvertedDocConsumerPerField> childFieldsToFlush = new Dictionary<string, InvertedDocConsumerPerField>();
-            IDictionary<string, InvertedDocEndConsumerPerField> endChildFieldsToFlush = new Dictionary<string, InvertedDocEndConsumerPerField>();
+            IDictionary<string, InvertedDocConsumerPerField> childFieldsToFlush = new JCG.Dictionary<string, InvertedDocConsumerPerField>();
+            IDictionary<string, InvertedDocEndConsumerPerField> endChildFieldsToFlush = new JCG.Dictionary<string, InvertedDocEndConsumerPerField>();
 
             foreach (KeyValuePair<string, DocFieldConsumerPerField> fieldToFlush in fieldsToFlush)
             {

--- a/src/Lucene.Net/Index/DocValuesFieldUpdates.cs
+++ b/src/Lucene.Net/Index/DocValuesFieldUpdates.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -34,8 +35,8 @@ namespace Lucene.Net.Index
 
         public class Container
         {
-            internal readonly IDictionary<string, NumericDocValuesFieldUpdates> numericDVUpdates = new Dictionary<string, NumericDocValuesFieldUpdates>();
-            internal readonly IDictionary<string, BinaryDocValuesFieldUpdates> binaryDVUpdates = new Dictionary<string, BinaryDocValuesFieldUpdates>();
+            internal readonly IDictionary<string, NumericDocValuesFieldUpdates> numericDVUpdates = new JCG.Dictionary<string, NumericDocValuesFieldUpdates>();
+            internal readonly IDictionary<string, BinaryDocValuesFieldUpdates> binaryDVUpdates = new JCG.Dictionary<string, BinaryDocValuesFieldUpdates>();
 
             internal virtual bool Any()
             {

--- a/src/Lucene.Net/Index/DocValuesProcessor.cs
+++ b/src/Lucene.Net/Index/DocValuesProcessor.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Documents;
 using Lucene.Net.Documents.Extensions;
 using System;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -34,7 +35,7 @@ namespace Lucene.Net.Index
         // TODO: somewhat wasteful we also keep a map here; would
         // be more efficient if we could "reuse" the map/hash
         // lookup DocFieldProcessor already did "above"
-        private readonly IDictionary<string, DocValuesWriter> writers = new Dictionary<string, DocValuesWriter>();
+        private readonly IDictionary<string, DocValuesWriter> writers = new JCG.Dictionary<string, DocValuesWriter>();
 
         private readonly Counter bytesUsed;
 

--- a/src/Lucene.Net/Index/FieldInfo.cs
+++ b/src/Lucene.Net/Index/FieldInfo.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -288,7 +289,7 @@ namespace Lucene.Net.Index
         {
             if (attributes is null)
             {
-                attributes = new Dictionary<string, string>();
+                attributes = new JCG.Dictionary<string, string>();
             }
 
             // The key was not previously assigned, null will be returned

--- a/src/Lucene.Net/Index/FieldInfos.cs
+++ b/src/Lucene.Net/Index/FieldInfos.cs
@@ -199,9 +199,9 @@ namespace Lucene.Net.Index
 
             internal FieldNumbers()
             {
-                this.nameToNumber = new Dictionary<string, int>();
-                this.numberToName = new Dictionary<int, string>();
-                this.docValuesType = new Dictionary<string, DocValuesType>();
+                this.nameToNumber = new JCG.Dictionary<string, int>();
+                this.numberToName = new JCG.Dictionary<int, string>();
+                this.docValuesType = new JCG.Dictionary<string, DocValuesType>();
             }
 
             /// <summary>
@@ -337,7 +337,7 @@ namespace Lucene.Net.Index
 
         internal sealed class Builder
         {
-            private readonly Dictionary<string, FieldInfo> byName = new Dictionary<string, FieldInfo>();
+            private readonly JCG.Dictionary<string, FieldInfo> byName = new JCG.Dictionary<string, FieldInfo>();
             private readonly FieldNumbers globalFieldNumbers;
 
             internal Builder()

--- a/src/Lucene.Net/Index/IndexFileDeleter.cs
+++ b/src/Lucene.Net/Index/IndexFileDeleter.cs
@@ -80,7 +80,7 @@ namespace Lucene.Net.Index
         /// Reference count for all files in the index.
         /// Counts how many existing commits reference a file.
         /// </summary>
-        private readonly IDictionary<string, RefCount> refCounts = new Dictionary<string, RefCount>(); // LUCENENET: marked readonly
+        private readonly IDictionary<string, RefCount> refCounts = new JCG.Dictionary<string, RefCount>(); // LUCENENET: marked readonly
 
         /// <summary>
         /// Holds all commits (segments_N) currently in the index.

--- a/src/Lucene.Net/Index/IndexWriter.cs
+++ b/src/Lucene.Net/Index/IndexWriter.cs
@@ -247,7 +247,7 @@ namespace Lucene.Net.Index
         internal readonly IndexFileDeleter deleter;
 
         // used by forceMerge to note those needing merging
-        private readonly IDictionary<SegmentCommitInfo, bool> segmentsToMerge = new Dictionary<SegmentCommitInfo, bool>();
+        private readonly IDictionary<SegmentCommitInfo, bool> segmentsToMerge = new JCG.Dictionary<SegmentCommitInfo, bool>();
 
         private int mergeMaxNumSegments;
 
@@ -3375,7 +3375,7 @@ namespace Lucene.Net.Index
                         SegmentInfos sis = new SegmentInfos(); // read infos from dir
                         sis.Read(dir);
                         JCG.HashSet<string> dsFilesCopied = new JCG.HashSet<string>();
-                        IDictionary<string, string> dsNames = new Dictionary<string, string>();
+                        IDictionary<string, string> dsNames = new JCG.Dictionary<string, string>();
                         JCG.HashSet<string> copiedFiles = new JCG.HashSet<string>();
                         foreach (SegmentCommitInfo info in sis.Segments)
                         {
@@ -3706,11 +3706,11 @@ namespace Lucene.Net.Index
 #pragma warning disable CS0618 // Type or member is obsolete
             if (info.Info.Attributes is null)
             {
-                attributes = new Dictionary<string, string>();
+                attributes = new JCG.Dictionary<string, string>();
             }
             else
             {
-                attributes = new Dictionary<string, string>(info.Info.Attributes);
+                attributes = new JCG.Dictionary<string, string>(info.Info.Attributes);
             }
 #pragma warning restore CS0618 // Type or member is obsolete
             if (docStoreFiles3xOnly != null)
@@ -4027,7 +4027,7 @@ namespace Lucene.Net.Index
             UninterruptableMonitor.Enter(this);
             try
             {
-                segmentInfos.UserData = new Dictionary<string, string>(commitUserData);
+                segmentInfos.UserData = new JCG.Dictionary<string, string>(commitUserData);
                 _ = changeCount.IncrementAndGet();
             }
             finally
@@ -5259,7 +5259,7 @@ namespace Lucene.Net.Index
                 // names.
                 string mergeSegmentName = NewSegmentName();
                 SegmentInfo si = new SegmentInfo(directory, Constants.LUCENE_MAIN_VERSION, mergeSegmentName, -1, false, codec, null);
-                IDictionary<string, string> details = new Dictionary<string, string>
+                IDictionary<string, string> details = new JCG.Dictionary<string, string>
                 {
                     ["mergeMaxNumSegments"] = "" + merge.MaxNumSegments,
                     ["mergeFactor"] = Convert.ToString(merge.Segments.Count)
@@ -5290,7 +5290,7 @@ namespace Lucene.Net.Index
 
         private static void SetDiagnostics(SegmentInfo info, string source, IDictionary<string, string> details)
         {
-            IDictionary<string, string> diagnostics = new Dictionary<string, string>
+            IDictionary<string, string> diagnostics = new JCG.Dictionary<string, string>
             {
                 ["source"] = source,
                 ["lucene.version"] = Constants.LUCENE_VERSION,
@@ -5932,7 +5932,7 @@ namespace Lucene.Net.Index
             try
             {
                 SegmentInfos newSIS = new SegmentInfos();
-                IDictionary<SegmentCommitInfo, SegmentCommitInfo> liveSIS = new Dictionary<SegmentCommitInfo, SegmentCommitInfo>();
+                IDictionary<SegmentCommitInfo, SegmentCommitInfo> liveSIS = new JCG.Dictionary<SegmentCommitInfo, SegmentCommitInfo>();
                 foreach (SegmentCommitInfo info in segmentInfos.Segments)
                 {
                     liveSIS[info] = info;

--- a/src/Lucene.Net/Index/PersistentSnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net/Index/PersistentSnapshotDeletionPolicy.cs
@@ -338,7 +338,7 @@ namespace Lucene.Net.Index
                         if (genLoaded == -1 || gen > genLoaded)
                         {
                             snapshotFiles.Add(file);
-                            IDictionary<long, int> m = new Dictionary<long, int>();
+                            IDictionary<long, int> m = new JCG.Dictionary<long, int>();
                             IndexInput @in = dir.OpenInput(file, IOContext.DEFAULT);
                             try
                             {

--- a/src/Lucene.Net/Index/ReadersAndUpdates.cs
+++ b/src/Lucene.Net/Index/ReadersAndUpdates.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -95,7 +96,7 @@ namespace Lucene.Net.Index
         // updates on the merged segment too.
         private bool isMerging = false;
 
-        private readonly IDictionary<string, DocValuesFieldUpdates> mergingDVUpdates = new Dictionary<string, DocValuesFieldUpdates>();
+        private readonly IDictionary<string, DocValuesFieldUpdates> mergingDVUpdates = new JCG.Dictionary<string, DocValuesFieldUpdates>();
 
         public ReadersAndUpdates(IndexWriter writer, SegmentCommitInfo info)
         {
@@ -696,7 +697,7 @@ namespace Lucene.Net.Index
 
                 // create a new map, keeping only the gens that are in use
                 IDictionary<long, ISet<string>> genUpdatesFiles = Info.UpdatesFiles;
-                IDictionary<long, ISet<string>> newGenUpdatesFiles = new Dictionary<long, ISet<string>>();
+                IDictionary<long, ISet<string>> newGenUpdatesFiles = new JCG.Dictionary<long, ISet<string>>();
                 long fieldInfosGen = Info.FieldInfosGen;
                 foreach (FieldInfo fi in fieldInfos)
                 {

--- a/src/Lucene.Net/Index/SegmentCommitInfo.cs
+++ b/src/Lucene.Net/Index/SegmentCommitInfo.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Index
         private long nextWriteFieldInfosGen;
 
         // Track the per-generation updates files
-        private readonly IDictionary<long, ISet<string>> genUpdatesFiles = new Dictionary<long, ISet<string>>();
+        private readonly IDictionary<long, ISet<string>> genUpdatesFiles = new JCG.Dictionary<long, ISet<string>>();
 
         private readonly AtomicInt64 sizeInBytes = new AtomicInt64(-1L); // LUCENENET NOTE: This was volatile in the original, using AtomicInt64 instead
 

--- a/src/Lucene.Net/Index/SegmentCoreReaders.cs
+++ b/src/Lucene.Net/Index/SegmentCoreReaders.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Index
         internal readonly DisposableThreadLocal<StoredFieldsReader> fieldsReaderLocal;
         internal readonly DisposableThreadLocal<TermVectorsReader> termVectorsLocal;
         internal readonly DisposableThreadLocal<IDictionary<string, object>> normsLocal =
-            new DisposableThreadLocal<IDictionary<string, object>>(() => new Dictionary<string, object>());
+            new DisposableThreadLocal<IDictionary<string, object>>(() => new JCG.Dictionary<string, object>());
         private readonly ISet<ICoreDisposedListener> coreClosedListeners = new JCG.LinkedHashSet<ICoreDisposedListener>().AsConcurrent();
 
         internal SegmentCoreReaders(SegmentReader owner, Directory dir, SegmentCommitInfo si, IOContext context, int termsIndexDivisor)

--- a/src/Lucene.Net/Index/SegmentDocValues.cs
+++ b/src/Lucene.Net/Index/SegmentDocValues.cs
@@ -6,6 +6,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -38,7 +39,7 @@ namespace Lucene.Net.Index
     /// </summary>
     internal sealed class SegmentDocValues
     {
-        private readonly IDictionary<long, RefCount<DocValuesProducer>> genDVProducers = new Dictionary<long, RefCount<DocValuesProducer>>();
+        private readonly IDictionary<long, RefCount<DocValuesProducer>> genDVProducers = new JCG.Dictionary<long, RefCount<DocValuesProducer>>();
 
         private RefCount<DocValuesProducer> NewDocValuesProducer(SegmentCommitInfo si, IOContext context, Directory dir, DocValuesFormat dvFormat, long gen, IList<FieldInfo> infos, int termsIndexDivisor)
         {

--- a/src/Lucene.Net/Index/SegmentInfo.cs
+++ b/src/Lucene.Net/Index/SegmentInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Lucene.Net.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -336,7 +337,7 @@ namespace Lucene.Net.Index
         {
             if (attributes is null)
             {
-                attributes = new Dictionary<string, string>();
+                attributes = new JCG.Dictionary<string, string>();
             }
             return attributes[key] = value;
         }

--- a/src/Lucene.Net/Index/SegmentInfos.cs
+++ b/src/Lucene.Net/Index/SegmentInfos.cs
@@ -551,7 +551,7 @@ namespace Lucene.Net.Index
                             }
                             else
                             {
-                                genUpdatesFiles = new Dictionary<long, ISet<string>>(numGensUpdatesFiles);
+                                genUpdatesFiles = new JCG.Dictionary<long, ISet<string>>(numGensUpdatesFiles);
                                 for (int i = 0; i < numGensUpdatesFiles; i++)
                                 {
                                     genUpdatesFiles[input.ReadInt64()] = input.ReadStringSet();
@@ -862,7 +862,7 @@ namespace Lucene.Net.Index
                 // dont directly access segments, use add method!!!
                 sis.Add((SegmentCommitInfo)(info.Clone()));
             }
-            sis.userData = new Dictionary<string, string>(userData);
+            sis.userData = new JCG.Dictionary<string, string>(userData);
             return sis;
         }
 

--- a/src/Lucene.Net/Index/SegmentReader.cs
+++ b/src/Lucene.Net/Index/SegmentReader.cs
@@ -60,12 +60,12 @@ namespace Lucene.Net.Index
         internal readonly SegmentDocValues segDocValues;
 
         internal readonly DisposableThreadLocal<IDictionary<string, object>> docValuesLocal =
-            new DisposableThreadLocal<IDictionary<string, object>>(() => new Dictionary<string, object>());
+            new DisposableThreadLocal<IDictionary<string, object>>(() => new JCG.Dictionary<string, object>());
 
         internal readonly DisposableThreadLocal<IDictionary<string, IBits>> docsWithFieldLocal =
-            new DisposableThreadLocal<IDictionary<string, IBits>>(() => new Dictionary<string, IBits>());
+            new DisposableThreadLocal<IDictionary<string, IBits>>(() => new JCG.Dictionary<string, IBits>());
 
-        internal readonly IDictionary<string, DocValuesProducer> dvProducersByField = new Dictionary<string, DocValuesProducer>();
+        internal readonly IDictionary<string, DocValuesProducer> dvProducersByField = new JCG.Dictionary<string, DocValuesProducer>();
         internal readonly ISet<DocValuesProducer> dvProducers = new JCG.HashSet<DocValuesProducer>(IdentityEqualityComparer<DocValuesProducer>.Default);
 
         private readonly FieldInfos fieldInfos; // LUCENENET specific - since it is readonly, made all internal classes use property
@@ -251,7 +251,7 @@ namespace Lucene.Net.Index
         // returns a gen->List<FieldInfo> mapping. Fields without DV updates have gen=-1
         private IDictionary<long, IList<FieldInfo>> GetGenInfos()
         {
-            IDictionary<long, IList<FieldInfo>> genInfos = new Dictionary<long, IList<FieldInfo>>();
+            IDictionary<long, IList<FieldInfo>> genInfos = new JCG.Dictionary<long, IList<FieldInfo>>();
             foreach (FieldInfo fi in FieldInfos)
             {
                 if (fi.DocValuesType == DocValuesType.NONE)

--- a/src/Lucene.Net/Index/SlowCompositeReaderWrapper.cs
+++ b/src/Lucene.Net/Index/SlowCompositeReaderWrapper.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support.Threading;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -199,7 +200,7 @@ namespace Lucene.Net.Index
 
         // TODO: this could really be a weak map somewhere else on the coreCacheKey,
         // but do we really need to optimize slow-wrapper any more?
-        private readonly IDictionary<string, OrdinalMap> cachedOrdMaps = new Dictionary<string, OrdinalMap>();
+        private readonly IDictionary<string, OrdinalMap> cachedOrdMaps = new JCG.Dictionary<string, OrdinalMap>();
 
         public override NumericDocValues GetNormValues(string field)
         {

--- a/src/Lucene.Net/Index/SnapshotDeletionPolicy.cs
+++ b/src/Lucene.Net/Index/SnapshotDeletionPolicy.cs
@@ -48,11 +48,11 @@ namespace Lucene.Net.Index
         /// Records how many snapshots are held against each
         /// commit generation
         /// </summary>
-        protected IDictionary<long, int> m_refCounts = new Dictionary<long, int>();
+        protected IDictionary<long, int> m_refCounts = new JCG.Dictionary<long, int>();
 
         /// <summary>
         /// Used to map gen to <see cref="IndexCommit"/>. </summary>
-        protected IDictionary<long, IndexCommit> m_indexCommits = new Dictionary<long, IndexCommit>();
+        protected IDictionary<long, IndexCommit> m_indexCommits = new JCG.Dictionary<long, IndexCommit>();
 
         /// <summary>
         /// Wrapped <see cref="IndexDeletionPolicy"/> </summary>
@@ -290,8 +290,8 @@ namespace Lucene.Net.Index
                 SnapshotDeletionPolicy other = (SnapshotDeletionPolicy)base.Clone();
                 other.primary = (IndexDeletionPolicy)this.primary.Clone();
                 other.m_lastCommit = null;
-                other.m_refCounts = new Dictionary<long, int>(m_refCounts);
-                other.m_indexCommits = new Dictionary<long, IndexCommit>(m_indexCommits);
+                other.m_refCounts = new JCG.Dictionary<long, int>(m_refCounts);
+                other.m_indexCommits = new JCG.Dictionary<long, IndexCommit>(m_indexCommits);
                 return other;
             }
             finally

--- a/src/Lucene.Net/Index/StandardDirectoryReader.cs
+++ b/src/Lucene.Net/Index/StandardDirectoryReader.cs
@@ -170,7 +170,7 @@ namespace Lucene.Net.Index
         {
             // we put the old SegmentReaders in a map, that allows us
             // to lookup a reader using its segment name
-            IDictionary<string, int> segmentReaders = new Dictionary<string, int>();
+            IDictionary<string, int> segmentReaders = new JCG.Dictionary<string, int>();
 
             if (oldReaders != null)
             {

--- a/src/Lucene.Net/Index/TermsHash.cs
+++ b/src/Lucene.Net/Index/TermsHash.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Index
 {
@@ -105,12 +106,12 @@ namespace Lucene.Net.Index
 
         internal override void Flush(IDictionary<string, InvertedDocConsumerPerField> fieldsToFlush, SegmentWriteState state)
         {
-            IDictionary<string, TermsHashConsumerPerField> childFields = new Dictionary<string, TermsHashConsumerPerField>();
+            IDictionary<string, TermsHashConsumerPerField> childFields = new JCG.Dictionary<string, TermsHashConsumerPerField>();
             IDictionary<string, InvertedDocConsumerPerField> nextChildFields;
 
             if (nextTermsHash != null)
             {
-                nextChildFields = new Dictionary<string, InvertedDocConsumerPerField>();
+                nextChildFields = new JCG.Dictionary<string, InvertedDocConsumerPerField>();
             }
             else
             {

--- a/src/Lucene.Net/Index/UpgradeIndexMergePolicy.cs
+++ b/src/Lucene.Net/Index/UpgradeIndexMergePolicy.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Index
         public override MergeSpecification FindForcedMerges(SegmentInfos segmentInfos, int maxSegmentCount, IDictionary<SegmentCommitInfo, bool> segmentsToMerge)
         {
             // first find all old segments
-            IDictionary<SegmentCommitInfo, bool> oldSegments = new Dictionary<SegmentCommitInfo, bool>();
+            IDictionary<SegmentCommitInfo, bool> oldSegments = new JCG.Dictionary<SegmentCommitInfo, bool>();
             foreach (SegmentCommitInfo si in segmentInfos.Segments)
             {
                 if (segmentsToMerge.TryGetValue(si, out bool v) && ShouldUpgradeSegment(si))

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -323,7 +323,7 @@ namespace Lucene.Net.Search
                     if (!readerCache.TryGetValue(readerKey, out innerCache) || innerCache is null)
                     {
                         // First time this reader is using FieldCache
-                        innerCache = new Dictionary<TKey, object>
+                        innerCache = new JCG.Dictionary<TKey, object>
                         {
                             [key] = value
                         };
@@ -351,7 +351,7 @@ namespace Lucene.Net.Search
                     if (!readerCache.TryGetValue(readerKey, out innerCache) || innerCache is null)
                     {
                         // First time this reader is using FieldCache
-                        innerCache = new Dictionary<TKey, object>
+                        innerCache = new JCG.Dictionary<TKey, object>
                         {
                             [key] = value = new FieldCache.CreationPlaceholder<TValue>()
                         };

--- a/src/Lucene.Net/Search/MultiPhraseQuery.cs
+++ b/src/Lucene.Net/Search/MultiPhraseQuery.cs
@@ -183,7 +183,7 @@ namespace Lucene.Net.Search
 
             private readonly Similarity similarity;
             private readonly Similarity.SimWeight stats;
-            private readonly IDictionary<Term, TermContext> termContexts = new Dictionary<Term, TermContext>();
+            private readonly IDictionary<Term, TermContext> termContexts = new JCG.Dictionary<Term, TermContext>();
 
             public MultiPhraseWeight(MultiPhraseQuery outerInstance, IndexSearcher searcher)
             {

--- a/src/Lucene.Net/Search/Payloads/PayloadSpanUtil.cs
+++ b/src/Lucene.Net/Search/Payloads/PayloadSpanUtil.cs
@@ -181,7 +181,7 @@ namespace Lucene.Net.Search.Payloads
 
         private void GetPayloads(ICollection<byte[]> payloads, SpanQuery query)
         {
-            IDictionary<Term, TermContext> termContexts = new Dictionary<Term, TermContext>();
+            IDictionary<Term, TermContext> termContexts = new JCG.Dictionary<Term, TermContext>();
             var terms = new JCG.SortedSet<Term>();
             query.ExtractTerms(terms);
             foreach (Term term in terms)

--- a/src/Lucene.Net/Search/SloppyPhraseScorer.cs
+++ b/src/Lucene.Net/Search/SloppyPhraseScorer.cs
@@ -538,7 +538,7 @@ namespace Lucene.Net.Search
         {
             // LUCENENET specific: OrderedDictionary<TKey, TValue> is a replacement for LinkedHashMap<K, V> in the JDK
             JCG.OrderedDictionary<Term, int> tord = new JCG.OrderedDictionary<Term, int>();
-            Dictionary<Term, int> tcnt = new Dictionary<Term, int>();
+            JCG.Dictionary<Term, int> tcnt = new JCG.Dictionary<Term, int>();
             for (PhrasePositions pp = min, prev = null; prev != max; pp = (prev = pp).next) // iterate cyclic list: done once handled max
             {
                 foreach (Term t in pp.terms)
@@ -621,7 +621,7 @@ namespace Lucene.Net.Search
         /// Map each term to the single group that contains it </summary>
         private static IDictionary<Term, int> TermGroups(JCG.OrderedDictionary<Term, int> tord, IList<FixedBitSet> bb) // LUCENENET: CA1822: Mark members as static
         {
-            Dictionary<Term, int> tg = new Dictionary<Term, int>();
+            JCG.Dictionary<Term, int> tg = new JCG.Dictionary<Term, int>();
             Term[] t = tord.Keys.ToArray(/*new Term[0]*/);
             for (int i = 0; i < bb.Count; i++) // i is the group no.
             {

--- a/src/Lucene.Net/Search/Spans/SpanWeight.cs
+++ b/src/Lucene.Net/Search/Spans/SpanWeight.cs
@@ -42,7 +42,7 @@ namespace Lucene.Net.Search.Spans
             this.m_similarity = searcher.Similarity;
             this.m_query = query;
 
-            m_termContexts = new Dictionary<Term, TermContext>();
+            m_termContexts = new JCG.Dictionary<Term, TermContext>();
             ISet<Term> terms = new JCG.SortedSet<Term>();
             query.ExtractTerms(terms);
             IndexReaderContext context = searcher.TopReaderContext;

--- a/src/Lucene.Net/Search/TopTermsRewrite.cs
+++ b/src/Lucene.Net/Search/TopTermsRewrite.cs
@@ -101,7 +101,7 @@ namespace Lucene.Net.Search
                 this.maxSize = maxSize;
                 this.stQueue = stQueue;
                 maxBoostAtt = Attributes.AddAttribute<IMaxNonCompetitiveBoostAttribute>();
-                visitedTerms = new Dictionary<BytesRef, ScoreTerm>();
+                visitedTerms = new JCG.Dictionary<BytesRef, ScoreTerm>();
             }
 
             private readonly IMaxNonCompetitiveBoostAttribute maxBoostAtt;

--- a/src/Lucene.Net/Store/CompoundFileDirectory.cs
+++ b/src/Lucene.Net/Store/CompoundFileDirectory.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Support.Threading;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Store
 {
@@ -170,7 +171,7 @@ namespace Lucene.Net.Store
                     entriesStream = dir.OpenChecksumInput(entriesFileName, IOContext.READ_ONCE);
                     CodecUtil.CheckHeader(entriesStream, CompoundFileWriter.ENTRY_CODEC, CompoundFileWriter.VERSION_START, CompoundFileWriter.VERSION_CURRENT);
                     int numEntries = entriesStream.ReadVInt32();
-                    mapping = new Dictionary<string, FileEntry>(numEntries);
+                    mapping = new JCG.Dictionary<string, FileEntry>(numEntries);
                     for (int i = 0; i < numEntries; i++)
                     {
                         FileEntry fileEntry = new FileEntry();
@@ -215,7 +216,7 @@ namespace Lucene.Net.Store
 
         private static IDictionary<string, FileEntry> ReadLegacyEntries(IndexInput stream, int firstInt)
         {
-            IDictionary<string, FileEntry> entries = new Dictionary<string, FileEntry>();
+            IDictionary<string, FileEntry> entries = new JCG.Dictionary<string, FileEntry>();
             int count;
             bool stripSegmentName;
             if (firstInt < CompoundFileWriter.FORMAT_PRE_VERSION)

--- a/src/Lucene.Net/Store/CompoundFileWriter.cs
+++ b/src/Lucene.Net/Store/CompoundFileWriter.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Store
         internal const string ENTRY_CODEC = "CompoundFileWriterEntries";
 
         private readonly Directory directory;
-        private readonly IDictionary<string, FileEntry> entries = new Dictionary<string, FileEntry>();
+        private readonly IDictionary<string, FileEntry> entries = new JCG.Dictionary<string, FileEntry>();
         private readonly ISet<string> seenIDs = new JCG.HashSet<string>();
         // all entries that are written to a sep. file but not yet moved into CFS
         private readonly LinkedList<FileEntry> pendingEntries = new LinkedList<FileEntry>();

--- a/src/Lucene.Net/Store/DataInput.cs
+++ b/src/Lucene.Net/Store/DataInput.cs
@@ -332,7 +332,7 @@ namespace Lucene.Net.Store
         /// </summary>
         public virtual IDictionary<string, string> ReadStringStringMap()
         {
-            IDictionary<string, string> map = new Dictionary<string, string>();
+            IDictionary<string, string> map = new JCG.Dictionary<string, string>();
             int count = ReadInt32();
             for (int i = 0; i < count; i++)
             {

--- a/src/Lucene.Net/Store/NativeFSLockFactory.cs
+++ b/src/Lucene.Net/Store/NativeFSLockFactory.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Store
 {
@@ -178,7 +179,7 @@ namespace Lucene.Net.Store
 
         // LUCENENET: NativeFSLocks in Java are in fact singletons; this is how we mimic that to track instances and make sure
         // IW.Unlock and IW.IsLocked works correctly
-        internal static readonly Dictionary<string, Lock> _locks = new Dictionary<string, Lock>();
+        internal static readonly JCG.Dictionary<string, Lock> _locks = new JCG.Dictionary<string, Lock>();
 
         /// <summary>
         /// Given a lock name, return the full prefixed path of the actual lock file.

--- a/src/Lucene.Net/Util/Automaton/Automaton.cs
+++ b/src/Lucene.Net/Util/Automaton/Automaton.cs
@@ -795,7 +795,7 @@ namespace Lucene.Net.Util.Automaton
             Automaton a = (Automaton)base.MemberwiseClone();
             if (!IsSingleton)
             {
-                Dictionary<State, State> m = new Dictionary<State, State>();
+                JCG.Dictionary<State, State> m = new JCG.Dictionary<State, State>();
                 State[] states = GetNumberedStates();
                 foreach (State s in states)
                 {

--- a/src/Lucene.Net/Util/Automaton/BasicOperations.cs
+++ b/src/Lucene.Net/Util/Automaton/BasicOperations.cs
@@ -401,7 +401,7 @@ namespace Lucene.Net.Util.Automaton
             Transition[][] transitions2 = a2.GetSortedTransitions();
             Automaton c = new Automaton();
             Queue<StatePair> worklist = new Queue<StatePair>(); // LUCENENET specific - Queue is much more performant than LinkedList
-            Dictionary<StatePair, StatePair> newstates = new Dictionary<StatePair, StatePair>();
+            JCG.Dictionary<StatePair, StatePair> newstates = new JCG.Dictionary<StatePair, StatePair>();
             StatePair p = new StatePair(c.initial, a1.initial, a2.initial);
             worklist.Enqueue(p);
             newstates[p] = p;
@@ -679,7 +679,7 @@ namespace Lucene.Net.Util.Automaton
             internal PointTransitions[] points = new PointTransitions[5];
 
             private const int HASHMAP_CUTOVER = 30;
-            private readonly Dictionary<int, PointTransitions> map = new Dictionary<int, PointTransitions>();
+            private readonly JCG.Dictionary<int, PointTransitions> map = new JCG.Dictionary<int, PointTransitions>();
             private bool useHash = false;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -802,7 +802,7 @@ namespace Lucene.Net.Util.Automaton
             SortedInt32Set.FrozenInt32Set initialset = new SortedInt32Set.FrozenInt32Set(initNumber, a.initial);
 
             Queue<SortedInt32Set.FrozenInt32Set> worklist = new Queue<SortedInt32Set.FrozenInt32Set>(); // LUCENENET specific - Queue is much more performant than LinkedList
-            IDictionary<SortedInt32Set.FrozenInt32Set, State> newstate = new Dictionary<SortedInt32Set.FrozenInt32Set, State>();
+            IDictionary<SortedInt32Set.FrozenInt32Set, State> newstate = new JCG.Dictionary<SortedInt32Set.FrozenInt32Set, State>();
 
             worklist.Enqueue(initialset);
 
@@ -928,8 +928,8 @@ namespace Lucene.Net.Util.Automaton
         public static void AddEpsilons(Automaton a, ICollection<StatePair> pairs)
         {
             a.ExpandSingleton();
-            Dictionary<State, JCG.HashSet<State>> forward = new Dictionary<State, JCG.HashSet<State>>();
-            Dictionary<State, JCG.HashSet<State>> back = new Dictionary<State, JCG.HashSet<State>>();
+            JCG.Dictionary<State, JCG.HashSet<State>> forward = new JCG.Dictionary<State, JCG.HashSet<State>>();
+            JCG.Dictionary<State, JCG.HashSet<State>> back = new JCG.Dictionary<State, JCG.HashSet<State>>();
             foreach (StatePair p in pairs)
             {
                 if (!forward.TryGetValue(p.s1, out JCG.HashSet<State> to))

--- a/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
+++ b/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
@@ -209,7 +209,7 @@ namespace Lucene.Net.Util.Automaton
         /// <summary>
         /// A "registry" for state interning.
         /// </summary>
-        private Dictionary<State, State> stateRegistry = new Dictionary<State, State>();
+        private JCG.Dictionary<State, State> stateRegistry = new JCG.Dictionary<State, State>();
 
         /// <summary>
         /// Root automaton state.

--- a/src/Lucene.Net/Util/Automaton/SpecialOperations.cs
+++ b/src/Lucene.Net/Util/Automaton/SpecialOperations.cs
@@ -233,7 +233,7 @@ namespace Lucene.Net.Util.Automaton
         {
             a.ExpandSingleton();
             // reverse all edges
-            Dictionary<State, ISet<Transition>> m = new Dictionary<State, ISet<Transition>>();
+            JCG.Dictionary<State, ISet<Transition>> m = new JCG.Dictionary<State, ISet<Transition>>();
             State[] states = a.GetNumberedStates();
             ISet<State> accept = new JCG.HashSet<State>();
             foreach (State s in states)

--- a/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
+++ b/src/Lucene.Net/Util/FieldCacheSanityChecker.cs
@@ -121,9 +121,9 @@ namespace Lucene.Net.Util
             // the indirect mapping lets MapOfSet dedup identical valIds for us
             // maps the (valId) identityhashCode of cache values to
             // sets of CacheEntry instances
-            MapOfSets<int, FieldCache.CacheEntry> valIdToItems = new MapOfSets<int, FieldCache.CacheEntry>(new Dictionary<int, ISet<FieldCache.CacheEntry>>(17));
+            MapOfSets<int, FieldCache.CacheEntry> valIdToItems = new MapOfSets<int, FieldCache.CacheEntry>(new JCG.Dictionary<int, ISet<FieldCache.CacheEntry>>(17));
             // maps ReaderField keys to Sets of ValueIds
-            MapOfSets<ReaderField, int> readerFieldToValIds = new MapOfSets<ReaderField, int>(new Dictionary<ReaderField, ISet<int>>(17));
+            MapOfSets<ReaderField, int> readerFieldToValIds = new MapOfSets<ReaderField, int>(new JCG.Dictionary<ReaderField, ISet<int>>(17));
 
             // any keys that we know result in more then one valId
             ISet<ReaderField> valMismatchKeys = new JCG.HashSet<ReaderField>();
@@ -217,7 +217,7 @@ namespace Lucene.Net.Util
         {
             JCG.List<Insanity> insanity = new JCG.List<Insanity>(23);
 
-            Dictionary<ReaderField, ISet<ReaderField>> badChildren = new Dictionary<ReaderField, ISet<ReaderField>>(17);
+            JCG.Dictionary<ReaderField, ISet<ReaderField>> badChildren = new JCG.Dictionary<ReaderField, ISet<ReaderField>>(17);
             MapOfSets<ReaderField, ReaderField> badKids = new MapOfSets<ReaderField, ReaderField>(badChildren); // wrapper
 
             IDictionary<int, ISet<FieldCache.CacheEntry>> viToItemSets = valIdToItems.Map;

--- a/src/Lucene.Net/Util/Fst/FST.cs
+++ b/src/Lucene.Net/Util/Fst/FST.cs
@@ -1737,7 +1737,7 @@ namespace Lucene.Net.Util.Fst
                 // Free up RAM:
                 inCounts = null;
 
-                topNodeMap = new Dictionary<int, int>(q.Count); // LUCENENET: Allocate the dictionary prior to the loop
+                topNodeMap = new JCG.Dictionary<int, int>(q.Count); // LUCENENET: Allocate the dictionary prior to the loop
                 for (int downTo = q.Count - 1; downTo >= 0; downTo--)
                 {
                     FST.NodeAndInCount? n = q.Pop();

--- a/src/Lucene.Net/Util/NamedSPILoader.cs
+++ b/src/Lucene.Net/Util/NamedSPILoader.cs
@@ -62,7 +62,7 @@
 //        {
 //            lock (this)
 //            {
-//                IDictionary<string, S> services = new Dictionary<string, S>(this.services);
+//                IDictionary<string, S> services = new JCG.Dictionary<string, S>(this.services);
 //                SPIClassIterator<S> loader = SPIClassIterator<S>.Get();
 
 //                // Ensure there is a default constructor (the SPIClassIterator contains types that don't)

--- a/src/Lucene.Net/Util/RamUsageEstimator.cs
+++ b/src/Lucene.Net/Util/RamUsageEstimator.cs
@@ -111,7 +111,7 @@ namespace Lucene.Net.Util
         /// Sizes of primitive classes.
         /// </summary>
         // LUCENENET specific - Identity comparer is not necessary here because Type is already representing an identity
-        private static readonly IDictionary<Type, int> primitiveSizes = new Dictionary<Type, int>(/*IdentityEqualityComparer<Type>.Default*/) // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
+        private static readonly IDictionary<Type, int> primitiveSizes = new JCG.Dictionary<Type, int>(/*IdentityEqualityComparer<Type>.Default*/) // LUCENENET: Avoid static constructors (see https://github.com/apache/lucenenet/pull/224#issuecomment-469284006)
         {
             [typeof(bool)] = NUM_BYTES_BOOLEAN,
             [typeof(sbyte)] = NUM_BYTES_BYTE,

--- a/src/Lucene.Net/Util/WeakIdentityMap.cs
+++ b/src/Lucene.Net/Util/WeakIdentityMap.cs
@@ -84,7 +84,7 @@
 //        /// <param name="reapOnRead"> controls if the map <a href="#reapInfo">cleans up the reference queue on every read operation</a>. </param>
 //        public static WeakIdentityMap<TKey, TValue> NewHashMap(bool reapOnRead)
 //        {
-//            return new WeakIdentityMap<TKey, TValue>(new Dictionary<IdentityWeakReference, TValue>(), reapOnRead);
+//            return new WeakIdentityMap<TKey, TValue>(new JCG.Dictionary<IdentityWeakReference, TValue>(), reapOnRead);
 //        }
 
 //        /// <summary>


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making.

Replace BCL `Dictionary<TKey, TValue>` with `JCG.Dictionary<TKey, TValue>` in Java-derived sources

Fixes #1273

## Description

Mechanical sweep that replaces every `System.Collections.Generic.Dictionary<TKey, TValue>` use in Java-derived sources with `J2N.Collections.Generic.Dictionary<TKey, TValue>`, consistently using the `JCG.Dictionary<TKey, TValue>` alias. ~54 files were already migrated; this sweeps the remaining ~272.

J2N's ``Dictionary<,>`` is feature-comparable to .NET 10's BCL implementation in performance, plus it adds JDK-`HashMap`-equivalent capabilities the BCL type lacks: `null` keys, removal-during-enumeration, `ReadOnlySpan<char>` alternate lookup, structural `Equals`/`GetHashCode`/`ToString`. Java code ported to .NET routinely passes `null` keys; using BCL `Dictionary<,>` was potentially masking bugs in extensions with low test coverage.

### What changed

- 552 `new Dictionary<...>` instantiations → `new JCG.Dictionary<...>`
- 133 files had `using JCG = J2N.Collections.Generic;` added (placed after non-alias `using` directives, alphabetical with other aliases)
- ~25 bare-type LHS declarations updated where the field/local type had to match the new RHS (compiler-driven via CS0029)
- 3 nested-generic args updated (e.g., `JCG.List<Dictionary<...>>` → `JCG.List<JCG.Dictionary<...>>`)
- 1 class inheritance updated: `HashMapAnonymousClass : Dictionary<string, string>` → `: JCG.Dictionary<string, string>` ([TestAnalysisSPILoader.cs](https://github.com/apache/lucenenet/blob/master/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestAnalysisSPILoader.cs))
- 1 method return type updated: `TestIndexWriter.GetLiveCommitData`

### Exclusions honored (per the issue)

- `Lucene.Net.CodeAnalysis.*` projects
- `Lucene.Net.Replicator.AspNetCore`
- `lucene-cli` and `Lucene.Net.Tests.Cli`
- `Lucene.Net.Tests.TestFramework.{DependencyInjection,NUnitExtensions}`
- All `Support/` folders and the `Lucene.Net.Support` namespace — **except** `TagSoup` and `Sax` under `Lucene.Net.Benchmark/Support/`, which are explicitly in scope per the issue
- LINQ `.ToDictionary()` calls (would return BCL `Dictionary<,>` by design — only one such call exists, and it's in an excluded project)

### Compatibility

Public API surface continues to expose `IDictionary<TKey, TValue>` (interface), not the concrete BCL type. **This is not a binary-breaking change.**

### Verification

- Full solution builds clean (0 errors, 44 pre-existing CA1859 perf warnings, none introduced)
- Core lib builds clean across all target frameworks: `net462`, `netstandard2.0`, `net8.0`, `net10.0`
- Full test suite run: **170 test runs across 36 test projects × multiple TFMs, 52,518 tests passed, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)