### PR TITLE
[CI] Add ASF Allow list workflow

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+name: 'ASF Allowlist Check'
+on:
+  pull_request:
+    paths: ['.github/**']
+  push:
+    branches: [master]
+    paths: ['.github/**']
+permissions:
+  contents: read
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: apache/infrastructure-actions/allowlist-check@4e9c961f587f72b170874b6f5cd4ac15f7f26eb8 # main


### PR DESCRIPTION
A composite GitHub Action that verifies all uses: refs in a project's workflow files are on the ASF Infrastructure approved allowlist:

https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md

Examples here:

https://github.com/apache/airflow/blob/main/.github/workflows/asf-allowlist-check.yml

https://github.com/apache/airflow-steward/blob/main/.github/workflows/asf-allowlist-check.yml