### PR TITLE
Update dev analyzers; fix some findings (#1168, #924, #1211, #1097)

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -40,7 +40,7 @@
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
     <J2NPackageVersion>[2.2.0-alpha-0042, 3.0.0)</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
-    <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.18</LuceneNetCodeAnalysisDevPackageVersion>
+    <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.34</LuceneNetCodeAnalysisDevPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.3.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
     <MicrosoftAspNetCoreTestHostPackageVersion>8.0.19</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftBclMemoryPackageVersion>10.0.0-rc.1.25451.107</MicrosoftBclMemoryPackageVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -40,7 +40,7 @@
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
     <J2NPackageVersion>[2.2.0-alpha-0042, 3.0.0)</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
-    <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.34</LuceneNetCodeAnalysisDevPackageVersion>
+    <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.36</LuceneNetCodeAnalysisDevPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.3.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
     <MicrosoftAspNetCoreTestHostPackageVersion>8.0.19</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftBclMemoryPackageVersion>10.0.0-rc.1.25451.107</MicrosoftBclMemoryPackageVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -31,6 +31,16 @@
     <NoWarn Label="Java array parameters can sometimes be replaced with .NET out or ref parameters">$(NoWarn);LuceneDev1003</NoWarn>
     <NoWarn Label="Return array may be able to be replaced with out values">$(NoWarn);LuceneDev1004</NoWarn>
     <NoWarn Label="Floating point values embedded in strings should be formatted with J2N.Numerics Single or Double ToString methods">$(NoWarn);LuceneDev1006</NoWarn>
+    <NoWarn Label="Generic Dictionary indexer '...' may throw KeyNotFoundException. Use TryGetValue instead.">$(NoWarn);LuceneDev1007</NoWarn>
+    <NoWarn Label="Generic Dictionary indexer '...' may throw KeyNotFoundException. Use TryGetValue and check the value for null.">$(NoWarn);LuceneDev1008</NoWarn>
+    <NoWarn Label="Call to 'Parse' on numeric type 'Single' should specify an IFormatProvider (typically CultureInfo.InvariantCulture).">$(NoWarn);LuceneDev2000</NoWarn>
+    <NoWarn Label="Call to 'ToString' on numeric type 'Int64' should specify an IFormatProvider (typically CultureInfo.InvariantCulture).">$(NoWarn);LuceneDev2001</NoWarn>
+    <NoWarn Label="Call to 'Convert.ToString' should specify an IFormatProvider (typically CultureInfo.InvariantCulture).">$(NoWarn);LuceneDev2002</NoWarn>
+    <NoWarn Label="Call to 'string.Format' with a numeric argument should specify an IFormatProvider (typically CultureInfo.InvariantCulture).">$(NoWarn);LuceneDev2003</NoWarn>
+    <NoWarn Label="Call to 'TryParse' on J2N numeric type 'Int32' should specify an IFormatProvider (typically CultureInfo.InvariantCulture).">$(NoWarn);LuceneDev2004</NoWarn>
+    <NoWarn Label="Numeric value of type 'Int32' is concatenated to a string and will be formatted using the current culture. Wrap with .ToString(CultureInfo.InvariantCulture) explicitly.">$(NoWarn);LuceneDev2005</NoWarn>
+    <NoWarn Label="Numeric value of type 'Int32' is interpolated into a string and will be formatted using the current culture. Use FormattableString.Invariant or wrap with .ToString(CultureInfo.InvariantCulture) explicitly.">$(NoWarn);LuceneDev2006</NoWarn>
+    <NoWarn Label="Call to 'Parse' passes a non-invariant IFormatProvider. Use CultureInfo.InvariantCulture unless current-culture behavior is intentional.">$(NoWarn);LuceneDev2007</NoWarn>
 
   </PropertyGroup>
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
@@ -78,7 +78,7 @@ namespace Lucene.Net.Analysis.Util
             }
 
             // LUCENENET: use more efficient implementation in MemoryExtensions
-            return s.StartsWith(prefix, StringComparison.Ordinal);
+            return s.StartsWith(prefix);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Lucene.Net.Analysis.Util
             }
 
             // LUCENENET: use more efficient implementation in MemoryExtensions
-            return s.EndsWith(suffix, StringComparison.Ordinal);
+            return s.EndsWith(suffix);
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Support/Util/NUnitTestFixtureBuilder.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/NUnitTestFixtureBuilder.cs
@@ -420,7 +420,7 @@ namespace Lucene.Net.Util
                 return true;
 
             // Look for the marker that indicates from was null
-            if (from is null && (to.GetTypeInfo().IsClass || to.FullName.StartsWith("System.Nullable")))
+            if (from is null && (to.GetTypeInfo().IsClass || to.FullName.StartsWith("System.Nullable", StringComparison.Ordinal)))
                 return true;
 
             if (convertibleValueTypes.ContainsKey(to) && convertibleValueTypes[to].Contains(from))

--- a/src/Lucene.Net.Tests.Highlighter/VectorHighlight/BreakIteratorBoundaryScannerTest.cs
+++ b/src/Lucene.Net.Tests.Highlighter/VectorHighlight/BreakIteratorBoundaryScannerTest.cs
@@ -94,11 +94,11 @@ namespace Lucene.Net.Search.VectorHighlight
             BreakIterator bi = BreakIterator.GetSentenceInstance(CultureInfo.CurrentCulture);
             IBoundaryScanner scanner = new BreakIteratorBoundaryScanner(bi);
 
-            int start = TEXT.IndexOf("any application");
-            int expected = TEXT.IndexOf("It is a");
+            int start = TEXT.IndexOf("any application", StringComparison.Ordinal);
+            int expected = TEXT.IndexOf("It is a", StringComparison.Ordinal);
             TestFindStartOffset(text, start, expected, scanner);
 
-            expected = TEXT.IndexOf("application that requires") + "application that requires\n".Length;
+            expected = TEXT.IndexOf("application that requires", StringComparison.Ordinal) + "application that requires\n".Length;
             TestFindEndOffset(text, start, expected, scanner);
         }
 

--- a/src/Lucene.Net.Tests/Support/TestHelpers.cs
+++ b/src/Lucene.Net.Tests/Support/TestHelpers.cs
@@ -321,7 +321,9 @@ namespace Lucene.Net
             E4,
         }
 
+#pragma warning disable LuceneDev4001
         [MethodImpl(MethodImplOptions.NoInlining)]
+#pragma warning restore LuceneDev4001
         public static void DoNotIgnore<T>(T value, int consumed)
         {
         }

--- a/src/dotnet/Lucene.Net.Tests.CodeAnalysis/Verifiers/DiagnosticVerifier.cs
+++ b/src/dotnet/Lucene.Net.Tests.CodeAnalysis/Verifiers/DiagnosticVerifier.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System;
 
 namespace TestHelper
 {
@@ -260,7 +261,7 @@ namespace TestHelper
                             Assert.IsTrue(location.IsInSource,
                                 $"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[i]}\r\n");
 
-                            string resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs") ? "GetCSharpResultAt" : "GetBasicResultAt";
+                            string resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ? "GetCSharpResultAt" : "GetBasicResultAt";
                             var linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
 
                             builder.AppendFormat("{0}({1}, {2}, {3}.{4})",


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Updates Lucene.Net.CodeAnalysis.Dev analyzer package to latest version, fixes some analysis warnings.

Related #1168
Related #924
Fixes #1211
Fixes #1097 

## Description

This updates the Lucene.Net.CodeAnalysis.Dev package to alpha 36. See the release notes for alpha 34 and alpha 36:
https://github.com/apache/lucenenet-codeanalysis-dev/releases/tag/v1.0.0-alpha.34
https://github.com/apache/lucenenet-codeanalysis-dev/releases/tag/v1.0.0-alpha.36

This update adds several new analyzers. The dictionary ones (1007-1008) and numeric formatting ones (2000-2007) were very noisy with several thousand combined warnings, so they have been suppressed with NoWarn except for a couple that had just a few findings and were easy to fix.

The remaining findings should be addressed as separate PRs.
