### PR TITLE
Add Infra-recommended branch protection rules

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,15 @@ github:
     # Enable discussions
     discussions: true
 
-  # Disallow forced pushes
-  protected_branches:
-    master: {}
+  rulesets:
+    - name: "Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "master"
+          - "release/*"
+        excludes: []
+      restrict_deletion: true
+      restrict_force_push: true
+      required_linear_history: true
+      required_conversation_resolution: true

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -42,6 +42,7 @@ github:
         includes:
           - "master"
           - "release/*"
+          - "docs/*"
         excludes: []
       restrict_deletion: true
       restrict_force_push: true


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Adopt Apache Infrastructure recommended branch protection rules

## Description

Apache Infra recommends adopting blocking forced pushes and blocking deletions of protected branches. This adopts those, along with requiring linear history and comment resolution on PRs (which seemed like low-friction additions, and things we already do in practice).

This supersedes the legacy branch protection rule with the more modern rulesets approach.
