### PR TITLE
fix: Render ASF policy links in static HTML footer

### DIFF
--- a/websites/site/docfx.json
+++ b/websites/site/docfx.json
@@ -41,7 +41,7 @@
       "_appFaviconPath": "logo/favicon.ico",
       "_enableSearch": false,
       "_appLogoPath": "logo/lucene-net-color.png",
-      "_appFooter": "Copyright &copy; 2025 The Apache Software Foundation, Licensed under the <a href='http://www.apache.org/licenses/LICENSE-2.0' target='_blank'>Apache License, Version 2.0</a><br/> <small>Apache Lucene.Net, Lucene.Net, Apache, the Apache feather logo, and the Apache Lucene.Net project logo are trademarks of The Apache Software Foundation. <br/>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</small>",
+      "_appFooter": "Copyright &copy; 2025 The Apache Software Foundation, Licensed under the <a href='https://www.apache.org/licenses/' target='_blank'>Apache License, Version 2.0</a><br/> <small>Apache Lucene.Net, Lucene.Net, Apache, the Apache logo, and the Apache Lucene.Net project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</small>",
       "_gitContribute": {
         "repo": "https://github.com/apache/lucenenet",
         "branch": "master"

--- a/websites/site/lucenetemplate/partials/footer.tmpl.partial
+++ b/websites/site/lucenetemplate/partials/footer.tmpl.partial
@@ -1,0 +1,16 @@
+<footer>
+  <div class="container">
+    <span class="pull-left">
+      {{{_appFooter}}}{{^_appFooter}}Copyright &copy; 2025 The Apache Software Foundation{{/_appFooter}}
+    </span>
+    <div class="asf-links text-center">
+      <a href="{{_asfFoundationHref}}">{{_asfFoundationText}}</a> |
+      <a href="{{_asfEventsHref}}">{{_asfEventsText}}</a> |
+      <a href="{{_asfLicenseHref}}">{{_asfLicenseText}}</a> |
+      <a href="{{_asfSecurityHref}}">{{_asfSecurityText}}</a> |
+      <a href="{{_asfSponsorshipHref}}">{{_asfSponsorshipText}}</a> |
+      <a href="{{_asfThanksHref}}">{{_asfThanksText}}</a> |
+      <a href="{{_asfPrivacyHref}}">{{_asfPrivacyText}}</a>
+    </div>
+  </div>
+</footer>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

The Lucene.NET website already has all required ASF policy links defined in docfx.json and toc.yml, but they're only rendered via client-side JavaScript. The ASF compliance scanner (https://whimsy.apache.org/site/) cannot execute JavaScript, so it reports 7 of 9 checks as failing.

This PR:
- Adds a footer.tmpl.partial that renders the ASF links as static HTML in the page footer (using the existing template variables)
- Fixes "Apache feather logo" → "Apache logo" in trademark text (ASF rebranded in September 2025)
- Updates license link to canonical https://www.apache.org/licenses/

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/
