### PR TITLE
Configure merge buttons to attempt fix to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,14 @@ github:
     # Enable discussions
     discussions: true
 
+  enabled_merge_buttons:
+    squash:  true
+    # default commit message when merging with a squash commit
+    # can either be: DEFAULT | PR_TITLE | PR_TITLE_AND_COMMIT_DETAILS | PR_TITLE_AND_DESC
+    squash_commit_message: PR_TITLE
+    merge: false
+    rebase: false
+
   rulesets:
     - name: "Branch Protection"
       type: branch
@@ -44,6 +52,8 @@ github:
           - "release/*"
           - "docs/*"
         excludes: []
+      bypass_teams:
+        - root
       restrict_deletion: true
       restrict_force_push: true
       required_linear_history: true


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Attempt fix to .asf.yaml

## Description

The .asf.yaml file is failing with an obscure error message:

> An error occurred while processing the github feature in .asf.yaml:
> 
> Validation failed while creating ruleset 'Branch Protection': Invalid request.
> 
> Invalid property /rules/3: data matches no possible input. See `documentation_url`.

It appears this error comes from the GitHub API, and basically means that one of the rule configurations is invalid.

The ASF YAML docs say that to use require linear history, the squash option must be enabled. I assumed it was by default (because we've been using it exclusively), but this is a shot in the dark to be explicit about it. This will also disable the merge and rebase types which we discourage use of in practice. 

Additionally, I'm adding the `bypass_teams` that was added automatically by Infra's bot to our other repos, the only other significant difference I could detect.

If this doesn't work, we might need to try removing the `required_` rules and see if that works. Otherwise, I'll reach out to Infra for help.
