### PR TITLE
Exclude binary fonts and test corpora from editorconfig-checker

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -9,7 +9,9 @@
     "\\.DotSettings$",
     "App\\.config$",
     "\\.htaccess$",
-    "packages\\.lock\\.json$"
+    "packages\\.lock\\.json$",
+    "\\.[Tt][Tt][Ff]$",
+    "src/Lucene\\.Net\\.Tests\\.Analysis\\.Common/Analysis/Core/.*\\.txt$"
   ],
   "AllowedContentTypes": [],
   "PassedFiles": [],


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Exclude binary fonts and test corpora from editorconfig-checker

## Description

editorconfig-checker v3.7.0 added stricter pre-decode binary detection. GOTHIC.TTF has an uppercase extension that bypasses the case-sensitive default \.ttf$ exclude, and two random-text test corpora under Analysis/Core/ contain byte sequences the new detector flags as binary.

Add both patterns to the Exclude list. The .editorconfig override for test .txt files only unsets formatting rules and cannot silence the encoding-detection check.