### PR TITLE
Throw on invalid offset 0 in LZ4 decompression, #1276

### DIFF
--- a/src/Lucene.Net.Tests/Codecs/Compressing/TestDecompressLZ4.cs
+++ b/src/Lucene.Net.Tests/Codecs/Compressing/TestDecompressLZ4.cs
@@ -1,0 +1,89 @@
+using Lucene.Net.Attributes;
+using Lucene.Net.Store;
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
+
+namespace Lucene.Net.Codecs.Compressing
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    [TestFixture]
+    public class TestDecompressLZ4 : LuceneTestCase
+    {
+        // LUCENENET specific: backported from upstream Lucene 10.4.0 (apache/lucene#15570)
+        [Test]
+        public void TestDecompressOffset0()
+        {
+            byte[] input = new byte[]
+            {
+                // token
+                0xE,
+                // offset 0 (invalid)
+                0,
+                0,
+                // last literal
+                // token
+                7 << 4,
+                // literal
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            };
+
+            byte[] output = new byte[18];
+
+            var e = Assert.Throws<IOException>(
+                () => LZ4.Decompress(new ByteArrayDataInput(input), output.Length, output, 0));
+            Assert.AreEqual("offset 0 is invalid", e.Message);
+        }
+
+        // LUCENENET specific - confirm the same fail-fast behavior surfaces through the
+        // CompressionMode.FAST.NewDecompressor() integration path that callers actually use.
+        [Test, LuceneNetSpecific]
+        public void TestDecompressOffset0ThroughCompressionMode()
+        {
+            byte[] input = new byte[]
+            {
+                0xE,
+                0,
+                0,
+                7 << 4,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            };
+
+            Decompressor decompressor = CompressionMode.FAST.NewDecompressor();
+            BytesRef bytes = new BytesRef();
+
+            var e = Assert.Throws<IOException>(
+                () => decompressor.Decompress(new ByteArrayDataInput(input), 18, 0, 18, bytes));
+            Assert.AreEqual("offset 0 is invalid", e.Message);
+        }
+    }
+}

--- a/src/Lucene.Net/Codecs/Compressing/LZ4.cs
+++ b/src/Lucene.Net/Codecs/Compressing/LZ4.cs
@@ -2,6 +2,7 @@ using J2N.Numerics;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Codecs.Compressing
@@ -137,7 +138,11 @@ namespace Lucene.Net.Codecs.Compressing
                 var byte1 = compressed.ReadByte();
                 var byte2 = compressed.ReadByte();
                 int matchDec = (byte1 & 0xFF) | ((byte2 & 0xFF) << 8);
-                if (Debugging.AssertsEnabled) Debugging.Assert(matchDec > 0);
+                // LUCENENET specific: backported from upstream Lucene 10.4.0 (apache/lucene#15570) - matchDec == 0 is invalid per the LZ4 block format
+                if (matchDec == 0)
+                {
+                    throw new IOException("offset 0 is invalid");
+                }
 
                 int matchLen = token & 0x0F;
                 if (matchLen == 0x0F)


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Throw on invalid offset 0 in LZ4 decompression

Fixes #1276

## Description

Backports upstream Lucene fix apache/lucene#15570 (Lucene 10.4.0): replaces the matchDec > 0 assert in LZ4.Decompress with an IOException so malformed input is rejected in all build modes rather than producing stale buffer contents.
