### PR TITLE
Replace LinkedHashSet<T> with OrderedHashSet<T>, #1272

### DIFF
--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
@@ -72,7 +72,8 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
             private PhonemeBuilder(Phoneme phoneme)
             {
-                this.phonemes = new JCG.LinkedHashSet<Phoneme>
+                // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+                this.phonemes = new JCG.OrderedHashSet<Phoneme>
                 {
                     phoneme
                 };
@@ -131,7 +132,8 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             /// <param name="maxPhonemes">The maximum number of phonemes to build up.</param>
             public void Apply(IPhonemeExpr phonemeExpr, int maxPhonemes)
             {
-                ISet<Phoneme> newPhonemes = new JCG.LinkedHashSet<Phoneme>(maxPhonemes);
+                // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+                ISet<Phoneme> newPhonemes = new JCG.OrderedHashSet<Phoneme>(maxPhonemes);
 
                 //EXPR_continue:
                 foreach (Phoneme left in this.phonemes)

--- a/src/Lucene.Net.Highlighter/VectorHighlight/FieldQuery.cs
+++ b/src/Lucene.Net.Highlighter/VectorHighlight/FieldQuery.cs
@@ -48,8 +48,9 @@ namespace Lucene.Net.Search.VectorHighlight
         internal FieldQuery(Query query, IndexReader reader, bool phraseHighlight, bool fieldMatch)
         {
             this.fieldMatch = fieldMatch;
-            // LUCENENET NOTE: LinkedHashSet cares about insertion order
-            ISet<Query> flatQueries = new JCG.LinkedHashSet<Query>();
+            // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+            // (insertion order is significant here)
+            ISet<Query> flatQueries = new JCG.OrderedHashSet<Query>();
             Flatten(query, reader, flatQueries);
             SaveTerms(flatQueries, reader);
             ICollection<Query> expandQueries = Expand(flatQueries);
@@ -189,7 +190,8 @@ namespace Lucene.Net.Search.VectorHighlight
         /// <returns></returns>
         internal ICollection<Query> Expand(ICollection<Query> flatQueries)
         {
-            ISet<Query> expandQueries = new JCG.LinkedHashSet<Query>();
+            // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+            ISet<Query> expandQueries = new JCG.OrderedHashSet<Query>();
 
             for (int i = 0; i < flatQueries.Count;)
             {

--- a/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
+++ b/src/Lucene.Net.Tests.Spatial/Prefix/SpatialOpRecursivePrefixTreeTest.cs
@@ -316,8 +316,10 @@ namespace Lucene.Net.Spatial.Prefix
                 // We ensure true-positive matches (if the predicate on the raw shapes match
                 //  then the search should find those same matches).
                 // approximations, false-positive matches
-                ISet<string> expectedIds = new JCG.LinkedHashSet<string>();//true-positives
-                ISet<string> secondaryIds = new JCG.LinkedHashSet<string>();//false-positives (unless disjoint)
+                // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+                ISet<string> expectedIds = new JCG.OrderedHashSet<string>();//true-positives
+                // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+                ISet<string> secondaryIds = new JCG.OrderedHashSet<string>();//false-positives (unless disjoint)
                 foreach (var entry in indexedShapes)
                 {
                     string id = entry.Key;
@@ -368,7 +370,8 @@ namespace Lucene.Net.Spatial.Prefix
                     args.DistErrPct = (0.0);//a hack; we want to be more detailed than gridSnap(queryShape)
                 Query query = strategy.MakeQuery(args);
                 SearchResults got = executeQuery(query, 100);
-                ISet<String> remainingExpectedIds = new JCG.LinkedHashSet<string>(expectedIds);
+                // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+                ISet<String> remainingExpectedIds = new JCG.OrderedHashSet<string>(expectedIds);
                 foreach (SearchResult result in got.results)
                 {
                     String id = result.GetId();

--- a/src/Lucene.Net.Tests/Search/TestFieldCache.cs
+++ b/src/Lucene.Net.Tests/Search/TestFieldCache.cs
@@ -362,7 +362,8 @@ namespace Lucene.Net.Search
             {
                 termOrds.SetDocument(i);
                 // this will remove identical terms. A DocTermOrds doesn't return duplicate ords for a docId
-                ISet<BytesRef> values = new JCG.LinkedHashSet<BytesRef>(multiValued[i]);
+                // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+                ISet<BytesRef> values = new JCG.OrderedHashSet<BytesRef>(multiValued[i]);
                 foreach (BytesRef v in values)
                 {
                     if (v is null)

--- a/src/Lucene.Net.Tests/Support/BaseConcurrentSetTestCase.cs
+++ b/src/Lucene.Net.Tests/Support/BaseConcurrentSetTestCase.cs
@@ -399,12 +399,13 @@ namespace Lucene.Net
         }
 
         /// <summary>
-        /// Runs the synchronized set tests using <see cref="J2N.Collections.Generic.LinkedHashSet{T}"/> as the inner set type.
+        /// Runs the synchronized set tests using <see cref="J2N.Collections.Generic.OrderedHashSet{T}"/> as the inner set type.
         /// </summary>
         [Test]
-        public void TestSynchronizedSet_LinkedHashSet()
+        public void TestSynchronizedSet_OrderedHashSet()
         {
-            BaseTestSynchronizedSet(() => new JCG.LinkedHashSet<object?>());
+            // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+            BaseTestSynchronizedSet(() => new JCG.OrderedHashSet<object?>());
         }
 
         protected void BaseTestSynchronizedSet(Func<ISet<object?>> innerSetFactory)

--- a/src/Lucene.Net.Tests/Support/TestConcurrentSet.cs
+++ b/src/Lucene.Net.Tests/Support/TestConcurrentSet.cs
@@ -38,8 +38,9 @@ namespace Lucene.Net
     /// </remarks>
     public class TestConcurrentSet : BaseConcurrentSetTestCase
     {
+        // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
         protected override ISet<T> NewSet<T>()
-            => new ConcurrentSet<T>(new JCG.LinkedHashSet<T>());
+            => new ConcurrentSet<T>(new JCG.OrderedHashSet<T>());
 
         protected override ISet<T> NewSet<T>(ISet<T> set)
             => new ConcurrentSet<T>(set);
@@ -51,7 +52,8 @@ namespace Lucene.Net
         [Test, LuceneNetSpecific]
         public async Task TestSyncRoot()
         {
-            var innerSet = new JCG.LinkedHashSet<int>();
+            // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+            var innerSet = new JCG.OrderedHashSet<int>();
             var set = new ConcurrentSet<int>(innerSet);
             Assert.IsNotNull(set.SyncRoot);
 
@@ -97,7 +99,8 @@ namespace Lucene.Net
         [Test, LuceneNetSpecific]
         public void TestGetEnumerator()
         {
-            var innerSet = new JCG.LinkedHashSet<int>();
+            // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+            var innerSet = new JCG.OrderedHashSet<int>();
             var set = new ConcurrentSet<int>(innerSet);
             for (int i = 0; i < 100; i++)
             {

--- a/src/Lucene.Net/Index/IndexReader.cs
+++ b/src/Lucene.Net/Index/IndexReader.cs
@@ -99,7 +99,8 @@ namespace Lucene.Net.Index
 
         // LUCENENET specific - de-nested IReaderClosedListener and renamed to IReaderDisposedListener
 
-        private readonly ISet<IReaderDisposedListener> readerDisposedListeners = new JCG.LinkedHashSet<IReaderDisposedListener>().AsConcurrent();
+        // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+        private readonly ISet<IReaderDisposedListener> readerDisposedListeners = new JCG.OrderedHashSet<IReaderDisposedListener>().AsConcurrent();
 
         private readonly ConditionalWeakTable<IndexReader, object> parentReaders = new ConditionalWeakTable<IndexReader, object>();
 

--- a/src/Lucene.Net/Index/SegmentCoreReaders.cs
+++ b/src/Lucene.Net/Index/SegmentCoreReaders.cs
@@ -70,7 +70,8 @@ namespace Lucene.Net.Index
         internal readonly DisposableThreadLocal<TermVectorsReader> termVectorsLocal;
         internal readonly DisposableThreadLocal<IDictionary<string, object>> normsLocal =
             new DisposableThreadLocal<IDictionary<string, object>>(() => new JCG.Dictionary<string, object>());
-        private readonly ISet<ICoreDisposedListener> coreClosedListeners = new JCG.LinkedHashSet<ICoreDisposedListener>().AsConcurrent();
+        // LUCENENET specific: OrderedHashSet<T> is a replacement for LinkedHashSet<E> in the JDK
+        private readonly ISet<ICoreDisposedListener> coreClosedListeners = new JCG.OrderedHashSet<ICoreDisposedListener>().AsConcurrent();
 
         internal SegmentCoreReaders(SegmentReader owner, Directory dir, SegmentCommitInfo si, IOContext context, int termsIndexDivisor)
         {


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making.

Replace LinkedHashSet<T> with OrderedHashSet<T>

Fixes #1272

## Description

Replaces the `JCG.LinkedHashSet<T>` usages with `JCG.OrderedHashSet<T>` (added in J2N 2.2.0-alpha-0042, already our floor in `.build/dependencies.props`), with the requested `// LUCENENET specific:` comment at each site.

Kept the already-imported `JCG` alias (the issue suggests `J2N.`) so this stays consistent with the recent `JCG.Dictionary` sweep in #1287; can switch to `J2N.` if preferred.

Touched 8 files across core, the highlighter, and the phonetic analyzer, plus their tests. In `BaseConcurrentSetTestCase` I renamed `TestSynchronizedSet_LinkedHashSet` to `_OrderedHashSet` and updated its `<see cref>`. `DaitchMokotoffSoundex` still names `LinkedHashSet` in a comment that explains the deliberate `List<T>` there, so I left it.

Built on net10.0 and the touched tests pass, including the synchronized-set test now running over `OrderedHashSet`.
