### PR TITLE
`.asf.yaml`: use a better repository description

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -10,7 +10,7 @@ notifications:
   # jobs: builds@lucenenet.apache.org # This is probably too noisy to enable
 
 github:
-  description: "Apache Lucene.NET is an open-source full-text search library written in C#. It is a port of the popular Java Apache Lucene project."
+  description: "Apache Lucene.NET is an open-source full-text search library written in C#, ported from the Apache Lucene project."
   homepage: https://lucenenet.apache.org/
   labels:
     - lucenenet

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -10,7 +10,7 @@ notifications:
   # jobs: builds@lucenenet.apache.org # This is probably too noisy to enable
 
 github:
-  description: "Apache Lucene.NET"
+  description: "Apache Lucene.NET is an open-source full-text search library written in C#. It is a port of the popular Java Apache Lucene project."
   homepage: https://lucenenet.apache.org/
   labels:
     - lucenenet


### PR DESCRIPTION
We can update the repo description to be more informative. We should use this small space or real estate as best we can.

The next image is from my GitHub profile the pinned repo sections showing the current repo descriptions:

<img width="958" height="836" alt="Screenshot 2026-06-09 at 2 34 57 am" src="https://github.com/user-attachments/assets/67180231-5975-456f-8290-e8ec63ce161d" />
