### PR TITLE
Upgrade .NET SDK in Azure DevOps to 10.0.301, #1322

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ variables:
 - name: BuildCounter
   value: $[counter(variables['VersionSuffix'],coalesce(variables['BuildCounterSeed'], 1250))]
 - name: DotNetSDKVersion
-  value: '10.0.100'
+  value: '10.0.301'
 - name: DocumentationArtifactName
   value: 'docs'
 - name: DocumentationArtifactZipFileName


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Upgrade .NET SDK in Azure DevOps to 10.0.301

Fixes #1322
Fixes #1295
(and possibly others)

## Description

After several days of iteration (aka wasted time and tokens) trying to hunt down the #1322 test failure, it turns out it was a bug in the .NET runtime that's already been fixed. https://github.com/dotnet/runtime/issues/121578

This bug was fixed in 10.0.2 (SDK 10.0.102). This explains why these tests would fail regularly on .NET 10 on Azure DevOps, but not on GitHub Actions: Azure DevOps was pinned to SDK 10.0.100 (runtime 10.0.0), while GitHub Actions uses the flexible "10.0.x" spec to get the latest version. It also explains why I was unable to reproduce locally, because I had a newer SDK version. As soon as I downgraded my runtime, it reproduced right away.

The symptom of the failing test is basically that exceptions in nested try/finally blocks were able to escape under some conditions. The code was properly expecting to catch these, but the runtime bug prevented it.