### PR TITLE
Add CITATION file to help users correctly cite the Lucene.NET software

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,7 +20,25 @@ message: If you use this software, please cite it as below.
 title: Apache Lucene.NET
 type: software
 authors:
-  - name: Apache Lucene.NET Project
+  - name: Apache Lucene.NET Contributors
 repository-code: https://github.com/apache/lucenenet
 url: https://lucenenet.apache.org
 license: Apache-2.0
+abstract: "Apache Lucene.NET is a C# port of the Apache Lucene search library targeting .NET developers. It provides a powerful indexing and search engine library with support for text analysis, relevance ranking, query processing, and scalable full-text search across large collections of documents."
+keywords:
+  - search
+  - information retrieval
+  - full-text search
+  - text analysis
+  - query processing
+  - inverted index
+  - document retrieval
+  - relevance ranking
+  - indexing
+  - tokenization
+  - stemming
+  - faceted search
+  - linguistic analysis
+  - phonetic search
+  - fuzzy search
+  - spatial search

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: Apache Lucene.NET
+type: software
+authors:
+  - name: Apache Lucene.NET Project
+repository-code: https://github.com/apache/lucenenet
+url: https://lucenenet.apache.org
+license: Apache-2.0


### PR DESCRIPTION
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files

Adding a `CITATION.cff` (Citation File Format) or a `CITATION` file is a standard way to ensure that researchers and developers give the Apache Lucene.NET project the credit it deserves in academic or professional papers.

Since Lucene.NET is a top-level Apache project, providing a clear citation helps track its impact across the industry.

### Recommended Content for `CITATION.cff`

The YAML-based **Citation File Format** is the modern standard because it's machine-readable (GitHub even renders it automatically into a "Cite this repository" button).

### Why this helps the project

* **Consistency:** It prevents users from guessing how to cite the project, leading to cleaner data in academic databases.
* **Visibility:** GitHub highlights the citation info in the sidebar, making it easy for users to copy/paste BibTeX or APA formats.
* **Professionalism:** It aligns Lucene.NET with other major open-source projects that prioritize reproducibility and formal recognition.

---

- refs https://github.com/apache/shiro/blob/main/CITATION.cff
- refs https://github.com/apache/sedona/blob/master/CITATION.cff see this Sedona CITATION file for extra "fields"