### PR TITLE
Scan TestFramework assembly in analysis discovery tests, #1126

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/AnalysisSPILoader.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/AnalysisSPILoader.cs
@@ -128,9 +128,10 @@ namespace Lucene.Net.Analysis.Util
             }
             else
             {
+                // LUCENENET Specific: Sort the keys for better error message readability
                 throw new ArgumentException("A SPI class of type " + clazz.Name + " with name '" + name + "' does not exist. " +
                     "You need to add the corresponding reference supporting this SPI to your project or AppDomain. " +
-                    "The current classpath supports the following names: " + string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", AvailableServices));
+                    "The current classpath supports the following names: " + new JCG.SortedSet<string>(AvailableServices));
             }
         }
 

--- a/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/GraphvizFormatter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using JCG = J2N.Collections.Generic;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -46,7 +47,7 @@ namespace Lucene.Net.Analysis.Ja
 
         public GraphvizFormatter(ConnectionCosts costs)
         {
-            this.costs = costs;
+            this.costs = costs ?? throw new ArgumentNullException(nameof(costs)); // LUCENENET: Added guard clause
             this.bestPathMap = new JCG.Dictionary<string, string>();
             sb.Append(FormatHeader());
             sb.Append("  init [style=invis]\n");
@@ -136,7 +137,7 @@ namespace Lucene.Net.Analysis.Ja
                     sb.Append(toNodeID);
 
                     string attrs;
-                    bestPathMap.TryGetValue(fromNodeID, out string path);
+                    bestPathMap.TryGetValue(fromNodeID, out string? path);
                     if (toNodeID.Equals(path, StringComparison.Ordinal))
                     {
                         // This arc is on best path

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseAnalyzer.cs
@@ -1,4 +1,3 @@
-using J2N.Collections.Generic.Extensions;
 using Lucene.Net.Analysis.Cjk;
 using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.Ja.Dict;
@@ -8,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using JCG = J2N.Collections.Generic;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -36,19 +36,19 @@ namespace Lucene.Net.Analysis.Ja
     {
         private readonly JapaneseTokenizerMode mode;
         private readonly ISet<string> stoptags;
-        private readonly UserDictionary userDict;
+        private readonly UserDictionary? userDict;
 
         public JapaneseAnalyzer(LuceneVersion matchVersion)
             : this(matchVersion, null, JapaneseTokenizer.DEFAULT_MODE, DefaultSetHolder.DEFAULT_STOP_SET, DefaultSetHolder.DEFAULT_STOP_TAGS)
         {
         }
 
-        public JapaneseAnalyzer(LuceneVersion matchVersion, UserDictionary userDict, JapaneseTokenizerMode mode, CharArraySet stopwords, ISet<string> stoptags)
+        public JapaneseAnalyzer(LuceneVersion matchVersion, UserDictionary? userDict, JapaneseTokenizerMode mode, CharArraySet stopwords, ISet<string> stoptags)
             : base(matchVersion, stopwords)
         {
             this.userDict = userDict;
             this.mode = mode;
-            this.stoptags = stoptags;
+            this.stoptags = stoptags ?? throw new ArgumentNullException(nameof(stoptags));
         }
 
         [Obsolete("Use DefaultStopSet instead. This method will be removed in 4.8.0 release candidate."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseBaseFormFilter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseBaseFormFilter.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Analysis.Ja.TokenAttributes;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.TokenAttributes.Extensions;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -49,7 +50,7 @@ namespace Lucene.Net.Analysis.Ja
             {
                 if (!keywordAtt.IsKeyword)
                 {
-                    string baseForm = basicFormAtt.GetBaseForm();
+                    string? baseForm = basicFormAtt.GetBaseForm();
                     if (baseForm != null)
                     {
                         termAtt.SetEmpty().Append(baseForm);

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseBaseFormFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseBaseFormFilterFactory.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Analysis.Util;
 using System;
 using System.Collections.Generic;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseIterationMarkCharFilter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseIterationMarkCharFilter.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Diagnostics;
 using System.IO;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseIterationMarkCharFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseIterationMarkCharFilterFactory.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Analysis.Util;
 using System;
 using System.Collections.Generic;
 using System.IO;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -58,7 +59,7 @@ namespace Lucene.Net.Analysis.Ja
             return new JapaneseIterationMarkCharFilter(input, normalizeKanji, normalizeKana);
         }
 
-        public virtual AbstractAnalysisFactory GetMultiTermComponent()
+        public virtual AbstractAnalysisFactory? GetMultiTermComponent()
         {
             return this;
         }

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilter.cs
@@ -1,5 +1,7 @@
 using Lucene.Net.Analysis.TokenAttributes;
+using System;
 using System.Text.RegularExpressions;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -49,6 +51,10 @@ namespace Lucene.Net.Analysis.Ja
         public JapaneseKatakanaStemFilter(TokenStream input, int minimumLength)
             : base(input)
         {
+            // LUCENENET: Added guard clause
+            if (minimumLength < 0)
+                throw new ArgumentOutOfRangeException(nameof(minimumLength), "Minimum length must be a non-negative integer.");
+
             this.minimumKatakanaLength = minimumLength;
             this.termAttr = AddAttribute<ICharTermAttribute>();
             this.keywordAttr = AddAttribute<IKeywordAttribute>();

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilterFactory.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Analysis.Util;
 using System;
 using System.Collections.Generic;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {

--- a/src/Lucene.Net.Analysis.Kuromoji/JapanesePartOfSpeechStopFilter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapanesePartOfSpeechStopFilter.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Analysis.Ja
 
         protected override bool Accept()
         {
-            string pos = posAtt.GetPartOfSpeech();
+            string? pos = posAtt.GetPartOfSpeech();
             return pos is null || !stopTags.Contains(pos);
         }
     }

--- a/src/Lucene.Net.Analysis.Kuromoji/JapanesePartOfSpeechStopFilter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapanesePartOfSpeechStopFilter.cs
@@ -3,6 +3,7 @@ using Lucene.Net.Analysis.Util;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -33,9 +34,9 @@ namespace Lucene.Net.Analysis.Ja
 
         [Obsolete("EnablePositionIncrements=false is not supported anymore as of Lucene 4.4.")]
         public JapanesePartOfSpeechStopFilter(LuceneVersion version, bool enablePositionIncrements, TokenStream input, ISet<string> stopTags)
-                  : base(version, enablePositionIncrements, input)
+            : base(version, enablePositionIncrements, input)
         {
-            this.stopTags = stopTags;
+            this.stopTags = stopTags ?? throw new ArgumentNullException(nameof(stopTags));
             this.posAtt = AddAttribute<IPartOfSpeechAttribute>();
         }
 
@@ -48,7 +49,7 @@ namespace Lucene.Net.Analysis.Ja
         public JapanesePartOfSpeechStopFilter(LuceneVersion version, TokenStream input, ISet<string> stopTags)
             : base(version, input)
         {
-            this.stopTags = stopTags;
+            this.stopTags = stopTags ?? throw new ArgumentNullException(nameof(stopTags));
             this.posAtt = AddAttribute<IPartOfSpeechAttribute>();
         }
 

--- a/src/Lucene.Net.Analysis.Kuromoji/JapanesePartOfSpeechStopFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapanesePartOfSpeechStopFilterFactory.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Analysis.Util;
 using System;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -39,7 +40,7 @@ namespace Lucene.Net.Analysis.Ja
     {
         private readonly string stopTagFiles;
         private readonly bool enablePositionIncrements;
-        private ISet<string> stopTags;
+        private ISet<string>? stopTags;
 
         /// <summary>Creates a new JapanesePartOfSpeechStopFilterFactory</summary>
         public JapanesePartOfSpeechStopFilterFactory(IDictionary<string, string> args)

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseReadingFormFilter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseReadingFormFilter.cs
@@ -2,7 +2,9 @@ using Lucene.Net.Analysis.Ja.TokenAttributes;
 using Lucene.Net.Analysis.Ja.Util;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.TokenAttributes.Extensions;
+using System;
 using System.Text;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -53,7 +55,7 @@ namespace Lucene.Net.Analysis.Ja
         {
             if (m_input.IncrementToken())
             {
-                string reading = readingAttr.GetReading();
+                string? reading = readingAttr.GetReading();
 
                 if (useRomaji)
                 {
@@ -61,13 +63,13 @@ namespace Lucene.Net.Analysis.Ja
                     {
                         // if its an OOV term, just try the term text
                         buffer.Length = 0;
-                        ToStringUtil.GetRomanization(buffer, termAttr.ToString());
+                        ToStringUtil.GetRomanization(buffer, termAttr.AsSpan());
                         termAttr.SetEmpty().Append(buffer);
                     }
                     else
                     {
                         buffer.Length = 0;
-                        ToStringUtil.GetRomanization(buffer, reading);
+                        ToStringUtil.GetRomanization(buffer, reading.AsSpan());
                         termAttr.SetEmpty().Append(buffer);
                     }
                 }

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseReadingFormFilterFactory.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseReadingFormFilterFactory.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Analysis.Util;
 using System;
 using System.Collections.Generic;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizer.cs
@@ -16,6 +16,7 @@ using System.IO;
 using System.Threading;
 using JCG = J2N.Collections.Generic;
 using Int64 = J2N.Numerics.Int64;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -85,21 +86,21 @@ namespace Lucene.Net.Analysis.Ja
         private const int MAX_UNKNOWN_WORD_LENGTH = 1024;
         private const int MAX_BACKTRACE_GAP = 1024;
 
-        private readonly IDictionary<JapaneseTokenizerType, IDictionary> dictionaryMap = new JCG.Dictionary<JapaneseTokenizerType, IDictionary>();
+        private readonly IDictionary<JapaneseTokenizerType, IDictionary?> dictionaryMap = new JCG.Dictionary<JapaneseTokenizerType, IDictionary?>();
 
         private readonly TokenInfoFST fst;
         private readonly TokenInfoDictionary dictionary;
         private readonly UnknownDictionary unkDictionary;
         private readonly ConnectionCosts costs;
-        private readonly UserDictionary userDictionary;
+        private readonly UserDictionary? userDictionary;
         private readonly CharacterDefinition characterDefinition;
 
         private readonly FST.Arc<Int64> arc = new FST.Arc<Int64>();
         private readonly FST.BytesReader fstReader;
         private readonly Int32sRef wordIdRef = new Int32sRef();
 
-        private readonly FST.BytesReader userFSTReader;
-        private readonly TokenInfoFST userFST;
+        private readonly FST.BytesReader? userFSTReader;
+        private readonly TokenInfoFST? userFST;
 
         private readonly RollingCharBuffer buffer = new RollingCharBuffer();
 
@@ -147,7 +148,7 @@ namespace Lucene.Net.Analysis.Ja
         /// <param name="userDictionary">Optional: if non-null, user dictionary.</param>
         /// <param name="discardPunctuation"><c>true</c> if punctuation tokens should be dropped from the output.</param>
         /// <param name="mode">Tokenization mode.</param>
-        public JapaneseTokenizer(TextReader input, UserDictionary userDictionary, bool discardPunctuation, JapaneseTokenizerMode mode)
+        public JapaneseTokenizer(TextReader input, UserDictionary? userDictionary, bool discardPunctuation, JapaneseTokenizerMode mode)
             : this(AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY, input, userDictionary, discardPunctuation, mode)
         {
         }
@@ -161,7 +162,7 @@ namespace Lucene.Net.Analysis.Ja
         /// <param name="discardPunctuation"><c>true</c> if punctuation tokens should be dropped from the output.</param>
         /// <param name="mode">Tokenization mode.</param>
         public JapaneseTokenizer
-            (AttributeFactory factory, TextReader input, UserDictionary userDictionary, bool discardPunctuation, JapaneseTokenizerMode mode)
+            (AttributeFactory factory, TextReader input, UserDictionary? userDictionary, bool discardPunctuation, JapaneseTokenizerMode mode)
             : base(factory, input)
         {
             this.termAtt = AddAttribute<ICharTermAttribute>();
@@ -218,7 +219,7 @@ namespace Lucene.Net.Analysis.Ja
             dictionaryMap[JapaneseTokenizerType.USER] = userDictionary;
         }
 
-        private GraphvizFormatter dotOut;
+        private GraphvizFormatter? dotOut;
 
         // LUCENENET specific - added getter and made into property
         // so we can set this during object initialization.
@@ -227,7 +228,7 @@ namespace Lucene.Net.Analysis.Ja
         /// Expert: set this to produce graphviz (dot) output of
         /// the Viterbi lattice
         /// </summary>
-        public GraphvizFormatter GraphvizFormatter
+        public GraphvizFormatter? GraphvizFormatter
         {
             get => this.dotOut;
             set => this.dotOut = value;
@@ -381,12 +382,8 @@ namespace Lucene.Net.Analysis.Ja
                 Parse();
             }
 
-            Token token = pending[pending.Count - 1]; // LUCENENET: The above loop ensures we don't get here unless we have at least 1 item
-            if (token != null)
-            {
-                pending.Remove(token);
-            }
-
+            Token token = pending[pending.Count - 1]!; // LUCENENET: The above loop ensures we don't get here unless we have at least 1 item
+            pending.Remove(token);
             int position = token.Position;
             int length = token.Length;
             ClearAttributes();
@@ -496,7 +493,7 @@ namespace Lucene.Net.Analysis.Ja
                     // including ending at future positions:
                     int leastIDX = -1;
                     int leastCost = int.MaxValue;
-                    Position leastPosData = null;
+                    Position? leastPosData = null;
                     for (int pos2 = pos; pos2 < positions.GetNextPos(); pos2++)
                     {
                         Position posData2 = positions.Get(pos2);
@@ -515,6 +512,7 @@ namespace Lucene.Net.Analysis.Ja
 
                     // We will always have at least one live path:
                     if (Debugging.AssertsEnabled) Debugging.Assert(leastIDX != -1);
+                    if (Debugging.AssertsEnabled) Debugging.Assert(leastPosData != null); // LUCENENET: Just to satisfy the compiler, we know this can't be null since leastIDX is not -1
 
                     // Second pass: prune all but the best path:
                     for (int pos2 = pos; pos2 < positions.GetNextPos(); pos2++)
@@ -539,10 +537,10 @@ namespace Lucene.Net.Analysis.Ja
                         }
                     }
 
-                    Backtrace(leastPosData, 0);
+                    Backtrace(leastPosData!, 0); // LUCENENET: Asserted above
 
                     // Re-base cost so we don't risk int overflow:
-                    Arrays.Fill(leastPosData.costs, 0, leastPosData.count, 0);
+                    Arrays.Fill(leastPosData!.costs, 0, leastPosData.count, 0);
 
                     if (pos != leastPosData.pos)
                     {
@@ -598,7 +596,8 @@ namespace Lucene.Net.Analysis.Ja
                             {
                                 Console.WriteLine("    USER word " + new string(buffer.Get(pos, posAhead - pos + 1)) + " toPos=" + (posAhead + 1));
                             }
-                            Add(userDictionary, posData, posAhead + 1, output + (int)arc.NextFinalOutput, JapaneseTokenizerType.USER, false);
+                            // LUCENENET: userDictionary is the source of userFST. If userFST is not null, then userDictionary is not null either.
+                            Add(userDictionary!, posData, posAhead + 1, output + (int)arc.NextFinalOutput, JapaneseTokenizerType.USER, false);
                             anyMatches = true;
                         }
                     }
@@ -906,7 +905,7 @@ namespace Lucene.Net.Analysis.Ja
 
             int pos = endPos;
             int bestIDX = fromIDX;
-            Token altToken = null;
+            Token? altToken = null;
 
             // We trace backwards, so this will be the leftWordID of
             // the token after the one we are now on:
@@ -1085,7 +1084,7 @@ namespace Lucene.Net.Analysis.Ja
 
                     // Expand the phraseID we recorded into the actual
                     // segmentation:
-                    int[] wordIDAndLength = userDictionary.LookupSegmentation(backID);
+                    int[] wordIDAndLength = userDictionary!.LookupSegmentation(backID); // LUCENENET: User arcs only exist when userDictionary (thus userFST) is non-null
                     int wordID = wordIDAndLength[0];
                     int current = 0;
                     for (int j = 1; j < wordIDAndLength.Length; j++)
@@ -1191,8 +1190,8 @@ namespace Lucene.Net.Analysis.Ja
 
         internal IDictionary GetDict(JapaneseTokenizerType type)
         {
-            dictionaryMap.TryGetValue(type, out IDictionary result);
-            return result;
+            dictionaryMap.TryGetValue(type, out IDictionary? result);
+            return result ?? throw new InvalidOperationException($"JapaneseTokenizerType {type} has no registered dictionary"); // LUCENENET: Added null check and exception. With the current code, this should never happen.
         }
 
         private static bool IsPunctuation(char ch)

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizerFactory.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseTokenizerFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja
 {
@@ -52,12 +53,12 @@ namespace Lucene.Net.Analysis.Ja
 
         private const string DISCARD_PUNCTUATION = "discardPunctuation"; // Expert option
 
-        private UserDictionary userDictionary;
+        private UserDictionary? userDictionary;
 
         private readonly JapaneseTokenizerMode mode;
         private readonly bool discardPunctuation;
-        private readonly string userDictionaryPath;
-        private readonly string userDictionaryEncoding;
+        private readonly string? userDictionaryPath;
+        private readonly string? userDictionaryEncoding;
 
         /// <summary>Creates a new <see cref="JapaneseTokenizerFactory"/>.</summary>
         public JapaneseTokenizerFactory(IDictionary<string, string> args)
@@ -84,7 +85,7 @@ namespace Lucene.Net.Analysis.Ja
             if (userDictionaryPath != null)
             {
                 Stream stream = loader.OpenResource(userDictionaryPath);
-                string encoding = userDictionaryEncoding;
+                string? encoding = userDictionaryEncoding;
                 if (encoding is null)
                 {
                     encoding = Encoding.UTF8.WebName;

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/BaseFormAttribute.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/BaseFormAttribute.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Util;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja.TokenAttributes
 {
@@ -27,7 +28,7 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
     /// </summary>
     public interface IBaseFormAttribute : IAttribute
     {
-        string GetBaseForm();
-        void SetToken(Token token);
+        string? GetBaseForm();
+        void SetToken(Token? token);
     }
 }

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/BaseFormAttributeImpl.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/BaseFormAttributeImpl.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Util;
 using System;
 using Attribute = Lucene.Net.Util.Attribute;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja.TokenAttributes
 {
@@ -26,14 +27,14 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
     /// </summary>
     public class BaseFormAttribute : Attribute, IBaseFormAttribute // LUCENENET specific: Not implementing ICloneable per Microsoft's recommendation
     {
-        private Token token;
+        private Token? token;
 
-        public virtual string GetBaseForm()
+        public virtual string? GetBaseForm()
         {
             return token?.GetBaseForm();
         }
 
-        public virtual void SetToken(Token token)
+        public virtual void SetToken(Token? token)
         {
             this.token = token;
         }

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/InflectionAttribute.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/InflectionAttribute.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Util;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja.TokenAttributes
 {
@@ -27,8 +28,8 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
     /// </summary>
     public interface IInflectionAttribute : IAttribute
     {
-        string GetInflectionType();
-        string GetInflectionForm();
-        void SetToken(Token token);
+        string? GetInflectionType();
+        string? GetInflectionForm();
+        void SetToken(Token? token);
     }
 }

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/InflectionAttributeImpl.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/InflectionAttributeImpl.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Analysis.Ja.Util;
 using Lucene.Net.Util;
 using System;
 using Attribute = Lucene.Net.Util.Attribute;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja.TokenAttributes
 {
@@ -27,19 +28,19 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
     /// </summary>
     public class InflectionAttribute : Attribute, IInflectionAttribute // LUCENENET specific: Not implementing ICloneable per Microsoft's recommendation
     {
-        private Token token;
+        private Token? token;
 
-        public virtual string GetInflectionType()
+        public virtual string? GetInflectionType()
         {
             return token?.GetInflectionType();
         }
 
-        public virtual string GetInflectionForm()
+        public virtual string? GetInflectionForm()
         {
             return token?.GetInflectionForm();
         }
 
-        public virtual void SetToken(Token token)
+        public virtual void SetToken(Token? token)
         {
             this.token = token;
         }
@@ -65,12 +66,12 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
             if (reflector is null)
                 throw new ArgumentNullException(nameof(reflector));
 
-            string type = GetInflectionType();
-            string typeEN = type is null ? null : ToStringUtil.GetInflectionTypeTranslation(type);
+            string? type = GetInflectionType();
+            string? typeEN = type is null ? null : ToStringUtil.GetInflectionTypeTranslation(type);
             reflector.Reflect<IInflectionAttribute>("inflectionType", type);
             reflector.Reflect<IInflectionAttribute>("inflectionType (en)", typeEN);
-            string form = GetInflectionForm();
-            string formEN = form is null ? null : ToStringUtil.GetInflectedFormTranslation(form);
+            string? form = GetInflectionForm();
+            string? formEN = form is null ? null : ToStringUtil.GetInflectedFormTranslation(form);
             reflector.Reflect<IInflectionAttribute>("inflectionForm", form);
             reflector.Reflect<IInflectionAttribute>("inflectionForm (en)", formEN);
         }

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/PartOfSpeechAttribute.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/PartOfSpeechAttribute.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Util;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja.TokenAttributes
 {
@@ -24,7 +25,7 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
     /// </summary>
     public interface IPartOfSpeechAttribute : IAttribute
     {
-        string GetPartOfSpeech();
-        void SetToken(Token token);
+        string? GetPartOfSpeech();
+        void SetToken(Token? token);
     }
 }

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/PartOfSpeechAttributeImpl.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/PartOfSpeechAttributeImpl.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Analysis.Ja.Util;
 using Lucene.Net.Util;
 using System;
 using Attribute = Lucene.Net.Util.Attribute;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja.TokenAttributes
 {
@@ -27,14 +28,14 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
     /// </summary>
     public class PartOfSpeechAttribute : Attribute, IPartOfSpeechAttribute // LUCENENET specific: Not implementing ICloneable per Microsoft's recommendation
     {
-        private Token token;
+        private Token? token;
 
-        public virtual string GetPartOfSpeech()
+        public virtual string? GetPartOfSpeech()
         {
             return token?.GetPartOfSpeech();
         }
 
-        public virtual void SetToken(Token token)
+        public virtual void SetToken(Token? token)
         {
             this.token = token;
         }
@@ -60,8 +61,8 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
             if (reflector is null)
                 throw new ArgumentNullException(nameof(reflector));
 
-            string partOfSpeech = GetPartOfSpeech();
-            string partOfSpeechEN = partOfSpeech is null ? null : ToStringUtil.GetPOSTranslation(partOfSpeech);
+            string? partOfSpeech = GetPartOfSpeech();
+            string? partOfSpeechEN = partOfSpeech is null ? null : ToStringUtil.GetPOSTranslation(partOfSpeech);
             reflector.Reflect<IPartOfSpeechAttribute>("partOfSpeech", partOfSpeech);
             reflector.Reflect<IPartOfSpeechAttribute>("partOfSpeech (en)", partOfSpeechEN);
         }

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/ReadingAttribute.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/ReadingAttribute.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Util;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja.TokenAttributes
 {
@@ -27,8 +28,8 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
     /// </summary>
     public interface IReadingAttribute : IAttribute
     {
-        string GetReading();
-        string GetPronunciation();
-        void SetToken(Token token);
+        string? GetReading();
+        string? GetPronunciation();
+        void SetToken(Token? token);
     }
 }

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/ReadingAttributeImpl.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/ReadingAttributeImpl.cs
@@ -2,6 +2,7 @@ using Lucene.Net.Analysis.Ja.Util;
 using Lucene.Net.Util;
 using System;
 using Attribute = Lucene.Net.Util.Attribute;
+#nullable enable
 
 namespace Lucene.Net.Analysis.Ja.TokenAttributes
 {
@@ -27,19 +28,19 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
     /// </summary>
     public class ReadingAttribute : Attribute, IReadingAttribute // LUCENENET specific: Not implementing ICloneable per Microsoft's recommendation
     {
-        private Token token;
+        private Token? token;
 
-        public virtual string GetReading()
+        public virtual string? GetReading()
         {
             return token?.GetReading();
         }
 
-        public virtual string GetPronunciation()
+        public virtual string? GetPronunciation()
         {
             return token?.GetPronunciation();
         }
 
-        public virtual void SetToken(Token token)
+        public virtual void SetToken(Token? token)
         {
             this.token = token;
         }
@@ -65,10 +66,10 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
             if (reflector is null)
                 throw new ArgumentNullException(nameof(reflector));
 
-            string reading = GetReading();
-            string readingEN = reading is null ? null : ToStringUtil.GetRomanization(reading);
-            string pronunciation = GetPronunciation();
-            string pronunciationEN = pronunciation is null ? null : ToStringUtil.GetRomanization(pronunciation);
+            string? reading = GetReading();
+            string? readingEN = reading is null ? null : ToStringUtil.GetRomanization(reading);
+            string? pronunciation = GetPronunciation();
+            string? pronunciationEN = pronunciation is null ? null : ToStringUtil.GetRomanization(pronunciation);
             reflector.Reflect<IReadingAttribute>("reading", reading);
             reflector.Reflect<IReadingAttribute>("reading (en)", readingEN);
             reflector.Reflect<IReadingAttribute>("pronunciation", pronunciation);

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/ReadingAttributeImpl.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/ReadingAttributeImpl.cs
@@ -67,9 +67,9 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
                 throw new ArgumentNullException(nameof(reflector));
 
             string? reading = GetReading();
-            string? readingEN = reading is null ? null : ToStringUtil.GetRomanization(reading);
+            string? readingEN = reading is null ? null : ToStringUtil.GetRomanization(reading.AsSpan());
             string? pronunciation = GetPronunciation();
-            string? pronunciationEN = pronunciation is null ? null : ToStringUtil.GetRomanization(pronunciation);
+            string? pronunciationEN = pronunciation is null ? null : ToStringUtil.GetRomanization(pronunciation.AsSpan());
             reflector.Reflect<IReadingAttribute>("reading", reading);
             reflector.Reflect<IReadingAttribute>("reading (en)", readingEN);
             reflector.Reflect<IReadingAttribute>("pronunciation", pronunciation);

--- a/src/Lucene.Net.Analysis.Kuromoji/Util/ToStringUtil.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/Util/ToStringUtil.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 using JCG = J2N.Collections.Generic;
 
@@ -252,7 +251,7 @@ namespace Lucene.Net.Analysis.Ja.Util
         /// <summary>
         /// Romanize katakana with modified hepburn
         /// </summary>
-        public static string GetRomanization(string s)
+        public static string GetRomanization(ReadOnlySpan<char> s)
         {
             StringBuilder result = new StringBuilder();
             try
@@ -271,7 +270,7 @@ namespace Lucene.Net.Analysis.Ja.Util
         /// </summary>
         // TODO: now that this is used by readingsfilter and not just for
         // debugging, fix this to really be a scheme that works best with IMEs
-        public static void GetRomanization(StringBuilder builder, string s)
+        public static void GetRomanization(StringBuilder builder, ReadOnlySpan<char> s)
         {
             int len = s.Length;
             for (int i = 0; i < len; i++)

--- a/src/Lucene.Net.Analysis.Phonetic/DoubleMetaphoneFilter.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/DoubleMetaphoneFilter.cs
@@ -47,7 +47,7 @@ namespace Lucene.Net.Analysis.Phonetic
         public DoubleMetaphoneFilter(TokenStream input, int maxCodeLength, bool inject)
             : base(input)
         {
-            this.encoder.MaxCodeLen = maxCodeLength;
+            this.encoder.MaxCodeLen = maxCodeLength; // LUCENENET: MaxCodeLen ensures the value is non-negative
             this.inject = inject;
             this.termAtt = AddAttribute<ICharTermAttribute>();
             this.posAtt = AddAttribute<IPositionIncrementAttribute>();

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
@@ -1,7 +1,5 @@
 // commons-codec version compatibility level: 1.9
-using J2N.Collections.Generic.Extensions;
 using J2N.Text;
-using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -455,7 +453,8 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                     foreach (string aWord in words)
                     {
                         string[] parts = aWord.Split('\'').TrimEnd();
-                        string lastPart = parts[parts.Length - 1];
+                        // LUCENENET: Fixed exception when the match results in 0 parts, although not sure this is the right way to handle it
+                        string lastPart = parts.Length > 0 ? parts[parts.Length - 1] : string.Empty;
                         words2.Add(lastPart);
                     }
                     words2.ExceptWith(NAME_PREFIXES[this.nameType]);
@@ -486,12 +485,18 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             {
                 // encode each word in a multi-word name separately (normally used for approx matches)
                 StringBuilder result = new StringBuilder();
+                // LUCENENET: Fixed issue with building the string when words2 is empty
+                bool first = true;
                 foreach (string word in words2)
                 {
-                    result.Append('-').Append(Encode(word));
+                    if (!first)
+                        result.Append('-');
+
+                    result.Append(Encode(word));
+                    first = false;
                 }
-                // return the result without the leading "-"
-                return result.ToString(1, result.Length - 1);
+                // return the result
+                return result.ToString();
             }
 
             PhonemeBuilder phonemeBuilder = PhonemeBuilder.Empty(languageSet);

--- a/src/Lucene.Net.Analysis.Phonetic/Language/DoubleMetaphone.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/DoubleMetaphone.cs
@@ -242,7 +242,13 @@ namespace Lucene.Net.Analysis.Phonetic.Language
         public virtual int MaxCodeLen
         {
             get => this.maxCodeLen;
-            set => this.maxCodeLen = value;
+            set
+            {
+                // LUCENENET: Added guard clause
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), "maxCodeLen must be a non-negative integer");
+                this.maxCodeLen = value;
+            }
         }
 
         //-- BEGIN HANDLERS --//

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAllAnalyzersHaveFactories.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAllAnalyzersHaveFactories.cs
@@ -99,7 +99,12 @@ namespace Lucene.Net.Analysis.Core
         [Test]
         public virtual void Test()
         {
-            IList<Type> analysisClasses = typeof(StandardAnalyzer).Assembly.GetTypes()
+            // LUCENENET specific: In Java, getClassesForPackage() scans the whole test classpath,
+            // which includes the test-framework (Mock*/Cranky/Validating types live there). In .NET
+            // those types are in a separate assembly (Lucene.Net.TestFramework), so we scan it in
+            // addition to Analysis.Common to match the upstream coverage. See GitHub #1126.
+            IList<Type> analysisClasses = new[] { typeof(StandardAnalyzer).Assembly, typeof(MockTokenizer).Assembly }
+                    .SelectMany(a => a.GetTypes())
                     .Where(c =>
                     {
                         var typeInfo = c;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAllAnalyzersHaveFactories.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestAllAnalyzersHaveFactories.cs
@@ -7,9 +7,8 @@ using Lucene.Net.Analysis.Nl;
 using Lucene.Net.Analysis.Path;
 using Lucene.Net.Analysis.Sinks;
 using Lucene.Net.Analysis.Snowball;
-using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Analysis.Stempel;
 using Lucene.Net.Analysis.Util;
-using Lucene.Net.Analysis;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System;
@@ -78,7 +77,10 @@ namespace Lucene.Net.Analysis.Core
                 typeof(ReversePathHierarchyTokenizer), // this is supported via an option to PathHierarchyTokenizer's factory
                 typeof(SnowballFilter), // this is called SnowballPorterFilterFactory
                 typeof(PatternKeywordMarkerFilter),
-                typeof(SetKeywordMarkerFilter)
+                typeof(SetKeywordMarkerFilter),
+
+                // LUCENENET specific: Added this exception because we are scanning the Stempel assembly
+                typeof(StempelFilter), // this is called StempelPolishStemFilterFactory
             });
         }
 
@@ -101,20 +103,16 @@ namespace Lucene.Net.Analysis.Core
         {
             // LUCENENET specific: In Java, getClassesForPackage() scans the whole test classpath,
             // which includes the test-framework (Mock*/Cranky/Validating types live there). In .NET
-            // those types are in a separate assembly (Lucene.Net.TestFramework), so we scan it in
-            // addition to Analysis.Common to match the upstream coverage. See GitHub #1126.
-            IList<Type> analysisClasses = new[] { typeof(StandardAnalyzer).Assembly, typeof(MockTokenizer).Assembly }
-                    .SelectMany(a => a.GetTypes())
-                    .Where(c =>
-                    {
-                        var typeInfo = c;
+            // we scan each assembly that has analysis types. See GitHub #1126.
+            IEnumerable<Type> analysisClasses = TestRandomChains.GetClassesForPackage()
+                .Where(c =>
+                {
+                    var typeInfo = c;
 
-                        return !typeInfo.IsAbstract && typeInfo.IsPublic && !typeInfo.IsInterface && typeInfo.IsClass && (typeInfo.GetCustomAttribute<ObsoleteAttribute>() is null)
-                            && !testComponents.Contains(c) && !crazyComponents.Contains(c) && !oddlyNamedComponents.Contains(c) && !deprecatedDuplicatedComponents.Contains(c)
-                            && (typeInfo.IsSubclassOf(typeof(Tokenizer)) || typeInfo.IsSubclassOf(typeof(TokenFilter)) || typeInfo.IsSubclassOf(typeof(CharFilter)));
-                    })
-                    .ToList();
-
+                    return !typeInfo.IsAbstract && typeInfo.IsPublic && !typeInfo.IsInterface && typeInfo.IsClass && (typeInfo.GetCustomAttribute<ObsoleteAttribute>() is null)
+                        && !testComponents.Contains(c) && !crazyComponents.Contains(c) && !oddlyNamedComponents.Contains(c) && !deprecatedDuplicatedComponents.Contains(c)
+                        && (typeInfo.IsSubclassOf(typeof(Tokenizer)) || typeInfo.IsSubclassOf(typeof(TokenFilter)) || typeInfo.IsSubclassOf(typeof(CharFilter)));
+                });
 
             foreach (Type c in analysisClasses)
             {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -187,7 +187,12 @@ namespace Lucene.Net.Analysis.Core
         {
             base.OneTimeSetUp();
 
-            IEnumerable<Type> analysisClasses = typeof(StandardAnalyzer).Assembly.GetTypes()
+            // LUCENENET specific: In Java, getClassesForPackage() scans the whole test classpath,
+            // which includes the test-framework (Mock*/Cranky/Validating types live there). In .NET
+            // those types are in a separate assembly (Lucene.Net.TestFramework), so we scan it in
+            // addition to Analysis.Common to match the upstream coverage. See GitHub #1126.
+            IEnumerable<Type> analysisClasses = new[] { typeof(StandardAnalyzer).Assembly, typeof(MockTokenizer).Assembly }
+                .SelectMany(a => a.GetTypes())
                 .Where(c =>
                 {
                     var typeInfo = c;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -1,30 +1,42 @@
 // Lucene version compatibility level 4.8.1
 
+using Egothor.Stemmer;
+using ICU4N.Text;
 using J2N;
 using J2N.Runtime.CompilerServices;
 using J2N.Text;
+using Lucene.Net.Analysis.Ar;
 using Lucene.Net.Analysis.CharFilters;
 using Lucene.Net.Analysis.Cjk;
+using Lucene.Net.Analysis.Cn.Smart;
 using Lucene.Net.Analysis.CommonGrams;
 using Lucene.Net.Analysis.Compound;
 using Lucene.Net.Analysis.Compound.Hyphenation;
 using Lucene.Net.Analysis.Hunspell;
+using Lucene.Net.Analysis.Icu;
+using Lucene.Net.Analysis.Icu.Segmentation;
+using Lucene.Net.Analysis.Ja;
 using Lucene.Net.Analysis.Miscellaneous;
+using Lucene.Net.Analysis.Morfologik;
 using Lucene.Net.Analysis.NGram;
 using Lucene.Net.Analysis.No;
 using Lucene.Net.Analysis.Path;
 using Lucene.Net.Analysis.Payloads;
+using Lucene.Net.Analysis.Phonetic;
+using Lucene.Net.Analysis.Phonetic.Language;
+using Lucene.Net.Analysis.Phonetic.Language.Bm;
 using Lucene.Net.Analysis.Snowball;
 using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Analysis.Stempel;
 using Lucene.Net.Analysis.Synonym;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Analysis.Wikipedia;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using Lucene.Net.Tartarus.Snowball;
-using Lucene.Net.Analysis;
 using Lucene.Net.Util;
 using Lucene.Net.Util.Automaton;
+using Morfologik.Stemming.Polish;
 using NUnit.Framework;
 using RandomizedTesting.Generators;
 using System;
@@ -189,10 +201,9 @@ namespace Lucene.Net.Analysis.Core
 
             // LUCENENET specific: In Java, getClassesForPackage() scans the whole test classpath,
             // which includes the test-framework (Mock*/Cranky/Validating types live there). In .NET
-            // those types are in a separate assembly (Lucene.Net.TestFramework), so we scan it in
-            // addition to Analysis.Common to match the upstream coverage. See GitHub #1126.
-            IEnumerable<Type> analysisClasses = new[] { typeof(StandardAnalyzer).Assembly, typeof(MockTokenizer).Assembly }
-                .SelectMany(a => a.GetTypes())
+            // we scan each assembly that has analysis types. See GitHub #1126.
+            IEnumerable<Type> analysisClasses =
+                GetClassesForPackage()
                 .Where(c =>
                 {
                     var typeInfo = c;
@@ -200,8 +211,8 @@ namespace Lucene.Net.Analysis.Core
                     return !typeInfo.IsAbstract && typeInfo.IsPublic && !typeInfo.IsInterface
                         && typeInfo.IsClass && (typeInfo.GetCustomAttribute<ObsoleteAttribute>() is null)
                         && (typeInfo.IsSubclassOf(typeof(Tokenizer)) || typeInfo.IsSubclassOf(typeof(TokenFilter)) || typeInfo.IsSubclassOf(typeof(CharFilter)));
-                })
-                .ToArray();
+                });
+
             tokenizers = new JCG.List<ConstructorInfo>();
             tokenfilters = new JCG.List<ConstructorInfo>();
             charfilters = new JCG.List<ConstructorInfo>();
@@ -218,19 +229,19 @@ namespace Lucene.Net.Analysis.Core
 
                     if (typeInfo.IsSubclassOf(typeof(Tokenizer)))
                     {
-                        assertTrue(ctor.ToString() + " has unsupported parameter types",
+                        assertTrue($"[{typeInfo}] {ctor.ToString()} has unsupported parameter types",
                             allowedTokenizerArgs.containsAll(ctor.GetParameters().Select(p => p.ParameterType).ToArray()));
                         tokenizers.Add(ctor);
                     }
                     else if (typeInfo.IsSubclassOf(typeof(TokenFilter)))
                     {
-                        assertTrue(ctor.ToString() + " has unsupported parameter types",
+                        assertTrue($"[{typeInfo}] {ctor.ToString()} has unsupported parameter types",
                             allowedTokenFilterArgs.containsAll(ctor.GetParameters().Select(p => p.ParameterType).ToArray()));
                         tokenfilters.Add(ctor);
                     }
                     else if (typeInfo.IsSubclassOf(typeof(CharFilter)))
                     {
-                        assertTrue(ctor.ToString() + " has unsupported parameter types",
+                        assertTrue($"[{typeInfo}] {ctor.ToString()} has unsupported parameter types",
                             allowedCharFilterArgs.containsAll(ctor.GetParameters().Select(p => p.ParameterType).ToArray()));
                         charfilters.Add(ctor);
                     }
@@ -263,6 +274,26 @@ namespace Lucene.Net.Analysis.Core
             base.OneTimeTearDown();
         }
 
+        private static IEnumerable<Assembly> GetAnalyzerAssemblies()
+        {
+            // LUCENENET NOTE: We don't include Lucene.Net.Analysis.OpenNLP here because its
+            // components require specific setup order and are generally not suitable for random chaining.
+
+            yield return typeof(Analyzer).Assembly; // Lucene.Net (No analyzers in 4.8.1, but this will include StandardAnalyzer in the future)
+            yield return typeof(ICUFoldingFilter).Assembly; // Lucene.Net.ICU
+            yield return typeof(ArabicAnalyzer).Assembly; // Lucene.Net.Analysis.Common
+            yield return typeof(JapaneseAnalyzer).Assembly; // Lucene.Net.Analysis.Kuromoji
+            yield return typeof(MorfologikAnalyzer).Assembly; // Lucene.Net.Analysis.Morfologik
+            yield return typeof(BeiderMorseFilter).Assembly; // Lucene.Net.Analysis.Phonetic
+            yield return typeof(SmartChineseAnalyzer).Assembly; // Lucene.Net.Analysis.SmartCn
+            yield return typeof(StempelFilter).Assembly; // Lucene.Net.Analysis.Stempel
+            yield return typeof(MockTokenizer).Assembly; // Lucene.Net.TestFramework
+        }
+
+        public static IEnumerable<Type> GetClassesForPackage()
+        {
+            return GetAnalyzerAssemblies().SelectMany(a => a.GetTypes());
+        }
 
         private interface IArgProducer
         {
@@ -314,6 +345,97 @@ namespace Lucene.Net.Analysis.Core
             }) },
             { typeof(CultureInfo), new AnonymousProducer((random) => {
                 return LuceneTestCase.RandomCulture(random);
+            }) },
+            { typeof(Normalizer2), new AnonymousProducer(static random => {
+                return random.Next(5) switch
+                {
+                    0 => Normalizer2.NFCInstance,
+                    1 => Normalizer2.NFDInstance,
+                    2 => Normalizer2.NFKCInstance,
+                    3 => Normalizer2.NFKDInstance,
+                    _ => Normalizer2.NFKCCaseFoldInstance,
+                };
+            }) },
+            { typeof(Transliterator), new AnonymousProducer(static random => {
+                string id = random.Next(8) switch
+                {
+                    0 => "Latin-Greek",
+                    1 => "Greek-Latin",
+                    2 => "Latin-Cyrillic",
+                    3 => "Cyrillic-Latin",
+                    4 => "Latin-Katakana",
+                    5 => "Katakana-Latin",
+                    6 => "Any-Latin",
+                    _ => "Latin-ASCII"
+                };
+
+                return Transliterator.GetInstance(id);
+            }) },
+            { typeof(ICUTokenizerConfig), new AnonymousProducer(static random => {
+                return new DefaultICUTokenizerConfig(
+                    cjkAsWords: random.NextBoolean(),
+                    myanmarAsWords: random.NextBoolean());
+            }) },
+            { typeof(ISet<string>), new AnonymousProducer(static random => { // For JapanesePartOfSpeechStopFilter
+                ISet<string> set = new JCG.HashSet<string>();
+                int num = random.nextInt(10);
+
+                for (int i = 0; i < num; i++)
+                {
+                    set.Add(TestUtil.RandomSimpleString(random));
+                }
+
+                return set;
+            }) },
+            { typeof(Ja.Dict.UserDictionary), new AnonymousProducer(static random => {
+                // LUCENENET specific - added the userdict.txt file from Lucene.Net.Test.Analysis.Kuromoji to the test resources and load it here
+                using Stream stream = typeof(TestRandomChains).getResourceAsStream("userdict.txt");
+                if (stream is null)
+                {
+                    throw RuntimeException.Create("Cannot find userdict.txt in test classpath!");
+                }
+                using var reader = new StreamReader(stream);
+                return new Ja.Dict.UserDictionary(reader);
+            }) },
+            { typeof(JapaneseTokenizerMode), new AnonymousProducer(static random => {
+                return RandomEnum<JapaneseTokenizerMode>(random);
+            }) },
+            { typeof(global::Morfologik.Stemming.Dictionary), new AnonymousProducer(static random => {
+                return new PolishStemmer().Dictionary;
+            }) },
+            { typeof(PhoneticEngine), new AnonymousProducer(static random => {
+                RuleType[] ruleTypes = { RuleType.APPROX, RuleType.EXACT };
+
+                return new PhoneticEngine(
+                    nameType: RandomEnum<NameType>(random),
+                    ruleType: ruleTypes[random.Next(ruleTypes.Length)],
+                    concat: random.NextBoolean());
+            }) },
+            { typeof(LanguageSet), new AnonymousProducer(static random => {
+                return Languages.ANY_LANGUAGE;
+            }) },
+            { typeof(IStringEncoder), new AnonymousProducer(static random => {
+                return random.Next(5) switch
+                {
+                    0 => new Metaphone(),
+                    1 => new DoubleMetaphone(),
+                    2 => new Soundex(),
+                    3 => new RefinedSoundex(),
+                    _ => new Caverphone2(),
+                };
+            }) },
+            { typeof(StempelStemmer), new AnonymousProducer(static random => {
+                MultiTrie2 t = new MultiTrie2(forward: random.NextBoolean());
+
+                string[] keys = { "a", "ba", "bb", "c" };
+                string[] vals = { "1111", "2222", "2223", "4444" };
+
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    t.Add(keys[i], vals[i]);
+                }
+
+                return new StempelStemmer(t);
             }) },
         };
 
@@ -1152,6 +1274,13 @@ namespace Lucene.Net.Analysis.Core
         {
             internal TextReader reader;
             internal string toString;
+        }
+
+        private static TEnum RandomEnum<TEnum>(Random random)
+            where TEnum : struct, Enum
+        {
+            TEnum[] values = (TEnum[])Enum.GetValues(typeof(TEnum));
+            return values[random.Next(values.Length)];
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Lucene.Net.Tests.Analysis.Common.csproj
+++ b/src/Lucene.Net.Tests.Analysis.Common/Lucene.Net.Tests.Analysis.Common.csproj
@@ -34,6 +34,10 @@
     <EmbeddedResource Include="**/*.txt" Exclude="bin/**/*.txt;obj/**/*.txt" Label="Text Test Data" />
     <EmbeddedResource Include="**/*.htm;**/*.html" Exclude="bin/**/*.htm;obj/**/*.htm;bin/**/*.html;obj/**/*.html" Label="HTML Test Data" />
     <EmbeddedResource Include="**/*.xml" Exclude="bin/**/*.xml;obj/**/*.xml" Label="XML Test Data" />
+
+    <!-- LUCENENET: Added this file because it is a dependency of TestRandomChains.
+      It is simpler to embed this one small file than to reference the Kuromoji test project. -->
+    <EmbeddedResource Include="..\Lucene.Net.Tests.Analysis.Kuromoji\userdict.txt" Link="Analysis\Core\userdict.txt" />
   </ItemGroup>
 
   <ItemGroup>
@@ -51,6 +55,27 @@
       <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Lucene.Net.TestFramework\Lucene.Net.TestFramework.csproj">
+      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Label="Required for TestRandomChains and TestAllAnalyzersHaveFactories">
+    <ProjectReference Include="..\dotnet\Lucene.Net.ICU\Lucene.Net.ICU.csproj">
+      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Lucene.Net.Analysis.Kuromoji\Lucene.Net.Analysis.Kuromoji.csproj">
+      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Lucene.Net.Analysis.Morfologik\Lucene.Net.Analysis.Morfologik.csproj">
+      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Lucene.Net.Analysis.Phonetic\Lucene.Net.Analysis.Phonetic.csproj">
+      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Lucene.Net.Analysis.SmartCn\Lucene.Net.Analysis.SmartCn.csproj">
+      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\Lucene.Net.Analysis.Stempel\Lucene.Net.Analysis.Stempel.csproj">
       <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/Lucene.Net.Tests.Analysis.Kuromoji.csproj
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/Lucene.Net.Tests.Analysis.Kuromoji.csproj
@@ -25,6 +25,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Lucene.Net.Tests.Analysis.Kuromoji</AssemblyTitle>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Scan TestFramework assembly in analysis discovery tests

Fixes #1126

## Description

TestRandomChains and TestAllAnalyzersHaveFactories discovered analysis components by scanning only the Analysis.Common assembly. In Java 4.8.1 these tests use `getClassesForPackage()` over the whole test classpath, which includes the test-framework's Mock*/Cranky/Validating components in package org.apache.lucene.analysis. In .NET those types live in the separate Lucene.Net.TestFramework assembly (already referenced), so they were never surfaced and the existing testComponents/brokenConstructors exclusion entries for them were dead code.

Scan Lucene.Net.TestFramework alongside Analysis.Common so the 10 test-framework components are discovered, matching 4.8.1's coverage.

The following types are added to coverage by this PR:
- MockTokenizer
- MockCharFilter
- MockTokenFilter
- MockGraphTokenFilter
- MockHoleInjectingTokenFilter
- MockRandomLookaheadTokenFilter
- MockFixedLengthPayloadFilter
- MockVariableLengthPayloadFilter
- CrankyTokenFilter
- ValidatingTokenFilter

## Scope Note

This PR intentionally does not fully cover all types mentioned in #1126. This only updates the set of types to match Lucene 4.8.1. I think the best approach is to backport the Lucene 9 change mentioned in that issue, but that would (to stay true to the upstream change) require a new unit test project (i.e. Lucene.Net.Tests.Analysis) that references all of the projects in question, and thus more GitHub/ADO pipeline changes, etc. and should be done in its own PR. I think our best approach for now is to make this match Lucene 4.8.1 (this PR), and save the rest of #1126 for later (either 4.8.0 final or post-4.8).