### PR TITLE
Add FileShare.Delete to SimpleFSDirectory and FSIndexOutput, #1283

### DIFF
--- a/src/Lucene.Net.Tests/Store/TestDirectory.cs
+++ b/src/Lucene.Net.Tests/Store/TestDirectory.cs
@@ -490,6 +490,120 @@ namespace Lucene.Net.Store
             }
         }
 
+        // LUCENENET specific: Regression test for #1283. A read handle held open by SimpleFSDirectory or
+        // NIOFSDirectory must not block deletion of the underlying file. On Windows this only works because the
+        // read FileStream is opened with FileShare.Delete (the delete becomes a deferred/pending delete); on
+        // POSIX, delete-while-open always works. After the delete, the still-open handle must keep returning the
+        // original bytes without corruption. The assertion only has teeth on Windows (POSIX ignores share modes
+        // and would pass regardless), but the behavior asserted is cross-platform, so the test is not gated.
+        // MMapDirectory is intentionally excluded: its read handle still lacks FileShare.Delete in master and is
+        // addressed separately in #1267.
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestDeleteWhileReadHandleOpen()
+        {
+            DirectoryInfo tempDir = CreateTempDir(GetType().Name);
+            var factories = new Func<Directory>[]
+            {
+                () => new SimpleFSDirectory(tempDir),
+                () => new NIOFSDirectory(tempDir),
+            };
+
+            byte[] expected = new byte[128];
+            for (int i = 0; i < expected.Length; i++)
+            {
+                expected[i] = (byte)i;
+            }
+
+            int n = 0;
+            foreach (var factory in factories)
+            {
+                using Directory dir = factory();
+                string name = "delete-while-read-" + n++;
+
+                using (IndexOutput output = dir.CreateOutput(name, NewIOContext(Random)))
+                {
+                    output.WriteBytes(expected, expected.Length);
+                }
+
+                IndexInput input = dir.OpenInput(name, NewIOContext(Random));
+                try
+                {
+                    // Read the first byte so the handle is genuinely active.
+                    Assert.AreEqual(expected[0], input.ReadByte());
+
+                    // The crux: deleting while a read handle is open must not throw.
+                    try
+                    {
+                        dir.DeleteFile(name);
+                    }
+                    catch (Exception e)
+                    {
+                        Assert.Fail("DeleteFile threw while a read handle was open (missing FileShare.Delete?) for "
+                            + dir.GetType().Name + ": " + e);
+                    }
+
+                    // The still-open handle must keep returning the original bytes (no corruption, handle still valid).
+                    byte[] actual = new byte[expected.Length - 1];
+                    input.ReadBytes(actual, 0, actual.Length);
+                    for (int i = 0; i < actual.Length; i++)
+                    {
+                        Assert.AreEqual(expected[i + 1], actual[i]);
+                    }
+                }
+                finally
+                {
+                    input.Dispose();
+                }
+            }
+        }
+
+        // LUCENENET specific: Regression test for #1283. The shared FSIndexOutput write handle (used by every
+        // FSDirectory subclass) is opened with FileShare.Delete, so deleting a file must succeed even while its
+        // write handle is still open. This makes the "if Lucene decides a file is deletable, the delete succeeds"
+        // guarantee hold unconditionally on Windows regardless of which of our own handles are open.
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestDeleteWhileWriteHandleOpen()
+        {
+            DirectoryInfo tempDir = CreateTempDir(GetType().Name);
+            var factories = new Func<Directory>[]
+            {
+                () => new SimpleFSDirectory(tempDir),
+                () => new NIOFSDirectory(tempDir),
+                () => new MMapDirectory(tempDir),
+            };
+
+            int n = 0;
+            foreach (var factory in factories)
+            {
+                using Directory dir = factory();
+                string name = "delete-while-write-" + n++;
+
+                IndexOutput output = dir.CreateOutput(name, NewIOContext(Random));
+                try
+                {
+                    output.WriteByte((byte)0x2A);
+                    output.Flush();
+
+                    // Deleting while the write handle is open must not throw.
+                    try
+                    {
+                        dir.DeleteFile(name);
+                    }
+                    catch (Exception e)
+                    {
+                        Assert.Fail("DeleteFile threw while a write handle was open (missing FileShare.Delete?) for "
+                            + dir.GetType().Name + ": " + e);
+                    }
+                }
+                finally
+                {
+                    output.Dispose();
+                }
+            }
+        }
+
 
 #pragma warning disable 612, 618
         [Test]

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -521,7 +521,12 @@ namespace Lucene.Net.Store
                     path: Path.Combine(parent.m_directory.FullName, name),
                     mode: FileMode.OpenOrCreate,
                     access: FileAccess.Write,
-                    share: FileShare.ReadWrite,
+                    // LUCENENET specific: Add FileShare.Delete (a deliberate divergence from upstream Java's
+                    // RandomAccessFile, which omits it) so that every handle Lucene.NET opens on a file permits
+                    // deletion. Windows blocks a delete unless all open handles allow Delete share; including it
+                    // here makes "if Lucene decides a file is deletable, the delete succeeds" hold unconditionally,
+                    // regardless of which handles are open, matching POSIX semantics (#1283).
+                    share: FileShare.ReadWrite | FileShare.Delete,
                     bufferSize: CHUNK_SIZE);
                 isOpen = true;
             }

--- a/src/Lucene.Net/Store/SimpleFSDirectory.cs
+++ b/src/Lucene.Net/Store/SimpleFSDirectory.cs
@@ -100,7 +100,10 @@ namespace Lucene.Net.Store
         {
             EnsureOpen();
             var path = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
-            var raf = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            // LUCENENET specific: Add FileShare.Delete (a deliberate divergence from upstream Java's RandomAccessFile,
+            // which omits it) to match NIOFSDirectory and our other handles, giving Windows the same delete-while-open
+            // semantics POSIX already provides so index files can be deleted while a read handle is open (#1283).
+            var raf = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new SimpleFSIndexInput("SimpleFSIndexInput(path=\"" + path + "\")", raf, context);
         }
 
@@ -108,7 +111,10 @@ namespace Lucene.Net.Store
         {
             EnsureOpen();
             var file = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
-            var descriptor = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            // LUCENENET specific: Add FileShare.Delete (a deliberate divergence from upstream Java's RandomAccessFile,
+            // which omits it) to match NIOFSDirectory and our other handles, giving Windows the same delete-while-open
+            // semantics POSIX already provides so index files can be deleted while a read handle is open (#1283).
+            var descriptor = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new IndexInputSlicerAnonymousClass(context, file, descriptor);
         }
 


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Add FileShare.Delete to SimpleFSDirectory and FSIndexOutput

Fixes #1283

## Description

SimpleFSDirectory opened its read handles with FileShare.ReadWrite, diverging from NIOFSDirectory (ReadWrite | Delete). On Windows this caused File.Delete to throw a sharing violation while a reader held the file open; IndexFileDeleter swallows that and defers the delete to a retry list, so superseded index files accumulate on disk for the lifetime of a long-lived reader.

Add FileShare.Delete to both SimpleFSDirectory read handles and to the shared FSIndexOutput write handle (used by all FSDirectory subclasses) so that every handle Lucene.NET opens on a file permits deletion. Windows requires all open handles to allow Delete share for a delete to succeed, making the guarantee unconditional and matching the POSIX delete-while-open semantics that IndexFileDeleter already assumes.

This is a deliberate divergence from upstream Java, whose RandomAccessFile (used by SimpleFS for both read and write) omits FILE_SHARE_DELETE on Windows; only FileChannel (NIOFS/MMap) includes it. MMapDirectory's read handle is addressed separately in #1267.

Adds Windows-gated regression tests in TestDirectory that confirm a delete succeeds while a read or write handle is open (and that the still-open read handle keeps returning the original bytes).