### PR TITLE
Fix random TestRandomChains failures by excluding broken-offsets producers, #1072

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/HyphenationCompoundWordTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/HyphenationCompoundWordTokenFilter.cs
@@ -244,7 +244,11 @@ namespace Lucene.Net.Analysis.Compound
                             m_tokens.Enqueue(new CompoundToken(this, start, partLength));
                         }
                     }
-                    else if (m_dictionary.Contains(m_termAtt.Buffer, start, partLength - 1))
+                    // LUCENENET specific - guard against a negative length (partLength == 0).
+                    // Upstream Java relies on CharArrayMap silently treating a negative length as
+                    // "not found", but Lucene.NET's CharArrayMap validates its arguments and throws
+                    // ArgumentOutOfRangeException. See the BOGUS/BROKEN/FUNKY/WACKO note above.
+                    else if (partLength - 1 >= 0 && m_dictionary.Contains(m_termAtt.Buffer, start, partLength - 1))
                     {
                         // check the dictionary again with a word that is one character
                         // shorter

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilter.cs
@@ -51,9 +51,11 @@ namespace Lucene.Net.Analysis.Ja
         public JapaneseKatakanaStemFilter(TokenStream input, int minimumLength)
             : base(input)
         {
-            // LUCENENET: Added guard clause
-            if (minimumLength < 0)
-                throw new ArgumentOutOfRangeException(nameof(minimumLength), "Minimum length must be a non-negative integer.");
+            // LUCENENET: Backport of the LUCENE-10352 guard clause. Enforcing minimumLength >= 1
+            // prevents a zero-length term (e.g. the single empty token a KeywordTokenizer emits for
+            // empty input) from reaching the term[length - 1] read in Stem() with length == 0.
+            if (minimumLength < 1)
+                throw new ArgumentOutOfRangeException(nameof(minimumLength), "minimumLength must be >=1");
 
             this.minimumKatakanaLength = minimumLength;
             this.termAttr = AddAttribute<ICharTermAttribute>();
@@ -83,18 +85,6 @@ namespace Lucene.Net.Analysis.Ja
 
         private int Stem(char[] term, int length)
         {
-            // LUCENENET specific (#1072): guard against a zero-length term. When
-            // minimumKatakanaLength == 0 a zero-length token (e.g. the single empty token a
-            // KeywordTokenizer emits for empty input) passes the length check below, IsKatakana
-            // vacuously returns true, and the term[length - 1] access below reads term[-1].
-            // Upstream Java has the same latent term[-1] read, but its TestRandomChains never
-            // exercises the kuromoji filters (separate module), so it never surfaces there.
-            // There is nothing to stem in a zero-length term, so return it unchanged.
-            if (length == 0)
-            {
-                return length;
-            }
-
             if (length < minimumKatakanaLength)
             {
                 return length;

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseKatakanaStemFilter.cs
@@ -83,6 +83,18 @@ namespace Lucene.Net.Analysis.Ja
 
         private int Stem(char[] term, int length)
         {
+            // LUCENENET specific (#1072): guard against a zero-length term. When
+            // minimumKatakanaLength == 0 a zero-length token (e.g. the single empty token a
+            // KeywordTokenizer emits for empty input) passes the length check below, IsKatakana
+            // vacuously returns true, and the term[length - 1] access below reads term[-1].
+            // Upstream Java has the same latent term[-1] read, but its TestRandomChains never
+            // exercises the kuromoji filters (separate module), so it never surfaces there.
+            // There is nothing to stem in a zero-length term, so return it unchanged.
+            if (length == 0)
+            {
+                return length;
+            }
+
             if (length < minimumKatakanaLength)
             {
                 return length;

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Compound/TestCompoundWordTokenFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Compound/TestCompoundWordTokenFilter.cs
@@ -4,6 +4,7 @@ using Lucene.Net.Analysis.Compound.Hyphenation;
 using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.Util;
+using Lucene.Net.Attributes;
 using Lucene.Net.Util;
 using NUnit.Framework;
 using System.IO;
@@ -264,6 +265,41 @@ namespace Lucene.Net.Analysis.Compound
                 return new TokenStreamComponents(tokenizer, filter);
             });
             CheckRandomData(Random, b, 1000 * RandomMultiplier);
+        }
+
+        /// <summary>
+        /// LUCENENET-specific regression test for <a href="https://github.com/apache/lucenenet/issues/1072">#1072</a>.
+        /// <para/>
+        /// When a term has leading non-letter characters (which the hyphenator counts via
+        /// <c>iIgnoreAtBeginning</c>) the resulting hyphenation points can contain two equal values,
+        /// so <see cref="HyphenationCompoundWordTokenFilter"/>'s <c>Decompose()</c> computes a
+        /// <c>partLength</c> of <c>0</c>. With <c>minSubwordSize == 0</c> that zero-length part is not
+        /// filtered out, and the genitive-'s fallback then probes the dictionary with a length of
+        /// <c>partLength - 1 == -1</c>. Upstream Java tolerates the negative length (its CharArrayMap
+        /// silently treats it as "not found"), but Lucene.NET's CharArrayMap validates its arguments
+        /// and throws <see cref="System.ArgumentOutOfRangeException"/>. The filter must not pass a
+        /// negative length downstream. The input <c>"...rindfleisch"</c> yields hyphenation points
+        /// <c>[0, 7, 11, 11]</c>, deterministically reproducing the crash that
+        /// <c>TestRandomChains</c> hit under seed <c>0xc0ab8518c470366f:0x6ed44cef961049a2</c>.
+        /// </summary>
+        [Test]
+        [LuceneNetSpecific] // Issue #1072
+        public virtual void TestZeroLengthSubwordDoesNotThrow()
+        {
+            CharArraySet dict = makeDictionary("rind", "fleisch");
+
+            using var @is = this.GetType().getResourceAsStream("da_UTF8.xml");
+            HyphenationTree hyphenator = HyphenationCompoundWordTokenFilter.GetHyphenationTree(@is);
+
+            // minSubwordSize == 0 is the configuration that lets a zero-length part through.
+            HyphenationCompoundWordTokenFilter tf = new HyphenationCompoundWordTokenFilter(TEST_VERSION_CURRENT,
+                new MockTokenizer(new StringReader("...rindfleisch"), MockTokenizer.WHITESPACE, false),
+                hyphenator, dict, CompoundWordTokenFilterBase.DEFAULT_MIN_WORD_SIZE, 0, 100, false);
+
+            // Before the fix this threw ArgumentOutOfRangeException while decomposing. The leading
+            // "..." shifts the matched subword offsets, so no subword survives the dictionary check;
+            // the only required behavior is that decomposition completes without throwing.
+            AssertTokenStreamContents(tf, new string[] { "...rindfleisch" });
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Core/TestRandomChains.cs
@@ -151,6 +151,16 @@ namespace Lucene.Net.Analysis.Core
                     foreach (ConstructorInfo ctor in c.GetConstructors())
                     {
                         brokenOffsetsConstructors[ctor] = ALWAYS;
+
+                        // LUCENENET specific (#1072): Also fully exclude these broken-offsets producers
+                        // from the random chains, not just relax offset validation. brokenOffsetsConstructors
+                        // only flips offsetsAreCorrect=false (which suppresses ValidatingTokenFilter's checks),
+                        // but the offending filter still runs and can feed backwards offsets into a downstream
+                        // word-combiner (e.g. ShingleFilter), which then throws from OffsetAttribute.SetOffset.
+                        // Upstream Lucene resolved this in 9.1 (LUCENE-10352) by excluding these classes via the
+                        // @IgnoreRandomChains annotation. Until that annotation is backported, exclude them here.
+                        // TODO: Remove this when LUCENE-10352 (IgnoreRandomChains) is backported.
+                        brokenConstructors[ctor] = ALWAYS;
                     }
                 }
             }
@@ -1169,8 +1179,8 @@ namespace Lucene.Net.Analysis.Core
                         // hack: MockGraph/MockLookahead has assertions that will trip if they follow
                         // an offsets violator. so we can't use them after e.g. wikipediatokenizer
                         if (!spec.offsetsAreCorrect &&
-                            (ctor.DeclaringType.Equals(typeof(MockGraphTokenFilter)))
-                                || ctor.DeclaringType.Equals(typeof(MockRandomLookaheadTokenFilter)))
+                            (ctor.DeclaringType.Equals(typeof(MockGraphTokenFilter))
+                                || ctor.DeclaringType.Equals(typeof(MockRandomLookaheadTokenFilter))))
                         {
                             continue;
                         }
@@ -1284,7 +1294,6 @@ namespace Lucene.Net.Analysis.Core
         }
 
         [Test]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
         public void TestRandomChains_()
         {
             int numIterations = AtLeast(20);
@@ -1311,7 +1320,6 @@ namespace Lucene.Net.Analysis.Core
 
         // we might regret this decision...
         [Test]
-        [AwaitsFix(BugUrl = "https://github.com/apache/lucenenet/issues/271#issuecomment-973005744")] // LUCENENET TODO: this test occasionally fails
         public void TestRandomChainsWithLargeStrings()
         {
             int numIterations = AtLeast(20);

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseKatakanaStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseKatakanaStemFilter.cs
@@ -1,6 +1,7 @@
 using Lucene.Net.Analysis.Core;
 using Lucene.Net.Analysis.Miscellaneous;
 using Lucene.Net.Analysis.Util;
+using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System;
 
@@ -92,6 +93,30 @@ namespace Lucene.Net.Analysis.Ja
             {
                 Tokenizer tokenizer = new KeywordTokenizer(reader);
                 return new TokenStreamComponents(tokenizer, new JapaneseKatakanaStemFilter(tokenizer));
+            });
+
+            CheckOneTerm(a, "", "");
+        }
+
+        /// <summary>
+        /// LUCENENET-specific regression test for <a href="https://github.com/apache/lucenenet/issues/1072">#1072</a>.
+        /// <para/>
+        /// With a <c>minimumLength</c> of <c>0</c>, a zero-length token (such as the single empty token a
+        /// <see cref="KeywordTokenizer"/> emits for empty input) would skip the length check in <c>Stem()</c>,
+        /// <c>IsKatakana</c> would vacuously return <c>true</c>, and the <c>term[length - 1]</c> access would
+        /// read <c>term[-1]</c>, throwing <see cref="IndexOutOfRangeException"/>. This was a residual
+        /// <c>TestRandomChains</c> failure reported on PR #1348 (e.g. seed
+        /// <c>0x951afd480395f9b7:0x63fc16274945f1a3</c>); upstream Java has the same latent read but never
+        /// exercises the kuromoji filters from its own random-chains test.
+        /// </summary>
+        [Test]
+        [LuceneNetSpecific] // Issue #1072
+        public void TestEmptyTermWithZeroMinimumLengthDoesNotThrow()
+        {
+            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
+            {
+                Tokenizer tokenizer = new KeywordTokenizer(reader);
+                return new TokenStreamComponents(tokenizer, new JapaneseKatakanaStemFilter(tokenizer, minimumLength: 0));
             });
 
             CheckOneTerm(a, "", "");

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseKatakanaStemFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseKatakanaStemFilter.cs
@@ -101,25 +101,21 @@ namespace Lucene.Net.Analysis.Ja
         /// <summary>
         /// LUCENENET-specific regression test for <a href="https://github.com/apache/lucenenet/issues/1072">#1072</a>.
         /// <para/>
-        /// With a <c>minimumLength</c> of <c>0</c>, a zero-length token (such as the single empty token a
-        /// <see cref="KeywordTokenizer"/> emits for empty input) would skip the length check in <c>Stem()</c>,
-        /// <c>IsKatakana</c> would vacuously return <c>true</c>, and the <c>term[length - 1]</c> access would
-        /// read <c>term[-1]</c>, throwing <see cref="IndexOutOfRangeException"/>. This was a residual
-        /// <c>TestRandomChains</c> failure reported on PR #1348 (e.g. seed
-        /// <c>0x951afd480395f9b7:0x63fc16274945f1a3</c>); upstream Java has the same latent read but never
-        /// exercises the kuromoji filters from its own random-chains test.
+        /// Verifies the LUCENE-10352 guard: the constructor must reject a <c>minimumLength</c> less than
+        /// <c>1</c>. A <c>minimumLength</c> of <c>0</c> would let a zero-length token (such as the single empty
+        /// token a <see cref="KeywordTokenizer"/> emits for empty input) skip the length check in <c>Stem()</c>,
+        /// after which the <c>term[length - 1]</c> access reads <c>term[-1]</c> and throws. This surfaced as a
+        /// residual <c>TestRandomChains</c> failure reported on PR #1348 (e.g. seed
+        /// <c>0x951afd480395f9b7:0x63fc16274945f1a3</c>).
         /// </summary>
         [Test]
         [LuceneNetSpecific] // Issue #1072
-        public void TestEmptyTermWithZeroMinimumLengthDoesNotThrow()
+        public void TestMinimumLengthLessThanOneThrows()
         {
-            Analyzer a = Analyzer.NewAnonymous(createComponents: (fieldName, reader) =>
-            {
-                Tokenizer tokenizer = new KeywordTokenizer(reader);
-                return new TokenStreamComponents(tokenizer, new JapaneseKatakanaStemFilter(tokenizer, minimumLength: 0));
-            });
+            Tokenizer tokenizer = new KeywordTokenizer(new System.IO.StringReader(""));
 
-            CheckOneTerm(a, "", "");
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JapaneseKatakanaStemFilter(tokenizer, minimumLength: 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JapaneseKatakanaStemFilter(tokenizer, minimumLength: -1));
         }
     }
 }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix random TestRandomChains failures by excluding broken-offsets producers

Fixes #1072 (at least as of Lucene's latest status quo exclusions)

## Description

TestRandomChains could fail intermittently (deterministic given a seed) with "startOffset must be non-negative, and endOffset must be >= startOffset" thrown from OffsetAttribute.SetOffset via ShingleFilter.IncrementToken. A broken-offsets producer (e.g. WordDelimiterFilter) emits backwards offsets that a downstream word-combiner (ShingleFilter) then passes to SetOffset, which rejects start > end.

The 8 known broken-offsets producers were only listed in brokenOffsetsConstructors, which merely relaxes ValidatingTokenFilter's checks (offsetsAreCorrect=false) but still lets the offending filter run and feed bad offsets downstream. Upstream Lucene resolved this in 9.1 (LUCENE-10352) by excluding these classes from random chains via the `@IgnoreRandomChains` annotation. Until that is backported, also add them to brokenConstructors with ALWAYS so they are fully excluded from the random chains.

Also fix an operator-precedence bug in NewFilterChain's MockGraph/MockRandomLookahead guard (misplaced parenthesis) to match upstream Java, and remove `[AwaitsFix]` from TestRandomChains_ and TestRandomChainsWithLargeStrings now that they pass reliably.
