### PR TITLE
Add required_pull_request_reviews section to .asf.yaml, #1321

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,3 +58,8 @@ github:
       restrict_force_push: true
       required_linear_history: true
       required_conversation_resolution: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_last_push_approval: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 0


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Add required_pull_request_reviews section to .asf.yaml

Fixes #1321

## Description

Per the [.asf.yaml docs](https://github.com/apache/infrastructure-asfyaml/blob/main/README.md), "If required_conversation_resolution is set, required_pull_request_reviews must be present as well." - since we're getting an error about the 4th (index 3) item and that's required_conversation_resolution, that's a pretty strong smoking gun that this is that issue. Leaving required reviewers at 0 to match our status quo.
