### PR TITLE
Use C# 14 and fix field warnings/errors, #1340

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <GitHubOrganization>apache</GitHubOrganization>
     <GitHubProject>lucenenet</GitHubProject>
   </PropertyGroup>

--- a/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
@@ -163,9 +163,9 @@ namespace Lucene.Net.Codecs.Memory
                 get
                 {
                     long numTerms = 0;
-                    foreach (DirectField field in fields.Values)
+                    foreach (DirectField f in fields.Values)
                     {
-                        numTerms += field.terms.Length;
+                        numTerms += f.terms.Length;
                     }
                     return numTerms;
                 }

--- a/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/DirectPostingsFormat.cs
@@ -163,9 +163,9 @@ namespace Lucene.Net.Codecs.Memory
                 get
                 {
                     long numTerms = 0;
-                    foreach (DirectField f in fields.Values)
+                    foreach (DirectField @field in fields.Values)
                     {
-                        numTerms += f.terms.Length;
+                        numTerms += @field.terms.Length;
                     }
                     return numTerms;
                 }

--- a/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
+++ b/src/Lucene.Net.Codecs/Memory/MemoryPostingsFormat.cs
@@ -931,13 +931,13 @@ namespace Lucene.Net.Codecs.Memory
             public override IComparer<BytesRef> Comparer => BytesRef.UTF8SortedAsUnicodeComparer;
 
             // LUCENENET specific - to avoid boxing, changed from CompareTo() to IndexOptionsComparer.Compare()
-            public override bool HasFreqs => IndexOptionsComparer.Default.Compare(field.IndexOptions, IndexOptions.DOCS_AND_FREQS) >= 0;
+            public override bool HasFreqs => IndexOptionsComparer.Default.Compare(this.field.IndexOptions, IndexOptions.DOCS_AND_FREQS) >= 0;
 
-            public override bool HasOffsets => IndexOptionsComparer.Default.Compare(field.IndexOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) >= 0;
+            public override bool HasOffsets => IndexOptionsComparer.Default.Compare(this.field.IndexOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) >= 0;
 
-            public override bool HasPositions => IndexOptionsComparer.Default.Compare(field.IndexOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
+            public override bool HasPositions => IndexOptionsComparer.Default.Compare(this.field.IndexOptions, IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0;
 
-            public override bool HasPayloads => field.HasPayloads;
+            public override bool HasPayloads => this.field.HasPayloads;
 
             public long RamBytesUsed()
             {

--- a/src/Lucene.Net.Facet/SortedSet/DefaultSortedSetDocValuesReaderState.cs
+++ b/src/Lucene.Net.Facet/SortedSet/DefaultSortedSetDocValuesReaderState.cs
@@ -125,7 +125,7 @@ namespace Lucene.Net.Facet.SortedSet
         /// <summary>
         /// Indexed field we are reading.
         /// </summary>
-        public override string Field => field;
+        public override string Field => this.field;
 
         public override IndexReader OrigReader => origReader;
 

--- a/src/Lucene.Net.Facet/Taxonomy/DocValuesOrdinalsReader.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/DocValuesOrdinalsReader.cs
@@ -82,7 +82,7 @@ namespace Lucene.Net.Facet.Taxonomy
             }
         }
 
-        public override string IndexFieldName => field;
+        public override string IndexFieldName => this.field;
 
         /// <summary>
         /// Subclass &amp; override if you change the encoding.

--- a/src/Lucene.Net.Queries/Function/ValueSources/ReverseOrdFieldSource.cs
+++ b/src/Lucene.Net.Queries/Function/ValueSources/ReverseOrdFieldSource.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Queries.Function.ValueSources
     {
         // LUCENENET NOTE: Made private and added public property for reading
         private readonly string field;
-        public string Field => field;
+        public string Field => this.field;
 
         public ReverseOrdFieldSource(string field)
         {

--- a/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
+++ b/src/Lucene.Net.QueryParser/ComplexPhrase/ComplexPhraseQueryParser.cs
@@ -227,7 +227,7 @@ namespace Lucene.Net.QueryParsers.ComplexPhrase
                 this.inOrder = inOrder;
             }
 
-            public string Field => field;
+            public string Field => this.field;
 
             // Called by ComplexPhraseQueryParser for each phrase after the main
             // parse

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/AbstractRangeQueryNode.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/AbstractRangeQueryNode.cs
@@ -52,21 +52,20 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Nodes
         {
             get
             {
-                string field = null;
+                string f = null;
                 T lower = (T)LowerBound;
                 T upper = (T)UpperBound;
 
                 if (lower != null)
                 {
-                    field = lower.Field;
-
+                    f = lower.Field;
                 }
                 else if (upper != null)
                 {
-                    field = upper.Field;
+                    f = upper.Field;
                 }
 
-                return field;
+                return f;
             }
             set
             {

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/AbstractRangeQueryNode.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/AbstractRangeQueryNode.cs
@@ -52,20 +52,20 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Nodes
         {
             get
             {
-                string f = null;
+                string @field = null;
                 T lower = (T)LowerBound;
                 T upper = (T)UpperBound;
 
                 if (lower != null)
                 {
-                    f = lower.Field;
+                    @field = lower.Field;
                 }
                 else if (upper != null)
                 {
-                    f = upper.Field;
+                    @field = upper.Field;
                 }
 
-                return f;
+                return @field;
             }
             set
             {

--- a/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/RegexpQueryNode.cs
+++ b/src/Lucene.Net.QueryParser/Flexible/Standard/Nodes/RegexpQueryNode.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.QueryParsers.Flexible.Standard.Nodes
 
         public virtual string Field
         {
-            get => field;
+            get => this.field;
             set => this.field = value;
         }
 

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/Lucene.Net.Tests.Analysis.Kuromoji.csproj
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/Lucene.Net.Tests.Analysis.Kuromoji.csproj
@@ -25,7 +25,6 @@
 
   <PropertyGroup>
     <AssemblyTitle>Lucene.Net.Tests.Analysis.Kuromoji</AssemblyTitle>
-    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lucene.Net/Index/Fields.cs
+++ b/src/Lucene.Net/Index/Fields.cs
@@ -78,9 +78,9 @@ namespace Lucene.Net.Index
             get
             {
                 long numTerms = 0;
-                foreach (string field in this)
+                foreach (string f in this)
                 {
-                    Terms terms = GetTerms(field);
+                    Terms terms = GetTerms(f);
                     if (terms != null)
                     {
                         long termCount = terms.Count;

--- a/src/Lucene.Net/Index/Fields.cs
+++ b/src/Lucene.Net/Index/Fields.cs
@@ -78,9 +78,9 @@ namespace Lucene.Net.Index
             get
             {
                 long numTerms = 0;
-                foreach (string f in this)
+                foreach (string @field in this)
                 {
-                    Terms terms = GetTerms(f);
+                    Terms terms = GetTerms(@field);
                     if (terms != null)
                     {
                         long termCount = terms.Count;

--- a/src/Lucene.Net/Search/CollectionStatistics.cs
+++ b/src/Lucene.Net/Search/CollectionStatistics.cs
@@ -53,7 +53,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Returns the field name </summary>
-        public string Field => field;
+        public string Field => this.field;
 
         /// <summary>
         /// Returns the total number of documents, regardless of

--- a/src/Lucene.Net/Search/DocTermOrdsRangeFilter.cs
+++ b/src/Lucene.Net/Search/DocTermOrdsRangeFilter.cs
@@ -194,7 +194,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Returns the field name for this filter </summary>
-        public virtual string Field => field;
+        public virtual string Field => this.field;
 
         /// <summary>
         /// Returns <c>true</c> if the lower endpoint is inclusive </summary>

--- a/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
+++ b/src/Lucene.Net/Search/FieldCacheRangeFilter.cs
@@ -787,7 +787,7 @@ namespace Lucene.Net.Search
 
         /// <summary>
         /// Returns the field name for this filter </summary>
-        public virtual string Field => field;
+        public virtual string Field => this.field;
 
         /// <summary>
         /// Returns <c>true</c> if the lower endpoint is inclusive </summary>

--- a/src/Lucene.Net/Search/FieldValueFilter.cs
+++ b/src/Lucene.Net/Search/FieldValueFilter.cs
@@ -63,7 +63,7 @@ namespace Lucene.Net.Search
         /// <summary>
         /// Returns the field this filter is applied on. </summary>
         /// <returns> The field this filter is applied on. </returns>
-        public virtual string Field => field;
+        public virtual string Field => this.field;
 
         /// <summary>
         /// Returns <c>true</c> if this filter is negated, otherwise <c>false</c> </summary>

--- a/src/Lucene.Net/Search/Similarities/BasicStats.cs
+++ b/src/Lucene.Net/Search/Similarities/BasicStats.cs
@@ -119,7 +119,7 @@ namespace Lucene.Net.Search.Similarities
         /// The field.
         /// </summary>
         // LUCENENET specific
-        public string Field => field;
+        public string Field => this.field;
 
         // -------------------------- Boost-related stuff --------------------------
 

--- a/src/Lucene.Net/Search/SortField.cs
+++ b/src/Lucene.Net/Search/SortField.cs
@@ -276,7 +276,7 @@ namespace Lucene.Net.Search
         /// Returns the name of the field.  Could return <c>null</c>
         /// if the sort is by <see cref="SortFieldType.SCORE"/> or <see cref="SortFieldType.DOC"/>. </summary>
         /// <returns> Name of field, possibly <c>null</c>. </returns>
-        public virtual string Field => field;
+        public virtual string Field => this.field;
 
         /// <summary>
         /// Returns the type of contents in the field. </summary>

--- a/src/Lucene.Net/Search/Spans/FieldMaskingSpanQuery.cs
+++ b/src/Lucene.Net/Search/Spans/FieldMaskingSpanQuery.cs
@@ -83,7 +83,7 @@ namespace Lucene.Net.Search.Spans
             this.field = maskedField;
         }
 
-        public override string Field => field;
+        public override string Field => this.field;
 
         public virtual SpanQuery MaskedQuery => maskedQuery;
 

--- a/src/Lucene.Net/Search/Spans/SpanOrQuery.cs
+++ b/src/Lucene.Net/Search/Spans/SpanOrQuery.cs
@@ -79,7 +79,7 @@ namespace Lucene.Net.Search.Spans
             return clauses.ToArray();
         }
 
-        public override string Field => field;
+        public override string Field => this.field;
 
         public override void ExtractTerms(ISet<Term> terms)
         {


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Use C# 14 and fix field warnings/errors

Partial #1340 

## Description

This is part 1 of 3 for #1340. I will do the ReadOnlySpan and extension block changes as follow-up PRs.

This sets LangVersion to 14 for the solution, and removes the explicit set of that from one place. It also fixes the `field` keyword warnings and errors, by either renaming local variables or adding `this.` qualification (to avoid a more extensive refactoring of renaming the fields).
