### PR TITLE
Bumped ICU4N to 60.1.0-alpha.440

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -34,7 +34,7 @@
         https://github.com/apache/lucene-solr/tree/31d7ec7bbfdcd2c4cc61d9d35e962165410b65fe/lucene/analysis/icu/src/data/utr30
         Just make sure they are adjusted to the right version of ICU/Lucene.
     <ICU4NPackageVersion>[60.1,60.2)</ICU4NPackageVersion> -->
-    <ICU4NPackageVersion>[60.1.0-alpha.438,60.1.0-alpha.446)</ICU4NPackageVersion>
+    <ICU4NPackageVersion>[60.1.0-alpha.440,60.1.0-alpha.446)</ICU4NPackageVersion>
     <IKVMPackageVersion>8.7.5</IKVMPackageVersion>
     <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->

--- a/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiTokenizer.cs
@@ -48,7 +48,7 @@ namespace Lucene.Net.Analysis.Th
     /// <para/>
     /// Unlike the JDK, this implementation is guaranteed to be stable across all supported target frameworks.
     /// While it does use ICU4N's <see cref="RuleBasedBreakIterator"/>, this implementation doesn't follow
-    /// the UAX #29 specification (http://unicode.org/reports/tr29) and is not guranteed to behave the same as
+    /// the UAX #29 specification (http://unicode.org/reports/tr29) and is not guaranteed to behave the same as
     /// either the one in the JDK or in ICU4J.
     /// <para/>
     /// This implementation is provided primarily for API compatibility with Lucene. If strict Unicode compliance

--- a/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiTokenizer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Th/ThaiTokenizer.cs
@@ -1,18 +1,15 @@
 // Lucene version compatibility level 4.8.1
 #if FEATURE_BREAKITERATOR
-using ICU4N.Support.Text;
 using ICU4N.Text;
 using J2N;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Support;
-using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Text.RegularExpressions;
 
 namespace Lucene.Net.Analysis.Th
 {
@@ -44,6 +41,19 @@ namespace Lucene.Net.Analysis.Th
     /// <summary>
     /// Tokenizer that use <see cref="BreakIterator"/> to tokenize Thai text.
     /// </summary>
+    /// <remarks>
+    /// This is an attempt to mimic the behavior of the JDK's <c>java.Text.BreakIterator</c> approach
+    /// to tokenizing Thai text. While it passes the Lucene tests, there may be innumerable differences
+    /// between this implementation and the one in the JDK.
+    /// <para/>
+    /// Unlike the JDK, this implementation is guaranteed to be stable across all supported target frameworks.
+    /// While it does use ICU4N's <see cref="RuleBasedBreakIterator"/>, this implementation doesn't follow
+    /// the UAX #29 specification (http://unicode.org/reports/tr29) and is not guranteed to behave the same as
+    /// either the one in the JDK or in ICU4J.
+    /// <para/>
+    /// This implementation is provided primarily for API compatibility with Lucene. If strict Unicode compliance
+    /// is desired, it is highly recommended to use the <see cref="Icu.Segmentation.ICUTokenizer"/> instead.
+    /// </remarks>
     public class ThaiTokenizer : SegmentingTokenizerBase
     {
         // LUCENENET specific - DBBI_AVAILABLE removed because ICU always has a dictionary-based BreakIterator


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fixes #998

## Description

This bumps ICU4N to 60.1.0-alpha.440 which contains the `Normalizer2` concurrency patch in https://github.com/NightOwl888/ICU4N/pull/122 that addresses the problems with random failures of `TestICUNormalizer2CharFilter.TestRandomStrings()` in concurrent environments.

### `ThaiTokenizer`

I made an attempt at documenting the "differences" between how `ThaiTokenizer` behaves and how `ICUTokenizer` behaves with Thai text. However, after adding several tests to check how they deal with transitions between Thai and non-Thai words and numerals, it turns out they behave identically in all cases I checked. I ended up temporarily replacing the `ThaiTokenizer` with the implementation of `ICUTokenizer` and discovered that all of the tests pass. So, the `ThaiWordBreaker` effectively is a poor-man's way of implementing part of the UAX #29 http://unicode.org/reports/tr29/ spec, but we cannot guarantee that it does completely comply for the Thai language.

I ended up adding documentation explaining that it does not guarantee to be compliant with the Unicode spec and recommended to use `ICUTokenizer` instead. But I am wondering whether we should just rewire the `ICUTokenizer` into the `ThaiTokenizer` and eliminate the "JDK compatible" attempt that is not guaranteed to be compatible with the JDK, anyway.

The JDK `RuleBasedBreakIterator` behaves differently across different vendors and versions, so there really is no stable target to hit, anyway. Some implementations don't even include a dictionary-based `BreakIterator` implementation, so Thai tokenization is impossible. Historically, this is one of the main motivations for creating the `lucene-analysis-icu` package which guarantees stability across JDK versions.