### PR TITLE
Reduce Azure DevOps Windows parallelism from 8 to 2, #1350

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -346,7 +346,7 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-latest'
-          maximumParallelJobs: 8
+          maximumParallelJobs: 2
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         Linux:
           osName: 'Linux'
@@ -381,7 +381,7 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-latest'
-          maximumParallelJobs: 8
+          maximumParallelJobs: 2
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
     displayName: 'Test net10.0,x86 on'
     pool:
@@ -406,7 +406,7 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-latest'
-          maximumParallelJobs: 8
+          maximumParallelJobs: 2
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         Linux:
           osName: 'Linux'
@@ -441,7 +441,7 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-latest'
-          maximumParallelJobs: 8
+          maximumParallelJobs: 2
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
     displayName: 'Test net9.0,x86 on'
     pool:
@@ -466,7 +466,7 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-latest'
-          maximumParallelJobs: 8
+          maximumParallelJobs: 2
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         Linux:
           osName: 'Linux'
@@ -501,7 +501,7 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-latest'
-          maximumParallelJobs: 8
+          maximumParallelJobs: 2
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
     displayName: 'Test net8.0,x86 on'
     pool:
@@ -526,7 +526,7 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-latest'
-          maximumParallelJobs: 8
+          maximumParallelJobs: 2
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
     displayName: 'Test net472,x64 on'
     pool:
@@ -551,7 +551,7 @@ stages:
         Windows:
           osName: 'Windows'
           imageName: 'windows-latest'
-          maximumParallelJobs: 8
+          maximumParallelJobs: 2
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
     displayName: 'Test net472,x86 on'
     pool:
@@ -583,7 +583,7 @@ stages:
         testBinariesArtifactName: '$(TestBinariesArtifactName)'
         nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
-        maximumParallelJobs: 8
+        maximumParallelJobs: 2
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
@@ -601,7 +601,7 @@ stages:
         testBinariesArtifactName: '$(TestBinariesArtifactName)'
         nugetArtifactName: '$(NuGetArtifactName)'
         testResultsArtifactName: '$(TestResultsArtifactName)'
-        maximumParallelJobs: 8
+        maximumParallelJobs: 2
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Reduce Azure DevOps Windows parallelism from 8 to 2

Fixes #1350

## Description

The KNearestNeighborClassifierTest.TestPerformance failures on Azure DevOps Windows agents are caused by CPU starvation. This could have changed over time due to an OS/agent upgrade, a SDK change, or simply that we're running more tests now than we were before (including more concurrent-load tests). The timed region (indexing 1000 docs + opening a reader) runs in under 400ms locally even for the exact seeds that took 123s-183s on Azure, and two of the three failing seeds used an in-memory RAMDirectory (so it is not disk/fsync/AV).

The test runner launches up to maximumParallelJobs dotnet test processes concurrently on a single shared agent VM. On the standard 2-core Windows hosted agents, 8 concurrent assemblies is ~4x oversubscription, which starves the perf-sensitive test and pushes its wall-clock past the 120s threshold. Lowering the Windows concurrency to 2 reduces oversubscription. Linux/macOS are left at 7 since the failures are (currently) Windows-only.

I ran this 9 times on ADO (3 in parallel, then 5 in parallel, then one isolated) and the #1350 failing test never came back. It did expose a few other known and previously-unknown failures which all seem concurrency-related, which is a good thing! These tests were not failing previously, likely because they were taking too long to preemptively multitask on the oversubscribed CPUs. These failing tests will be evaluated independently of this PR.