### PR TITLE
Validate file paths for FSDirectory and Replicator

### DIFF
--- a/src/Lucene.Net.Replicator/LocalReplicator.cs
+++ b/src/Lucene.Net.Replicator/LocalReplicator.cs
@@ -1,4 +1,5 @@
 using J2N.Threading.Atomic;
+using Lucene.Net.Support.Text;
 using Lucene.Net.Support.Threading;
 using System;
 using System.Collections.Generic;
@@ -256,6 +257,12 @@ namespace Lucene.Net.Replicator
 
         public virtual Stream ObtainFile(string sessionId, string source, string fileName)
         {
+            // LUCENENET-specific: validate the file name is valid for replication
+            if (!fileName.IsValidSinglePathComponent())
+            {
+                throw new ArgumentException("File name is not valid for replication", nameof(fileName));
+            }
+
             UninterruptableMonitor.Enter(syncLock);
             try
             {

--- a/src/Lucene.Net.Replicator/PerSessionDirectoryFactory.cs
+++ b/src/Lucene.Net.Replicator/PerSessionDirectoryFactory.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Store;
+using Lucene.Net.Support.Text;
 using System;
 using System.IO;
 using Directory = Lucene.Net.Store.Directory;
@@ -42,6 +43,17 @@ namespace Lucene.Net.Replicator
 
         public virtual Directory GetDirectory(string sessionId, string source)
         {
+            // LUCENENET-specific: validate sessionId and source are valid for paths
+            if (!sessionId.IsValidSinglePathComponent())
+            {
+                throw new ArgumentException("Session ID is not valid for replication", nameof(sessionId));
+            }
+
+            if (!source.IsValidSinglePathComponent())
+            {
+                throw new ArgumentException("Source is not valid for replication", nameof(source));
+            }
+
             string sourceDirectory = Path.Combine(workingDirectory, sessionId, source);
             System.IO.Directory.CreateDirectory(sourceDirectory);
             if (!System.IO.Directory.Exists(sourceDirectory))
@@ -51,7 +63,16 @@ namespace Lucene.Net.Replicator
 
         public virtual void CleanupSession(string sessionId)
         {
-            if (string.IsNullOrEmpty(sessionId)) throw new ArgumentException("sessionID cannot be empty", nameof(sessionId));
+            if (string.IsNullOrEmpty(sessionId))
+            {
+                throw new ArgumentException("sessionID cannot be empty", nameof(sessionId));
+            }
+
+            // LUCENENET-specific: validate sessionId is valid for paths
+            if (!sessionId.IsValidSinglePathComponent())
+            {
+                throw new ArgumentException("Session ID is not valid for replication", nameof(sessionId));
+            }
 
             string sessionDirectory = Path.Combine(workingDirectory, sessionId);
             System.IO.Directory.Delete(sessionDirectory, true);

--- a/src/Lucene.Net.Replicator/SessionToken.cs
+++ b/src/Lucene.Net.Replicator/SessionToken.cs
@@ -7,6 +7,7 @@ using JCG = J2N.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Lucene.Net.Support.IO;
+using Lucene.Net.Support.Text;
 
 namespace Lucene.Net.Replicator
 {
@@ -76,7 +77,16 @@ namespace Lucene.Net.Replicator
                 IList<RevisionFile> files = new JCG.List<RevisionFile>(numFiles);
                 for (int i = 0; i < numFiles; i++)
                 {
-                    files.Add(new RevisionFile(reader.ReadUTF(), reader.ReadInt64()));
+                    string fileName = reader.ReadUTF();
+                    long length = reader.ReadInt64();
+
+                    // LUCENENET-specific: validate that fileName is valid for replication
+                    if (!fileName.IsValidSinglePathComponent())
+                    {
+                        throw new ArgumentException("File name is not valid for replication", nameof(fileName));
+                    }
+
+                    files.Add(new RevisionFile(fileName, length));
                 }
                 sourceFiles.Add(source, files);
                 --numSources;

--- a/src/Lucene.Net.Tests.Replicator/LocalReplicatorTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/LocalReplicatorTest.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Attributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Support.Threading;
@@ -89,6 +90,27 @@ namespace Lucene.Net.Replicator
             {
                 // expected
             }
+        }
+
+        // LUCENENET-specific: covers fileName validation in LocalReplicator.ObtainFile.
+        // Validation runs before session lookup, so a fresh (never-published) replicator is sufficient.
+        [Test, LuceneNetSpecific]
+        [TestCase("../../a.txt")]
+        [TestCase("..\\a.txt")]
+        [TestCase("/a/b")]
+        [TestCase("C:\\folder\\file")]
+        [TestCase("subdir/file.txt")]
+        [TestCase("subdir\\file.txt")]
+        [TestCase("..")]
+        [TestCase(".")]
+        [TestCase("name\0extra")]
+        [TestCase("")]
+        public void TestObtainFileRejectsInvalidFileName(string invalidFileName)
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                using Stream _ = replicator.ObtainFile("session1", "src", invalidFileName);
+            }, $"ObtainFile should reject fileName '{invalidFileName}'");
         }
 
         [Test]

--- a/src/Lucene.Net.Tests.Replicator/PerSessionDirectoryFactoryTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/PerSessionDirectoryFactoryTest.cs
@@ -1,0 +1,116 @@
+using Lucene.Net.Attributes;
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System;
+using System.IO;
+using Directory = Lucene.Net.Store.Directory;
+
+namespace Lucene.Net.Replicator
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    // LUCENENET-specific: covers sessionId and source name validation in PerSessionDirectoryFactory
+    // for the GetDirectory and CleanupSession entry points.
+    [LuceneNetSpecific]
+    public class PerSessionDirectoryFactoryTest : ReplicatorTestCase
+    {
+        private static readonly string[] InvalidPathComponents =
+        {
+            "../a",
+            "..\\a",
+            "/a",
+            "C:\\folder",
+            "subdir/segment",
+            "subdir\\segment",
+            "..",
+            ".",
+            "name\0extra",
+            "",
+        };
+
+        [Test]
+        [TestCaseSource(nameof(InvalidPathComponents))]
+        public void TestGetDirectoryRejectsInvalidSessionId(string sessionId)
+        {
+            DirectoryInfo workDir = CreateTempDir("perSessionFactoryGetSession");
+            PerSessionDirectoryFactory factory = new PerSessionDirectoryFactory(workDir.FullName);
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                using Directory _ = factory.GetDirectory(sessionId, "src");
+            }, $"GetDirectory should reject sessionId '{sessionId}'");
+        }
+
+        [Test]
+        [TestCaseSource(nameof(InvalidPathComponents))]
+        public void TestGetDirectoryRejectsInvalidSource(string source)
+        {
+            DirectoryInfo workDir = CreateTempDir("perSessionFactoryGetSource");
+            PerSessionDirectoryFactory factory = new PerSessionDirectoryFactory(workDir.FullName);
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                using Directory _ = factory.GetDirectory("session1", source);
+            }, $"GetDirectory should reject source '{source}'");
+        }
+
+        [Test]
+        [TestCaseSource(nameof(InvalidPathComponents))]
+        public void TestCleanupSessionRejectsInvalidSessionId(string sessionId)
+        {
+            DirectoryInfo workDir = CreateTempDir("perSessionFactoryCleanup");
+            PerSessionDirectoryFactory factory = new PerSessionDirectoryFactory(workDir.FullName);
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                factory.CleanupSession(sessionId);
+            }, $"CleanupSession should reject sessionId '{sessionId}'");
+        }
+
+        [Test]
+        public void TestCleanupSessionDoesNotTouchSiblingDirectory()
+        {
+            // A sessionId that resolves to a sibling of the workingDirectory must be rejected by
+            // validation. The sibling directory and its contents must remain untouched.
+            DirectoryInfo workDir = CreateTempDir("perSessionFactorySiblingWork");
+            DirectoryInfo sibling = CreateTempDir("perSessionFactorySibling");
+            string siblingFile = Path.Combine(sibling.FullName, "marker.txt");
+            File.WriteAllText(siblingFile, "untouched");
+
+            PerSessionDirectoryFactory factory = new PerSessionDirectoryFactory(workDir.FullName);
+            string relative = Path.GetRelativePath(workDir.FullName, sibling.FullName);
+
+            Assert.Throws<ArgumentException>(() => factory.CleanupSession(relative));
+            assertTrue("sibling directory must still exist", System.IO.Directory.Exists(sibling.FullName));
+            assertTrue("sibling file must still exist", File.Exists(siblingFile));
+        }
+
+        [Test]
+        public void TestGetDirectoryAcceptsValidNames()
+        {
+            DirectoryInfo workDir = CreateTempDir("perSessionFactoryValid");
+            PerSessionDirectoryFactory factory = new PerSessionDirectoryFactory(workDir.FullName);
+
+            using Directory dir = factory.GetDirectory("session-abc", "src");
+            assertNotNull(dir);
+
+            string expected = Path.Combine(workDir.FullName, "session-abc", "src");
+            assertTrue("expected session directory to exist on disk", System.IO.Directory.Exists(expected));
+        }
+    }
+}

--- a/src/Lucene.Net.Tests.Replicator/PerSessionDirectoryFactoryTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/PerSessionDirectoryFactoryTest.cs
@@ -93,7 +93,9 @@ namespace Lucene.Net.Replicator
             File.WriteAllText(siblingFile, "untouched");
 
             PerSessionDirectoryFactory factory = new PerSessionDirectoryFactory(workDir.FullName);
-            string relative = Path.GetRelativePath(workDir.FullName, sibling.FullName);
+            // Path.GetRelativePath is not available on .NET Framework; compute manually.
+            // Both temp dirs share the same parent, so the relative path is "../<siblingName>".
+            string relative = Path.Combine("..", sibling.Name);
 
             Assert.Throws<ArgumentException>(() => factory.CleanupSession(relative));
             assertTrue("sibling directory must still exist", System.IO.Directory.Exists(sibling.FullName));

--- a/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
+++ b/src/Lucene.Net.Tests.Replicator/SessionTokenTest.cs
@@ -101,6 +101,60 @@ namespace Lucene.Net.Replicator
             Assert.IsFalse(result.Contains("System.Collections.Generic.Dictionary"), "Should not contain generic Dictionary type");
         }
 
+        // LUCENENET-specific: covers RevisionFile.FileName validation in the
+        // SessionToken(IDataInput) deserialization constructor.
+        [Test, LuceneNetSpecific]
+        [TestCase("../../../a.txt")]
+        [TestCase("..\\..\\a.txt")]
+        [TestCase("/a/b")]
+        [TestCase("C:\\folder\\file")]
+        [TestCase("subdir/file.txt")]
+        [TestCase("..")]
+        [TestCase(".")]
+        [TestCase("name\0extra")]
+        [TestCase("")]
+        public void TestDeserializeRejectsInvalidFileName(string invalidFileName)
+        {
+            using MemoryStream ms = new MemoryStream();
+            DataOutputStream dos = new DataOutputStream(ms);
+            dos.WriteUTF("session1");
+            dos.WriteUTF("ver1");
+            dos.WriteInt32(1);
+            dos.WriteUTF("source1");
+            dos.WriteInt32(1);
+            dos.WriteUTF(invalidFileName);
+            dos.WriteInt64(123L);
+            dos.Flush();
+            ms.Position = 0;
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _ = new SessionToken(new DataInputStream(ms));
+            }, $"SessionToken should reject RevisionFile.FileName '{invalidFileName}'");
+        }
+
+        [Test, LuceneNetSpecific]
+        [TestCase("segments.gen")]
+        [TestCase("_0.cfs")]
+        [TestCase(".hidden")]
+        public void TestDeserializeAcceptsValidFileName(string fileName)
+        {
+            using MemoryStream ms = new MemoryStream();
+            DataOutputStream dos = new DataOutputStream(ms);
+            dos.WriteUTF("session1");
+            dos.WriteUTF("ver1");
+            dos.WriteInt32(1);
+            dos.WriteUTF("source1");
+            dos.WriteInt32(1);
+            dos.WriteUTF(fileName);
+            dos.WriteInt64(123L);
+            dos.Flush();
+            ms.Position = 0;
+
+            SessionToken token = new SessionToken(new DataInputStream(ms));
+            assertEquals(fileName, token.SourceFiles["source1"][0].FileName);
+        }
+
         // Mock implementation for testing
         private class MockRevision : IRevision
         {

--- a/src/Lucene.Net.Tests/Store/TestDirectory.cs
+++ b/src/Lucene.Net.Tests/Store/TestDirectory.cs
@@ -535,5 +535,102 @@ namespace Lucene.Net.Store
                 }
             }
         }
+
+        // LUCENENET-specific: covers EnsureCanWrite name validation across FSDirectory subclasses.
+        [Test, LuceneNetSpecific]
+        [TestCase("../../foo.txt")]
+        [TestCase("..\\foo.txt")]
+        [TestCase("/tmp/foo.txt")]
+        [TestCase("subdir/file.txt")]
+        [TestCase("subdir\\file.txt")]
+        [TestCase("..")]
+        [TestCase(".")]
+        [TestCase("")]
+        public void TestCreateOutputRejectsInvalidName(string invalidName)
+        {
+            DirectoryInfo path = CreateTempDir("ensureCanWrite");
+            foreach (FSDirectory dir in new FSDirectory[]
+            {
+                new SimpleFSDirectory(path),
+                new NIOFSDirectory(path),
+                new MMapDirectory(path),
+            })
+            {
+                try
+                {
+                    Assert.Throws<ArgumentException>(() =>
+                    {
+                        using IndexOutput _ = dir.CreateOutput(invalidName, IOContext.DEFAULT);
+                    }, $"{dir.GetType().Name}.CreateOutput should reject '{invalidName}'");
+                }
+                finally
+                {
+                    dir.Dispose();
+                }
+            }
+        }
+
+        // LUCENENET-specific: covers EnsureCanRead name validation across FSDirectory subclasses.
+        [Test, LuceneNetSpecific]
+        [TestCase("../../foo.txt")]
+        [TestCase("..\\foo.txt")]
+        [TestCase("/tmp/foo.txt")]
+        [TestCase("subdir/file.txt")]
+        [TestCase("subdir\\file.txt")]
+        [TestCase("..")]
+        [TestCase(".")]
+        [TestCase("")]
+        public void TestOpenInputRejectsInvalidName(string invalidName)
+        {
+            DirectoryInfo path = CreateTempDir("ensureCanRead");
+            foreach (FSDirectory dir in new FSDirectory[]
+            {
+                new SimpleFSDirectory(path),
+                new NIOFSDirectory(path),
+                new MMapDirectory(path),
+            })
+            {
+                try
+                {
+                    Assert.Throws<ArgumentException>(() =>
+                    {
+                        using IndexInput _ = dir.OpenInput(invalidName, IOContext.DEFAULT);
+                    }, $"{dir.GetType().Name}.OpenInput should reject '{invalidName}'");
+                }
+                finally
+                {
+                    dir.Dispose();
+                }
+            }
+        }
+
+        // NIOFSDirectory and SimpleFSDirectory have their own CreateSlicer overload that opens its
+        // own FileStream rather than delegating to OpenInput, so validation must fire there too.
+        [Test, LuceneNetSpecific]
+        [TestCase("../../foo.txt")]
+        [TestCase("..\\foo.txt")]
+        [TestCase("/tmp/foo.txt")]
+        public void TestCreateSlicerRejectsInvalidName(string invalidName)
+        {
+            DirectoryInfo path = CreateTempDir("ensureCanReadSlicer");
+            foreach (FSDirectory dir in new FSDirectory[]
+            {
+                new SimpleFSDirectory(path),
+                new NIOFSDirectory(path),
+            })
+            {
+                try
+                {
+                    Assert.Throws<ArgumentException>(() =>
+                    {
+                        using Directory.IndexInputSlicer _ = dir.CreateSlicer(invalidName, IOContext.DEFAULT);
+                    }, $"{dir.GetType().Name}.CreateSlicer should reject '{invalidName}'");
+                }
+                finally
+                {
+                    dir.Dispose();
+                }
+            }
+        }
     }
 }

--- a/src/Lucene.Net.Tests/Support/Text/TestStringExtensions.cs
+++ b/src/Lucene.Net.Tests/Support/Text/TestStringExtensions.cs
@@ -44,5 +44,42 @@ namespace Lucene.Net.Support.Text
             Assert.IsFalse("hello".Contains("WORLD", StringComparison.OrdinalIgnoreCase));
         }
 #endif
+
+        [TestCase("segments.gen")]
+        [TestCase("_0.cfs")]
+        [TestCase("_0_Lucene41_0.tip")]
+        [TestCase(".hidden")]
+        [TestCase("a..b..c")]
+        [TestCase("name-with-dashes_and_underscores.ext")]
+        [LuceneNetSpecific]
+        public void TestIsValidSinglePathComponent_AcceptsValidNames(string path)
+        {
+            Assert.IsTrue(path.IsValidSinglePathComponent(),
+                $"expected '{path}' to be a valid single path component");
+        }
+
+        [TestCase("")]                          // empty
+        [TestCase(".")]                         // current-directory literal
+        [TestCase("..")]                        // parent-directory literal
+        [TestCase("foo/bar")]                   // forward-slash separator
+        [TestCase("foo\\bar")]                  // backslash separator (rejected even on POSIX)
+        [TestCase("../../a/b")]                 // multi-level forward-slash sequence
+        [TestCase("..\\..\\a\\b")]              // multi-level backslash sequence
+        [TestCase("..\\a")]                     // single-level backslash sequence
+        [TestCase("/a/b")]                      // absolute POSIX path
+        [TestCase("/tmp/file.txt")]             // absolute POSIX path
+        [TestCase("C:\\folder\\file")]          // path containing a Windows volume separator
+        [TestCase("C:\\file.txt")]              // path containing a Windows volume separator
+        [TestCase("name\0extra")]               // embedded NUL
+        [TestCase("name/")]                     // trailing forward slash
+        [TestCase("name\\")]                    // trailing backslash
+        [TestCase("\\")]                        // bare backslash
+        [TestCase("/")]                         // bare forward slash
+        [LuceneNetSpecific]
+        public void TestIsValidSinglePathComponent_RejectsInvalidNames(string path)
+        {
+            Assert.IsFalse(path.IsValidSinglePathComponent(),
+                $"expected '{path}' to be rejected as a single path component");
+        }
     }
 }

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -1,5 +1,6 @@
 using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
+using Lucene.Net.Support.Text;
 using Lucene.Net.Support.Threading;
 using Lucene.Net.Util;
 using System;
@@ -361,6 +362,12 @@ namespace Lucene.Net.Store
 
         protected virtual void EnsureCanWrite(string name)
         {
+            // LUCENENET-specific: validate the name is valid for a FSDirectory
+            if (!name.IsValidSinglePathComponent())
+            {
+                throw new ArgumentException("File name is not valid for a FSDirectory", nameof(name));
+            }
+
             if (!m_directory.Exists)
             {
                 try
@@ -398,6 +405,17 @@ namespace Lucene.Net.Store
             finally
             {
                 UninterruptableMonitor.Exit(m_syncLock);
+            }
+        }
+
+        // LUCENENET-specific: backported method signature (but not implementation, yet)
+        // from Lucene 6.0.0 as extensibility point to override name validation if needed
+        protected virtual void EnsureCanRead(string name)
+        {
+            // LUCENENET-specific: validate the name is valid for a FSDirectory
+            if (!name.IsValidSinglePathComponent())
+            {
+                throw new ArgumentException("File name is not valid for a FSDirectory", nameof(name));
             }
         }
 

--- a/src/Lucene.Net/Store/MMapDirectory.cs
+++ b/src/Lucene.Net/Store/MMapDirectory.cs
@@ -192,6 +192,7 @@ namespace Lucene.Net.Store
         public override IndexInput OpenInput(string name, IOContext context)
         {
             EnsureOpen();
+            EnsureCanRead(name); // LUCENENET-specific: backported call site from Lucene 6.0.0
             var file = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
             var fc = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return new MMapIndexInput(this, "MMapIndexInput(path=\"" + file + "\")", fc);
@@ -199,6 +200,7 @@ namespace Lucene.Net.Store
 
         public override IndexInputSlicer CreateSlicer(string name, IOContext context)
         {
+            // LUCENENET NOTE: name is validated in OpenInput call below
             var full = (MMapIndexInput)OpenInput(name, context);
             return new IndexInputSlicerAnonymousClass(this, full);
         }

--- a/src/Lucene.Net/Store/NIOFSDirectory.cs
+++ b/src/Lucene.Net/Store/NIOFSDirectory.cs
@@ -102,6 +102,7 @@ namespace Lucene.Net.Store
         public override IndexInput OpenInput(string name, IOContext context)
         {
             EnsureOpen();
+            EnsureCanRead(name); // LUCENENET-specific: backported call site from Lucene 6.0.0
             var path = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
             var fc = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new NIOFSIndexInput("NIOFSIndexInput(path=\"" + path + "\")", fc, context);
@@ -110,6 +111,7 @@ namespace Lucene.Net.Store
         public override IndexInputSlicer CreateSlicer(string name, IOContext context)
         {
             EnsureOpen();
+            EnsureCanRead(name); // LUCENENET-specific: this method is not in Lucene 6.0.0 but added to match OpenInput above
             var path = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
             var fc = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new IndexInputSlicerAnonymousClass(context, path, fc);

--- a/src/Lucene.Net/Store/SimpleFSDirectory.cs
+++ b/src/Lucene.Net/Store/SimpleFSDirectory.cs
@@ -99,6 +99,7 @@ namespace Lucene.Net.Store
         public override IndexInput OpenInput(string name, IOContext context)
         {
             EnsureOpen();
+            EnsureCanRead(name); // LUCENENET-specific: backported call site from Lucene 6.0.0
             var path = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
             var raf = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return new SimpleFSIndexInput("SimpleFSIndexInput(path=\"" + path + "\")", raf, context);
@@ -107,6 +108,7 @@ namespace Lucene.Net.Store
         public override IndexInputSlicer CreateSlicer(string name, IOContext context)
         {
             EnsureOpen();
+            EnsureCanRead(name); // LUCENENET-specific: this method is not in Lucene 6.0.0 but added to match OpenInput above
             var file = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
             var descriptor = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return new IndexInputSlicerAnonymousClass(context, file, descriptor);

--- a/src/Lucene.Net/Support/Text/StringExtensions.cs
+++ b/src/Lucene.Net/Support/Text/StringExtensions.cs
@@ -1,5 +1,6 @@
 using J2N.Text;
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Support.Text
@@ -31,7 +32,7 @@ namespace Lucene.Net.Support.Text
         /// </summary>
         /// <param name="input">The string in which to seek characters from <paramref name="charsToCompare"/>.</param>
         /// <param name="charsToCompare">An array of characters to check.</param>
-        /// <returns><c>true</c> if any <paramref name="charsToCompare"/> are found, otherwise; <c>false</c>.</returns>
+        /// <returns><c>true</c> if any <paramref name="charsToCompare"/> are found; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ContainsAny(this string input, char[] charsToCompare)
         {
@@ -57,7 +58,7 @@ namespace Lucene.Net.Support.Text
         /// <param name="input">The string in which to seek <paramref name="value"/>.</param>
         /// <param name="value">The string to check for.</param>
         /// <param name="comparison">The <see cref="StringComparison"/> to use.</param>
-        /// <returns><c>true</c> if <paramref name="value"/> is found, otherwise; <c>false</c>.</returns>
+        /// <returns><c>true</c> if <paramref name="value"/> is found; otherwise, <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Contains(this string input, string value, StringComparison comparison)
         {
@@ -69,5 +70,28 @@ namespace Lucene.Net.Support.Text
             return input.AsSpan().Contains(value.AsSpan(), comparison);
         }
 #endif
+
+#nullable enable
+        /// <summary>
+        /// Returns <c>true</c> if <paramref name="path"/> is a valid, single path component for use in index
+        /// file system access. A valid value is either a file name or a directory name, without any directory
+        /// or volume separators.
+        /// </summary>
+        /// <param name="path">The file name to check.</param>
+        /// <returns><c>true</c> if <paramref name="path"/> is a valid path component;
+        /// otherwise, <c>false</c>.</returns>
+        public static bool IsValidSinglePathComponent(this string path)
+        {
+            // NOTE: `path == Path.GetFileName(path)` ensures there are no directory components, such as
+            // directory separators or volume names. This works for both file and folder names, despite the use of
+            // Path.GetFileName() for the latter. If `path` ends with a directory separator, it's invalid anyway.
+            return !string.IsNullOrEmpty(path)
+                   && path != "."
+                   && path != ".."
+                   && path == Path.GetFileName(path) // see NOTE above
+                   && path.IndexOfAny(Path.GetInvalidFileNameChars()) < 0
+                   && path.IndexOf('\\') < 0; // backslash is not an invalid character on Linux/macOS but is invalid for this purpose
+        }
+#nullable restore
     }
 }

--- a/src/Lucene.Net/Support/Text/StringExtensions.cs
+++ b/src/Lucene.Net/Support/Text/StringExtensions.cs
@@ -85,12 +85,14 @@ namespace Lucene.Net.Support.Text
             // NOTE: `path == Path.GetFileName(path)` ensures there are no directory components, such as
             // directory separators or volume names. This works for both file and folder names, despite the use of
             // Path.GetFileName() for the latter. If `path` ends with a directory separator, it's invalid anyway.
+            // Check IndexOfAny before Path.GetFileName: on .NET Framework, Path.GetFileName throws
+            // ArgumentException for strings containing NUL or other characters that are illegal in paths.
             return !string.IsNullOrEmpty(path)
                    && path != "."
                    && path != ".."
-                   && path == Path.GetFileName(path) // see NOTE above
                    && path.IndexOfAny(Path.GetInvalidFileNameChars()) < 0
-                   && path.IndexOf('\\') < 0; // backslash is not an invalid character on Linux/macOS but is invalid for this purpose
+                   && path.IndexOf('\\') < 0 // backslash is not an invalid character on Linux/macOS but is invalid for this purpose
+                   && path == Path.GetFileName(path); // see NOTE above
         }
 #nullable restore
     }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Validate file paths for FSDirectory and Replicator

## Description

FSDirectory and Replicator do not validate that string segments are valid for file paths, which can result in some bugs and issues. This adds validation with unit tests.
