### PR TITLE
Fix debug asserts and docs for VIntUtils, #1279

### DIFF
--- a/src/Lucene.Net/Support/VIntUtils.cs
+++ b/src/Lucene.Net/Support/VIntUtils.cs
@@ -43,8 +43,8 @@ namespace Lucene.Net.Support
 
         /// <summary>
         /// Tries to read a 32-bit VInt from the given <paramref name="source"/>.
-        /// <paramref name="source"/> must be at least <see cref="MaxVInt32Length"/> bytes
-        /// in length to avoid possible out-of-range exceptions.
+        /// <paramref name="source"/> must be at least 1 byte in length, and be well-formed if multibyte,
+        /// to avoid possible out-of-range exceptions.
         /// </summary>
         /// <param name="source">The source bytes to read from.</param>
         /// <param name="value">The decoded value (undefined if the method returns <c>false</c>).</param>
@@ -55,7 +55,7 @@ namespace Lucene.Net.Support
         /// extra high bits set.</returns>
         public static bool TryReadVInt32(ReadOnlySpan<byte> source, out int value, out int count)
         {
-            Debug.Assert(source.Length >= MaxVInt32Length);
+            Debug.Assert(source.Length >= 1);
             byte b = source[0];
             if (b <= sbyte.MaxValue) // LUCENENET: Optimized equivalent of "if ((sbyte)b >= 0)"
             {
@@ -98,8 +98,8 @@ namespace Lucene.Net.Support
 
         /// <summary>
         /// Tries to read a 64-bit VInt from the given <paramref name="source"/>.
-        /// <paramref name="source"/> must be at least <see cref="MaxVInt64Length"/> bytes
-        /// in length to avoid possible out-of-range exceptions.
+        /// <paramref name="source"/> must be at least 1 byte in length, and be well-formed if multibyte,
+        /// to avoid possible out-of-range exceptions.
         /// </summary>
         /// <param name="source">The source bytes to read from.</param>
         /// <param name="value">The decoded value (undefined if the method returns <c>false</c>).</param>
@@ -109,7 +109,7 @@ namespace Lucene.Net.Support
         /// the continuation bit set (which would indicate a negative value, disallowed).</returns>
         public static bool TryReadVInt64(ReadOnlySpan<byte> source, out long value, out int count)
         {
-            Debug.Assert(source.Length >= MaxVInt64Length);
+            Debug.Assert(source.Length >= 1);
             byte b = source[0];
             if (b <= sbyte.MaxValue)
             {


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix debug asserts and docs for VIntUtils

Related #1279

## Description

A Debug-mode and docs bug was discovered during testing changes for #1267. It is valid to have a less-than-max-length vint at the end of a stream, array, etc., but we were asserting that the length had to be at least the max vint length. This is incorrect. The only constraint is that the span is at least length 1, and that it is well-formed (i.e. there is at least one more byte if the prior byte has the high bit set). It is perfectly fine to have a 1-byte vint at the end of an array, for example.

This PR corrects the assertion and the XML doc comments. It has no production impact, and is on an internal class so no public documentation impact either.