### PR TITLE
Fix GroupingSearch.TotalGroupCount null when groupOffset exceeds group count, #1362

### DIFF
--- a/src/Lucene.Net.Grouping/GroupingSearch.cs
+++ b/src/Lucene.Net.Grouping/GroupingSearch.cs
@@ -450,7 +450,10 @@ namespace Lucene.Net.Search.Grouping
             if (topSearchGroups is null)
             {
                 // LUCENENET specific - optimized empty array creation
-                return new TopGroups<T>(Array.Empty<SortField>(), Array.Empty<SortField>(), 0, 0, Array.Empty<GroupDocs<T>>(), float.NaN);
+                var emptyResult = new TopGroups<T>(Array.Empty<SortField>(), Array.Empty<SortField>(), 0, 0, Array.Empty<GroupDocs<T>>(), float.NaN);
+                return AllGroups
+                    ? new TopGroups<T>(emptyResult, MatchingGroups.Count)
+                    : emptyResult;
             }
 
             int topNInsideGroup = GroupDocsOffset + GroupDocsLimit;

--- a/src/Lucene.Net.Tests.Grouping/GroupingSearchTest.cs
+++ b/src/Lucene.Net.Tests.Grouping/GroupingSearchTest.cs
@@ -335,6 +335,48 @@ namespace Lucene.Net.Search.Grouping
             dir.Dispose();
         }
 
+        // LUCENENET specific - regression test for #1362
+        [Test]
+        [LuceneNetSpecific]
+        public virtual void TestSetAllGroups_GroupOffsetBeyondGroupCount_TotalGroupCountNotNull()
+        {
+            // When groupOffset exceeds the number of groups, topSearchGroups is null and
+            // the early return path must still populate TotalGroupCount from allGroupsCollector.
+            using Directory dir = NewDirectory();
+            RandomIndexWriter w = new RandomIndexWriter(
+                Random,
+                dir,
+                NewIndexWriterConfig(TEST_VERSION_CURRENT,
+                    new MockAnalyzer(Random)).SetMergePolicy(NewLogMergePolicy()));
+
+            // Index 2 documents in the same group.
+            Document doc = new Document();
+            doc.Add(new StringField("group", "foo", Field.Store.NO));
+            doc.Add(new TextField("content", "hello world", Field.Store.NO));
+            w.AddDocument(doc);
+
+            doc = new Document();
+            doc.Add(new StringField("group", "foo", Field.Store.NO));
+            doc.Add(new TextField("content", "hello world", Field.Store.NO));
+            w.AddDocument(doc);
+
+            IndexSearcher indexSearcher = NewSearcher(w.GetReader());
+            w.Dispose();
+
+            // groupOffset=5 exceeds the 1 matching group, so topSearchGroups will be null
+            // in the first-pass collector. With SetAllGroups(true), TotalGroupCount must
+            // still be set to the real group count (1), not left null.
+            var gs = GroupingSearch.ByField("group");
+            gs.SetAllGroups(true);
+            TopGroups<BytesRef> groups = gs.Search(indexSearcher, null, new TermQuery(new Index.Term("content", "hello")), 5, 10);
+
+            assertNotNull("TotalGroupCount must not be null when SetAllGroups(true) and groupOffset exceeds group count", groups.TotalGroupCount);
+            assertEquals(1, groups.TotalGroupCount.GetValueOrDefault());
+            assertEquals(0, groups.Groups.Length);
+
+            indexSearcher.IndexReader.Dispose();
+        }
+
         // LUCENENET specific - tests for the CancellationToken support
         // added to GroupingSearch. See #922.
 


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix GroupingSearch.TotalGroupCount null when groupOffset exceeds group count

Fixes #1362

## Description

When SetAllGroups(true) and groupOffset is larger than the number of matching groups, the early-return path now wraps the empty TopGroups with the MatchingGroups.Count so TotalGroupCount is populated correctly.
