### PR TITLE
[CI] Add Python bandit security linter as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,3 +106,11 @@ repos:
       - id: gitleaks
         name: run gitleaks
         description: check for secrets with gitleaks
+  - repo: https://github.com/PyCQA/bandit
+    rev: 92ae8b82fb422a639f0ed8d99e96cea769594e08 # frozen: 1.9.4
+    hooks:
+      - id: bandit
+        name: run bandit
+        description: check Python code for security issues
+        args: ['-c=pyproject.toml']
+        additional_dependencies: ['bandit[toml]']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.bandit]
+skips = ["B101"] # https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html#b101-assert-used


### PR DESCRIPTION
Bandit is a tool designed to find common security issues in Python code.

Setup `pyproject.toml` with one global bandit ignore.  There were 2 instances of B101 in the code base and we can use inline ignores if needed.

https://bandit.readthedocs.io/en/latest/config.html

https://github.com/pycqa/bandit

https://bandit.readthedocs.io/en/latest/start.html#version-control-integration

https://github.com/PyCQA/bandit/commit/92ae8b82fb422a639f0ed8d99e96cea769594e08

```
lucenenet % find . -type f -name "*.py"                                               

./src/Lucene.Net/Util/Packed/gen_Packed64SingleBlock.py
./src/Lucene.Net/Util/Packed/gen_Direct.py
./src/Lucene.Net/Util/Packed/gen_BulkOperation.py
./src/Lucene.Net/Util/Packed/gen_PackedThreeBlocks.py
```

pyproject.toml is the standard, unified configuration file used for modern Python projects. Introduced by Python Enhancement Proposal PEP 518, it serves as a single source of truth to manage project metadata, build systems, dependencies, and individual developer tools.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/