### PR TITLE
website: add missing `_appName` docfx config entries

### DIFF
--- a/websites/apidocs/docfx.global.json
+++ b/websites/apidocs/docfx.global.json
@@ -1,4 +1,5 @@
 {
+  "_appName": "Apache Lucene.NET Search Engine Library",
   "_appTitle": "Apache Lucene.NET 4.8.0-ci Documentation",
   "_disableContribution": true,
   "_appFaviconPath": "logo/favicon.ico",

--- a/websites/site/docfx.json
+++ b/websites/site/docfx.json
@@ -35,6 +35,7 @@
       }
     ],
     "globalMetadata": {
+      "_appName": "Apache Lucene.NET Search Engine Library",
       "_appTitle": "Apache Lucene.NET 4.8.0",
       "_disableContribution": false,
       "_disableBreadcrumb": false,


### PR DESCRIPTION
`_appName` is used in the site/docs in 4 places all in HTML `img` tags for the `alt` attribute text.

This is for the site and docs logo.

You need alt text (the alt attribute) on HTML `<img>` tags primarily to ensure web accessibility, provide fallback text when images fail to load, and improve Search Engine Optimization (SEO). Without it, screen readers and search engine crawlers are left blind to what your image represents

Currently we have empty "alt" text:

<img width="550" height="136" alt="Screenshot 2026-06-21 at 5 23 03 am" src="https://github.com/user-attachments/assets/7114ec84-5c6e-4155-bf3a-2ac188ef594a" />

---

```
lucenenet % grep -r "_appName" websites 

websites/apidocs/Templates/LuceneTemplate/partials/logo.tmpl.partial:  <img id="logo" class="svg" src="{{_luceneNetRel}}{{{_appLogoPath}}}{{^_appLogoPath}}logo.svg{{/_appLogoPath}}" alt="{{_appName}}" >
websites/apidocs/Templates/DefaultTemplateNoAssets/partials/_logo.liquid:  <img id="logo" class="svg" src="{{_luceneNetRel}}{{_appLogoPath}}" alt="{{_appName}}" >
websites/apidocs/Templates/DefaultTemplateNoAssets/partials/_logo.liquid:  <img id="logo" class="svg" src="{{_luceneNetRel}}logo.svg" alt="{{_appName}}" >
websites/apidocs/Templates/DefaultTemplateNoAssets/partials/logo.tmpl.partial:  <img id="logo" class="svg" src="{{_luceneNetRel}}{{{_appLogoPath}}}{{^_appLogoPath}}logo.svg{{/_appLogoPath}}" alt="{{_appName}}" >
```
