### PR TITLE
Remove unnecessary `string.AsSpan()` calls as of C# 14, #1340

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
@@ -375,13 +375,12 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         ///        hyphenation point. </param>
         /// <returns> a <see cref="Hyphenation"/> object representing the
         ///         hyphenated word or null if word is not hyphenated. </returns>
+        // LUCENENET: string overload retained here for public API for non-C#-14 callers
         public virtual Hyphenation Hyphenate(string word, int remainCharCount, int pushCharCount)
         {
             // LUCENENET: use Span instead of ToCharArray
             return Hyphenate(word.AsSpan(), 0, word.Length, remainCharCount, pushCharCount);
         }
-
-
 
         /// <summary>
         /// Hyphenate word and return an array of hyphenation points.

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/HyphenationTree.cs
@@ -366,30 +366,13 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         }
 
         /// <summary>
-        /// Hyphenate word and return a <see cref="Hyphenation"/> object.
-        /// </summary>
-        /// <param name="word"> the word to be hyphenated </param>
-        /// <param name="remainCharCount"> Minimum number of characters allowed before the
-        ///        hyphenation point. </param>
-        /// <param name="pushCharCount"> Minimum number of characters allowed after the
-        ///        hyphenation point. </param>
-        /// <returns> a <see cref="Hyphenation"/> object representing the
-        ///         hyphenated word or null if word is not hyphenated. </returns>
-        // LUCENENET: string overload retained here for public API for non-C#-14 callers
-        public virtual Hyphenation Hyphenate(string word, int remainCharCount, int pushCharCount)
-        {
-            // LUCENENET: use Span instead of ToCharArray
-            return Hyphenate(word.AsSpan(), 0, word.Length, remainCharCount, pushCharCount);
-        }
-
-        /// <summary>
         /// Hyphenate word and return an array of hyphenation points.
         /// </summary>
         /// <remarks>
-        /// w = "****nnllllllnnn*****", where n is a non-letter, l is a letter, all n
-        /// may be absent, the first n is at offset, the first l is at offset +
-        /// iIgnoreAtBeginning; word = ".llllll.'\0'***", where all l in w are copied
-        /// into word. In the first part of the routine len = w.length, in the second
+        /// w = "****nnllllllnnn*****".AsSpan(offset, len), where n is a non-letter,
+        /// l is a letter, all n may be absent, the first n is at offset, the first l is
+        /// at offset + iIgnoreAtBeginning; word = ".llllll.'\0'***", where all l in w are
+        /// copied into word. In the first part of the routine len = w.length, in the second
         /// part of the routine len = word.length. Three indices are used: index(w),
         /// the index in w, index(word), the index in word, letterindex(word), the
         /// index in the letter part of word. The following relations exist: index(w) =
@@ -398,18 +381,22 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// offset - 1 + iIgnoreAtBeginning index(w) = letterindex(word) + offset +
         /// iIgnoreAtBeginning
         /// </remarks>
-        /// <param name="w"> char array that contains the word </param>
-        /// <param name="offset"> Offset to first character in word </param>
-        /// <param name="len"> Length of word </param>
-        /// <param name="remainCharCount"> Minimum number of characters allowed before the
-        ///        hyphenation point. </param>
-        /// <param name="pushCharCount"> Minimum number of characters allowed after the
-        ///        hyphenation point. </param>
-        /// <returns> a <see cref="Hyphenation"/> object representing the
-        ///         hyphenated word or null if word is not hyphenated. </returns>
-        public virtual Hyphenation Hyphenate(ReadOnlySpan<char> w, int offset, int len, int remainCharCount, int pushCharCount)
+        /// <param name="w">
+        /// <see cref="ReadOnlySpan{T}"/> that contains the word. This should be sliced
+        /// to the desired offset and length before passing in if necessary.
+        /// </param>
+        /// <param name="remainCharCount">
+        /// Minimum number of characters allowed before the hyphenation point.
+        /// </param>
+        /// <param name="pushCharCount">
+        /// Minimum number of characters allowed after the hyphenation point.
+        /// </param>
+        /// <returns>
+        /// a <see cref="Hyphenation"/> object representing the hyphenated word or null if word is not hyphenated.
+        /// </returns>
+        public virtual Hyphenation Hyphenate(ReadOnlySpan<char> w, int remainCharCount, int pushCharCount)
         {
-            int i;
+            int i, len = w.Length;
             // LUCENENET: optimized method for Span and stackalloc
             Span<char> word = (len + 3) * sizeof(char) > Constants.MaxStackByteLimit ? new char[len + 3] : stackalloc char[len + 3];
 
@@ -420,7 +407,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
             bool bEndOfLetters = false;
             for (i = 1; i <= len; i++)
             {
-                c[0] = w[offset + i - 1];
+                c[0] = w[i - 1];
                 int nc = m_classmap.Find(c, 0);
                 if (nc < 0) // found a non-letter character ...
                 {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/TernaryTree.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/Hyphenation/TernaryTree.cs
@@ -146,6 +146,7 @@ namespace Lucene.Net.Analysis.Compound.Hyphenation
         /// same prefix is inserted. This saves a lot of space, specially for long
         /// keys.
         /// </summary>
+        // LUCENENET: string overload retained here for public API for non-C#-14 callers
         public void Insert(string key, char val)
             => Insert(key.AsSpan(), val);
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/HyphenationCompoundWordTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/HyphenationCompoundWordTokenFilter.cs
@@ -188,7 +188,7 @@ namespace Lucene.Net.Analysis.Compound
         protected override void Decompose()
         {
             // get the hyphenation points
-            Hyphenation.Hyphenation hyphens = hyphenator.Hyphenate(m_termAtt.Buffer, 0, m_termAtt.Length, 1, 1);
+            Hyphenation.Hyphenation hyphens = hyphenator.Hyphenate(m_termAtt.AsSpan(), 1, 1);
             // No hyphen points found -> exit
             if (hyphens is null)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/El/GreekStemmer.cs
@@ -1004,7 +1004,7 @@ namespace Lucene.Net.Analysis.El
         /// <param name="suffix"> A <see cref="string"/> object to check if the word given ends with these characters. </param>
         /// <returns> True if the word ends with the suffix given , false otherwise. </returns>
         private static bool EndsWith(char[] s, int len, string suffix) // LUCENENET: CA1822: Mark members as static
-            => s.AsSpan(0, len).EndsWith(suffix.AsSpan()); // LUCENENET specific - optimized for ReadOnlySpan<char>
+            => s.AsSpan(0, len).EndsWith(suffix); // LUCENENET specific - optimized for ReadOnlySpan<char>
 
         /// <summary>
         /// Checks if the word contained in the leading portion of <see cref="T:char[]"/> array ,

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -3827,7 +3827,7 @@ namespace Lucene.Net.Analysis.Util
 
 #if FEATURE_SPANFORMATTABLE
             else if (key is ISpanFormattable spanFormattable &&
-                spanFormattable.TryFormat(reuse, out int charsWritten, string.Empty, invariant))
+                spanFormattable.TryFormat(reuse, out int charsWritten, ReadOnlySpan<char>.Empty, invariant))
             {
                 chars = reuse.Slice(0, charsWritten).ToArray();
                 return CharReturnType.CharArray;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -3827,7 +3827,7 @@ namespace Lucene.Net.Analysis.Util
 
 #if FEATURE_SPANFORMATTABLE
             else if (key is ISpanFormattable spanFormattable &&
-                spanFormattable.TryFormat(reuse, out int charsWritten, string.Empty.AsSpan(), invariant))
+                spanFormattable.TryFormat(reuse, out int charsWritten, string.Empty, invariant))
             {
                 chars = reuse.Slice(0, charsWritten).ToArray();
                 return CharReturnType.CharArray;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/StemmerUtil.cs
@@ -38,26 +38,10 @@ namespace Lucene.Net.Analysis.Util
         /// <remarks>
         /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
         /// </remarks>
+        // LUCENENET: string overload retained here for public API for non-C#-14 callers
         public static bool StartsWith(ReadOnlySpan<char> s, string prefix)
         {
             return StartsWith(s, prefix.AsSpan());
-        }
-
-        /// <summary>
-        /// Returns true if the character array starts with the prefix.
-        /// </summary>
-        /// <param name="s"> Input Buffer </param>
-        /// <param name="len"> length of input buffer </param>
-        /// <param name="prefix"> Prefix string to test </param>
-        /// <returns> <c>true</c> if <paramref name="s"/> starts with <paramref name="prefix"/> </returns>
-        /// <remarks>
-        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
-        /// Callers should prefer the overload without the <paramref name="len"/> parameter and use a slice instead,
-        /// but this overload is provided for compatibility with existing code.
-        /// </remarks>
-        internal static bool StartsWith(ReadOnlySpan<char> s, int len, string prefix)
-        {
-            return StartsWith(s.Slice(0, len), prefix.AsSpan());
         }
 
         /// <summary>
@@ -107,26 +91,10 @@ namespace Lucene.Net.Analysis.Util
         /// <remarks>
         /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
         /// </remarks>
+        // LUCENENET: string overload retained here for public API for non-C#-14 callers
         public static bool EndsWith(ReadOnlySpan<char> s, string suffix)
         {
             return EndsWith(s, suffix.AsSpan());
-        }
-
-        /// <summary>
-        /// Returns true if the character array ends with the suffix.
-        /// </summary>
-        /// <param name="s"> Input Buffer </param>
-        /// <param name="len"> length of input buffer </param>
-        /// <param name="suffix"> Suffix string to test </param>
-        /// <returns> <c>true</c> if <paramref name="s"/> ends with <paramref name="suffix"/> </returns>
-        /// <remarks>
-        /// LUCENENET NOTE: This method has been converted to use <see cref="ReadOnlySpan{T}"/>.
-        /// Callers should prefer the overload without the <paramref name="len"/> parameter and use a slice instead,
-        /// but this overload is provided for compatibility with existing code.
-        /// </remarks>
-        internal static bool EndsWith(ReadOnlySpan<char> s, int len, string suffix)
-        {
-            return EndsWith(s.Slice(0, len), suffix.AsSpan());
         }
 
         /// <summary>

--- a/src/Lucene.Net.Analysis.Kuromoji/JapaneseReadingFormFilter.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/JapaneseReadingFormFilter.cs
@@ -69,7 +69,7 @@ namespace Lucene.Net.Analysis.Ja
                     else
                     {
                         buffer.Length = 0;
-                        ToStringUtil.GetRomanization(buffer, reading.AsSpan());
+                        ToStringUtil.GetRomanization(buffer, reading);
                         termAttr.SetEmpty().Append(buffer);
                     }
                 }

--- a/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/ReadingAttributeImpl.cs
+++ b/src/Lucene.Net.Analysis.Kuromoji/TokenAttributes/ReadingAttributeImpl.cs
@@ -67,9 +67,9 @@ namespace Lucene.Net.Analysis.Ja.TokenAttributes
                 throw new ArgumentNullException(nameof(reflector));
 
             string? reading = GetReading();
-            string? readingEN = reading is null ? null : ToStringUtil.GetRomanization(reading.AsSpan());
+            string? readingEN = reading is null ? null : ToStringUtil.GetRomanization(reading);
             string? pronunciation = GetPronunciation();
-            string? pronunciationEN = pronunciation is null ? null : ToStringUtil.GetRomanization(pronunciation.AsSpan());
+            string? pronunciationEN = pronunciation is null ? null : ToStringUtil.GetRomanization(pronunciation);
             reflector.Reflect<IReadingAttribute>("reading", reading);
             reflector.Reflect<IReadingAttribute>("reading (en)", readingEN);
             reflector.Reflect<IReadingAttribute>("pronunciation", pronunciation);

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
@@ -636,13 +636,13 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                             // exact match
                             return new RPatternHelper(isMatchSB: (input) =>
                             {
-                                return input.Length == 1 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
+                                return input.Length == 1 && Contains(bContent, input[0]) == shouldMatch;
                             }, isMatchStr: (input) =>
                             {
-                                return input.Length == 1 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
+                                return input.Length == 1 && Contains(bContent, input[0]) == shouldMatch;
                             }, isMatchCS: (input) =>
                             {
-                                return input.Length == 1 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
+                                return input.Length == 1 && Contains(bContent, input[0]) == shouldMatch;
                             });
                         }
                         else if (startsWith)
@@ -650,13 +650,13 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                             // first char
                             return new RPatternHelper(isMatchSB: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent, input[0]) == shouldMatch;
                             }, isMatchStr: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent, input[0]) == shouldMatch;
                             }, isMatchCS: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent.AsSpan(), input[0]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent, input[0]) == shouldMatch;
                             });
                         }
                         else if (endsWith)
@@ -664,13 +664,13 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                             // last char
                             return new RPatternHelper(isMatchSB: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent.AsSpan(), input[input.Length - 1]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch;
                             }, isMatchStr: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent.AsSpan(), input[input.Length - 1]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch;
                             }, isMatchCS: (input) =>
                             {
-                                return input.Length > 0 && Contains(bContent.AsSpan(), input[input.Length - 1]) == shouldMatch;
+                                return input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch;
                             });
                         }
                     }

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CategoryPathUtils.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CategoryPathUtils.cs
@@ -90,7 +90,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 }
 
                 // LUCENENET specific - calculate the hash code without the allocation caused by Subsequence() and ToString()
-                if (!charBlockArray.Equals(offset, len, cp.Components[i].AsSpan())) // LUCENENET: Corrected 2nd parameter
+                if (!charBlockArray.Equals(offset, len, cp.Components[i])) // LUCENENET: Corrected 2nd parameter
                 {
                     return false;
                 }

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestStemmerUtil.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestStemmerUtil.cs
@@ -38,7 +38,7 @@ namespace Lucene.Net.Analysis.Util
         public void TestStartsWith(string input, int len, string prefix, bool expected)
         {
             // test len overload
-            Assert.AreEqual(expected, StemmerUtil.StartsWith(input.AsSpan(), len, prefix));
+            Assert.AreEqual(expected, StemmerUtil.StartsWith(input, len, prefix));
 
             // test no len overload
             Assert.AreEqual(expected, StemmerUtil.StartsWith(input.AsSpan(0, len), prefix));
@@ -53,7 +53,7 @@ namespace Lucene.Net.Analysis.Util
         public void TestEndsWith(string input, int len, string prefix, bool expected)
         {
             // test len overload
-            Assert.AreEqual(expected, StemmerUtil.EndsWith(input.AsSpan(), len, prefix));
+            Assert.AreEqual(expected, StemmerUtil.EndsWith(input, len, prefix));
 
             // test no len overload
             Assert.AreEqual(expected, StemmerUtil.EndsWith(input.AsSpan(0, len), prefix));

--- a/src/Lucene.Net.Tests.Analysis.SmartCn/Hhmm/TestBuildDictionary.cs
+++ b/src/Lucene.Net.Tests.Analysis.SmartCn/Hhmm/TestBuildDictionary.cs
@@ -271,9 +271,9 @@ namespace Lucene.Net.Analysis.Cn.Smart.Hhmm
 
         private static void CheckBigramDictionary(BigramDictionary bigramDict)
         {
-            Assert.AreEqual(10000, bigramDict.GetFrequency("锲而不舍@、".AsSpan()), "Frequency for '锲而不舍@、' should be 10000.");
-            Assert.AreEqual(15000, bigramDict.GetFrequency("聆听@了".AsSpan()), "Frequency for '聆听@了' should be 15000.");
-            Assert.AreEqual(20000, bigramDict.GetFrequency("魅力@，".AsSpan()), "Frequency for '魅力@，' should be 20000.");
+            Assert.AreEqual(10000, bigramDict.GetFrequency("锲而不舍@、"), "Frequency for '锲而不舍@、' should be 10000.");
+            Assert.AreEqual(15000, bigramDict.GetFrequency("聆听@了"), "Frequency for '聆听@了' should be 15000.");
+            Assert.AreEqual(20000, bigramDict.GetFrequency("魅力@，"), "Frequency for '魅力@，' should be 20000.");
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Store/TestByteArrayDataOutput.cs
+++ b/src/Lucene.Net.Tests/Store/TestByteArrayDataOutput.cs
@@ -44,7 +44,7 @@ namespace Lucene.Net.Store
         {
             byte[] bytes = new byte[10];
             ByteArrayDataOutput @out = new ByteArrayDataOutput(bytes);
-            @out.WriteChars("ABC".AsSpan());
+            @out.WriteChars("ABC");
 
             ByteArrayDataInput @in = new ByteArrayDataInput(bytes);
             Assert.AreEqual("ABC", @in.ReadString());

--- a/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
@@ -404,7 +404,7 @@ namespace Lucene.Net.Util
             string unicode = TestUtil.RandomRealisticUnicodeString(Random);
             var utf8 = new byte[IOUtils.ENCODING_UTF_8_NO_BOM.GetMaxByteCount(unicode.Length)];
 
-            bool success = UnicodeUtil.TryUTF16toUTF8(unicode.AsSpan(), utf8.AsSpan(), out int bytesWritten);
+            bool success = UnicodeUtil.TryUTF16toUTF8(unicode, utf8, out int bytesWritten);
 
             Assert.IsTrue(success);
             Assert.AreEqual(unicode, IOUtils.ENCODING_UTF_8_NO_BOM.GetString(utf8, 0, bytesWritten));

--- a/src/Lucene.Net/Store/DataOutput.cs
+++ b/src/Lucene.Net/Store/DataOutput.cs
@@ -322,7 +322,7 @@ namespace Lucene.Net.Store
         {
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
-            WriteChars(s.AsSpan());
+            WriteChars(s);
         }
 
 #nullable enable


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Remove unnecessary `string.AsSpan()` calls as of C# 14

Fixes #1340

## Description

I reviewed all instances of calling `.AsSpan()` on strings, which are no longer necessary for method arguments for `ReadOnlySpan<char>` parameters as of C# 14. There weren't very many. I was also able to remove two internal methods from StemmerUtil. In other cases, I left the public string overload APIs so as to not make it a breaking change for non-C#-14 callers and commented as such. The calls that remain are needed to either force the overload resolution for the public API, or are not used as arguments.