### PR TITLE
docs: add JSDoc type annotation for preTransform parameter

### DIFF
--- a/websites/apidocs/Templates/DefaultTemplateNoAssets/toc.extension.js
+++ b/websites/apidocs/Templates/DefaultTemplateNoAssets/toc.extension.js
@@ -21,6 +21,7 @@
 
 /**
  * This method will be called at the start of exports.transform in toc.html.js
+ * @param {Object} model
  */
 exports.preTransform = function (model) {
   return model;


### PR DESCRIPTION
### 问题背景
函数 `preTransform` 的参数 `model` 缺少 JSDoc 类型注解，这降低了代码的可读性和开发效率，因为 IDE 和静态分析工具无法提供类型提示。

### 修改内容
- 在 `preTransform` 函数上方添加了 `@param {Object} model` 注解，明确指定参数类型为 Object。
- 这增强了代码的自文档性，使开发者和工具能更好地理解参数用途，提升代码质量。

### 验证方式
- 由于修改仅限于添加注解，不影响代码逻辑，运行现有测试套件确保所有测试通过。
- 手动检查文件中的注解是否正确应用。

### 其他信息
- 没有 breaking changes，对现有 API 无影响。
- 不需要更新文档，因为修改是注解添加，符合仓库的代码风格。