### PR TITLE
Bumped J2N to 2.2.0-alpha-0048

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -38,7 +38,7 @@
     <IKVMPackageVersion>8.7.5</IKVMPackageVersion>
     <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
-    <J2NPackageVersion>[2.2.0-alpha-0042, 3.0.0)</J2NPackageVersion>
+    <J2NPackageVersion>[2.2.0-alpha-0048, 3.0.0)</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
     <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.36</LuceneNetCodeAnalysisDevPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.3.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1321,7 +1321,7 @@ namespace Lucene.Net.Util
             {
                 while (iter.MoveNext())
                 {
-                    stream.WriteLine(Collections.ToString(iter.Current));
+                    stream.WriteLine(string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", iter.Current));
                 }
             }
             stream.WriteLine("*** END " + label + " ***");

--- a/src/Lucene.Net/Support/Collections.cs
+++ b/src/Lucene.Net/Support/Collections.cs
@@ -163,21 +163,7 @@ namespace Lucene.Net.Support
         /// </summary>
         public static string? ToString(object? obj)
         {
-            if (obj is null)
-            {
-                return "null";
-            }
-
-            Type t = obj.GetType();
-            if (t.IsGenericType
-                && (t.ImplementsGenericInterface(typeof(ICollection<>)))
-                || t.ImplementsGenericInterface(typeof(IDictionary<,>)))
-            {
-                dynamic genericType = Convert.ChangeType(obj, t);
-                return ToString(genericType);
-            }
-
-            return Convert.ToString(obj, CultureInfo.InvariantCulture);
+            return string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", obj);
         }
 
         public static ReadOnlyList<T> AsReadOnly<T>(IList<T> list)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Related to #1284 and #1311

Bumped J2N to [2.2.0-alpha-0048](https://github.com/NightOwl888/J2N/releases/tag/v2.2.0-alpha-0048) so we can integrate the latest features

## Details

This upgrades to a version of J2N that contains the new `CountdownLatch` implementation that allows signaling after reaching 0 without throwing exceptions.

It also removes the one call to `dynamic` because the support for it was removed from J2N in https://github.com/NightOwl888/J2N/pull/181 as part of #1278. That same PR also significantly improved the performance of `Aggressive` mode, so we can simply use `string.Format(J2N.Text.StringFormatter.InvariantCulture, "{0}", collection)` to format collections. It also correctly handles `IStructuralFormattable`, which all J2N collections implement to improve performance.

> NOTE: This also updates `LuceneTestCase.DumpEnumerator()` to use the above approach rather than calling `Collections.ToString()`, since the types involved may be broader than collections and `StringFormatter` handles all known differences in formatting between .NET and Java.



