### PR TITLE
Implement IsTestThread to fix flaky TestFlushExceptions

### DIFF
--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -896,6 +896,11 @@ namespace Lucene.Net.Util
         {
             // LUCENENET TODO: Not sure how to convert these
             //ParentChainCallRule.SetupCalled = true;
+
+            // LUCENENET specific: capture the thread running the test method so that
+            // IsTestThread can distinguish it from background threads (e.g. ConcurrentMergeScheduler
+            // merge threads). This mirrors Java's ThreadAndTestNameRule.testCaseThread.
+            testCaseThread = Thread.CurrentThread;
         }
 
         /// <summary>
@@ -982,6 +987,11 @@ namespace Lucene.Net.Util
                 NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] An exception occurred during TearDown:");
                 RandomizedContext.PrintStackTrace(ex, NUnit.Framework.TestContext.Error);
                 throw; // LUCENENET: Throw to preserve stack details of original throw.
+            }
+            finally
+            {
+                // LUCENENET specific: clear the captured test thread (see SetUp()).
+                testCaseThread = null;
             }
         }
 
@@ -1148,14 +1158,22 @@ namespace Lucene.Net.Util
         }
 
         /// <summary>
+        /// LUCENENET specific: the thread that is executing the current test method, captured
+        /// in <see cref="SetUp()"/> and cleared in <see cref="TearDown()"/>. Used by
+        /// <see cref="IsTestThread"/>. This is <c>[ThreadStatic]</c> so that tests running in
+        /// parallel each track their own test thread, and background threads (which never run
+        /// <see cref="SetUp()"/>) see <c>null</c>.
+        /// </summary>
+        [ThreadStatic]
+        private static Thread testCaseThread;
+
+        /// <summary>
         /// Returns true if and only if the calling thread is the primary thread
         /// executing the test case.
-        /// <para/>
-        /// LUCENENET: Not Implemented - always returns true
         /// </summary>
-        /*Assert.IsNotNull(ThreadAndTestNameRule.TestCaseThread, "Test case thread not set?");
-                return Thread.CurrentThread == ThreadAndTestNameRule.TestCaseThread;*/
-        internal static bool IsTestThread => true; // LUCENENET specific - changed from public to internal since there is no way to support it
+        // LUCENENET specific - changed from public to internal since IsTestThread is only meaningful
+        // within the test framework. Mirrors Java's check against ThreadAndTestNameRule.testCaseThread.
+        internal static bool IsTestThread => testCaseThread != null && Thread.CurrentThread == testCaseThread;
 
         /// <summary>
         /// Asserts that <see cref="FieldCacheSanityChecker"/> does not detect any

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -1173,7 +1173,7 @@ namespace Lucene.Net.Util
         /// </summary>
         // LUCENENET specific - changed from public to internal since IsTestThread is only meaningful
         // within the test framework. Mirrors Java's check against ThreadAndTestNameRule.testCaseThread.
-        internal static bool IsTestThread => testCaseThread != null && Thread.CurrentThread == testCaseThread;
+        internal static bool IsTestThread => Thread.CurrentThread == testCaseThread;
 
         /// <summary>
         /// Asserts that <see cref="FieldCacheSanityChecker"/> does not detect any


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Implement IsTestThread to fix flaky TestFlushExceptions

(Related to flaky failure on #1311 / #1284)

## Description

`LuceneTestCase.IsTestThread` was hardcoded to always return true, so the flush-failure injection in `TestConcurrentMergeScheduler.TestFlushExceptions` fired on background ConcurrentMergeScheduler merge threads (which also flush via `CompressingStoredFieldsWriter.Flush()`), not just the test thread. When a merge thread happened to be flushing during the SetDoFail/Flush window and `Random.NextBoolean()` returned true, the merge threw, surfacing as a flaky MergeException at teardown.

Capture the test-case thread in SetUp (cleared in TearDown) in a `[ThreadStatic]` field and have IsTestThread compare against it, mirroring Java's `ThreadAndTestNameRule.testCaseThread`. Tests run with `LevelOfParallelism(1)`, and NUnit runs SetUp, the test body, and TearDown on the same thread, so the capture lines up with the thread executing the test method. Background merge threads never run SetUp, so they correctly see a null test thread and are excluded.