### PR TITLE
`.asf.yaml`: Updated Maintenance Branch Protection rules to allow `docs/*`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,12 +44,11 @@ github:
     rebase: false
 
   rulesets:
-    - name: "Branch Protection"
+    - name: "Main Branch Protection"
       type: branch
       branches:
         includes:
           - "master"
-          - "docs/*"
         excludes: []
       bypass_teams:
         - root
@@ -62,11 +61,12 @@ github:
         require_last_push_approval: false
         require_code_owner_reviews: false
         required_approving_review_count: 0
-    - name: "Release Branch Protection"
+    - name: "Maintenace Branch Protection"
       type: branch
       branches:
         includes:
           - "release/*"
+          - "docs/*"
         excludes: []
       bypass_teams:
         - root


### PR DESCRIPTION
… we will be creating new branches from master and have merge commits in master's commit history

<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

The branch protection rules are blocking the API docs release and will continue to do so as long as they are in place. The procedure requires creating a new branch from `master`, which has merge commits in its history.

The branch protection rule is incompatible with the repository's existing history. The merge commit predates our current workflow and is inherited from `master`. We should relax linear-history requirements on release and docs maintenance branches rather than attempt a repository-wide history rewrite.
