### PR TITLE
SWEEP: Removal of ICharSequence from most places, #1337

### DIFF
--- a/src/Lucene.Net.Analysis.Common/Analysis/Compound/CompoundWordTokenFilterBase.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Compound/CompoundWordTokenFilterBase.cs
@@ -1,13 +1,14 @@
 // Lucene version compatibility level 4.8.1
-using J2N.Text;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.TokenAttributes.Extensions;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Util;
-using Lucene.Net.Support;
 using System;
 using System.Collections.Generic;
+#if !FEATURE_QUEUE_TRYDEQUEUE_TRYPEEK
+using Lucene.Net.Support;
+#endif
 
 namespace Lucene.Net.Analysis.Compound
 {
@@ -115,7 +116,7 @@ namespace Lucene.Net.Analysis.Compound
             {
                 if (Debugging.AssertsEnabled) Debugging.Assert(current != null);
                 RestoreState(current); // keep all other attributes untouched
-                m_termAtt.SetEmpty().Append(token.Text);
+                m_termAtt.SetEmpty().Append(token.Text.Span);
                 m_offsetAtt.SetOffset(token.StartOffset, token.EndOffset);
                 posIncAtt.PositionIncrement = 0;
                 return true;
@@ -161,10 +162,10 @@ namespace Lucene.Net.Analysis.Compound
         /// </summary>
         protected class CompoundToken
         {
-            private readonly ICharSequence txt;
+            private readonly ReadOnlyMemory<char> txt;
             private readonly int startOffset, endOffset;
 
-            public ICharSequence Text => txt; // LUCENENET specific: changed public field into property backed by private field
+            public ReadOnlyMemory<char> Text => txt; // LUCENENET specific: changed public field into property backed by private field
 
             public int StartOffset => startOffset; // LUCENENET specific: changed public field into property backed by private field
 
@@ -174,7 +175,7 @@ namespace Lucene.Net.Analysis.Compound
             /// Construct the compound token based on a slice of the current <see cref="CompoundWordTokenFilterBase.m_termAtt"/>. </summary>
             public CompoundToken(CompoundWordTokenFilterBase compoundWordTokenFilterBase, int offset, int length)
             {
-                this.txt = compoundWordTokenFilterBase.m_termAtt.Subsequence(offset, length); // LUCENENET: Corrected 2nd Subsequence parameter
+                this.txt = compoundWordTokenFilterBase.m_termAtt.AsMemory(offset, length); // LUCENENET: Corrected 2nd Subsequence parameter
 
                 // offsets of the original word
                 int startOff = compoundWordTokenFilterBase.m_offsetAtt.StartOffset;

--- a/src/Lucene.Net.Analysis.Common/Analysis/En/KStemFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/En/KStemFilter.cs
@@ -68,9 +68,9 @@ namespace Lucene.Net.Analysis.En
 
             char[] term = termAttribute.Buffer;
             int len = termAttribute.Length;
-            if ((!keywordAtt.IsKeyword) && stemmer.Stem(term, len))
+            if (!keywordAtt.IsKeyword && stemmer.Stem(term, len))
             {
-                termAttribute.SetEmpty().Append(stemmer.AsCharSequence());
+                termAttribute.SetEmpty().Append(stemmer.AsSpan());
             }
 
             return true;

--- a/src/Lucene.Net.Analysis.Common/Analysis/En/KStemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/En/KStemmer.cs
@@ -1833,9 +1833,9 @@ namespace Lucene.Net.Analysis.En
             return word.ToString();
         }
 
-        internal virtual ICharSequence AsCharSequence()
+        internal virtual ReadOnlySpan<char> AsSpan()
         {
-            return result != null ? (ICharSequence)new CharsRef(result) : word;
+            return result != null ? result.AsSpan() : word.AsSpan();
         }
 
         internal virtual string String => result;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/HunspellStemFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/HunspellStemFilter.cs
@@ -97,7 +97,7 @@ namespace Lucene.Net.Analysis.Hunspell
                 buffer.RemoveAt(0);
                 RestoreState(savedState);
                 posIncAtt.PositionIncrement = 0;
-                termAtt.SetEmpty().Append(nextStem);
+                termAtt.SetEmpty().Append(nextStem.AsSpan());
                 return true;
             }
 
@@ -125,7 +125,7 @@ namespace Lucene.Net.Analysis.Hunspell
 
             CharsRef stem = buffer[0];
             buffer.RemoveAt(0);
-            termAtt.SetEmpty().Append(stem);
+            termAtt.SetEmpty().Append(stem.AsSpan());
 
             if (longestOnly)
             {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Stemmer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Hunspell/Stemmer.cs
@@ -1,5 +1,4 @@
 // Lucene version compatibility level 4.10.4
-using J2N.Text;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Store;
@@ -254,10 +253,11 @@ namespace Lucene.Net.Analysis.Hunspell
             IList<CharsRef> deduped = new JCG.List<CharsRef>();
             foreach (CharsRef s in stems)
             {
-                if (!terms.Contains((ICharSequence)s)) // LUCENENET: Cast to get to ICharSequence overload
+                ReadOnlySpan<char> sSpan = s.AsSpan();
+                if (!terms.Contains(sSpan)) // LUCENENET: use ReadOnlySpan<char> overload
                 {
                     deduped.Add(s);
-                    terms.Add((ICharSequence)s); // LUCENENET: Cast to get to ICharSequence overload
+                    terms.Add(sSpan); // LUCENENET: use ReadOnlySpan<char> overload
                 }
             }
             return deduped;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PatternAnalyzer.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/PatternAnalyzer.cs
@@ -589,8 +589,7 @@ namespace Lucene.Net.Analysis.Miscellaneous
         // Nested classes:
         ///////////////////////////////////////////////////////////////////////////////
         /// <summary>
-        /// A <see cref="StringReader"/> that exposes it's contained string for fast direct access.
-        /// Might make sense to generalize this to ICharSequence and make it public?
+        /// A <see cref="StringReader"/> that exposes its contained string for fast direct access.
         /// </summary>
         internal sealed class FastStringReader : StringReader
         {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/StemmerOverrideFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Miscellaneous/StemmerOverrideFilter.cs
@@ -1,6 +1,5 @@
 // Lucene version compatibility level 4.8.1
 using J2N;
-using J2N.Text;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Util;
 using Lucene.Net.Util.Fst;
@@ -188,12 +187,10 @@ namespace Lucene.Net.Analysis.Miscellaneous
             /// <param name="output"> the stemmer override output char sequence </param>
             /// <returns> <c>false</c> if the input has already been added to this builder otherwise <c>true</c>. </returns>
             /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="output"/> is <c>null</c>.</exception>
-            // LUCENENET specific overload of ICharSequence
-            public virtual bool Add(string input, string output)
+            // LUCENENET specific method for ReadOnlySpan<char>
+            public virtual bool Add(ReadOnlySpan<char> input, string output)
             {
                 // LUCENENET: Added guard clauses
-                if (input is null)
-                    throw new ArgumentNullException(nameof(input));
                 if (output is null)
                     throw new ArgumentNullException(nameof(output));
 
@@ -202,13 +199,11 @@ namespace Lucene.Net.Analysis.Miscellaneous
                 {
                     // convert on the fly to lowercase
 
-                    // LUCENENET: Reduce allocations/improve throughput by using stack and spans
-                    var source = input.AsSpan();
                     if (length * sizeof(char) <= Constants.MaxStackByteLimit)
                     {
                         // Fast path - use the stack
                         Span<char> buffer = stackalloc char[length];
-                        source.ToLowerInvariant(buffer);
+                        input.ToLowerInvariant(buffer);
 
                         UnicodeUtil.UTF16toUTF8(buffer, spare);
                     }
@@ -219,14 +214,14 @@ namespace Lucene.Net.Analysis.Miscellaneous
                         char[] buffer = charsSpare.Chars;
 
                         var destination = buffer.AsSpan(0, length);
-                        source.ToLowerInvariant(destination);
+                        input.ToLowerInvariant(destination);
 
                         UnicodeUtil.UTF16toUTF8(buffer, 0, length, spare);
                     }
                 }
                 else
                 {
-                    UnicodeUtil.UTF16toUTF8(input, 0, length, spare);
+                    UnicodeUtil.UTF16toUTF8(input.Slice(0, length), spare);
                 }
                 if (hash.Add(spare) >= 0)
                 {
@@ -234,85 +229,6 @@ namespace Lucene.Net.Analysis.Miscellaneous
                     return true;
                 }
                 return false;
-            }
-
-            /// <summary>
-            /// Adds an input string and it's stemmer override output to this builder.
-            /// </summary>
-            /// <param name="input"> the input char sequence </param>
-            /// <param name="output"> the stemmer override output char sequence </param>
-            /// <returns> <c>false</c> if the input has already been added to this builder otherwise <c>true</c>. </returns>
-            /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="output"/> is <c>null</c>.</exception>
-            // LUCENENET specific overload of ICharSequence
-            public virtual bool Add(char[] input, string output)
-            {
-                // LUCENENET: Added guard clauses
-                if (input is null)
-                    throw new ArgumentNullException(nameof(input));
-                if (output is null)
-                    throw new ArgumentNullException(nameof(output));
-
-                int length = input.Length;
-                if (ignoreCase)
-                {
-                    // convert on the fly to lowercase
-
-                    // LUCENENET: Reduce allocations/improve throughput by using stack and spans
-                    var source = new ReadOnlySpan<char>(input);
-                    if (length * sizeof(char) <= Constants.MaxStackByteLimit)
-                    {
-                        // Fast path - use the stack
-                        Span<char> buffer = stackalloc char[length];
-                        source.ToLowerInvariant(buffer);
-
-                        UnicodeUtil.UTF16toUTF8(buffer, spare);
-                    }
-                    else
-                    {
-                        // Slow path - use the heap
-                        charsSpare.Grow(length);
-                        char[] buffer = charsSpare.Chars;
-
-                        var destination = buffer.AsSpan(0, length);
-                        source.ToLowerInvariant(destination);
-
-                        UnicodeUtil.UTF16toUTF8(buffer, 0, length, spare);
-                    }
-                }
-                else
-                {
-                    UnicodeUtil.UTF16toUTF8(input, 0, length, spare);
-                }
-                if (hash.Add(spare) >= 0)
-                {
-                    outputValues.Add(output);
-                    return true;
-                }
-                return false;
-            }
-
-            /// <summary>
-            /// Adds an input string and it's stemmer override output to this builder.
-            /// </summary>
-            /// <param name="input"> the input char sequence </param>
-            /// <param name="output"> the stemmer override output char sequence </param>
-            /// <returns> <c>false</c> if the input has already been added to this builder otherwise <c>true</c>. </returns>
-            /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="output"/> is <c>null</c>.</exception>
-            // LUCENENET specific overload of ICharSequence
-            public virtual bool Add(ICharSequence input, string output)
-            {
-                // LUCENENET: Added guard clauses
-                if (input is null)
-                    throw new ArgumentNullException(nameof(input));
-                if (output is null)
-                    throw new ArgumentNullException(nameof(output));
-
-                if (input is CharArrayCharSequence charArrayCharSequence && charArrayCharSequence.HasValue)
-                    return Add(charArrayCharSequence.Value, output);
-
-                // LUCENENET: In .NET, the indexer for StringBuilder is slow, so we are better off
-                // converting to a string in all other cases.
-                return Add(input.ToString(), output);
             }
 
             /// <summary>

--- a/src/Lucene.Net.Analysis.Common/Analysis/NGram/EdgeNGramTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/NGram/EdgeNGramTokenFilter.cs
@@ -175,7 +175,7 @@ namespace Lucene.Net.Analysis.NGram
                     {
                         curTermBuffer = (char[])termAtt.Buffer.Clone();
                         curTermLength = termAtt.Length;
-                        curCodePointCount = charUtils.CodePointCount(termAtt);
+                        curCodePointCount = charUtils.CodePointCount(termAtt.AsSpan());
                         curGramSize = minGram;
                         tokStart = offsetAtt.StartOffset;
                         tokEnd = offsetAtt.EndOffset;

--- a/src/Lucene.Net.Analysis.Common/Analysis/NGram/NGramTokenFilter.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/NGram/NGramTokenFilter.cs
@@ -159,7 +159,7 @@ namespace Lucene.Net.Analysis.NGram
                     {
                         curTermBuffer = (char[])termAtt.Buffer.Clone();
                         curTermLength = termAtt.Length;
-                        curCodePointCount = charUtils.CodePointCount(termAtt);
+                        curCodePointCount = charUtils.CodePointCount(termAtt.AsSpan());
                         curGramSize = minGram;
                         curPos = 0;
                         curPosInc = posIncAtt.PositionIncrement;

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -489,6 +489,18 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         public virtual bool ContainsKey(string text)
         {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
+            return keys[GetSlot(text)] != null;
+        }
+
+        /// <summary>
+        /// <c>true</c> if the <paramref name="text"/> <see cref="ReadOnlySpan{T}"/> is in the <see cref="Keys"/>;
+        /// otherwise <c>false</c>
+        /// </summary>
+        public virtual bool ContainsKey(ReadOnlySpan<char> text)
+        {
             return keys[GetSlot(text)] != null;
         }
 
@@ -623,6 +635,9 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="KeyNotFoundException"><paramref name="text"/> is not found in the dictionary.</exception>
         internal virtual TValue Get(string text, bool throwIfNotFound = true)
         {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
             var value = values[GetSlot(text)];
             if (value is not null)
             {
@@ -714,7 +729,7 @@ namespace Lucene.Net.Analysis.Util
         /// Returns <c>true</c> if the <see cref="string"/> is in the set.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
-        private int GetSlot(string text)
+        private int GetSlot(ReadOnlySpan<char> text)
         {
             int code = GetHashCode(text);
             int pos = code & (keys.Length - 1);
@@ -808,6 +823,9 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         public virtual bool Put(string text, TValue value, [MaybeNullWhen(returnValue: true)] out TValue previousValue) // LUCENENET: Refactored to use out value to support value types
         {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
             MapValue? oldValue = PutImpl(text, new MapValue(value));
             if (oldValue is not null)
             {
@@ -930,9 +948,9 @@ namespace Lucene.Net.Analysis.Util
             // than casting using *as* and then checking for null.
             // http://stackoverflow.com/q/1583050/181087
             if (text is string str)
-                return PutImpl(str, value);
+                return PutImpl(str.AsSpan(), value);
             if (text is char[] charArray)
-                return PutImpl(charArray, value);
+                return PutImpl(charArray.AsSpan(), value);
             if (text is ICharSequence cs)
                 return PutImpl(cs, value);
 
@@ -946,18 +964,13 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// Add the given mapping.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private MapValue? PutImpl(string text, MapValue value)
+        private MapValue? PutImpl(ReadOnlySpan<char> text, MapValue value)
         {
-            // LUCENENET: Added guard clause
-            if (text is null)
-                throw new ArgumentNullException(nameof(text));
-
             // LUCENENET specific - only allocate char array if it is required.
             if (ignoreCase)
             {
-                return PutImpl(text.ToCharArray(), value);
+                return PutImpl(text.ToArray(), value);
             }
             version++;
             int slot = GetSlot(text);
@@ -967,7 +980,7 @@ namespace Lucene.Net.Analysis.Util
                 values[slot] = value;
                 return oldValue;
             }
-            keys[slot] = text.ToCharArray();
+            keys[slot] = text.ToArray();
             values[slot] = value;
             count++;
 
@@ -1100,6 +1113,16 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
+        /// Sets the value of the mapping of the chars inside this <see cref="ReadOnlySpan{T}"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void Set(ReadOnlySpan<char> text)
+        {
+            SetImpl(text, PLACEHOLDER);
+        }
+
+        /// <summary>
         /// Sets the value of the mapping of the chars inside this <see cref="string"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
@@ -1154,7 +1177,7 @@ namespace Lucene.Net.Analysis.Util
         void ICharArrayDictionary.Set(char[] text) => Set(text);
         void ICharArrayDictionary.Set(ICharSequence text) => Set(text);
         void ICharArrayDictionary.Set<T>(T text) => Set(text);
-        void ICharArrayDictionary.Set(string text) => Set(text);
+        void ICharArrayDictionary.Set(ReadOnlySpan<char> text) => Set(text);
 
         #endregion Set
 
@@ -1316,17 +1339,13 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// LUCENENET specific. Like PutImpl, but doesn't have a return value or lookup to get the old value.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetImpl(string text, MapValue value)
+        private void SetImpl(ReadOnlySpan<char> text, MapValue value)
         {
-            if (text is null)
-                throw new ArgumentNullException(nameof(text));
-
             // LUCENENET specific - only allocate char array if it is required.
             if (ignoreCase)
             {
-                SetImpl(text.ToCharArray(), value);
+                SetImpl(text.ToArray(), value);
                 return;
             }
             version++;
@@ -1336,7 +1355,7 @@ namespace Lucene.Net.Analysis.Util
                 values[slot] = value;
                 return;
             }
-            keys[slot] = text.ToCharArray();
+            keys[slot] = text.ToArray();
             values[slot] = value;
             count++;
 
@@ -1718,7 +1737,7 @@ namespace Lucene.Net.Analysis.Util
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool Equals(string text1, char[] text2)
+        private bool Equals(ReadOnlySpan<char> text1, ReadOnlySpan<char> text2)
         {
             int length = text1.Length;
             if (length != text2.Length)
@@ -1730,7 +1749,7 @@ namespace Lucene.Net.Analysis.Util
                 for (int i = 0; i < length;)
                 {
                     int codePointAt = charUtils.CodePointAt(text1, i);
-                    if (Character.ToLower(codePointAt, CultureInfo.InvariantCulture) != charUtils.CodePointAt(text2, i, text2.Length)) // LUCENENET specific - need to use invariant culture to match Java
+                    if (Character.ToLower(codePointAt, CultureInfo.InvariantCulture) != charUtils.CodePointAt(text2, i)) // LUCENENET specific - need to use invariant culture to match Java
                     {
                         return false;
                     }
@@ -1892,11 +1911,8 @@ namespace Lucene.Net.Analysis.Util
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int GetHashCode(string text)
+        private int GetHashCode(ReadOnlySpan<char> text)
         {
-            if (text is null)
-                throw new ArgumentNullException(nameof(text)); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
-
             int code = 0;
             int length = text.Length;
             if (ignoreCase)
@@ -1985,8 +2001,7 @@ namespace Lucene.Net.Analysis.Util
         /// Primarily for internal use by <see cref="CharArraySet"/>.
         /// </summary>
         /// <returns><c>true</c> if the text was added, <c>false</c> if the text already existed.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
-        internal virtual bool Put(string text)
+        internal virtual bool Put(ReadOnlySpan<char> text)
         {
             return PutImpl(text, PLACEHOLDER) is null;
         }
@@ -2004,7 +2019,7 @@ namespace Lucene.Net.Analysis.Util
 
         bool ICharArrayDictionary.Put(char[] text, int startIndex, int length) => Put(text, startIndex, length);
         bool ICharArrayDictionary.Put(char[] text) => Put(text);
-        bool ICharArrayDictionary.Put(string text) => Put(text);
+        bool ICharArrayDictionary.Put(ReadOnlySpan<char> text) => Put(text);
         bool ICharArrayDictionary.Put(ICharSequence text) => Put(text);
         bool ICharArrayDictionary.Put<T>(T text) => Put(text);
 
@@ -2145,6 +2160,9 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         public virtual bool TryGetValue(string text, [NotNullWhen(returnValue: false)] out TValue value)
         {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
             var val = values[GetSlot(text)];
             if (val != null)
             {
@@ -3263,7 +3281,7 @@ namespace Lucene.Net.Analysis.Util
         bool ContainsKey(char[] text, int startIndex, int length);
         bool ContainsKey(char[] text);
         bool ContainsKey<T>(T text);
-        bool ContainsKey(string text);
+        bool ContainsKey(ReadOnlySpan<char> text);
         bool ContainsKey(ICharSequence text);
         int Count { get; }
         bool IgnoreCase { get; }
@@ -3273,12 +3291,12 @@ namespace Lucene.Net.Analysis.Util
         bool Put(char[] text);
         bool Put(ICharSequence text);
         bool Put<T>(T text);
-        bool Put(string text);
+        bool Put(ReadOnlySpan<char> text);
         void Set(char[] text, int startIndex, int length);
         void Set(char[] text);
         void Set(ICharSequence text);
         void Set<T>(T text);
-        void Set(string text);
+        void Set(ReadOnlySpan<char> text);
         ICharArrayDictionaryEnumerator GetEnumerator();
     }
 
@@ -3457,7 +3475,7 @@ namespace Lucene.Net.Analysis.Util
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
             }
 
-            internal override bool Put(string text)
+            internal override bool Put(ReadOnlySpan<char> text)
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
             }
@@ -3589,6 +3607,11 @@ namespace Lucene.Net.Analysis.Util
             }
 
             internal override void Set(ICharSequence text, TValue? value)
+            {
+                throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
+            }
+
+            internal override void Set(ReadOnlySpan<char> text)
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
             }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayMap.cs
@@ -215,35 +215,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Creates a dictionary from the mappings in another dictionary.
-        /// </summary>
-        /// <param name="matchVersion">
-        ///          compatibility match version see <see cref="CharArrayDictionary{TValue}"/> for details. </param>
-        /// <param name="collection">
-        ///          a dictionary (<see cref="T:IDictionary{ICharSequence,V}"/>) whose mappings to be copied. </param>
-        /// <param name="ignoreCase">
-        ///          <c>false</c> if and only if the set should be case sensitive;
-        ///          otherwise <c>true</c>. </param>
-        /// <exception cref="ArgumentNullException"><paramref name="collection"/> is <c>null</c>.</exception>
-        public CharArrayDictionary(LuceneVersion matchVersion, IDictionary<ICharSequence, TValue> collection, bool ignoreCase)
-            : this(matchVersion, collection?.Count ?? 0, ignoreCase)
-        {
-            // LUCENENET: Added guard clause
-            if (collection is null)
-                throw new ArgumentNullException(nameof(collection));
-
-            foreach (var v in collection)
-            {
-                // LUCENENET: S1699: Don't call call protected members in the constructor
-                if (keys[GetSlot(v.Key)] != null) // ContainsKey
-                {
-                    throw new ArgumentException(string.Format(SR.Argument_AddingDuplicate, v.Key));
-                }
-                SetImpl(v.Key, new MapValue(v.Value));
-            }
-        }
-
-        /// <summary>
         /// Create set from the supplied dictionary (used internally for readonly maps...)
         /// </summary>
         internal CharArrayDictionary(CharArrayDictionary<TValue> toCopy)
@@ -291,28 +262,6 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">An element with <paramref name="text"/> already exists in the dictionary.</exception>
         public virtual void Add(char[] text, TValue value)
-        {
-            if (ContainsKey(text))
-            {
-                throw new ArgumentException(string.Format(SR.Argument_AddingDuplicate, text), nameof(text));
-            }
-            Set(text, value);
-        }
-
-        /// <summary>
-        /// Adds the <paramref name="value"/> for the passed in <paramref name="text"/>.
-        /// </summary>
-        /// <param name="text">The string-able type to be added/updated in the dictionary.</param>
-        /// <param name="value">The corresponding value for the given <paramref name="text"/>.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        /// <exception cref="ArgumentException">An element with <paramref name="text"/> already exists in the dictionary.</exception>
-        public virtual void Add(ICharSequence text, TValue value)
         {
             if (ContainsKey(text))
             {
@@ -440,7 +389,7 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than zero.</exception>
         /// <exception cref="ArgumentException">The number of elements in the source is greater
         /// than the available space from <paramref name="index"/> to the end of the destination array.</exception>
-        internal void CopyTo(KeyValuePair<ICharSequence, TValue>[] array, int index) // internal for testing
+        internal void CopyTo(KeyValuePair<ReadOnlyMemory<char>, TValue>[] array, int index) // internal for testing
         {
             if (array is null)
                 throw new ArgumentNullException(nameof(array));
@@ -452,7 +401,7 @@ namespace Lucene.Net.Analysis.Util
             using var iter = GetEnumerator();
             for (int i = index; iter.MoveNext(); i++)
             {
-                array[i] = new KeyValuePair<ICharSequence, TValue>(((char[])iter.CurrentKey.Clone()).AsCharSequence(), iter.CurrentValue!);
+                array[i] = new KeyValuePair<ReadOnlyMemory<char>, TValue>((char[])iter.CurrentKey.Clone(), iter.CurrentValue!);
             }
         }
 
@@ -505,31 +454,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// <c>true</c> if the <paramref name="text"/> <see cref="ICharSequence"/> is in the <see cref="Keys"/>;
-        /// otherwise <c>false</c>
-        /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        public virtual bool ContainsKey(ICharSequence text)
-        {
-            if (text is null || !text.HasValue)
-                throw new ArgumentNullException(nameof(text));
-
-            if (text is CharArrayCharSequence charArrayCs)
-                return ContainsKey(charArrayCs.Value!);
-            if (text is StringBuilderCharSequence stringBuilderCs)
-                return ContainsKey(stringBuilderCs.Value!.ToString()); // LUCENENET: Indexing into a StringBuilder is slow, so materialize
-
-            return keys[GetSlot(text)] != null;
-        }
-
-
-        /// <summary>
         /// <c>true</c> if the <paramref name="text"/> <see cref="object.ToString()"/> (in the invariant culture)
         /// is in the <see cref="Keys"/>;  otherwise <c>false</c>
         /// </summary>
@@ -543,8 +467,6 @@ namespace Lucene.Net.Analysis.Util
                 return ContainsKey(str);
             if (text is char[] charArray)
                 return ContainsKey(charArray, 0, charArray.Length);
-            if (text is ICharSequence cs)
-                return ContainsKey(cs);
 
             var returnType = CharArrayDictionary.ConvertObjectToChars(text, out char[] chars, out string s);
             if (returnType == CharArrayDictionary.CharReturnType.String)
@@ -596,39 +518,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Returns the value of the mapping of the chars inside this <see cref="ICharSequence"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        /// <exception cref="KeyNotFoundException"><paramref name="text"/> is not found in the dictionary.</exception>
-        internal virtual TValue Get(ICharSequence text, bool throwIfNotFound = true)
-        {
-            if (text is null || !text.HasValue)
-                throw new ArgumentNullException(nameof(text));
-
-            if (text is StringCharSequence strCs)
-                return Get(strCs.Value!, throwIfNotFound);
-            if (text is CharArrayCharSequence charArrayCs)
-                return Get(charArrayCs.Value!, throwIfNotFound);
-            if (text is StringBuilderCharSequence stringBuilderCs)
-                return Get(stringBuilderCs.Value!.ToString(), throwIfNotFound); // LUCENENET: Indexing into a StringBuilder is slow, so materialize
-
-            var value = values[GetSlot(text)];
-            if (value is not null)
-            {
-                return value.Value;
-            }
-            if (throwIfNotFound)
-                throw new KeyNotFoundException(string.Format(SR.Arg_KeyNotFoundWithKey, text));
-            return default!;
-        }
-
-        /// <summary>
         /// Returns the value of the mapping of the chars inside this <see cref="string"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
@@ -665,8 +554,6 @@ namespace Lucene.Net.Analysis.Util
                 return Get(str, throwIfNotFound);
             if (text is char[] charArray)
                 return Get(charArray, 0, charArray.Length, throwIfNotFound);
-            if (text is ICharSequence cs)
-                return Get(cs, throwIfNotFound);
 
             var returnType = CharArrayDictionary.ConvertObjectToChars(text, out char[] chars, out string s);
             if (returnType == CharArrayDictionary.CharReturnType.String)
@@ -693,34 +580,6 @@ namespace Lucene.Net.Analysis.Util
                     pos = code & (keys.Length - 1);
                     text2 = keys[pos];
                 } while (text2 != null && !Equals(text, startIndex, length, text2));
-            }
-            return pos;
-        }
-
-        /// <summary>
-        /// Returns <c>true</c> if the <see cref="ICharSequence"/> is in the set.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        private int GetSlot(ICharSequence text)
-        {
-            int code = GetHashCode(text);
-            int pos = code & (keys.Length - 1);
-            char[] text2 = keys[pos];
-            if (text2 != null && !Equals(text, text2))
-            {
-                int inc = ((code >> 8) + code) | 1;
-                do
-                {
-                    code += inc;
-                    pos = code & (keys.Length - 1);
-                    text2 = keys[pos];
-                } while (text2 != null && !Equals(text, text2));
             }
             return pos;
         }
@@ -837,37 +696,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Add the given mapping.
-        /// <para/>
-        /// <b>Note:</b> The <see cref="this[ICharSequence]"/> setter is more efficient than this method if
-        /// the <paramref name="previousValue"/> is not required.
-        /// </summary>
-        /// <param name="text">A text with which the specified <paramref name="value"/> is associated.</param>
-        /// <param name="value">The value to be associated with the specified <paramref name="text"/>.</param>
-        /// <param name="previousValue">The previous value associated with the text, or the default for the type of <paramref name="value"/>
-        /// parameter if there was no mapping for <paramref name="text"/>.</param>
-        /// <returns><c>true</c> if the mapping was added, <c>false</c> if the text already existed. The <paramref name="previousValue"/>
-        /// will be populated if the result is <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        public virtual bool Put(ICharSequence text, TValue value, [MaybeNullWhen(returnValue: true)] out TValue previousValue) // LUCENENET: Refactored to use out value to support value types
-        {
-            MapValue? oldValue = PutImpl(text, new MapValue(value));
-            if (oldValue is not null)
-            {
-                previousValue = oldValue.Value;
-                return false;
-            }
-            previousValue = default;
-            return true;
-        }
-
-        /// <summary>
         /// Add the given mapping using the <see cref="object.ToString()"/> representation
         /// of <paramref name="text"/> in the <see cref="CultureInfo.InvariantCulture"/>.
         /// <para/>
@@ -900,42 +728,6 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// Add the given mapping.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private MapValue? PutImpl(ICharSequence text, MapValue value)
-        {
-            // LUCENENET: Added guard clause
-            if (text is null || !text.HasValue)
-                throw new ArgumentNullException(nameof(text));
-
-            if (text is CharArrayCharSequence charArrayCs)
-                return PutImpl(charArrayCs.Value ?? Array.Empty<char>(), value);
-            if (text is StringBuilderCharSequence stringBuilderCs) // LUCENENET: Indexing into a StringBuilder is slow, so materialize
-            {
-                var sb = stringBuilderCs.Value!;
-                char[] result = new char[sb.Length];
-                sb.CopyTo(sourceIndex: 0, result, destinationIndex: 0, sb.Length);
-                return PutImpl(result, value);
-            }
-
-            int length = text.Length;
-            char[] buffer = new char[length];
-            for (int i = 0; i < length; i++)
-            {
-                buffer[i] = text[i];
-            }
-            return PutImpl(buffer, value);
-        }
-
-        /// <summary>
-        /// Add the given mapping.
-        /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private MapValue? PutImpl<T>(T text, MapValue value)
@@ -951,8 +743,6 @@ namespace Lucene.Net.Analysis.Util
                 return PutImpl(str.AsSpan(), value);
             if (text is char[] charArray)
                 return PutImpl(charArray.AsSpan(), value);
-            if (text is ICharSequence cs)
-                return PutImpl(cs, value);
 
             var returnType = CharArrayDictionary.ConvertObjectToChars(text, out char[] chars, out string s);
             if (returnType == CharArrayDictionary.CharReturnType.String)
@@ -1100,19 +890,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Sets the value of the mapping of the chars inside this <see cref="ICharSequence"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal virtual void Set(ICharSequence text)
-        {
-            if (text is null || !text.HasValue)
-                throw new ArgumentNullException(nameof(text));
-
-            SetImpl(text, PLACEHOLDER);
-        }
-
-        /// <summary>
         /// Sets the value of the mapping of the chars inside this <see cref="ReadOnlySpan{T}"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
@@ -1157,11 +934,6 @@ namespace Lucene.Net.Analysis.Util
                 Set(charArray);
                 return;
             }
-            if (text is ICharSequence cs)
-            {
-                Set(cs);
-                return;
-            }
 
             var returnType = CharArrayDictionary.ConvertObjectToChars(text, out char[] chars, out string s);
             if (returnType == CharArrayDictionary.CharReturnType.String)
@@ -1175,7 +947,6 @@ namespace Lucene.Net.Analysis.Util
 
         void ICharArrayDictionary.Set(char[] text, int startIndex, int length) => Set(text, startIndex, length);
         void ICharArrayDictionary.Set(char[] text) => Set(text);
-        void ICharArrayDictionary.Set(ICharSequence text) => Set(text);
         void ICharArrayDictionary.Set<T>(T text) => Set(text);
         void ICharArrayDictionary.Set(ReadOnlySpan<char> text) => Set(text);
 
@@ -1222,24 +993,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Sets the value of the mapping of the chars inside this <see cref="ICharSequence"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.</exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal virtual void Set(ICharSequence text, TValue? value)
-        {
-            if (text is null || !text.HasValue)
-                throw new ArgumentNullException(nameof(text));
-
-            SetImpl(text, new MapValue(value));
-        }
-
-        /// <summary>
         /// Sets the value of the mapping of the chars inside this <see cref="string"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
@@ -1275,11 +1028,6 @@ namespace Lucene.Net.Analysis.Util
                 Set(charArray, 0, charArray.Length, value);
                 return;
             }
-            if (text is ICharSequence cs)
-            {
-                Set(cs, value);
-                return;
-            }
 
             var returnType = CharArrayDictionary.ConvertObjectToChars(text, out char[] chars, out string s);
             if (returnType == CharArrayDictionary.CharReturnType.String)
@@ -1294,47 +1042,6 @@ namespace Lucene.Net.Analysis.Util
         #endregion Set (value)
 
         #region SetImpl
-
-        /// <summary>
-        /// LUCENENET specific. Like PutImpl, but doesn't have a return value or lookup to get the old value.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetImpl(ICharSequence text, MapValue value)
-        {
-            // LUCENENET: Added guard clause
-            if (text is null || !text.HasValue)
-                throw new ArgumentNullException(nameof(text));
-
-            if (text is CharArrayCharSequence charArrayCs)
-            {
-                SetImpl(charArrayCs.Value ?? Array.Empty<char>(), value);
-                return;
-            }
-            if (text is StringBuilderCharSequence stringBuilderCs) // LUCENENET: Indexing into a StringBuilder is slow, so materialize
-            {
-                var sb = stringBuilderCs.Value!;
-                char[] result = new char[sb.Length];
-                sb.CopyTo(sourceIndex: 0, result, destinationIndex: 0, sb.Length);
-                SetImpl(result, value);
-                return;
-            }
-
-            int length = text.Length;
-            char[] buffer = new char[length];
-            for (int i = 0; i < length; i++)
-            {
-                buffer[i] = text[i];
-            }
-
-            SetImpl(buffer, value);
-        }
 
         /// <summary>
         /// LUCENENET specific. Like PutImpl, but doesn't have a return value or lookup to get the old value.
@@ -1489,33 +1196,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// This implementation enumerates over the specified <see cref="T:IDictionary{ICharSequence,TValue}"/>'s
-        /// entries, and calls this dictionary's <see cref="Set(ICharSequence, TValue?)"/> operation once for each entry.
-        /// </summary>
-        /// <param name="collection">A dictionary of values to add/update in the current dictionary.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="collection"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// An element in the collection has a <c>null</c> text.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The text's <see cref="ICharSequence.HasValue"/> property for a given element in the collection returns <c>false</c>.
-        /// </exception>
-        public virtual void PutAll(IDictionary<ICharSequence, TValue> collection)
-        {
-            if (collection is null)
-                throw new ArgumentNullException(nameof(collection));
-
-            foreach (var kvp in collection)
-            {
-                Set(kvp.Key, kvp.Value);
-            }
-        }
-
-        /// <summary>
         /// This implementation enumerates over the specified <see cref="T:IDictionary{T,TValue}"/>'s
         /// entries, and calls this dictionary's <see cref="Set{T}(T, TValue?)"/> operation once for each entry.
         /// </summary>
@@ -1574,33 +1254,6 @@ namespace Lucene.Net.Analysis.Util
         /// An element in the collection is <c>null</c>.
         /// </exception>
         public virtual void PutAll(IEnumerable<KeyValuePair<string, TValue>> collection)
-        {
-            if (collection is null)
-                throw new ArgumentNullException(nameof(collection));
-
-            foreach (var kvp in collection)
-            {
-                Set(kvp.Key, kvp.Value);
-            }
-        }
-
-        /// <summary>
-        /// This implementation enumerates over the specified <see cref="T:IEnumerable{KeyValuePair{ICharSequence,TValue}}"/>'s
-        /// entries, and calls this dictionary's <see cref="Set(ICharSequence, TValue)"/> operation once for each entry.
-        /// </summary>
-        /// <param name="collection">The values to add/update in the current dictionary.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="collection"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// An element in the collection has a <c>null</c> text.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The text's <see cref="ICharSequence.HasValue"/> property for a given element in the collection returns <c>false</c>.
-        /// </exception>
-        public virtual void PutAll(IEnumerable<KeyValuePair<ICharSequence, TValue>> collection)
         {
             if (collection is null)
                 throw new ArgumentNullException(nameof(collection));
@@ -1695,39 +1348,6 @@ namespace Lucene.Net.Analysis.Util
                 for (int i = 0; i < length; i++)
                 {
                     if (text1[startIndex + i] != text2[i])
-                    {
-                        return false;
-                    }
-                }
-            }
-            return true;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool Equals(ICharSequence text1, char[] text2)
-        {
-            int length = text1.Length;
-            if (length != text2.Length)
-            {
-                return false;
-            }
-            if (ignoreCase)
-            {
-                for (int i = 0; i < length;)
-                {
-                    int codePointAt = charUtils.CodePointAt(text1, i);
-                    if (Character.ToLower(codePointAt, CultureInfo.InvariantCulture) != charUtils.CodePointAt(text2, i, text2.Length)) // LUCENENET specific - need to use invariant culture to match Java
-                    {
-                        return false;
-                    }
-                    i += Character.CharCount(codePointAt);
-                }
-            }
-            else
-            {
-                for (int i = 0; i < length; i++)
-                {
-                    if (text1[i] != text2[i])
                     {
                         return false;
                     }
@@ -1878,39 +1498,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int GetHashCode(ICharSequence text)
-        {
-            if (text is null || !text.HasValue)
-                throw new ArgumentNullException(nameof(text)); // LUCENENET specific - changed from IllegalArgumentException to ArgumentNullException (.NET convention)
-
-            int code = 0;
-            int length = text.Length;
-            if (ignoreCase)
-            {
-                for (int i = 0; i < length;)
-                {
-                    unchecked
-                    {
-                        int codePointAt = charUtils.CodePointAt(text, i);
-                        code = code * 31 + Character.ToLower(codePointAt, CultureInfo.InvariantCulture); // LUCENENET specific - need to use invariant culture to match Java
-                        i += Character.CharCount(codePointAt);
-                    }
-                }
-            }
-            else
-            {
-                for (int i = 0; i < length; i++)
-                {
-                    unchecked
-                    {
-                        code = code * 31 + text[i];
-                    }
-                }
-            }
-            return code;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int GetHashCode(ReadOnlySpan<char> text)
         {
             int code = 0;
@@ -1985,22 +1572,6 @@ namespace Lucene.Net.Analysis.Util
         /// Primarily for internal use by <see cref="CharArraySet"/>.
         /// </summary>
         /// <returns><c>true</c> if the text was added, <c>false</c> if the text already existed.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.</exception>
-        internal virtual bool Put(ICharSequence text)
-        {
-            return PutImpl(text, PLACEHOLDER) is null;
-        }
-
-        /// <summary>
-        /// Adds a placeholder with the given <paramref name="text"/> as the text.
-        /// Primarily for internal use by <see cref="CharArraySet"/>.
-        /// </summary>
-        /// <returns><c>true</c> if the text was added, <c>false</c> if the text already existed.</returns>
         internal virtual bool Put(ReadOnlySpan<char> text)
         {
             return PutImpl(text, PLACEHOLDER) is null;
@@ -2020,7 +1591,6 @@ namespace Lucene.Net.Analysis.Util
         bool ICharArrayDictionary.Put(char[] text, int startIndex, int length) => Put(text, startIndex, length);
         bool ICharArrayDictionary.Put(char[] text) => Put(text);
         bool ICharArrayDictionary.Put(ReadOnlySpan<char> text) => Put(text);
-        bool ICharArrayDictionary.Put(ICharSequence text) => Put(text);
         bool ICharArrayDictionary.Put<T>(T text) => Put(text);
 
         /// <summary>
@@ -2120,43 +1690,6 @@ namespace Lucene.Net.Analysis.Util
         /// if the text is found; otherwise, the default value for the type of the value parameter.
         /// This parameter is passed uninitialized.</param>
         /// <returns><c>true</c> if the <see cref="CharArrayDictionary{TValue}"/> contains an element with the specified text; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        public virtual bool TryGetValue(ICharSequence text, [MaybeNullWhen(returnValue: false)] out TValue value)
-        {
-            if (text is null || !text.HasValue)
-                throw new ArgumentNullException(nameof(text));
-
-            if (text is StringCharSequence strCs)
-                return TryGetValue(strCs.Value!, out value);
-            if (text is CharArrayCharSequence charArrayCs)
-                return TryGetValue(charArrayCs.Value!, out value);
-            if (text is StringBuilderCharSequence stringBuilderCs) // LUCENENET: Indexing into a StringBuilder is slow, so materialize
-                return TryGetValue(stringBuilderCs.Value!.ToString(), out value);
-
-            var val = values[GetSlot(text)];
-            if (val != null)
-            {
-                value = val.Value;
-                return true;
-            }
-            value = default;
-            return false;
-        }
-
-        /// <summary>
-        /// Gets the value associated with the specified text.
-        /// </summary>
-        /// <param name="text">The text of the value to get.</param>
-        /// <param name="value">When this method returns, contains the value associated with the specified text,
-        /// if the text is found; otherwise, the default value for the type of the value parameter.
-        /// This parameter is passed uninitialized.</param>
-        /// <returns><c>true</c> if the <see cref="CharArrayDictionary{TValue}"/> contains an element with the specified text; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         public virtual bool TryGetValue(string text, [NotNullWhen(returnValue: false)] out TValue value)
         {
@@ -2194,8 +1727,6 @@ namespace Lucene.Net.Analysis.Util
                 return TryGetValue(str, out value);
             if (text is char[] charArray)
                 return TryGetValue(charArray, 0, charArray.Length, out value);
-            if (text is ICharSequence cs)
-                return TryGetValue(cs, out value);
 
             var returnType = CharArrayDictionary.ConvertObjectToChars(text, out char[] chars, out string s);
             if (returnType == CharArrayDictionary.CharReturnType.String)
@@ -2230,23 +1761,6 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="text">The text of the value to get or set.</param>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         public virtual TValue this[char[] text]
-        {
-            get => Get(text, throwIfNotFound: true);
-            set => Set(text, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the value associated with the specified text.
-        /// </summary>
-        /// <param name="text">The text of the value to get or set.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        public virtual TValue this[ICharSequence text]
         {
             get => Get(text, throwIfNotFound: true);
             set => Set(text, value);
@@ -2629,7 +2143,7 @@ namespace Lucene.Net.Analysis.Util
         /// <remarks>
         /// For purposes of enumeration, each item is a <see cref="KeyValuePair{TKey, TValue}"/> structure
         /// representing a value and its text. There are also properties allowing direct access
-        /// to the <see cref="T:char[]"/> array of each element and quick conversions to <see cref="string"/> or <see cref="ICharSequence"/>.
+        /// to the <see cref="T:char[]"/> array of each element and quick conversions to <see cref="string"/>
         /// <para/>
         /// The <c>foreach</c> statement of the C# language (<c>for each</c> in C++, <c>For Each</c> in Visual Basic)
         /// hides the complexity of enumerators. Therefore, using <c>foreach</c> is recommended instead of directly manipulating the enumerator.
@@ -2720,9 +2234,9 @@ namespace Lucene.Net.Analysis.Util
             {
                 CopyTo(chars, index);
             }
-            else if (array is KeyValuePair<ICharSequence, TValue>[] charSequences)
+            else if (array is KeyValuePair<ReadOnlyMemory<char>, TValue>[] memory)
             {
-                CopyTo(charSequences, index);
+                CopyTo(memory, index);
             }
             else if (array is DictionaryEntry[] dictEntryArray)
             {
@@ -2897,10 +2411,6 @@ namespace Lucene.Net.Analysis.Util
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_KeyCollectionSet);
             }
-            public override bool Add(ICharSequence text)
-            {
-                throw UnsupportedOperationException.Create(SR.NotSupported_KeyCollectionSet);
-            }
             public override bool Add(string text)
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_KeyCollectionSet);
@@ -2920,7 +2430,7 @@ namespace Lucene.Net.Analysis.Util
         /// <para/>
         /// This enumerator exposes <see cref="CurrentKey"/> efficient access to the
         /// underlying <see cref="T:char[]"/>. It also has <see cref="CurrentKeyString"/>,
-        /// <see cref="CurrentKeyCharSequence"/>, and <see cref="CurrentValue"/> properties for
+        /// <see cref="CurrentKeySpan"/>, and <see cref="CurrentValue"/> properties for
         /// convenience.
         /// </summary>
         /// <remarks>
@@ -2994,10 +2504,10 @@ namespace Lucene.Net.Analysis.Util
             internal bool HasNext => pos < dictionary.keys.Length;
 
             /// <summary>
-            /// Gets the current text as a <see cref="CharArrayCharSequence"/>.
+            /// Gets the current text as a <see cref="ReadOnlySpan{T}"/>.
             /// </summary>
-            // LUCENENET specific - quick access to ICharSequence interface
-            public ICharSequence CurrentKeyCharSequence
+            // LUCENENET specific - quick access to ReadOnlySpan<char>
+            public ReadOnlySpan<char> CurrentKeySpan
             {
                 get
                 {
@@ -3007,7 +2517,7 @@ namespace Lucene.Net.Analysis.Util
                     char[] key = dictionary.keys[lastPos];
                     if (key is null)
                         throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
-                    return key.AsCharSequence();
+                    return key.AsSpan();
                 }
             }
 
@@ -3282,19 +2792,16 @@ namespace Lucene.Net.Analysis.Util
         bool ContainsKey(char[] text);
         bool ContainsKey<T>(T text);
         bool ContainsKey(ReadOnlySpan<char> text);
-        bool ContainsKey(ICharSequence text);
         int Count { get; }
         bool IgnoreCase { get; }
         bool IsReadOnly { get; }
         LuceneVersion MatchVersion { get; }
         bool Put(char[] text, int startIndex, int length);
         bool Put(char[] text);
-        bool Put(ICharSequence text);
         bool Put<T>(T text);
         bool Put(ReadOnlySpan<char> text);
         void Set(char[] text, int startIndex, int length);
         void Set(char[] text);
-        void Set(ICharSequence text);
         void Set<T>(T text);
         void Set(ReadOnlySpan<char> text);
         ICharArrayDictionaryEnumerator GetEnumerator();
@@ -3309,7 +2816,7 @@ namespace Lucene.Net.Analysis.Util
     {
         bool NotStartedOrEnded { get; }
         bool MoveNext();
-        ICharSequence CurrentKeyCharSequence { get; }
+        ReadOnlySpan<char> CurrentKeySpan { get; }
         string CurrentKeyString { get; }
         char[] CurrentKey { get; }
         void Reset();
@@ -3445,11 +2952,6 @@ namespace Lucene.Net.Analysis.Util
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
             }
 
-            public override bool Put(ICharSequence text, TValue value, [MaybeNullWhen(true)] out TValue previousValue)
-            {
-                throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
-            }
-
             public override bool Put(string text, TValue value, [MaybeNullWhen(true)] out TValue previousValue)
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
@@ -3466,11 +2968,6 @@ namespace Lucene.Net.Analysis.Util
             }
 
             internal override bool Put(char[] text)
-            {
-                throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
-            }
-
-            internal override bool Put(ICharSequence text)
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
             }
@@ -3501,11 +2998,6 @@ namespace Lucene.Net.Analysis.Util
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
             }
 
-            public override void Add(ICharSequence text, TValue value)
-            {
-                throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
-            }
-
             public override void Add<T>(T text, TValue value)
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
@@ -3518,12 +3010,6 @@ namespace Lucene.Net.Analysis.Util
             }
 
             public override TValue this[char[] text]
-            {
-                get => base[text];
-                set => throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
-            }
-
-            public override TValue this[ICharSequence text]
             {
                 get => base[text];
                 set => throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
@@ -3551,11 +3037,6 @@ namespace Lucene.Net.Analysis.Util
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
             }
 
-            public override void PutAll(IDictionary<ICharSequence, TValue> collection)
-            {
-                throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
-            }
-
             public override void PutAll<T>(IDictionary<T, TValue> collection)
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
@@ -3567,11 +3048,6 @@ namespace Lucene.Net.Analysis.Util
             }
 
             public override void PutAll(IEnumerable<KeyValuePair<char[], TValue>> collection)
-            {
-                throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
-            }
-
-            public override void PutAll(IEnumerable<KeyValuePair<ICharSequence, TValue>> collection)
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
             }
@@ -3597,16 +3073,6 @@ namespace Lucene.Net.Analysis.Util
             }
 
             internal override void Set(char[] text, int startIndex, int length, TValue? value)
-            {
-                throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
-            }
-
-            internal override void Set(ICharSequence text)
-            {
-                throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
-            }
-
-            internal override void Set(ICharSequence text, TValue? value)
             {
                 throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
             }
@@ -3674,14 +3140,6 @@ namespace Lucene.Net.Analysis.Util
                 return false;
             }
 
-            public override bool ContainsKey(ICharSequence text)
-            {
-                if (text is null)
-                    throw new ArgumentNullException(nameof(text));
-
-                return false;
-            }
-
             public override bool ContainsKey<T>(T text)
             {
                 if (text is null)
@@ -3707,16 +3165,6 @@ namespace Lucene.Net.Analysis.Util
 
                 if (throwIfNotFound)
                     throw new KeyNotFoundException(string.Format(SR.Arg_KeyNotFoundWithKey, new string(text)));
-                return default!;
-            }
-
-            internal override V Get(ICharSequence text, bool throwIfNotFound = true)
-            {
-                if (text is null)
-                    throw new ArgumentNullException(nameof(text));
-
-                if (throwIfNotFound)
-                    throw new KeyNotFoundException(string.Format(SR.Arg_KeyNotFoundWithKey, text));
                 return default!;
             }
 
@@ -3791,37 +3239,6 @@ namespace Lucene.Net.Analysis.Util
             {
                 char[] result = new char[stringBuilder.Length];
                 stringBuilder.CopyTo(sourceIndex: 0, result, destinationIndex: 0, stringBuilder.Length);
-                chars = result;
-                return CharReturnType.CharArray;
-            }
-
-            // ICharSequence types
-            else if (key is StringCharSequence strCs)
-            {
-                str = strCs.Value ?? string.Empty;
-                return CharReturnType.String;
-            }
-            else if (key is CharArrayCharSequence charArrayCs)
-            {
-                chars = charArrayCs.Value ?? Array.Empty<char>();
-                return CharReturnType.CharArray;
-            }
-            else if (key is StringBuilderCharSequence stringBuilderCs && stringBuilderCs.HasValue)
-            {
-                var sb = stringBuilderCs.Value!;
-                char[] result = new char[sb.Length];
-                sb.CopyTo(sourceIndex: 0, result, destinationIndex: 0, sb.Length);
-                chars = result;
-                return CharReturnType.CharArray;
-            }
-            else if (key is ICharSequence cs && cs.HasValue)
-            {
-                int length = cs.Length;
-                char[] result = new char[length];
-                for (int i = 0; i < length; i++)
-                {
-                    result[i] = cs[i];
-                }
                 chars = result;
                 return CharReturnType.CharArray;
             }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArraySet.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArraySet.cs
@@ -268,6 +268,18 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         public virtual bool Contains(string text)
         {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
+            return map.ContainsKey(text.AsSpan()); // LUCENENET: use ReadOnlySpan<char> overload
+        }
+
+        /// <summary>
+        /// <c>true</c> if the <see cref="ReadOnlySpan{T}"/> is in the set.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
+        public virtual bool Contains(ReadOnlySpan<char> text)
+        {
             return map.ContainsKey(text);
         }
 
@@ -312,6 +324,20 @@ namespace Lucene.Net.Analysis.Util
         /// <returns><c>true</c> if <paramref name="text"/> was added to the set; <c>false</c> if it already existed prior to this call.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         public virtual bool Add(string text)
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
+            return map.Put(text.AsSpan()); // LUCENENET: use ReadOnlySpan<char> overload
+        }
+
+        /// <summary>
+        /// Adds a <see cref="ReadOnlySpan{T}"/> into the set
+        /// </summary>
+        /// <param name="text">The text to be added to the set.</param>
+        /// <returns><c>true</c> if <paramref name="text"/> was added to the set; <c>false</c> if it already existed prior to this call.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
+        public virtual bool Add(ReadOnlySpan<char> text)
         {
             return map.Put(text);
         }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArraySet.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArraySet.cs
@@ -1,5 +1,4 @@
 // Lucene version compatibility level 4.8.1
-using J2N.Text;
 using Lucene.Net.Support;
 using Lucene.Net.Util;
 using System;
@@ -172,41 +171,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Creates a set from a collection of <see cref="ICharSequence"/>s.
-        /// </summary>
-        /// <param name="matchVersion">
-        ///          Compatibility match version see <see cref="CharArraySet"/> for details. </param>
-        /// <param name="collection">
-        ///          A collection whose elements to be placed into the set. </param>
-        /// <param name="ignoreCase">
-        ///          <c>false</c> if and only if the set should be case sensitive
-        ///          otherwise <c>true</c>. </param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="collection"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// A given element within the <paramref name="collection"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <see cref="ICharSequence.HasValue"/> property for a given element in the <paramref name="collection"/> returns <c>false</c>.
-        /// </exception>
-        public CharArraySet(LuceneVersion matchVersion, IEnumerable<ICharSequence> collection, bool ignoreCase)
-            : this(matchVersion, collection is ICollection<ICharSequence> c ? c.Count : DefaultSetSize, ignoreCase)
-        {
-            // LUCENENET: Added guard clause
-            if (collection is null)
-                throw new ArgumentNullException(nameof(collection));
-
-            foreach (ICharSequence text in collection)
-            {
-                // LUCENENET: S1699: Don't call call protected members in the constructor
-                map.Set(text);
-            }
-        }
-
-        /// <summary>
         /// Create set from the specified map (internal only), used also by <see cref="CharArrayDictionary{TValue}.Keys"/>
         /// </summary>
         internal CharArraySet(ICharArrayDictionary map)
@@ -245,21 +209,6 @@ namespace Lucene.Net.Analysis.Util
                 throw new ArgumentNullException(nameof(text));
 
             return map.ContainsKey(text, 0, text.Length);
-        }
-
-        /// <summary>
-        /// <c>true</c> if the <see cref="ICharSequence"/> is in the set.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="text"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <paramref name="text"/>'s <see cref="ICharSequence.HasValue"/> property returns <c>false</c>.
-        /// </exception>
-        public virtual bool Contains(ICharSequence text)
-        {
-            return map.ContainsKey(text);
         }
 
         /// <summary>
@@ -302,17 +251,6 @@ namespace Lucene.Net.Analysis.Util
         /// <returns><c>true</c> if <paramref name="text"/> was added to the set; <c>false</c> if it already existed prior to this call.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         public virtual bool Add<T>(T text)
-        {
-            return map.Put(text);
-        }
-
-        /// <summary>
-        /// Adds a <see cref="ICharSequence"/> into the set
-        /// </summary>
-        /// <param name="text">The text to be added to the set.</param>
-        /// <returns><c>true</c> if <paramref name="text"/> was added to the set; <c>false</c> if it already existed prior to this call.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
-        public virtual bool Add(ICharSequence text)
         {
             return map.Put(text);
         }
@@ -518,9 +456,6 @@ namespace Lucene.Net.Analysis.Util
         /// <para/>
         /// A given element within the <paramref name="collection"/> is <c>null</c>.
         /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <see cref="ICharSequence.HasValue"/> property for a given element in the <paramref name="collection"/> returns <c>false</c>.
         /// </exception>
         public static CharArraySet Copy<T>(LuceneVersion matchVersion, IEnumerable<T> collection)
         {
@@ -555,10 +490,6 @@ namespace Lucene.Net.Analysis.Util
             else if (collection is IEnumerable<char[]> charArrayCollection)
             {
                 return new CharArraySet(matchVersion, charArrayCollection, ignoreCase);
-            }
-            else if (collection is IEnumerable<ICharSequence> charSequenceCollection)
-            {
-                return new CharArraySet(matchVersion, charSequenceCollection, ignoreCase);
             }
 
             return new CharArraySet(matchVersion, collection.Select(text =>
@@ -601,7 +532,7 @@ namespace Lucene.Net.Analysis.Util
         /// Enumerates the elements of a <see cref="CharArraySet"/> object.
         /// <para/>
         /// This implementation provides direct access to the <see cref="T:char[]"/> array of the underlying collection
-        /// as well as convenience properties for converting to <see cref="string"/> and <see cref="ICharSequence"/>.
+        /// as well as convenience properties for converting to <see cref="string"/> and <see cref="ReadOnlySpan{T}"/>.
         /// </summary>
         /// <remarks>
         /// The <c>foreach</c> statement of the C# language (<c>for each</c> in C++, <c>For Each</c> in Visual Basic)
@@ -916,71 +847,6 @@ namespace Lucene.Net.Analysis.Util
             }
         }
 
-        /// <summary>
-        /// Copies the entire <see cref="CharArraySet"/> to a one-dimensional <see cref="T:ICharSequence[]"/> array,
-        /// starting at the specified index of the target array.
-        /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:ICharSequence[]"/> Array that is the destination of the
-        /// elements copied from <see cref="CharArraySet"/>. The Array must have zero-based indexing.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="array"/> is null.</exception>
-        /// <exception cref="ArgumentException">The number of elements in the source is greater
-        /// than the available space in the destination array.</exception>
-        public void CopyTo(ICharSequence[] array)
-        {
-            CopyTo(array, 0, map.Count);
-        }
-
-        /// <summary>
-        /// Copies the entire <see cref="CharArraySet"/> to a one-dimensional <see cref="T:ICharSequence[]"/> array,
-        /// starting at the specified index of the target array.
-        /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:ICharSequence[]"/> Array that is the destination of the
-        /// elements copied from <see cref="CharArraySet"/>. The Array must have zero-based indexing.</param>
-        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="array"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> is less than zero.</exception>
-        /// <exception cref="ArgumentException">The number of elements in the source is greater
-        /// than the available space from <paramref name="arrayIndex"/> to the end of the destination array.</exception>
-        public void CopyTo(ICharSequence[] array, int arrayIndex)
-        {
-            CopyTo(array, arrayIndex, map.Count);
-        }
-
-        /// <summary>
-        /// Copies the entire <see cref="CharArraySet"/> to a one-dimensional <see cref="T:ICharSequence[]"/> array,
-        /// starting at the specified index of the target array.
-        /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:ICharSequence[]"/> Array that is the destination of the
-        /// elements copied from <see cref="CharArraySet"/>. The Array must have zero-based indexing.</param>
-        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="array"/> is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> or <paramref name="count"/> is less than zero.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="arrayIndex"/> is greater than the length of the destination <paramref name="array"/>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="count"/> is greater than the available space from the <paramref name="arrayIndex"/>
-        /// to the end of the destination <paramref name="array"/>.
-        /// </exception>
-        internal void CopyTo(ICharSequence[] array, int arrayIndex, int count)
-        {
-            if (array is null)
-                throw new ArgumentNullException(nameof(array));
-            if (arrayIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(arrayIndex), arrayIndex, SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count), count, SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (arrayIndex > array.Length || count > array.Length - arrayIndex)
-                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
-
-            using var iter = GetEnumerator();
-            for (int i = arrayIndex, numCopied = 0; numCopied < count && iter.MoveNext(); i++, numCopied++)
-            {
-                array[i] = ((char[])iter.CurrentValue.Clone()).AsCharSequence();
-            }
-        }
-
         [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "Following Microsoft's coding style")]
         void ICollection.CopyTo(Array array, int index)
         {
@@ -1011,10 +877,6 @@ namespace Lucene.Net.Analysis.Util
             else if (array is IList<char[]> chars)
             {
                 CopyTo(chars, index);
-            }
-            else if (array is ICharSequence[] charSequences)
-            {
-                CopyTo(charSequences, index);
             }
             else
             {
@@ -1124,43 +986,6 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="other">The collection to compare to the current set.</param>
         /// <returns><c>true</c> if the current set is equal to other; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
-        public virtual bool SetEquals(IEnumerable<ICharSequence> other)
-        {
-            if (other is null)
-                throw new ArgumentNullException(nameof(other));
-
-            if (other is CharArraySet charArraySet)
-                return this.map.Equals(charArraySet.map);
-
-            if (other is ICollection<ICharSequence> otherAsCollection)
-            {
-                if (this.Count != otherAsCollection.Count)
-                    return false;
-
-                // already confirmed that the sets have the same number of distinct elements, so if
-                // one is a superset of the other then they must be equal
-                return ContainsAllElements(otherAsCollection);
-            }
-
-            int otherCount = 0;
-            foreach (var local in other)
-            {
-                if (local is null || !local.HasValue || !this.Contains(local))
-                {
-                    return false;
-                }
-                otherCount++;
-            }
-            return this.Count == otherCount;
-        }
-
-        // LUCENENET - Added to ensure equality checking works in tests
-        /// <summary>
-        /// Determines whether the current set and the specified collection contain the same elements.
-        /// </summary>
-        /// <param name="other">The collection to compare to the current set.</param>
-        /// <returns><c>true</c> if the current set is equal to other; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
         public virtual bool SetEquals<T>(IEnumerable<T> other)
         {
             if (other is null)
@@ -1182,7 +1007,7 @@ namespace Lucene.Net.Analysis.Util
             int otherCount = 0;
             foreach (var local in other)
             {
-                if (local is null || (local is ICharSequence charSequence && !charSequence.HasValue) || !this.Contains(local))
+                if (local is null || !this.Contains(local))
                 {
                     return false;
                 }
@@ -1203,39 +1028,6 @@ namespace Lucene.Net.Analysis.Util
         /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
         /// <exception cref="NotSupportedException">This set instance is read-only.</exception>
         public virtual bool UnionWith(IEnumerable<char[]> other)
-        {
-            if (other is null)
-                throw new ArgumentNullException(nameof(other));
-            if (IsReadOnly)
-                throw UnsupportedOperationException.Create(SR.NotSupported_ReadOnlyCollection);
-
-            bool modified = false;
-            foreach (var item in other)
-            {
-                modified |= Add(item);
-            }
-            return modified;
-        }
-
-        /// <summary>
-        /// Modifies the current <see cref="CharArraySet"/> to contain all elements that are present
-        /// in itself, the specified collection, or both.
-        /// </summary>
-        /// <param name="other">The collection whose elements should be merged into the <see cref="CharArraySet"/>.</param>
-        /// <returns><c>true</c> if this <see cref="CharArraySet"/> changed as a result of the call.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="other"/> is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// A given element within the collection is <c>null</c>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// The <see cref="ICharSequence.HasValue"/> property for a given element in the collection returns <c>false</c>.
-        /// </exception>
-        /// <exception cref="NotSupportedException">This set instance is read-only.</exception>
-        public virtual bool UnionWith(IEnumerable<ICharSequence> other)
         {
             if (other is null)
                 throw new ArgumentNullException(nameof(other));
@@ -1409,38 +1201,6 @@ namespace Lucene.Net.Analysis.Util
         /// <param name="other">The collection to compare to the current <see cref="CharArraySet"/> object.</param>
         /// <returns><c>true</c> if this <see cref="CharArraySet"/> object is a subset of <paramref name="other"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
-        [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "Following Microsoft's coding style")]
-        public virtual bool IsSubsetOf(IEnumerable<ICharSequence> other)
-        {
-            if (other is null)
-                throw new ArgumentNullException(nameof(other));
-
-            if (this.Count == 0)
-            {
-                return true;
-            }
-            CharArraySet? set = other as CharArraySet;
-            if (set != null)
-            {
-                if (this.Count > set.Count)
-                {
-                    return false;
-                }
-                return this.IsSubsetOfCharArraySet(set);
-            }
-            // we just need to return true if the other set
-            // contains all of the elements of the this set,
-            // but we need to use the comparison rules of the current set.
-            this.GetFoundAndUnfoundCounts(other, out int foundCount, out int _);
-            return foundCount == this.Count;
-        }
-
-        /// <summary>
-        /// Determines whether a <see cref="CharArraySet"/> object is a subset of the specified collection.
-        /// </summary>
-        /// <param name="other">The collection to compare to the current <see cref="CharArraySet"/> object.</param>
-        /// <returns><c>true</c> if this <see cref="CharArraySet"/> object is a subset of <paramref name="other"/>; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
         public virtual bool IsSubsetOf<T>(IEnumerable<T> other)
         {
             if (other is null)
@@ -1498,34 +1258,6 @@ namespace Lucene.Net.Analysis.Util
                 throw new ArgumentNullException(nameof(other));
 
             ICollection<char[]>? is2 = other as ICollection<char[]>;
-            if (is2 != null)
-            {
-                if (is2.Count == 0)
-                {
-                    return true;
-                }
-                CharArraySet? set = other as CharArraySet;
-                if ((set != null) && (set.Count > this.Count))
-                {
-                    return false;
-                }
-            }
-            return this.ContainsAllElements(other);
-        }
-
-        /// <summary>
-        /// Determines whether a <see cref="CharArraySet"/> object is a superset of the specified collection.
-        /// </summary>
-        /// <param name="other">The collection to compare to the current <see cref="CharArraySet"/> object.</param>
-        /// <returns><c>true</c> if this <see cref="CharArraySet"/> object is a superset of <paramref name="other"/>; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
-        [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "Following Microsoft's coding style")]
-        public virtual bool IsSupersetOf(IEnumerable<ICharSequence> other)
-        {
-            if (other is null)
-                throw new ArgumentNullException(nameof(other));
-
-            ICollection<ICharSequence>? is2 = other as ICollection<ICharSequence>;
             if (is2 != null)
             {
                 if (is2.Count == 0)
@@ -1610,42 +1342,6 @@ namespace Lucene.Net.Analysis.Util
                 throw new ArgumentNullException(nameof(other));
 
             ICollection<char[]>? is2 = other as ICollection<char[]>;
-            if (is2 != null)
-            {
-                if (this.Count == 0)
-                {
-                    return (is2.Count > 0);
-                }
-                CharArraySet? set = other as CharArraySet;
-                if (set != null)
-                {
-                    if (this.Count >= set.Count)
-                    {
-                        return false;
-                    }
-                    return this.IsSubsetOfCharArraySet(set);
-                }
-            }
-            // we just need to return true if the other set
-            // contains all of the elements of the this set plus at least one more,
-            // but we need to use the comparison rules of the current set.
-            this.GetFoundAndUnfoundCounts(other, out int foundCount, out int unfoundCount);
-            return foundCount == this.Count && unfoundCount > 0;
-        }
-
-        /// <summary>
-        /// Determines whether a <see cref="CharArraySet"/> object is a proper subset of the specified collection.
-        /// </summary>
-        /// <param name="other">The collection to compare to the current <see cref="CharArraySet"/> object.</param>
-        /// <returns><c>true</c> if this <see cref="CharArraySet"/> object is a proper subset of <paramref name="other"/>; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
-        [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "Following Microsoft's coding style")]
-        public virtual bool IsProperSubsetOf(IEnumerable<ICharSequence> other)
-        {
-            if (other is null)
-                throw new ArgumentNullException(nameof(other));
-
-            ICollection<ICharSequence>? is2 = other as ICollection<ICharSequence>;
             if (is2 != null)
             {
                 if (this.Count == 0)
@@ -1774,43 +1470,6 @@ namespace Lucene.Net.Analysis.Util
         /// <returns><c>true</c> if this <see cref="CharArraySet"/> object is a proper superset of <paramref name="other"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
         [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "Following Microsoft's coding style")]
-        public virtual bool IsProperSupersetOf(IEnumerable<ICharSequence> other)
-        {
-            if (other is null)
-                throw new ArgumentNullException(nameof(other));
-
-            if (this.Count == 0)
-            {
-                return false;
-            }
-            ICollection<ICharSequence>? is2 = other as ICollection<ICharSequence>;
-            if (is2 != null)
-            {
-                if (is2.Count == 0)
-                {
-                    return true;
-                }
-                CharArraySet? set = other as CharArraySet;
-                if (set != null)
-                {
-                    if (set.Count >= this.Count)
-                    {
-                        return false;
-                    }
-                    return this.ContainsAllElements(set);
-                }
-            }
-            this.GetFoundAndUnfoundCounts(other, out int foundCount, out int unfoundCount);
-            return foundCount < this.Count && unfoundCount == 0;
-        }
-
-        /// <summary>
-        /// Determines whether a <see cref="CharArraySet"/> object is a proper superset of the specified collection.
-        /// </summary>
-        /// <param name="other">The collection to compare to the current <see cref="CharArraySet"/> object.</param>
-        /// <returns><c>true</c> if this <see cref="CharArraySet"/> object is a proper superset of <paramref name="other"/>; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
-        [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "Following Microsoft's coding style")]
         public virtual bool IsProperSupersetOf<T>(IEnumerable<T> other)
         {
             if (other is null)
@@ -1869,30 +1528,6 @@ namespace Lucene.Net.Analysis.Util
                 foreach (var local in other)
                 {
                     if (local is not null && this.Contains(local))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Determines whether the current <see cref="CharArraySet"/> object and a specified collection share common elements.
-        /// </summary>
-        /// <param name="other">The collection to compare to the current <see cref="CharArraySet"/> object.</param>
-        /// <returns><c>true</c> if the <see cref="CharArraySet"/> object and <paramref name="other"/> share at least one common element; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="other"/> is <c>null</c>.</exception>
-        public virtual bool Overlaps(IEnumerable<ICharSequence> other)
-        {
-            if (other is null)
-                throw new ArgumentNullException(nameof(other));
-
-            if (this.Count != 0)
-            {
-                foreach (var local in other)
-                {
-                    if (local is not null && local.HasValue && this.Contains(local))
                     {
                         return true;
                     }
@@ -1985,29 +1620,11 @@ namespace Lucene.Net.Analysis.Util
         /// </summary>
         /// <param name="other">collection to be checked for containment in this collection</param>
         /// <returns><c>true</c> if this <see cref="CharArraySet"/> contains all of the elements in the specified collection; otherwise, <c>false</c>.</returns>
-        private bool ContainsAllElements(IEnumerable<ICharSequence> other)
-        {
-            foreach (var local in other)
-            {
-                if (local is null || !local.HasValue || !this.Contains(local))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /// <summary>
-        /// Returns <c>true</c> if this collection contains all of the elements
-        /// in the specified collection.
-        /// </summary>
-        /// <param name="other">collection to be checked for containment in this collection</param>
-        /// <returns><c>true</c> if this <see cref="CharArraySet"/> contains all of the elements in the specified collection; otherwise, <c>false</c>.</returns>
         private bool ContainsAllElements<T>(IEnumerable<T> other)
         {
             foreach (var local in other)
             {
-                if (local is null || (local is ICharSequence charSequence && !charSequence.HasValue) || !this.Contains(local))
+                if (local is null || !this.Contains(local))
                 {
                     return false;
                 }
@@ -2051,23 +1668,6 @@ namespace Lucene.Net.Analysis.Util
             foreach (var item in other)
             {
                 if (item is not null && this.Contains(item))
-                {
-                    foundCount++;
-                }
-                else
-                {
-                    unfoundCount++;
-                }
-            }
-        }
-
-        private void GetFoundAndUnfoundCounts(IEnumerable<ICharSequence> other, out int foundCount, out int unfoundCount)
-        {
-            foundCount = 0;
-            unfoundCount = 0;
-            foreach (var item in other)
-            {
-                if (item is not null && item.HasValue && this.Contains(item))
                 {
                     foundCount++;
                 }

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArraySet.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArraySet.cs
@@ -648,11 +648,11 @@ namespace Lucene.Net.Analysis.Util
             }
 
             /// <summary>
-            /// Gets the current value as a <see cref="CharArrayCharSequence"/>.
+            /// Gets the current value as a <see cref="ReadOnlySpan{T}"/>.
             /// </summary>
-            // LUCENENET specific - quick access to ICharSequence interface
-            public ICharSequence CurrentValueCharSequence
-                => enumerator.CurrentKeyCharSequence;
+            // LUCENENET specific - quick access to ReadOnlySpan<char>
+            public ReadOnlySpan<char> CurrentValueSpan
+                => enumerator.CurrentKeySpan;
 
             /// <summary>
             /// Gets the current value... do not modify the returned char[].

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
@@ -73,7 +73,7 @@ namespace Lucene.Net.Analysis.Util
         }
 
         /// <summary>
-        /// Returns the code point at the given index of the <see cref="string"/>.
+        /// Returns the code point at the given index of the <see cref="ReadOnlySpan{T}"/>.
         /// Depending on the <see cref="LuceneVersion"/> passed to
         /// <see cref="CharacterUtils.GetInstance(LuceneVersion)"/> this method mimics the behavior
         /// of <c>Character.CodePointAt(char[], int)</c> as it would have been
@@ -85,12 +85,10 @@ namespace Lucene.Net.Analysis.Util
         ///          the offset to the char values in the chars array to be converted
         /// </param>
         /// <returns> the Unicode code point at the given index </returns>
-        /// <exception cref="ArgumentNullException">
-        ///           - if the sequence is null. </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///           - if the value offset is negative or not less than the length of
         ///           the character sequence. </exception>
-        public abstract int CodePointAt(string seq, int offset);
+        public abstract int CodePointAt(ReadOnlySpan<char> seq, int offset);
 
         /// <summary>
         /// Returns the code point at the given index of the <see cref="ICharSequence"/>.
@@ -138,6 +136,10 @@ namespace Lucene.Net.Analysis.Util
         /// <summary>
         /// Return the number of characters in <paramref name="seq"/>. </summary>
         public abstract int CodePointCount(string seq);
+
+        /// <summary>
+        /// Return the number of characters in <paramref name="seq"/>. </summary>
+        public abstract int CodePointCount(ReadOnlySpan<char> seq);
 
         /// <summary>
         /// Return the number of characters in <paramref name="seq"/>. </summary>
@@ -359,10 +361,11 @@ namespace Lucene.Net.Analysis.Util
 
         private sealed class Java5CharacterUtils : CharacterUtils
         {
-            public override int CodePointAt(string seq, int offset)
+            public override int CodePointAt(ReadOnlySpan<char> seq, int offset)
             {
                 return Character.CodePointAt(seq, offset);
             }
+
             public override int CodePointAt(ICharSequence seq, int offset)
             {
                 return Character.CodePointAt(seq, offset);
@@ -423,6 +426,11 @@ namespace Lucene.Net.Analysis.Util
                 return Character.CodePointCount(seq, 0, seq.Length);
             }
 
+            public override int CodePointCount(ReadOnlySpan<char> seq)
+            {
+                return Character.CodePointCount(seq);
+            }
+
             public override int CodePointCount(ICharSequence seq)
             {
                 if (seq is null)
@@ -458,11 +466,9 @@ namespace Lucene.Net.Analysis.Util
         // and TestCharArraySet.TestSingleHighSurrogateBWComapt() tests.
         private class Java4CharacterUtils : CharacterUtils
         {
-            public override int CodePointAt(string seq, int offset)
+            public override int CodePointAt(ReadOnlySpan<char> seq, int offset)
             {
                 // LUCENENET specific - added guard clauses
-                if (seq is null)
-                    throw new ArgumentNullException(nameof(seq));
                 if (offset < 0 || offset >= seq.Length)
                     throw new ArgumentOutOfRangeException(nameof(offset));
 
@@ -515,6 +521,11 @@ namespace Lucene.Net.Analysis.Util
                 if (seq is null)
                     throw new ArgumentNullException(nameof(seq)); // LUCENENET specific - added null guard clause
 
+                return seq.Length;
+            }
+
+            public override int CodePointCount(ReadOnlySpan<char> seq)
+            {
                 return seq.Length;
             }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharacterUtils.cs
@@ -91,26 +91,6 @@ namespace Lucene.Net.Analysis.Util
         public abstract int CodePointAt(ReadOnlySpan<char> seq, int offset);
 
         /// <summary>
-        /// Returns the code point at the given index of the <see cref="ICharSequence"/>.
-        /// Depending on the <see cref="LuceneVersion"/> passed to
-        /// <see cref="CharacterUtils.GetInstance(LuceneVersion)"/> this method mimics the behavior
-        /// of <c>Character.CodePointAt(char[], int)</c> as it would have been
-        /// available on a Java 1.4 JVM or on a later virtual machine version.
-        /// </summary>
-        /// <param name="seq">
-        ///          a character sequence </param>
-        /// <param name="offset">
-        ///          the offset to the char values in the chars array to be converted
-        /// </param>
-        /// <returns> the Unicode code point at the given index </returns>
-        /// <exception cref="ArgumentNullException">
-        ///           - if the sequence is null. </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        ///           - if the value offset is negative or not less than the length of
-        ///           the character sequence. </exception>
-        public abstract int CodePointAt(ICharSequence seq, int offset);
-
-        /// <summary>
         /// Returns the code point at the given index of the char array where only elements
         /// with index less than the limit are used.
         /// Depending on the <see cref="LuceneVersion"/> passed to
@@ -135,19 +115,7 @@ namespace Lucene.Net.Analysis.Util
 
         /// <summary>
         /// Return the number of characters in <paramref name="seq"/>. </summary>
-        public abstract int CodePointCount(string seq);
-
-        /// <summary>
-        /// Return the number of characters in <paramref name="seq"/>. </summary>
         public abstract int CodePointCount(ReadOnlySpan<char> seq);
-
-        /// <summary>
-        /// Return the number of characters in <paramref name="seq"/>. </summary>
-        public abstract int CodePointCount(ICharSequence seq);
-
-        /// <summary>
-        /// Return the number of characters in <paramref name="seq"/>. </summary>
-        public abstract int CodePointCount(char[] seq);
 
         /// <summary>
         /// Return the number of characters in <paramref name="seq"/>. </summary>
@@ -366,11 +334,6 @@ namespace Lucene.Net.Analysis.Util
                 return Character.CodePointAt(seq, offset);
             }
 
-            public override int CodePointAt(ICharSequence seq, int offset)
-            {
-                return Character.CodePointAt(seq, offset);
-            }
-
             public override int CodePointAt(char[] chars, int offset, int limit)
             {
                 return Character.CodePointAt(chars, offset, limit);
@@ -418,33 +381,9 @@ namespace Lucene.Net.Analysis.Util
                 return result;
             }
 
-            public override int CodePointCount(string seq)
-            {
-                if (seq is null)
-                    throw new ArgumentNullException(nameof(seq)); // LUCENENET specific - added null guard clause
-
-                return Character.CodePointCount(seq, 0, seq.Length);
-            }
-
             public override int CodePointCount(ReadOnlySpan<char> seq)
             {
                 return Character.CodePointCount(seq);
-            }
-
-            public override int CodePointCount(ICharSequence seq)
-            {
-                if (seq is null)
-                    throw new ArgumentNullException(nameof(seq)); // LUCENENET specific - added null guard clause
-
-                return Character.CodePointCount(seq, 0, seq.Length);
-            }
-
-            public override int CodePointCount(char[] seq)
-            {
-                if (seq is null)
-                    throw new ArgumentNullException(nameof(seq)); // LUCENENET specific - added null guard clause
-
-                return Character.CodePointCount(seq, 0, seq.Length);
             }
 
             public override int CodePointCount(StringBuilder seq)
@@ -469,17 +408,6 @@ namespace Lucene.Net.Analysis.Util
             public override int CodePointAt(ReadOnlySpan<char> seq, int offset)
             {
                 // LUCENENET specific - added guard clauses
-                if (offset < 0 || offset >= seq.Length)
-                    throw new ArgumentOutOfRangeException(nameof(offset));
-
-                return seq[offset];
-            }
-
-            public override int CodePointAt(ICharSequence seq, int offset)
-            {
-                // LUCENENET specific - added guard clauses
-                if (seq is null)
-                    throw new ArgumentNullException(nameof(seq));
                 if (offset < 0 || offset >= seq.Length)
                     throw new ArgumentOutOfRangeException(nameof(offset));
 
@@ -516,32 +444,8 @@ namespace Lucene.Net.Analysis.Util
                 return read == numChars;
             }
 
-            public override int CodePointCount(string seq)
-            {
-                if (seq is null)
-                    throw new ArgumentNullException(nameof(seq)); // LUCENENET specific - added null guard clause
-
-                return seq.Length;
-            }
-
             public override int CodePointCount(ReadOnlySpan<char> seq)
             {
-                return seq.Length;
-            }
-
-            public override int CodePointCount(ICharSequence seq)
-            {
-                if (seq is null)
-                    throw new ArgumentNullException(nameof(seq)); // LUCENENET specific - added null guard clause
-
-                return seq.Length;
-            }
-
-            public override int CodePointCount(char[] seq)
-            {
-                if (seq is null)
-                    throw new ArgumentNullException(nameof(seq)); // LUCENENET specific - added null guard clause
-
                 return seq.Length;
             }
 

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/OpenStringBuilder.cs
@@ -40,7 +40,7 @@ namespace Lucene.Net.Analysis.Util
     /// <para />
     /// This type also implements <see cref="ISpanAppendable"/> to allow for efficient appending of <see cref="ReadOnlySpan{T}"/>.
     /// </remarks>
-    public class OpenStringBuilder : IAppendable, ISpanAppendable, ICharSequence, IBufferWriter<char>
+    public class OpenStringBuilder : IAppendable, ISpanAppendable, IBufferWriter<char>
     {
         protected char[] m_buf;
         protected int m_len;
@@ -49,8 +49,6 @@ namespace Lucene.Net.Analysis.Util
             : this(32)
         {
         }
-
-        bool ICharSequence.HasValue => m_buf != null;
 
         public OpenStringBuilder(int size)
         {

--- a/src/Lucene.Net.Analysis.ICU/Analysis/Icu/ICUNormalizer2CharFilter.cs
+++ b/src/Lucene.Net.Analysis.ICU/Analysis/Icu/ICUNormalizer2CharFilter.cs
@@ -187,9 +187,9 @@ namespace Lucene.Net.Analysis.Icu
 
             while (checkedInputBoundary <= bufLen - 1)
             {
-                int charLen = Character.CharCount(inputBuffer.CodePointAt(checkedInputBoundary));
+                int charLen = Character.CharCount(inputBuffer.Array.CodePointAt(checkedInputBoundary));
                 checkedInputBoundary += charLen;
-                if (checkedInputBoundary < bufLen && normalizer.HasBoundaryBefore(inputBuffer
+                if (checkedInputBoundary < bufLen && normalizer.HasBoundaryBefore(inputBuffer.Array
                   .CodePointAt(checkedInputBoundary)))
                 {
                     foundBoundary = true;

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/PhoneticEngine.cs
@@ -86,20 +86,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             /// Creates a new phoneme builder containing all phonemes in this one extended by <paramref name="str"/>.
             /// </summary>
             /// <param name="str">The characters to append to the phonemes.</param>
-            public void Append(ICharSequence str)
-            {
-                foreach (Phoneme ph in this.phonemes)
-                {
-                    ph.Append(str.ToString());
-                }
-            }
-
-            /// <summary>
-            /// Creates a new phoneme builder containing all phonemes in this one extended by <paramref name="str"/>.
-            /// </summary>
-            /// <param name="str">The characters to append to the phonemes.</param>
-            // LUCENENET specific
-            public void Append(string str)
+            public void Append(ReadOnlySpan<char> str)
             {
                 foreach (Phoneme ph in this.phonemes)
                 {

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
@@ -103,7 +103,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                 return true;
             }
 
-            public bool IsMatch(ICharSequence input)
+            public bool IsMatch(ReadOnlySpan<char> input)
             {
                 return true;
             }
@@ -173,8 +173,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static string CreateResourceName(NameType nameType, RuleType rt, string lang)
         {
-            return string.Format("{0}_{1}_{2}.txt",
-                                 nameType.GetName(), rt.GetName(), lang);
+            return $"{nameType.GetName()}_{rt.GetName()}_{lang}.txt";
         }
 
         private static TextReader CreateScanner(NameType nameType, RuleType rt, string lang)
@@ -192,7 +191,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private static TextReader CreateScanner(string lang)
         {
-            string resName = string.Format("{0}.txt", lang);
+            string resName = $"{lang}.txt";
             Stream rulesIS = typeof(Languages).FindAndGetManifestResourceStream(resName);
 
             if (rulesIS is null)
@@ -203,7 +202,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             return new StreamReader(rulesIS, ResourceConstants.ENCODING);
         }
 
-        private static bool EndsWith(ICharSequence input, string suffix)
+        private static bool EndsWith(ReadOnlySpan<char> input, string suffix)
         {
             if (suffix.Length > input.Length)
             {
@@ -504,11 +503,14 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
         private class RPatternHelper : IRPattern
         {
-            private readonly Func<StringBuilder, bool> isMatchSB;
-            private readonly Func<string, bool> isMatchStr;
-            private readonly Func<ICharSequence, bool> isMatchCS;
+            // LUCENENET specific: needed to work around ReadOnlySpan<char> not being eligible for Predicate<T>
+            public delegate bool SpanPredicate(ReadOnlySpan<char> input);
 
-            public RPatternHelper(Func<StringBuilder, bool> isMatchSB, Func<string, bool> isMatchStr, Func<ICharSequence, bool> isMatchCS)
+            private readonly Predicate<StringBuilder> isMatchSB;
+            private readonly Predicate<string> isMatchStr;
+            private readonly SpanPredicate isMatchCS;
+
+            public RPatternHelper(Predicate<StringBuilder> isMatchSB, Predicate<string> isMatchStr, SpanPredicate isMatchCS)
             {
                 this.isMatchSB = isMatchSB;
                 this.isMatchStr = isMatchStr;
@@ -525,7 +527,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                 return isMatchStr(input);
             }
 
-            public bool IsMatch(ICharSequence input)
+            public bool IsMatch(ReadOnlySpan<char> input)
             {
                 return isMatchCS(input);
             }
@@ -551,30 +553,18 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                     if (content.Length == 0)
                     {
                         // empty
-                        return new RPatternHelper(isMatchSB: (input) =>
-                        {
-                            return input.Length == 0;
-                        }, isMatchStr: (input) =>
-                        {
-                            return input.Length == 0;
-                        }, isMatchCS: (input) =>
-                        {
-                            return input.Length == 0;
-                        });
+                        return new RPatternHelper(
+                            isMatchSB: input => input.Length == 0,
+                            isMatchStr: input => input.Length == 0,
+                            isMatchCS: input => input.Length == 0);
                     }
                     else
                     {
 
-                        return new RPatternHelper(isMatchSB: (input) =>
-                        {
-                            return input.Equals(content);
-                        }, isMatchStr: (input) =>
-                        {
-                            return input.Equals(content);
-                        }, isMatchCS: (input) =>
-                        {
-                            return input.Equals(content);
-                        });
+                        return new RPatternHelper(
+                            isMatchSB: input => input.Equals(content),
+                            isMatchStr: input => input.Equals(content),
+                            isMatchCS: input => input.SequenceEqual(content));
                     }
                 }
                 else if ((startsWith || endsWith) && content.Length == 0)
@@ -585,31 +575,19 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                 else if (startsWith)
                 {
                     // matches from start
-                    return new RPatternHelper(isMatchSB: (input) =>
-                    {
-                        return StartsWith(input, content);
-                    }, isMatchStr: (input) =>
-                    {
-                        return StartsWith(input, content);
-                    }, isMatchCS: (input) =>
-                    {
-                        return StartsWith(input, content);
-                    });
+                    return new RPatternHelper(
+                        isMatchSB: input => StartsWith(input, content),
+                        isMatchStr: input => StartsWith(input, content),
+                        isMatchCS: input => StartsWith(input, content));
 
                 }
                 else if (endsWith)
                 {
                     // matches from start
-                    return new RPatternHelper(isMatchSB: (input) =>
-                    {
-                        return EndsWith(input, content);
-                    }, isMatchStr: (input) =>
-                    {
-                        return EndsWith(input, content);
-                    }, isMatchCS: (input) =>
-                    {
-                        return EndsWith(input, content);
-                    });
+                    return new RPatternHelper(
+                        isMatchSB: input => EndsWith(input, content),
+                        isMatchStr: input => EndsWith(input, content),
+                        isMatchCS: input => EndsWith(input, content));
                 }
             }
             else
@@ -634,66 +612,49 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
                         if (startsWith && endsWith)
                         {
                             // exact match
-                            return new RPatternHelper(isMatchSB: (input) =>
-                            {
-                                return input.Length == 1 && Contains(bContent, input[0]) == shouldMatch;
-                            }, isMatchStr: (input) =>
-                            {
-                                return input.Length == 1 && Contains(bContent, input[0]) == shouldMatch;
-                            }, isMatchCS: (input) =>
-                            {
-                                return input.Length == 1 && Contains(bContent, input[0]) == shouldMatch;
-                            });
+                            return new RPatternHelper(
+                                isMatchSB: input => input.Length == 1 && Contains(bContent, input[0]) == shouldMatch,
+                                isMatchStr: input => input.Length == 1 && Contains(bContent, input[0]) == shouldMatch,
+                                isMatchCS: input => input.Length == 1 && Contains(bContent, input[0]) == shouldMatch);
                         }
                         else if (startsWith)
                         {
                             // first char
-                            return new RPatternHelper(isMatchSB: (input) =>
-                            {
-                                return input.Length > 0 && Contains(bContent, input[0]) == shouldMatch;
-                            }, isMatchStr: (input) =>
-                            {
-                                return input.Length > 0 && Contains(bContent, input[0]) == shouldMatch;
-                            }, isMatchCS: (input) =>
-                            {
-                                return input.Length > 0 && Contains(bContent, input[0]) == shouldMatch;
-                            });
+                            return new RPatternHelper(
+                                isMatchSB: input => input.Length > 0 && Contains(bContent, input[0]) == shouldMatch,
+                                isMatchStr: input => input.Length > 0 && Contains(bContent, input[0]) == shouldMatch,
+                                isMatchCS: input => input.Length > 0 && Contains(bContent, input[0]) == shouldMatch);
                         }
                         else if (endsWith)
                         {
                             // last char
-                            return new RPatternHelper(isMatchSB: (input) =>
-                            {
-                                return input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch;
-                            }, isMatchStr: (input) =>
-                            {
-                                return input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch;
-                            }, isMatchCS: (input) =>
-                            {
-                                return input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch;
-                            });
+                            return new RPatternHelper(
+                                isMatchSB: input => input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch,
+                                isMatchStr: input => input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch,
+                                isMatchCS: input => input.Length > 0 && Contains(bContent, input[input.Length - 1]) == shouldMatch);
                         }
                     }
                 }
             }
+
             Regex pattern = new Regex(regex, RegexOptions.Compiled);
 
-            return new RPatternHelper(isMatchSB: (input) =>
+            return new RPatternHelper(isMatchSB: input =>
             {
                 Match matcher = pattern.Match(input.ToString());
                 return matcher.Success;
-            }, isMatchStr: (input) =>
+            }, isMatchStr: input =>
             {
                 Match matcher = pattern.Match(input);
                 return matcher.Success;
-            }, isMatchCS: (input) =>
+            }, isMatchCS: input =>
             {
                 Match matcher = pattern.Match(input.ToString());
                 return matcher.Success;
             });
         }
 
-        private static bool StartsWith(ICharSequence input, string prefix)
+        private static bool StartsWith(ReadOnlySpan<char> input, string prefix)
         {
             if (prefix.Length > input.Length)
             {
@@ -804,10 +765,10 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
         /// <see cref="LContext"/> matches <paramref name="input"/> up to <paramref name="i"/>, <see cref="Pattern"/> matches at <paramref name="i"/> and
         /// <see cref="RContext"/> matches from the end of the match of <see cref="Pattern"/> to the end of <paramref name="input"/>.
         /// </summary>
-        /// <param name="input">The input <see cref="ICharSequence"/>.</param>
+        /// <param name="input">The input <see cref="ReadOnlySpan{T}"/>.</param>
         /// <param name="i">The int position within the input.</param>
         /// <returns><c>true</c> if the pattern and left/right context match, <c>false</c> otherwise.</returns>
-        public virtual bool PatternAndContextMatches(ICharSequence input, int i)
+        public virtual bool PatternAndContextMatches(ReadOnlySpan<char> input, int i)
         {
             if (i < 0)
             {
@@ -825,15 +786,15 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
 
             // evaluate the pattern, left context and right context
             // fail early if any of the evaluations is not successful
-            if (!input.Subsequence(i, ipl - i).Equals(this.pattern)) // LUCENENET: Corrected 2nd Subsequence parameter
+            if (!input.Slice(i, ipl - i).SequenceEqual(this.pattern)) // LUCENENET: Corrected 2nd Subsequence parameter
             {
                 return false;
             }
-            else if (!this.rContext.IsMatch(input.Subsequence(ipl, input.Length - ipl))) // LUCENENET: Corrected 2nd Subsequence parameter
+            else if (!this.rContext.IsMatch(input.Slice(ipl, input.Length - ipl))) // LUCENENET: Corrected 2nd Subsequence parameter
             {
                 return false;
             }
-            return this.lContext.IsMatch(input.Subsequence(0, i - 0)); // LUCENENET: Corrected 2nd Subsequence parameter
+            return this.lContext.IsMatch(input.Slice(0, i - 0)); // LUCENENET: Corrected 2nd Subsequence parameter
         }
 
         /// <summary>
@@ -963,7 +924,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             this.languages = languages;
         }
 
-        public Phoneme(ICharSequence phonemeText, LanguageSet languages)
+        public Phoneme(ReadOnlySpan<char> phonemeText, LanguageSet languages)
         {
             this.phonemeText = new StringBuilder(phonemeText.ToString());
             this.languages = languages;
@@ -1024,7 +985,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
     /// </summary>
     public interface IRPattern
     {
-        bool IsMatch(ICharSequence input);
+        bool IsMatch(ReadOnlySpan<char> input);
         bool IsMatch(string input);
         bool IsMatch(StringBuilder input);
     }

--- a/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
+++ b/src/Lucene.Net.Analysis.Phonetic/Language/Bm/Rule.cs
@@ -942,7 +942,7 @@ namespace Lucene.Net.Analysis.Phonetic.Language.Bm
             this.phonemeText.Append(phonemeRight.phonemeText);
         }
 
-        public Phoneme Append(string str)
+        public Phoneme Append(ReadOnlySpan<char> str)
         {
             this.phonemeText.Append(str);
             return this;

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
@@ -1,4 +1,6 @@
 // Lucene version compatibility level 4.8.1
+
+using J2N.IO;
 using J2N.Text;
 using Lucene.Net.Support;
 using Lucene.Net.Support.IO;
@@ -39,8 +41,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
     // To make things simpler, we are using extension methods on Stream since
     // BinaryReader and BinaryWriter throw exceptions if surrogate pairs wind up
     // in separate chunks.
-    internal class CharBlockArray : IAppendable, ICharSequence,
-        ISpanAppendable /* LUCENENET specific */
+    internal class CharBlockArray : IAppendable, ISpanAppendable /* LUCENENET specific */
     {
         private const long serialVersionUID = 1L;
 
@@ -147,9 +148,9 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             return this;
         }
 
-        public virtual CharBlockArray Append(ICharSequence? value)
+        public virtual CharBlockArray Append(CharBlockArray? value)
         {
-            if (value is null) // needed for Appendable compliance
+            if (value is null)
             {
                 return this; // No-op
             }
@@ -157,7 +158,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             return Append(value, 0, value.Length);
         }
 
-        public virtual CharBlockArray Append(ICharSequence? value, int startIndex, int length)
+        public virtual CharBlockArray Append(CharBlockArray? value, int startIndex, int length)
         {
             // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
             if (startIndex < 0)
@@ -175,48 +176,27 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 return this;
             if (startIndex > value.Length - length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
-
 
             int end = startIndex + length;
             for (int i = startIndex; i < end; i++)
             {
                 Append(value[i]);
             }
+
             return this;
         }
 
-        public virtual CharBlockArray Append(char[]? value)
+        public virtual CharBlockArray Append(CharBuffer? value)
         {
-            if (value is null) // needed for Appendable compliance
+            if (value is null)
             {
                 return this; // No-op
             }
 
-            int remain = value.Length;
-            int offset = 0;
-            while (remain > 0)
-            {
-                if (this.current.length == this.blockSize)
-                {
-                    AddBlock();
-                }
-                int toCopy = remain;
-                int remainingInBlock = this.blockSize - this.current.length;
-                if (remainingInBlock < toCopy)
-                {
-                    toCopy = remainingInBlock;
-                }
-                Arrays.Copy(value, offset, this.current.chars, this.current.length, toCopy);
-                offset += toCopy;
-                remain -= toCopy;
-                this.current.length += toCopy;
-            }
-
-            this.length += value.Length;
-            return this;
+            return Append(value, 0, value.Length);
         }
 
-        public virtual CharBlockArray Append(char[]? value, int startIndex, int length)
+        public virtual CharBlockArray Append(CharBuffer? value, int startIndex, int length)
         {
             // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
             if (startIndex < 0)
@@ -235,101 +215,12 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             if (startIndex > value.Length - length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
 
-            int offset = startIndex;
-            int remain = length;
-            while (remain > 0)
+            int end = startIndex + length;
+            for (int i = startIndex; i < end; i++)
             {
-                if (this.current.length == this.blockSize)
-                {
-                    AddBlock();
-                }
-                int toCopy = remain;
-                int remainingInBlock = this.blockSize - this.current.length;
-                if (remainingInBlock < toCopy)
-                {
-                    toCopy = remainingInBlock;
-                }
-                Arrays.Copy(value, offset, this.current.chars, this.current.length, toCopy);
-                offset += toCopy;
-                remain -= toCopy;
-                this.current.length += toCopy;
+                Append(value[i]);
             }
 
-            this.length += length;
-            return this;
-        }
-
-        public virtual CharBlockArray Append(string? value)
-        {
-            if (value is null) // needed for Appendable compliance
-            {
-                return this; // No-op
-            }
-
-            int remain = value.Length;
-            int offset = 0;
-            while (remain > 0)
-            {
-                if (this.current.length == this.blockSize)
-                {
-                    AddBlock();
-                }
-                int toCopy = remain;
-                int remainingInBlock = this.blockSize - this.current.length;
-                if (remainingInBlock < toCopy)
-                {
-                    toCopy = remainingInBlock;
-                }
-                value.CopyTo(offset, this.current.chars, this.current.length, toCopy);
-                offset += toCopy;
-                remain -= toCopy;
-                this.current.length += toCopy;
-            }
-
-            this.length += value.Length;
-            return this;
-        }
-
-        public virtual CharBlockArray Append(string? value, int startIndex, int length)
-        {
-            // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
-            if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
-            if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
-
-            if (value is null)
-            {
-                if (startIndex == 0 && length == 0)
-                    return this;
-                throw new ArgumentNullException(nameof(value));
-            }
-            if (length == 0)
-                return this;
-            if (startIndex > value.Length - length)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
-
-            int offset = startIndex;
-            int remain = length;
-            while (remain > 0)
-            {
-                if (this.current.length == this.blockSize)
-                {
-                    AddBlock();
-                }
-                int toCopy = remain;
-                int remainingInBlock = this.blockSize - this.current.length;
-                if (remainingInBlock < toCopy)
-                {
-                    toCopy = remainingInBlock;
-                }
-                value.CopyTo(offset, this.current.chars, this.current.length, toCopy);
-                offset += toCopy;
-                remain -= toCopy;
-                this.current.length += toCopy;
-            }
-
-            this.length += length;
             return this;
         }
 
@@ -441,7 +332,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
 
         IAppendable IAppendable.Append(string value) => Append(value);
 
-        IAppendable IAppendable.Append(string value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(string value, int startIndex, int count) => Append(value.AsSpan(startIndex, count));
 
         IAppendable IAppendable.Append(StringBuilder value) => Append(value);
 
@@ -449,11 +340,11 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
 
         IAppendable IAppendable.Append(char[] value) => Append(value);
 
-        IAppendable IAppendable.Append(char[] value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(char[] value, int startIndex, int count) => Append(value.AsSpan(startIndex, count));
 
-        IAppendable IAppendable.Append(ICharSequence value) => Append(value);
+        IAppendable IAppendable.Append(ICharSequence value) => Append(value?.ToString());
 
-        IAppendable IAppendable.Append(ICharSequence value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(ICharSequence value, int startIndex, int count) => Append(value == null ? ReadOnlySpan<char>.Empty : value.ToString().AsSpan(startIndex, count));
 
         #endregion
 
@@ -481,32 +372,6 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
         }
 
         public virtual int Length => this.length;
-
-
-        // LUCENENET specific
-        bool ICharSequence.HasValue => true;
-
-        public virtual ICharSequence Subsequence(int startIndex, int length)
-        {
-            int remaining = length;
-            StringBuilder sb = new StringBuilder(remaining);
-            int blockIdx = BlockIndex(startIndex);
-            int indexInBlock = IndexInBlock(startIndex);
-            while (remaining > 0)
-            {
-                Block b = blocks[blockIdx++];
-                int numToAppend = Math.Min(remaining, b.length - indexInBlock);
-                sb.Append(b.chars, indexInBlock, numToAppend);
-                remaining -= numToAppend;
-                indexInBlock = 0; // 2nd+ iterations read from start of the block
-            }
-            return new StringBuilderCharSequence(sb);
-        }
-
-        ICharSequence ICharSequence.Subsequence(int startIndex, int length)
-        {
-            return Subsequence(startIndex, length);
-        }
 
         public override string ToString()
         {

--- a/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
+++ b/src/Lucene.Net.Facet/Taxonomy/WriterCache/CharBlockArray.cs
@@ -186,44 +186,6 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             return this;
         }
 
-        public virtual CharBlockArray Append(CharBuffer? value)
-        {
-            if (value is null)
-            {
-                return this; // No-op
-            }
-
-            return Append(value, 0, value.Length);
-        }
-
-        public virtual CharBlockArray Append(CharBuffer? value, int startIndex, int length)
-        {
-            // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
-            if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
-            if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
-
-            if (value is null)
-            {
-                if (startIndex == 0 && length == 0)
-                    return this;
-                throw new ArgumentNullException(nameof(value));
-            }
-            if (length == 0)
-                return this;
-            if (startIndex > value.Length - length)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
-
-            int end = startIndex + length;
-            for (int i = startIndex; i < end; i++)
-            {
-                Append(value[i]);
-            }
-
-            return this;
-        }
-
         public virtual CharBlockArray Append(StringBuilder? value)
         {
             if (value is null) // needed for Appendable compliance

--- a/src/Lucene.Net.TestFramework/Util/TestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/TestUtil.cs
@@ -835,7 +835,7 @@ namespace Lucene.Net.Util
                 case 4:
                     CharsRef chars = new CharsRef(@ref.Length);
                     UnicodeUtil.UTF8toUTF16(@ref.Bytes, @ref.Offset, @ref.Length, chars);
-                    return chars;
+                    return new StringCharSequence(chars.ToString());
                 case 3:
                     return CharBuffer.Wrap(@ref.Utf8ToString());
                 default:

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestStemmerOverrideFilter.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Miscellaneous/TestStemmerOverrideFilter.cs
@@ -74,19 +74,6 @@ namespace Lucene.Net.Analysis.Miscellaneous
             AssertTokenStreamContents(stream, new string[] { "books" });
         }
 
-        [Test, LuceneNetSpecific]
-        public virtual void TestIgnoreCase_CharSequence()
-        {
-            // lets make booked stem to books
-            // the override filter will convert "booked" to "books",
-            // but also mark it with KeywordAttribute so Porter will not change it.
-            StemmerOverrideFilter.Builder builder = new StemmerOverrideFilter.Builder(true);
-            builder.Add("boOkEd".AsCharSequence(), "books");
-            Tokenizer tokenizer = new KeywordTokenizer(new StringReader("BooKeD"));
-            TokenStream stream = new PorterStemFilter(new StemmerOverrideFilter(tokenizer, builder.Build()));
-            AssertTokenStreamContents(stream, new string[] { "books" });
-        }
-
         [Test]
         public virtual void TestNoOverrides()
         {

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/NGramTokenizerTest.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/NGram/NGramTokenizerTest.cs
@@ -139,9 +139,9 @@ namespace Lucene.Net.Analysis.NGram
             TestNGrams(minGram, maxGram, s, nonTokenChars, false);
         }
 
-        internal static int[] toCodePoints(string s)
+        internal static int[] toCodePoints(ReadOnlySpan<char> s)
         {
-            int[] codePoints = new int[Character.CodePointCount(s, 0, s.Length)];
+            int[] codePoints = new int[Character.CodePointCount(s)];
             for (int i = 0, j = 0; i < s.Length; ++j)
             {
                 codePoints[j] = Character.CodePointAt(s, i);
@@ -150,18 +150,7 @@ namespace Lucene.Net.Analysis.NGram
             return codePoints;
         }
 
-        internal static int[] toCodePoints(ICharSequence s)
-        {
-            int[] codePoints = new int[Character.CodePointCount(s, 0, s.Length)];
-            for (int i = 0, j = 0; i < s.Length; ++j)
-            {
-                codePoints[j] = Character.CodePointAt(s, i);
-                i += Character.CharCount(codePoints[j]);
-            }
-            return codePoints;
-        }
-
-        internal static bool isTokenChar(string nonTokenChars, int codePoint)
+        internal static bool isTokenChar(ReadOnlySpan<char> nonTokenChars, int codePoint)
         {
             for (int i = 0; i < nonTokenChars.Length;)
             {
@@ -207,7 +196,7 @@ namespace Lucene.Net.Analysis.NGram
                         }
                     }
                     assertTrue(grams.IncrementToken());
-                    assertArrayEquals(Arrays.CopyOfRange(codePoints, start, end), toCodePoints(termAtt));
+                    assertArrayEquals(Arrays.CopyOfRange(codePoints, start, end), toCodePoints(termAtt.AsSpan()));
                     assertEquals(1, posIncAtt.PositionIncrement);
                     assertEquals(1, posLenAtt.PositionLength);
                     assertEquals(offsets[start], offsetAtt.StartOffset);

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharArrayMap.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharArrayMap.cs
@@ -375,7 +375,7 @@ namespace Lucene.Net.Analysis.Util
             {
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.Current; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentKey; });
-                Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentKeyCharSequence; });
+                Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentKeySpan; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentKeyString; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentValue; });
 
@@ -383,14 +383,14 @@ namespace Lucene.Net.Analysis.Util
                 {
                     Assert.DoesNotThrow(() => { var _ = iter.Current; });
                     Assert.DoesNotThrow(() => { var _ = iter.CurrentKey; });
-                    Assert.DoesNotThrow(() => { var _ = iter.CurrentKeyCharSequence; });
+                    Assert.DoesNotThrow(() => { var _ = iter.CurrentKeySpan; });
                     Assert.DoesNotThrow(() => { var _ = iter.CurrentKeyString; });
                     Assert.DoesNotThrow(() => { var _ = iter.CurrentValue; });
                 }
 
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.Current; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentKey; });
-                Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentKeyCharSequence; });
+                Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentKeySpan; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentKeyString; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentValue; });
             }
@@ -440,7 +440,7 @@ namespace Lucene.Net.Analysis.Util
 
                 Assert.Throws<InvalidOperationException>(() => { var _ = ours.Current; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = ours.CurrentKey; });
-                Assert.Throws<InvalidOperationException>(() => { var _ = ours.CurrentKeyCharSequence; });
+                Assert.Throws<InvalidOperationException>(() => { var _ = ours.CurrentKeySpan; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = ours.CurrentKeyString; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = ours.CurrentValue; });
             }
@@ -462,18 +462,18 @@ namespace Lucene.Net.Analysis.Util
             {
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.Current; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentValue; });
-                Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentValueCharSequence; });
+                Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentValueSpan; });
 
                 while (iter.MoveNext())
                 {
                     Assert.DoesNotThrow(() => { var _ = iter.Current; });
                     Assert.DoesNotThrow(() => { var _ = iter.CurrentValue; });
-                    Assert.DoesNotThrow(() => { var _ = iter.CurrentValueCharSequence; });
+                    Assert.DoesNotThrow(() => { var _ = iter.CurrentValueSpan; });
                 }
 
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.Current; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentValue; });
-                Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentValueCharSequence; });
+                Assert.Throws<InvalidOperationException>(() => { var _ = iter.CurrentValueSpan; });
             }
 
             using (var ours = map.Keys.GetEnumerator())
@@ -503,7 +503,7 @@ namespace Lucene.Net.Analysis.Util
 
                 Assert.Throws<InvalidOperationException>(() => { var _ = ours.Current; });
                 Assert.Throws<InvalidOperationException>(() => { var _ = ours.CurrentValue; });
-                Assert.Throws<InvalidOperationException>(() => { var _ = ours.CurrentValueCharSequence; });
+                Assert.Throws<InvalidOperationException>(() => { var _ = ours.CurrentValueSpan; });
             }
         }
 
@@ -609,7 +609,7 @@ namespace Lucene.Net.Analysis.Util
             {
                 return ArrayEqualityComparer<char>.OneDimensional.Equals(x.Key, y.Key);
             }
-            public int GetHashCode([DisallowNull] KeyValuePair<char[], int?> obj)
+            public int GetHashCode(KeyValuePair<char[], int?> obj)
             {
                 return ArrayEqualityComparer<char>.OneDimensional.GetHashCode(obj.Key);
             }
@@ -631,7 +631,7 @@ namespace Lucene.Net.Analysis.Util
             assertTrue(stopwords.SetEquals(array1));
 
             // Bounded to lower start index
-            int startIndex = 3;
+            const int startIndex = 3;
             var array2 = new KeyValuePair<char[], int?>[target.Count + startIndex];
             target.CopyTo(array2, startIndex);
 
@@ -642,38 +642,38 @@ namespace Lucene.Net.Analysis.Util
             assertTrue(stopwords.SetEquals(array2.Skip(startIndex).ToArray()));
         }
 
-        private class KvpCharSequenceEqualityComparer : IEqualityComparer<KeyValuePair<ICharSequence, int?>>
+        private class KvpReadOnlyMemoryEqualityComparer : IEqualityComparer<KeyValuePair<ReadOnlyMemory<char>, int?>>
         {
-            public static readonly KvpCharSequenceEqualityComparer Instance = new KvpCharSequenceEqualityComparer();
+            public static readonly KvpReadOnlyMemoryEqualityComparer Instance = new KvpReadOnlyMemoryEqualityComparer();
 
-            public bool Equals(KeyValuePair<ICharSequence, int?> x, KeyValuePair<ICharSequence, int?> y)
+            public bool Equals(KeyValuePair<ReadOnlyMemory<char>, int?> x, KeyValuePair<ReadOnlyMemory<char>, int?> y)
             {
                 return StringComparer.OrdinalIgnoreCase.Equals(x.Key.ToString(), y.Key.ToString());
             }
-            public int GetHashCode([DisallowNull] KeyValuePair<ICharSequence, int?> obj)
+            public int GetHashCode(KeyValuePair<ReadOnlyMemory<char>, int?> obj)
             {
-                return obj.Key is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Key.ToString());
+                return obj.Key.IsEmpty ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Key.ToString());
             }
         }
 
         [Test, LuceneNetSpecific]
-        public virtual void TestCopyTo_ICharSequence_Int32()
+        public virtual void TestCopyTo_ReadOnlyMemory_Int32()
         {
-            var stopwords = new JCG.HashSet<KeyValuePair<ICharSequence, int?>>(
-                TestCharArraySet.TEST_STOP_WORDS.Select(x => new KeyValuePair<ICharSequence, int?>(key: new StringCharSequence(x), value: 0)),
-                KvpCharSequenceEqualityComparer.Instance);
+            var stopwords = new JCG.HashSet<KeyValuePair<ReadOnlyMemory<char>, int?>>(
+                TestCharArraySet.TEST_STOP_WORDS.Select(x => new KeyValuePair<ReadOnlyMemory<char>, int?>(key: x.AsMemory(), value: 0)),
+                KvpReadOnlyMemoryEqualityComparer.Instance);
             var target = new CharArrayDictionary<int?>(TEST_VERSION_CURRENT, stopwords.Count, ignoreCase: false);
             foreach (var kvp in stopwords)
                 target.Put(kvp.Key, kvp.Value, out _);
 
             // Full array
-            var array1 = new KeyValuePair<ICharSequence, int?>[target.Count];
+            var array1 = new KeyValuePair<ReadOnlyMemory<char>, int?>[target.Count];
             target.CopyTo(array1, 0);
             assertTrue(stopwords.SetEquals(array1));
 
             // Bounded to lower start index
-            int startIndex = 3;
-            var array2 = new KeyValuePair<ICharSequence, int?>[target.Count + startIndex];
+            const int startIndex = 3;
+            var array2 = new KeyValuePair<ReadOnlyMemory<char>, int?>[target.Count + startIndex];
             target.CopyTo(array2, startIndex);
 
             assertEquals(default, array2[0]);

--- a/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharArraySet.cs
+++ b/src/Lucene.Net.Tests.Analysis.Common/Analysis/Util/TestCharArraySet.cs
@@ -760,10 +760,6 @@ namespace Lucene.Net.Analysis.Util
             {
                 return new CharArraySet(TEST_VERSION_CURRENT, (IList<char[]>)(object)values, ignoreCase);
             }
-            else if (type.Equals(typeof(ICharSequence)))
-            {
-                return new CharArraySet(TEST_VERSION_CURRENT, (IList<ICharSequence>)(object)values, ignoreCase);
-            }
 
             var result = new CharArraySet(TEST_VERSION_CURRENT, values.Count, ignoreCase);
 
@@ -1124,19 +1120,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         [Test, LuceneNetSpecific]
-        public virtual void TestIsSubsetOfCharSequence()
-        {
-            var originalValues = new JCG.List<ICharSequence> { "sally".AsCharSequence(), "sells".AsCharSequence(), "seashells".AsCharSequence(), "by".AsCharSequence(), "the".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence() };
-            CharArraySet target = new CharArraySet(TEST_VERSION_CURRENT, originalValues, false);
-            var subset = new JCG.List<ICharSequence> { "seashells".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence(), null, new CharArrayCharSequence(null) };
-            var superset = new JCG.List<ICharSequence> { "introducing".AsCharSequence(), "sally".AsCharSequence(), "sells".AsCharSequence(), "seashells".AsCharSequence(), "by".AsCharSequence(), "the".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence(), "and".AsCharSequence(), "more".AsCharSequence(), null, new CharArrayCharSequence(null) };
-
-            assertFalse(target.IsSubsetOf(subset));
-            assertTrue(target.IsSubsetOf(superset));
-            assertTrue(target.IsSubsetOf(originalValues));
-        }
-
-        [Test, LuceneNetSpecific]
         public virtual void TestIsSubsetOfObject()
         {
             var originalValues = new string[] { "sally", "sells", "seashells", "by", "the", "sea", "shore" };
@@ -1174,19 +1157,6 @@ namespace Lucene.Net.Analysis.Util
             assertFalse(target.IsProperSubsetOf(subset));
             assertTrue(target.IsProperSubsetOf(superset));
             assertFalse(target.IsProperSubsetOf(originalValuesCopy));
-        }
-
-        [Test, LuceneNetSpecific]
-        public virtual void TestIsProperSubsetOfCharSequence()
-        {
-            var originalValues = new JCG.List<ICharSequence> { "sally".AsCharSequence(), "sells".AsCharSequence(), "seashells".AsCharSequence(), "by".AsCharSequence(), "the".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence() };
-            CharArraySet target = new CharArraySet(TEST_VERSION_CURRENT, originalValues, false);
-            var subset = new JCG.List<ICharSequence> { "seashells".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence(), null, new CharArrayCharSequence(null) };
-            var superset = new JCG.List<ICharSequence> { "introducing".AsCharSequence(), "sally".AsCharSequence(), "sells".AsCharSequence(), "seashells".AsCharSequence(), "by".AsCharSequence(), "the".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence(), "and".AsCharSequence(), "more".AsCharSequence(), null, new CharArrayCharSequence(null) };
-
-            assertFalse(target.IsProperSubsetOf(subset));
-            assertTrue(target.IsProperSubsetOf(superset));
-            assertFalse(target.IsProperSubsetOf(originalValues));
         }
 
         [Test, LuceneNetSpecific]
@@ -1230,19 +1200,6 @@ namespace Lucene.Net.Analysis.Util
         }
 
         [Test, LuceneNetSpecific]
-        public virtual void TestIsSupersetOfCharSequence()
-        {
-            var originalValues = new JCG.List<ICharSequence> { "sally".AsCharSequence(), "sells".AsCharSequence(), "seashells".AsCharSequence(), "by".AsCharSequence(), "the".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence() };
-            CharArraySet target = new CharArraySet(TEST_VERSION_CURRENT, originalValues, false);
-            var subset = new JCG.List<ICharSequence> { "seashells".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence() };
-            var superset = new JCG.List<ICharSequence> { "introducing".AsCharSequence(), "sally".AsCharSequence(), "sells".AsCharSequence(), "seashells".AsCharSequence(), "by".AsCharSequence(), "the".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence(), "and".AsCharSequence(), "more".AsCharSequence(), null, new CharArrayCharSequence(null) };
-
-            assertTrue(target.IsSupersetOf(subset));
-            assertFalse(target.IsSupersetOf(superset));
-            assertTrue(target.IsSupersetOf(originalValues));
-        }
-
-        [Test, LuceneNetSpecific]
         public virtual void TestIsSupersetOfObject()
         {
             var originalValues = new string[] { "sally", "sells", "seashells", "by", "the", "sea", "shore" };
@@ -1280,19 +1237,6 @@ namespace Lucene.Net.Analysis.Util
             assertTrue(target.IsProperSupersetOf(subset));
             assertFalse(target.IsProperSupersetOf(superset));
             assertFalse(target.IsProperSupersetOf(originalValuesCopy));
-        }
-
-        [Test, LuceneNetSpecific]
-        public virtual void TestIsProperSupersetOfCharSequence()
-        {
-            var originalValues = new JCG.List<ICharSequence> { "sally".AsCharSequence(), "sells".AsCharSequence(), "seashells".AsCharSequence(), "by".AsCharSequence(), "the".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence() };
-            CharArraySet target = new CharArraySet(TEST_VERSION_CURRENT, originalValues, false);
-            var subset = new JCG.List<ICharSequence> { "seashells".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence() };
-            var superset = new JCG.List<ICharSequence> { "introducing".AsCharSequence(), "sally".AsCharSequence(), "sells".AsCharSequence(), "seashells".AsCharSequence(), "by".AsCharSequence(), "the".AsCharSequence(), "sea".AsCharSequence(), "shore".AsCharSequence(), "and".AsCharSequence(), "more".AsCharSequence(), null, new CharArrayCharSequence(null) };
-
-            assertTrue(target.IsProperSupersetOf(subset));
-            assertFalse(target.IsProperSupersetOf(superset));
-            assertFalse(target.IsProperSupersetOf(originalValues));
         }
 
         [Test, LuceneNetSpecific]
@@ -1703,42 +1647,6 @@ namespace Lucene.Net.Analysis.Util
             assertNull(array3[3]);
             assertNull(array3[4]);
             assertTrue(target.IsProperSupersetOf(array3.Skip(startIndex).Take(count).ToArray()));
-        }
-
-        [Test, LuceneNetSpecific]
-        public virtual void TestCopyToCharSequence()
-        {
-            var stopwords = new HashSet<ICharSequence>(TEST_STOP_WORDS.Select(x => x.AsCharSequence()));
-            var target = new CharArraySet(TEST_VERSION_CURRENT, stopwords, ignoreCase: false);
-
-            // Full array
-            var array1 = new ICharSequence[target.Count];
-            target.CopyTo(array1);
-            assertTrue(stopwords.SetEquals(array1));
-
-            // Bounded to lower start index
-            int startIndex = 3;
-            var array2 = new ICharSequence[target.Count + startIndex];
-            target.CopyTo(array2, startIndex);
-
-            assertNull(array2[0]);
-            assertNull(array2[1]);
-            assertNull(array2[2]);
-            assertTrue(stopwords.IsProperSubsetOf(array2));
-            assertTrue(stopwords.SetEquals(array2.Skip(startIndex).ToArray()));
-
-            // Constrianed both start index and count
-            startIndex = 5;
-            int count = 7;
-            var array3 = new ICharSequence[count + startIndex];
-            target.CopyTo(array3, startIndex, count);
-
-            assertNull(array3[0]);
-            assertNull(array3[1]);
-            assertNull(array3[2]);
-            assertNull(array3[3]);
-            assertNull(array3[4]);
-            assertTrue(stopwords.IsProperSupersetOf(array3.Skip(startIndex).Take(count).ToArray()));
         }
 
         #endregion

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestExtendedMode.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestExtendedMode.cs
@@ -54,7 +54,7 @@ namespace Lucene.Net.Analysis.Ja
                     ts.Reset();
                     while (ts.IncrementToken())
                     {
-                        assertTrue(UnicodeUtil.ValidUTF16String(termAtt));
+                        assertTrue(UnicodeUtil.ValidUTF16String(termAtt.AsSpan()));
                     }
                     ts.End();
                 }

--- a/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseTokenizer.cs
+++ b/src/Lucene.Net.Tests.Analysis.Kuromoji/TestJapaneseTokenizer.cs
@@ -282,7 +282,7 @@ namespace Lucene.Net.Analysis.Ja
                     ts.Reset();
                     while (ts.IncrementToken())
                     {
-                        assertTrue(UnicodeUtil.ValidUTF16String(termAtt));
+                        assertTrue(UnicodeUtil.ValidUTF16String(termAtt.AsSpan()));
                     }
                     ts.End();
                 }

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
@@ -141,10 +141,10 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             t.Append(new StringBuilder(t.ToString())); // LUCENENET: StringBuilder doesn't implement ICharSequence
             Assert.AreEqual("123456789012341234567890123456123456789012341234567890123456", t.ToString());
             // very wierd, to test if a subSlice is wrapped correct :)
-            CharBuffer buf = CharBuffer.Wrap("0123456789".ToCharArray(), 3, 5);
+            var buf = "0123456789".ToCharArray().AsSpan(3, 5);
             Assert.AreEqual("34567", buf.ToString());
             t = new CharBlockArray();
-            t.Append(buf, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
+            t.Append(buf.Slice(1, 2 - 1)); // LUCENENET: Corrected 3rd parameter
             Assert.AreEqual("4", t.ToString());
             CharBlockArray t2 = new CharBlockArray();
             t2.Append("test");
@@ -261,10 +261,10 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             t.Append(new StringBuilder(t.ToString()));
             Assert.AreEqual("567890123456567890123456", t.ToString());
             // very wierd, to test if a subSlice is wrapped correct :)
-            CharBuffer buf = CharBuffer.Wrap("012345678901234567890123456789".ToCharArray(), 3, 15);
+            var buf = "012345678901234567890123456789".ToCharArray().AsSpan(3, 15);
             Assert.AreEqual("345678901234567", buf.ToString());
             t = new CharBlockArray();
-            t.Append(buf, 1, 14 - 1);
+            t.Append(buf.Slice(1, 14 - 1));
             Assert.AreEqual("4567890123456", t.ToString());
 
             // finally use a completely custom ReadOnlySpan<char> that is not catched by instanceof checks

--- a/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
+++ b/src/Lucene.Net.Tests.Facet/Taxonomy/WriterCache/TestCharBlockArray.cs
@@ -1,8 +1,6 @@
 // Lucene version compatibility level 4.8.1
 using J2N.IO;
-using J2N.Text;
 using Lucene.Net.Attributes;
-using Lucene.Net.Support;
 using NUnit.Framework;
 using System;
 using System.IO;
@@ -77,6 +75,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 {
                     array.Append(s[j]);
                 }
+
                 builder.Append(s);
             }
 
@@ -95,6 +94,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
                 array = CharBlockArray.Open(@in);
                 AssertEqualsInternal("GrowingCharArray<->StringBuilder mismatch after flush/load.", builder, array);
             }
+
             f.Delete();
         }
 
@@ -127,35 +127,35 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             Assert.AreEqual("12345678", t.ToString());
             t.Append('9');
             Assert.AreEqual("123456789", t.ToString());
-            t.Append("0".AsCharSequence());
+            t.Append("0".AsSpan());
             Assert.AreEqual("1234567890", t.ToString());
-            t.Append("0123456789".AsCharSequence(), 1, 3 - 1); // LUCENENET: Corrected 3rd parameter
+            t.Append("0123456789".AsSpan(1, 3 - 1)); // LUCENENET: Corrected parameter
             Assert.AreEqual("123456789012", t.ToString());
             //t.Append((ICharSequence) CharBuffer.wrap("0123456789".ToCharArray()), 3, 5);
-            t.Append("0123456789".ToCharArray(), 3, 5 - 3); // LUCENENET: no CharBuffer in .NET, so we test char[], start, end overload // LUCENENET: Corrected 3rd parameter
+            t.Append("0123456789".ToCharArray().AsSpan(3, 5 - 3)); // LUCENENET: no CharBuffer in .NET, so we test char[], start, end overload // LUCENENET: Corrected parameter
             Assert.AreEqual("12345678901234", t.ToString());
-            t.Append((ICharSequence)t);
+            t.Append(t);
             Assert.AreEqual("1234567890123412345678901234", t.ToString());
-            t.Append(/*(ICharSequence)*/ new StringBuilder("0123456789"), 5, 7 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence, corrected 3rd argument
+            t.Append(new StringBuilder("0123456789"), 5, 7 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence, corrected 3rd argument
             Assert.AreEqual("123456789012341234567890123456", t.ToString());
-            t.Append(/*(ICharSequence)*/ new StringBuilder(t.ToString())); // LUCENENET: StringBuilder doesn't implement ICharSequence
+            t.Append(new StringBuilder(t.ToString())); // LUCENENET: StringBuilder doesn't implement ICharSequence
             Assert.AreEqual("123456789012341234567890123456123456789012341234567890123456", t.ToString());
             // very wierd, to test if a subSlice is wrapped correct :)
             CharBuffer buf = CharBuffer.Wrap("0123456789".ToCharArray(), 3, 5);
             Assert.AreEqual("34567", buf.ToString());
             t = new CharBlockArray();
-            t.Append((ICharSequence)buf, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
+            t.Append(buf, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
             Assert.AreEqual("4", t.ToString());
             CharBlockArray t2 = new CharBlockArray();
             t2.Append("test");
-            t.Append((ICharSequence)t2);
+            t.Append(t2);
             Assert.AreEqual("4test", t.ToString());
-            t.Append((ICharSequence)t2, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
+            t.Append(t2, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
             Assert.AreEqual("4teste", t.ToString());
 
             try
             {
-                t.Append((ICharSequence)t2, 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2, 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
 #pragma warning disable 168
@@ -166,7 +166,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
 
             try
             {
-                t.Append((ICharSequence)t2, 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2, 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
 #pragma warning disable 168
@@ -176,14 +176,14 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             }
 
             string expected = t.ToString();
-            t.Append((ICharSequence)null); // No-op
+            t.Append((string)null); // No-op
             Assert.AreEqual(expected, t.ToString());
 
 
             // LUCENENET specific - test string overloads
             try
             {
-                t.Append((string)t2.ToString(), 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.ToString().AsSpan(1, 5 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
 #pragma warning disable 168
@@ -194,7 +194,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
 
             try
             {
-                t.Append((string)t2.ToString(), 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.ToString().AsSpan(1, 0 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
 #pragma warning disable 168
@@ -210,7 +210,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             // LUCENENET specific - test char[] overloads
             try
             {
-                t.Append((char[])t2.ToString().ToCharArray(), 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.ToString().ToCharArray().AsSpan(1, 5 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
 #pragma warning disable 168
@@ -221,7 +221,7 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
 
             try
             {
-                t.Append((char[])t2.ToString().ToCharArray(), 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.ToString().ToCharArray().AsSpan(1, 0 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
 #pragma warning disable 168
@@ -242,24 +242,24 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             CharBlockArray t = new CharBlockArray();
             t.Append("01234567890123456789012345678901234567890123456789"); // LUCENENET specific overload that accepts string
             assertEquals("01234567890123456789012345678901234567890123456789", t.ToString());
-            t.Append("01234567890123456789012345678901234567890123456789", 3, 50 - 3); // LUCENENET specific overload that accepts string, startIndex, charCount
+            t.Append("01234567890123456789012345678901234567890123456789".AsSpan(3, 50 - 3)); // LUCENENET specific overload that accepts string, startIndex, charCount
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
             t = new CharBlockArray();
             t.Append("01234567890123456789012345678901234567890123456789".ToCharArray()); // LUCENENET specific overload that accepts char[]
             assertEquals("01234567890123456789012345678901234567890123456789", t.ToString());
-            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray(), 3, 50 - 3); // LUCENENET specific overload that accepts char[], startIndex, charCount
+            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray().AsSpan(3, 50 - 3)); // LUCENENET specific overload that accepts char[], startIndex, charCount
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
             t = new CharBlockArray();
-            t.Append(new StringCharSequence("01234567890123456789012345678901234567890123456789"));
+            t.Append("01234567890123456789012345678901234567890123456789".AsSpan());
             //t.Append((ICharSequence) CharBuffer.wrap("01234567890123456789012345678901234567890123456789".ToCharArray()), 3, 50); // LUCENENET: No CharBuffer in .NET
-            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray(), 3, 50 - 3); // LUCENENET specific overload that accepts char[], startIndex, charCount
+            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray().AsSpan(3, 50 - 3)); // LUCENENET specific overload that accepts char[], startIndex, charCount
             //              "01234567890123456789012345678901234567890123456789"
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
             t = new CharBlockArray();
-            t.Append(/*(ICharSequence)*/ new StringBuilder("01234567890123456789"), 5, 17 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence
-            Assert.AreEqual((ICharSequence)new StringCharSequence("567890123456"), t /*.ToString()*/);
+            t.Append( /*(ICharSequence)*/ new StringBuilder("01234567890123456789"), 5, 17 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence
+            Assert.AreEqual("567890123456", t.ToString());
             t.Append(new StringBuilder(t.ToString()));
-            Assert.AreEqual((ICharSequence)new StringCharSequence("567890123456567890123456"), t /*.ToString()*/);
+            Assert.AreEqual("567890123456567890123456", t.ToString());
             // very wierd, to test if a subSlice is wrapped correct :)
             CharBuffer buf = CharBuffer.Wrap("012345678901234567890123456789".ToCharArray(), 3, 15);
             Assert.AreEqual("345678901234567", buf.ToString());
@@ -267,9 +267,9 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             t.Append(buf, 1, 14 - 1);
             Assert.AreEqual("4567890123456", t.ToString());
 
-            // finally use a completely custom ICharSequence that is not catched by instanceof checks
+            // finally use a completely custom ReadOnlySpan<char> that is not catched by instanceof checks
             const string longTestString = "012345678901234567890123456789";
-            t.Append(new CharSequenceAnonymousClass(longTestString));
+            t.Append(longTestString.AsSpan());
             Assert.AreEqual("4567890123456" + longTestString, t.ToString());
         }
 
@@ -295,38 +295,6 @@ namespace Lucene.Net.Facet.Taxonomy.WriterCache
             // test with a long span slice
             t.Append("01234567890123456789012345678901234567890123456789".AsSpan(3, 50 - 3));
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
-        }
-
-        private sealed class CharSequenceAnonymousClass : ICharSequence
-        {
-            private readonly string longTestString; // LUCENENET: made readonly
-
-            public CharSequenceAnonymousClass(string longTestString)
-            {
-                this.longTestString = longTestString;
-            }
-
-            bool ICharSequence.HasValue => longTestString != null; // LUCENENET specific (implementation of ICharSequence)
-
-            public char CharAt(int i)
-            {
-                return longTestString[i];
-            }
-
-            // LUCENENET specific - Added to .NETify
-            public char this[int i] => longTestString[i];
-
-            public int Length => longTestString.Length;
-
-            public ICharSequence Subsequence(int startIndex, int length) // LUCENENET: Changed semantics to startIndex/length to match .NET
-            {
-                return new StringCharSequence(longTestString.Substring(startIndex, length));
-            }
-
-            public override string ToString()
-            {
-                return longTestString;
-            }
         }
     }
 }

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -182,14 +182,14 @@ namespace Lucene.Net.Analysis.TokenAttributes
             Assert.AreEqual("12345678901234", t.ToString());
             t.Append(t.ToString()); // LUCENENET: CharTermAttribute no longer implements ICharSequence
             Assert.AreEqual("1234567890123412345678901234", t.ToString());
-            t.Append(new StringBuilder("0123456789").ToString().AsSpan(5, 7 - 5)); // LUCENENET: StringBuilder doesn't implement ICharSequence, corrected 3rd argument
+            t.Append(new StringBuilder("0123456789").ToString().AsSpan(5, 7 - 5)); // LUCENENET: StringBuilder doesn't implement ICharSequence, corrected argument
             Assert.AreEqual("123456789012341234567890123456", t.ToString());
             t.Append(new StringBuilder(t.ToString()));
             Assert.AreEqual("123456789012341234567890123456123456789012341234567890123456", t.ToString()); // LUCENENET: StringBuilder doesn't implement ICharSequence
             // very wierd, to test if a subSlice is wrapped correct :)
-            CharBuffer buf = CharBuffer.Wrap("0123456789".ToCharArray(), 3, 5);
+            var buf = "0123456789".ToCharArray().AsSpan(3, 5);
             Assert.AreEqual("34567", buf.ToString());
-            t.SetEmpty().Append(buf, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
+            t.SetEmpty().Append(buf.Slice(1, 2 - 1)); // LUCENENET: Corrected parameter
             Assert.AreEqual("4", t.ToString());
             ICharTermAttribute t2 = new CharTermAttribute();
             t2.Append("test");
@@ -210,7 +210,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
             try
             {
-                t.Append(t2.AsSpan(1, 0 - 1)); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.AsSpan(1, 0 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
             catch (ArgumentOutOfRangeException /*iobe*/)
@@ -284,7 +284,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
             t.SetEmpty();
             t.Append("01234567890123456789012345678901234567890123456789".AsSpan());
-            t.Append(CharBuffer.Wrap("01234567890123456789012345678901234567890123456789".ToCharArray()), 3, 50 - 3); // LUCENENET: Corrected 3rd parameter
+            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray().AsSpan(3, 50 - 3)); // LUCENENET: Corrected parameter
             //              "01234567890123456789012345678901234567890123456789"
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
             t.SetEmpty().Append(new StringBuilder("01234567890123456789"), 5, 17 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence
@@ -292,9 +292,9 @@ namespace Lucene.Net.Analysis.TokenAttributes
             t.Append(new StringBuilder(t.ToString()));
             Assert.AreEqual("567890123456567890123456", t.ToString());
             // very wierd, to test if a subSlice is wrapped correct :)
-            CharBuffer buf = CharBuffer.Wrap("012345678901234567890123456789".ToCharArray(), 3, 15);
+            var buf = "012345678901234567890123456789".ToCharArray().AsSpan(3, 15);
             Assert.AreEqual("345678901234567", buf.ToString());
-            t.SetEmpty().Append(buf, 1, 14 - 1);
+            t.SetEmpty().Append(buf.Slice(1, 14 - 1));
             Assert.AreEqual("4567890123456", t.ToString());
 
             // finally use a completely custom ReadOnlySpan that is not catched by instanceof checks

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -1,12 +1,9 @@
 using J2N.IO;
-using J2N.Text;
 using Lucene.Net.Analysis.TokenAttributes.Extensions;
 using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Text;
-using System.Text.RegularExpressions;
 using Assert = Lucene.Net.TestFramework.Assert;
 using JCG = J2N.Collections.Generic;
 
@@ -177,34 +174,34 @@ namespace Lucene.Net.Analysis.TokenAttributes
             Assert.AreEqual("12345678", t.ToString());
             t.Append('9');
             Assert.AreEqual("123456789", t.ToString());
-            t.Append(new StringCharSequence("0"));
+            t.Append("0".AsSpan());
             Assert.AreEqual("1234567890", t.ToString());
-            t.Append(new StringCharSequence("0123456789"), 1, 3 - 1); // LUCENENET: Corrected 3rd parameter
+            t.Append("0123456789".AsSpan(1, 3 - 1)); // LUCENENET: Corrected parameter
             Assert.AreEqual("123456789012", t.ToString());
-            t.Append(/*(ICharSequence)*/ CharBuffer.Wrap("0123456789".ToCharArray()), 3, 5 - 3); // LUCENENET: Corrected 3rd parameter
+            t.Append("0123456789".ToCharArray().AsSpan(3, 5 - 3)); // LUCENENET: Corrected parameter
             Assert.AreEqual("12345678901234", t.ToString());
-            t.Append((ICharSequence)new StringCharSequence(t.ToString())); // LUCENENET: CharTermAttribute no longer implements ICharSequence
+            t.Append(t.ToString()); // LUCENENET: CharTermAttribute no longer implements ICharSequence
             Assert.AreEqual("1234567890123412345678901234", t.ToString());
-            t.Append(/*(ICharSequence)*/ new StringBuilder("0123456789").ToString(), 5, 7 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence, corrected 3rd argument
+            t.Append(new StringBuilder("0123456789").ToString().AsSpan(5, 7 - 5)); // LUCENENET: StringBuilder doesn't implement ICharSequence, corrected 3rd argument
             Assert.AreEqual("123456789012341234567890123456", t.ToString());
-            t.Append(/*(ICharSequence)*/ new StringBuilder(t.ToString()));
+            t.Append(new StringBuilder(t.ToString()));
             Assert.AreEqual("123456789012341234567890123456123456789012341234567890123456", t.ToString()); // LUCENENET: StringBuilder doesn't implement ICharSequence
             // very wierd, to test if a subSlice is wrapped correct :)
             CharBuffer buf = CharBuffer.Wrap("0123456789".ToCharArray(), 3, 5);
             Assert.AreEqual("34567", buf.ToString());
-            t.SetEmpty().Append(/*(ICharSequence)*/ buf, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
+            t.SetEmpty().Append(buf, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
             Assert.AreEqual("4", t.ToString());
             ICharTermAttribute t2 = new CharTermAttribute();
             t2.Append("test");
             // LUCENENET: CharTermAttribute no longer implements ICharSequence, so wrap its text in a StringCharSequence
-            t.Append((ICharSequence)new StringCharSequence(t2.ToString()));
+            t.Append(t2.AsSpan());
             Assert.AreEqual("4test", t.ToString());
-            t.Append((ICharSequence)new StringCharSequence(t2.ToString()), 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
+            t.Append(t2.AsSpan(1, 2 - 1)); // LUCENENET: Corrected parameter
             Assert.AreEqual("4teste", t.ToString());
 
             try
             {
-                t.Append((ICharSequence)new StringCharSequence(t2.ToString()), 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.AsSpan(1, 5 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
             catch (ArgumentOutOfRangeException /*iobe*/)
@@ -213,14 +210,14 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
             try
             {
-                t.Append((ICharSequence)new StringCharSequence(t2.ToString()), 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.AsSpan(1, 0 - 1)); // LUCENENET: Corrected 3rd parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
             catch (ArgumentOutOfRangeException /*iobe*/)
             {
             }
 
-            t.Append((ICharSequence)null); // LUCENENET specific: No-op for appending null
+            t.Append((string)null); // LUCENENET specific: No-op for appending null
             // LUCENENET specific: Excluding "null" from the result string
             // because in .NET `StringBuilder.Append((string)null)` is a no-op
             // rather than appending the string "null", so we do the same to match.
@@ -230,7 +227,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
             // LUCENENET specific - test string overloads
             try
             {
-                t.Append((string)t2.ToString(), 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.AsSpan(1, 5 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
             catch (ArgumentOutOfRangeException /*iobe*/)
@@ -239,7 +236,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
             try
             {
-                t.Append((string)t2.ToString(), 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.AsSpan(1, 0 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
             catch (ArgumentOutOfRangeException /*iobe*/)
@@ -252,7 +249,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
             // LUCENENET specific - test char[] overloads
             try
             {
-                t.Append((char[])t2.ToString().ToCharArray(), 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.ToString()!.ToCharArray().AsSpan(1, 5 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
             catch (ArgumentOutOfRangeException /*iobe*/)
@@ -261,7 +258,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
             try
             {
-                t.Append((char[])t2.ToString().ToCharArray(), 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append(t2.ToString()!.ToCharArray().AsSpan(1, 0 - 1)); // LUCENENET: Corrected parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
             catch (ArgumentOutOfRangeException /*iobe*/)
@@ -278,19 +275,19 @@ namespace Lucene.Net.Analysis.TokenAttributes
             CharTermAttribute t = new CharTermAttribute();
             t.Append("01234567890123456789012345678901234567890123456789"); // LUCENENET specific overload that accepts string
             assertEquals("01234567890123456789012345678901234567890123456789", t.ToString());
-            t.Append("01234567890123456789012345678901234567890123456789", 3, 50 - 3); // LUCENENET specific overload that accepts string, startIndex, charCount
+            t.Append("01234567890123456789012345678901234567890123456789".AsSpan(3, 50 - 3)); // LUCENENET specific overload that accepts string, startIndex, charCount
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
             t.SetEmpty();
             t.Append("01234567890123456789012345678901234567890123456789".ToCharArray()); // LUCENENET specific overload that accepts char[]
             assertEquals("01234567890123456789012345678901234567890123456789", t.ToString());
-            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray(), 3, 50 - 3); // LUCENENET specific overload that accepts char[], startIndex, charCount
+            t.Append("01234567890123456789012345678901234567890123456789".ToCharArray().AsSpan(3, 50 - 3)); // LUCENENET specific overload that accepts char[], startIndex, charCount
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
             t.SetEmpty();
-            t.Append(new StringCharSequence("01234567890123456789012345678901234567890123456789"));
-            t.Append(/*(ICharSequence)*/ CharBuffer.Wrap("01234567890123456789012345678901234567890123456789".ToCharArray()), 3, 50 - 3); // LUCENENET: Corrected 3rd parameter
+            t.Append("01234567890123456789012345678901234567890123456789".AsSpan());
+            t.Append(CharBuffer.Wrap("01234567890123456789012345678901234567890123456789".ToCharArray()), 3, 50 - 3); // LUCENENET: Corrected 3rd parameter
             //              "01234567890123456789012345678901234567890123456789"
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
-            t.SetEmpty().Append(/*(ICharSequence)*/ new StringBuilder("01234567890123456789"), 5, 17 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence
+            t.SetEmpty().Append(new StringBuilder("01234567890123456789"), 5, 17 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence
             Assert.AreEqual("567890123456", t.ToString());
             t.Append(new StringBuilder(t.ToString()));
             Assert.AreEqual("567890123456567890123456", t.ToString());
@@ -300,9 +297,9 @@ namespace Lucene.Net.Analysis.TokenAttributes
             t.SetEmpty().Append(buf, 1, 14 - 1);
             Assert.AreEqual("4567890123456", t.ToString());
 
-            // finally use a completely custom ICharSequence that is not catched by instanceof checks
+            // finally use a completely custom ReadOnlySpan that is not catched by instanceof checks
             const string longTestString = "012345678901234567890123456789";
-            t.Append(new CharSequenceAnonymousClass(longTestString));
+            t.Append(longTestString.AsSpan());
             Assert.AreEqual("4567890123456" + longTestString, t.ToString());
         }
 
@@ -327,38 +324,6 @@ namespace Lucene.Net.Analysis.TokenAttributes
             // test with a long span slice
             t.Append("01234567890123456789012345678901234567890123456789".AsSpan(3, 50 - 3));
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
-        }
-
-        private sealed class CharSequenceAnonymousClass : ICharSequence
-        {
-            private readonly string longTestString;
-
-            public CharSequenceAnonymousClass(string longTestString)
-            {
-                this.longTestString = longTestString;
-            }
-
-            bool ICharSequence.HasValue => longTestString != null; // LUCENENET specific (implementation of ICharSequence)
-
-            public char CharAt(int i)
-            {
-                return longTestString[i];
-            }
-
-            // LUCENENET specific - Added to .NETify
-            public char this[int i] => longTestString[i];
-
-            public int Length => longTestString.Length;
-
-            public ICharSequence Subsequence(int startIndex, int length) // LUCENENET: Changed semantics to startIndex/length to match .NET
-            {
-                return new StringCharSequence(longTestString.Substring(startIndex, length));
-            }
-
-            public override string ToString()
-            {
-                return longTestString;
-            }
         }
 
         [Test]

--- a/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
+++ b/src/Lucene.Net.Tests/Analysis/TokenAttributes/TestCharTermAttributeImpl.cs
@@ -160,33 +160,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
             });
         }
 
-        [Test]
-        public virtual void TestCharSequenceInterface()
-        {
-            const string s = "0123456789";
-            CharTermAttribute t = new CharTermAttribute();
-            t.Append(s);
-
-            Assert.AreEqual(s.Length, t.Length);
-            Assert.AreEqual("12", t.Subsequence(1, 3 - 1).ToString()); // LUCENENET: Corrected 2nd parameter of Subsequence
-            Assert.AreEqual(s, t.Subsequence(0, s.Length - 0).ToString()); // LUCENENET: Corrected 2nd parameter of Subsequence
-
-            Assert.IsTrue(Regex.IsMatch(t.ToString(), "01\\d+"));
-            Assert.IsTrue(Regex.IsMatch(t.Subsequence(3, 5 - 3).ToString(), "34")); // LUCENENET: Corrected 2nd parameter of Subsequence
-
-            Assert.AreEqual(s.Substring(3, 4), t.Subsequence(3, 7 - 3).ToString()); // LUCENENET: Corrected 2nd parameter of Subsequence
-
-            for (int i = 0; i < s.Length; i++)
-            {
-                Assert.IsTrue(t[i] == s[i]);
-            }
-
-            // LUCENENET specific to test indexer
-            for (int i = 0; i < s.Length; i++)
-            {
-                Assert.IsTrue(t[i] == s[i]);
-            }
-        }
+        // LUCENENET: removed TestCharSequenceInterface
 
         [Test]
         public virtual void TestAppendableInterface()
@@ -209,7 +183,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
             Assert.AreEqual("123456789012", t.ToString());
             t.Append(/*(ICharSequence)*/ CharBuffer.Wrap("0123456789".ToCharArray()), 3, 5 - 3); // LUCENENET: Corrected 3rd parameter
             Assert.AreEqual("12345678901234", t.ToString());
-            t.Append((ICharSequence)t);
+            t.Append((ICharSequence)new StringCharSequence(t.ToString())); // LUCENENET: CharTermAttribute no longer implements ICharSequence
             Assert.AreEqual("1234567890123412345678901234", t.ToString());
             t.Append(/*(ICharSequence)*/ new StringBuilder("0123456789").ToString(), 5, 7 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence, corrected 3rd argument
             Assert.AreEqual("123456789012341234567890123456", t.ToString());
@@ -222,14 +196,15 @@ namespace Lucene.Net.Analysis.TokenAttributes
             Assert.AreEqual("4", t.ToString());
             ICharTermAttribute t2 = new CharTermAttribute();
             t2.Append("test");
-            t.Append((ICharSequence)t2);
+            // LUCENENET: CharTermAttribute no longer implements ICharSequence, so wrap its text in a StringCharSequence
+            t.Append((ICharSequence)new StringCharSequence(t2.ToString()));
             Assert.AreEqual("4test", t.ToString());
-            t.Append((ICharSequence)t2, 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
+            t.Append((ICharSequence)new StringCharSequence(t2.ToString()), 1, 2 - 1); // LUCENENET: Corrected 3rd parameter
             Assert.AreEqual("4teste", t.ToString());
 
             try
             {
-                t.Append((ICharSequence)t2, 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append((ICharSequence)new StringCharSequence(t2.ToString()), 1, 5 - 1); // LUCENENET: Corrected 3rd parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
             catch (ArgumentOutOfRangeException /*iobe*/)
@@ -238,7 +213,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
             try
             {
-                t.Append((ICharSequence)t2, 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
+                t.Append((ICharSequence)new StringCharSequence(t2.ToString()), 1, 0 - 1); // LUCENENET: Corrected 3rd parameter
                 Assert.Fail("Should throw ArgumentOutOfRangeException");
             }
             catch (ArgumentOutOfRangeException /*iobe*/)
@@ -316,9 +291,9 @@ namespace Lucene.Net.Analysis.TokenAttributes
             //              "01234567890123456789012345678901234567890123456789"
             Assert.AreEqual("0123456789012345678901234567890123456789012345678934567890123456789012345678901234567890123456789", t.ToString());
             t.SetEmpty().Append(/*(ICharSequence)*/ new StringBuilder("01234567890123456789"), 5, 17 - 5); // LUCENENET: StringBuilder doesn't implement ICharSequence
-            Assert.AreEqual((ICharSequence)new StringCharSequence("567890123456"), t /*.ToString()*/);
+            Assert.AreEqual("567890123456", t.ToString());
             t.Append(new StringBuilder(t.ToString()));
-            Assert.AreEqual((ICharSequence)new StringCharSequence("567890123456567890123456"), t /*.ToString()*/);
+            Assert.AreEqual("567890123456567890123456", t.ToString());
             // very wierd, to test if a subSlice is wrapped correct :)
             CharBuffer buf = CharBuffer.Wrap("012345678901234567890123456789".ToCharArray(), 3, 15);
             Assert.AreEqual("345678901234567", buf.ToString());
@@ -430,23 +405,24 @@ namespace Lucene.Net.Analysis.TokenAttributes
             {
             }
 
-            try
-            {
-                _ = t.Subsequence(0, 5 - 0); // LUCENENET: Corrected 2nd parameter of Subsequence
-                Assert.Fail("Should throw ArgumentOutOfRangeException");
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-            }
-
-            try
-            {
-                _ = t.Subsequence(5, 0 - 5); // LUCENENET: Corrected 2nd parameter of Subsequence
-                Assert.Fail("Should throw ArgumentOutOfRangeException");
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-            }
+            // LUCENENET: removed ICharSequence support
+            // try
+            // {
+            //     _ = t.Subsequence(0, 5 - 0); // LUCENENET: Corrected 2nd parameter of Subsequence
+            //     Assert.Fail("Should throw ArgumentOutOfRangeException");
+            // }
+            // catch (ArgumentOutOfRangeException)
+            // {
+            // }
+            //
+            // try
+            // {
+            //     _ = t.Subsequence(5, 0 - 5); // LUCENENET: Corrected 2nd parameter of Subsequence
+            //     Assert.Fail("Should throw ArgumentOutOfRangeException");
+            // }
+            // catch (ArgumentOutOfRangeException)
+            // {
+            // }
         }
 
         /*

--- a/src/Lucene.Net.Tests/Util/TestBytesRef.cs
+++ b/src/Lucene.Net.Tests/Util/TestBytesRef.cs
@@ -7,6 +7,9 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Assert = Lucene.Net.TestFramework.Assert;
+#if !FEATURE_ENCODING_GETSTRING_READONLYSPAN
+using J2N.Text;
+#endif
 
 namespace Lucene.Net.Util
 {

--- a/src/Lucene.Net.Tests/Util/TestBytesRef.cs
+++ b/src/Lucene.Net.Tests/Util/TestBytesRef.cs
@@ -1,4 +1,3 @@
-using J2N.Text;
 using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System;
@@ -69,19 +68,7 @@ namespace Lucene.Net.Util
             Assert.AreEqual("\uFFFF", new BytesRef("\uFFFF").Utf8ToString());
         }
 
-        [Test, LuceneNetSpecific]
-        public virtual void TestFromCharSequence()
-        {
-            for (int i = 0; i < 100; i++)
-            {
-                ICharSequence s = new StringCharSequence(TestUtil.RandomUnicodeString(Random));
-                ICharSequence s2 = new BytesRef(s).Utf8ToString().AsCharSequence();
-                Assert.AreEqual(s, s2);
-            }
-
-            // only for 4.x
-            Assert.AreEqual("\uFFFF", new BytesRef("\uFFFF").Utf8ToString());
-        }
+        // LUCENENET: removed TestFromCharSequence
 
         // LUCENE-3590, AIOOBE if you append to a bytesref with offset != 0
         [Test]

--- a/src/Lucene.Net.Tests/Util/TestCharsRef.cs
+++ b/src/Lucene.Net.Tests/Util/TestCharsRef.cs
@@ -1,4 +1,3 @@
-using J2N.Text;
 using Lucene.Net.Attributes;
 using NUnit.Framework;
 using System;
@@ -181,75 +180,7 @@ namespace Lucene.Net.Util
             }
         }
 
-        // LUCENE-3590: fix off-by-one in subsequence, and fully obey interface
-        // LUCENE-4671: fix subSequence
-        [Test]
-        public virtual void TestCharSequenceSubSequence()
-        {
-            ICharSequence[] sequences = {
-                new CharsRef("abc"),
-                new CharsRef("0abc".ToCharArray(), 1, 3),
-                new CharsRef("abc0".ToCharArray(), 0, 3),
-                new CharsRef("0abc0".ToCharArray(), 1, 3)
-            };
-
-            foreach (ICharSequence c in sequences)
-            {
-                DoTestSequence(c);
-            }
-        }
-
-        private void DoTestSequence(ICharSequence c)
-        {
-            // slice
-            Assert.AreEqual("a", c.Subsequence(0, 1 - 0).ToString()); // LUCENENET: Corrected 2nd parameter
-            // mid subsequence
-            Assert.AreEqual("b", c.Subsequence(1, 2 - 1).ToString()); // LUCENENET: Corrected 2nd parameter
-            // end subsequence
-            Assert.AreEqual("bc", c.Subsequence(1, 3 - 1).ToString()); // LUCENENET: Corrected 2nd parameter
-            // empty subsequence
-            Assert.AreEqual("", c.Subsequence(0, 0 - 0).ToString()); // LUCENENET: Corrected 2nd parameter
-
-            try
-            {
-                c.Subsequence(-1, 1 - -1); // LUCENENET: Corrected 2nd parameter
-                Assert.Fail();
-            }
-            catch (Exception expected) when (expected.IsIndexOutOfBoundsException())
-            {
-                // expected exception
-            }
-
-            try
-            {
-                c.Subsequence(0, -1 - 0); // LUCENENET: Corrected 2nd parameter
-                Assert.Fail();
-            }
-            catch (Exception expected) when (expected.IsIndexOutOfBoundsException())
-            {
-                // expected exception
-            }
-
-            try
-            {
-                c.Subsequence(0, 4 - 0); // LUCENENET: Corrected 2nd parameter
-                Assert.Fail();
-            }
-            catch (Exception expected) when (expected.IsIndexOutOfBoundsException())
-            {
-                // expected exception
-            }
-
-            try
-            {
-                c.Subsequence(2, 1 - 2); // LUCENENET: Corrected 2nd parameter
-                Assert.Fail();
-            }
-            catch (Exception expected) when (expected.IsIndexOutOfBoundsException())
-            {
-                // expected exception
-            }
-        }
+        // LUCENENET: removed TestCharSequenceSubSequence and DoTestSequence - CharsRef no longer implements ICharSequence
 
 #if FEATURE_SERIALIZABLE
 

--- a/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
+++ b/src/Lucene.Net.Tests/Util/TestUnicodeUtil.cs
@@ -196,46 +196,6 @@ namespace Lucene.Net.Util
         }
 
         [Test, LuceneNetSpecific]
-        public virtual void TestUTF8toUTF32_ICharSequence()
-        {
-            BytesRef utf8 = new BytesRef(20);
-            Int32sRef utf32 = new Int32sRef(20);
-            int[] codePoints = new int[20];
-            int num = AtLeast(50000);
-            for (int i = 0; i < num; i++)
-            {
-                string s = TestUtil.RandomUnicodeString(Random);
-                UnicodeUtil.UTF16toUTF8(s.AsCharSequence(), 0, s.Length, utf8);
-                UnicodeUtil.UTF8toUTF32(utf8, utf32);
-
-                int charUpto = 0;
-                int intUpto = 0;
-
-                while (charUpto < s.Length)
-                {
-                    int cp = Character.CodePointAt(s, charUpto);
-                    codePoints[intUpto++] = cp;
-                    charUpto += Character.CharCount(cp);
-                }
-                if (!ArrayUtil.Equals(codePoints, 0, utf32.Int32s, utf32.Offset, intUpto))
-                {
-                    Console.WriteLine("FAILED");
-                    for (int j = 0; j < s.Length; j++)
-                    {
-                        Console.WriteLine("  char[" + j + "]=" + ((int)s[j]).ToString("x"));
-                    }
-                    Console.WriteLine();
-                    Assert.AreEqual(intUpto, utf32.Length);
-                    for (int j = 0; j < intUpto; j++)
-                    {
-                        Console.WriteLine("  " + utf32.Int32s[j].ToString("x") + " vs " + codePoints[j].ToString("x"));
-                    }
-                    Assert.Fail("mismatch");
-                }
-            }
-        }
-
-        [Test, LuceneNetSpecific]
         public virtual void TestUTF8toUTF32_CharArray()
         {
             BytesRef utf8 = new BytesRef(20);

--- a/src/Lucene.Net/Analysis/Token.cs
+++ b/src/Lucene.Net/Analysis/Token.cs
@@ -1,4 +1,3 @@
-using J2N.Text;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.TokenAttributes.Extensions;
 using Lucene.Net.Index;
@@ -66,7 +65,7 @@ namespace Lucene.Net.Analysis
     /// one of the constructors that starts with null text.  To load
     /// the token from a char[] use <see cref="ICharTermAttribute.CopyBuffer(char[], int, int)"/>.
     /// To load from a <see cref="string"/> use <see cref="ICharTermAttribute.Clear()"/> (or <see cref="CharTermAttributeExtensions.SetEmpty{T}(T)"/>) followed by
-    /// <see cref="ICharTermAttribute.Append(string)"/> or <see cref="ICharTermAttribute.Append(string, int, int)"/>.
+    /// <see cref="ICharTermAttribute.Append(ReadOnlySpan{char})"/>.
     /// Alternatively you can get the <see cref="Token"/>'s termBuffer by calling either <see cref="ICharTermAttribute.Buffer"/>,
     /// if you know that your text is shorter than the capacity of the termBuffer
     /// or <see cref="ICharTermAttribute.ResizeBuffer(int)"/>, if there is any possibility
@@ -111,11 +110,6 @@ namespace Lucene.Net.Analysis
     ///     <item><description>The startOffset and endOffset represent the start and offset in the source text, so be careful in adjusting them.</description></item>
     ///     <item><description>When caching a reusable token, clone it. When injecting a cached token into a stream that can be reset, clone it again.</description></item>
     /// </list>
-    /// </para>
-    /// <para>
-    /// <b>Please note:</b> With Lucene 3.1, the <see cref="CharTermAttribute.ToString()"/> method had to be changed to match the
-    /// <see cref="ICharSequence"/> interface introduced by the interface <see cref="ICharTermAttribute"/>.
-    /// this method now only prints the term text, no additional information anymore.
     /// </para>
     /// </summary>
     public class Token : CharTermAttribute, ITypeAttribute, IPositionIncrementAttribute, IFlagsAttribute, IOffsetAttribute, IPayloadAttribute, IPositionLengthAttribute
@@ -448,47 +442,11 @@ namespace Lucene.Net.Analysis
 
         /// <summary>
         /// Shorthand for calling <see cref="Clear"/>,
-        /// <see cref="ICharTermAttribute.CopyBuffer(char[], int, int)"/>,
+        /// <see cref="ICharTermAttribute.Append(ReadOnlySpan{char})"/>,
         /// <see cref="SetOffset"/>,
         /// <see cref="Type"/> (set) </summary>
         /// <returns> this <see cref="Token"/> instance  </returns>
-        public virtual Token Reinit(char[] newTermBuffer, int newTermOffset, int newTermLength, int newStartOffset, int newEndOffset, string newType)
-        {
-            CheckOffsets(newStartOffset, newEndOffset);
-            ClearNoTermBuffer();
-            CopyBuffer(newTermBuffer, newTermOffset, newTermLength);
-            payload = null;
-            positionIncrement = 1;
-            startOffset = newStartOffset;
-            endOffset = newEndOffset;
-            type = newType;
-            return this;
-        }
-
-        /// <summary>
-        /// Shorthand for calling <see cref="Clear"/>,
-        /// <see cref="ICharTermAttribute.CopyBuffer(char[], int, int)"/>,
-        /// <see cref="SetOffset"/>,
-        /// <see cref="Type"/> (set) on <see cref="TypeAttribute.DEFAULT_TYPE"/> </summary>
-        /// <returns> this <see cref="Token"/> instance  </returns>
-        public virtual Token Reinit(char[] newTermBuffer, int newTermOffset, int newTermLength, int newStartOffset, int newEndOffset)
-        {
-            CheckOffsets(newStartOffset, newEndOffset);
-            ClearNoTermBuffer();
-            CopyBuffer(newTermBuffer, newTermOffset, newTermLength);
-            startOffset = newStartOffset;
-            endOffset = newEndOffset;
-            type = TokenAttributes.TypeAttribute.DEFAULT_TYPE;
-            return this;
-        }
-
-        /// <summary>
-        /// Shorthand for calling <see cref="Clear"/>,
-        /// <see cref="ICharTermAttribute.Append(string)"/>,
-        /// <see cref="SetOffset"/>,
-        /// <see cref="Type"/> (set) </summary>
-        /// <returns> this <see cref="Token"/> instance  </returns>
-        public virtual Token Reinit(string newTerm, int newStartOffset, int newEndOffset, string newType)
+        public virtual Token Reinit(ReadOnlySpan<char> newTerm, int newStartOffset, int newEndOffset, string newType)
         {
             CheckOffsets(newStartOffset, newEndOffset);
             Clear();
@@ -501,49 +459,15 @@ namespace Lucene.Net.Analysis
 
         /// <summary>
         /// Shorthand for calling <see cref="Clear"/>,
-        /// <see cref="ICharTermAttribute.Append(string, int, int)"/>,
-        /// <see cref="SetOffset"/>,
-        /// <see cref="Type"/> (set) </summary>
-        /// <returns> this <see cref="Token"/> instance  </returns>
-        public virtual Token Reinit(string newTerm, int newTermOffset, int newTermLength, int newStartOffset, int newEndOffset, string newType)
-        {
-            CheckOffsets(newStartOffset, newEndOffset);
-            Clear();
-            Append(newTerm, newTermOffset, newTermOffset + newTermLength);
-            startOffset = newStartOffset;
-            endOffset = newEndOffset;
-            type = newType;
-            return this;
-        }
-
-        /// <summary>
-        /// Shorthand for calling <see cref="Clear"/>,
-        /// <see cref="ICharTermAttribute.Append(string)"/>,
+        /// <see cref="ICharTermAttribute.Append(ReadOnlySpan{char})"/>,
         /// <see cref="SetOffset"/>,
         /// <see cref="Type"/> (set) on <see cref="TypeAttribute.DEFAULT_TYPE"/> </summary>
         /// <returns> this <see cref="Token"/> instance  </returns>
-        public virtual Token Reinit(string newTerm, int newStartOffset, int newEndOffset)
+        public virtual Token Reinit(ReadOnlySpan<char> newTerm, int newStartOffset, int newEndOffset)
         {
             CheckOffsets(newStartOffset, newEndOffset);
             Clear();
             Append(newTerm);
-            startOffset = newStartOffset;
-            endOffset = newEndOffset;
-            type = TokenAttributes.TypeAttribute.DEFAULT_TYPE;
-            return this;
-        }
-
-        /// <summary>
-        /// Shorthand for calling <see cref="Clear"/>,
-        /// <see cref="ICharTermAttribute.Append(string, int, int)"/>,
-        /// <see cref="SetOffset"/>,
-        /// <see cref="Type"/> (set) on <see cref="TypeAttribute.DEFAULT_TYPE"/> </summary>
-        /// <returns> this <see cref="Token"/> instance  </returns>
-        public virtual Token Reinit(string newTerm, int newTermOffset, int newTermLength, int newStartOffset, int newEndOffset)
-        {
-            CheckOffsets(newStartOffset, newEndOffset);
-            Clear();
-            Append(newTerm, newTermOffset, newTermOffset + newTermLength);
             startOffset = newStartOffset;
             endOffset = newEndOffset;
             type = TokenAttributes.TypeAttribute.DEFAULT_TYPE;

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
@@ -95,144 +95,10 @@ namespace Lucene.Net.Analysis.TokenAttributes
         void Clear();
 
         /// <summary>
-        /// Appends the contents of the <see cref="ICharSequence"/> to this character sequence.
-        /// <para/>
-        /// The characters of the <see cref="ICharSequence"/> argument are appended, in order, increasing the length of
-        /// this sequence by the length of the argument. If <paramref name="value"/> is <c>null</c>, this method is a no-op.
-        /// <para/>
-        /// IMPORTANT: This method uses .NET semantics. In Lucene, a <c>null</c> <paramref name="value"/> would append the
-        /// string <c>"null"</c> to the instance, but in Lucene.NET a <c>null</c> value will be ignored.
-        /// </summary>
-        new ICharTermAttribute Append(ICharSequence value);
-
-        /// <summary>
-        /// Appends the a string representation of the specified <see cref="ICharSequence"/> to this instance.
-        /// <para>
-        /// The characters of the <see cref="ICharSequence"/> argument are appended, in order, increasing the length of
-        /// this sequence by the length of <paramref name="count"/>. If <paramref name="value"/> is <c>null</c>
-        /// and <paramref name="startIndex"/> and <paramref name="count"/> are not 0, an
-        /// <see cref="ArgumentNullException"/> is thrown.
-        /// </para>
-        /// </summary>
-        /// <param name="value">The sequence of characters to append.</param>
-        /// <param name="startIndex">The start index of the <see cref="ICharSequence"/> to begin copying characters.</param>
-        /// <param name="count">The number of characters to append.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>, and
-        /// <paramref name="startIndex"/> and <paramref name="count"/> are not zero.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="count"/> is less than zero.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="startIndex"/> is less than zero.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
-        /// </exception>
-        new ICharTermAttribute Append(ICharSequence value, int startIndex, int count); // LUCENENET: changed to startIndex/length to match .NET
-
-        /// <summary>
         /// Appends the supplied <see cref="char"/> to this character sequence.
         /// </summary>
         /// <param name="value">The <see cref="char"/> to append.</param>
         new ICharTermAttribute Append(char value);
-
-        /// <summary>
-        /// Appends the contents of the <see cref="T:char[]"/> array to this character sequence.
-        /// <para/>
-        /// The characters of the <see cref="T:char[]"/> argument are appended, in order, increasing the length of
-        /// this sequence by the length of the <paramref name="value"/>.
-        /// If <paramref name="value"/> is <c>null</c>, this method is a no-op.
-        /// <para/>
-        /// This method uses .NET semantics. In Lucene, a <c>null</c> <paramref name="value"/> would append the
-        /// string <c>"null"</c> to the instance, but in Lucene.NET a <c>null</c> value will be safely ignored.
-        /// </summary>
-        /// <param name="value">The <see cref="T:char[]"/> array to append.</param>
-        /// <remarks>
-        /// LUCENENET specific method, added to simulate using the CharBuffer class in Java.
-        /// </remarks>
-        new ICharTermAttribute Append(char[] value);
-
-        /// <summary>
-        /// Appends the string representation of the <see cref="T:char[]"/> array to this instance.
-        /// <para>
-        /// The characters of the <see cref="T:char[]"/> argument are appended, in order, increasing the length of
-        /// this sequence by the length of the <paramref name="value"/>. If <paramref name="value"/> is <c>null</c>
-        /// and <paramref name="startIndex"/> and <paramref name="count"/> are not 0, an
-        /// <see cref="ArgumentNullException"/> is thrown.
-        /// </para>
-        /// </summary>
-        /// <param name="value">The sequence of characters to append.</param>
-        /// <param name="startIndex">The start index of the <see cref="T:char[]"/> to begin copying characters.</param>
-        /// <param name="count">The number of characters to append.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>, and
-        /// <paramref name="startIndex"/> and <paramref name="count"/> are not zero.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="count"/> is less than zero.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="startIndex"/> is less than zero.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
-        /// </exception>
-        /// <remarks>
-        /// LUCENENET specific method, added to simulate using the CharBuffer class in Java. Note that
-        /// the <see cref="CopyBuffer(char[], int, int)"/> method provides similar functionality.
-        /// </remarks>
-        new ICharTermAttribute Append(char[] value, int startIndex, int count); // LUCENENET: changed to startIndex/length to match .NET
-
-        /// <summary>
-        /// Appends the specified <see cref="string"/> to this character sequence.
-        /// <para>
-        /// The characters of the <see cref="string"/> argument are appended, in order, increasing the length of
-        /// this sequence by the length of the argument. If argument is <c>null</c>, this method is a no-op.
-        /// <para/>
-        /// This method uses .NET semantics. In Lucene, a <c>null</c> <paramref name="value"/> would append the
-        /// string <c>"null"</c> to the instance, but in Lucene.NET a <c>null</c> value will be safely ignored.
-        /// </para>
-        /// </summary>
-        /// <param name="value">The sequence of characters to append.</param>
-        /// <remarks>
-        /// LUCENENET specific method, added because the .NET <see cref="string"/> data type
-        /// doesn't implement <see cref="ICharSequence"/>.
-        /// </remarks>
-        new ICharTermAttribute Append(string value);
-
-        /// <summary>
-        /// Appends the contents of the <see cref="string"/> to this character sequence.
-        /// <para>
-        /// The characters of the <see cref="string"/> argument are appended, in order, increasing the length of
-        /// this sequence by the length of <paramref name="value"/>. If <paramref name="value"/> is <c>null</c>
-        /// and <paramref name="startIndex"/> and <paramref name="count"/> are not 0, an
-        /// <see cref="ArgumentNullException"/> is thrown.
-        /// </para>
-        /// </summary>
-        /// <param name="value">The sequence of characters to append.</param>
-        /// <param name="startIndex">The start index of the <see cref="string"/> to begin copying characters.</param>
-        /// <param name="count">The number of characters to append.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>, and
-        /// <paramref name="startIndex"/> and <paramref name="count"/> are not zero.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="count"/> is less than zero.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="startIndex"/> is less than zero.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
-        /// </exception>
-        /// <remarks>
-        /// LUCENENET specific method, added because the .NET <see cref="string"/> data type
-        /// doesn't implement <see cref="ICharSequence"/>.
-        /// </remarks>
-        new ICharTermAttribute Append(string value, int startIndex, int count); // LUCENENET TODO: API - change to startIndex/length to match .NET
-
 
         /// <summary>
         /// Appends a string representation of the specified <see cref="StringBuilder"/> to this character sequence.
@@ -270,8 +136,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
         /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
         /// </exception>
         /// <remarks>
-        /// LUCENENET specific method, added because the .NET <see cref="StringBuilder"/> data type
-        /// doesn't implement <see cref="ICharSequence"/>.
+        /// LUCENENET specific method.
         /// </remarks>
         new ICharTermAttribute Append(StringBuilder value, int startIndex, int count);
 

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttribute.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
     /// <summary>
     /// The term text of a <see cref="Token"/>.
     /// </summary>
-    public interface ICharTermAttribute : IAttribute, ICharSequence, IAppendable,
+    public interface ICharTermAttribute : IAttribute, IAppendable,
         IBufferWriter<char> // LUCENENET specific
     {
         /// <summary>
@@ -78,10 +78,10 @@ namespace Lucene.Net.Analysis.TokenAttributes
         /// chaining is not required.
         /// </remarks>
         /// <seealso cref="CharTermAttributeExtensions.SetLength{T}(T, int)"/>
-        new int Length { get; set; }
+        int Length { get; set; }
 
         // LUCENENET specific: Redefining this[] to make it settable
-        new char this[int index] { get; set; }
+        char this[int index] { get; set; }
 
         /// <summary>
         /// Clears the values in this attribute and resets it to its

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
@@ -1,3 +1,4 @@
+using J2N.IO;
 using J2N.Text;
 using Lucene.Net.Support;
 using System;
@@ -165,78 +166,10 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
         // *** Appendable interface ***
 
-        public CharTermAttribute Append(string value, int startIndex, int charCount)
-        {
-            // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
-            if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
-            if (charCount < 0)
-                throw new ArgumentOutOfRangeException(nameof(charCount), $"{nameof(charCount)} must not be negative.");
-
-            if (value is null)
-            {
-                if (startIndex == 0 && charCount == 0)
-                    return this;
-                throw new ArgumentNullException(nameof(value));
-            }
-            if (charCount == 0)
-                return this;
-            if (startIndex > value.Length - charCount)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(charCount)} <= {nameof(Length)}.");
-
-            value.CopyTo(startIndex, InternalResizeBuffer(termLength + charCount), termLength, charCount);
-            Length += charCount;
-
-            return this;
-        }
-
         public CharTermAttribute Append(char value)
         {
             ResizeBuffer(termLength + 1)[termLength++] = value;
             return this;
-        }
-
-        public CharTermAttribute Append(char[] value)
-        {
-            if (value is null)
-                //return AppendNull();
-                return this; // No-op
-
-            int len = value.Length;
-            value.CopyTo(InternalResizeBuffer(termLength + len), termLength);
-            Length += len;
-
-            return this;
-        }
-
-        public CharTermAttribute Append(char[] value, int startIndex, int charCount)
-        {
-            // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
-            if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
-            if (charCount < 0)
-                throw new ArgumentOutOfRangeException(nameof(charCount), $"{nameof(charCount)} must not be negative.");
-
-            if (value is null)
-            {
-                if (startIndex == 0 && charCount == 0)
-                    return this;
-                throw new ArgumentNullException(nameof(value));
-            }
-            if (charCount == 0)
-                return this;
-            if (startIndex > value.Length - charCount)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(charCount)} <= {nameof(Length)}.");
-
-            Arrays.Copy(value, startIndex, InternalResizeBuffer(termLength + charCount), termLength, charCount);
-            Length += charCount;
-
-            return this;
-        }
-
-        public CharTermAttribute Append(string value)
-        {
-            return Append(value, 0, value?.Length ?? 0);
         }
 
         public CharTermAttribute Append(StringBuilder value)
@@ -277,31 +210,18 @@ namespace Lucene.Net.Analysis.TokenAttributes
             return this;
         }
 
-        public CharTermAttribute Append(ICharTermAttribute value)
-        {
-            if (value is null) // needed for Appendable compliance
-            {
-                //return AppendNull();
-                return this; // No-op
-            }
-            int len = value.Length;
-            Arrays.Copy(value.Buffer, 0, ResizeBuffer(termLength + len), termLength, len);
-            termLength += len;
-            return this;
-        }
-
-        public CharTermAttribute Append(ICharSequence value)
+        public CharTermAttribute Append(CharBuffer value)
         {
             if (value is null)
-                //return AppendNull();
+            {
                 return this; // No-op
+            }
 
             return Append(value, 0, value.Length);
         }
 
-        public CharTermAttribute Append(ICharSequence value, int startIndex, int charCount)
+        public CharTermAttribute Append(CharBuffer value, int startIndex, int charCount)
         {
-            // LUCENENET: Changed semantics to be the same as the StringBuilder in .NET
             if (startIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
             if (charCount < 0)
@@ -318,11 +238,25 @@ namespace Lucene.Net.Analysis.TokenAttributes
             if (startIndex > value.Length - charCount)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(charCount)} <= {nameof(Length)}.");
 
-            ResizeBuffer(termLength + charCount);
+            int end = startIndex + charCount;
+            for (int i = startIndex; i < end; i++)
+            {
+                Append(value[i]);
+            }
 
-            for (int i = 0; i < charCount; i++)
-                termBuffer[termLength++] = value[startIndex + i];
+            return this;
+        }
 
+        public CharTermAttribute Append(ICharTermAttribute value)
+        {
+            if (value is null) // needed for Appendable compliance
+            {
+                //return AppendNull();
+                return this; // No-op
+            }
+            int len = value.Length;
+            Arrays.Copy(value.Buffer, 0, ResizeBuffer(termLength + len), termLength, len);
+            termLength += len;
             return this;
         }
 
@@ -456,19 +390,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
         #region ICharTermAttribute Members
 
-        ICharTermAttribute ICharTermAttribute.Append(ICharSequence value) => Append(value);
-
-        ICharTermAttribute ICharTermAttribute.Append(ICharSequence value, int startIndex, int count) => Append(value, startIndex, count);
-
         ICharTermAttribute ICharTermAttribute.Append(char value) => Append(value);
-
-        ICharTermAttribute ICharTermAttribute.Append(char[] value) => Append(value);
-
-        ICharTermAttribute ICharTermAttribute.Append(char[] value, int startIndex, int count) => Append(value, startIndex, count);
-
-        ICharTermAttribute ICharTermAttribute.Append(string value) => Append(value);
-
-        ICharTermAttribute ICharTermAttribute.Append(string value, int startIndex, int count) => Append(value, startIndex, count);
 
         ICharTermAttribute ICharTermAttribute.Append(StringBuilder value) => Append(value);
 
@@ -486,7 +408,7 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
         IAppendable IAppendable.Append(string value) => Append(value);
 
-        IAppendable IAppendable.Append(string value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(string value, int startIndex, int count) => Append(value.AsSpan(startIndex, count));
 
         IAppendable IAppendable.Append(StringBuilder value) => Append(value);
 
@@ -494,11 +416,11 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
         IAppendable IAppendable.Append(char[] value) => Append(value);
 
-        IAppendable IAppendable.Append(char[] value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(char[] value, int startIndex, int count) => Append(value.AsSpan(startIndex, count));
 
-        IAppendable IAppendable.Append(ICharSequence value) => Append(value);
+        IAppendable IAppendable.Append(ICharSequence value) => Append(value?.ToString());
 
-        IAppendable IAppendable.Append(ICharSequence value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(ICharSequence value, int startIndex, int count) => Append(value == null ? ReadOnlySpan<char>.Empty : value.ToString().AsSpan(startIndex, count));
 
         #endregion
 

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
@@ -59,9 +59,6 @@ namespace Lucene.Net.Analysis.TokenAttributes
         {
         }
 
-        // LUCENENET specific - ICharSequence member from J2N
-        bool ICharSequence.HasValue => termBuffer != null;
-
         public void CopyBuffer(char[] buffer, int offset, int length)
         {
             // LUCENENET: Added guard clauses.
@@ -164,25 +161,6 @@ namespace Lucene.Net.Analysis.TokenAttributes
 
                 termBuffer[index] = value;
             }
-        }
-
-        public ICharSequence Subsequence(int startIndex, int length)
-        {
-            // From Apache Harmony String class
-            if (termBuffer is null || (startIndex == 0 && length == termBuffer.Length))
-            {
-                return new CharArrayCharSequence(termBuffer);
-            }
-            if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
-            if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
-            if (startIndex > Length - length) // Checks for int overflow
-                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
-
-            char[] result = new char[length];
-            Arrays.Copy(termBuffer, startIndex, result, 0, length);
-            return new CharArrayCharSequence(result);
         }
 
         // *** Appendable interface ***

--- a/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
+++ b/src/Lucene.Net/Analysis/TokenAttributes/CharTermAttributeImpl.cs
@@ -210,43 +210,6 @@ namespace Lucene.Net.Analysis.TokenAttributes
             return this;
         }
 
-        public CharTermAttribute Append(CharBuffer value)
-        {
-            if (value is null)
-            {
-                return this; // No-op
-            }
-
-            return Append(value, 0, value.Length);
-        }
-
-        public CharTermAttribute Append(CharBuffer value, int startIndex, int charCount)
-        {
-            if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"{nameof(startIndex)} must not be negative.");
-            if (charCount < 0)
-                throw new ArgumentOutOfRangeException(nameof(charCount), $"{nameof(charCount)} must not be negative.");
-
-            if (value is null)
-            {
-                if (startIndex == 0 && charCount == 0)
-                    return this;
-                throw new ArgumentNullException(nameof(value));
-            }
-            if (charCount == 0)
-                return this;
-            if (startIndex > value.Length - charCount)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(charCount)} <= {nameof(Length)}.");
-
-            int end = startIndex + charCount;
-            for (int i = startIndex; i < end; i++)
-            {
-                Append(value[i]);
-            }
-
-            return this;
-        }
-
         public CharTermAttribute Append(ICharTermAttribute value)
         {
             if (value is null) // needed for Appendable compliance

--- a/src/Lucene.Net/Analysis/package.md
+++ b/src/Lucene.Net/Analysis/package.md
@@ -398,10 +398,7 @@ public override TokenStream GetTokenStream(string fieldName, Reader reader)
   <tr>
     <td><xref:Lucene.Net.Analysis.TokenAttributes.ICharTermAttribute></td>
     <td>
-      The term text of a token.  Implements J2N.Text.ICharSequence
-      (providing properties Length and this[int], and allowing e.g. for direct
-      use with J2N.Text.IAppendable (allowing the term text to be appended to.)
-      In .NET, we can only use this indirectly with the [Regex](https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex) class by first calling ToString() and then passing the string to the Regex.
+      The term text of a token.
     </td>
   </tr>
   <tr>

--- a/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
+++ b/src/Lucene.Net/Util/Automaton/DaciukMihovAutomatonBuilder.cs
@@ -246,11 +246,12 @@ namespace Lucene.Net.Util.Automaton
             // Descend in the automaton (find matching prefix).
             int pos = 0, max = current.Length;
             State next, state = root;
-            while (pos < max && (next = state.LastChild(Character.CodePointAt(current, pos))) != null)
+            ReadOnlySpan<char> currentSpan = current.AsSpan();
+            while (pos < max && (next = state.LastChild(currentSpan.CodePointAt(pos))) != null)
             {
                 state = next;
                 // todo, optimize me
-                pos += Character.CharCount(Character.CodePointAt(current, pos));
+                pos += Character.CharCount(currentSpan.CodePointAt(pos));
             }
 
             if (state.HasChildren)
@@ -258,7 +259,7 @@ namespace Lucene.Net.Util.Automaton
                 ReplaceOrRegister(state);
             }
 
-            AddSuffix(state, current, pos);
+            AddSuffix(state, currentSpan, pos);
         }
 
         /// <summary>
@@ -373,12 +374,12 @@ namespace Lucene.Net.Util.Automaton
         /// (inclusive) to state <paramref name="state"/>.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void AddSuffix(State state, ICharSequence current, int fromIndex) // LUCENENET: CA1822: Mark members as static
+        private static void AddSuffix(State state, ReadOnlySpan<char> current, int fromIndex) // LUCENENET: CA1822: Mark members as static
         {
             int len = current.Length;
             while (fromIndex < len)
             {
-                int cp = Character.CodePointAt(current, fromIndex);
+                int cp = current.CodePointAt(fromIndex);
                 state = state.NewState(cp);
                 fromIndex += Character.CharCount(cp);
             }

--- a/src/Lucene.Net/Util/BytesRef.cs
+++ b/src/Lucene.Net/Util/BytesRef.cs
@@ -1,4 +1,3 @@
-using J2N.Text;
 using Lucene.Net.Diagnostics;
 using Lucene.Net.Support;
 using System;
@@ -6,9 +5,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 using WritableArrayAttribute = Lucene.Net.Support.WritableArrayAttribute;
+#if FEATURE_MEMORYMARSHAL_CREATEREADONLYSPAN && FEATURE_MEMORYMARSHAL_GETARRAYDATAREFERENCE
+using System.Runtime.InteropServices;
+#endif
 
 namespace Lucene.Net.Util
 {
@@ -128,18 +129,6 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// Initialize the <see cref="T:byte[]"/> from the UTF8 bytes
-        /// for the provided <see cref="ICharSequence"/>.
-        /// </summary>
-        /// <param name="text"> This must be well-formed
-        /// unicode text, with no unpaired surrogates. </param>
-        public BytesRef(ICharSequence text)
-            : this()
-        {
-            CopyChars(text);
-        }
-
-        /// <summary>
-        /// Initialize the <see cref="T:byte[]"/> from the UTF8 bytes
         /// for the provided <see cref="ReadOnlySpan{Char}"/>.
         /// </summary>
         /// <param name="text"> This must be well-formed
@@ -160,18 +149,6 @@ namespace Lucene.Net.Util
             : this()
         {
             CopyChars(text);
-        }
-
-        /// <summary>
-        /// Copies the UTF8 bytes for this <see cref="ICharSequence"/>.
-        /// </summary>
-        /// <param name="text"> Must be well-formed unicode text, with no
-        /// unpaired surrogates or invalid UTF16 code units. </param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyChars(ICharSequence text)
-        {
-            if (Debugging.AssertsEnabled) Debugging.Assert(Offset == 0); // TODO broken if offset != 0
-            UnicodeUtil.UTF16toUTF8(text, 0, text.Length, this);
         }
 
         /// <summary>

--- a/src/Lucene.Net/Util/CharsRef.cs
+++ b/src/Lucene.Net/Util/CharsRef.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using WritableArrayAttribute = Lucene.Net.Support.WritableArrayAttribute;
+#if FEATURE_MEMORYMARSHAL_CREATEREADONLYSPAN && FEATURE_MEMORYMARSHAL_GETARRAYDATAREFERENCE
+using System.Runtime.InteropServices;
+#endif
 
 namespace Lucene.Net.Util
 {
@@ -38,7 +40,7 @@ namespace Lucene.Net.Util
     [Serializable]
 #endif
     // LUCENENET specific: Not implementing ICloneable per Microsoft's recommendation
-    public sealed class CharsRef : IComparable<CharsRef>, ICharSequence, IEquatable<CharsRef> // LUCENENET specific - implemented IEquatable<CharsRef>
+    public sealed class CharsRef : IComparable<CharsRef>, IEquatable<CharsRef> // LUCENENET specific - implemented IEquatable<CharsRef>
     {
         /// <summary>
         /// An empty character array for convenience </summary>
@@ -46,8 +48,6 @@ namespace Lucene.Net.Util
         [SuppressMessage("Performance", "S3887:Use an immutable collection or reduce the accessibility of the non-private readonly field", Justification = "Collection is immutable")]
         [SuppressMessage("Performance", "S2386:Use an immutable collection or reduce the accessibility of the public static field", Justification = "Collection is immutable")]
         public static readonly char[] EMPTY_CHARS = Array.Empty<char>();
-
-        bool ICharSequence.HasValue => true;
 
         /// <summary>
         /// The contents of the <see cref="CharsRef"/>. Should never be <c>null</c>.
@@ -343,26 +343,6 @@ namespace Lucene.Net.Util
                 }
                 return chars[Offset + index];
             }
-        }
-
-        public ICharSequence Subsequence(int startIndex, int length)
-        {
-            // NOTE: must do a real check here to meet the specs of CharSequence
-            //if (start < 0 || end > Length || start > end)
-            //{
-            //    throw new IndexOutOfRangeException();
-            //}
-
-            // LUCENENET specific - changed semantics from start/end to startIndex/length to match .NET
-            // From Apache Harmony String class
-            if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex));
-            if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length));
-            if (startIndex > Length - length) // LUCENENET: Checks for int overflow
-                throw new ArgumentOutOfRangeException(nameof(length), $"Index and length must refer to a location within the string. For example {nameof(startIndex)} + {nameof(length)} <= {nameof(Length)}.");
-
-            return new CharsRef(chars, Offset + startIndex, length);
         }
 
         /// @deprecated this comparer is only a transition mechanism

--- a/src/Lucene.Net/Util/Fst/Util.cs
+++ b/src/Lucene.Net/Util/Fst/Util.cs
@@ -969,7 +969,7 @@ namespace Lucene.Net.Util.Fst
         /// Just maps each UTF16 unit (char) to the <see cref="int"/>s in an
         /// <see cref="Int32sRef"/>.
         /// </summary>
-        public static Int32sRef ToUTF16(string s, Int32sRef scratch)
+        public static Int32sRef ToUTF16(ReadOnlySpan<char> s, Int32sRef scratch)
         {
             int charLimit = s.Length;
             scratch.Offset = 0;
@@ -984,10 +984,10 @@ namespace Lucene.Net.Util.Fst
 
         /// <summary>
         /// Decodes the Unicode codepoints from the provided
-        /// <see cref="ICharSequence"/> and places them in the provided scratch
+        /// <see cref="ReadOnlySpan{T}"/> and places them in the provided scratch
         /// <see cref="Int32sRef"/>, which must not be <c>null</c>, returning it.
         /// </summary>
-        public static Int32sRef ToUTF32(string s, Int32sRef scratch)
+        public static Int32sRef ToUTF32(ReadOnlySpan<char> s, Int32sRef scratch)
         {
             int charIdx = 0;
             int intIdx = 0;
@@ -996,28 +996,6 @@ namespace Lucene.Net.Util.Fst
             {
                 scratch.Grow(intIdx + 1);
                 int utf32 = Character.CodePointAt(s, charIdx);
-                scratch.Int32s[intIdx] = utf32;
-                charIdx += Character.CharCount(utf32);
-                intIdx++;
-            }
-            scratch.Length = intIdx;
-            return scratch;
-        }
-
-        /// <summary>
-        /// Decodes the Unicode codepoints from the provided
-        /// <see cref="T:char[]"/> and places them in the provided scratch
-        /// <see cref="Int32sRef"/>, which must not be <c>null</c>, returning it.
-        /// </summary>
-        public static Int32sRef ToUTF32(char[] s, int offset, int length, Int32sRef scratch)
-        {
-            int charIdx = offset;
-            int intIdx = 0;
-            int charLimit = offset + length;
-            while (charIdx < charLimit)
-            {
-                scratch.Grow(intIdx + 1);
-                int utf32 = Character.CodePointAt(s, charIdx, charLimit);
                 scratch.Int32s[intIdx] = utf32;
                 charIdx += Character.CharCount(utf32);
                 intIdx++;

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -308,96 +308,6 @@ namespace Lucene.Net.Util
         }
 
         /// <summary>
-        /// Encode characters from this <see cref="ICharSequence"/>, starting at <paramref name="offset"/>
-        /// for <paramref name="length"/> characters. After encoding, <c>result.Offset</c> will always be 0.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="result"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="offset"/> or <paramref name="length"/> is less than zero.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="offset"/> and <paramref name="length"/> refer to a location outside of <paramref name="source"/>.
-        /// </exception>
-        // TODO: broken if incoming result.offset != 0
-        public static void UTF16toUTF8(ICharSequence source, int offset, int length, BytesRef result)
-        {
-            // LUCENENET: Added guard clauses
-            if (source is null)
-                throw new ArgumentNullException(nameof(source));
-            if (result is null)
-                throw new ArgumentNullException(nameof(result));
-            if (offset < 0)
-                throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(offset)} must not be negative.");
-            if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length), $"{nameof(length)} must not be negative.");
-            if (offset > source.Length - length) // Checks for int overflow
-                throw new ArgumentOutOfRangeException(nameof(length),
-                    $"Index and length must refer to a location within the string. For example {nameof(offset)} + {nameof(length)} <= source.{nameof(source.Length)}.");
-
-            int end = offset + length;
-
-            var @out = result.Bytes;
-            result.Offset = 0;
-            // Pre-allocate for worst case 4-for-1
-            int maxLen = length * 4;
-            if (@out.Length < maxLen)
-            {
-                @out = result.Bytes = new byte[maxLen];
-            }
-
-            int upto = 0;
-            for (int i = offset; i < end; i++)
-            {
-                var code = (int)source[i];
-                if (code < 0x80)
-                {
-                    @out[upto++] = (byte)code;
-                }
-                else if (code < 0x800)
-                {
-                    @out[upto++] = (byte)(0xC0 | (code >> 6));
-                    @out[upto++] = (byte)(0x80 | (code & 0x3F));
-                }
-                else if (code < 0xD800 || code > 0xDFFF)
-                {
-                    @out[upto++] = (byte)(0xE0 | (code >> 12));
-                    @out[upto++] = (byte)(0x80 | ((code >> 6) & 0x3F));
-                    @out[upto++] = (byte)(0x80 | (code & 0x3F));
-                }
-                else
-                {
-                    // surrogate pair
-                    // confirm valid high surrogate
-                    if (code < 0xDC00 && (i < end - 1))
-                    {
-                        int utf32 = (int)source[i + 1];
-                        // confirm valid low surrogate and write pair
-                        if (utf32 >= 0xDC00 && utf32 <= 0xDFFF)
-                        {
-                            utf32 = (code << 10) + utf32 + SURROGATE_OFFSET;
-                            i++;
-                            @out[upto++] = (byte)(0xF0 | (utf32 >> 18));
-                            @out[upto++] = (byte)(0x80 | ((utf32 >> 12) & 0x3F));
-                            @out[upto++] = (byte)(0x80 | ((utf32 >> 6) & 0x3F));
-                            @out[upto++] = (byte)(0x80 | (utf32 & 0x3F));
-                            continue;
-                        }
-                    }
-
-                    // replace unpaired surrogate or out-of-order low surrogate
-                    // with substitution character
-                    @out[upto++] = 0xEF;
-                    @out[upto++] = 0xBF;
-                    @out[upto++] = 0xBD;
-                }
-            }
-
-            //assert matches(s, offset, length, out, upto);
-            result.Length = upto;
-        }
-
-        /// <summary>
         /// Encode characters from this <see cref="string"/>, starting at <paramref name="offset"/>
         /// for <paramref name="length"/> characters. After encoding, <c>result.Offset</c> will always be 0.
         /// <para/>
@@ -545,45 +455,7 @@ namespace Lucene.Net.Util
         }
         */
 
-        public static bool ValidUTF16String(ICharSequence s)
-        {
-            int size = s.Length;
-            for (int i = 0; i < size; i++)
-            {
-                char ch = s[i];
-                if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END)
-                {
-                    if (i < size - 1)
-                    {
-                        i++;
-                        char nextCH = s[i];
-                        if (nextCH >= UNI_SUR_LOW_START && nextCH <= UNI_SUR_LOW_END)
-                        {
-                            // Valid surrogate pair
-                        }
-                        else
-                        {
-                            // Unmatched high surrogate
-                            return false;
-                        }
-                    }
-                    else
-                    {
-                        // Unmatched high surrogate
-                        return false;
-                    }
-                }
-                else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END)
-                {
-                    // Unmatched low surrogate
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        // LUCENENET specific overload because ReadOnlySpan<char> doesn't implement ICharSequence
+        // LUCENENET specific overload
         public static bool ValidUTF16String(ReadOnlySpan<char> s)
         {
             int size = s.Length;
@@ -622,7 +494,7 @@ namespace Lucene.Net.Util
             return true;
         }
 
-        // LUCENENET specific overload because StringBuilder doesn't implement ICharSequence
+        // LUCENENET specific overload
         public static bool ValidUTF16String(StringBuilder s)
         {
             int size = s.Length;

--- a/src/Lucene.Net/Util/UnicodeUtil.cs
+++ b/src/Lucene.Net/Util/UnicodeUtil.cs
@@ -583,8 +583,8 @@ namespace Lucene.Net.Util
             return true;
         }
 
-        // LUCENENET specific overload because string doesn't implement ICharSequence
-        public static bool ValidUTF16String(string s)
+        // LUCENENET specific overload because ReadOnlySpan<char> doesn't implement ICharSequence
+        public static bool ValidUTF16String(ReadOnlySpan<char> s)
         {
             int size = s.Length;
             for (int i = 0; i < size; i++)


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Removal of ICharSequence from most places.

Fixes #1337

## Description

ICharSequence is not necessary in the era of `ReadOnlySpan<char>`. This sweep removes most references to it, leaving only those for IAppendable support (falling back to a more-expensive ToString operation, to be removed in #1338) and in the query node types (that have custom implementations that should be done separately. Where possible, it was replaced with ReadOnlySpan<char>. Some tests had to be adapted with AsSpan/Slice to mimic the prior behavior.

This is a breaking change because of the removal of overloads that can affect non-modern-.NET/C#14 users.