### PR TITLE
Added `SpanTools.ValueStringBuilder.Generator` Reference

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -70,6 +70,7 @@
     <NUnitPackageVersion>3.14.0</NUnitPackageVersion>
     <RandomizedTestingGeneratorsPackageVersion>2.7.8</RandomizedTestingGeneratorsPackageVersion>
     <SharpZipLibPackageVersion>1.4.2</SharpZipLibPackageVersion>
+    <SpanToolsValueStringBuilderGeneratorPackageVersion>1.0.0-alpha.113</SpanToolsValueStringBuilderGeneratorPackageVersion>
     <Spatial4nPackageVersion>0.4.1.1</Spatial4nPackageVersion>
     <SystemMemoryPackageVersion>4.6.3</SystemMemoryPackageVersion>
     <SystemNetHttpPackageVersion>4.3.4</SystemNetHttpPackageVersion>

--- a/src/Lucene.Net.Tests/Support/Text/TestValueStringBuilder.cs
+++ b/src/Lucene.Net.Tests/Support/Text/TestValueStringBuilder.cs
@@ -1,0 +1,108 @@
+using J2N.Globalization;
+using Lucene.Net.Attributes;
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System;
+using Assert = Lucene.Net.TestFramework.Assert;
+
+namespace Lucene.Net.Text
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Smoke tests for <see cref="ValueStringBuilder"/> to ensure it has been generated with
+    /// the configured values. More thorough tests are performed in SpanTools
+    /// <a href="https://www.nuget.org/packages/SpanTools.ValueStringBuilder.Generator">
+    /// https://www.nuget.org/packages/SpanTools.ValueStringBuilder.Generator</a>
+    /// </summary>
+    [TestFixture, LuceneNetSpecific]
+    public class TestValueStringBuilder : LuceneTestCase
+    {
+        [Test]
+        public void TestJavaStyleLastIndexOf()
+        {
+            using ValueStringBuilder sb = new(stackalloc char[8]);
+            sb.Append("aaaaa");
+            Assert.AreEqual(2, sb.LastIndexOf("aa", 2));
+        }
+
+        [Test]
+        public void TestJavaStyleFormatting()
+        {
+            using CultureContext context = new("pt");
+            using ValueStringBuilder sb = new(stackalloc char[8]);
+            sb.Append(123d);
+            Assert.AreEqual("123.0", sb.ToString());
+        }
+
+        // Tests MaxLength tracking
+        [Test]
+        public void TestFitsIntialBuffer_BeyondInitialBuffer_ReturnsMaxLength()
+        {
+            using ValueStringBuilder sb = new(stackalloc char[8]);
+            sb.Append("Hello");
+            sb.Append("World");
+            Assert.IsFalse(sb.FitsInitialBuffer(out int charsLength));
+            Assert.AreEqual(10, charsLength);
+        }
+
+        [Test]
+        public void TestFitsIntialBuffer_WithinInitialBuffer_ReturnsLength()
+        {
+            using ValueStringBuilder sb = new(stackalloc char[8]);
+            sb.Append("Hello");
+            sb.Append("W");
+            Assert.IsTrue(sb.FitsInitialBuffer(out int charsLength));
+            Assert.AreEqual(6, charsLength);
+            Assert.AreEqual(6, sb.Length);
+        }
+
+        [Test]
+        public void TestAsMemory()
+        {
+            using ValueStringBuilder sb = new(8);
+            sb.Append("Hello");
+            ReadOnlyMemory<char> memory = sb.AsMemory();
+            sb.Append("World");
+            Assert.AreNotEqual("HelloWorld", memory.Span.ToString()); // This is guaranteed not to be the same memory as otherMemory
+            ReadOnlyMemory<char> otherMemory = sb.AsMemory();
+            Assert.AreEqual("HelloWorld", otherMemory.Span.ToString());
+        }
+
+        [Test]
+        public void TestPreload()
+        {
+            Span<char> destination = stackalloc char[10];
+            "Hello".AsSpan().CopyTo(destination);
+            ValueStringBuilder sb = new(destination);
+            try
+            {
+                sb.Length = 5; // "Consume" the preloaded value
+                sb.Append("World");
+                Assert.AreEqual("HelloWorld", sb.ToString());
+                Assert.IsTrue(sb.FitsInitialBuffer(out int charsLength));
+                Assert.AreEqual(10, charsLength);
+                Assert.AreEqual(10, sb.Length);
+            }
+            finally
+            {
+                sb.Dispose(); // Technically not required; best practice to call this
+            }
+        }
+    }
+}

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -36,7 +36,14 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-
+  <PropertyGroup Label="SpanTools.ValueStringBuilder.Generator Settings">
+    <ValueStringBuilder_Namespace>Lucene.Net.Text</ValueStringBuilder_Namespace>
+    <ValueStringBuilder_IncludeMaxLengthTracking>true</ValueStringBuilder_IncludeMaxLengthTracking>
+    <ValueStringBuilder_IncludeAsMemoryMethods>true</ValueStringBuilder_IncludeAsMemoryMethods>
+    <ValueStringBuilder_IncludeCodepointSupport>true</ValueStringBuilder_IncludeCodepointSupport>
+    <ValueStringBuilder_UseJavaStyleFormatting>true</ValueStringBuilder_UseJavaStyleFormatting>
+    <ValueStringBuilder_UseJavaStyleIndexOf>true</ValueStringBuilder_UseJavaStyleIndexOf>
+  </PropertyGroup>
 
   <PropertyGroup Label="NuGet Package File Paths">
     <LuceneNetDotNetDir>$(SolutionDir)src\dotnet\</LuceneNetDotNetDir>
@@ -56,6 +63,7 @@
   <ItemGroup>
     <PackageReference Include="J2N" Version="$(J2NPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
+    <PackageReference Include="SpanTools.ValueStringBuilder.Generator" Version="$(SpanToolsValueStringBuilderGeneratorPackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Added `SpanTools.ValueStringBuilder.Generator` Reference

## Description

This adds a private dependency on `SpanTools.ValueStringBuilder.Generator` which provides a `ValueStringBuilder` ref struct in the `Lucene.Net.Text` namespace. This class is generated using an `IIncrementalGenerator` in the build pipeline.

A few smoke tests were added to verify the configured options are enabled, but most of the tests for `ValueStringBuilder` exist in the `SpanTools` repository. Currently, the test coverage isn't very thorough. This prerelease was rushed to be available while removing/replacing `ICharSequence` is still a task we are working on.

The configured options are:

- **ValueStringBuilder_Namespace**=Lucene.Net.Text
- **ValueStringBuilder_IncludeMaxLengthTracking**=true
- **ValueStringBuilder_IncludeAsMemoryMethods**=true
- **ValueStringBuilder_IncludeCodepointSupport**=true
- **ValueStringBuilder_UseJavaStyleFormatting**=true
- **ValueStringBuilder_UseJavaStyleIndexOf**=true

The `ValueStringBuilder` exists in the `Lucene.Net` assembly and is internal. To use it in other assemblies, be sure that the `InternalsVisibleTo` attribute is applied to the project that uses it.

`ValueStringBuilder` is generally a better option as a destination than `System.Text.StringBuilder` since when tuned correctly, the vast majority of its operations occur on the stack. It falls back to using the shared array pool, which also avoids GC operations that would occur when using class-based string builders.