### PR TITLE
`Lucene-Net-Website.yml`: Don't persist checkout credentials on PR branch

### DIFF
--- a/.github/workflows/Lucene-Net-Website.yml
+++ b/.github/workflows/Lucene-Net-Website.yml
@@ -122,6 +122,7 @@ jobs:
           repository: ${{ env.SITE_REPO }}
           ref: asf-site
           path: website-repo
+          persist-credentials: false
 
       - name: Copy website files
         run: Get-ChildItem -Path "$Env:GITHUB_WORKSPACE\main-repo\websites\site\_site" | Copy-Item -Destination "$Env:GITHUB_WORKSPACE\website-repo" -Recurse -Force


### PR DESCRIPTION
…hen checking out PR branch

<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

`Lucene-Net-Website.yml`: Don't persist checkout credentials on PR branch

## Description

This is among a series of issues yet to be fixed in the website build automation. This is an attempt to get the `create-pull-request` task to work. It is failing due to duplicate authorization headers and per ChatGPT, not persisting the credentials from checking out the branch is probably a fix.
