### PR TITLE
Website: 4.8.0 beta00018 release updates

### DIFF
--- a/websites/site/contributing/documentation.md
+++ b/websites/site/contributing/documentation.md
@@ -41,17 +41,24 @@ This ensures the website is always synched with the `master` branch and PRs that
 
 ### Build script
 
+#### Local Build and Host
+
 To build the website and run it on your machine, run the PowerShell script: `./websites/site/site.ps1` with the `-ServeDocs` flag. For example:
 
-```
+```console
 ./websites/site/site.ps1 -ServeDocs
 ```
 
 When executed this will build the site and host it at [http://localhost:8081](http://localhost:8081).
 
+#### Release Build
+
+> [!IMPORTANT]
+> The following steps are automated in the `Lucene-Net-Website.yml` workflow. This workflow runs automatically when a PR or branch that contains website changes is merged/pushed to the `master` branch. The workflow submits a new PR with the compiled website content to the `lucenenet-site` repository. The below information is provided in case the automation fails and the release needs to be done manually.
+
 To build the website for release, run the script:
 
-```
+```console
 ./websites/site/site.ps1
 ```
 
@@ -137,17 +144,25 @@ publish docs site
 
 ### Build script
 
+#### Local Build and Host
+
 To build the api docs and run it on your machine, run the PowerShell script: `./websites/apidocs/docs.ps1`. For example:
 
-```
+```console
 ./websites/apidocs/docs.ps1 -ServeDocs -LuceneNetVersion 4.8.0-beta00008 -BaseUrl http://localhost:8080
 ```
 
 When executed this will build the site and host it at [http://localhost:8080](http://localhost:8080). _(Ensure to pass in the current version of Lucene.Net you are building.)_
 
+#### Release Build
+
+> [!IMPORTANT]
+> The following steps are automated in the `Lucene-Net-Documentation.yml` workflow. This workflow runs automatically when changes are pushed to the corresponding `docs/[Version]` branch. The workflow submits a new PR with the compiled API documentation content to the `lucenenet-site` repository. The below information is provided in case the automation fails and the release needs to be done manually.
+
+
 To build the api docs for release, run the script:
 
-```
+```console
 ./websites/apidocs/docs.ps1 -LuceneNetVersion 4.8.0-beta00008
 ```
 
@@ -156,13 +171,13 @@ This will build the site with all live parameters configured correctly and outpu
 The script parameters are:
 
 - `-LuceneNetVersion` _(mandatory)_ This is the Lucene.Net version including pre-release information that is being built. For example: `4.8.0-beta00008`. _(This value will correspond to the folder and branch name where the docs get hosted, see below)_
-* `-ServeDocs` _(optional)_ A boolean switch. If present, it will build the docs and host the site. If not present it will build the static site to be hosted elsewhere.
-* `-Clean` _(optional)_ A boolean switch.  If present, it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occurring with the incremental build.
-* `-DisableMetaData` _(optional)_ A boolean switch. If present it will disable the docfx metadata build operation of the docs build. Can be handy when debugging the docs build.
-* `-DisableBuild` _(optional)_ A boolean switch. If present it will disable the site building operation of the docs build. Can be handy when debugging the docs build.
-* `-DisablePlugins` _(optional)_ A boolean switch. If present it will not build the custom Lucene.Net `DocumentationTools.sln` docsfx plugins and exclude them from the build.
-* `-LogLevel` _(optional)_ Default is Warning. Options are: Diagnostic, Verbose, Info, Warning, Error.
-* `-BaseUrl` _(optional)_ Default is https://lucenenet.apache.org/docs/. Used to set the base URL of the docfx xref map files for cross linking between project builds.
+- `-ServeDocs` _(optional)_ A boolean switch. If present, it will build the docs and host the site. If not present it will build the static site to be hosted elsewhere.
+- `-Clean` _(optional)_ A boolean switch.  If present, it will clear all caches and tool files before it builds again. This is handy if a new version of docfx is available or if there's odd things occurring with the incremental build.
+- `-DisableMetaData` _(optional)_ A boolean switch. If present it will disable the docfx metadata build operation of the docs build. Can be handy when debugging the docs build.
+- `-DisableBuild` _(optional)_ A boolean switch. If present it will disable the site building operation of the docs build. Can be handy when debugging the docs build.
+- `-DisablePlugins` _(optional)_ A boolean switch. If present it will not build the custom Lucene.Net `DocumentationTools.sln` docsfx plugins and exclude them from the build.
+- `-LogLevel` _(optional)_ Default is Warning. Options are: Diagnostic, Verbose, Info, Warning, Error.
+- `-BaseUrl` _(optional)_ Default is https://lucenenet.apache.org/docs/. Used to set the base URL of the docfx xref map files for cross linking between project builds.
 
 ### File/folder structure
 
@@ -194,12 +209,12 @@ To use the dotnet tool you must download the current tag of the Java Lucene proj
 
 Then install the tool:
 
-```
+```console
 dotnet tool install javadoc2markdown --add-source https://pkgs.dev.azure.com/lucene-net/_packaging/lucene-net-tools/nuget/v3/index.json --tool-path ./
 ```
 
 Then run the command:
-```
+```console
 javadoc2markdown <LUCENE DIRECTORY> <LUCENENET DIRECTORY>
 ```
 

--- a/websites/site/docfx.json
+++ b/websites/site/docfx.json
@@ -42,7 +42,7 @@
       "_appFaviconPath": "logo/favicon.ico",
       "_enableSearch": false,
       "_appLogoPath": "logo/lucene-net-color.png",
-      "_appFooter": "Copyright &copy; 2025 The Apache Software Foundation, Licensed under the <a href='https://www.apache.org/licenses/' target='_blank'>Apache License, Version 2.0</a><br/> <small>Apache Lucene.Net, Lucene.Net, Apache, the Apache logo, and the Apache Lucene.Net project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</small>",
+      "_appFooter": "Copyright &copy; 2026 The Apache Software Foundation, Licensed under the <a href='https://www.apache.org/licenses/' target='_blank'>Apache License, Version 2.0</a><br/> <small>Apache Lucene.Net, Lucene.Net, Apache, the Apache logo, and the Apache Lucene.Net project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</small>",
       "_gitContribute": {
         "repo": "https://github.com/apache/lucenenet",
         "branch": "master"

--- a/websites/site/docs.md
+++ b/websites/site/docs.md
@@ -11,6 +11,7 @@ _disableBreadcrumb: true
 
 The API docs are slightly different between versions, each one is listed below:
 
+- [4.8.0-beta00018](https://lucenenet.apache.org/docs/4.8.0-beta00018/)
 - [4.8.0-beta00017](https://lucenenet.apache.org/docs/4.8.0-beta00017/)
 - [4.8.0-beta00016](https://lucenenet.apache.org/docs/4.8.0-beta00016/)
 - [4.8.0-beta00015](https://lucenenet.apache.org/docs/4.8.0-beta00015/)

--- a/websites/site/download/download.md
+++ b/websites/site/download/download.md
@@ -6,6 +6,12 @@ uid: download
 
 ---
 
+## [Lucene 4.8.0-beta00018](xref:download/4.8.0-beta00018)
+
+_Status:_ **`Beta`**
+
+_Released:_ `2026-06-22`
+
 ## [Lucene 4.8.0-beta00017](xref:download/4.8.0-beta00017)
 
 _Status:_ **`Beta`**

--- a/websites/site/download/toc.yml
+++ b/websites/site/download/toc.yml
@@ -1,3 +1,5 @@
+- name: Version 4.8.0-beta00018
+  href: version-4.8.0-beta00018.md
 - name: Version 4.8.0-beta00017
   href: version-4.8.0-beta00017.md
 - name: Version 4.8.0-beta00016

--- a/websites/site/download/version-4.8.0-beta00018.md
+++ b/websites/site/download/version-4.8.0-beta00018.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: download/4.8.0-beta00018
 version: 4.8.0-beta00018
 ---

--- a/websites/site/download/version-4.8.0-beta00018.md
+++ b/websites/site/download/version-4.8.0-beta00018.md
@@ -1,0 +1,69 @@
+﻿---
+uid: download/4.8.0-beta00018
+version: 4.8.0-beta00018
+---
+
+# Download Lucene.Net 4.8.0-beta00018
+
+---
+
+## Lucene 4.8.0-beta00018
+
+_Status:_ **`Beta`**
+
+_Released:_ `2026-06-22`
+
+- Binary release: **[Lucene.Net-4.8.0-beta00018.bin.zip](https://www.apache.org/dyn/closer.lua/lucenenet/4.8.0-beta00018/Apache-Lucene.Net-4.8.0-beta00018.bin.zip)** [[PGP](https://downloads.apache.org/lucenenet/4.8.0-beta00018/Apache-Lucene.Net-4.8.0-beta00018.bin.zip.asc)] [[SHA512](https://downloads.apache.org/lucenenet/4.8.0-beta00018/Apache-Lucene.Net-4.8.0-beta00018.bin.zip.sha512)]
+- Source release: **[Lucene.Net-4.8.0-beta00018.src.zip](https://www.apache.org/dyn/closer.lua/lucenenet/4.8.0-beta00018/Apache-Lucene.Net-4.8.0-beta00018.src.zip)** [[PGP](https://downloads.apache.org/lucenenet/4.8.0-beta00018/Apache-Lucene.Net-4.8.0-beta00018.src.zip.asc)] [[SHA512](https://downloads.apache.org/lucenenet/4.8.0-beta00018/Apache-Lucene.Net-4.8.0-beta00018.src.zip.sha512)]
+- [Change log](https://github.com/apache/lucenenet/releases/tag/Lucene.Net_4_8_0_beta00018)
+
+<div class="nuget-well" style="text-align:left;">
+    PM> Install-Package Lucene.Net -Version 4.8.0-beta00018
+</div>
+
+### Source code
+
+- [Git Repository](https://github.com/apache/lucenenet)
+
+### Supported Frameworks
+
+- .NET 8.0
+- .NET 6.0
+- [.NET Standard 2.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard)
+- [.NET Standard 2.0](https://docs.microsoft.com/en-us/dotnet/standard/net-standard)
+- .NET Framework 4.6.2
+
+### Remaining work
+
+See **[Current Status](xref:contributing/current-status)** for more details on the remaining work
+
+This version is a direct port of the Java Lucene project at [this release](https://github.com/apache/lucene-solr/releases/tag/releases%2Flucene-solr%2F4.8.0)
+
+### All Packages
+
+- [Lucene.Net](https://www.nuget.org/packages/Lucene.Net/) - Core library
+- [Lucene.Net.Analysis.Common](https://www.nuget.org/packages/Lucene.Net.Analysis.Common/) - Analyzers for indexing content in different languages and domains
+- [Lucene.Net.Analysis.Kuromoji](https://www.nuget.org/packages/Lucene.Net.Analysis.Kuromoji/) - Japanese Morphological Analyzer
+- [Lucene.Net.Analysis.Morfologik](https://www.nuget.org/packages/Lucene.Net.Analysis.Morfologik/) - Analyzer for dictionary stemming, built-in Polish dictionary
+- [Lucene.Net.Analysis.OpenNLP](https://www.nuget.org/packages/Lucene.Net.Analysis.OpenNLP/) - OpenNLP Library Integration
+- [Lucene.Net.Analysis.Phonetic](https://www.nuget.org/packages/Lucene.Net.Analysis.Phonetic/) - Analyzer for indexing phonetic signatures (for sounds-alike search)
+- [Lucene.Net.Analysis.SmartCn](https://www.nuget.org/packages/Lucene.Net.Analysis.SmartCn/) - Analyzer for indexing Chinese
+- [Lucene.Net.Analysis.Stempel](https://www.nuget.org/packages/Lucene.Net.Analysis.Stempel/) - Analyzer for indexing Polish
+- [Lucene.Net.Benchmark](https://www.nuget.org/packages/Lucene.Net.Benchmark/) - System for benchmarking Lucene
+- [Lucene.Net.Classification](https://www.nuget.org/packages/Lucene.Net.Classification/) - Classification module for Lucene
+- [Lucene.Net.Codecs](https://www.nuget.org/packages/Lucene.Net.Codecs/) - Lucene codecs and postings formats
+- [Lucene.Net.Expressions](https://www.nuget.org/packages/Lucene.Net.Expressions/) - Dynamically computed values to sort/facet/search on based on a pluggable grammar
+- [Lucene.Net.Facet](https://www.nuget.org/packages/Lucene.Net.Facet/) - Faceted indexing and search capabilities
+- [Lucene.Net.Grouping](https://www.nuget.org/packages/Lucene.Net.Grouping/) - Collectors for grouping search results
+- [Lucene.Net.Highlighter](https://www.nuget.org/packages/Lucene.Net.Highlighter/) - Highlights search keywords in results
+- [Lucene.Net.ICU](https://www.nuget.org/packages/Lucene.Net.ICU/) - Specialized ICU (International Components for Unicode) Analyzers and Highlighters
+- [Lucene.Net.Join](https://www.nuget.org/packages/Lucene.Net.Join/) - Index-time and Query-time joins for normalized content
+- [Lucene.Net.Memory](https://www.nuget.org/packages/Lucene.Net.Memory/) - Single-document in-memory index implementation
+- [Lucene.Net.Misc](https://www.nuget.org/packages/Lucene.Net.Misc/) - Index tools and other miscellaneous code
+- [Lucene.Net.Queries](https://www.nuget.org/packages/Lucene.Net.Queries/) - Filters and Queries that add to core Lucene
+- [Lucene.Net.QueryParser](https://www.nuget.org/packages/Lucene.Net.QueryParser/) - Text to Query parsers and parsing framework
+- [Lucene.Net.Replicator](https://www.nuget.org/packages/Lucene.Net.Replicator/) Files replication utility
+- [Lucene.Net.Sandbox](https://www.nuget.org/packages/Lucene.Net.Sandbox/) - Various third party contributions and new ideas
+- [Lucene.Net.Spatial](https://www.nuget.org/packages/Lucene.Net.Spatial/) - Geospatial search
+- [Lucene.Net.Suggest](https://www.nuget.org/packages/Lucene.Net.Suggest/) - Auto-suggest and Spellchecking support
+- [Lucene.Net.TestFramework](https://www.nuget.org/packages/Lucene.Net.TestFramework/) - Framework for testing Lucene-based applications

--- a/websites/site/lucenetemplate/.htaccess
+++ b/websites/site/lucenetemplate/.htaccess
@@ -32,7 +32,7 @@
 # version, with [R=301] signaling permanent redirects and [L] preventing further
 # rule processing.
 #
-# Note: This file is line ending and BOM sensitive. It MUST use LF line endings and 
+# Note: This file is line ending and BOM sensitive. It MUST use LF line endings and
 # MUST NOT have a BOM.
 
 
@@ -41,5 +41,5 @@ RewriteEngine On
 # Redirect /docs/latest/ to /docs/3.0.3/
 RewriteRule ^docs/latest/(.*)$ /docs/3.0.3/$1 [R=301,L]
 
-# Redirect /docs/absolute-latest/ to /docs/4.8.0-beta00017/
-RewriteRule ^docs/absolute(?:-latest|Latest)/(.*)$ /docs/4.8.0-beta00017/$1 [R=301,L]
+# Redirect /docs/absolute-latest/ to /docs/4.8.0-beta00018/
+RewriteRule ^docs/absolute(?:-latest|Latest)/(.*)$ /docs/4.8.0-beta00018/$1 [R=301,L]

--- a/websites/site/lucenetemplate/partials/footer.tmpl.partial
+++ b/websites/site/lucenetemplate/partials/footer.tmpl.partial
@@ -1,7 +1,7 @@
 <footer>
   <div class="container">
     <span class="pull-left">
-      {{{_appFooter}}}{{^_appFooter}}Copyright &copy; 2025 The Apache Software Foundation{{/_appFooter}}
+      {{{_appFooter}}}{{^_appFooter}}Copyright &copy; 2026 The Apache Software Foundation{{/_appFooter}}
     </span>
     <div class="asf-links text-center">
       <a href="{{_asfFoundationHref}}">{{_asfFoundationText}}</a> |

--- a/websites/site/lucenetemplate/styles/fonts.css
+++ b/websites/site/lucenetemplate/styles/fonts.css
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/websites/site/lucenetemplate/styles/fonts.css
+++ b/websites/site/lucenetemplate/styles/fonts.css
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 @font-face {
   font-family: 'Lato';
   font-style: normal;

--- a/websites/site/release-notes/version-4.8.0-beta00018.md
+++ b/websites/site/release-notes/version-4.8.0-beta00018.md
@@ -14,6 +14,11 @@ version: 4.8.0-beta00018
 ## What's Changed
 ### 🐞 Bug Fixes
 * FuzzyQuery produces a wrong result when prefix is equal to the term length by @paulirwin in https://github.com/apache/lucenenet/pull/1002
+* Validate PatternParser DTDs against expected name by @paulirwin in https://github.com/apache/lucenenet/pull/1358
+* Validate file paths for FSDirectory and Replicator by @paulirwin in https://github.com/apache/lucenenet/pull/1357
+* Bumped ICU4N to 60.1.0-alpha.440 by @NightOwl888 in https://github.com/apache/lucenenet/pull/1353
+* ShingleFilter produces invalid queries by @tohidemyname in https://github.com/apache/lucenenet/pull/946
+* Fix SegmentInfos replace doesn't update userData by @tohidemyname in https://github.com/apache/lucenenet/pull/948
 ### 🚀 Performance Improvements
 * SWEEP: Replace J2N's TripleShift call with C# 11's unsigned right shift operator by @paulirwin in https://github.com/apache/lucenenet/pull/1007
 ### 🏆 Improvements
@@ -22,11 +27,20 @@ version: 4.8.0-beta00018
 * website/site/.htaccess - bug fix by removing BOM and update to beta0017 redirection by @rclabo in https://github.com/apache/lucenenet/pull/1005
 * Updated .htaccess copy and release procedure by @NightOwl888 in https://github.com/apache/lucenenet/pull/1010
 * Added GitHub Automation for Release Notes by @NightOwl888 in https://github.com/apache/lucenenet/pull/1011
-### 💪 Other Changes
-* ShingleFilter produces invalid queries by @tohidemyname in https://github.com/apache/lucenenet/pull/946
-* Fix SegmentInfos replace doesn't update userData by @tohidemyname in https://github.com/apache/lucenenet/pull/948
+* fix: Render ASF policy links in static HTML footer by @rbowen in https://github.com/apache/lucenenet/pull/1303
+* Fix/apidocs breadcrumb toc asf by @zka26 in https://github.com/apache/lucenenet/pull/1232
+* README: fix typo MacOS -> macOS by @jbampton in https://github.com/apache/lucenenet/pull/1179
+* Added ASF-required links using drop-down menu and unified navigation by @zka26 in https://github.com/apache/lucenenet/pull/1198
+* fix: Self-host all external website dependencies by @mmafrar in https://github.com/apache/lucenenet/pull/1197
+* Fix typos by @jbampton in https://github.com/apache/lucenenet/pull/1177
+* Replace lucene.testSettings.config references with lucene.testsettings.json by @paulirwin in https://github.com/apache/lucenenet/pull/1035
 
 ## New Contributors
+* @jbampton made their first contribution in https://github.com/apache/lucenenet/pull/1177
+* @mmafrar made their first contribution in https://github.com/apache/lucenenet/pull/1197
+* @rbowen made their first contribution in https://github.com/apache/lucenenet/pull/1303
 * @tohidemyname made their first contribution in https://github.com/apache/lucenenet/pull/946
+* @zka26 made their first contribution in https://github.com/apache/lucenenet/pull/1198
 
 **Full Changelog**: https://github.com/apache/lucenenet/compare/Lucene.Net_4_8_0_beta00017...Lucene.Net_4_8_0_beta00018
+

--- a/websites/site/release-notes/version-4.8.0-beta00018.md
+++ b/websites/site/release-notes/version-4.8.0-beta00018.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: releasenotes/4.8.0-beta00018
 version: 4.8.0-beta00018
 ---

--- a/websites/site/release-notes/version-4.8.0-beta00018.md
+++ b/websites/site/release-notes/version-4.8.0-beta00018.md
@@ -1,0 +1,32 @@
+﻿---
+uid: releasenotes/4.8.0-beta00018
+version: 4.8.0-beta00018
+---
+
+# Lucene.NET 4.8.0-beta00018 Release Notes
+
+---
+
+> This is a maintenance update that upgrades ICU4N to the latest version, since several serious concurrency and resource loading bugs have been patched since the last Lucene.NET release.
+
+<!-- Release notes generated using configuration in .github/release.yml at Lucene.Net_4_8_0_beta00018 -->
+
+## What's Changed
+### 🐞 Bug Fixes
+* FuzzyQuery produces a wrong result when prefix is equal to the term length by @paulirwin in https://github.com/apache/lucenenet/pull/1002
+### 🚀 Performance Improvements
+* SWEEP: Replace J2N's TripleShift call with C# 11's unsigned right shift operator by @paulirwin in https://github.com/apache/lucenenet/pull/1007
+### 🏆 Improvements
+* Added "Improvements" Category for Release Notes by @NightOwl888 in https://github.com/apache/lucenenet/pull/1015
+### 📄 Website and API Documentation
+* website/site/.htaccess - bug fix by removing BOM and update to beta0017 redirection by @rclabo in https://github.com/apache/lucenenet/pull/1005
+* Updated .htaccess copy and release procedure by @NightOwl888 in https://github.com/apache/lucenenet/pull/1010
+* Added GitHub Automation for Release Notes by @NightOwl888 in https://github.com/apache/lucenenet/pull/1011
+### 💪 Other Changes
+* ShingleFilter produces invalid queries by @tohidemyname in https://github.com/apache/lucenenet/pull/946
+* Fix SegmentInfos replace doesn't update userData by @tohidemyname in https://github.com/apache/lucenenet/pull/948
+
+## New Contributors
+* @tohidemyname made their first contribution in https://github.com/apache/lucenenet/pull/946
+
+**Full Changelog**: https://github.com/apache/lucenenet/compare/Lucene.Net_4_8_0_beta00017...Lucene.Net_4_8_0_beta00018


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

4.8.0 beta00018 release updates

## Description

Now that the website automation is fixed, we have changed the website content management to use `master` as the source of truth instead of `docs/[version]`, which is what we have been doing for the past few releases.

This PR cherry-picks the commits that bring the `master` branch up to date with the `docs/4.8.0-beta00018` branch. It also contains the following updates:

- The 4.8.0-beta00018 API docs link was added to the `docs.md` file.
- The `documentation.md` procedure now includes headings for "Local Build and Host" and "Release Build", the latter of which contains a red warning that the information is only provided in case the automation fails.

> [!NOTE]
> Merging this PR (as well as future updates to the `websites/site` directory) will start the `Lucene-Net-Website.yml` workflow, which will subsequently build a new website and submit a PR to https://github.com/apache/lucenent-site with the compiled content. The person who merges website PRs must then review and decide whether to merge the PR, save it for later, or reject it.
>
> These release PRs may simply be closed without merging if the changes would put the site into an inconsistent state or if there is some other reason not to update the website with the changes (such as the changes applying to a future release).
>
> Going forward, website updates no longer need to be cherry-picked to `docs/[version]` branches, since we will consider the `master` branch the source of truth. But it also means we need to be vigilant about not merging website updates that should be delayed for later.