### PR TITLE
Implement IEnumerable/IEnumerator in AbstractAppendingInt64Buffer, #279

### DIFF
--- a/src/Lucene.Net.Tests/Util/Packed/TestPackedInts.cs
+++ b/src/Lucene.Net.Tests/Util/Packed/TestPackedInts.cs
@@ -1195,16 +1195,17 @@ namespace Lucene.Net.Util.Packed
                         Assert.AreEqual(arr[i], buf.Get(i));
                     }
 
-                    AbstractAppendingInt64Buffer.Iterator it = buf.GetIterator();
+                    using var it = buf.GetEnumerator();
                     for (int i = 0; i < arr.Length; ++i)
                     {
+                        bool hasNext = it.MoveNext();
                         if (Random.NextBoolean())
                         {
-                            Assert.IsTrue(it.HasNext);
+                            Assert.IsTrue(hasNext);
                         }
-                        Assert.AreEqual(arr[i], it.Next());
+                        Assert.AreEqual(arr[i], it.Current);
                     }
-                    Assert.IsFalse(it.HasNext);
+                    Assert.IsFalse(it.MoveNext());
 
 
                     long[] target = new long[arr.Length + 1024]; // check the request for more is OK.

--- a/src/Lucene.Net/Index/BinaryDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/BinaryDocValuesWriter.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Diagnostics;
 using System;
 using System.Collections.Generic;
 
@@ -147,7 +148,8 @@ namespace Lucene.Net.Index
                 BytesRef v = null;
                 if (upto < size)
                 {
-                    lengthsEnumerator.MoveNext();
+                    bool moved = lengthsEnumerator.MoveNext();
+                    if (Debugging.AssertsEnabled) Debugging.Assert(moved);
                     int length = (int)lengthsEnumerator.Current;
                     value.Grow(length);
                     value.Length = length;

--- a/src/Lucene.Net/Index/BinaryDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/BinaryDocValuesWriter.cs
@@ -136,7 +136,7 @@ namespace Lucene.Net.Index
         {
             // Use yield return instead of ucsom IEnumerable
             var value = new BytesRef();
-            AppendingDeltaPackedInt64Buffer.Iterator lengthsIterator = lengths.GetIterator();
+            using var lengthsEnumerator = lengths.GetEnumerator();
             int size = (int)lengths.Count;
             DataInput bytesIterator = bytes.GetDataInput();
             int maxDoc = maxDocParam;
@@ -147,7 +147,8 @@ namespace Lucene.Net.Index
                 BytesRef v = null;
                 if (upto < size)
                 {
-                    int length = (int)lengthsIterator.Next();
+                    lengthsEnumerator.MoveNext();
+                    int length = (int)lengthsEnumerator.Current;
                     value.Grow(length);
                     value.Length = length;
                     try

--- a/src/Lucene.Net/Index/NumericDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/NumericDocValuesWriter.cs
@@ -102,7 +102,7 @@ namespace Lucene.Net.Index
         private IEnumerable<long?> GetNumericIterator(int maxDoc)
         {
             // LUCENENET specific: using yield return instead of custom iterator type. Much less code.
-            AbstractAppendingInt64Buffer.Iterator iter = pending.GetIterator();
+            using var enumerator = pending.GetEnumerator();
             int size = (int)pending.Count;
             int upto = 0;
 
@@ -111,7 +111,8 @@ namespace Lucene.Net.Index
                 long? value;
                 if (upto < size)
                 {
-                    var v = iter.Next();
+                    enumerator.MoveNext();
+                    var v = enumerator.Current;
                     if (docsWithField is null || docsWithField.Get(upto))
                     {
                         value = v;

--- a/src/Lucene.Net/Index/NumericDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/NumericDocValuesWriter.cs
@@ -1,3 +1,4 @@
+using Lucene.Net.Diagnostics;
 using Lucene.Net.Util.Packed;
 using System;
 using System.Collections.Generic;
@@ -111,7 +112,8 @@ namespace Lucene.Net.Index
                 long? value;
                 if (upto < size)
                 {
-                    enumerator.MoveNext();
+                    bool moved = enumerator.MoveNext();
+                    if (Debugging.AssertsEnabled) Debugging.Assert(moved);
                     var v = enumerator.Current;
                     if (docsWithField is null || docsWithField.Get(upto))
                     {

--- a/src/Lucene.Net/Index/SortedDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedDocValuesWriter.cs
@@ -123,16 +123,16 @@ namespace Lucene.Net.Index
                 ordMap[sortedValues[ord]] = ord;
             }
 
-            dvConsumer.AddSortedField(fieldInfo, GetBytesRefEnumberable(valueCount, sortedValues),
+            dvConsumer.AddSortedField(fieldInfo, GetBytesRefEnumerable(valueCount, sortedValues),
                                       // doc -> ord
-                                      GetOrdsEnumberable(maxDoc, ordMap));
+                                      GetOrdsEnumerable(maxDoc, ordMap));
         }
 
         public override void Abort()
         {
         }
 
-        private IEnumerable<BytesRef> GetBytesRefEnumberable(int valueCount, int[] sortedValues)
+        private IEnumerable<BytesRef> GetBytesRefEnumerable(int valueCount, int[] sortedValues)
         {
             var scratch = new BytesRef();
 
@@ -142,14 +142,15 @@ namespace Lucene.Net.Index
             }
         }
 
-        private IEnumerable<long?> GetOrdsEnumberable(int maxDoc, int[] ordMap)
+        private IEnumerable<long?> GetOrdsEnumerable(int maxDoc, int[] ordMap)
         {
-            AppendingDeltaPackedInt64Buffer.Iterator iter = pending.GetIterator();
+            using var enumerator = pending.GetEnumerator();
             if (Debugging.AssertsEnabled) Debugging.Assert(pending.Count == maxDoc);
 
             for (int i = 0; i < maxDoc; ++i)
             {
-                int ord = (int)iter.Next();
+                enumerator.MoveNext();
+                int ord = (int)enumerator.Current;
                 yield return ord == -1 ? ord : ordMap[ord];
             }
         }

--- a/src/Lucene.Net/Index/SortedDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedDocValuesWriter.cs
@@ -149,7 +149,8 @@ namespace Lucene.Net.Index
 
             for (int i = 0; i < maxDoc; ++i)
             {
-                enumerator.MoveNext();
+                bool moved = enumerator.MoveNext();
+                if (Debugging.AssertsEnabled) Debugging.Assert(moved);
                 int ord = (int)enumerator.Current;
                 yield return ord == -1 ? ord : ordMap[ord];
             }

--- a/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
@@ -208,7 +208,8 @@ namespace Lucene.Net.Index
 
             for (int docUpto = 0; docUpto < maxDoc; ++docUpto)
             {
-                enumerator.MoveNext();
+                bool moved = enumerator.MoveNext();
+                if (Debugging.AssertsEnabled) Debugging.Assert(moved);
                 yield return enumerator.Current;
             }
         }
@@ -227,11 +228,13 @@ namespace Lucene.Net.Index
                 {
                     // refill next doc, and sort remapped ords within the doc.
                     currentUpTo = 0;
-                    counts.MoveNext();
+                    bool countsMoved = counts.MoveNext();
+                    if (Debugging.AssertsEnabled) Debugging.Assert(countsMoved);
                     currentLength = (int)counts.Current;
                     for (int j = 0; j < currentLength; j++)
                     {
-                        enumerator.MoveNext();
+                        bool moved = enumerator.MoveNext();
+                        if (Debugging.AssertsEnabled) Debugging.Assert(moved);
                         cd[j] = ordMap[(int)enumerator.Current];
                     }
                     Array.Sort(cd, 0, currentLength);

--- a/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
+++ b/src/Lucene.Net/Index/SortedSetDocValuesWriter.cs
@@ -202,13 +202,14 @@ namespace Lucene.Net.Index
         [SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType", Justification = "Matches Lucene")]
         private IEnumerable<long?> GetOrdCountEnumerable(int maxDoc)
         {
-            AppendingDeltaPackedInt64Buffer.Iterator iter = pendingCounts.GetIterator();
+            using var enumerator = pendingCounts.GetEnumerator();
 
             if (Debugging.AssertsEnabled) Debugging.Assert(pendingCounts.Count == maxDoc, "MaxDoc: {0}, pending.Count: {1}", maxDoc, pending.Count);
 
             for (int docUpto = 0; docUpto < maxDoc; ++docUpto)
             {
-                yield return iter.Next();
+                enumerator.MoveNext();
+                yield return enumerator.Current;
             }
         }
 
@@ -216,8 +217,8 @@ namespace Lucene.Net.Index
         private IEnumerable<long?> GetOrdsEnumerable(int[] ordMap, int maxCountPerDoc)
         {
             int currentUpTo = 0, currentLength = 0;
-            AppendingPackedInt64Buffer.Iterator iter = pending.GetIterator();
-            AppendingDeltaPackedInt64Buffer.Iterator counts = pendingCounts.GetIterator();
+            using var enumerator = pending.GetEnumerator();
+            using var counts = pendingCounts.GetEnumerator();
             int[] cd = new int[maxCountPerDoc]; // LUCENENET specific - renamed from currentDoc to cd to prevent conflict
 
             for (long ordUpto = 0; ordUpto < pending.Count; ++ordUpto)
@@ -226,10 +227,12 @@ namespace Lucene.Net.Index
                 {
                     // refill next doc, and sort remapped ords within the doc.
                     currentUpTo = 0;
-                    currentLength = (int)counts.Next();
+                    counts.MoveNext();
+                    currentLength = (int)counts.Current;
                     for (int j = 0; j < currentLength; j++)
                     {
-                        cd[j] = ordMap[(int)iter.Next()];
+                        enumerator.MoveNext();
+                        cd[j] = ordMap[(int)enumerator.Current];
                     }
                     Array.Sort(cd, 0, currentLength);
                 }

--- a/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
@@ -1,5 +1,7 @@
 using Lucene.Net.Diagnostics;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Lucene.Net.Util.Packed
@@ -26,7 +28,8 @@ namespace Lucene.Net.Util.Packed
     /// <para/>
     /// NOTE: This was AbstractAppendingLongBuffer in Lucene
     /// </summary>
-    public abstract class AbstractAppendingInt64Buffer : Int64Values // LUCENENET NOTE: made public rather than internal because has public subclasses
+    public abstract class AbstractAppendingInt64Buffer : Int64Values, // LUCENENET NOTE: made public rather than internal because has public subclasses
+        IEnumerable<long> // LUCENENET specific
     {
         internal const int MIN_PAGE_SIZE = 64;
 
@@ -105,7 +108,7 @@ namespace Lucene.Net.Util.Packed
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void Grow(int newBlockCount)
         {
-            Array.Resize<PackedInt32s.Reader>(ref values, newBlockCount);
+            Array.Resize(ref values, newBlockCount);
         }
 
         internal abstract void PackPendingValues();
@@ -144,12 +147,16 @@ namespace Lucene.Net.Util.Packed
         /// <summary>
         /// Return an iterator over the values of this buffer.
         /// </summary>
-        public virtual Iterator GetIterator()
+        public virtual Enumerator GetEnumerator()
         {
-            return new Iterator(this);
+            return new Enumerator(this);
         }
 
-        public sealed class Iterator
+        IEnumerator<long> IEnumerable<long>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public sealed class Enumerator : IEnumerator<long>
         {
             private readonly AbstractAppendingInt64Buffer outerInstance;
 
@@ -157,20 +164,10 @@ namespace Lucene.Net.Util.Packed
             internal int vOff, pOff;
             internal int currentCount; // number of entries of the current page
 
-            internal Iterator(AbstractAppendingInt64Buffer outerInstance)
+            internal Enumerator(AbstractAppendingInt64Buffer outerInstance)
             {
                 this.outerInstance = outerInstance;
-                vOff = pOff = 0;
-                if (outerInstance.valuesOff == 0)
-                {
-                    currentValues = outerInstance.pending;
-                    currentCount = outerInstance.pendingOff;
-                }
-                else
-                {
-                    currentValues = new long[outerInstance.values[0].Count];
-                    FillValues();
-                }
+                Reset(); // LUCENENET specific - moved from ctor
             }
 
             internal void FillValues()
@@ -191,15 +188,24 @@ namespace Lucene.Net.Util.Packed
             }
 
             /// <summary>
-            /// Whether or not there are remaining values. </summary>
-            public bool HasNext => pOff < currentCount;
+            /// Gets the current value.
+            /// </summary>
+            public long Current { get; private set; }
+
+            object IEnumerator.Current => Current;
 
             /// <summary>
-            /// Return the next long in the buffer. </summary>
-            public long Next()
+            /// Advances the enumerator to the next value.
+            /// </summary>
+            public bool MoveNext()
             {
-                if (Debugging.AssertsEnabled) Debugging.Assert(HasNext);
-                long result = currentValues[pOff++];
+                if (pOff >= currentCount)
+                {
+                    return false;
+                }
+
+                Current = currentValues[pOff++];
+
                 if (pOff == currentCount)
                 {
                     vOff += 1;
@@ -213,7 +219,33 @@ namespace Lucene.Net.Util.Packed
                         currentCount = 0;
                     }
                 }
-                return result;
+
+                return true;
+            }
+
+            /// <summary>
+            /// Resets the enumerator to its initial position.
+            /// </summary>
+            public void Reset()
+            {
+                vOff = pOff = 0;
+                if (outerInstance.valuesOff == 0)
+                {
+                    currentValues = outerInstance.pending;
+                    currentCount = outerInstance.pendingOff;
+                }
+                else
+                {
+                    currentValues = new long[outerInstance.values[0].Count];
+                    FillValues();
+                }
+            }
+
+            /// <summary>
+            /// Dispose of the resources used by the <see cref="Enumerator"/>.
+            /// </summary>
+            public void Dispose()
+            {
             }
         }
 

--- a/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
+++ b/src/Lucene.Net/Util/Packed/AbstractAppendingLongBuffer.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Util.Packed
     /// <para/>
     /// NOTE: This was AbstractAppendingLongBuffer in Lucene
     /// </summary>
-    public abstract class AbstractAppendingInt64Buffer : Int64Values, // LUCENENET NOTE: made public rather than internal because has public subclasses
+    internal abstract class AbstractAppendingInt64Buffer : Int64Values,
         IEnumerable<long> // LUCENENET specific
     {
         internal const int MIN_PAGE_SIZE = 64;

--- a/src/Lucene.Net/Util/Packed/AppendingDeltaPackedLongBuffer.cs
+++ b/src/Lucene.Net/Util/Packed/AppendingDeltaPackedLongBuffer.cs
@@ -30,7 +30,7 @@ namespace Lucene.Net.Util.Packed
     /// <para/>
     /// @lucene.internal
     /// </summary>
-    public sealed class AppendingDeltaPackedInt64Buffer : AbstractAppendingInt64Buffer
+    internal sealed class AppendingDeltaPackedInt64Buffer : AbstractAppendingInt64Buffer // LUCENENET: made internal until LUCENE-5792 lands
     {
         internal long[] minValues;
 

--- a/src/Lucene.Net/Util/Packed/AppendingPackedLongBuffer.cs
+++ b/src/Lucene.Net/Util/Packed/AppendingPackedLongBuffer.cs
@@ -28,7 +28,7 @@ namespace Lucene.Net.Util.Packed
     /// <para/>
     /// @lucene.internal
     /// </summary>
-    public sealed class AppendingPackedInt64Buffer : AbstractAppendingInt64Buffer
+    internal sealed class AppendingPackedInt64Buffer : AbstractAppendingInt64Buffer // LUCENENET: made internal until LUCENE-5792 lands
     {
         /// <summary>
         /// Initialize a <see cref="AppendingPackedInt64Buffer"/>. </summary>

--- a/src/Lucene.Net/Util/Packed/MonotonicAppendingLongBuffer.cs
+++ b/src/Lucene.Net/Util/Packed/MonotonicAppendingLongBuffer.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Util.Packed
     /// <para/>
     /// @lucene.internal
     /// </summary>
-    public sealed class MonotonicAppendingInt64Buffer : AbstractAppendingInt64Buffer
+    internal sealed class MonotonicAppendingInt64Buffer : AbstractAppendingInt64Buffer // LUCENENET: made internal until LUCENE-5792 lands
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static long ZigZagDecode(long n)


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Implement IEnumerable/IEnumerator in AbstractAppendingInt64Buffer

Fixes #279 (as the final remaining item)

## Description

This implements IEnumerable properly in AbstractAppendingInt64Buffer, and updates the usages of the prior GetIterator method to use the enumerator.
