### PR TITLE
Fix for `DebugAssertException` detection during testing + `VIntUtils` length assertions

### DIFF
--- a/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
+++ b/src/Lucene.Net.TestFramework/Support/Util/LuceneTestFrameworkInitializer.cs
@@ -3,7 +3,6 @@ using Lucene.Net.Configuration;
 using NUnit.Framework;
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 
 namespace Lucene.Net.Util
 {
@@ -358,11 +357,13 @@ namespace Lucene.Net.Util
             // Identify the Debug.Assert() exception so it can be excluded from being swallowed by catch blocks.
             // These types are internal, so we can identify them using Reflection.
             Lucene.ExceptionExtensions.DebugAssertExceptionType =
+                // Microsoft.NET.Test.Sdk 16.6.0+ (used by Visual Studio Test Explorer)
+                Type.GetType("Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException, testhost")
                 // .NET 5/.NET Core 3.x
-                Type.GetType("System.Diagnostics.DebugProvider+DebugAssertException, System.Private.CoreLib")
+                ?? Type.GetType("System.Diagnostics.DebugProvider+DebugAssertException, System.Private.CoreLib")
                 // .NET Core 2.x
                 ?? Type.GetType("System.Diagnostics.Debug+DebugAssertException, System.Private.CoreLib");
-                // .NET Framework doesn't throw in this case
+            // .NET Framework doesn't throw in this case
         }
 
         /// <summary>

--- a/src/Lucene.Net.Tests.AllProjects/Support/AssemblyScanningTestCase.cs
+++ b/src/Lucene.Net.Tests.AllProjects/Support/AssemblyScanningTestCase.cs
@@ -59,10 +59,23 @@ namespace Lucene.Net.Support
         };
 
 
-        public static readonly Assembly[] DotNetAssemblies = new Assembly[]
+        public static readonly Assembly[] DotNetAssemblies = LoadDotNetAssemblies();
+
+        private static Assembly[] LoadDotNetAssemblies()
         {
-            typeof(Exception).Assembly
-        };
+            var list = new List<Assembly>()
+            {
+                typeof(Exception).Assembly
+            };
+
+            Assembly testHostAssembly = Type.GetType("Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException, testhost")?.Assembly;
+            if (testHostAssembly is not null)
+            {
+                list.Add(testHostAssembly);
+            }
+
+            return list.ToArray();
+        }
 
         public static readonly Assembly[] NUnitAssemblies = new Assembly[]
         {

--- a/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/ExceptionScanningTestCase.cs
+++ b/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/ExceptionScanningTestCase.cs
@@ -39,11 +39,21 @@ namespace Lucene.Net.Support.ExceptionHandling
     public abstract class ExceptionScanningTestCase : AssemblyScanningTestCase
     {
         // Internal types references
-        private static readonly Type DebugAssertExceptionType =
+        private static readonly Type ClrDebugAssertExceptionType =
             // .NET 5/.NET Core 3.x
             Type.GetType("System.Diagnostics.DebugProvider+DebugAssertException, System.Private.CoreLib")
             // .NET Core 2.x
             ?? Type.GetType("System.Diagnostics.Debug+DebugAssertException, System.Private.CoreLib");
+
+        private static readonly Type TestHostDebugAssertExceptionType =
+            // Microsoft.NET.Test.Sdk 16.6.0+ (used by Visual Studio Test Explorer)
+            Type.GetType("Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException, testhost");
+
+        private static readonly Type DebugAssertExceptionType =
+            // Microsoft.NET.Test.Sdk 16.6.0+ (used by Visual Studio Test Explorer)
+            TestHostDebugAssertExceptionType
+            // .NET Core
+            ?? ClrDebugAssertExceptionType;
         // .NET Framework doesn't throw in this case
 
         private static readonly Type MetadataExceptionType =
@@ -465,15 +475,28 @@ namespace Lucene.Net.Support.ExceptionHandling
             };
 
             // Special case - this doesn't exist on .NET Framework, so we only add it if not null
-            if (DebugAssertExceptionType is not null)
+            if (ClrDebugAssertExceptionType is not null)
             {
-                result[DebugAssertExceptionType] = (exceptionType, message) =>
+                result[ClrDebugAssertExceptionType] = (exceptionType, message) =>
                 {
                     //private sealed class DebugAssertException : Exception
                     //{
                     //    internal DebugAssertException(string? message, string? detailMessage, string? stackTrace)
                     BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
-                    return Activator.CreateInstance(DebugAssertExceptionType, flags, null, new object[] { message, null, null }, CultureInfo.InvariantCulture);
+                    return Activator.CreateInstance(ClrDebugAssertExceptionType, flags, null, new object[] { message, null, null }, CultureInfo.InvariantCulture);
+                };
+            }
+
+            // Special case - Microsoft.NET.Test.Sdk 16.6.0+ contains its own Debug.Assert type that is thrown when debugging tests
+            if (TestHostDebugAssertExceptionType is not null)
+            {
+                result[TestHostDebugAssertExceptionType] = (exceptionType, message) =>
+                {
+                    //internal sealed class DebugAssertException : Exception
+                    //{
+                    //public DebugAssertException(string message, string stackTrace) : base(message)
+                    BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+                    return Activator.CreateInstance(TestHostDebugAssertExceptionType, flags, null, new object[] { message, string.Empty }, CultureInfo.InvariantCulture);
                 };
             }
 

--- a/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/TestExceptionExtensions.cs
+++ b/src/Lucene.Net.Tests.AllProjects/Support/ExceptionHandling/TestExceptionExtensions.cs
@@ -381,6 +381,29 @@ namespace Lucene.Net.Support.ExceptionHandling
             }
         }
 
+#if DEBUG
+        /// <summary>
+        /// Tests to ensure that the DebugAssertException type string is correct for the current test environment.
+        /// If this test fails, it means that the DebugAssertException has changed location and the
+        /// <see cref="LuceneTestFrameworkInitializer.InitializeStaticState()"/> method needs to be updated with
+        /// the new type string.
+        /// <para/>
+        /// Microsoft controls this location, it is internal, and changes from time to time. Currently, it is in
+        /// Microsoft.NET.Test.Sdk as of version 16.6.0.
+        /// <para/>
+        /// Note that this exception only applies when the test SDK is attached. If the test SDK is not attached,
+        /// then this exception falls back to a different exception type in the current .NET SDK. This can happen
+        /// in DEBUG mode when running as a console application, for example.
+        /// </summary>
+        [Test]
+        public void TestDebugAssertExceptionTypeString()
+        {
+            Assert.IsNotNull(
+                Type.GetType("Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException, testhost"),
+                "DebugAssertException type not found for the current test enviornment. This means that the DebugAssertException has changed location and the LuceneTestFrameworkInitializer.InitializeStaticState() method needs to be updated with the new type string.");
+        }
+#endif
+
         private class MyException : Exception
         {
             public MyException(string message) : base(message)

--- a/src/Lucene.Net.Tests/Support/TestVIntUtils.cs
+++ b/src/Lucene.Net.Tests/Support/TestVIntUtils.cs
@@ -171,5 +171,93 @@ namespace Lucene.Net.Support
             assertEquals(VIntUtils.MaxVInt32Length, EncodeVInt32(-1).Length);
             assertEquals(VIntUtils.MaxVInt64Length, EncodeVInt64(long.MaxValue).Length);
         }
+
+#if DEBUG
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(127)]
+        [TestCase(128)]
+        [TestCase(16383)]
+        [TestCase(16384)]
+        [TestCase(2097151)]
+        [TestCase(2097152)]
+        [TestCase(268435455)]
+        [TestCase(int.MaxValue)]
+        [TestCase(-1)]
+        [LuceneNetSpecific]
+        public void TestReadVInt32_DebugAssertRequiresCompleteSpan(int value)
+        {
+            byte[] encoded = EncodeVInt32(value);
+
+            // Every prefix shorter than the encoded value should assert.
+            for (int length = 0; length < encoded.Length; length++)
+            {
+                Assert.Throws(Lucene.ExceptionExtensions.DebugAssertExceptionType, () =>
+                {
+                    VIntUtils.TryReadVInt32(encoded.AsSpan(0, length), out _, out _);
+                }, $"Expected {Lucene.ExceptionExtensions.DebugAssertExceptionType.AssemblyQualifiedName} for value {value} with span length {length}.");
+            }
+
+            // The exact encoded length should succeed.
+            {
+                Assert.DoesNotThrow(() =>
+                {
+                    bool ok = VIntUtils.TryReadVInt32(encoded, out int result, out int count);
+
+                    assertTrue(ok);
+                    assertEquals(value, result);
+                    assertEquals(encoded.Length, count);
+                });
+            }
+        }
+
+        [TestCase(0L)]
+        [TestCase(1L)]
+        [TestCase(127L)]
+        [TestCase(128L)]
+        [TestCase(16383L)]
+        [TestCase(16384L)]
+        [TestCase(2097151L)]
+        [TestCase(2097152L)]
+        [TestCase(268435455L)]
+        [TestCase(268435456L)]
+        [TestCase(34359738367L)]
+        [TestCase(34359738368L)]
+        [TestCase(4398046511103L)]
+        [TestCase(4398046511104L)]
+        [TestCase(562949953421311L)]
+        [TestCase(562949953421312L)]
+        [TestCase(72057594037927935L)]
+        [TestCase(72057594037927936L)]
+        [TestCase(long.MaxValue)]
+        [LuceneNetSpecific]
+        public void TestReadVInt64_DebugAssertRequiresCompleteSpan(long value)
+        {
+            byte[] encoded = EncodeVInt64(value);
+
+            // Every prefix shorter than the encoded value should assert.
+            for (int length = 0; length < encoded.Length; length++)
+            {
+                Assert.Throws(Lucene.ExceptionExtensions.DebugAssertExceptionType, () =>
+                {
+                    VIntUtils.TryReadVInt64(encoded.AsSpan(0, length), out _, out _);
+                }, $"Expected {Lucene.ExceptionExtensions.DebugAssertExceptionType.AssemblyQualifiedName} for value {value} with span length {length}.");
+            }
+
+            // The exact encoded length should succeed.
+            {
+                Assert.DoesNotThrow(() =>
+                {
+                    bool ok = VIntUtils.TryReadVInt64(encoded, out long result, out int count);
+
+                    assertTrue(ok);
+                    assertEquals(value, result);
+                    assertEquals(encoded.Length, count);
+                });
+            }
+        }
+
+#endif
     }
 }

--- a/src/Lucene.Net/Support/VIntUtils.cs
+++ b/src/Lucene.Net/Support/VIntUtils.cs
@@ -55,7 +55,7 @@ namespace Lucene.Net.Support
         /// extra high bits set.</returns>
         public static bool TryReadVInt32(ReadOnlySpan<byte> source, out int value, out int count)
         {
-            Debug.Assert(source.Length >= 1);
+            AssertCanContainVInt32(source);
             byte b = source[0];
             if (b <= sbyte.MaxValue) // LUCENENET: Optimized equivalent of "if ((sbyte)b >= 0)"
             {
@@ -109,7 +109,7 @@ namespace Lucene.Net.Support
         /// the continuation bit set (which would indicate a negative value, disallowed).</returns>
         public static bool TryReadVInt64(ReadOnlySpan<byte> source, out long value, out int count)
         {
-            Debug.Assert(source.Length >= 1);
+            AssertCanContainVInt64(source);
             byte b = source[0];
             if (b <= sbyte.MaxValue)
             {
@@ -179,6 +179,42 @@ namespace Lucene.Net.Support
             count = 9;
             value = i;
             return b <= sbyte.MaxValue;
+        }
+
+        [Conditional("DEBUG")]
+        private static void AssertCanContainVInt32(ReadOnlySpan<byte> source)
+        {
+            int length = source.Length;
+            if (length >= MaxVInt32Length) return;
+
+            int limit = Math.Min(length, MaxVInt32Length);
+
+            for (int i = 0; i < limit; i++)
+            {
+                if ((source[i] & 0x80) == 0)
+                    return;
+            }
+
+            Debug.Assert(length >= MaxVInt32Length,
+                "The span is too short to contain a complete VInt32.");
+        }
+
+        [Conditional("DEBUG")]
+        private static void AssertCanContainVInt64(ReadOnlySpan<byte> source)
+        {
+            int length = source.Length;
+            if (length >= MaxVInt64Length) return;
+
+            int limit = Math.Min(length, MaxVInt64Length);
+
+            for (int i = 0; i < limit; i++)
+            {
+                if ((source[i] & 0x80) == 0)
+                    return;
+            }
+
+            Debug.Assert(length >= MaxVInt64Length,
+                "The span is too short to contain a complete VInt64.");
         }
 
         // LUCENENET: The throw sites below are factored into dedicated, non-inlined helpers so the


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fix for `DebugAssertException` detection during testing + `VIntUtils` length assertions

## Description

While reviewing #1373, I discovered that the length checking was incorrectly requiring the length to be at least the max length allowed. I fixed it on the #1373 branch and then decided it was better off as its own PR, but when I cherry picked onto `master`, I discovered that #1360 already had a fix, but #1373 hadn't been rebased against `master`. Still, this provides more robust checking to ensure that the length is at least as long as it should be to hold the value. This is entirely implemented in `Debug` builds and is entirely removed from the compile in `Release` builds.

This also revealed that the `DebugAssertException` had changed in `Microsoft.NET.Test.Sdk` 16.6.0 when testing, which replaces the CLR `DebugAssertException` type. As such, our exception handling was not treating `Debug.Assert()` exceptions correctly according to how Java does. This updates the `LuceneTestFrameworkInitializer` to correctly set that exception type so `Debug.Assert()` exceptions are caught when Lucene swallows them and ignored when Lucene ignores them.

This also adds a `TestDebugAssertExceptionTypeString()` test to detect if the `Microsoft.NET.Test.Sdk` can no longer be found at its current location to help catch any changes to it in the future. However, do note that this test only works in `Debug` builds.


