### PR TITLE
[CI] Add prek hook `yamllint`; Minor YAML formatting

### DIFF
--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -115,10 +115,10 @@ steps:
     performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
   condition: and(succeeded(), contains('${{ parameters.framework }}', 'net8.'))
 
-    # Hack: .NET 8+ no longer installs the x86 bits and they must be installed separately. However, it is not
-    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
-    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
-    # This code only works on Windows.
+  # Hack: .NET 8+ no longer installs the x86 bits and they must be installed separately. However, it is not
+  # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+  # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+  # This code only works on Windows.
 - pwsh: |
     $sdkVersion = '8.0.404'
     $architecture = '${{ parameters.vsTestPlatform }}'
@@ -140,10 +140,10 @@ steps:
     performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
   condition: and(succeeded(), contains('${{ parameters.framework }}', 'net9.'))
 
-    # Hack: .NET 8+ no longer installs the x86 bits and they must be installed separately. However, it is not
-    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
-    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
-    # This code only works on Windows.
+  # Hack: .NET 8+ no longer installs the x86 bits and they must be installed separately. However, it is not
+  # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+  # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+  # This code only works on Windows.
 - pwsh: |
     $sdkVersion = '9.0.308'
     $architecture = '${{ parameters.vsTestPlatform }}'

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+# https://yamllint.readthedocs.io/en/stable/
+extends: default
+
+rules:
+  braces: disable
+  brackets: disable
+  colons: disable
+  comments: disable
+  document-start: disable
+  indentation: disable
+  line-length: disable
+  truthy: disable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,8 @@
 # | **Priority 20** | `fix-byte-order-marker` | **File Cleanups (Broad)**: Fix BOM first so subsequent steps work with clean UTF-8 text. |
 # | **Priority 30** | `trailing-whitespace` | **Formatting (Broad)**: Cleans up whitespace on files before other hooks validate them. |
 # | **Priority 40** | `doctoc`, `oxipng`, `file-contents-sorter` | **Disjoint Modifiers**: These modify different sets of files (`README.md`, `.png` files, and `codespell.txt` respectively). Running them concurrently is safe. |
-# | **Priority 50** | `codespell`, `check-ast`, `check-builtin-literals`, `check-case-conflict`, `check-executables-have-shebangs`, `check-illegal-windows-names`, `check-json`, `check-merge-conflict`, `check-vcs-permalinks`, `check-xml`, `check-yaml`, `debug-statements`, `detect-aws-credentials`, `detect-private-key`, `forbid-submodules`, `gitleaks`, `bandit`|
+# | **Priority 50** | `codespell`, `check-ast`, `check-builtin-literals`, `check-case-conflict`, `check-executables-have-shebangs`, `check-illegal-windows-names`, `check-json`, `check-merge-conflict`, `check-vcs-permalinks` |
+# |                 | `check-xml`, `check-yaml`, `debug-statements`, `detect-aws-credentials`, `detect-private-key`, `forbid-submodules`, `gitleaks`, `bandit`, `yamllint` |
 # |                 | **Read-Only / Syntax / Security**: The bulk of the suite. These hooks only read and validate files without modifying them, allowing full parallel execution. |
 
 # https://prek.j178.dev/installation/
@@ -179,4 +180,14 @@ repos:
         exclude: ^\.github/.*$
         types: [markdown]
         files: \.md$
+        priority: 50
+  - repo: https://github.com/adrienverge/yamllint
+    rev: cba56bcde1fdd01c1deb3f945e69764c291a6530 # frozen: v1.38.0
+    hooks:
+      - id: yamllint
+        name: run yamllint
+        description: check YAML files with yamllint
+        args: [--strict, -c=.github/linters/.yaml-lint.yml]
+        types: [yaml]
+        files: \.ya?ml$
         priority: 50

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -618,7 +618,7 @@ stages:
       vmImage: 'windows-latest'
 
     steps:
-      # We checkout here because we need to publish the source code along with the symbols for debugging
+    # We checkout here because we need to publish the source code along with the symbols for debugging
     - checkout: self # self represents the repo where the initial Pipelines YAML file was found
       fetchDepth: '1'  # the depth of commits to ask Git to fetch
 
@@ -630,13 +630,13 @@ stages:
         artifactName: '$(VersionArtifactName)'
         targetPath: '$(System.DefaultWorkingDirectory)/$(VersionArtifactName)'
 
-      # For debugging this pipeline
+    # For debugging this pipeline
     #- pwsh: |
     #    Get-ChildItem -Path $(System.DefaultWorkingDirectory)
     #    Get-ChildItem -Path '$(VersionArtifactName)'
 
-      # NOTE: We are setting Build.BuildNumber here to the NuGet package version to work around the limitation that
-      # the version cannot be passed to the Index Sources & Publish Symbols task.
+    # NOTE: We are setting Build.BuildNumber here to the NuGet package version to work around the limitation that
+    # the version cannot be passed to the Index Sources & Publish Symbols task.
     - pwsh: |
         $version = Get-Content '$(VersionArtifactName)/$(PackageVersionFileName)' -Raw
         Write-Host "##vso[task.setvariable variable=PackageVersion;]$version"
@@ -682,8 +682,8 @@ stages:
 
     - template: '.build/azure-templates/show-all-files.yml' # Uncomment for debugging
 
-      # NOTE: We are setting Build.BuildNumber here to the NuGet package version to work around the limitation that
-      # the version cannot be passed to the Index Sources & Publish Symbols task.
+    # NOTE: We are setting Build.BuildNumber here to the NuGet package version to work around the limitation that
+    # the version cannot be passed to the Index Sources & Publish Symbols task.
     - pwsh: |
         $version = Get-Content '$(Build.ArtifactStagingDirectory)/$(VersionArtifactName)/$(PackageVersionFileName)' -Raw
         $vcsLabel = 'Lucene.Net_' + $version.Replace('.', '_').Replace('-', '_')

--- a/websites/apidocs/toc/toc.yml
+++ b/websites/apidocs/toc/toc.yml
@@ -5,4 +5,3 @@ items:
   topicHref: https://lucenenet.apache.org/docs/4.8.0-ci/cli/index.html
 - name: Lucene.Net Website
   topicHref: https://lucenenet.apache.org/
-


### PR DESCRIPTION
Setup basic yamllint config file with a 8 rules disabled

refs https://github.com/apache/shiro/pulls?q=is%3Apr+yamllint+is%3Aclosed

https://github.com/adrienverge/yamllint/commit/cba56bcde1fdd01c1deb3f945e69764c291a6530

There are about 20 rules:

https://yamllint.readthedocs.io/en/stable/rules.html

https://github.com/adrienverge/yamllint

Used on Apache Sedona:

https://github.com/apache/sedona/blob/ca9d238460cf4acfe82f365c756fa40baa4f36b0/.pre-commit-config.yaml#L532

Used on Apache Airflow:

https://github.com/apache/airflow/blob/b641f1f152d7b241f88ecad3c767e371ff490367/.pre-commit-config.yaml#L423

Example config:

https://github.com/apache/sedona/blob/master/.github/linters/.yaml-lint.yml


<img width="662" height="341" alt="Screenshot 2026-07-06 at 8 36 19 am" src="https://github.com/user-attachments/assets/549b2891-2172-46fc-92c3-b5b7de7f2480" />

