### PR TITLE
Enable JIRA autolinks to LUCENE and LUCENENET issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -73,3 +73,8 @@ github:
       restrict_deletion: true
       restrict_force_push: false
       required_linear_history: false
+
+  # autolink LUCENE- and LUCENENET- issues to Jira for historical reference
+  autolink_jira:
+    - LUCENE
+    - LUCENENET


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Enable JIRA autolinks to LUCENE and LUCENENET issues

## Description

This is a `.asf.yaml` change that enables the autolinks feature for our GitHub project. Docs: https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#autolinks-for-jira

This will be helpful in our porting efforts as we cite Lucene JIRA issues for historical references. This will automatically turn them into links to the Apache JIRA. See #1381 as an example issue that could benefit from this greatly.

I figured we might as well go ahead and throw in LUCENENET as well, in case there are any references floating around to those old JIRA issues.