### PR TITLE
Clean up and fix Python and Shell shebang lines

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------------
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/Lucene.Net/Util/Packed/gen_BulkOperation.py
+++ b/src/Lucene.Net/Util/Packed/gen_BulkOperation.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net/Util/Packed/gen_Direct.py
+++ b/src/Lucene.Net/Util/Packed/gen_Direct.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net/Util/Packed/gen_Packed64SingleBlock.py
+++ b/src/Lucene.Net/Util/Packed/gen_Packed64SingleBlock.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net/Util/Packed/gen_PackedThreeBlocks.py
+++ b/src/Lucene.Net/Util/Packed/gen_PackedThreeBlocks.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
While many modern shells are forgiving, a space between #! and the path is an unnecessary risk.

https://en.wikipedia.org/wiki/Shebang_(Unix)
