### PR TITLE
Port Lucene 4.8.1 fixes for AnalyzingSuggester, OfflineSorter, and SpecialOperations, #1381

### DIFF
--- a/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
+++ b/src/Lucene.Net.Suggest/Suggest/Analyzing/AnalyzingSuggester.cs
@@ -979,7 +979,8 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             ReplaceSep(automaton);
             automaton = ConvertAutomaton(automaton);
 
-            if (Debugging.AssertsEnabled) Debugging.Assert(SpecialOperations.IsFinite(automaton));
+            // TODO: LUCENE-5660 re-enable this once we disallow massive suggestion strings
+            // if (Debugging.AssertsEnabled) Debugging.Assert(SpecialOperations.IsFinite(automaton));
 
             // Get all paths from the automaton (there can be
             // more than one path, eg if the analyzer created a

--- a/src/Lucene.Net.TestFramework/Support/ApiScanTestBase.cs
+++ b/src/Lucene.Net.TestFramework/Support/ApiScanTestBase.cs
@@ -1109,6 +1109,63 @@ namespace Lucene.Net.Util
         private static IEnumerable<Type> GetTypesToTest(Assembly assembly) =>
             assembly.GetTypes()
                 .Where(t => !t.HasAttribute<GeneratedCodeAttribute>(inherit: false)
-                            && !t.HasAttribute<CompilerGeneratedAttribute>(inherit: false));
+                            && !t.HasAttribute<CompilerGeneratedAttribute>(inherit: false)
+                            && IsPartOfEffectiveApi(t));
+
+        /// <summary>
+        /// Returns whether the type is part of the effective API surface.
+        /// <para />
+        /// Types that are part of the effective API surface include <c>public</c> types, as well as
+        /// nested types that are either <c>public</c>, <c>protected</c>, or <c>protected internal</c> and where the
+        /// declaring type hierarchy is public.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        private static bool IsPartOfEffectiveApi(Type type)
+        {
+            while (type != null)
+            {
+                if (!type.IsNested)
+                {
+                    return type.IsPublic;
+                }
+
+                if (type.IsNestedPublic)
+                {
+                    type = type.DeclaringType!;
+                    continue;
+                }
+
+                if (type.IsNestedFamily || type.IsNestedFamORAssem) // protected or protected internal
+                {
+                    type = type.DeclaringType!;
+
+                    // Every containing type must itself be externally inheritable to see protected members
+                    while (type != null)
+                    {
+                        if (!IsExternallyInheritable(type))
+                            return false;
+
+                        type = type.DeclaringType;
+                    }
+
+                    return true;
+                }
+
+                return false;
+            }
+
+            return false;
+        }
+
+        private static bool IsExternallyInheritable(Type type)
+        {
+            if (!type.IsNested)
+                return type.IsPublic;
+
+            return type.IsNestedPublic ||
+                   type.IsNestedFamily ||
+                   type.IsNestedFamORAssem;
+        }
     }
 }

--- a/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
@@ -1,6 +1,5 @@
 using J2N;
 using J2N.Runtime.CompilerServices;
-using Lucene.Net.Support;
 using Lucene.Net.Diagnostics;
 using RandomizedTesting.Generators;
 using System;
@@ -49,7 +48,7 @@ namespace Lucene.Net.Util.Automaton
                 }
                 try
                 {
-                    new RegExp(regexp, RegExpSyntax.NONE);
+                    _ = new RegExp(regexp, RegExpSyntax.NONE);
                     return regexp;
                 }
                 catch (Exception e) when (e.IsException())
@@ -353,6 +352,84 @@ namespace Lucene.Net.Util.Automaton
             a.deterministic = true;
             a.ClearNumberedStates();
             a.RemoveDeadTransitions();
+        }
+
+        /// <summary>
+        /// Simple, original implementation of getFiniteStrings.
+        ///
+        /// <para/>
+        /// Returns the set of accepted strings, assuming that at most
+        /// <paramref name="limit"/> strings are accepted. If more than <paramref name="limit"/>
+        /// strings are accepted, the first <paramref name="limit"/> strings found are returned. If <paramref name="limit"/>&lt;0, then
+        /// the limit is infinite.
+        ///
+        /// <para/>
+        /// This implementation is recursive: it uses one stack
+        /// frame for each digit in the returned strings (i.e., max
+        /// is the max length returned string).
+        /// </summary>
+        /// <param name="a">The automaton.</param>
+        /// <param name="limit">The maximum number of strings to return.</param>
+        /// <returns>A set of accepted strings.</returns>
+        public static ISet<Int32sRef> GetFiniteStringsRecursive(Automaton a, int limit)
+        {
+            JCG.HashSet<Int32sRef> strings = new JCG.HashSet<Int32sRef>();
+            if (a.IsSingleton)
+            {
+                if (limit > 0)
+                {
+                    strings.Add(Fst.Util.ToUTF32(a.Singleton, new Int32sRef()));
+                }
+            }
+            else if (!GetFiniteStrings(a.initial, new JCG.HashSet<State>(), strings, new Int32sRef(), limit))
+            {
+                return strings;
+            }
+
+            return strings;
+        }
+
+        /// <summary>
+        /// Returns the strings that can be produced from the given state, or
+        /// false if more than <paramref name="limit"/> strings are found.
+        /// <paramref name="limit"/>&lt;0 means "infinite".
+        /// </summary>
+        private static bool GetFiniteStrings(State s, JCG.HashSet<State> pathstates,
+            JCG.HashSet<Int32sRef> strings, Int32sRef path, int limit)
+        {
+            pathstates.Add(s);
+            foreach (Transition t in s.GetTransitions())
+            {
+                if (pathstates.Contains(t.to))
+                {
+                    return false;
+                }
+
+                for (int n = t.min; n <= t.max; n++)
+                {
+                    path.Grow(path.Length + 1);
+                    path.Int32s[path.Length] = n;
+                    path.Length++;
+                    if (t.to.accept)
+                    {
+                        strings.Add(Int32sRef.DeepCopyOf(path));
+                        if (limit >= 0 && strings.Count > limit)
+                        {
+                            return false;
+                        }
+                    }
+
+                    if (!GetFiniteStrings(t.to, pathstates, strings, path, limit))
+                    {
+                        return false;
+                    }
+
+                    path.Length--;
+                }
+            }
+
+            pathstates.Remove(s);
+            return true;
         }
 
         /// <summary>

--- a/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
+++ b/src/Lucene.Net.TestFramework/Util/Automaton/AutomatonTestUtil.cs
@@ -6,6 +6,10 @@ using System;
 using System.Collections.Generic;
 using JCG = J2N.Collections.Generic;
 
+#if !FEATURE_QUEUE_TRYDEQUEUE_TRYPEEK
+using Lucene.Net.Support;
+#endif
+
 namespace Lucene.Net.Util.Automaton
 {
     /*

--- a/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingSuggesterTest.cs
+++ b/src/Lucene.Net.Tests.Suggest/Suggest/Analyzing/AnalyzingSuggesterTest.cs
@@ -1499,24 +1499,24 @@ namespace Lucene.Net.Search.Suggest.Analyzing
             return asList;
         }
 
-        // LUCENENET TODO: This is a test from Lucene 4.8.1 that currently produces a stack overflow
-        //// TODO: we need BaseSuggesterTestCase?
-        //[Test]
-        //public void TestTooLongSuggestion()
-        //{
-        //    Analyzer a = new MockAnalyzer(Random);
-        //    AnalyzingSuggester suggester = new AnalyzingSuggester(a);
-        //    String bigString = TestUtil.RandomSimpleString(Random, 60000, 60000);
-        //    try
-        //    {
-        //        suggester.Build(new InputArrayEnumerator(new Input[] {
-        //            new Input(bigString, 7)}));
-        //        fail("did not hit expected exception");
-        //    }
-        //    catch (Exception iae) when (iae.IsIllegalArgumentException())
-        //    {
-        //        // expected
-        //    }
-        //}
+        // TODO: we need BaseSuggesterTestCase?
+        [Test]
+        public void TestTooLongSuggestion()
+        {
+            Analyzer a = new MockAnalyzer(Random);
+            AnalyzingSuggester suggester = new AnalyzingSuggester(a);
+            string bigString = TestUtil.RandomSimpleString(Random, 60000, 60000);
+            try
+            {
+                suggester.Build(new InputArrayEnumerator([
+                    new Input(bigString, 7)
+                ]));
+                Assert.Fail("did not hit expected exception");
+            }
+            catch (ArgumentOutOfRangeException /*iae*/) // LUCENENET-specific AOORE for .NET semantics
+            {
+                // expected
+            }
+        }
     }
 }

--- a/src/Lucene.Net.Tests/Util/Automaton/TestSpecialOperations.cs
+++ b/src/Lucene.Net.Tests/Util/Automaton/TestSpecialOperations.cs
@@ -1,6 +1,9 @@
 using NUnit.Framework;
+using RandomizedTesting.Generators;
+using System;
 using System.Collections.Generic;
 using Assert = Lucene.Net.TestFramework.Assert;
+using JCG = J2N.Collections.Generic;
 
 namespace Lucene.Net.Util.Automaton
 {
@@ -42,14 +45,28 @@ namespace Lucene.Net.Util.Automaton
         }
 
         /// <summary>
+        /// Pass false for testRecursive if the expected strings
+        /// may be too long
+        /// </summary>
+        private static ISet<Int32sRef> GetFiniteStrings(Automaton a, int limit, bool testRecursive) // LUCENENET: made static
+        {
+            ISet<Int32sRef> result = SpecialOperations.GetFiniteStrings(a, limit);
+            if (testRecursive)
+            {
+                Assert.AreEqual(AutomatonTestUtil.GetFiniteStringsRecursive(a, limit), result);
+            }
+            return result;
+        }
+
+        /// <summary>
         /// Basic test for getFiniteStrings
         /// </summary>
         [Test]
-        public virtual void TestFiniteStrings()
+        public virtual void TestFiniteStringsBasic()
         {
             Automaton a = BasicOperations.Union(BasicAutomata.MakeString("dog"), BasicAutomata.MakeString("duck"));
             MinimizationOperations.Minimize(a);
-            ISet<Int32sRef> strings = SpecialOperations.GetFiniteStrings(a, -1);
+            ISet<Int32sRef> strings = GetFiniteStrings(a, -1, true);
             Assert.AreEqual(2, strings.Count);
             Int32sRef dog = new Int32sRef();
             Util.ToInt32sRef(new BytesRef("dog"), dog);
@@ -57,6 +74,204 @@ namespace Lucene.Net.Util.Automaton
             Int32sRef duck = new Int32sRef();
             Util.ToInt32sRef(new BytesRef("duck"), duck);
             Assert.IsTrue(strings.Contains(duck));
+        }
+
+        [Test]
+        public void TestFiniteStringsEatsStack()
+        {
+            char[] chars = new char[50000];
+            TestUtil.RandomFixedLengthUnicodeString(Random, chars, 0, chars.Length);
+            string bigString1 = new string(chars);
+            TestUtil.RandomFixedLengthUnicodeString(Random, chars, 0, chars.Length);
+            string bigString2 = new string(chars);
+            Automaton a = BasicOperations.Union(BasicAutomata.MakeString(bigString1), BasicAutomata.MakeString(bigString2));
+            ISet<Int32sRef> strings = GetFiniteStrings(a, -1, false);
+            Assert.AreEqual(2, strings.Count);
+            Int32sRef scratch = new Int32sRef();
+            Util.ToUTF32(bigString1.ToCharArray(), 0, bigString1.Length, scratch);
+            Assert.IsTrue(strings.Contains(scratch));
+            Util.ToUTF32(bigString2.ToCharArray(), 0, bigString2.Length, scratch);
+            Assert.IsTrue(strings.Contains(scratch));
+        }
+
+        [Test]
+        public void TestRandomFiniteStrings1()
+        {
+            int numStrings = AtLeast(500);
+            if (Verbose)
+            {
+                Console.WriteLine($"TEST: numStrings={numStrings}");
+            }
+
+            ISet<Int32sRef> strings = new JCG.HashSet<Int32sRef>();
+            IList<Automaton> automata = new List<Automaton>();
+            for (int i = 0; i < numStrings; i++)
+            {
+                string s = TestUtil.RandomSimpleString(Random, 1, 200);
+                automata.Add(BasicAutomata.MakeString(s));
+                Int32sRef scratch = new Int32sRef();
+                Util.ToUTF32(s.ToCharArray(), 0, s.Length, scratch);
+                strings.Add(scratch);
+                if (Verbose)
+                {
+                    Console.WriteLine($"  add string={s}");
+                }
+            }
+
+            // TODO: we could sometimes use
+            // DaciukMihovAutomatonBuilder here
+
+            // TODO: what other random things can we do here...
+            Automaton a = BasicOperations.Union(automata);
+            if (Random.NextBoolean())
+            {
+                Automaton.Minimize(a);
+                if (Verbose)
+                {
+                    Console.WriteLine($"TEST: a.minimize numStates={a.GetNumberOfStates()}");
+                }
+            }
+            else if (Random.NextBoolean())
+            {
+                if (Verbose)
+                {
+                    Console.WriteLine("TEST: a.determinize");
+                }
+                a.Determinize();
+            }
+            else if (Random.NextBoolean())
+            {
+                if (Verbose)
+                {
+                    Console.WriteLine("TEST: a.reduce");
+                }
+                a.Reduce();
+            }
+            else if (Random.NextBoolean())
+            {
+                if (Verbose)
+                {
+                    Console.WriteLine("TEST: a.getNumberedStates");
+                }
+                a.GetNumberedStates();
+            }
+
+            ISet<Int32sRef> actual = GetFiniteStrings(a, -1, true);
+            if (!strings.Equals(actual))
+            {
+                Console.WriteLine($"strings.size()={strings.Count} actual.size={actual.Count}");
+                IList<Int32sRef> x = new List<Int32sRef>(strings);
+                x.Sort();
+                IList<Int32sRef> y = new List<Int32sRef>(actual);
+                y.Sort();
+                int end = Math.Min(x.Count, y.Count);
+                for (int i = 0; i < end; i++)
+                {
+                    Console.WriteLine($"  i={i} string={ToString(x[i])} actual={ToString(y[i])}");
+                }
+                Assert.Fail("wrong strings found");
+            }
+        }
+
+        // ascii only!
+        private static string ToString(Int32sRef ints)
+        {
+            BytesRef br = new BytesRef(ints.Length);
+            for (int i = 0; i < ints.Length; i++)
+            {
+                br.Bytes[i] = (byte) ints.Int32s[i];
+            }
+            br.Length = ints.Length;
+            return br.Utf8ToString();
+        }
+
+        [Test]
+        public void TestWithCycle()
+        {
+            try
+            {
+                SpecialOperations.GetFiniteStrings(new RegExp("abc.*", RegExpSyntax.NONE).ToAutomaton(), -1);
+                Assert.Fail("did not hit exception");
+            }
+            catch (Exception iae) when (iae.IsIllegalArgumentException())
+            {
+                // expected
+            }
+        }
+
+        [Test]
+        public void TestRandomFiniteStrings2()
+        {
+            // Just makes sure we can run on any random finite
+            // automaton:
+            int iters = AtLeast(100);
+            for (int i = 0; i < iters; i++)
+            {
+                Automaton a = AutomatonTestUtil.RandomAutomaton(Random);
+                try
+                {
+                    // Must pass a limit because the random automaton
+                    // can accept MANY strings:
+                    SpecialOperations.GetFiniteStrings(a, TestUtil.NextInt32(Random, 1, 1000));
+                    // NOTE: cannot do this, because the method is not
+                    // guaranteed to detect cycles when you have a limit
+                    //assertTrue(SpecialOperations.isFinite(a));
+                }
+                catch (Exception iae) when (iae.IsIllegalArgumentException())
+                {
+                    Assert.IsFalse(SpecialOperations.IsFinite(a));
+                }
+            }
+        }
+
+        [Test]
+        public void TestInvalidLimit()
+        {
+            Automaton a = AutomatonTestUtil.RandomAutomaton(Random);
+            try
+            {
+                SpecialOperations.GetFiniteStrings(a, -7);
+                Assert.Fail("did not hit exception");
+            }
+            catch (ArgumentOutOfRangeException /*iae*/) // LUCENENET-specific AOORE
+            {
+                // expected
+            }
+        }
+
+        [Test]
+        public void TestInvalidLimit2()
+        {
+            Automaton a = AutomatonTestUtil.RandomAutomaton(Random);
+            try
+            {
+                SpecialOperations.GetFiniteStrings(a, 0);
+                Assert.Fail("did not hit exception");
+            }
+            catch (ArgumentOutOfRangeException /*iae*/) // LUCENENET-specific AOORE
+            {
+                // expected
+            }
+        }
+
+        [Test]
+        public void TestSingletonNoLimit()
+        {
+            ISet<Int32sRef> result = SpecialOperations.GetFiniteStrings(BasicAutomata.MakeString("foobar"), -1);
+            Assert.AreEqual(1, result.Count);
+            Int32sRef scratch = new Int32sRef();
+            Util.ToUTF32("foobar".ToCharArray(), 0, 6, scratch);
+            Assert.IsTrue(result.Contains(scratch));
+        }
+
+        [Test]
+        public void TestSingletonLimit1()
+        {
+            ISet<Int32sRef> result = SpecialOperations.GetFiniteStrings(BasicAutomata.MakeString("foobar"), 1);
+            Assert.AreEqual(1, result.Count);
+            Int32sRef scratch = new Int32sRef();
+            Util.ToUTF32("foobar".ToCharArray(), 0, 6, scratch);
+            Assert.IsTrue(result.Contains(scratch));
         }
     }
 }

--- a/src/Lucene.Net.Tests/Util/TestOfflineSorter.cs
+++ b/src/Lucene.Net.Tests/Util/TestOfflineSorter.cs
@@ -311,5 +311,27 @@ namespace Lucene.Net.Util
             Assert.Throws<ArgumentOutOfRangeException>(() => OfflineSorter.BufferSize.Megabytes(0), "min mb is 0.5");
             Assert.Throws<ArgumentOutOfRangeException>(() => OfflineSorter.BufferSize.Megabytes(-1), "min mb is 0.5");
         }
+
+        [Test, LuceneNetSpecific]
+        public void TestWrite_ArgumentValidation()
+        {
+            FileInfo file = new FileInfo(Path.Combine(tempDir.FullName, "testWrite_ArgumentValidation"));
+            using var stream = new FileStream(file.FullName, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.Read,
+                bufferSize: OfflineSorter.DEFAULT_FILESTREAM_BUFFER_SIZE, FileOptions.DeleteOnClose);
+            using OfflineSorter.ByteSequencesWriter w = new OfflineSorter.ByteSequencesWriter(stream, leaveOpen: true);
+
+            // ReSharper disable AccessToDisposedClosure
+            Assert.Throws<ArgumentNullException>(() => w.Write(((byte[])null)!));
+            Assert.Throws<ArgumentNullException>(() => w.Write(((BytesRef)null)!));
+            Assert.Throws<ArgumentOutOfRangeException>(() => w.Write([], -1, 1), "datum");
+            Assert.Throws<ArgumentOutOfRangeException>(() => w.Write([], 0, -1), "datum");
+            Assert.Throws<ArgumentException>(() => w.Write([], 0, 1), "datum");
+
+            // validate that len is less than or equal to short.MaxValue
+            var bigArray = new byte[short.MaxValue + 2]; // give extra space so that off <= bytes.Length - len
+            Assert.Throws<ArgumentOutOfRangeException>(() => w.Write(bigArray, 0, short.MaxValue + 1), "datum");
+            Assert.DoesNotThrow(() => w.Write(bigArray, 0, short.MaxValue));
+            // ReSharper restore AccessToDisposedClosure
+        }
     }
 }

--- a/src/Lucene.Net/Util/Automaton/SpecialOperations.cs
+++ b/src/Lucene.Net/Util/Automaton/SpecialOperations.cs
@@ -1,5 +1,8 @@
 using J2N.Collections.Generic.Extensions;
 using J2N.Text;
+using Lucene.Net.Diagnostics;
+using Lucene.Net.Support;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -272,70 +275,193 @@ namespace Lucene.Net.Util.Automaton
             return accept;
         }
 
+        private class PathNode
+        {
+            /// <summary>
+            /// Which state the path node ends on, whose
+            /// transitions we are enumerating.
+            /// </summary>
+            public State state;
+
+            /// <summary>
+            /// Which state the current transition leads to.
+            /// </summary>
+            public State to;
+
+            /// <summary>
+            /// Which transition we are on.
+            /// </summary>
+            public int transition;
+
+            /// <summary>
+            /// Which label we are on, in the min-max range of the
+            /// current Transition
+            /// </summary>
+            public int label;
+
+            public void ResetState(State state)
+            {
+                if (Debugging.AssertsEnabled) Debugging.Assert(state.NumTransitions != 0);
+                this.state = state;
+                transition = 0;
+                Transition t = state.TransitionsArray[transition];
+                label = t.min;
+                to = t.to;
+            }
+
+            /// <summary>
+            /// Returns next label of current transition, or
+            /// advances to next transition and returns its first
+            /// label, if current one is exhausted.  If there are
+            /// no more transitions, returns -1.
+            /// </summary>
+            public int NextLabel()
+            {
+                if (label > state.TransitionsArray[transition].max)
+                {
+                    // We've exhausted the current transition's labels;
+                    // move to next transitions:
+                    transition++;
+                    if (transition >= state.NumTransitions)
+                    {
+                        // We're done iterating transitions leaving this state
+                        return -1;
+                    }
+                    Transition t = state.TransitionsArray[transition];
+                    label = t.min;
+                    to = t.to;
+                }
+                return label++;
+            }
+        }
+
+        private static PathNode GetNode(PathNode[] nodes, int index)
+        {
+            if (Debugging.AssertsEnabled) Debugging.Assert(index < nodes.Length);
+            if (nodes[index] == null)
+            {
+                nodes[index] = new PathNode();
+            }
+            return nodes[index];
+        }
+
         // TODO: this is a dangerous method ... Automaton could be
         // huge ... and it's better in general for caller to
         // enumerate & process in a single walk:
 
         /// <summary>
-        /// Returns the set of accepted strings, assuming that at most
-        /// <paramref name="limit"/> strings are accepted. If more than <paramref name="limit"/>
-        /// strings are accepted, the first limit strings found are returned. If <paramref name="limit"/>&lt;0, then
-        /// the limit is infinite.
+        /// Returns the set of accepted strings, up to at most
+        /// <paramref name="limit"/> strings. If more than <paramref name="limit"/>
+        /// strings are accepted, the first limit strings found are returned. If <paramref name="limit"/> == -1, then
+        /// the limit is infinite. If the <see cref="Automaton"/> has
+        /// cycles then this method might throw <see cref="ArgumentOutOfRangeException"/>
+        /// but that is not guaranteed when the limit is set.
         /// </summary>
         public static ISet<Int32sRef> GetFiniteStrings(Automaton a, int limit)
         {
-            JCG.HashSet<Int32sRef> strings = new JCG.HashSet<Int32sRef>();
+            JCG.HashSet<Int32sRef> results = new JCG.HashSet<Int32sRef>();
+
+            if (limit == -1 || limit > 0)
+            {
+                // OK
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(limit),
+                    $"limit must be -1 (which means no limit), or > 0; got: {limit}");
+            }
+
             if (a.IsSingleton)
             {
-                if (limit > 0)
-                {
-                    strings.Add(Util.ToUTF32(a.Singleton, new Int32sRef()));
-                }
+                // Easy case: automaton accepts only 1 string
+                results.Add(Util.ToUTF32(a.singleton, new Int32sRef()));
             }
-            else if (!GetFiniteStrings(a.initial, new JCG.HashSet<State>(), strings, new Int32sRef(), limit))
+            else
             {
-                return strings;
-            }
-            return strings;
-        }
+                if (a.initial.accept)
+                {
+                    // Special case the empty string, as usual:
+                    results.Add(new Int32sRef());
+                }
 
-        /// <summary>
-        /// Returns the strings that can be produced from the given state, or
-        /// <c>false</c> if more than <paramref name="limit"/> strings are found.
-        /// <paramref name="limit"/>&lt;0 means "infinite".
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool GetFiniteStrings(State s, JCG.HashSet<State> pathstates, JCG.HashSet<Int32sRef> strings, Int32sRef path, int limit)
-        {
-            pathstates.Add(s);
-            foreach (Transition t in s.GetTransitions())
-            {
-                if (pathstates.Contains(t.to))
+                if (a.initial.NumTransitions > 0 && (limit == -1 || results.Count < limit))
                 {
-                    return false;
-                }
-                for (int n = t.min; n <= t.max; n++)
-                {
-                    path.Grow(path.Length + 1);
-                    path.Int32s[path.Length] = n;
-                    path.Length++;
-                    if (t.to.accept)
+                    // TODO: we could use state numbers here and just
+                    // alloc array, but asking for states array can be
+                    // costly (it's lazily computed):
+
+                    // Tracks which states are in the current path, for
+                    // cycle detection:
+                    JCG.HashSet<State> pathStates = new JCG.HashSet<State>();
+
+                    // Stack to hold our current state in the
+                    // recursion/iteration:
+                    PathNode[] nodes = new PathNode[4];
+
+                    pathStates.Add(a.initial);
+                    PathNode root = GetNode(nodes, 0);
+                    root.ResetState(a.initial);
+
+                    Int32sRef @string = new Int32sRef(1);
+                    @string.Length = 1;
+
+                    while (@string.Length > 0)
                     {
-                        strings.Add(Int32sRef.DeepCopyOf(path));
-                        if (limit >= 0 && strings.Count > limit)
+                        PathNode node = nodes[@string.Length - 1];
+
+                        // Get next label leaving the current node:
+                        int label = node.NextLabel();
+
+                        if (label != -1)
                         {
-                            return false;
+                            @string.Int32s[@string.Length - 1] = label;
+
+                            if (node.to.accept)
+                            {
+                                // This transition leads to an accept state,
+                                // so we save the current string:
+                                results.Add(Int32sRef.DeepCopyOf(@string));
+                                if (results.Count == limit)
+                                {
+                                    break;
+                                }
+                            }
+
+                            if (node.to.NumTransitions != 0)
+                            {
+                                // Now recurse: the destination of this transition has
+                                // outgoing transitions:
+                                if (pathStates.Contains(node.to))
+                                {
+                                    throw new ArgumentException("automaton has cycles");
+                                }
+                                pathStates.Add(node.to);
+
+                                // Push node onto stack:
+                                if (nodes.Length == @string.Length)
+                                {
+                                    PathNode[] newNodes = new PathNode[ArrayUtil.Oversize(nodes.Length+1, RamUsageEstimator.NUM_BYTES_OBJECT_REF)];
+                                    Arrays.Copy(nodes, 0, newNodes, 0, nodes.Length);
+                                    nodes = newNodes;
+                                }
+                                GetNode(nodes, @string.Length).ResetState(node.to);
+                                @string.Length++;
+                                @string.Grow(@string.Length);
+                            }
+                        }
+                        else
+                        {
+                            // No more transitions leaving this state,
+                            // pop/return back to previous state:
+                            if (Debugging.AssertsEnabled) Debugging.Assert(pathStates.Contains(node.state));
+                            pathStates.Remove(node.state);
+                            @string.Length--;
                         }
                     }
-                    if (!GetFiniteStrings(t.to, pathstates, strings, path, limit))
-                    {
-                        return false;
-                    }
-                    path.Length--;
                 }
             }
-            pathstates.Remove(s);
-            return true;
+
+            return results;
         }
     }
 }

--- a/src/Lucene.Net/Util/Automaton/State.cs
+++ b/src/Lucene.Net/Util/Automaton/State.cs
@@ -7,6 +7,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+// operator overloads purposefully use reference equality
+#pragma warning disable CS0660, CS0661
 
 /*
  * dk.brics.automaton
@@ -359,22 +361,6 @@ namespace Lucene.Net.Util.Automaton
         public virtual int CompareTo(State s)
         {
             return s.id - id;
-        }
-
-        // LUCENENET NOTE: DO NOT IMPLEMENT Equals() with structural equality!!!
-        // Although it doesn't match GetHashCode(), checking for
-        // reference equality is by design.
-        // Implementing Equals() causes difficult to diagnose
-        // IndexOutOfRangeExceptions when using FuzzyTermsEnum.
-        // See GH-296.
-        // Overriding here to prevent CS0660 warning due to defining the == operator.
-        // ReSharper disable once BaseObjectEqualsIsObjectEquals
-        public override bool Equals(object obj) => base.Equals(obj);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override int GetHashCode()
-        {
-            return id;
         }
 
         #region Operator overrides

--- a/src/Lucene.Net/Util/OfflineSorter.cs
+++ b/src/Lucene.Net/Util/OfflineSorter.cs
@@ -670,7 +670,7 @@ namespace Lucene.Net.Util
             /// by the bytes.
             /// </summary>
             /// <exception cref="ArgumentNullException"><paramref name="bytes"/> is <c>null</c>.</exception>
-            /// <exception cref="ArgumentOutOfRangeException"><paramref name="off"/> or <paramref name="len"/> is less than 0.</exception>
+            /// <exception cref="ArgumentOutOfRangeException"><paramref name="off"/> or <paramref name="len"/> is less than 0, or <paramref name="len"/> is greater than <see cref="short.MaxValue"/>.</exception>
             /// <exception cref="ArgumentException"><paramref name="off"/> and <paramref name="len"/> refer to a position outside of the array.</exception>
             public virtual void Write(byte[] bytes, int off, int len)
             {
@@ -682,6 +682,9 @@ namespace Lucene.Net.Util
                     throw new ArgumentOutOfRangeException(nameof(len), "Non-negative number required.");
                 if (off > bytes.Length - len) // Checks for int overflow
                     throw new ArgumentException("Index and length must refer to a location within the array.");
+
+                if (len > short.MaxValue)
+                    throw new ArgumentOutOfRangeException(nameof(len), $"len must be <= {short.MaxValue}; got {len}");
 
                 os.Write((short)len);
                 os.Write(bytes, off, len);


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Backport Lucene 4.8.1 fixes for AnalyzingSuggester, OfflineSorter, and SpecialOperations

Partial #1381 (Batch 4)

## Description

This PR backports commits 8c4e8268181 (LUCENE-5628) and 9d10d6f92cc (LUCENE-5660) from Lucene 4.8.1. This has the added benefit of re-enabling the commented-out TestTooLongSuggestion test!

Batch 1 (PR #1413) incorrectly included the OfflineSorter change; that is actually part of LUCENE-5660; it was just difficult to tell that since the commit message did not mention a JIRA number. I'm going to remove that from that PR since it is necessary here for the test to pass.