### PR TITLE
fix(docs): keep right menu below sticky header

### DIFF
--- a/websites/apidocs/Templates/LuceneTemplateAssets/styles/main.css
+++ b/websites/apidocs/Templates/LuceneTemplateAssets/styles/main.css
@@ -780,9 +780,9 @@ button:focus-visible {
       width: auto !important; /* back to natural width */
     }
 
-    /* Reverts 9.1 sideaffix margin change, so they are more uniform with the desktop mode one */
+    /* Keep the right affix below the wrapped sticky header */
     .sideaffix {
-      margin-top: 50px !important;
+      margin-top: 100px !important;
     }
   }
 


### PR DESCRIPTION
- [x] I've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [x] I've included unit or integration tests for my change, where applicable.
- [x] I've included inline docs for my change, where applicable.
- [x] There's an open issue for the PR that I am making.

Keep the desktop docs side menu below the sticky header

Fixes #1407

## Description

I increased the desktop offset for the API docs side affix so its first entries no longer sit underneath the wrapped sticky header at viewport widths of 1200px and above.

I verified the change against the current 4.8.0-beta00018 docs page by replacing its stylesheet in headless Chromium with this branch's stylesheet. At 1200, 1215, 1280, 1350, and 1600px, the 195px-tall header ends before the side menu starts at 200px, and every visible menu entry remains inside the viewport.

## Validation

- `uvx prek run --files websites/apidocs/Templates/LuceneTemplateAssets/styles/main.css`
- Headless Chromium layout regression check at 1200, 1215, 1280, 1350, and 1600px
- `git diff --check origin/master...HEAD`

I did not run the complete Windows-based DocFX website build locally; the browser regression check exercises the changed stylesheet against the published docs markup.
