### PR TITLE
Prevent users from overriding test framework setup/teardown functionality, #1087

### DIFF
--- a/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
+++ b/src/Lucene.Net.TestFramework/Lucene.Net.TestFramework.csproj
@@ -116,6 +116,7 @@
     <InternalsVisibleTo Include="Lucene.Net.Tests.TestFramework.DependencyInjection" />
 
     <InternalsVisibleTo Include="Lucene.Net.TestFramework.TestData.NUnit" />
+    <InternalsVisibleTo Include="Lucene.Net.Tests.TestFramework.NUnitExtensions" />
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -18,6 +18,7 @@ using RandomizedTesting.Generators;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -73,7 +74,13 @@ namespace Lucene.Net.Util
     /// so using them on the <see cref="OneTimeSetUp"/> and
     /// <see cref="OneTimeTearDown"/> method overrides is not strictly required. Any
     /// code in these methods is executed within the test framework's control and
-    /// ensure proper setup has been made. <b>Try not to use static initializers
+    /// ensure proper setup has been made. The test framework's own mandatory
+    /// setup/teardown work runs in framework-owned static methods
+    /// (<see cref="__OneTimeSetUp()"/>, <see cref="__OneTimeTearDown()"/> and
+    /// <see cref="__TearDown()"/>) that NUnit runs before/after the overridable
+    /// methods, so it runs even if an override fails to call the base method;
+    /// calling the base method is still required to preserve the behavior of
+    /// intermediate base classes. <b>Try not to use static initializers
     /// (including complex readonly field initializers).</b> Static initializers are
     /// executed before any setup rules are fired and may cause you (or somebody
     /// else) headaches.
@@ -83,7 +90,9 @@ namespace Lucene.Net.Util
     /// For instance-level setup, use <see cref="Before"/> and <see cref="After"/> annotated
     /// methods. If you override either <see cref="SetUp()"/> or <see cref="TearDown()"/> in
     /// your subclass, make sure you call <c>base.SetUp()</c> and
-    /// <c>base.TearDown()</c>. This is detected and enforced.
+    /// <c>base.TearDown()</c>. The test framework's mandatory per-test cleanup is
+    /// guaranteed to run even if you don't, but the base calls are still required to
+    /// preserve the behavior of intermediate base classes.
     /// </para>
     ///
     /// <h3>Specifying test cases</h3>
@@ -905,6 +914,12 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// For subclasses to override. Overrides must call <c>base.TearDown()</c>.
+        /// <para/>
+        /// LUCENENET specific: The test framework's mandatory per-test cleanup (failure
+        /// reproduction reporting and disposing resources registered with
+        /// <see cref="DisposeAfterTest"/>) runs in <see cref="__TearDown()"/> after all
+        /// <c>[TearDown]</c> methods, so it runs even if an override fails to call
+        /// <c>base.TearDown()</c>. See #1087.
         /// </summary>
         [After]
         public virtual void TearDown()
@@ -912,7 +927,33 @@ namespace Lucene.Net.Util
             /* LUCENENET TODO: Not sure how to convert these
                 ParentChainCallRule.TeardownCalled = true;
                 */
-            TestResult result = TestExecutionContext.CurrentContext.CurrentResult;
+        }
+
+        /// <summary>
+        /// The test framework's per-test teardown method. This method is called by NUnit and is
+        /// not intended for use by user code; it must be public for NUnit to call it. It is
+        /// declared <c>static</c> so subclasses cannot override it, and because it is declared at
+        /// the root of the <see cref="LuceneTestCase"/> inheritance hierarchy, NUnit guarantees it
+        /// runs after all <c>[TearDown]</c> methods of subclasses (teardown methods run in
+        /// most-derived-first order). This ensures the test framework's mandatory per-test cleanup
+        /// runs even if an override of <see cref="TearDown()"/> fails to call
+        /// <c>base.TearDown()</c>. See #1087.
+        /// </summary>
+        // LUCENENET specific
+        [After]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void __TearDown() => FrameworkTearDown(TestExecutionContext.CurrentContext);
+
+        /// <summary>
+        /// The test framework's mandatory per-test teardown work, formerly in
+        /// <see cref="TearDown()"/>. Called from <see cref="__TearDown()"/> after all
+        /// <c>[TearDown]</c> methods complete, so subclasses cannot disable it by failing to call
+        /// <c>base.TearDown()</c>. See #1087.
+        /// </summary>
+        // LUCENENET specific
+        internal static void FrameworkTearDown(TestExecutionContext context)
+        {
+            TestResult result = context.CurrentResult;
 
             if (result.ResultState == ResultState.Failure || result.ResultState == ResultState.Error)
             {
@@ -996,15 +1037,44 @@ namespace Lucene.Net.Util
         }
 
         /// <summary>
-        /// Sets up dependency injection of codec factories for running the test class,
-        /// and also picks random defaults for culture, time zone, similarity, and default codec.
+        /// For subclasses to override to add class (suite-level) setup behavior. Overrides
+        /// must call <c>base.OneTimeSetUp()</c> BEFORE setting up their test fixture.
         /// <para/>
-        /// If you override this method, be sure to call <c>base.OneTimeSetUp()</c> BEFORE setting
-        /// up your test fixture.
+        /// LUCENENET specific: The test framework's mandatory suite setup (dependency injection of
+        /// codec factories and picking random defaults for culture, time zone, similarity, and
+        /// default codec) runs in <see cref="__OneTimeSetUp()"/> before any <c>[OneTimeSetUp]</c>
+        /// methods, so it runs even if an override fails to call <c>base.OneTimeSetUp()</c>.
+        /// See #1087.
         /// </summary>
         // LUCENENET specific method for setting up dependency injection of test classes.
         [OneTimeSetUp]
         public virtual void OneTimeSetUp()
+        {
+        }
+
+        /// <summary>
+        /// The test framework's suite setup method. This method is called by NUnit and is not
+        /// intended for use by user code; it must be public for NUnit to call it. It is declared
+        /// <c>static</c> so subclasses cannot override it, and because it is declared at the root
+        /// of the <see cref="LuceneTestCase"/> inheritance hierarchy, NUnit guarantees it runs
+        /// before all <c>[OneTimeSetUp]</c> methods of subclasses (setup methods run in
+        /// base-first order). This ensures the test framework's mandatory suite setup runs even
+        /// if an override of <see cref="OneTimeSetUp()"/> fails to call
+        /// <c>base.OneTimeSetUp()</c>. See #1087.
+        /// </summary>
+        // LUCENENET specific
+        [OneTimeSetUp]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void __OneTimeSetUp() => FrameworkOneTimeSetUp(TestExecutionContext.CurrentContext);
+
+        /// <summary>
+        /// The test framework's mandatory suite setup work, formerly in <see cref="OneTimeSetUp()"/>.
+        /// Called from <see cref="__OneTimeSetUp()"/> before any <c>[OneTimeSetUp]</c> methods
+        /// run, so subclasses cannot disable it by failing to call <c>base.OneTimeSetUp()</c>.
+        /// See #1087.
+        /// </summary>
+        // LUCENENET specific
+        internal static void FrameworkOneTimeSetUp(TestExecutionContext context)
         {
             try
             {
@@ -1016,7 +1086,7 @@ namespace Lucene.Net.Util
                 if (FailOnTestFixtureOneTimeSetUpError)
                 {
                     // LUCENENET: Patch NUnit so it will report all of the tests in the class as a failure if we got an exception.
-                    TestExecutionContext.CurrentContext.CurrentTest.MakeAllInvalid(ex, $"An exception occurred during OneTimeSetUp:\n{ex}");
+                    context.CurrentTest.MakeAllInvalid(ex, $"An exception occurred during OneTimeSetUp:\n{ex}");
                 }
                 else
                 {
@@ -1026,15 +1096,46 @@ namespace Lucene.Net.Util
         }
 
         /// <summary>
-        /// Tears down random defaults and cleans up temporary files.
+        /// For subclasses to override to add class (suite-level) teardown behavior. Overrides
+        /// must call <c>base.OneTimeTearDown()</c> AFTER tearing down their test fixture.
         /// <para/>
-        /// If you override this method, be sure to call <c>base.OneTimeTearDown()</c> AFTER
-        /// tearing down your test fixture.
+        /// LUCENENET specific: The test framework's mandatory suite teardown (tearing down random
+        /// defaults, cleaning up temporary files, and disposing resources registered with
+        /// <see cref="DisposeAfterSuite"/>) runs in <see cref="__OneTimeTearDown()"/> after all
+        /// <c>[OneTimeTearDown]</c> methods, so it runs even if an override fails to call
+        /// <c>base.OneTimeTearDown()</c>. See #1087.
         /// </summary>
         // LUCENENET specific method for setting up dependency injection of test classes.
         [OneTimeTearDown]
         public virtual void OneTimeTearDown()
         {
+        }
+
+        /// <summary>
+        /// The test framework's suite teardown method. This method is called by NUnit and is not
+        /// intended for use by user code; it must be public for NUnit to call it. It is declared
+        /// <c>static</c> so subclasses cannot override it, and because it is declared at the root
+        /// of the <see cref="LuceneTestCase"/> inheritance hierarchy, NUnit guarantees it runs
+        /// after all <c>[OneTimeTearDown]</c> methods of subclasses (teardown methods run in
+        /// most-derived-first order). This ensures the test framework's mandatory suite teardown
+        /// runs even if an override of <see cref="OneTimeTearDown()"/> fails to call
+        /// <c>base.OneTimeTearDown()</c>. See #1087.
+        /// </summary>
+        // LUCENENET specific
+        [OneTimeTearDown]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void __OneTimeTearDown() => FrameworkOneTimeTearDown(TestExecutionContext.CurrentContext);
+
+        /// <summary>
+        /// The test framework's mandatory suite teardown work, formerly in
+        /// <see cref="OneTimeTearDown()"/>. Called from <see cref="__OneTimeTearDown()"/> after
+        /// all <c>[OneTimeTearDown]</c> methods complete, so subclasses cannot disable it by
+        /// failing to call <c>base.OneTimeTearDown()</c>. See #1087.
+        /// </summary>
+        // LUCENENET specific
+        internal static void FrameworkOneTimeTearDown(TestExecutionContext context)
+        {
+            string fixtureName = context.CurrentTest.TypeInfo?.FullName ?? context.CurrentTest.FullName;
             try
             {
                 ClassEnvRule.After();
@@ -1042,7 +1143,7 @@ namespace Lucene.Net.Util
             catch (Exception ex) when (ex.IsThrowable())
             {
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
-                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during ClassEnvRule.After() in {GetType().FullName}:\n{ex}");
+                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during ClassEnvRule.After() in {fixtureName}:\n{ex}");
             }
             try
             {
@@ -1051,7 +1152,7 @@ namespace Lucene.Net.Util
             catch (Exception ex) when (ex.IsThrowable())
             {
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
-                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during CleanupTemporaryFiles() in {GetType().FullName}:\n{ex}");
+                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during CleanupTemporaryFiles() in {fixtureName}:\n{ex}");
             }
 
             // LUCENENET: DisposeAfterSuite runs last
@@ -1062,7 +1163,7 @@ namespace Lucene.Net.Util
             catch (Exception ex) when (ex.IsThrowable())
             {
                 // LUCENENET: Patch NUnit so it will report a failure in stderr if there was an exception during teardown.
-                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during RandomizedContext.DisposeResources() in {GetType().FullName}:");
+                NUnit.Framework.TestContext.Error.WriteLine($"[ERROR] OneTimeTearDown: An exception occurred during RandomizedContext.DisposeResources() in {fixtureName}:");
                 RandomizedContext.PrintStackTrace(ex, NUnit.Framework.TestContext.Error);
                 throw; // LUCENENET: Throw to preserve stack details of original throw.
             }
@@ -1134,7 +1235,16 @@ namespace Lucene.Net.Util
         /// Gets the current type being tested.
         /// </summary>
         public static Type TestType
-            => TestExecutionContext.CurrentContext.CurrentTest.Fixture?.GetType(); // LUCENENET specific - renamed from testClass()
+        {
+            // LUCENENET specific - renamed from testClass()
+            get
+            {
+                // LUCENENET: Prefer TypeInfo, which is available whether or not the fixture
+                // instance has been constructed yet. Fall back to the fixture instance's type.
+                var currentTest = TestExecutionContext.CurrentContext.CurrentTest;
+                return currentTest.TypeInfo?.Type ?? currentTest.Fixture?.GetType();
+            }
+        }
 
         /// <summary>
         /// Return the name of the currently executing test case.

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -76,11 +76,12 @@ namespace Lucene.Net.Util
     /// code in these methods is executed within the test framework's control and
     /// ensure proper setup has been made. The test framework's own mandatory
     /// setup/teardown work runs in framework-owned static methods
-    /// (<see cref="__OneTimeSetUp()"/>, <see cref="__OneTimeTearDown()"/> and
-    /// <see cref="__TearDown()"/>) that NUnit runs before/after the overridable
-    /// methods, so it runs even if an override fails to call the base method;
-    /// calling the base method is still required to preserve the behavior of
-    /// intermediate base classes. <b>Try not to use static initializers
+    /// (<see cref="__OneTimeSetUp()"/>, <see cref="__OneTimeTearDown()"/>,
+    /// <see cref="__SetUp()"/> and <see cref="__TearDown()"/>) that NUnit runs
+    /// before/after the overridable methods, so it runs even if an override fails
+    /// to call the base method; calling the base method is still required to
+    /// preserve the behavior of intermediate base classes.
+    /// <b>Try not to use static initializers
     /// (including complex readonly field initializers).</b> Static initializers are
     /// executed before any setup rules are fired and may cause you (or somebody
     /// else) headaches.
@@ -899,13 +900,44 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// For subclasses to override. Overrides must call <c>base.SetUp()</c>.
+        /// <para/>
+        /// LUCENENET specific: This method body must remain empty. The test framework's mandatory
+        /// per-test setup runs in <see cref="__SetUp()"/> before all <c>[SetUp]</c> methods, so it
+        /// runs even if an override fails to call <c>base.SetUp()</c>. Framework work must not be
+        /// added here: when a subclass does not override this method, it runs at the same level as
+        /// <see cref="__SetUp()"/>, where NUnit does not define the relative order of the two.
+        /// See #1087.
         /// </summary>
         [Before]
         public virtual void SetUp()
         {
             // LUCENENET TODO: Not sure how to convert these
             //ParentChainCallRule.SetupCalled = true;
+        }
 
+        /// <summary>
+        /// The test framework's per-test setup method. This method is called by NUnit and is not
+        /// intended for use by user code. It is declared <c>static</c> so subclasses cannot
+        /// override it, and because it is declared at the root of the <see cref="LuceneTestCase"/>
+        /// inheritance hierarchy, NUnit guarantees it runs before all <c>[SetUp]</c> methods of
+        /// subclasses (setup methods run in base-first order). This ensures the test framework's
+        /// mandatory per-test setup runs even if an override of <see cref="SetUp()"/> fails to
+        /// call <c>base.SetUp()</c>. See #1087.
+        /// </summary>
+        // LUCENENET specific
+        [Before]
+        [CLSCompliant(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected static void __SetUp() => FrameworkSetUp();
+
+        /// <summary>
+        /// The test framework's mandatory per-test setup work. Called from <see cref="__SetUp()"/>
+        /// before any <c>[SetUp]</c> methods run, so subclasses cannot disable it by failing to
+        /// call <c>base.SetUp()</c>. See #1087.
+        /// </summary>
+        // LUCENENET specific
+        internal static void FrameworkSetUp()
+        {
             // LUCENENET specific: capture the thread running the test method so that
             // IsTestThread can distinguish it from background threads (e.g. ConcurrentMergeScheduler
             // merge threads). This mirrors Java's ThreadAndTestNameRule.testCaseThread.
@@ -915,11 +947,13 @@ namespace Lucene.Net.Util
         /// <summary>
         /// For subclasses to override. Overrides must call <c>base.TearDown()</c>.
         /// <para/>
-        /// LUCENENET specific: The test framework's mandatory per-test cleanup (failure
-        /// reproduction reporting and disposing resources registered with
-        /// <see cref="DisposeAfterTest"/>) runs in <see cref="__TearDown()"/> after all
+        /// LUCENENET specific: This method body must remain empty. The test framework's mandatory
+        /// per-test cleanup (failure reproduction reporting and disposing resources registered
+        /// with <see cref="DisposeAfterTest"/>) runs in <see cref="__TearDown()"/> after all
         /// <c>[TearDown]</c> methods, so it runs even if an override fails to call
-        /// <c>base.TearDown()</c>. See #1087.
+        /// <c>base.TearDown()</c>. Framework work must not be added here: when a subclass does not
+        /// override this method, it runs at the same level as <see cref="__TearDown()"/>, where
+        /// NUnit does not define the relative order of the two. See #1087.
         /// </summary>
         [After]
         public virtual void TearDown()
@@ -931,18 +965,18 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// The test framework's per-test teardown method. This method is called by NUnit and is
-        /// not intended for use by user code; it must be public for NUnit to call it. It is
-        /// declared <c>static</c> so subclasses cannot override it, and because it is declared at
-        /// the root of the <see cref="LuceneTestCase"/> inheritance hierarchy, NUnit guarantees it
-        /// runs after all <c>[TearDown]</c> methods of subclasses (teardown methods run in
-        /// most-derived-first order). This ensures the test framework's mandatory per-test cleanup
-        /// runs even if an override of <see cref="TearDown()"/> fails to call
-        /// <c>base.TearDown()</c>. See #1087.
+        /// not intended for use by user code. It is declared <c>static</c> so subclasses cannot
+        /// override it, and because it is declared at the root of the <see cref="LuceneTestCase"/>
+        /// inheritance hierarchy, NUnit guarantees it runs after all <c>[TearDown]</c> methods of
+        /// subclasses (teardown methods run in most-derived-first order). This ensures the test
+        /// framework's mandatory per-test cleanup runs even if an override of
+        /// <see cref="TearDown()"/> fails to call <c>base.TearDown()</c>. See #1087.
         /// </summary>
         // LUCENENET specific
         [After]
+        [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void __TearDown() => FrameworkTearDown(TestExecutionContext.CurrentContext);
+        protected static void __TearDown() => FrameworkTearDown(TestExecutionContext.CurrentContext);
 
         /// <summary>
         /// The test framework's mandatory per-test teardown work, formerly in
@@ -1040,11 +1074,14 @@ namespace Lucene.Net.Util
         /// For subclasses to override to add class (suite-level) setup behavior. Overrides
         /// must call <c>base.OneTimeSetUp()</c> BEFORE setting up their test fixture.
         /// <para/>
-        /// LUCENENET specific: The test framework's mandatory suite setup (dependency injection of
-        /// codec factories and picking random defaults for culture, time zone, similarity, and
-        /// default codec) runs in <see cref="__OneTimeSetUp()"/> before any <c>[OneTimeSetUp]</c>
-        /// methods, so it runs even if an override fails to call <c>base.OneTimeSetUp()</c>.
-        /// See #1087.
+        /// LUCENENET specific: This method body must remain empty. The test framework's mandatory
+        /// suite setup (dependency injection of codec factories and picking random defaults for
+        /// culture, time zone, similarity, and default codec) runs in
+        /// <see cref="__OneTimeSetUp()"/> before any <c>[OneTimeSetUp]</c> methods, so it runs
+        /// even if an override fails to call <c>base.OneTimeSetUp()</c>. Framework work must not
+        /// be added here: when a subclass does not override this method, it runs at the same level
+        /// as <see cref="__OneTimeSetUp()"/>, where NUnit does not define the relative order of
+        /// the two. See #1087.
         /// </summary>
         // LUCENENET specific method for setting up dependency injection of test classes.
         [OneTimeSetUp]
@@ -1054,18 +1091,18 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// The test framework's suite setup method. This method is called by NUnit and is not
-        /// intended for use by user code; it must be public for NUnit to call it. It is declared
-        /// <c>static</c> so subclasses cannot override it, and because it is declared at the root
-        /// of the <see cref="LuceneTestCase"/> inheritance hierarchy, NUnit guarantees it runs
-        /// before all <c>[OneTimeSetUp]</c> methods of subclasses (setup methods run in
-        /// base-first order). This ensures the test framework's mandatory suite setup runs even
-        /// if an override of <see cref="OneTimeSetUp()"/> fails to call
-        /// <c>base.OneTimeSetUp()</c>. See #1087.
+        /// intended for use by user code. It is declared <c>static</c> so subclasses cannot
+        /// override it, and because it is declared at the root of the <see cref="LuceneTestCase"/>
+        /// inheritance hierarchy, NUnit guarantees it runs before all <c>[OneTimeSetUp]</c>
+        /// methods of subclasses (setup methods run in base-first order). This ensures the test
+        /// framework's mandatory suite setup runs even if an override of
+        /// <see cref="OneTimeSetUp()"/> fails to call <c>base.OneTimeSetUp()</c>. See #1087.
         /// </summary>
         // LUCENENET specific
         [OneTimeSetUp]
+        [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void __OneTimeSetUp() => FrameworkOneTimeSetUp(TestExecutionContext.CurrentContext);
+        protected static void __OneTimeSetUp() => FrameworkOneTimeSetUp(TestExecutionContext.CurrentContext);
 
         /// <summary>
         /// The test framework's mandatory suite setup work, formerly in <see cref="OneTimeSetUp()"/>.
@@ -1099,11 +1136,14 @@ namespace Lucene.Net.Util
         /// For subclasses to override to add class (suite-level) teardown behavior. Overrides
         /// must call <c>base.OneTimeTearDown()</c> AFTER tearing down their test fixture.
         /// <para/>
-        /// LUCENENET specific: The test framework's mandatory suite teardown (tearing down random
-        /// defaults, cleaning up temporary files, and disposing resources registered with
-        /// <see cref="DisposeAfterSuite"/>) runs in <see cref="__OneTimeTearDown()"/> after all
-        /// <c>[OneTimeTearDown]</c> methods, so it runs even if an override fails to call
-        /// <c>base.OneTimeTearDown()</c>. See #1087.
+        /// LUCENENET specific: This method body must remain empty. The test framework's mandatory
+        /// suite teardown (tearing down random defaults, cleaning up temporary files, and
+        /// disposing resources registered with <see cref="DisposeAfterSuite"/>) runs in
+        /// <see cref="__OneTimeTearDown()"/> after all <c>[OneTimeTearDown]</c> methods, so it
+        /// runs even if an override fails to call <c>base.OneTimeTearDown()</c>. Framework work
+        /// must not be added here: when a subclass does not override this method, it runs at the
+        /// same level as <see cref="__OneTimeTearDown()"/>, where NUnit does not define the
+        /// relative order of the two. See #1087.
         /// </summary>
         // LUCENENET specific method for setting up dependency injection of test classes.
         [OneTimeTearDown]
@@ -1113,18 +1153,18 @@ namespace Lucene.Net.Util
 
         /// <summary>
         /// The test framework's suite teardown method. This method is called by NUnit and is not
-        /// intended for use by user code; it must be public for NUnit to call it. It is declared
-        /// <c>static</c> so subclasses cannot override it, and because it is declared at the root
-        /// of the <see cref="LuceneTestCase"/> inheritance hierarchy, NUnit guarantees it runs
-        /// after all <c>[OneTimeTearDown]</c> methods of subclasses (teardown methods run in
-        /// most-derived-first order). This ensures the test framework's mandatory suite teardown
-        /// runs even if an override of <see cref="OneTimeTearDown()"/> fails to call
-        /// <c>base.OneTimeTearDown()</c>. See #1087.
+        /// intended for use by user code. It is declared <c>static</c> so subclasses cannot
+        /// override it, and because it is declared at the root of the <see cref="LuceneTestCase"/>
+        /// inheritance hierarchy, NUnit guarantees it runs after all <c>[OneTimeTearDown]</c>
+        /// methods of subclasses (teardown methods run in most-derived-first order). This ensures
+        /// the test framework's mandatory suite teardown runs even if an override of
+        /// <see cref="OneTimeTearDown()"/> fails to call <c>base.OneTimeTearDown()</c>. See #1087.
         /// </summary>
         // LUCENENET specific
         [OneTimeTearDown]
+        [CLSCompliant(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void __OneTimeTearDown() => FrameworkOneTimeTearDown(TestExecutionContext.CurrentContext);
+        protected static void __OneTimeTearDown() => FrameworkOneTimeTearDown(TestExecutionContext.CurrentContext);
 
         /// <summary>
         /// The test framework's mandatory suite teardown work, formerly in

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -911,8 +911,6 @@ namespace Lucene.Net.Util
         [Before]
         public virtual void SetUp()
         {
-            // LUCENENET TODO: Not sure how to convert these
-            //ParentChainCallRule.SetupCalled = true;
         }
 
         /// <summary>
@@ -938,6 +936,9 @@ namespace Lucene.Net.Util
         // LUCENENET specific
         internal static void FrameworkSetUp()
         {
+            // LUCENENET TODO: Not sure how to convert these
+            //ParentChainCallRule.SetupCalled = true;
+
             // LUCENENET specific: capture the thread running the test method so that
             // IsTestThread can distinguish it from background threads (e.g. ConcurrentMergeScheduler
             // merge threads). This mirrors Java's ThreadAndTestNameRule.testCaseThread.
@@ -958,9 +959,6 @@ namespace Lucene.Net.Util
         [After]
         public virtual void TearDown()
         {
-            /* LUCENENET TODO: Not sure how to convert these
-                ParentChainCallRule.TeardownCalled = true;
-                */
         }
 
         /// <summary>
@@ -987,6 +985,9 @@ namespace Lucene.Net.Util
         // LUCENENET specific
         internal static void FrameworkTearDown(TestExecutionContext context)
         {
+            /* LUCENENET TODO: Not sure how to convert these
+                ParentChainCallRule.TeardownCalled = true;
+                */
             TestResult result = context.CurrentResult;
 
             if (result.ResultState == ResultState.Failure || result.ResultState == ResultState.Error)

--- a/src/Lucene.Net.Tests.TestFramework.NUnitExtensions/Util/LuceneTestCaseLifecycleGuardTests.cs
+++ b/src/Lucene.Net.Tests.TestFramework.NUnitExtensions/Util/LuceneTestCaseLifecycleGuardTests.cs
@@ -70,13 +70,16 @@ namespace Lucene.Net.Util
             Assert.IsTrue(LifecycleGuardNoBaseFixture.SuiteDisposable.Disposed,
                 "A resource registered with DisposeAfterSuite must be disposed.");
 
+            // The test thread was captured for IsTestThread, even though the override never calls
+            // base.SetUp().
+            Assert.IsTrue(LifecycleGuardNoBaseFixture.IsTestThreadInTest,
+                "IsTestThread must be true on the test thread; the framework's per-test setup must run.");
+
             // The framework teardown work runs AFTER the user's teardown methods. (The disposal
             // order of the suite-scoped resource cannot be asserted here because the TestBuilder
             // harness shares a single RandomizedContext between the suite and its tests, so the
             // temp dir check below stands in for the suite-level ordering instead.)
-            List<string> events = LifecycleGuardNoBaseFixture.Events;
-            Assert.IsTrue(events.IndexOf("User.TearDown") < events.IndexOf("Disposed:TestDisposable"),
-                "Test-scoped resources must be disposed after the fixture's TearDown. Events: " + string.Join(", ", events));
+            LifecycleAssert.AssertBefore(LifecycleGuardNoBaseFixture.Events, "User.TearDown", "Disposed:TestDisposable");
             Assert.IsTrue(LifecycleGuardNoBaseFixture.TempDirExistedInOneTimeTearDown,
                 "The temporary directory must still exist during the fixture's OneTimeTearDown; framework cleanup runs after it.");
         }
@@ -100,8 +103,8 @@ namespace Lucene.Net.Util
             ITestResult child = result.Children.Single();
             Assert.AreEqual(ResultState.Failure, child.ResultState);
 
-            // Guards against the framework teardown running twice (e.g. once from an overridable
-            // method's base call and once from the framework-owned lifecycle method).
+            // The framework teardown appends the reproduction info by rewriting the test result,
+            // so running it more than once per test would duplicate the (multi-page) block.
             Assert.AreEqual(1, CountOccurrences(child.Message, ReproduceInfoMarker),
                 "The failure reproduction info must be appended exactly once. Message: " + child.Message);
         }

--- a/src/Lucene.Net.Tests.TestFramework.NUnitExtensions/Util/LuceneTestCaseLifecycleGuardTests.cs
+++ b/src/Lucene.Net.Tests.TestFramework.NUnitExtensions/Util/LuceneTestCaseLifecycleGuardTests.cs
@@ -1,0 +1,141 @@
+using Lucene.Net.Attributes;
+using Lucene.Net.NUnit.TestUtilities;
+using Lucene.Net.TestData.Lifecycle;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Assert = Lucene.Net.TestFramework.Assert;
+
+namespace Lucene.Net.Util
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Verifies that the test framework's mandatory setup/teardown work cannot be disabled by a
+    /// subclass that overrides <see cref="LuceneTestCase.OneTimeSetUp()"/>,
+    /// <see cref="LuceneTestCase.OneTimeTearDown()"/>, <see cref="LuceneTestCase.SetUp()"/> or
+    /// <see cref="LuceneTestCase.TearDown()"/> without calling the base method. The framework
+    /// work runs in static framework-owned lifecycle methods
+    /// (<see cref="LuceneTestCase.__OneTimeSetUp()"/>, <see cref="LuceneTestCase.__OneTimeTearDown()"/>
+    /// and <see cref="LuceneTestCase.__TearDown()"/>) declared at the root of the inheritance
+    /// hierarchy, which NUnit runs before all subclass setup methods and after all subclass
+    /// teardown methods, respectively. See issue #1087.
+    /// </summary>
+    [TestFixture, LuceneNetSpecific]
+    public class LuceneTestCaseLifecycleGuardTests
+    {
+        private const string ReproduceInfoMarker = "To reproduce this test result";
+
+        [Test]
+        public void FrameworkLifecycle_RunsWhenOverridesSkipBaseCalls()
+        {
+            LifecycleGuardNoBaseFixture.Reset();
+
+            ITestResult result = TestBuilder.RunTestFixture(typeof(LifecycleGuardNoBaseFixture));
+
+            Assert.AreEqual(ResultState.Success, result.ResultState);
+
+            // The randomized environment (culture etc.) was applied before the fixture's
+            // OneTimeSetUp, even though the override never calls base.OneTimeSetUp().
+            Assert.IsTrue(LifecycleGuardNoBaseFixture.CultureAppliedInOneTimeSetUp,
+                "The randomized culture must be applied before the fixture's OneTimeSetUp runs.");
+
+            // The temporary directory was cleaned up, even though the override never calls
+            // base.OneTimeTearDown().
+            Assert.IsNotNull(LifecycleGuardNoBaseFixture.TempDir);
+            Assert.IsFalse(Directory.Exists(LifecycleGuardNoBaseFixture.TempDir.FullName),
+                "The temporary directory must be cleaned up after the suite completes.");
+
+            // Resources registered with DisposeAfterTest/DisposeAfterSuite were disposed.
+            Assert.IsTrue(LifecycleGuardNoBaseFixture.TestDisposable.Disposed,
+                "A resource registered with DisposeAfterTest must be disposed.");
+            Assert.IsTrue(LifecycleGuardNoBaseFixture.SuiteDisposable.Disposed,
+                "A resource registered with DisposeAfterSuite must be disposed.");
+
+            // The framework teardown work runs AFTER the user's teardown methods. (The disposal
+            // order of the suite-scoped resource cannot be asserted here because the TestBuilder
+            // harness shares a single RandomizedContext between the suite and its tests, so the
+            // temp dir check below stands in for the suite-level ordering instead.)
+            List<string> events = LifecycleGuardNoBaseFixture.Events;
+            Assert.IsTrue(events.IndexOf("User.TearDown") < events.IndexOf("Disposed:TestDisposable"),
+                "Test-scoped resources must be disposed after the fixture's TearDown. Events: " + string.Join(", ", events));
+            Assert.IsTrue(LifecycleGuardNoBaseFixture.TempDirExistedInOneTimeTearDown,
+                "The temporary directory must still exist during the fixture's OneTimeTearDown; framework cleanup runs after it.");
+        }
+
+        [Test]
+        public void ReproduceInfo_AddedToFailedTestWhenTearDownSkipsBase()
+        {
+            ITestResult result = TestBuilder.RunTestFixture(typeof(LifecycleGuardNoBaseFailingFixture));
+
+            ITestResult child = result.Children.Single();
+            Assert.AreEqual(ResultState.Failure, child.ResultState);
+            Assert.AreEqual(1, CountOccurrences(child.Message, ReproduceInfoMarker),
+                "The failure reproduction info must be appended exactly once. Message: " + child.Message);
+        }
+
+        [Test]
+        public void ReproduceInfo_AddedToFailedTestExactlyOnceWithBaseCalls()
+        {
+            ITestResult result = TestBuilder.RunTestFixture(typeof(LifecycleGuardBaseCallFailingFixture));
+
+            ITestResult child = result.Children.Single();
+            Assert.AreEqual(ResultState.Failure, child.ResultState);
+
+            // Guards against the framework teardown running twice (e.g. once from an overridable
+            // method's base call and once from the framework-owned lifecycle method).
+            Assert.AreEqual(1, CountOccurrences(child.Message, ReproduceInfoMarker),
+                "The failure reproduction info must be appended exactly once. Message: " + child.Message);
+        }
+
+        [Test]
+        public void SuiteResources_DisposedWhenOneTimeSetUpThrows()
+        {
+            LifecycleGuardThrowingOneTimeSetUpFixture.Reset();
+
+            ITestResult result = TestBuilder.RunTestFixture(typeof(LifecycleGuardThrowingOneTimeSetUpFixture));
+
+            Assert.AreNotEqual(ResultState.Success, result.ResultState);
+            Assert.IsTrue(LifecycleGuardThrowingOneTimeSetUpFixture.SuiteDisposable.Disposed,
+                "Suite-scoped resources must be disposed even when OneTimeSetUp throws.");
+        }
+
+        [Test]
+        public void FrameworkTearDown_RunsOnEveryRepeatAttempt()
+        {
+            LifecycleGuardRepeatFixture.Reset();
+
+            ITestResult result = TestBuilder.RunTestFixture(typeof(LifecycleGuardRepeatFixture));
+
+            Assert.AreEqual(ResultState.Success, result.ResultState);
+            Assert.AreEqual(3, LifecycleGuardRepeatFixture.Disposables.Count,
+                "The test must run once per repeat attempt.");
+            for (int i = 0; i < LifecycleGuardRepeatFixture.Disposables.Count; i++)
+            {
+                Assert.IsTrue(LifecycleGuardRepeatFixture.Disposables[i].Disposed,
+                    $"The resource registered on attempt {i} must be disposed by the framework teardown of that attempt.");
+            }
+        }
+
+        private static int CountOccurrences(string text, string value)
+            => text is null ? 0 : Regex.Matches(text, Regex.Escape(value)).Count;
+    }
+}

--- a/src/Lucene.Net.Tests.TestFramework.NUnitExtensions/Util/LuceneTestCaseLifecycleOrderingTests.cs
+++ b/src/Lucene.Net.Tests.TestFramework.NUnitExtensions/Util/LuceneTestCaseLifecycleOrderingTests.cs
@@ -1,0 +1,115 @@
+using Lucene.Net.Attributes;
+using Lucene.Net.NUnit.TestUtilities;
+using Lucene.Net.TestData.Lifecycle;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using System.Collections.Generic;
+using System.IO;
+using Assert = Lucene.Net.TestFramework.Assert;
+
+namespace Lucene.Net.Util
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Pins the NUnit lifecycle ordering guarantees that <see cref="LuceneTestCase"/>'s design
+    /// depends on (issue #1087): setup methods run base-level-first and teardown methods run
+    /// derived-level-first (so the framework's static lifecycle methods at the root of the
+    /// hierarchy always bracket all user code); an overridden virtual lifecycle method runs once,
+    /// at the override's declaring level; and same-named static lifecycle methods (the Java
+    /// Lucene convention) run at every level. Only cross-level ordering is asserted; the relative
+    /// order of multiple lifecycle methods declared at the SAME level is unspecified by NUnit
+    /// and deliberately not asserted here.
+    /// </summary>
+    [TestFixture, LuceneNetSpecific]
+    public class LuceneTestCaseLifecycleOrderingTests
+    {
+        [Test]
+        public void LifecycleMethods_RunBaseLevelFirstForSetUpAndDerivedLevelFirstForTearDown()
+        {
+            LifecycleOrderingLevel1Fixture.Reset();
+
+            ITestResult result = TestBuilder.RunTestFixture(typeof(LifecycleOrderingLevel2Fixture));
+
+            Assert.AreEqual(ResultState.Success, result.ResultState);
+            List<string> events = LifecycleOrderingLevel1Fixture.Events;
+
+            // The framework's suite setup runs before the first user method at any level, and its
+            // temp file cleanup runs after the last user teardown at any level.
+            Assert.IsTrue(LifecycleOrderingLevel1Fixture.CultureAppliedInFirstUserMethod,
+                "The randomized culture must be applied before the base-most user one-time setup runs.");
+            Assert.IsTrue(LifecycleOrderingLevel1Fixture.TempDirExistedInLastUserTearDown,
+                "The temporary directory must still exist during the base-most user one-time teardown.");
+            Assert.IsFalse(Directory.Exists(LifecycleOrderingLevel1Fixture.TempDir.FullName),
+                "The temporary directory must be cleaned up after the suite completes.");
+
+            // One-time setup: base level before derived level, and the override chain (declared
+            // at level 2) runs at level 2, AFTER level 1's uniquely-named method. This is the
+            // "relocation" behavior that motivated moving the framework work to static methods.
+            AssertBefore(events, "L1.OneTimeSetUp", "L2.OneTimeSetUp");
+            AssertBefore(events, "L1.OneTimeSetUp", "Chain.OneTimeSetUp.L1");
+            AssertBefore(events, "Chain.OneTimeSetUp.L1", "Chain.OneTimeSetUp.L2");
+            AssertBefore(events, "L2.OneTimeSetUp", "Test");
+            AssertBefore(events, "Chain.OneTimeSetUp.L2", "Test");
+
+            // Per-test setup: base level before all of the derived level's methods.
+            AssertBefore(events, "L1.SetUp", "L2.SetUp");
+            AssertBefore(events, "L1.SetUp", "Chain.SetUp.L2");
+            AssertBefore(events, "L2.SetUp", "Test");
+            AssertBefore(events, "Chain.SetUp.L2", "Test");
+
+            // Per-test teardown: all of the derived level's methods before the base level's.
+            AssertBefore(events, "Test", "L2.TearDown");
+            AssertBefore(events, "Test", "Chain.TearDown.L2");
+            AssertBefore(events, "L2.TearDown", "L1.TearDown");
+            AssertBefore(events, "Chain.TearDown.L2", "L1.TearDown");
+
+            // One-time teardown: derived level first (including the override chain, which runs at
+            // level 2 and unwinds most-derived-first), base level last.
+            AssertBefore(events, "Chain.OneTimeTearDown.L2", "Chain.OneTimeTearDown.L1");
+            AssertBefore(events, "L2.OneTimeTearDown", "L1.OneTimeTearDown");
+            AssertBefore(events, "Chain.OneTimeTearDown.L1", "L1.OneTimeTearDown");
+        }
+
+        [Test]
+        public void SameNamedStaticLifecycleMethods_RunAtEveryLevel()
+        {
+            StaticLifecycleLevel1Fixture.Reset();
+
+            ITestResult result = TestBuilder.RunTestFixture(typeof(StaticLifecycleLevel2Fixture));
+
+            Assert.AreEqual(ResultState.Success, result.ResultState);
+
+            // Both the hidden base method and the derived method run, base-first for setup and
+            // derived-first for teardown, matching JUnit's static hook semantics.
+            Assert.AreEqual(
+                new[] { "L1.BeforeClass", "L2.BeforeClass", "Test", "L2.AfterClass", "L1.AfterClass" },
+                StaticLifecycleLevel1Fixture.Events);
+        }
+
+        private static void AssertBefore(List<string> events, string first, string second)
+        {
+            int firstIndex = events.IndexOf(first);
+            int secondIndex = events.IndexOf(second);
+            Assert.IsTrue(firstIndex >= 0, $"Expected event '{first}' to be recorded. Events: {string.Join(", ", events)}");
+            Assert.IsTrue(secondIndex >= 0, $"Expected event '{second}' to be recorded. Events: {string.Join(", ", events)}");
+            Assert.IsTrue(firstIndex < secondIndex,
+                $"Expected '{first}' to run before '{second}'. Events: {string.Join(", ", events)}");
+        }
+    }
+}

--- a/src/Lucene.Net.Tests.TestFramework.NUnitExtensions/Util/LuceneTestCaseLifecycleOrderingTests.cs
+++ b/src/Lucene.Net.Tests.TestFramework.NUnitExtensions/Util/LuceneTestCaseLifecycleOrderingTests.cs
@@ -103,13 +103,6 @@ namespace Lucene.Net.Util
         }
 
         private static void AssertBefore(List<string> events, string first, string second)
-        {
-            int firstIndex = events.IndexOf(first);
-            int secondIndex = events.IndexOf(second);
-            Assert.IsTrue(firstIndex >= 0, $"Expected event '{first}' to be recorded. Events: {string.Join(", ", events)}");
-            Assert.IsTrue(secondIndex >= 0, $"Expected event '{second}' to be recorded. Events: {string.Join(", ", events)}");
-            Assert.IsTrue(firstIndex < secondIndex,
-                $"Expected '{first}' to run before '{second}'. Events: {string.Join(", ", events)}");
-        }
+            => LifecycleAssert.AssertBefore(events, first, second);
     }
 }

--- a/src/dotnet/Lucene.Net.TestFramework.TestData.NUnit/Lifecycle/LifecycleGuardFixtures.cs
+++ b/src/dotnet/Lucene.Net.TestFramework.TestData.NUnit/Lifecycle/LifecycleGuardFixtures.cs
@@ -62,6 +62,7 @@ namespace Lucene.Net.TestData.Lifecycle
         public static readonly List<string> Events = new List<string>();
         public static bool CultureAppliedInOneTimeSetUp;
         public static bool TempDirExistedInOneTimeTearDown;
+        public static bool IsTestThreadInTest;
         public static DirectoryInfo TempDir;
         public static TrackingDisposable SuiteDisposable;
         public static TrackingDisposable TestDisposable;
@@ -71,6 +72,7 @@ namespace Lucene.Net.TestData.Lifecycle
             Events.Clear();
             CultureAppliedInOneTimeSetUp = false;
             TempDirExistedInOneTimeTearDown = false;
+            IsTestThreadInTest = false;
             TempDir = null;
             SuiteDisposable = null;
             TestDisposable = null;
@@ -101,6 +103,10 @@ namespace Lucene.Net.TestData.Lifecycle
         public void TestA()
         {
             TestDisposable = DisposeAfterTest(new TrackingDisposable(nameof(TestDisposable), Events));
+
+            // The framework's per-test setup captures the test thread for IsTestThread, even
+            // though this fixture's SetUp override never calls base.SetUp().
+            IsTestThreadInTest = IsTestThread;
             Events.Add("Test");
         }
     }
@@ -122,10 +128,10 @@ namespace Lucene.Net.TestData.Lifecycle
     }
 
     /// <summary>
-    /// Has a failing test and no lifecycle overrides, so the framework teardown runs at the
-    /// traditional <c>base.TearDown()</c> position. Used to verify that the run-once guard
-    /// prevents the framework work from also running a second time from the lifecycle backstop
-    /// (the reproduction information must appear exactly once). See issue #1087.
+    /// Has a failing test and no lifecycle overrides at all, so the inherited (empty) lifecycle
+    /// methods run alongside the test framework's own. Used to verify that the framework teardown
+    /// work runs exactly once for such a fixture, so the failure reproduction information is
+    /// appended to the test result a single time. See issue #1087.
     /// </summary>
     public class LifecycleGuardBaseCallFailingFixture : LuceneTestCase
     {

--- a/src/dotnet/Lucene.Net.TestFramework.TestData.NUnit/Lifecycle/LifecycleGuardFixtures.cs
+++ b/src/dotnet/Lucene.Net.TestFramework.TestData.NUnit/Lifecycle/LifecycleGuardFixtures.cs
@@ -1,0 +1,195 @@
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace Lucene.Net.TestData.Lifecycle
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// A disposable that records its disposal into a shared event list, so tests can verify both
+    /// that the test framework disposed it and where the disposal happened relative to the
+    /// fixture's own lifecycle events.
+    /// </summary>
+    public sealed class TrackingDisposable : IDisposable
+    {
+        private readonly string name;
+        private readonly List<string> events;
+
+        public TrackingDisposable(string name, List<string> events)
+        {
+            this.name = name;
+            this.events = events;
+        }
+
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+        {
+            Disposed = true;
+            events.Add("Disposed:" + name);
+        }
+    }
+
+    /// <summary>
+    /// Overrides all four <see cref="LuceneTestCase"/> lifecycle methods and deliberately never
+    /// calls the base methods. Used to verify that the test framework's mandatory setup/teardown
+    /// work still runs (issue #1087): the randomized environment is applied before the fixture's
+    /// <c>OneTimeSetUp</c>, temporary files are cleaned up, and resources registered with
+    /// <see cref="LuceneTestCase.DisposeAfterTest"/>/<see cref="LuceneTestCase.DisposeAfterSuite"/>
+    /// are disposed after the fixture's own teardown methods.
+    /// </summary>
+    public class LifecycleGuardNoBaseFixture : LuceneTestCase
+    {
+        public static readonly List<string> Events = new List<string>();
+        public static bool CultureAppliedInOneTimeSetUp;
+        public static bool TempDirExistedInOneTimeTearDown;
+        public static DirectoryInfo TempDir;
+        public static TrackingDisposable SuiteDisposable;
+        public static TrackingDisposable TestDisposable;
+
+        public static void Reset()
+        {
+            Events.Clear();
+            CultureAppliedInOneTimeSetUp = false;
+            TempDirExistedInOneTimeTearDown = false;
+            TempDir = null;
+            SuiteDisposable = null;
+            TestDisposable = null;
+        }
+
+        public override void OneTimeSetUp()
+        {
+            // Deliberately does NOT call base.OneTimeSetUp().
+            CultureAppliedInOneTimeSetUp = Thread.CurrentThread.CurrentCulture.Name == ClassEnvRule.locale?.Name;
+            TempDir = CreateTempDir("lifecycle-guard-nobase");
+            SuiteDisposable = DisposeAfterSuite(new TrackingDisposable(nameof(SuiteDisposable), Events));
+            Events.Add("User.OneTimeSetUp");
+        }
+
+        public override void SetUp() => Events.Add("User.SetUp"); // Deliberately does NOT call base.SetUp().
+
+        public override void TearDown() => Events.Add("User.TearDown"); // Deliberately does NOT call base.TearDown().
+
+        public override void OneTimeTearDown()
+        {
+            // Deliberately does NOT call base.OneTimeTearDown(). The temporary directory must
+            // still exist here, because the framework's cleanup runs after this method.
+            TempDirExistedInOneTimeTearDown = Directory.Exists(TempDir.FullName);
+            Events.Add("User.OneTimeTearDown");
+        }
+
+        [Test]
+        public void TestA()
+        {
+            TestDisposable = DisposeAfterTest(new TrackingDisposable(nameof(TestDisposable), Events));
+            Events.Add("Test");
+        }
+    }
+
+    /// <summary>
+    /// Has a failing test and a <c>TearDown</c> override that never calls <c>base.TearDown()</c>.
+    /// Used to verify that the failure reproduction information is still appended to the test
+    /// result by the test framework (issue #1087).
+    /// </summary>
+    public class LifecycleGuardNoBaseFailingFixture : LuceneTestCase
+    {
+        public override void TearDown()
+        {
+            // Deliberately does NOT call base.TearDown().
+        }
+
+        [Test]
+        public void TestThatFails() => Assert.Fail("intentional failure");
+    }
+
+    /// <summary>
+    /// Has a failing test and no lifecycle overrides, so the framework teardown runs at the
+    /// traditional <c>base.TearDown()</c> position. Used to verify that the run-once guard
+    /// prevents the framework work from also running a second time from the lifecycle backstop
+    /// (the reproduction information must appear exactly once). See issue #1087.
+    /// </summary>
+    public class LifecycleGuardBaseCallFailingFixture : LuceneTestCase
+    {
+        [Test]
+        public void TestThatFails() => Assert.Fail("intentional failure");
+    }
+
+    /// <summary>
+    /// Throws from <c>OneTimeSetUp</c> after registering a suite-scoped disposable. Used to
+    /// verify that the test framework's suite teardown (which disposes suite-scoped resources)
+    /// still runs when a fixture's one-time setup fails. See issue #1087.
+    /// </summary>
+    public class LifecycleGuardThrowingOneTimeSetUpFixture : LuceneTestCase
+    {
+        public static readonly List<string> Events = new List<string>();
+        public static TrackingDisposable SuiteDisposable;
+
+        public static void Reset()
+        {
+            Events.Clear();
+            SuiteDisposable = null;
+        }
+
+        public override void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+            SuiteDisposable = DisposeAfterSuite(new TrackingDisposable(nameof(SuiteDisposable), Events));
+            throw new InvalidOperationException("intentional failure");
+        }
+
+        [Test]
+        public void TestA()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Uses <c>[Repeat]</c> with a <c>TearDown</c> override that never calls
+    /// <c>base.TearDown()</c>, registering a test-scoped disposable on each attempt. Used to
+    /// verify that the framework teardown runs on every repeat attempt (which reuse the same
+    /// NUnit execution context), disposing the resources registered by each attempt. See
+    /// issue #1087.
+    /// </summary>
+    public class LifecycleGuardRepeatFixture : LuceneTestCase
+    {
+        public static readonly List<string> Events = new List<string>();
+        public static readonly List<TrackingDisposable> Disposables = new List<TrackingDisposable>();
+
+        public static void Reset()
+        {
+            Events.Clear();
+            Disposables.Clear();
+        }
+
+        public override void TearDown()
+        {
+            // Deliberately does NOT call base.TearDown().
+        }
+
+        [Test]
+        [Repeat(3)]
+        public void TestRegistersDisposablePerAttempt()
+        {
+            Disposables.Add(DisposeAfterTest(new TrackingDisposable("TestDisposable" + Disposables.Count, Events)));
+        }
+    }
+}

--- a/src/dotnet/Lucene.Net.TestFramework.TestData.NUnit/Lifecycle/LifecycleOrderingFixtures.cs
+++ b/src/dotnet/Lucene.Net.TestFramework.TestData.NUnit/Lifecycle/LifecycleOrderingFixtures.cs
@@ -1,0 +1,170 @@
+using Lucene.Net.Util;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace Lucene.Net.TestData.Lifecycle
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Middle level of a three-level hierarchy (<see cref="LuceneTestCase"/> at the root) that
+    /// mixes the two lifecycle conventions NUnit supports: uniquely-named methods carrying the
+    /// NUnit attributes directly (pinned to this level), and virtual override chains (which NUnit
+    /// runs once, at the most derived override's level). Records the order its methods fire so
+    /// tests can pin the NUnit ordering guarantees the test framework's design depends on
+    /// (issue #1087): setup methods run base-level-first, teardown methods run
+    /// derived-level-first, and the framework's own work brackets all of them.
+    /// </summary>
+    public abstract class LifecycleOrderingLevel1Fixture : LuceneTestCase
+    {
+        public static readonly List<string> Events = new List<string>();
+        public static bool CultureAppliedInFirstUserMethod;
+        public static bool TempDirExistedInLastUserTearDown;
+        public static DirectoryInfo TempDir;
+
+        public static void Reset()
+        {
+            Events.Clear();
+            CultureAppliedInFirstUserMethod = false;
+            TempDirExistedInLastUserTearDown = false;
+            TempDir = null;
+        }
+
+        protected static void Record(string s) => Events.Add(s);
+
+        [OneTimeSetUp]
+        public void Level1OneTimeSetUp()
+        {
+            // This level's only one-time setup method, so it is the first USER method to run
+            // (the override chain below lives at level 2). The framework's suite setup must
+            // already have applied the randomized environment by now.
+            CultureAppliedInFirstUserMethod = Thread.CurrentThread.CurrentCulture.Name == ClassEnvRule.locale?.Name;
+            TempDir = CreateTempDir("lifecycle-ordering");
+            Record("L1.OneTimeSetUp");
+        }
+
+        [OneTimeTearDown]
+        public void Level1OneTimeTearDown()
+        {
+            // This level's only one-time teardown method, so it is the last USER method to run.
+            // The framework's temp file cleanup must not have run yet.
+            TempDirExistedInLastUserTearDown = Directory.Exists(TempDir.FullName);
+            Record("L1.OneTimeTearDown");
+        }
+
+        [SetUp]
+        public void Level1SetUp() => Record("L1.SetUp");
+
+        [TearDown]
+        public void Level1TearDown() => Record("L1.TearDown");
+
+        public override void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+            Record("Chain.OneTimeSetUp.L1");
+        }
+
+        public override void OneTimeTearDown()
+        {
+            Record("Chain.OneTimeTearDown.L1");
+            base.OneTimeTearDown();
+        }
+    }
+
+    /// <summary>
+    /// Most derived level of the ordering hierarchy. Its overrides make the virtual chains run
+    /// at THIS level (NUnit runs an overridden method at the override's declaring level, not the
+    /// base's), which is the "relocation" behavior described in issue #1087.
+    /// </summary>
+    public class LifecycleOrderingLevel2Fixture : LifecycleOrderingLevel1Fixture
+    {
+        [OneTimeSetUp]
+        public void Level2OneTimeSetUp() => Record("L2.OneTimeSetUp");
+
+        [OneTimeTearDown]
+        public void Level2OneTimeTearDown() => Record("L2.OneTimeTearDown");
+
+        [SetUp]
+        public void Level2SetUp() => Record("L2.SetUp");
+
+        [TearDown]
+        public void Level2TearDown() => Record("L2.TearDown");
+
+        public override void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+            Record("Chain.OneTimeSetUp.L2");
+        }
+
+        public override void OneTimeTearDown()
+        {
+            Record("Chain.OneTimeTearDown.L2");
+            base.OneTimeTearDown();
+        }
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            Record("Chain.SetUp.L2");
+        }
+
+        public override void TearDown()
+        {
+            Record("Chain.TearDown.L2");
+            base.TearDown();
+        }
+
+        [Test]
+        public void TestA() => Record("Test");
+    }
+
+    /// <summary>
+    /// Base of a hierarchy using the Java Lucene convention: same-named static lifecycle methods
+    /// at every level (hiding, not overriding). NUnit must run BOTH, base-level-first for setup
+    /// and derived-level-first for teardown, matching JUnit's static hook semantics. This is the
+    /// pattern the issue #1087 follow-up will convert subclasses to.
+    /// </summary>
+    public abstract class StaticLifecycleLevel1Fixture : LuceneTestCase
+    {
+        public static readonly List<string> Events = new List<string>();
+
+        public static void Reset() => Events.Clear();
+
+        protected static void Record(string s) => Events.Add(s);
+
+        [OneTimeSetUp]
+        public static void BeforeClass() => Record("L1.BeforeClass");
+
+        [OneTimeTearDown]
+        public static void AfterClass() => Record("L1.AfterClass");
+    }
+
+    public class StaticLifecycleLevel2Fixture : StaticLifecycleLevel1Fixture
+    {
+        [OneTimeSetUp]
+        public static new void BeforeClass() => Record("L2.BeforeClass");
+
+        [OneTimeTearDown]
+        public static new void AfterClass() => Record("L2.AfterClass");
+
+        [Test]
+        public void TestA() => Record("Test");
+    }
+}

--- a/src/dotnet/Lucene.Net.TestFramework.TestData.NUnit/TestUtilities/LifecycleAssert.cs
+++ b/src/dotnet/Lucene.Net.TestFramework.TestData.NUnit/TestUtilities/LifecycleAssert.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using Assert = Lucene.Net.TestFramework.Assert;
+
+namespace Lucene.Net.NUnit.TestUtilities
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Assertions over the ordered lifecycle event lists that the lifecycle test fixtures record.
+    /// </summary>
+    public static class LifecycleAssert
+    {
+        /// <summary>
+        /// Asserts that both <paramref name="first"/> and <paramref name="second"/> were recorded
+        /// in <paramref name="events"/>, and that <paramref name="first"/> was recorded before
+        /// <paramref name="second"/>. Asserting that both events exist matters: a missing event
+        /// yields an index of -1, which would otherwise satisfy a bare index comparison and hide
+        /// the very lifecycle regression these tests exist to catch.
+        /// </summary>
+        public static void AssertBefore(IList<string> events, string first, string second)
+        {
+            int firstIndex = events.IndexOf(first);
+            int secondIndex = events.IndexOf(second);
+
+            Assert.IsTrue(firstIndex >= 0, $"Expected event '{first}' to be recorded. Events: {string.Join(", ", events)}");
+            Assert.IsTrue(secondIndex >= 0, $"Expected event '{second}' to be recorded. Events: {string.Join(", ", events)}");
+            Assert.IsTrue(firstIndex < secondIndex,
+                $"Expected '{first}' to run before '{second}'. Events: {string.Join(", ", events)}");
+        }
+    }
+}


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Prevent users from overriding test framework setup/teardown functionality

Fixes #1087

## Description

See #1087 and discussion for context. Currently, the setup/teardown methods are virtual and can be overridden by users. If a user does this and does not call the base method (or calls it out of order), unexpected things could happen.

I spent a good deal of time evaluating NUnit 4's Execution Hooks feature for this. It doesn't quite work cleanly for what we need without a few modifications (which I'm currently discussing with their team over at https://github.com/nunit/nunit/issues/5368). So to unblock this issue and avoid having to wait for those things to be fixed, I adopted the suggestion from that thread of using non-virtual methods to work around the problem. That means that this PR does not require NUnit 4 to be merged first (although not being able to use EHs right now does not invalidate the other benefits of upgrading NUnit, who are about to release v5 soon).

In NUnit, if you give a test method a unique name from your overridable method (like prefixing it with underscores like I did here), it will run separate from the other method's inheritance stack, starting with the base level first. This solves the problem by moving the framework setup/teardown into dedicated static methods. Static methods are inherently non-virtual (can't be overridden), and because they're on the base class, they run when we need them to in the framework. Meanwhile, this PR retains the existing virtual SetUp/TearDown methods to allow for derived classes to override. The static methods are marked editor browseable never so that they do not show up in intellisense, and are non-CLS Compliant because of the leading double underscores. Finally, they are `protected` to further shield them from prying eyes from the outside. 

This is not as clean of a solution as execution hooks (a derived class could still call i.e. `__SetUp()`, if they manually type it without IDE help), but after many hours of analysis, it's probably as good as we're going to get without them.

Since the original methods are retained, this is not a breaking change from a compilation standpoint. There are some slight changes in behavior that would likely not affect anyone in the real world. Because these are fringe concerns and currently usage of our test framework is low, I don't think this warrants the "breaking change" label:

- `DisposeAfterTest`-registered resources are now disposed after all `[TearDown]` methods rather than at the `base.TearDown()` call position. A fixture doing `base.TearDown(); dir.Dispose();` now gets a different disposal order.
- `ClassEnvRule.Before()` (randomized culture/codec/timezone/similarity) now runs before all user one-time setup code, including code an override ran before `base.OneTimeSetUp()` and any uniquely-named `[OneTimeSetUp]` methods at intermediate levels.

Several unit tests were added to help enforce the invariant that we must have the correct order when dealing with lifecycle events.

AI: Claude Code (Opus 4.8 and 5; Fable 5) helped me work through this analysis and wrote most of this code.

--- 

### Next Steps

If there are any recommended changes from a maintainer here, I kindly request going ahead and making the changes yourself ("allow edits" is enabled on this PR). I've spent more time on this issue than I would have liked (or is perhaps even warranted), and I have run out of energy on it. I would greatly appreciate the collaboration of your commits or at least GitHub code suggestion blocks in comments that can be easily applied.