### PR TITLE
Reduce lock scope in `FSDirectory.DeleteFile`, #1428

### DIFF
--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -317,33 +317,33 @@ namespace Lucene.Net.Store
             EnsureOpen();
             string file = Path.Combine(m_directory.FullName, name);
 
-                // LUCENENET specific: We need to explicitly throw when the file has already been deleted,
-                // since FileInfo doesn't do that for us.
-                // (An enhancement carried over from Lucene 8.2.0)
-                if (!File.Exists(file))
-                {
-                    throw new FileNotFoundException("Cannot delete " + file + " because it doesn't exist.");
-                }
+            // LUCENENET specific: We need to explicitly throw when the file has already been deleted,
+            // since FileInfo doesn't do that for us.
+            // (An enhancement carried over from Lucene 8.2.0)
+            if (!File.Exists(file))
+            {
+                throw new FileNotFoundException("Cannot delete " + file + " because it doesn't exist.");
+            }
 
-            // LUCENENET specific: Do NOT hold m_syncLock while deleting. On a network share (SMB),
+            // LUCENENET NOTE: Do NOT hold m_syncLock while deleting. On a network share (SMB),
             // File.Delete can block for a long time (e.g. waiting for the server to break an
             // oplock/lease on a file this client still has open). Holding m_syncLock here would
             // block every concurrent Sync() and IndexOutput.Dispose() on this directory behind
             // a single stalled delete, freezing the whole writer. Only the m_staleFiles
             // bookkeeping below needs the lock (see remarks for the m_staleFiles field);
             // upstream Java likewise performs the delete without any directory-wide lock.
-                try
+            try
+            {
+                File.Delete(file);
+                if (File.Exists(file))
                 {
-                    File.Delete(file);
-                    if (File.Exists(file))
-                    {
-                        throw new IOException("Cannot delete " + file);
-                    }
+                    throw new IOException("Cannot delete " + file);
                 }
-                catch (Exception e)
-                {
-                    throw new IOException("Cannot delete " + file, e);
-                }
+            }
+            catch (Exception e)
+            {
+                throw new IOException("Cannot delete " + file, e);
+            }
 
             UninterruptableMonitor.Enter(m_syncLock);
             try

--- a/src/Lucene.Net/Store/FSDirectory.cs
+++ b/src/Lucene.Net/Store/FSDirectory.cs
@@ -317,10 +317,6 @@ namespace Lucene.Net.Store
             EnsureOpen();
             string file = Path.Combine(m_directory.FullName, name);
 
-            // LUCENENET Specific: See remarks for m_staleFiles field.
-            UninterruptableMonitor.Enter(m_syncLock);
-            try
-            {
                 // LUCENENET specific: We need to explicitly throw when the file has already been deleted,
                 // since FileInfo doesn't do that for us.
                 // (An enhancement carried over from Lucene 8.2.0)
@@ -329,6 +325,13 @@ namespace Lucene.Net.Store
                     throw new FileNotFoundException("Cannot delete " + file + " because it doesn't exist.");
                 }
 
+            // LUCENENET specific: Do NOT hold m_syncLock while deleting. On a network share (SMB),
+            // File.Delete can block for a long time (e.g. waiting for the server to break an
+            // oplock/lease on a file this client still has open). Holding m_syncLock here would
+            // block every concurrent Sync() and IndexOutput.Dispose() on this directory behind
+            // a single stalled delete, freezing the whole writer. Only the m_staleFiles
+            // bookkeeping below needs the lock (see remarks for the m_staleFiles field);
+            // upstream Java likewise performs the delete without any directory-wide lock.
                 try
                 {
                     File.Delete(file);
@@ -342,6 +345,9 @@ namespace Lucene.Net.Store
                     throw new IOException("Cannot delete " + file, e);
                 }
 
+            UninterruptableMonitor.Enter(m_syncLock);
+            try
+            {
                 m_staleFiles.Remove(name);
             }
             finally

--- a/src/Lucene.Net/Store/MMapDirectory.cs
+++ b/src/Lucene.Net/Store/MMapDirectory.cs
@@ -194,13 +194,7 @@ namespace Lucene.Net.Store
             EnsureOpen();
             EnsureCanRead(name); // LUCENENET-specific: backported call site from Lucene 6.0.0
             var file = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
-            // LUCENENET specific: Add FileShare.Delete (a deliberate divergence from upstream Java's RandomAccessFile,
-            // which omits it) to match SimpleFSDirectory, NIOFSDirectory and our other handles, giving Windows the same
-            // delete-while-open semantics POSIX already provides so index files can be deleted while a read handle is
-            // open (#1283). Without it, a pending delete of a still-mapped file on an SMB share can block inside
-            // File.Delete while the server waits for this client's lease break, which cannot complete while mapped
-            // views are active.
-            var fc = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var fc = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return new MMapIndexInput(this, "MMapIndexInput(path=\"" + file + "\")", fc);
         }
 

--- a/src/Lucene.Net/Store/MMapDirectory.cs
+++ b/src/Lucene.Net/Store/MMapDirectory.cs
@@ -194,7 +194,13 @@ namespace Lucene.Net.Store
             EnsureOpen();
             EnsureCanRead(name); // LUCENENET-specific: backported call site from Lucene 6.0.0
             var file = Path.Combine(Directory.FullName, name); // LUCENENET specific: changed to use string file name instead of allocating a FileInfo (#832)
-            var fc = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            // LUCENENET specific: Add FileShare.Delete (a deliberate divergence from upstream Java's RandomAccessFile,
+            // which omits it) to match SimpleFSDirectory, NIOFSDirectory and our other handles, giving Windows the same
+            // delete-while-open semantics POSIX already provides so index files can be deleted while a read handle is
+            // open (#1283). Without it, a pending delete of a still-mapped file on an SMB share can block inside
+            // File.Delete while the server waits for this client's lease break, which cannot complete while mapped
+            // views are active.
+            var fc = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             return new MMapIndexInput(this, "MMapIndexInput(path=\"" + file + "\")", fc);
         }
 


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Related to #1428 hanging process on File.Delete

## Description

I found (with help of AI) two places where locking behaviour for Fails on file.delete could be improved. I extract the relevant part of it and would be happy, you can integrate it too.