### PR TITLE
docs: explain omitted Sandbox query types

### DIFF
--- a/src/Lucene.Net.Sandbox/Queries/package.md
+++ b/src/Lucene.Net.Sandbox/Queries/package.md
@@ -21,3 +21,14 @@ summary: *content
 -->
 
 Additional queries (some may have caveats or limitations)
+
+## Query types not included from Lucene 4.8.1
+
+The Java Sandbox `RegexQuery` family is not included in this package because it
+was superseded by `RegexpQuery` in the main Lucene search package. Use
+`Lucene.Net.Search.RegexpQuery` for regular-expression queries instead.
+
+The deprecated `SlowCollated` query types are also not included. For indexed
+collation keys, use `CollationKeyAnalyzer` or `ICUCollationKeyAnalyzer` from
+the analysis packages. These replacements are supported alternatives to the
+old Sandbox types and avoid carrying forward APIs that were removed upstream.


### PR DESCRIPTION
## Summary

- document why the Lucene 4.8.1 Sandbox RegexQuery family was not ported
- point users to Lucene.Net.Search.RegexpQuery
- document the supported collation-key analyzer alternatives for the omitted SlowCollated types

This is the documentation-only portion of #1341. The API-check suppression is intentionally deferred until #1314 is merged, per maintainer guidance.

Closes #1341