### PR TITLE
Upgrade docfx to 2.78.5, docs target to net10, and increase docs build perf

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.77.0",
+      "version": "2.78.5",
       "commands": [
         "docfx"
       ],

--- a/.github/workflows/Lucene-Net-Documentation.yml
+++ b/.github/workflows/Lucene-Net-Documentation.yml
@@ -32,6 +32,14 @@ name: 'Lucene.Net.Documentation'
 
 on:
   workflow_dispatch:
+  # 2026-08-09 - build (but do not publish) the API docs for any pull request that touches the docs sources, the docs
+  # plugins, or this workflow file. This lets changes to the docs build be validated in CI before they are merged.
+  # The steps that push to the site repo are skipped for pull requests - see the `if:` conditions below.
+  pull_request:
+    paths:
+    - 'websites/apidocs/**/*'
+    - 'src/docs/LuceneDocsPlugins/**/*'
+    - '.github/workflows/Lucene-Net-Documentation.yml'
   push:
     # 2026-06-23 - when both tags and branches are used, they are ORed. However, note that when paths is used, it is ANDed to each of them.
     tags:
@@ -188,6 +196,7 @@ jobs:
           path: '${{github.workspace}}/main-repo/websites/apidocs/_site'
 
       - name: Checkout Lucene.Net website
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ env.SITE_REPO }}
@@ -195,6 +204,7 @@ jobs:
           path: website-repo
 
       - name: Copy documentation site files
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           $source = "$Env:GITHUB_WORKSPACE\main-repo\websites\apidocs\_site"
           $dest = "$Env:GITHUB_WORKSPACE\website-repo\docs\$Env:RELEASE_VERSION"
@@ -212,6 +222,7 @@ jobs:
       # Because we are always building the docs against a consistent version
       - name: Create Pull Request
         id: cpr
+        if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.LUCENE_NET_WEBSITE_BUILD }}
@@ -227,6 +238,7 @@ jobs:
             - For version ${{ env.RELEASE_VERSION }}
 
       - name: Check outputs
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/Lucene-Net-Documentation.yml
+++ b/.github/workflows/Lucene-Net-Documentation.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Build docs
         run: ./main-repo/websites/apidocs/docs.ps1 -Clean -LuceneNetVersion ${{ env.RELEASE_VERSION }}
-        shell: powershell
+        shell: pwsh
 
       - name: Upload apidocs as build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/Lucene-Net-Website.yml
+++ b/.github/workflows/Lucene-Net-Website.yml
@@ -28,6 +28,13 @@ name: 'Lucene.Net.Website'
 
 on:
   workflow_dispatch:
+  # 2026-08-09 - build (but do not publish) the website for any pull request that touches the website sources or this
+  # workflow file. This lets changes to the website build be validated in CI before they are merged. The steps that push
+  # to the site repo are skipped for pull requests - see the `if:` conditions below.
+  pull_request:
+    paths:
+    - 'websites/site/**/*'
+    - '.github/workflows/Lucene-Net-Website.yml'
   push:
     # 2026-06-23 - when only tags and paths are used, they are ANDed together, not ORed, so the presence of a Website_* tag blocked the automation from triggering.
     # Howevever, if both tags and branches are present then we have 1) tags AND paths OR 2) branches AND paths. So, we need to specify them all if we want either or.
@@ -49,8 +56,10 @@ env:
 
 jobs:
   build:
-    # CRITICAL FIX: Only run this job if it is executing on the main upstream repository
-    if: github.repository == 'apache/lucenenet'
+    # CRITICAL FIX: Only run this job if it is executing on the main upstream repository, so that forks do not attempt
+    # to build and publish the website. Pull requests are exempt because they only build - the steps that publish to the
+    # site repo are skipped for pull requests (see the `if:` conditions below).
+    if: ${{ github.repository == 'apache/lucenenet' || github.event_name == 'pull_request' }}
     runs-on: windows-latest
     steps:
 
@@ -119,6 +128,7 @@ jobs:
           path: '${{github.workspace}}/main-repo/websites/site/_site'
 
       - name: Checkout Lucene.Net website
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ env.SITE_REPO }}
@@ -127,11 +137,13 @@ jobs:
           persist-credentials: false
 
       - name: Copy website files
+        if: ${{ github.event_name != 'pull_request' }}
         run: Get-ChildItem -Path "$Env:GITHUB_WORKSPACE\main-repo\websites\site\_site" | Copy-Item -Destination "$Env:GITHUB_WORKSPACE\website-repo" -Recurse -Force
         shell: powershell
 
       - name: Create Pull Request
         id: cpr
+        if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.LUCENE_NET_WEBSITE_BUILD }}
@@ -147,6 +159,7 @@ jobs:
             For release version ${{ env.RELEASE_VERSION }}
 
       - name: Check outputs
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/src/docs/LuceneDocsPlugins/AggregatePostProcessor.cs
+++ b/src/docs/LuceneDocsPlugins/AggregatePostProcessor.cs
@@ -18,6 +18,7 @@
 using Docfx.Plugins;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Threading;
 
 namespace LuceneDocsPlugins;
 
@@ -40,11 +41,11 @@ public class AggregatePostProcessor : IPostProcessor
         return metadata;
     }
 
-    public Manifest Process(Manifest manifest, string outputFolder)
+    public Manifest Process(Manifest manifest, string outputFolder, CancellationToken cancellationToken)
     {
         foreach (var postProcessor in _postProcessors)
         {
-            manifest = postProcessor.Process(manifest, outputFolder);
+            manifest = postProcessor.Process(manifest, outputFolder, cancellationToken);
         }
 
         return manifest;

--- a/src/docs/LuceneDocsPlugins/EnvironmentVariableProcessor.cs
+++ b/src/docs/LuceneDocsPlugins/EnvironmentVariableProcessor.cs
@@ -20,6 +20,7 @@ using Docfx.Plugins;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace LuceneDocsPlugins;
 
@@ -30,12 +31,14 @@ public class EnvironmentVariableProcessor : IPostProcessor
         return metadata;
     }
 
-    public Manifest Process(Manifest manifest, string outputFolder)
+    public Manifest Process(Manifest manifest, string outputFolder, CancellationToken cancellationToken)
     {
         foreach (var manifestItem in manifest.Files.Where(x => x.Type == "Conceptual"))
         {
             foreach (var manifestItemOutputFile in manifestItem.Output)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var outputPath = Path.Combine(outputFolder, manifestItemOutputFile.Value.RelativePath);
 
                 var content = File.ReadAllText(outputPath);

--- a/src/docs/LuceneDocsPlugins/LuceneDocsPlugins.csproj
+++ b/src/docs/LuceneDocsPlugins/LuceneDocsPlugins.csproj
@@ -47,8 +47,8 @@ under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docfx.Plugins" Version="2.77.0" />
-    <PackageReference Include="Docfx.Common" Version="2.77.0" />
+    <PackageReference Include="Docfx.Plugins" Version="2.78.5" />
+    <PackageReference Include="Docfx.Common" Version="2.78.5" />
     <PackageReference Include="System.Composition" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/docs/LuceneDocsPlugins/LuceneNoteProcessor.cs
+++ b/src/docs/LuceneDocsPlugins/LuceneNoteProcessor.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace LuceneDocsPlugins;
 
@@ -42,12 +43,14 @@ public partial class LuceneNoteProcessor : IPostProcessor
         return metadata;
     }
 
-    public Manifest Process(Manifest manifest, string outputFolder)
+    public Manifest Process(Manifest manifest, string outputFolder, CancellationToken cancellationToken)
     {
         foreach (var manifestItem in manifest.Files)
         {
             foreach (var manifestItemOutputFile in manifestItem.Output)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var outputPath = Path.Combine(outputFolder, manifestItemOutputFile.Value.RelativePath);
 
                 var content = File.ReadAllText(outputPath);

--- a/websites/apidocs/docfx.analysis-common.json
+++ b/websites/apidocs/docfx.analysis-common.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-common",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-kuromoji.json
+++ b/websites/apidocs/docfx.analysis-kuromoji.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-kuromoji",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-morfologik.json
+++ b/websites/apidocs/docfx.analysis-morfologik.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-morfologik",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-opennlp.json
+++ b/websites/apidocs/docfx.analysis-opennlp.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-opennlp",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-phonetic.json
+++ b/websites/apidocs/docfx.analysis-phonetic.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-phonetic",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-smartcn.json
+++ b/websites/apidocs/docfx.analysis-smartcn.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-smartcn",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.analysis-stempel.json
+++ b/websites/apidocs/docfx.analysis-stempel.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/analysis-stempel",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.benchmark.json
+++ b/websites/apidocs/docfx.benchmark.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/benchmark",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.classification.json
+++ b/websites/apidocs/docfx.classification.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/classification",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.codecs.json
+++ b/websites/apidocs/docfx.codecs.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/codecs",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.core.json
+++ b/websites/apidocs/docfx.core.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/core",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.demo.json
+++ b/websites/apidocs/docfx.demo.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/demo",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.expressions.json
+++ b/websites/apidocs/docfx.expressions.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/expressions",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.facet.json
+++ b/websites/apidocs/docfx.facet.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/facet",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.grouping.json
+++ b/websites/apidocs/docfx.grouping.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/grouping",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.highlighter.json
+++ b/websites/apidocs/docfx.highlighter.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/highlighter",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.icu.json
+++ b/websites/apidocs/docfx.icu.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/icu",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.join.json
+++ b/websites/apidocs/docfx.join.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/join",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.json
+++ b/websites/apidocs/docfx.json
@@ -16,7 +16,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -35,7 +35,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Common",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -54,7 +54,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Kuromoji",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -73,7 +73,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Morfologik",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -92,7 +92,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.OpenNLP",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -111,7 +111,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Phonetic",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -130,7 +130,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.SmartCn",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -149,7 +149,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Analysis.Stempel",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -168,7 +168,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Benchmarks",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -187,7 +187,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Classification",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -206,7 +206,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Codecs",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -225,7 +225,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Expressions",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -244,7 +244,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Facet",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -263,7 +263,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Grouping",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -282,7 +282,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Highlighter",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -301,7 +301,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.ICU",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -320,7 +320,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Join",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -339,7 +339,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Memory",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -358,7 +358,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Misc",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -377,7 +377,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Queries",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -396,7 +396,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.QueryParser",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -415,7 +415,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Replicator",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -434,7 +434,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Sandbox",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -453,7 +453,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Spatial",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -472,7 +472,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Suggest",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -490,7 +490,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.TestFramework",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     },
     {
@@ -509,7 +509,7 @@
       ],
       "dest": "obj/docfx/api/Lucene.Net.Demo",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.memory.json
+++ b/websites/apidocs/docfx.memory.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/memory",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.misc.json
+++ b/websites/apidocs/docfx.misc.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/misc",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.queries.json
+++ b/websites/apidocs/docfx.queries.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/queries",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.queryparser.json
+++ b/websites/apidocs/docfx.queryparser.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/queryparser",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.replicator.json
+++ b/websites/apidocs/docfx.replicator.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/replicator",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.sandbox.json
+++ b/websites/apidocs/docfx.sandbox.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/sandbox",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.spatial.json
+++ b/websites/apidocs/docfx.spatial.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/spatial",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.suggest.json
+++ b/websites/apidocs/docfx.suggest.json
@@ -15,7 +15,7 @@
       ],
       "dest": "obj/docfx/api/suggest",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docfx.test-framework.json
+++ b/websites/apidocs/docfx.test-framework.json
@@ -16,7 +16,7 @@
       "dest": "obj/docfx/api/test-framework",
       "filter": "filterConfig.yml",
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -32,11 +32,22 @@ param (
     [Parameter(Mandatory = $false)]
     [string] $BaseUrl = 'https://lucenenet.apache.org/docs/',
     [Parameter(Mandatory = $false)]
-    [int] $StagingPort = 8080
+    [int] $StagingPort = 8080,
+    # Number of docfx projects to build concurrently. Set to 1 to build everything serially.
+    # Named to match the $maximumParallelJobs property used by the psake build in .build/runbuild.ps1.
+    [Parameter(Mandatory = $false)]
+    [int] $maximumParallelJobs = [Math]::Max(1, [Math]::Min(8, [Environment]::ProcessorCount - 1))
 )
 $MinimumSdkVersion = "8.0.100" # Minimum Required .NET SDK (must not be a pre-release)
 
 $ErrorActionPreference = "Stop"
+
+# This script builds the docfx projects concurrently using ForEach-Object -Parallel, which was
+# introduced in PowerShell 7. Windows PowerShell 5.1 fails with a confusing parameter binding
+# error, so check for it up front and explain what is needed.
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    throw "PowerShell 7 or higher is required to build the API docs (found $($PSVersionTable.PSVersion)). Run this script with 'pwsh' instead of 'powershell'."
+}
 
 # if the base URL is the lucene live site default value we also need to include the version
 if ($BaseUrl -eq 'https://lucenenet.apache.org/docs/') {
@@ -166,20 +177,35 @@ if ($? -and $DisableMetaData -eq $false) {
         Set-Location $PreviousLocation
     }
 
-    foreach ($proj in $DocFxJsonMeta) {
-        $projFile = Join-Path -Path $ApiDocsFolder $proj
+    # Metadata generation has no cross-project dependencies (unlike the build step below, which
+    # consumes other projects' xref maps), and each config writes to its own obj/docfx/api/<name>
+    # folder. That makes it safe to run these concurrently. The duplicates in $DocFxJsonMeta only
+    # exist to work around circular xref maps during the build, so we de-duplicate here.
+    $MetaProjects = $DocFxJsonMeta | Select-Object -Unique
 
-        $DocFxLog = Join-Path -Path $ApiDocsFolder "obj\${proj}.meta.log"
+    Write-Host "Building api metadata for $($MetaProjects.Count) projects (up to $maximumParallelJobs at a time)..."
 
-        # build the output
+    $MetaResults = $MetaProjects | ForEach-Object -ThrottleLimit $maximumParallelJobs -Parallel {
+        $proj = $_
+        $projFile = Join-Path -Path $using:ApiDocsFolder $proj
+        $DocFxLog = Join-Path -Path $using:ApiDocsFolder "obj\${proj}.meta.log"
+
+        # Each runspace has its own current directory, so this does not race with the other jobs.
+        Set-Location $using:RepoRoot
+
         Write-Host "Building api metadata for $projFile..."
-        $PreviousLocation = Get-Location
-        Set-Location $RepoRoot
-        try {
-            & dotnet tool run docfx metadata $projFile --log "$DocFxLog" --logLevel $LogLevel --noRestore
-        } finally {
-            Set-Location $PreviousLocation
-        }
+        # Capture docfx's console output rather than letting it flow into this block's output
+        # stream, which is reserved for the result object below, then echo it via Write-Host.
+        $output = & dotnet tool run docfx metadata $projFile --log "$DocFxLog" --logLevel $using:LogLevel --noRestore 2>&1
+        $exitCode = $LASTEXITCODE
+        Write-Host ($output | Out-String)
+
+        [pscustomobject]@{ Project = $proj; ExitCode = $exitCode }
+    }
+
+    $FailedMeta = @($MetaResults | Where-Object { $_.ExitCode -ne 0 })
+    if ($FailedMeta.Count -gt 0) {
+        throw "Failed to build api metadata for: $(($FailedMeta | ForEach-Object { $_.Project }) -join ', ')"
     }
 }
 
@@ -201,33 +227,86 @@ if ($? -and $DisableBuild -eq $false) {
     # Update the CLI link to the latest LuceneNetVersion
     (Get-Content -Path $BreadcrumbPath -Raw) -Replace '(?<="_navCliHref":\s*?"https?\:\/\/lucenenet\.apache\.org\/docs\/)\d+?\.\d+?\.\d+?(?:\.\d+?)?(?:-\w+)?', $LuceneNetVersion | Set-Content -Path $BreadcrumbPath
 
-    foreach ($proj in $DocFxJsonMeta) {
-        $projFile = Join-Path -Path $ApiDocsFolder $proj
+    # Unlike metadata generation, the build step DOES have cross-project dependencies: each config
+    # consumes the xrefmap.yml produced by the projects listed in its "xref" section. So the configs
+    # are grouped into waves that are run one after another, while the members of a single wave -
+    # which do not depend on each other - are built concurrently.
+    #
+    # The waves below preserve the ordering the serial build relied on:
+    #   1. codecs/core/analysis-common have circular xref maps between them, so they are built in the
+    #      original order, one at a time, and core/codecs are rebuilt in the last wave to pick up the
+    #      xref maps that did not exist yet on their first pass (the "intentional duplicates").
+    #   2. icu must precede highlighter, and queryparser/analysis-common must precede demo.
+    $DocFxBuildWaves = @(
+        , @("docfx.codecs.json")
+        , @("docfx.core.json")
+        , @("docfx.analysis-common.json")
+        , @(
+            "docfx.analysis-kuromoji.json",
+            "docfx.analysis-morfologik.json",
+            "docfx.analysis-opennlp.json",
+            "docfx.analysis-phonetic.json",
+            "docfx.analysis-smartcn.json",
+            "docfx.analysis-stempel.json",
+            "docfx.benchmark.json",
+            "docfx.classification.json",
+            "docfx.expressions.json",
+            "docfx.facet.json",
+            "docfx.grouping.json",
+            "docfx.icu.json",
+            "docfx.join.json",
+            "docfx.memory.json",
+            "docfx.misc.json",
+            "docfx.queries.json",
+            "docfx.queryparser.json",
+            "docfx.replicator.json",
+            "docfx.sandbox.json",
+            "docfx.spatial.json",
+            "docfx.suggest.json",
+            "docfx.test-framework.json"
+        )
+        , @("docfx.highlighter.json", "docfx.demo.json")
+        # intentional duplicates - see note above
+        , @("docfx.codecs.json")
+        , @("docfx.core.json")
+    )
 
-        $DocFxLog = Join-Path -Path $ApiDocsFolder "obj\${proj}.build.log"
+    foreach ($wave in $DocFxBuildWaves) {
+        $BuildResults = $wave | ForEach-Object -ThrottleLimit $maximumParallelJobs -Parallel {
+            $proj = $_
+            $projFile = Join-Path -Path $using:ApiDocsFolder $proj
+            $DocFxLog = Join-Path -Path $using:ApiDocsFolder "obj\${proj}.build.log"
 
-        Start-Sleep -Seconds 1
+            # Each runspace has its own current directory, so this does not race with the other jobs.
+            Set-Location $using:RepoRoot
 
-        # build the output
-        Write-Host "Building site output for $projFile..."
-        $PreviousLocation = Get-Location
-        Set-Location $RepoRoot
-        try {
-            & dotnet tool run docfx build $projFile --log "$DocFxLog" --logLevel $LogLevel --debug --maxParallelism 1
-        } finally {
-            Set-Location $PreviousLocation
+            Write-Host "Building site output for $projFile..."
+            # Capture docfx's console output rather than letting it flow into this block's output
+            # stream, which is reserved for the result object below, then echo it via Write-Host.
+            $output = & dotnet tool run docfx build $projFile --log "$DocFxLog" --logLevel $using:LogLevel --debug --maxParallelism 1 2>&1
+            $exitCode = $LASTEXITCODE
+            Write-Host ($output | Out-String)
+
+            if ($exitCode -eq 0) {
+                # Add the baseUrl to the output xrefmap, see https://github.com/dotnet/docfx/issues/2346#issuecomment-356054027
+                $projFileJson = Get-Content $projFile | ConvertFrom-Json
+                $projBuildDest = $projFileJson.build.dest
+                $buildOutputFolder = Join-Path -Path ((Get-Item $projFile).DirectoryName) $projBuildDest
+                $xrefFile = Join-Path $buildOutputFolder "xrefmap.yml"
+                $xrefMap = Get-Content $xrefFile -Raw
+                $xrefMap = $xrefMap.Replace("### YamlMime:XRefMap", "").Trim()
+                $projBaseUrl = $using:BaseUrl + $projBuildDest.Substring(5, $projBuildDest.Length - 5) # trim the _site part of the string
+                $xrefMap = "### YamlMime:XRefMap" + [Environment]::NewLine + "baseUrl: " + $projBaseUrl + "/" + [Environment]::NewLine + $xrefMap
+                Set-Content -Path $xrefFile -Value $xrefMap
+            }
+
+            [pscustomobject]@{ Project = $proj; ExitCode = $exitCode }
         }
 
-        # Add the baseUrl to the output xrefmap, see https://github.com/dotnet/docfx/issues/2346#issuecomment-356054027
-        $projFileJson = Get-Content $projFile | ConvertFrom-Json
-        $projBuildDest = $projFileJson.build.dest
-        $buildOutputFolder = Join-Path -Path ((Get-Item $projFile).DirectoryName) $projBuildDest
-        $xrefFile = Join-Path $buildOutputFolder "xrefmap.yml"
-        $xrefMap = Get-Content $xrefFile -Raw
-        $xrefMap = $xrefMap.Replace("### YamlMime:XRefMap", "").Trim()
-        $projBaseUrl = $BaseUrl + $projBuildDest.Substring(5, $projBuildDest.Length - 5) # trim the _site part of the string
-        $xrefMap = "### YamlMime:XRefMap" + [Environment]::NewLine + "baseUrl: " + $projBaseUrl + "/" + [Environment]::NewLine + $xrefMap
-        Set-Content -Path $xrefFile -Value $xrefMap
+        $FailedBuild = @($BuildResults | Where-Object { $_.ExitCode -ne 0 })
+        if ($FailedBuild.Count -gt 0) {
+            throw "Failed to build site output for: $(($FailedBuild | ForEach-Object { $_.Project }) -join ', ')"
+        }
     }
 }
 

--- a/websites/apidocs/docs.ps1
+++ b/websites/apidocs/docs.ps1
@@ -57,6 +57,7 @@ $env:LuceneNetReleaseTag = $VCSLabel
 $PSScriptFilePath = (Get-Item $MyInvocation.MyCommand.Path).FullName
 $RepoRoot = (get-item $PSScriptFilePath).Directory.Parent.Parent.FullName;
 $ApiDocsFolder = Join-Path -Path $RepoRoot -ChildPath "websites\apidocs";
+$SolutionFile = Join-Path -Path $RepoRoot -ChildPath "Lucene.Net.sln";
 $CliIndexPath = Join-Path -Path $RepoRoot -ChildPath "src\dotnet\tools\lucene-cli\docs\index.md";
 $TocPath1 = Join-Path -Path $ApiDocsFolder -ChildPath "toc.yml"
 $TocPath2 = Join-Path -Path $ApiDocsFolder -ChildPath "toc\toc.yml"
@@ -151,6 +152,20 @@ $DocFxJsonMeta = @(
 $DocFxJsonSite = Join-Path -Path $ApiDocsFolder "docfx.site.json"
 
 if ($? -and $DisableMetaData -eq $false) {
+    # Restore the whole solution once up front so that each `docfx metadata` invocation below can be
+    # passed --noRestore. Otherwise docfx runs a NuGet restore for every project it inspects, which
+    # repeats the same restore work ~30 times (once per config in $DocFxJsonMeta).
+    # NOTE: The TargetFramework here must match the one in the "properties" section of each docfx.*.json.
+    Write-Host "Restoring $SolutionFile for API metadata..."
+    $PreviousLocation = Get-Location
+    Set-Location $RepoRoot
+    try {
+        & dotnet restore "$SolutionFile" -p:TargetFramework=net10.0
+        if (-not $?) { throw "Failed to restore $SolutionFile" }
+    } finally {
+        Set-Location $PreviousLocation
+    }
+
     foreach ($proj in $DocFxJsonMeta) {
         $projFile = Join-Path -Path $ApiDocsFolder $proj
 
@@ -161,7 +176,7 @@ if ($? -and $DisableMetaData -eq $false) {
         $PreviousLocation = Get-Location
         Set-Location $RepoRoot
         try {
-            & dotnet tool run docfx metadata $projFile --log "$DocFxLog" --logLevel $LogLevel
+            & dotnet tool run docfx metadata $projFile --log "$DocFxLog" --logLevel $LogLevel --noRestore
         } finally {
             Set-Location $PreviousLocation
         }


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Upgrade docfx to 2.78.5, docs target to net10, and increase docs build perf

## Description

This PR:
- Upgrades docfx to 2.78.5 (primarily for net10 support, but also to keep it evergreen)
- Updates the docs plugins to use the docfx 2.78.5 package, which necessitated adding the CancellationToken parameter (with bonus cancellation support too)
- Updates the docs targets to use the net10.0 target (instead of net8.0)
- Parallelizes the build to dramatically improve the performance of the docs build.

## Performance

The docs build historically has taken several minutes to run. This makes iterating on improving the docs harder. By parallelizing the Powershell build, it now takes a fraction of a time.

Command (from `websites/apidocs/`):
```shell
time pwsh ./docs.ps1 -Clean -LuceneNetVersion 4.8.0-ci
```

Before (latest master):
```
331.80 real       359.01 user        41.10 sys
```

After (this PR):
```
93.96 real       348.58 user        41.17 sys
```

Result: roughly 3.5x speed-up (on macOS arm64 M4 Max), reducing it from ~5.5min to ~1.5min. Your mileage will vary based on your OS and hardware, but it should perform better the more cores you have.

## Notes

Previously, we had been encountering a file-locking issue with the toc file, that necessitated us specifying parallelism of 1 and sleeping between runs. This contributed to the poor performance. By parallelizing instead at the process level, this conflict seems to be avoided, as I could not reproduce any locking issues after many runs. It also carefully batches them into "waves" to avoid the circular dependency issues, which might have contributed to the issue previously.

Because this uses parallelism in PowerShell, it requires PowerShell 7+, aka PowerShell Core. Windows PowerShell 5.x is no longer supported for building the docs with this change, so a check is added at script launch. PS7 is cross-platform and truly open-source, so it is a better fit for our open-source project anyways.

AI: Coded and tested with the assistance of Claude Code (Opus 5).