### PR TITLE
Bump Microsoft.Extensions parent version to 10.0.10

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -49,7 +49,7 @@
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisVisualBasicPackageVersion>2.6.1</MicrosoftCodeAnalysisVisualBasicPackageVersion>
     <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>$(MicrosoftCodeAnalysisVisualBasicPackageVersion)</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <MicrosoftExtensionsParentVersion>10.0.7</MicrosoftExtensionsParentVersion>
+    <MicrosoftExtensionsParentVersion>10.0.10</MicrosoftExtensionsParentVersion>
     <MicrosoftExtensionsConfigurationPackageVersion>$(MicrosoftExtensionsParentVersion)</MicrosoftExtensionsConfigurationPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>$(MicrosoftExtensionsParentVersion)</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationCommandLinePackageVersion>$(MicrosoftExtensionsParentVersion)</MicrosoftExtensionsConfigurationCommandLinePackageVersion>


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Bump Microsoft.Extensions parent version to 10.0.10

## Description

This fixes a few vulnerabilities in System.Security.Cryptography.Xml 10.0.7.