### PR TITLE
Remove outdated System.Text.Json pinned reference

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -80,7 +80,6 @@
     <SystemRuntimeInteropServicesRuntimeInformationPackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>4.3.0</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion Condition=" '$(TargetFramework)' == 'net472' ">5.0.0</SystemTextEncodingCodePagesPackageVersion>
-    <SystemTextJsonPackageVersion>6.0.10</SystemTextJsonPackageVersion>
     <SystemTextRegularExpressionsPackageVersion>4.3.1</SystemTextRegularExpressionsPackageVersion>
     <TimeZoneConverterPackageVersion>6.1.0</TimeZoneConverterPackageVersion>
   </PropertyGroup>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -55,10 +55,6 @@
     <PackageReference Include="ICU4N" Version="$(ICU4NPackageVersion)" />
     <PackageReference Include="IKVM" Version="$(IKVMPackageVersion)" />
     <PackageReference Include="IKVM.Maven.Sdk" Version="$(IKVMMavenSdkPackageVersion)" />
-
-    <!-- This is a transitive dependency of IKVM, but the version it references is vulnerable. We are currently blocked from upgrading
-        IKVM due to the Azure DevOps limitation of 10GB for a single build agent, so we have to add this reference instead. -->
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Remove outdated System.Text.Json pinned reference

## Description

This was necessary at one point in the past to resolve a vulnerable package warning; it is no longer necessary since STJ ships with .NET 8/10 targeted by the OpenNLP library. Combined with #1435, there are now zero warnings when building the solution again.
