### PR TITLE
Guard GetCanonicalPath against null

### DIFF
--- a/src/Lucene.Net.Tests/Support/IO/TestFileSupport.cs
+++ b/src/Lucene.Net.Tests/Support/IO/TestFileSupport.cs
@@ -184,6 +184,14 @@ namespace Lucene.Net.Support.IO
             }
         }
 
+        [Test, LuceneNetSpecific]
+        public void TestGetCanonicalPathNullPath()
+        {
+            FileSystemInfo path = null;
+
+            Assert.Throws<ArgumentNullException>(() => path.GetCanonicalPath());
+        }
+
         private static string addTrailingSlash(string path)
         {
             if (Path.DirectorySeparatorChar == path[path.Length - 1])

--- a/src/Lucene.Net/Support/IO/FileSupport.cs
+++ b/src/Lucene.Net/Support/IO/FileSupport.cs
@@ -536,6 +536,11 @@ namespace Lucene.Net.Support.IO
         // LUCENENET NOTE: Implementation ported mostly from Apache Harmony
         public static string GetCanonicalPath(this FileSystemInfo path)
         {
+            if (path is null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
             string absPath = path.FullName; // LUCENENET NOTE: This internally calls GetFullPath(), which resolves relative paths
             byte[] result = Encoding.UTF8.GetBytes(absPath);
 


### PR DESCRIPTION
## Summary\n\n- throw ArgumentNullException when GetCanonicalPath receives a null FileSystemInfo\n- add a focused regression test\n\nThis is the small, separate null-contract piece from #1409. I ran the focused Lucene.Net.Support.IO.TestFileSupport tests on .NET 9 with the repository's test project override: 6 passed. The repository currently targets .NET 10 by default, which is not installed in this environment, so I kept the test command and result explicit for review.