### PR TITLE
Upgrade Microsoft.Bcl.Memory to 10.0.11

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -43,7 +43,7 @@
     <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.36</LuceneNetCodeAnalysisDevPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.3.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
     <MicrosoftAspNetCoreTestHostPackageVersion>8.0.19</MicrosoftAspNetCoreTestHostPackageVersion>
-    <MicrosoftBclMemoryPackageVersion>10.0.0-rc.1.25451.107</MicrosoftBclMemoryPackageVersion>
+    <MicrosoftBclMemoryPackageVersion>10.0.11</MicrosoftBclMemoryPackageVersion>
     <MicrosoftCodeAnalysisAnalyzersPackageVersion>2.9.8</MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.6.1</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Upgrade Microsoft.Bcl.Memory to 10.0.11

## Description

I noticed when reviewing the codebase that Microsoft.Bcl.Memory was still pinned to a 10.0 RC version from a change back before .NET 10 came out in 2025. This upgrades it to the latest version in the 10.x line. Presumably we might even get some bug fixes this way.

Note that this is particularly important for any .NET Framework/Standard users that depend on our library, so that they aren't pulling in a year-old RC version accidentally, if they don't already explicitly depend on a newer version.