### PR TITLE
chore(xml): standardize XML declaration encoding to lowercase utf-8 (#1336)

### DIFF
--- a/src/Lucene.Net.Tests.QueryParser/Xml/BooleanFilter.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/BooleanFilter.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/BooleanQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/BooleanQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/BoostingQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/BoostingQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/BoostingTermQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/BoostingTermQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/CachedFilter.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/CachedFilter.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/ConstantScoreQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/ConstantScoreQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/DisjunctionMaxQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/DisjunctionMaxQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/DuplicateFilterQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/DuplicateFilterQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/FuzzyLikeThisQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/FuzzyLikeThisQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/LikeThisQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/LikeThisQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/MatchAllDocsQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/MatchAllDocsQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/NestedBooleanQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/NestedBooleanQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/NumericRangeFilterQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/NumericRangeFilterQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/NumericRangeQueryQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/NumericRangeQueryQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/RangeFilterQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/RangeFilterQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/SpanQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/SpanQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/TermQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/TermQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/TermsFilterQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/TermsFilterQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/TermsQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/TermsQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/UserInputQuery.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/UserInputQuery.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/Lucene.Net.Tests.QueryParser/Xml/UserInputQueryCustomField.xml
+++ b/src/Lucene.Net.Tests.QueryParser/Xml/UserInputQueryCustomField.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/java/index-compat/pom.xml
+++ b/src/java/index-compat/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
## Summary

Standardizes the XML declaration encoding casing to lowercase `encoding="utf-8"` across the codebase, as proposed and discussed in #1336.

### Changes
- Updated the remaining 21 XML test files under `src/Lucene.Net.Tests.QueryParser/Xml/` and `src/java/index-compat/pom.xml` from `encoding="UTF-8"` to lowercase `encoding="utf-8"`.
- Aligns all XML declaration headers across the repository with modern conventions and existing standards in the project.

Closes #1336.
