### PR TITLE
Fix editorconfig-checker url and pin to 4.0.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -291,6 +291,7 @@ dotnet_diagnostic.S907.severity = none
 
 # Files that tests read should not change from Lucene
 [**/src/Lucene.Net.Tests.*/**.txt]
+charset = unset
 trim_trailing_whitespace = unset
 insert_final_newline = unset
 resharper_enforce_empty_line_at_end_of_file = false

--- a/.github/workflows/EditorConfig-Rules-Check.yml
+++ b/.github/workflows/EditorConfig-Rules-Check.yml
@@ -34,9 +34,16 @@ jobs:
         run: |
           echo "🔍 Running EditorConfig Checker..."
 
-          if ec; then
+          # First pass emits GitHub workflow commands, which surface as inline
+          # annotations on changed lines. Annotations are not rendered for files
+          # outside the diff, so on failure we re-run in the default format to
+          # list every offending file (and line) in the log itself.
+          if ec -f github-actions; then
             echo "✅ EditorConfig Checker Success"
           else
+            echo ""
+            echo "❌ EditorConfig violations:"
+            ec -f default || true
             echo ""
             echo "📘 Common IDE Setup Help"
             echo ""

--- a/.github/workflows/EditorConfig-Rules-Check.yml
+++ b/.github/workflows/EditorConfig-Rules-Check.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Install EditorConfig Checker
         run: |
-          curl -sSfL https://github.com/editorconfig-checker/editorconfig-checker/releases/latest/download/ec-linux-amd64.tar.gz -o ec.tar.gz
+          curl -sSfL https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v4.0.1/editorconfig-checker-linux-amd64.tar.gz -o ec.tar.gz
           mkdir -p ec-temp
           tar -xzf ec.tar.gz -C ec-temp
 

--- a/.github/workflows/EditorConfig-Rules-Check.yml
+++ b/.github/workflows/EditorConfig-Rules-Check.yml
@@ -16,10 +16,10 @@ jobs:
           tar -xzf ec.tar.gz -C ec-temp
 
           # Dynamically find the binary
-          EC_PATH=$(find ec-temp -type f -name "ec-linux-amd64" -perm -111 | head -n 1)
+          EC_PATH=$(find ec-temp -type f -name "editorconfig-checker" -perm -111 | head -n 1)
 
           if [ -z "$EC_PATH" ]; then
-            echo "❌ Could not locate ec-linux-amd64 binary in archive"
+            echo "❌ Could not locate editorconfig-checker binary in archive"
             exit 1
           fi
 


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Fix editorconfig-checker url and pin to 4.0.1

Fixes #1455

## Description

The download URL for the "latest" release of editorconfig-checker moved. This fixes the download URL and also pins to 4.0.1 so this isn't a moving target.
