### PR TITLE
Bumped J2N to 2.2.0-alpha-0053

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -38,7 +38,7 @@
     <IKVMPackageVersion>8.7.5</IKVMPackageVersion>
     <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
-    <J2NPackageVersion>[2.2.0-alpha-0048, 3.0.0)</J2NPackageVersion>
+    <J2NPackageVersion>[2.2.0-alpha-0053, 3.0.0)</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
     <LuceneNetCodeAnalysisDevPackageVersion>1.0.0-alpha.36</LuceneNetCodeAnalysisDevPackageVersion>
     <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.3.0</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- Please do NOT submit PRs for features in newer versions of Lucene. We should keep the target version consistent across our repository to make the upgrade process to newer versions of Lucene go smoothly. -->

<!-- If this is your first PR in the Lucene.NET repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

`.build/dependencies.props:` Bumped J2N to 2.2.0-alpha-0053

## Description

This bumps the J2N dependency to 2.2.0-alpha-0053. This version of J2N contains the new `TextBuilder` and `PooledTextBuilder` classes which are important to replace `System.Text.StringBuilder`. Unlike `System.Text.StringBuilder`, `TextBuilder` and `PooledTextBuilder` are directly convertible to `ReadOnlySpan<char>` (even implicitly) and `ReadOnlyMemory<char>` so they will become important tools in the toolbox when converting `CharSequence` APIs from Java into .NET.
