### PR TITLE
Replace OpenNLP via IKVM with NOpenNLP, #1438

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -64,7 +64,7 @@
     <MorfologikPolishPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikPolishPackageVersion>
     <MorfologikStemmingPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikStemmingPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
-    <NOpenNLPPackageVersion>1.9.5-beta.1</NOpenNLPPackageVersion>
+    <NOpenNLPPackageVersion>1.9.5-beta.2</NOpenNLPPackageVersion>
     <NUnit3TestAdapterPackageVersion>4.6.0</NUnit3TestAdapterPackageVersion>
     <NUnitPackageVersion>3.14.0</NUnitPackageVersion>
     <RandomizedTestingGeneratorsPackageVersion>2.7.8</RandomizedTestingGeneratorsPackageVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -35,8 +35,6 @@
         Just make sure they are adjusted to the right version of ICU/Lucene.
     <ICU4NPackageVersion>[60.1,60.2)</ICU4NPackageVersion> -->
     <ICU4NPackageVersion>[60.1.0-alpha.440,60.1.0-alpha.446)</ICU4NPackageVersion>
-    <IKVMPackageVersion>8.7.5</IKVMPackageVersion>
-    <IKVMMavenSdkPackageVersion>1.6.7</IKVMMavenSdkPackageVersion>
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
     <J2NPackageVersion>[2.2.0-alpha-0053, 3.0.0)</J2NPackageVersion>
     <LiquidTestReportsMarkdownPackageVersion>1.0.9</LiquidTestReportsMarkdownPackageVersion>
@@ -66,6 +64,7 @@
     <MorfologikPolishPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikPolishPackageVersion>
     <MorfologikStemmingPackageVersion>$(MorfologikFsaPackageVersion)</MorfologikStemmingPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
+    <NOpenNLPPackageVersion>1.9.5-beta.1</NOpenNLPPackageVersion>
     <NUnit3TestAdapterPackageVersion>4.6.0</NUnit3TestAdapterPackageVersion>
     <NUnitPackageVersion>3.14.0</NUnitPackageVersion>
     <RandomizedTestingGeneratorsPackageVersion>2.7.8</RandomizedTestingGeneratorsPackageVersion>
@@ -82,9 +81,5 @@
     <SystemTextEncodingCodePagesPackageVersion Condition=" '$(TargetFramework)' == 'net472' ">5.0.0</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextRegularExpressionsPackageVersion>4.3.1</SystemTextRegularExpressionsPackageVersion>
     <TimeZoneConverterPackageVersion>6.1.0</TimeZoneConverterPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Label="Maven Package Reference Versions">
-    <OpenNLPToolsMavenReferenceVersion>1.9.1</OpenNLPToolsMavenReferenceVersion>
-    <OSGICoreMavenReferenceVersion>4.2.0</OSGICoreMavenReferenceVersion>
   </PropertyGroup>
 </Project>

--- a/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
+++ b/src/Lucene.Net.Analysis.OpenNLP/Lucene.Net.Analysis.OpenNLP.csproj
@@ -30,16 +30,9 @@
   <Import Project="$(SolutionDir).build/nuget.props" />
 
   <PropertyGroup>
-    <!-- Currently, IKVM doesn't officially support building NetFX on anything but Windows, so we skip it for contributors who may be on various platforms.
-        We can remove the condition once that has been addressed. See: https://github.com/ikvmnet/ikvm-maven/issues/49 -->
-    <!-- net10.0 is conditional on VS version (VS2024+ = 18.0) -->
-    <!-- .NET Framework is conditional on VS version (VS2024+ = 18.0) due to invalid build warnings with C# 14.0 build features -->
-    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' == 'true' ">net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) And '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);net472</TargetFrameworks>
-
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>Lucene.Net.Analysis.OpenNLP</AssemblyTitle>
-    <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp</PackageTags>
+    <PackageTags>$(PackageTags);analysis;natural;language;processing;opennlp;nopennlp</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
     <RootNamespace>Lucene.Net.Analysis.OpenNlp</RootNamespace>
@@ -53,13 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="ICU4N" Version="$(ICU4NPackageVersion)" />
-    <PackageReference Include="IKVM" Version="$(IKVMPackageVersion)" />
-    <PackageReference Include="IKVM.Maven.Sdk" Version="$(IKVMMavenSdkPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <MavenReference Include="org.apache.opennlp:opennlp-tools" Version="$(OpenNLPToolsMavenReferenceVersion)" />
-    <MavenReference Include="org.osgi:org.osgi.core" Version="$(OSGICoreMavenReferenceVersion)" />
+    <PackageReference Include="NOpenNLP.Tools" Version="$(NOpenNLPPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Analysis.OpenNLP/OpenNLPSentenceBreakIterator.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/OpenNLPSentenceBreakIterator.cs
@@ -3,7 +3,7 @@ using ICU4N.Support.Text;
 using ICU4N.Text;
 using Lucene.Net.Analysis.OpenNlp.Tools;
 using Lucene.Net.Analysis.Util;
-using opennlp.tools.util;
+using NOpenNLP.Tools.Util;
 using System;
 using System.Diagnostics;
 using System.Text;
@@ -249,7 +249,7 @@ namespace Lucene.Net.Analysis.OpenNlp
             for (int i = 0; i < spans.Length; ++i)
             {
                 // Adjust start positions to match those of the passed-in CharacterIterator
-                sentenceStarts[i] = spans[i].getStart() + text.BeginIndex;
+                sentenceStarts[i] = spans[i].Start + text.BeginIndex;
             }
         }
 

--- a/src/Lucene.Net.Analysis.OpenNLP/OpenNLPTokenizer.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/OpenNLPTokenizer.cs
@@ -3,7 +3,7 @@ using Lucene.Net.Analysis.OpenNlp.Tools;
 using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Analysis.Util;
 using Lucene.Net.Util;
-using opennlp.tools.util;
+using NOpenNLP.Tools.Util;
 using System;
 using System.IO;
 
@@ -92,9 +92,9 @@ namespace Lucene.Net.Analysis.OpenNlp
             }
             ClearAttributes();
             Span term = termSpans[termNum];
-            termAtt.CopyBuffer(m_buffer, sentenceStart + term.getStart(), term.length());
-            offsetAtt.SetOffset(CorrectOffset(m_offset + sentenceStart + term.getStart()),
-                                CorrectOffset(m_offset + sentenceStart + term.getEnd()));
+            termAtt.CopyBuffer(m_buffer, sentenceStart + term.Start, term.Length);
+            offsetAtt.SetOffset(CorrectOffset(m_offset + sentenceStart + term.Start),
+                                CorrectOffset(m_offset + sentenceStart + term.End));
             if (termNum == termSpans.Length - 1)
             {
                 flagsAtt.Flags = flagsAtt.Flags | EOS_FLAG_BIT; // mark the last token in the sentence with EOS_FLAG_BIT

--- a/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPChunkerOp.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPChunkerOp.cs
@@ -1,7 +1,6 @@
 // Lucene version compatibility level 8.2.0
 using Lucene.Net.Support.Threading;
-using opennlp.tools.chunker;
-
+using NOpenNLP.Tools.Chunker;
 
 namespace Lucene.Net.Analysis.OpenNlp.Tools
 {
@@ -40,9 +39,9 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             UninterruptableMonitor.Enter(this);
             try
             {
-                string[] chunks = chunker.chunk(words, tags);
+                string[] chunks = chunker.Chunk(words, tags);
                 if (probs != null)
-                    chunker.probs(probs);
+                    chunker.Probs(probs);
                 return chunks;
             }
             finally

--- a/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPLemmatizerOp.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPLemmatizerOp.cs
@@ -1,5 +1,6 @@
 // Lucene version compatibility level 8.2.0
-using opennlp.tools.lemmatizer;
+
+using NOpenNLP.Tools.Lemmatizer;
 using System.Diagnostics;
 using System.IO;
 
@@ -39,7 +40,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
         public NLPLemmatizerOp(Stream dictionary, LemmatizerModel lemmatizerModel)
         {
             Debug.Assert(dictionary != null || lemmatizerModel != null, "At least one parameter must be non-null");
-            dictionaryLemmatizer = dictionary is null ? null : new DictionaryLemmatizer(new ikvm.io.InputStreamWrapper(dictionary));
+            dictionaryLemmatizer = dictionary is null ? null : new DictionaryLemmatizer(dictionary);
             lemmatizerME = lemmatizerModel is null ? null : new LemmatizerME(lemmatizerModel);
         }
 
@@ -49,7 +50,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             string[] maxEntLemmas = null;
             if (dictionaryLemmatizer != null)
             {
-                lemmas = dictionaryLemmatizer.lemmatize(words, postags);
+                lemmas = dictionaryLemmatizer.Lemmatize(words, postags);
                 for (int i = 0; i < lemmas.Length; ++i)
                 {
                     if (lemmas[i].Equals("O"))
@@ -58,7 +59,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
                         {  // fall back to the MaxEnt lemmatizer if it's enabled
                             if (maxEntLemmas is null)
                             {
-                                maxEntLemmas = lemmatizerME.lemmatize(words, postags);
+                                maxEntLemmas = lemmatizerME.Lemmatize(words, postags);
                             }
                             if ("_".Equals(maxEntLemmas[i]))
                             {
@@ -78,7 +79,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             }
             else
             {                           // there is only a MaxEnt lemmatizer
-                maxEntLemmas = lemmatizerME.lemmatize(words, postags);
+                maxEntLemmas = lemmatizerME.Lemmatize(words, postags);
                 for (int i = 0; i < maxEntLemmas.Length; ++i)
                 {
                     if ("_".Equals(maxEntLemmas[i]))

--- a/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPNERTaggerOp.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPNERTaggerOp.cs
@@ -1,7 +1,7 @@
 // Lucene version compatibility level 8.2.0
 using Lucene.Net.Support.Threading;
-using opennlp.tools.namefind;
-using opennlp.tools.util;
+using NOpenNLP.Tools.Namefind;
+using NOpenNLP.Tools.Util;
 
 namespace Lucene.Net.Analysis.OpenNlp.Tools
 {
@@ -39,7 +39,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
     /// </summary>
     public class NLPNERTaggerOp
     {
-        private readonly TokenNameFinder nameFinder;
+        private readonly ITokenNameFinder nameFinder;
 
         public NLPNERTaggerOp(TokenNameFinderModel model)
         {
@@ -48,7 +48,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
 
         public virtual Span[] GetNames(string[] words)
         {
-            Span[] names = nameFinder.find(words);
+            Span[] names = nameFinder.Find(words);
             return names;
         }
 
@@ -57,7 +57,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             UninterruptableMonitor.Enter(this);
             try
             {
-                nameFinder.clearAdaptiveData();
+                nameFinder.ClearAdaptiveData();
             }
             finally
             {

--- a/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPPOSTaggerOp.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPPOSTaggerOp.cs
@@ -1,6 +1,6 @@
 // Lucene version compatibility level 8.2.0
 using Lucene.Net.Support.Threading;
-using opennlp.tools.postag;
+using NOpenNLP.Tools.Postag;
 
 namespace Lucene.Net.Analysis.OpenNlp.Tools
 {
@@ -27,7 +27,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
     /// </summary>
     public class NLPPOSTaggerOp
     {
-        private readonly POSTagger tagger = null;
+        private readonly IPOSTagger tagger = null;
 
         public NLPPOSTaggerOp(POSModel model)
         {
@@ -39,7 +39,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             UninterruptableMonitor.Enter(this);
             try
             {
-                return tagger.tag(words);
+                return tagger.Tag(words);
             }
             finally
             {

--- a/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPSentenceDetectorOp.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPSentenceDetectorOp.cs
@@ -1,7 +1,7 @@
 // Lucene version compatibility level 8.2.0
 using Lucene.Net.Support.Threading;
-using opennlp.tools.sentdetect;
-using opennlp.tools.util;
+using NOpenNLP.Tools.Sentdetect;
+using NOpenNLP.Tools.Util;
 
 namespace Lucene.Net.Analysis.OpenNlp.Tools
 {
@@ -47,7 +47,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             {
                 if (sentenceSplitter != null)
                 {
-                    return sentenceSplitter.sentPosDetect(line);
+                    return sentenceSplitter.SentPosDetect(line);
                 }
                 else
                 {

--- a/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPTokenizerOp.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/Tools/NLPTokenizerOp.cs
@@ -1,7 +1,7 @@
 // Lucene version compatibility level 8.2.0
 using Lucene.Net.Support.Threading;
-using opennlp.tools.tokenize;
-using opennlp.tools.util;
+using NOpenNLP.Tools.Tokenize;
+using NOpenNLP.Tools.Util;
 
 namespace Lucene.Net.Analysis.OpenNlp.Tools
 {
@@ -51,7 +51,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
                     span1[0] = new Span(0, sentence.Length);
                     return span1;
                 }
-                return tokenizer.tokenizePos(sentence);
+                return tokenizer.TokenizePos(sentence);
             }
             finally
             {

--- a/src/Lucene.Net.Analysis.OpenNLP/Tools/OpenNLPOpsFactory.cs
+++ b/src/Lucene.Net.Analysis.OpenNLP/Tools/OpenNLPOpsFactory.cs
@@ -1,11 +1,11 @@
 // Lucene version compatibility level 8.2.0
 using Lucene.Net.Analysis.Util;
-using opennlp.tools.chunker;
-using opennlp.tools.lemmatizer;
-using opennlp.tools.namefind;
-using opennlp.tools.postag;
-using opennlp.tools.sentdetect;
-using opennlp.tools.tokenize;
+using NOpenNLP.Tools.Chunker;
+using NOpenNLP.Tools.Lemmatizer;
+using NOpenNLP.Tools.Namefind;
+using NOpenNLP.Tools.Postag;
+using NOpenNLP.Tools.Sentdetect;
+using NOpenNLP.Tools.Tokenize;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
@@ -63,7 +63,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             return sentenceModels.GetOrAdd(modelName, (modelName) =>
             {
                 using Stream resource = loader.OpenResource(modelName);
-                return new SentenceModel(new ikvm.io.InputStreamWrapper(resource));
+                return new SentenceModel(resource);
             });
         }
 
@@ -86,7 +86,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             return tokenizerModels.GetOrAdd(modelName, (modelName) =>
             {
                 using Stream resource = loader.OpenResource(modelName);
-                return new TokenizerModel(new ikvm.io.InputStreamWrapper(resource));
+                return new TokenizerModel(resource);
             });
         }
 
@@ -102,7 +102,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             return posTaggerModels.GetOrAdd(modelName, (modelName) =>
             {
                 using Stream resource = loader.OpenResource(modelName);
-                return new POSModel(new ikvm.io.InputStreamWrapper(resource));
+                return new POSModel(resource);
             });
         }
 
@@ -118,7 +118,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             return chunkerModels.GetOrAdd(modelName, (modelName) =>
             {
                 using Stream resource = loader.OpenResource(modelName);
-                return new ChunkerModel(new ikvm.io.InputStreamWrapper(resource));
+                return new ChunkerModel(resource);
             });
         }
 
@@ -134,7 +134,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             return nerModels.GetOrAdd(modelName, (modelName) =>
             {
                 using Stream resource = loader.OpenResource(modelName);
-                return new TokenNameFinderModel(new ikvm.io.InputStreamWrapper(resource));
+                return new TokenNameFinderModel(resource);
             });
         }
 
@@ -178,7 +178,7 @@ namespace Lucene.Net.Analysis.OpenNlp.Tools
             return lemmatizerModels.GetOrAdd(modelName, (modelName) =>
             {
                 using Stream resource = loader.OpenResource(modelName);
-                return new LemmatizerModel(new ikvm.io.InputStreamWrapper(resource));
+                return new LemmatizerModel(resource);
             });
         }
 

--- a/src/Lucene.Net.Analysis.OpenNLP/overview.md
+++ b/src/Lucene.Net.Analysis.OpenNLP/overview.md
@@ -38,22 +38,11 @@ Since the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> is not store
 - <xref:Lucene.Net.Analysis.Payloads.TypeAsPayloadTokenFilter> copies the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> value to the <xref:Lucene.Net.Analysis.TokenAttributes.IPayloadAttribute>
 - <xref:Lucene.Net.Analysis.Miscellaneous.TypeAsSynonymFilter> creates a cloned token at the same position as each tagged token, and copies the <xref:Lucene.Net.Analysis.TokenAttributes.ITypeAttribute> value to the <xref:Lucene.Net.Analysis.TokenAttributes.ICharTermAttribute>, optionally with a customized prefix (so that tags effectively occupy a different namespace from token text).
 
-Named Entity Recognition is also supported by OpenNLP, but there is no OpenNLPNERFilter included. For an implementation, see the [lucenenet-opennlp-mavenreference-demo](https://github.com/NightOwl888/lucenenet-opennlp-mavenreference-demo).
+Named Entity Recognition is also supported by OpenNLP, but there is no OpenNLPNERFilter included.
 
-## MavenReference Primer
+## Underlying NLP library
 
-When a `<PackageReference>` is included for this NuGet package in your SDK-style MSBuild project, it will automatically include transitive dependencies to [`opennlp-tools` on maven.org](https://search.maven.org/artifact/org.apache.opennlp/opennlp-tools/1.9.4/bundle). The transitive dependency will automatically include a `<MavenReference>` in your MSBuild project.
-
-The `<MavenReference>` item group operates similar to a dependency in Maven. All transitive dependencies are collected and resolved, and then the final output is produced. However, unlike `PackageReference`s, `MavenReference`s are collected by the final output project, and reassessed. That is, each dependent Project within your .NET SDK-style solution contributes its `MavenReference`s to project(s) which include it, and each project makes its own dependency graph. Projects do not contribute their final built assemblies up. They only contribute their dependencies. Allowing each project in a complicated solution to make its own local conflict resolution attempt.
-
-> [!NOTE]
-> `<MavenReference>` is only supported on SDK-style MSBuild projects.
-
-## MavenReference Example
-
-This means this package can be combined with other related packages on Maven in your project and they can be accessed using the same path as in Java like a namespace in .NET. For example, you can add a `<MavenReference>` to your project to include a reference to [`opennlp-uima`](https://search.maven.org/artifact/org.apache.opennlp/opennlp-uima/1.9.1/jar). The UIMA (Unstructured Information Management Architecture) integration module is designed to work with the Apache UIMA framework. UIMA is a framework for building applications that analyze unstructured information, and it's often used for processing natural language text. The opennlp-uima module allows you to integrate OpenNLP functionality into UIMA pipelines, leveraging the capabilities of both frameworks.
-
-Here's a basic outline of how you might extend an existing Lucene.NET analyzer to incorporate OpenNLP-UIMA annotators:
+This module is built on [NOpenNLP](https://github.com/nopennlp/nopennlp), a C# port of Apache OpenNLP 1.9.5. NOpenNLP is referenced as an ordinary NuGet package, so using this module requires nothing beyond a `<PackageReference>`:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -62,62 +51,9 @@ Here's a basic outline of how you might extend an existing Lucene.NET analyzer t
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lucene.Net.Analysis.OpenNLP" Version="4.8.0-beta00017" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <MavenReference Include="org.apache.opennlp:opennlp-uima" Version="1.9.1" />
+    <PackageReference Include="Lucene.Net.Analysis.OpenNLP" Version="[VERSION]" />
   </ItemGroup>
 </Project>
 ```
 
-```c#
-using Lucene.Net.Analysis;
-using Lucene.Net.Analysis.Core;
-using Lucene.Net.Analysis.Util;
-using Lucene.Net.Util;
-using org.apache.uima.analysis_engine;
-using System.IO;
-
-public class CustomOpenNLPAnalyzer : OpenNLPTokenizerFactory
-{
-    // ... constructor and other methods ...
-
-    public override Tokenizer Create(AttributeFactory factory, TextReader reader)
-    {
-        Tokenizer tokenizer = base.Create(factory, reader);
-
-        // Wrap the tokenizer with UIMA annotators
-        AnalysisEngineDescription uimaSentenceAnnotator = CreateUIMASentenceAnnotator();
-        AnalysisEngineDescription uimaTokenAnnotator = CreateUIMATokenAnnotator();
-
-        // Combine OpenNLP-UIMA annotators with the existing tokenizer
-        AnalysisEngine tokenizerAndUIMAAnnotators = CreateAggregate(uimaSentenceAnnotator, uimaTokenAnnotator);
-
-        return new UIMATokenizer(tokenizer, tokenizerAndUIMAAnnotators);
-    }
-
-    // ... other methods ...
-
-    private AnalysisEngineDescription CreateUIMASentenceAnnotator() {
-        // Create and configure UIMA sentence annotator
-        // ...
-
-        return /* UIMA sentence annotator description */;
-    }
-
-    private AnalysisEngineDescription CreateUIMATokenAnnotator() {
-        // Create and configure UIMA token annotator
-        // ...
-
-        return /* UIMA token annotator description */;
-    }
-}
-```
-
-In the above example, `CustomOpenNLPAnalyzer` extends `OpenNLPTokenizerFactory` (assuming that's the analyzer you're using), and it wraps the OpenNLP tokenizer with UIMA annotators. You'll need to replace the placeholder methods (`CreateUIMASentenceAnnotator` and `CreateUIMATokenAnnotator`) with the actual code to create and configure your UIMA annotators. Please note that configuring NLP can be complex. See the [OpenNLP 1.9.4 Manual](https://opennlp.apache.org/docs/1.9.4/manual/opennlp.html) and [OpenNLP UIMA 1.9.4 API Documentation](https://opennlp.apache.org/docs/1.9.4/apidocs/opennlp-uima/index.html) for details.
-
-> [!NOTE]
-> IKVM (and `<MavenReference>`) does not support Java SE higher than version 8. So it will not be possible to add a `<MavenReference>` to OpenNLP 2.x until support is added for it in IKVM.
-
-For a more complete example, see the [lucenenet-opennlp-mavenreference-demo](https://github.com/NightOwl888/lucenenet-opennlp-mavenreference-demo).
+NOpenNLP ports the `opennlp-tools` module, keeping the upstream OpenNLP type and member names with .NET casing conventions applied, so the [OpenNLP Manual](https://opennlp.apache.org/docs/1.9.4/manual/opennlp.html) and Java examples generally carry over. Its API reference is at [nopennlp.github.io/nopennlp](https://nopennlp.github.io/nopennlp/).


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/apache/lucenenet/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a change, please [open an issue](https://github.com/apache/lucenenet/issues/new/choose) to discuss the change or find an existing issue.

Replace OpenNLP via IKVM with NOpenNLP

Fixes #1438

## Description

This replaces the Java-based Maven reference to OpenNLP that runs on IKVM, with the new community [NOpenNLP](https://github.com/nopennlp/nopennlp) project I started. This is a true C# port of OpenNLP, not requiring any Java runtime (and with only J2N as a dependency). (Note: the bulk of the porting work was done by Claude Code, but much was done by hand or with my [JavaToCSharp](https://github.com/paulirwin/JavaToCSharp) project.) NOpenNLP is available on NuGet as prerelease currently as the [NOpenNLP.Tools package](https://www.nuget.org/packages/NOpenNLP.Tools/).

NOpenNLP has dramatically better performance than OpenNLP via IKVM, and in some cases it even outperforms OpenNLP running in a real JVM, before doing any work to optimize for performance. You can see some of the early benchmarks in [this PR description](https://github.com/nopennlp/nopennlp/pull/2), or run them yourself at the NOpenNLP repo. All OpenNLP tests pass, and this will shave many GB off the build agents and minutes off the restore/build/test times.

AI: overview.md changes written by Claude Code (Opus 5); the rest by me.
